### PR TITLE
Contracts: Per block gas limit

### DIFF
--- a/substrate/runtime/contract/src/genesis_config.rs
+++ b/substrate/runtime/contract/src/genesis_config.rs
@@ -16,7 +16,7 @@
 
 //! Build the contract module part of the genesis block storage.
 
-use {Trait, ContractFee, CallBaseFee, CreateBaseFee, GasPrice, MaxDepth};
+use {Trait, ContractFee, CallBaseFee, CreateBaseFee, GasPrice, MaxDepth, BlockGasLimit};
 
 use runtime_primitives;
 use runtime_io::{self, twox_128};
@@ -34,6 +34,7 @@ pub struct GenesisConfig<T: Trait> {
 	pub create_base_fee: T::Gas,
 	pub gas_price: T::Balance,
 	pub max_depth: u32,
+	pub block_gas_limit: T::Gas,
 }
 
 impl<T: Trait> runtime_primitives::BuildStorage for GenesisConfig<T> {
@@ -43,7 +44,8 @@ impl<T: Trait> runtime_primitives::BuildStorage for GenesisConfig<T> {
 			twox_128(<CallBaseFee<T>>::key()).to_vec() => self.call_base_fee.encode(),
 			twox_128(<CreateBaseFee<T>>::key()).to_vec() => self.create_base_fee.encode(),
 			twox_128(<GasPrice<T>>::key()).to_vec() => self.gas_price.encode(),
-			twox_128(<MaxDepth<T>>::key()).to_vec() => self.max_depth.encode()
+			twox_128(<MaxDepth<T>>::key()).to_vec() => self.max_depth.encode(),
+			twox_128(<BlockGasLimit<T>>::key()).to_vec() => self.block_gas_limit.encode()
 		];
 		Ok(r.into())
 	}

--- a/substrate/runtime/contract/src/tests.rs
+++ b/substrate/runtime/contract/src/tests.rs
@@ -128,6 +128,7 @@ fn new_test_ext(existential_deposit: u64, gas_price: u64) -> runtime_io::TestExt
 			create_base_fee: 175,
 			gas_price,
 			max_depth: 100,
+			block_gas_limit: 100_000_000,
 		}.build_storage()
 			.unwrap(),
 	);

--- a/substrate/runtime/contract/src/tests.rs
+++ b/substrate/runtime/contract/src/tests.rs
@@ -248,8 +248,8 @@ fn contract_transfer_oog() {
 			// 2 * 135 - base gas fee for call (by contract)
 			100_000_000 - (2 * 6) - (2 * 135) - (2 * 135),
 		);
-		assert_eq!(Staking::free_balance(&1), 11,);
-		assert_eq!(Staking::free_balance(&CONTRACT_SHOULD_TRANSFER_TO), 0,);
+		assert_eq!(Staking::free_balance(&1), 11);
+		assert_eq!(Staking::free_balance(&CONTRACT_SHOULD_TRANSFER_TO), 0);
 	});
 }
 
@@ -280,7 +280,7 @@ fn contract_transfer_max_depth() {
 			// 2 * 135 * 100 - base gas fee for call (by transaction) multiplied by max depth (100).
 			100_000_000 - (2 * 135 * 100) - (2 * 6 * 100),
 		);
-		assert_eq!(Staking::free_balance(&CONTRACT_SHOULD_TRANSFER_TO), 11,);
+		assert_eq!(Staking::free_balance(&CONTRACT_SHOULD_TRANSFER_TO), 11);
 	});
 }
 
@@ -506,12 +506,12 @@ fn account_removal_removes_storage() {
 			// Setup two accounts with free balance above than exsistential threshold.
 			{
 				Staking::set_free_balance(&1, 110);
-                Staking::increase_total_stake_by(110);
+				Staking::increase_total_stake_by(110);
 				<StorageOf<Test>>::insert(1, b"foo".to_vec(), b"1".to_vec());
 				<StorageOf<Test>>::insert(1, b"bar".to_vec(), b"2".to_vec());
 
 				Staking::set_free_balance(&2, 110);
-                Staking::increase_total_stake_by(110);
+				Staking::increase_total_stake_by(110);
 				<StorageOf<Test>>::insert(2, b"hello".to_vec(), b"3".to_vec());
 				<StorageOf<Test>>::insert(2, b"world".to_vec(), b"4".to_vec());
 			}

--- a/substrate/runtime/contract/src/tests.rs
+++ b/substrate/runtime/contract/src/tests.rs
@@ -441,9 +441,9 @@ fn refunds_unused_gas() {
 		Staking::set_free_balance(&0, 100_000_000);
 		Staking::increase_total_stake_by(100_000_000);
 
-		assert_ok!(Contract::call(&0, 1, 0, 100_000, Vec::new(),));
+		assert_ok!(Contract::call(&0, 1, 0, 100_000, Vec::new()));
 
-		assert_eq!(Staking::free_balance(&0), 100_000_000 - 4 - (2 * 135),);
+		assert_eq!(Staking::free_balance(&0), 100_000_000 - 4 - (2 * 135));
 	});
 }
 
@@ -455,9 +455,9 @@ fn call_with_zero_value() {
 		Staking::set_free_balance(&0, 100_000_000);
 		Staking::increase_total_stake_by(100_000_000);
 
-		assert_ok!(Contract::call(&0, 1, 0, 100_000, Vec::new(),));
+		assert_ok!(Contract::call(&0, 1, 0, 100_000, Vec::new()));
 
-		assert_eq!(Staking::free_balance(&0), 100_000_000 - (2 * 135),);
+		assert_eq!(Staking::free_balance(&0), 100_000_000 - (2 * 135));
 	});
 }
 
@@ -469,7 +469,7 @@ fn create_with_zero_endowment() {
 		Staking::set_free_balance(&0, 100_000_000);
 		Staking::increase_total_stake_by(100_000_000);
 
-		assert_ok!(Contract::create(&0, 0, 100_000, code_nop, Vec::new(),));
+		assert_ok!(Contract::create(&0, 0, 100_000, code_nop, Vec::new()));
 
 		assert_eq!(
 			Staking::free_balance(&0),
@@ -543,6 +543,6 @@ fn top_level_call_refunds_even_if_fails() {
 			"vm execute returned error while call"
 		);
 
-		assert_eq!(Staking::free_balance(&0), 100_000_000 - (4 * 3) - (4 * 135),);
+		assert_eq!(Staking::free_balance(&0), 100_000_000 - (4 * 3) - (4 * 135));
 	});
 }


### PR DESCRIPTION
Introduce per block gas limit checking.

Before buying gas we check how much gas available to spend in this block. The available gas is computed by substracting spent gas from the block limit. Spent gas is increased at the same time when we do refunds and reset at the block finilization stage.

