### PR TITLE
Limit number of retries for light client queries

### DIFF
--- a/substrate/client/src/light/backend.rs
+++ b/substrate/client/src/light/backend.rs
@@ -196,6 +196,7 @@ impl<Block, S, F, H, C> StateBackend<H, C> for OnDemandState<Block, S, F>
 				block: self.block,
 				header: header.expect("if block above guarantees that header is_some(); qed"),
 				key: key.to_vec(),
+				retry_count: None,
 			})
 			.into_future().wait()
 	}

--- a/substrate/client/src/light/blockchain.rs
+++ b/substrate/client/src/light/blockchain.rs
@@ -101,6 +101,7 @@ impl<S, F, Block> BlockchainHeaderBackend<Block> for Blockchain<S, F> where Bloc
 					.remote_header(RemoteHeaderRequest {
 						cht_root: self.storage.cht_root(cht::SIZE, number)?,
 						block: number,
+						retry_count: None,
 					})
 					.into_future().wait()
 					.map(Some)

--- a/substrate/client/src/light/call_executor.rs
+++ b/substrate/client/src/light/call_executor.rs
@@ -73,6 +73,7 @@ impl<B, F, Block> CallExecutor<Block, KeccakHasher, RlpCodec> for RemoteCallExec
 			header: block_header,
 			method: method.into(),
 			call_data: call_data.to_vec(),
+			retry_count: None,
 		}).into_future().wait()
 	}
 
@@ -168,6 +169,7 @@ mod tests {
 			},
 			method: "authorities".into(),
 			call_data: vec![],
+			retry_count: None,
 		}, remote_execution_proof).unwrap();
 	}
 }

--- a/substrate/client/src/light/fetcher.rs
+++ b/substrate/client/src/light/fetcher.rs
@@ -43,6 +43,8 @@ pub struct RemoteCallRequest<Header: HeaderT> {
 	pub method: String,
 	/// Call data.
 	pub call_data: Vec<u8>,
+	/// Number of times to retry request. None means that default RETRY_COUNT is used.
+	pub retry_count: Option<usize>,
 }
 
 /// Remote canonical header request.
@@ -52,6 +54,8 @@ pub struct RemoteHeaderRequest<Header: HeaderT> {
 	pub cht_root: Header::Hash,
 	/// Number of the header to query.
 	pub block: Header::Number,
+	/// Number of times to retry request. None means that default RETRY_COUNT is used.
+	pub retry_count: Option<usize>,
 }
 
 /// Remote storage read request.
@@ -63,6 +67,8 @@ pub struct RemoteReadRequest<Header: HeaderT> {
 	pub header: Header,
 	/// Storage key to read.
 	pub key: Vec<u8>,
+	/// Number of times to retry request. None means that default RETRY_COUNT is used.
+	pub retry_count: Option<usize>,
 }
 
 /// Light client data fetcher. Implementations of this trait must check if remote data
@@ -264,6 +270,7 @@ pub mod tests {
 			block: remote_block_header.hash(),
 			header: remote_block_header,
 			key: b":auth:len".to_vec(),
+			retry_count: None,
 		}, remote_read_proof).unwrap().unwrap()[0], authorities_len as u8);
 	}
 
@@ -273,6 +280,7 @@ pub mod tests {
 		assert_eq!((&local_checker as &FetchChecker<Block>).check_header_proof(&RemoteHeaderRequest::<Header> {
 			cht_root: local_cht_root,
 			block: 1,
+			retry_count: None,
 		}, Some(remote_block_header.clone()), remote_header_proof).unwrap(), remote_block_header);
 	}
 
@@ -283,6 +291,7 @@ pub mod tests {
 		assert!((&local_checker as &FetchChecker<Block>).check_header_proof(&RemoteHeaderRequest::<Header> {
 			cht_root: Default::default(),
 			block: 1,
+			retry_count: None,
 		}, Some(remote_block_header.clone()), remote_header_proof).is_err());
 	}
 
@@ -293,6 +302,7 @@ pub mod tests {
 		assert!((&local_checker as &FetchChecker<Block>).check_header_proof(&RemoteHeaderRequest::<Header> {
 			cht_root: local_cht_root,
 			block: 1,
+			retry_count: None,
 		}, Some(remote_block_header.clone()), remote_header_proof).is_err());
 	}
 }


### PR DESCRIPTION
Implementation of [this comment](https://github.com/paritytech/substrate/issues/150#discussion_r189261529)