### PR TITLE
New slashing mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
  "polkadot-service 0.2.2",
  "polkadot-transaction-pool 0.1.0",
  "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-cli 0.2.2",
+ "substrate-cli 0.2.4",
  "substrate-client 0.1.0",
  "substrate-codec 0.1.0",
  "substrate-extrinsic-pool 0.1.0",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-cli"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -121,7 +121,7 @@ impl Convert<AccountId, SessionKey> for SessionKeyConversion {
 }
 
 impl session::Trait for Concrete {
-	const NOTE_OFFLINE_POSITION: u32 = 1;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type ConvertAccountIdToSessionKey = SessionKeyConversion;
 	type OnSessionChange = Staking;
 }

--- a/polkadot/consensus/src/offline_tracker.rs
+++ b/polkadot/consensus/src/offline_tracker.rs
@@ -161,6 +161,7 @@ mod tests {
 		assert_eq!(tracker.reports(&[v, v2, v3]), vec![0, 2]);
 
 		tracker.note_new_block(&[v, v2]);
+		tracker.note_round_end(v, false);
 		assert_eq!(tracker.reports(&[v, v2, v3]), vec![0]);
 	}
 }

--- a/polkadot/runtime/src/checked_block.rs
+++ b/polkadot/runtime/src/checked_block.rs
@@ -16,7 +16,7 @@
 
 //! Typesafe block interaction.
 
-use super::{Call, Block, TIMESTAMP_SET_POSITION, PARACHAINS_SET_POSITION, NOTE_OFFLINE_POSITION};
+use super::{Call, Block, TIMESTAMP_SET_POSITION, PARACHAINS_SET_POSITION, NOTE_MISSED_PROPOSAL_POSITION};
 use timestamp::Call as TimestampCall;
 use parachains::Call as ParachainsCall;
 use staking::Call as StakingCall;
@@ -92,8 +92,8 @@ impl CheckedBlock {
 
 	/// Extract the noted offline validator indices (if any) from the block.
 	pub fn noted_offline(&self) -> &[u32] {
-		self.inner.extrinsics.get(NOTE_OFFLINE_POSITION as usize).and_then(|xt| match xt.extrinsic.function {
-			Call::Staking(StakingCall::note_offline(ref x)) => Some(&x[..]),
+		self.inner.extrinsics.get(NOTE_MISSED_PROPOSAL_POSITION as usize).and_then(|xt| match xt.extrinsic.function {
+			Call::Staking(StakingCall::note_missed_proposal(ref x)) => Some(&x[..]),
 			_ => None,
 		}).unwrap_or(&[])
 	}

--- a/polkadot/runtime/src/checked_block.rs
+++ b/polkadot/runtime/src/checked_block.rs
@@ -19,7 +19,7 @@
 use super::{Call, Block, TIMESTAMP_SET_POSITION, PARACHAINS_SET_POSITION, NOTE_OFFLINE_POSITION};
 use timestamp::Call as TimestampCall;
 use parachains::Call as ParachainsCall;
-use session::Call as SessionCall;
+use staking::Call as StakingCall;
 use primitives::parachain::CandidateReceipt;
 
 /// Provides a type-safe wrapper around a structurally valid block.
@@ -93,7 +93,7 @@ impl CheckedBlock {
 	/// Extract the noted offline validator indices (if any) from the block.
 	pub fn noted_offline(&self) -> &[u32] {
 		self.inner.extrinsics.get(NOTE_OFFLINE_POSITION as usize).and_then(|xt| match xt.extrinsic.function {
-			Call::Session(SessionCall::note_offline(ref x)) => Some(&x[..]),
+			Call::Staking(StakingCall::note_offline(ref x)) => Some(&x[..]),
 			_ => None,
 		}).unwrap_or(&[])
 	}

--- a/polkadot/runtime/src/lib.rs
+++ b/polkadot/runtime/src/lib.rs
@@ -86,7 +86,7 @@ pub const TIMESTAMP_SET_POSITION: u32 = 0;
 /// The position of the parachains set extrinsic.
 pub const PARACHAINS_SET_POSITION: u32 = 1;
 /// The position of the offline nodes noting extrinsic.
-pub const NOTE_OFFLINE_POSITION: u32 = 2;
+pub const NOTE_MISSED_PROPOSAL_POSITION: u32 = 2;
 
 /// The address format for describing accounts.
 pub type Address = staking::Address<Concrete>;
@@ -162,7 +162,7 @@ impl Convert<AccountId, SessionKey> for SessionKeyConversion {
 }
 
 impl session::Trait for Concrete {
-	const NOTE_OFFLINE_POSITION: u32 = NOTE_OFFLINE_POSITION;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = NOTE_MISSED_PROPOSAL_POSITION;
 	type ConvertAccountIdToSessionKey = SessionKeyConversion;
 	type OnSessionChange = Staking;
 }

--- a/polkadot/runtime/src/lib.rs
+++ b/polkadot/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub struct Concrete;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: ver_str!("polkadot"),
 	impl_name: ver_str!("parity-polkadot"),
-	authoring_version: 1,
+	authoring_version: 2,
 	spec_version: 4,
 	impl_version: 0,
 };

--- a/polkadot/runtime/src/lib.rs
+++ b/polkadot/runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: ver_str!("polkadot"),
 	impl_name: ver_str!("parity-polkadot"),
 	authoring_version: 1,
-	spec_version: 3,
+	spec_version: 4,
 	impl_version: 0,
 };
 

--- a/polkadot/runtime/src/parachains.rs
+++ b/polkadot/runtime/src/parachains.rs
@@ -265,7 +265,7 @@ mod tests {
 		type Header = Header;
 	}
 	impl session::Trait for Test {
-		const NOTE_OFFLINE_POSITION: u32 = 1;
+		const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 		type ConvertAccountIdToSessionKey = Identity;
 		type OnSessionChange = ();
 	}

--- a/polkadot/runtime/src/utils.rs
+++ b/polkadot/runtime/src/utils.rs
@@ -21,7 +21,7 @@ use super::{Call, UncheckedExtrinsic, Extrinsic, Staking};
 use runtime_primitives::traits::{Checkable, AuxLookup};
 use timestamp::Call as TimestampCall;
 use parachains::Call as ParachainsCall;
-use session::Call as SessionCall;
+use staking::Call as StakingCall;
 
 /// Produces the list of inherent extrinsics.
 pub fn inherent_extrinsics(data: ::primitives::InherentData) -> Vec<UncheckedExtrinsic> {
@@ -41,7 +41,7 @@ pub fn inherent_extrinsics(data: ::primitives::InherentData) -> Vec<UncheckedExt
 
 	if !data.offline_indices.is_empty() {
 		inherent.push(make_inherent(
-			Call::Session(SessionCall::note_offline(data.offline_indices))
+			Call::Staking(StakingCall::note_offline(data.offline_indices))
 		));
 	}
 

--- a/polkadot/runtime/src/utils.rs
+++ b/polkadot/runtime/src/utils.rs
@@ -41,7 +41,7 @@ pub fn inherent_extrinsics(data: ::primitives::InherentData) -> Vec<UncheckedExt
 
 	if !data.offline_indices.is_empty() {
 		inherent.push(make_inherent(
-			Call::Staking(StakingCall::note_offline(data.offline_indices))
+			Call::Staking(StakingCall::note_missed_proposal(data.offline_indices))
 		));
 	}
 

--- a/substrate/runtime/contract/src/tests.rs
+++ b/substrate/runtime/contract/src/tests.rs
@@ -54,7 +54,7 @@ impl staking::Trait for Test {
 	type OnAccountKill = Contract;
 }
 impl session::Trait for Test {
-	const NOTE_OFFLINE_POSITION: u32 = 1;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type ConvertAccountIdToSessionKey = Identity;
 	type OnSessionChange = Staking;
 }

--- a/substrate/runtime/council/src/lib.rs
+++ b/substrate/runtime/council/src/lib.rs
@@ -649,7 +649,7 @@ mod tests {
 		type Header = Header;
 	}
 	impl session::Trait for Test {
-		const NOTE_OFFLINE_POSITION: u32 = 1;
+		const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 		type ConvertAccountIdToSessionKey = Identity;
 		type OnSessionChange = staking::Module<Test>;
 	}

--- a/substrate/runtime/democracy/src/lib.rs
+++ b/substrate/runtime/democracy/src/lib.rs
@@ -391,7 +391,7 @@ mod tests {
 		type Header = Header;
 	}
 	impl session::Trait for Test {
-		const NOTE_OFFLINE_POSITION: u32 = 1;
+		const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 		type ConvertAccountIdToSessionKey = Identity;
 		type OnSessionChange = staking::Module<Test>;
 	}

--- a/substrate/runtime/executive/src/lib.rs
+++ b/substrate/runtime/executive/src/lib.rs
@@ -252,7 +252,7 @@ mod tests {
 		type Header = Header;
 	}
 	impl session::Trait for Test {
-		const NOTE_OFFLINE_POSITION: u32 = 1;
+		const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 		type ConvertAccountIdToSessionKey = Identity;
 		type OnSessionChange = staking::Module<Test>;
 	}

--- a/substrate/runtime/primitives/src/traits.rs
+++ b/substrate/runtime/primitives/src/traits.rs
@@ -26,7 +26,8 @@ use codec::{Codec, Encode};
 pub use integer_sqrt::IntegerSquareRoot;
 pub use num_traits::{Zero, One, Bounded};
 pub use num_traits::ops::checked::{CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
-use rstd::ops::{Add, Sub, Mul, Div, Rem, AddAssign, SubAssign, MulAssign, DivAssign, RemAssign};
+use rstd::ops::{Add, Sub, Mul, Div, Rem, AddAssign, SubAssign, MulAssign, DivAssign,
+	RemAssign, Shl, Shr};
 
 /// A lazy value.
 pub trait Lazy<T: ?Sized> {
@@ -132,6 +133,7 @@ pub trait SimpleArithmetic:
 	Mul<Self, Output = Self> + MulAssign<Self> +
 	Div<Self, Output = Self> + DivAssign<Self> +
 	Rem<Self, Output = Self> + RemAssign<Self> +
+	Shl<u32, Output = Self> + Shr<u32, Output = Self> +
 	CheckedAdd +
 	CheckedSub +
 	CheckedMul +
@@ -145,6 +147,7 @@ impl<T:
 	Mul<Self, Output = Self> + MulAssign<Self> +
 	Div<Self, Output = Self> + DivAssign<Self> +
 	Rem<Self, Output = Self> + RemAssign<Self> +
+	Shl<u32, Output = Self> + Shr<u32, Output = Self> +
 	CheckedAdd +
 	CheckedSub +
 	CheckedMul +

--- a/substrate/runtime/session/src/lib.rs
+++ b/substrate/runtime/session/src/lib.rs
@@ -358,36 +358,6 @@ mod tests {
 	}
 
 	#[test]
-	fn should_identify_broken_validation() {
-		with_externalities(&mut new_test_ext(), || {
-			System::set_block_number(2);
-			assert_eq!(Session::blocks_remaining(), 0);
-			Timestamp::set_timestamp(0);
-			assert_ok!(Session::set_length(3));
-			Session::check_rotate_session();
-			assert_eq!(Session::current_index(), 1);
-			assert_eq!(Session::length(), 3);
-			assert_eq!(Session::current_start(), 0);
-			assert_eq!(Session::ideal_session_duration(), 15);
-			// ideal end = 0 + 15 * 3 = 15
-			// broken_limit = 15 * 130 / 100 = 19
-
-			System::set_block_number(3);
-			assert_eq!(Session::blocks_remaining(), 2);
-			Timestamp::set_timestamp(9);				// earliest end = 9 + 2 * 5 = 19; OK.
-			assert!(!Session::broken_validation());
-			Session::check_rotate_session();
-
-			System::set_block_number(4);
-			assert_eq!(Session::blocks_remaining(), 1);
-			Timestamp::set_timestamp(15);				// another 1 second late. earliest end = 15 + 1 * 5 = 20; broken.
-			assert!(Session::broken_validation());
-			Session::check_rotate_session();
-			assert_eq!(Session::current_index(), 2);
-		});
-	}
-
-	#[test]
 	fn should_work_with_early_exit() {
 		with_externalities(&mut new_test_ext(), || {
 			System::set_block_number(1);

--- a/substrate/runtime/session/src/lib.rs
+++ b/substrate/runtime/session/src/lib.rs
@@ -51,13 +51,13 @@ use runtime_support::{StorageValue, StorageMap};
 use runtime_support::dispatch::Result;
 
 /// A session has changed.
-pub trait OnSessionChange<T, A> {
+pub trait OnSessionChange<T> {
 	/// Session has changed.
-	fn on_session_change(time_elapsed: T, bad_validators: Vec<A>);
+	fn on_session_change(time_elapsed: T, should_reward: bool);
 }
 
-impl<T, A> OnSessionChange<T, A> for () {
-	fn on_session_change(_: T, _: Vec<A>) {}
+impl<T> OnSessionChange<T> for () {
+	fn on_session_change(_: T, _: bool) {}
 }
 
 pub trait Trait: timestamp::Trait {
@@ -65,7 +65,7 @@ pub trait Trait: timestamp::Trait {
 	const NOTE_OFFLINE_POSITION: u32;
 
 	type ConvertAccountIdToSessionKey: Convert<Self::AccountId, Self::SessionKey>;
-	type OnSessionChange: OnSessionChange<Self::Moment, Self::AccountId>;
+	type OnSessionChange: OnSessionChange<Self::Moment>;
 }
 
 decl_module! {
@@ -80,7 +80,7 @@ decl_module! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
 		fn set_length(new: T::BlockNumber) -> Result = 0;
-		fn force_new_session(normal_rotation: bool) -> Result = 1;
+		fn force_new_session(apply_rewards: bool) -> Result = 1;
 	}
 }
 
@@ -139,8 +139,8 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Forces a new session.
-	pub fn force_new_session(normal_rotation: bool) -> Result {
-		<ForcingNewSession<T>>::put(normal_rotation);
+	pub fn force_new_session(apply_rewards: bool) -> Result {
+		<ForcingNewSession<T>>::put(apply_rewards);
 		Ok(())
 	}
 
@@ -178,15 +178,15 @@ impl<T: Trait> Module<T> {
 		// check block number and call next_session if necessary.
 		let block_number = <system::Module<T>>::block_number();
 		let is_final_block = ((block_number - Self::last_length_change()) % Self::length()).is_zero();
-		let bad_validators = <BadValidators<T>>::take().unwrap_or_default();
-		let should_end_session = <ForcingNewSession<T>>::take().is_some() || !bad_validators.is_empty() || is_final_block;
+		let (should_end_session, apply_rewards) = <ForcingNewSession<T>>::take()
+			.map_or((is_final_block, is_final_block), |apply_rewards| (true, apply_rewards));
 		if should_end_session {
-			Self::rotate_session(is_final_block, bad_validators);
+			Self::rotate_session(is_final_block, apply_rewards);
 		}
 	}
 
 	/// Move onto next session: register the new authority set.
-	pub fn rotate_session(is_final_block: bool, bad_validators: Vec<T::AccountId>) {
+	pub fn rotate_session(is_final_block: bool, apply_rewards: bool) {
 		let now = <timestamp::Module<T>>::get();
 		let time_elapsed = now.clone() - Self::current_start();
 
@@ -206,7 +206,7 @@ impl<T: Trait> Module<T> {
 			<LastLengthChange<T>>::put(block_number);
 		}
 
-		T::OnSessionChange::on_session_change(time_elapsed, bad_validators);
+		T::OnSessionChange::on_session_change(time_elapsed, apply_rewards);
 
 		// Update any changes in session keys.
 		Self::validators().iter().enumerate().for_each(|(i, v)| {

--- a/substrate/runtime/session/src/lib.rs
+++ b/substrate/runtime/session/src/lib.rs
@@ -62,7 +62,7 @@ impl<T> OnSessionChange<T> for () {
 
 pub trait Trait: timestamp::Trait {
 	// the position of the required timestamp-set extrinsic.
-	const NOTE_OFFLINE_POSITION: u32;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32;
 
 	type ConvertAccountIdToSessionKey: Convert<Self::AccountId, Self::SessionKey>;
 	type OnSessionChange: OnSessionChange<Self::Moment>;
@@ -148,9 +148,9 @@ impl<T: Trait> Module<T> {
 	pub fn note_offline(aux: &T::PublicAux, offline_val_indices: Vec<u32>) -> Result {
 		assert!(aux.is_empty());
 		assert!(
-			<system::Module<T>>::extrinsic_index() == T::NOTE_OFFLINE_POSITION,
+			<system::Module<T>>::extrinsic_index() == T::NOTE_MISSED_PROPOSAL_POSITION,
 			"note_offline extrinsic must be at position {} in the block",
-			T::NOTE_OFFLINE_POSITION
+			T::NOTE_MISSED_PROPOSAL_POSITION
 		);
 
 		let vs = Self::validators();
@@ -321,7 +321,7 @@ mod tests {
 		type Moment = u64;
 	}
 	impl Trait for Test {
-		const NOTE_OFFLINE_POSITION: u32 = 1;
+		const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 		type ConvertAccountIdToSessionKey = Identity;
 		type OnSessionChange = ();
 	}

--- a/substrate/runtime/staking/src/genesis_config.rs
+++ b/substrate/runtime/staking/src/genesis_config.rs
@@ -26,7 +26,8 @@ use {runtime_io, primitives};
 use super::{Trait, ENUM_SET_SIZE, EnumSet, NextEnumSet, Intentions, CurrentEra,
 	BondingDuration, CreationFee, TransferFee, ReclaimRebate,
 	ExistentialDeposit, TransactionByteFee, TransactionBaseFee, TotalStake,
-	SessionsPerEra, ValidatorCount, FreeBalance, SessionReward, EarlyEraSlash};
+	SessionsPerEra, ValidatorCount, FreeBalance, SessionReward, EarlyEraSlash,
+	OfflineSlashGrace};
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -46,6 +47,7 @@ pub struct GenesisConfig<T: Trait> {
 	pub existential_deposit: T::Balance,
 	pub session_reward: T::Balance,
 	pub early_era_slash: T::Balance,
+	pub offline_slash_grace: u32,
 }
 
 impl<T: Trait> GenesisConfig<T> where T::AccountId: From<u64> {
@@ -65,6 +67,7 @@ impl<T: Trait> GenesisConfig<T> where T::AccountId: From<u64> {
 			reclaim_rebate: T::Balance::sa(0),
 			session_reward: T::Balance::sa(0),
 			early_era_slash: T::Balance::sa(0),
+			offline_slash_grace: 1,
 		}
 	}
 
@@ -92,6 +95,7 @@ impl<T: Trait> GenesisConfig<T> where T::AccountId: From<u64> {
 			reclaim_rebate: T::Balance::sa(0),
 			session_reward: T::Balance::sa(0),
 			early_era_slash: T::Balance::sa(0),
+			offline_slash_grace: 1,
 		}
 	}
 }
@@ -113,6 +117,7 @@ impl<T: Trait> Default for GenesisConfig<T> {
 			reclaim_rebate: T::Balance::sa(0),
 			session_reward: T::Balance::sa(0),
 			early_era_slash: T::Balance::sa(0),
+			offline_slash_grace: 0,
 		}
 	}
 }
@@ -136,6 +141,7 @@ impl<T: Trait> primitives::BuildStorage for GenesisConfig<T> {
 			Self::hash(<CurrentEra<T>>::key()).to_vec() => self.current_era.encode(),
 			Self::hash(<SessionReward<T>>::key()).to_vec() => self.session_reward.encode(),
 			Self::hash(<EarlyEraSlash<T>>::key()).to_vec() => self.early_era_slash.encode(),
+			Self::hash(<OfflineSlashGrace<T>>::key()).to_vec() => self.offline_slash_grace.encode(),
 			Self::hash(<TotalStake<T>>::key()).to_vec() => total_stake.encode()
 		];
 

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -52,7 +52,7 @@ use runtime_support::{StorageValue, StorageMap, Parameter};
 use runtime_support::dispatch::Result;
 use session::OnSessionChange;
 use primitives::traits::{Zero, One, Bounded, RefInto, SimpleArithmetic, Executable, MakePayment,
-	As, AuxLookup, Member, CheckedAdd, CheckedSub};
+	As, AuxLookup, Member, CheckedAdd, CheckedSub, MaybeEmpty};
 use address::Address as RawAddress;
 
 mod mock;
@@ -98,7 +98,40 @@ impl<AccountId> OnAccountKill<AccountId> for () {
 	fn on_account_kill(_who: &AccountId) {}
 }
 
+/// Preference of what happens on a slash event.
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Copy)]
+pub struct SlashPreference {
+	/// Validator should ensure this many more slashes than is necessary before being unstaked.
+	pub unstake_threshold: u32,
+}
+
+impl Decode for SlashPreference {
+	fn decode<I: Input>(input: &mut I) -> Option<Self> {
+		Some(SlashPreference {
+			unstake_threshold: Decode::decode(input)?
+		})
+	}
+}
+
+impl Encode for SlashPreference {
+	fn encode_to<T: Output>(&self, dest: &mut T) {
+		self.unstake_threshold.encode_to(dest)
+	}
+}
+
+impl Default for SlashPreference {
+	fn default() -> Self {
+		SlashPreference {
+			unstake_threshold: 0,
+		}
+	}
+}
+
 pub trait Trait: system::Trait + session::Trait {
+	/// The allowed extrinsic position for `missed_proposal` inherent.
+	const NOTE_MISSED_PROPOSAL_POSITION: u32;
+
 	/// The balance of an account.
 	type Balance: Parameter + SimpleArithmetic + Codec + Default + Copy + As<Self::AccountIndex> + As<usize> + As<u64>;
 	/// Type used for storing an account's index; implies the maximum number of accounts the system
@@ -117,9 +150,11 @@ decl_module! {
 	pub enum Call where aux: T::PublicAux {
 		fn transfer(aux, dest: RawAddress<T::AccountId, T::AccountIndex>, value: T::Balance) -> Result = 0;
 		fn stake(aux) -> Result = 1;
-		fn unstake(aux, index: u32) -> Result = 2;
+		fn unstake(aux, intentions_index: u32) -> Result = 2;
 		fn nominate(aux, target: RawAddress<T::AccountId, T::AccountIndex>) -> Result = 3;
 		fn unnominate(aux, target_index: u32) -> Result = 4;
+		fn register_slash_preference(aux, intentions_index: u32, p: SlashPreference) -> Result = 5;
+		fn note_missed_proposal(aux, intentions_index: u32) -> Result = 6;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -127,7 +162,7 @@ decl_module! {
 		fn set_sessions_per_era(new: T::BlockNumber) -> Result = 0;
 		fn set_bonding_duration(new: T::BlockNumber) -> Result = 1;
 		fn set_validator_count(new: u32) -> Result = 2;
-		fn force_new_era(should_slash: bool) -> Result = 3;
+		fn force_new_era(apply_rewards: bool) -> Result = 3;
 	}
 }
 
@@ -159,9 +194,13 @@ decl_storage! {
 	pub SessionReward get(session_reward): b"sta:session_reward" => required T::Balance;
 	// Slash, per validator that is taken per abnormal era end.
 	pub EarlyEraSlash get(early_era_slash): b"sta:early_era_slash" => required T::Balance;
+	// Number of instances of grace period before slashing begins for offline validators.
+	pub OfflineSlashGrace get(offline_slash_grace): b"sta:offline_slash_grace" => default u32;
 
 	// The current era index.
 	pub CurrentEra get(current_era): b"sta:era" => required T::BlockNumber;
+	// Preference over how many times the validator should get slashed for being offline before they are automatically unstaked.
+	pub SlashPreferenceOf get(slash_preference_of): b"sta:slash_preference_of" => default map [ T::AccountId => SlashPreference ];
 	// All the accounts with a desire to stake.
 	pub Intentions get(intentions): b"sta:wil:" => default Vec<T::AccountId>;
 	// All nominator -> nominee relationships.
@@ -177,8 +216,10 @@ decl_storage! {
 	// The current era stake threshold
 	pub StakeThreshold get(stake_threshold): b"sta:stake_threshold" => required T::Balance;
 
-	// The current bad validator slash.
-	pub CurrentSlash get(current_slash): b"sta:current_slash" => default T::Balance;
+	// Which of the validators are currently being slashed.
+	pub Slashing get(slashing): b"sta:slashing" => default Vec<T::AccountId>;
+	// The number of slashes a given validator has had in a row.
+	pub SlashCount get(slash_count): b"sta:slash_count" => default map [ T::AccountId => u32 ];
 
 	// The next free enumeration set.
 	pub NextEnumSet get(next_enum_set): b"sta:next_enum" => required T::AccountIndex;
@@ -247,6 +288,20 @@ impl<T: Trait> Module<T> {
 		Self::free_balance(who) + Self::reserved_balance(who)
 	}
 
+	/// Balance of a (potential) validator that includes all nominators.
+	pub fn nomination_balance(who: &T::AccountId) -> T::Balance {
+		Self::nominators_for(who).iter()
+			.map(Self::voting_balance)
+			.fold(Zero::zero(), |acc, x| acc + x)
+	}
+
+	/// The total balance that can be slashed from an account.
+	pub fn slashable_balance(who: &T::AccountId) -> T::Balance {
+		Self::nominators_for(who).iter()
+			.map(Self::voting_balance)
+			.fold(Self::voting_balance(who), |acc, x| acc + x)
+	}
+
 	/// Some result as `slash(who, value)` (but without the side-effects) assuming there are no
 	/// balance changes in the meantime and only the reserved balance is not taken into account.
 	pub fn can_slash(who: &T::AccountId, value: T::Balance) -> bool {
@@ -261,6 +316,22 @@ impl<T: Trait> Module<T> {
 		} else {
 			false
 		}
+	}
+
+	/// Lookup an T::AccountIndex to get an Id, if there's one there.
+	pub fn lookup_index(index: T::AccountIndex) -> Option<T::AccountId> {
+		let enum_set_size = Self::enum_set_size();
+		let set = Self::enum_set(index / enum_set_size);
+		let i: usize = (index % enum_set_size).as_();
+		set.get(i).map(|x| x.clone())
+	}
+
+	/// `true` if the account `index` is ready for reclaim.
+	pub fn can_reclaim(try_index: T::AccountIndex) -> bool {
+		let enum_set_size = Self::enum_set_size();
+		let try_set = Self::enum_set(try_index / enum_set_size);
+		let i = (try_index % enum_set_size).as_();
+		i < try_set.len() && Self::voting_balance(&try_set[i]).is_zero()
 	}
 
 	/// The block at which the `who`'s funds become entirely liquid.
@@ -327,18 +398,8 @@ impl<T: Trait> Module<T> {
 	/// Retract the desire to stake for the transactor.
 	///
 	/// Effects will be felt at the beginning of the next era.
-	fn unstake(aux: &T::PublicAux, position: u32) -> Result {
-		let aux = aux.ref_into();
-		let position = position as usize;
-		let mut intentions = <Intentions<T>>::get();
-//		let position = intentions.iter().position(|t| t == aux.ref_into()).ok_or("Cannot unstake if not already staked.")?;
-		if intentions.get(position) != Some(aux) {
-			return Err("Invalid index")
-		}
-		intentions.swap_remove(position);
-		<Intentions<T>>::put(intentions);
-		<Bondage<T>>::insert(aux.ref_into(), Self::current_era() + Self::bonding_duration());
-		Ok(())
+	fn unstake(aux: &T::PublicAux, intentions_index: u32) -> Result {
+		Self::apply_unstake(aux.ref_into(), intentions_index as usize)
 	}
 
 	fn nominate(aux: &T::PublicAux, target: RawAddress<T::AccountId, T::AccountIndex>) -> Result {
@@ -389,6 +450,63 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
+	/// Set the given account's preference for slashing behaviour should they be a validator. 
+	/// 
+	/// An error (no-op) if `Self::intentions()[intentions_index] != aux`.
+	fn register_slash_preference(
+		aux: &T::PublicAux,
+		intentions_index: u32,
+		p: SlashPreference
+	) -> Result {
+		let aux = aux.ref_into();
+
+		if Self::intentions().get(intentions_index as usize) != Some(aux) {
+			return Err("Invalid index")
+		}
+		
+		<SlashPreferenceOf<T>>::insert(aux, p);
+
+		Ok(())
+	}
+
+	/// Note the previous block's validator missed their opportunity to propose a block. This only comes in
+	/// if 2/3+1 of the validators agree that no proposal was submitted. It's only relevant
+	/// for the previous block.
+	fn note_missed_proposal(aux: &T::PublicAux, validator_index: u32) -> Result {
+		assert!(aux.is_empty());
+		assert!(
+			<system::Module<T>>::extrinsic_index() == T::NOTE_MISSED_PROPOSAL_POSITION,
+			"note_missed_proposal extrinsic must be at position {} in the block",
+			T::NOTE_MISSED_PROPOSAL_POSITION
+		);
+
+		// TODO: slash or unstake
+		let v = <session::Module<T>>::validators()[validator_index as usize].clone();
+		let slash_count = Self::slash_count(&v);
+		<SlashCount<T>>::insert(v.clone(), slash_count + 1);
+		let grace = Self::offline_slash_grace();
+
+		if slash_count >= grace {
+			let instances = slash_count - grace;
+			let slash = Self::early_era_slash() << instances;
+			let next_slash = slash << 1u32;
+			let _ = Self::slash_validator(&v, slash);
+			if instances >= Self::slash_preference_of(&v).unstake_threshold
+				|| Self::slashable_balance(&v) < next_slash
+			{
+				if let Some(pos) = Self::intentions().into_iter().position(|x| &x == &v) {
+					Self::apply_unstake(&v, pos)
+						.expect("pos derived correctly from Self::intentions(); \
+							apply_unstake can only fail if pos wrong; \
+							Self::intentions() doesn't change; qed");
+				}
+				Self::force_new_era(false);
+			}
+		}
+
+		Ok(())
+	}
+
 	// PRIV DISPATCH
 
 	/// Set the number of sessions in an era.
@@ -411,9 +529,9 @@ impl<T: Trait> Module<T> {
 
 	/// Force there to be a new era. This also forces a new session immediately after by
 	/// setting `normal_rotation` to be false. Validators will get slashed.
-	fn force_new_era(should_slash: bool) -> Result {
+	fn force_new_era(apply_rewards: bool) -> Result {
 		<ForcingNewEra<T>>::put(());
-		<session::Module<T>>::force_new_session(!should_slash)
+		<session::Module<T>>::force_new_session(apply_rewards)
 	}
 
 	// PUBLIC MUTABLES (DANGEROUS)
@@ -590,60 +708,73 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
-	/// Session has just changed. We need to determine whether we pay a reward, slash and/or
-	/// move to a new era.
-	fn new_session(actual_elapsed: T::Moment, bad_validators: Vec<T::AccountId>) {
-		let session_index = <session::Module<T>>::current_index();
-		let early_exit_era = !bad_validators.is_empty();
-
-		if early_exit_era {
-			// slash
-			let slash = Self::current_slash() + Self::early_era_slash();
-			<CurrentSlash<T>>::put(&slash);
-			for v in bad_validators.into_iter() {
-				if let Some(rem) = Self::slash(&v, slash) {
-					let noms = Self::current_nominators_for(&v);
-					let total = noms.iter().map(Self::voting_balance).fold(T::Balance::zero(), |acc, x| acc + x);
-					if !total.is_zero() {
-						let safe_mul_rational = |b| b * rem / total;// TODO: avoid overflow
-						for n in noms.iter() {
-							let _ = Self::slash(n, safe_mul_rational(Self::voting_balance(n)));	// best effort - not much that can be done on fail.
-						}
-					}
+	/// Slash a given validator by a specific amount. Removes the slash from their balance by preference,
+	/// and reduces the nominators' balance if needed.
+	fn slash_validator(v: &T::AccountId, slash: T::Balance) {
+		if let Some(rem) = Self::slash(v, slash) {
+			let noms = Self::current_nominators_for(v);
+			let total = noms.iter().map(Self::voting_balance).fold(T::Balance::zero(), |acc, x| acc + x);
+			if !total.is_zero() {
+				let safe_mul_rational = |b| b * rem / total;// TODO: avoid overflow
+				for n in noms.iter() {
+					let _ = Self::slash(n, safe_mul_rational(Self::voting_balance(n)));	// best effort - not much that can be done on fail.
 				}
 			}
-		} else {
-			// Zero any cumulative slash since we're healthy now.
-			<CurrentSlash<T>>::kill();
-
-			// reward
-			let ideal_elapsed = <session::Module<T>>::ideal_session_duration();
-			let per65536: u64 = (T::Moment::sa(65536u64) * ideal_elapsed.clone() / actual_elapsed.max(ideal_elapsed)).as_();
-			let reward = Self::session_reward() * T::Balance::sa(per65536) / T::Balance::sa(65536u64);
-			// apply good session reward
-			for v in <session::Module<T>>::validators().iter() {
-				let noms = Self::current_nominators_for(v);
-				let total = noms.iter().map(Self::voting_balance).fold(Self::voting_balance(v), |acc, x| acc + x);
-				if !total.is_zero() {
-					let safe_mul_rational = |b| b * reward / total;// TODO: avoid overflow
-					for n in noms.iter() {
-						let _ = Self::reward(n, safe_mul_rational(Self::voting_balance(n)));
-					}
-					let _ = Self::reward(v, safe_mul_rational(Self::voting_balance(v)));
-				}
-			}
-		}
-		if <ForcingNewEra<T>>::take().is_some()
-			|| ((session_index - Self::last_era_length_change()) % Self::sessions_per_era()).is_zero()
-			|| early_exit_era
-		{
-			Self::new_era();
 		}
 	}
 
-	/// Balance of a (potential) validator that includes all nominators.
-	fn nomination_balance(who: &T::AccountId) -> T::Balance {
-		Self::nominators_for(who).iter().map(Self::voting_balance).fold(Zero::zero(), |acc, x| acc + x)
+	/// Reward a given validator by a specific amount. Add the reward to their, and their nominators'
+	/// balance, pro-rata.
+	fn reward_validator(who: &T::AccountId, reward: T::Balance) {
+		let noms = Self::current_nominators_for(who);
+		let total = noms.iter().map(Self::voting_balance).fold(Self::voting_balance(who), |acc, x| acc + x);
+		if !total.is_zero() {
+			let safe_mul_rational = |b| b * reward / total;// TODO: avoid overflow
+			for n in noms.iter() {
+				let _ = Self::reward(n, safe_mul_rational(Self::voting_balance(n)));
+			}
+			let _ = Self::reward(who, safe_mul_rational(Self::voting_balance(who)));
+		}
+	}
+
+	/// Actually carry out the unstake operation.
+	/// Assumes `intentions()[intentions_index] == who`.
+	fn apply_unstake(who: &T::AccountId, intentions_index: usize) -> Result {
+		let mut intentions = Self::intentions();
+		if intentions.get(intentions_index) != Some(who) {
+			return Err("Invalid index");
+		}
+		intentions.swap_remove(intentions_index);
+		<Intentions<T>>::put(intentions);
+		<SlashPreferenceOf<T>>::remove(who);
+		<Bondage<T>>::insert(who, Self::current_era() + Self::bonding_duration());
+		Ok(())
+	}
+
+	/// Get the reward for the session, assuming it ends with this block.
+	fn this_session_reward(actual_elapsed: T::Moment) -> T::Balance {
+		let ideal_elapsed = <session::Module<T>>::ideal_session_duration();
+		let per65536: u64 = (T::Moment::sa(65536u64) * ideal_elapsed.clone() / actual_elapsed.max(ideal_elapsed)).as_();
+		Self::session_reward() * T::Balance::sa(per65536) / T::Balance::sa(65536u64)
+	}
+
+	/// Session has just changed. We need to determine whether we pay a reward, slash and/or
+	/// move to a new era.
+	fn new_session(actual_elapsed: T::Moment, should_reward: bool) {
+		if should_reward {
+			// apply good session reward
+			let reward = Self::this_session_reward(actual_elapsed);
+			for v in <session::Module<T>>::validators().iter() {
+				Self::reward_validator(v, reward);
+			}
+		}
+
+		let session_index = <session::Module<T>>::current_index();
+		if <ForcingNewEra<T>>::take().is_some()
+			|| ((session_index - Self::last_era_length_change()) % Self::sessions_per_era()).is_zero()
+		{
+			Self::new_era();
+		}
 	}
 
 	/// The era has changed - enact new staking set.
@@ -662,7 +793,7 @@ impl<T: Trait> Module<T> {
 			}
 		}
 
-		let minimum_allowed = Self::early_era_slash();
+//		let minimum_allowed = Self::early_era_slash();
 
 		// evaluate desired staking amounts and nominations and optimise to find the best
 		// combination of validators, then use session::internal::set_validators().
@@ -671,8 +802,8 @@ impl<T: Trait> Module<T> {
 		// TODO: this is not sound. this should be moved to an off-chain solution mechanism.
 		let mut intentions = <Intentions<T>>::get()
 			.into_iter()
-			.map(|v| (Self::voting_balance(&v) + Self::nomination_balance(&v), v))
-			.filter(|&(b, _)| b >= minimum_allowed)
+			.map(|v| (Self::slashable_balance(&v), v))
+//			.filter(|&(b, _)| b >= minimum_allowed)
 			.collect::<Vec<_>>();
 		intentions.sort_unstable_by(|&(ref b1, _), &(ref b2, _)| b2.cmp(&b1));
 
@@ -697,22 +828,6 @@ impl<T: Trait> Module<T> {
 
 	fn enum_set_size() -> T::AccountIndex {
 		T::AccountIndex::sa(ENUM_SET_SIZE)
-	}
-
-	/// Lookup an T::AccountIndex to get an Id, if there's one there.
-	pub fn lookup_index(index: T::AccountIndex) -> Option<T::AccountId> {
-		let enum_set_size = Self::enum_set_size();
-		let set = Self::enum_set(index / enum_set_size);
-		let i: usize = (index % enum_set_size).as_();
-		set.get(i).map(|x| x.clone())
-	}
-
-	/// `true` if the account `index` is ready for reclaim.
-	pub fn can_reclaim(try_index: T::AccountIndex) -> bool {
-		let enum_set_size = Self::enum_set_size();
-		let try_set = Self::enum_set(try_index / enum_set_size);
-		let i = (try_index % enum_set_size).as_();
-		i < try_set.len() && Self::voting_balance(&try_set[i]).is_zero()
 	}
 
 	/// Register a new account (with existential balance).
@@ -808,9 +923,9 @@ impl<T: Trait> Executable for Module<T> {
 	}
 }
 
-impl<T: Trait> OnSessionChange<T::Moment, T::AccountId> for Module<T> {
-	fn on_session_change(elapsed: T::Moment, bad_validators: Vec<T::AccountId>) {
-		Self::new_session(elapsed, bad_validators);
+impl<T: Trait> OnSessionChange<T::Moment> for Module<T> {
+	fn on_session_change(elapsed: T::Moment, should_reward: bool) {
+		Self::new_session(elapsed, should_reward);
 	}
 }
 

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -500,7 +500,7 @@ impl<T: Trait> Module<T> {
 							apply_unstake can only fail if pos wrong; \
 							Self::intentions() doesn't change; qed");
 				}
-				Self::force_new_era(false);
+				let _ = Self::force_new_era(false);
 			}
 		}
 

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -163,6 +163,7 @@ decl_module! {
 		fn set_bonding_duration(new: T::BlockNumber) -> Result = 1;
 		fn set_validator_count(new: u32) -> Result = 2;
 		fn force_new_era(apply_rewards: bool) -> Result = 3;
+		fn set_offline_slash_grace(new: u32) -> Result = 4;
 	}
 }
 
@@ -479,7 +480,6 @@ impl<T: Trait> Module<T> {
 		);
 
 		for validator_index in offline_val_indices.into_iter() {
-			// TODO: slash or unstake
 			let v = <session::Module<T>>::validators()[validator_index as usize].clone();
 			let slash_count = Self::slash_count(&v);
 			<SlashCount<T>>::insert(v.clone(), slash_count + 1);
@@ -532,6 +532,12 @@ impl<T: Trait> Module<T> {
 	fn force_new_era(apply_rewards: bool) -> Result {
 		<ForcingNewEra<T>>::put(());
 		<session::Module<T>>::force_new_session(apply_rewards)
+	}
+
+	/// Set the offline slash grace period.
+	fn set_offline_slash_grace(new: u32) -> Result {
+		<OfflineSlashGrace<T>>::put(&new);
+		Ok(())
 	}
 
 	// PUBLIC MUTABLES (DANGEROUS)

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -123,7 +123,7 @@ impl Encode for SlashPreference {
 impl Default for SlashPreference {
 	fn default() -> Self {
 		SlashPreference {
-			unstake_threshold: 0,
+			unstake_threshold: 3,
 		}
 	}
 }

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -130,7 +130,7 @@ impl Default for SlashPreference {
 
 pub trait Trait: system::Trait + session::Trait {
 	/// The allowed extrinsic position for `missed_proposal` inherent.
-//	const NOTE_OFFLINE_POSITION: u32;	// TODO: uncomment when removed from session::Trait
+//	const NOTE_MISSED_PROPOSAL_POSITION: u32;	// TODO: uncomment when removed from session::Trait
 
 	/// The balance of an account.
 	type Balance: Parameter + SimpleArithmetic + Codec + Default + Copy + As<Self::AccountIndex> + As<usize> + As<u64>;
@@ -154,7 +154,7 @@ decl_module! {
 		fn nominate(aux, target: RawAddress<T::AccountId, T::AccountIndex>) -> Result = 3;
 		fn unnominate(aux, target_index: u32) -> Result = 4;
 		fn register_slash_preference(aux, intentions_index: u32, p: SlashPreference) -> Result = 5;
-		fn note_offline(aux, offline_val_indices: Vec<u32>) -> Result = 6;
+		fn note_missed_proposal(aux, offline_val_indices: Vec<u32>) -> Result = 6;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -470,12 +470,12 @@ impl<T: Trait> Module<T> {
 	/// Note the previous block's validator missed their opportunity to propose a block. This only comes in
 	/// if 2/3+1 of the validators agree that no proposal was submitted. It's only relevant
 	/// for the previous block.
-	fn note_offline(aux: &T::PublicAux, offline_val_indices: Vec<u32>) -> Result {
+	fn note_missed_proposal(aux: &T::PublicAux, offline_val_indices: Vec<u32>) -> Result {
 		assert!(aux.is_empty());
 		assert!(
-			<system::Module<T>>::extrinsic_index() == T::NOTE_OFFLINE_POSITION,
-			"note_offline extrinsic must be at position {} in the block",
-			T::NOTE_OFFLINE_POSITION
+			<system::Module<T>>::extrinsic_index() == T::NOTE_MISSED_PROPOSAL_POSITION,
+			"note_missed_proposal extrinsic must be at position {} in the block",
+			T::NOTE_MISSED_PROPOSAL_POSITION
 		);
 
 		for validator_index in offline_val_indices.into_iter() {

--- a/substrate/runtime/staking/src/mock.rs
+++ b/substrate/runtime/staking/src/mock.rs
@@ -54,7 +54,7 @@ impl timestamp::Trait for Test {
 	type Moment = u64;
 }
 impl Trait for Test {
-	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
+	const NOTE_OFFLINE_POSITION: u32 = 1;
 	type Balance = u64;
 	type AccountIndex = u64;
 	type OnAccountKill = ();

--- a/substrate/runtime/staking/src/mock.rs
+++ b/substrate/runtime/staking/src/mock.rs
@@ -45,7 +45,7 @@ impl system::Trait for Test {
 	type Header = Header;
 }
 impl session::Trait for Test {
-	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 0;
 	type ConvertAccountIdToSessionKey = Identity;
 	type OnSessionChange = Staking;
 }
@@ -54,7 +54,6 @@ impl timestamp::Trait for Test {
 	type Moment = u64;
 }
 impl Trait for Test {
-	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type Balance = u64;
 	type AccountIndex = u64;
 	type OnAccountKill = ();
@@ -99,6 +98,7 @@ pub fn new_test_ext(ext_deposit: u64, session_length: u64, sessions_per_era: u64
 		reclaim_rebate: 0,
 		session_reward: reward,
 		early_era_slash: if monied { 20 } else { 0 },
+		offline_slash_grace: 0,
 	}.build_storage().unwrap());
 	t.extend(timestamp::GenesisConfig::<Test>{
 		period: 5

--- a/substrate/runtime/staking/src/mock.rs
+++ b/substrate/runtime/staking/src/mock.rs
@@ -45,7 +45,7 @@ impl system::Trait for Test {
 	type Header = Header;
 }
 impl session::Trait for Test {
-	const NOTE_OFFLINE_POSITION: u32 = 1;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type ConvertAccountIdToSessionKey = Identity;
 	type OnSessionChange = Staking;
 }
@@ -54,7 +54,7 @@ impl timestamp::Trait for Test {
 	type Moment = u64;
 }
 impl Trait for Test {
-	const NOTE_OFFLINE_POSITION: u32 = 1;
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type Balance = u64;
 	type AccountIndex = u64;
 	type OnAccountKill = ();

--- a/substrate/runtime/staking/src/mock.rs
+++ b/substrate/runtime/staking/src/mock.rs
@@ -54,6 +54,7 @@ impl timestamp::Trait for Test {
 	type Moment = u64;
 }
 impl Trait for Test {
+	const NOTE_MISSED_PROPOSAL_POSITION: u32 = 1;
 	type Balance = u64;
 	type AccountIndex = u64;
 	type OnAccountKill = ();

--- a/substrate/runtime/staking/src/tests.rs
+++ b/substrate/runtime/staking/src/tests.rs
@@ -27,10 +27,10 @@ fn note_null_missed_proposal_should_work() {
 	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
 		assert_eq!(Staking::offline_slash_grace(), 0);
 		assert_eq!(Staking::slash_count(&10), 0);
-		assert_eq!(Staking::free_balance(&10), 30);
+		assert_eq!(Staking::free_balance(&10), 1);
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![]));
 		assert_eq!(Staking::slash_count(&10), 0);
-		assert_eq!(Staking::free_balance(&10), 30);
+		assert_eq!(Staking::free_balance(&10), 1);
 	});
 }
 
@@ -48,8 +48,26 @@ fn note_missed_proposal_should_work() {
 }
 
 #[test]
-fn note_offline_slash_grace_should_work() {
+fn note_missed_proposal_exponent_should_work() {
 	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
+		Staking::set_free_balance(&10, 70);
+		assert_eq!(Staking::offline_slash_grace(), 0);
+		assert_eq!(Staking::slash_count(&10), 0);
+		assert_eq!(Staking::free_balance(&10), 70);
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
+		assert_eq!(Staking::slash_count(&10), 1);
+		assert_eq!(Staking::free_balance(&10), 50);
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
+		assert_eq!(Staking::slash_count(&10), 2);
+		assert_eq!(Staking::free_balance(&10), 10);
+	});
+}
+
+#[test]
+fn note_missed_proposal_grace_should_work() {
+	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
+		Staking::set_free_balance(&10, 30);
+		Staking::set_free_balance(&20, 30);
 		assert_ok!(Staking::set_offline_slash_grace(1));
 		assert_eq!(Staking::offline_slash_grace(), 1);
 
@@ -57,15 +75,15 @@ fn note_offline_slash_grace_should_work() {
 		assert_eq!(Staking::free_balance(&10), 30);
 
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
-		assert_eq!(Staking::slash_count(&10), 0);
+		assert_eq!(Staking::slash_count(&10), 1);
 		assert_eq!(Staking::free_balance(&10), 30);
 		assert_eq!(Staking::slash_count(&20), 0);
 		assert_eq!(Staking::free_balance(&20), 30);
 
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0, 1]));
-		assert_eq!(Staking::slash_count(&10), 1);
+		assert_eq!(Staking::slash_count(&10), 2);
 		assert_eq!(Staking::free_balance(&10), 10);
-		assert_eq!(Staking::slash_count(&20), 0);
+		assert_eq!(Staking::slash_count(&20), 1);
 		assert_eq!(Staking::free_balance(&20), 30);
 	});
 }

--- a/substrate/runtime/staking/src/tests.rs
+++ b/substrate/runtime/staking/src/tests.rs
@@ -31,24 +31,12 @@ fn note_null_missed_proposal_should_work() {
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![]));
 		assert_eq!(Staking::slash_count(&10), 0);
 		assert_eq!(Staking::free_balance(&10), 1);
+		assert!(Staking::forcing_new_era().is_none());
 	});
 }
 
 #[test]
 fn note_missed_proposal_should_work() {
-	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
-		Staking::set_free_balance(&10, 30);
-		assert_eq!(Staking::offline_slash_grace(), 0);
-		assert_eq!(Staking::slash_count(&10), 0);
-		assert_eq!(Staking::free_balance(&10), 30);
-		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
-		assert_eq!(Staking::slash_count(&10), 1);
-		assert_eq!(Staking::free_balance(&10), 10);
-	});
-}
-
-#[test]
-fn note_missed_proposal_exponent_should_work() {
 	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
 		Staking::set_free_balance(&10, 70);
 		assert_eq!(Staking::offline_slash_grace(), 0);
@@ -57,34 +45,111 @@ fn note_missed_proposal_exponent_should_work() {
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
 		assert_eq!(Staking::slash_count(&10), 1);
 		assert_eq!(Staking::free_balance(&10), 50);
+		assert!(Staking::forcing_new_era().is_none());
+	});
+}
+
+#[test]
+fn note_missed_proposal_exponent_should_work() {
+	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
+		Staking::set_free_balance(&10, 150);
+		assert_eq!(Staking::offline_slash_grace(), 0);
+		assert_eq!(Staking::slash_count(&10), 0);
+		assert_eq!(Staking::free_balance(&10), 150);
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
+		assert_eq!(Staking::slash_count(&10), 1);
+		assert_eq!(Staking::free_balance(&10), 130);
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
 		assert_eq!(Staking::slash_count(&10), 2);
-		assert_eq!(Staking::free_balance(&10), 10);
+		assert_eq!(Staking::free_balance(&10), 90);
+		assert!(Staking::forcing_new_era().is_none());
 	});
 }
 
 #[test]
 fn note_missed_proposal_grace_should_work() {
 	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
-		Staking::set_free_balance(&10, 30);
-		Staking::set_free_balance(&20, 30);
+		Staking::set_free_balance(&10, 70);
+		Staking::set_free_balance(&20, 70);
 		assert_ok!(Staking::set_offline_slash_grace(1));
 		assert_eq!(Staking::offline_slash_grace(), 1);
 
 		assert_eq!(Staking::slash_count(&10), 0);
-		assert_eq!(Staking::free_balance(&10), 30);
+		assert_eq!(Staking::free_balance(&10), 70);
 
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
 		assert_eq!(Staking::slash_count(&10), 1);
-		assert_eq!(Staking::free_balance(&10), 30);
+		assert_eq!(Staking::free_balance(&10), 70);
 		assert_eq!(Staking::slash_count(&20), 0);
-		assert_eq!(Staking::free_balance(&20), 30);
+		assert_eq!(Staking::free_balance(&20), 70);
 
 		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0, 1]));
 		assert_eq!(Staking::slash_count(&10), 2);
-		assert_eq!(Staking::free_balance(&10), 10);
+		assert_eq!(Staking::free_balance(&10), 50);
 		assert_eq!(Staking::slash_count(&20), 1);
-		assert_eq!(Staking::free_balance(&20), 30);
+		assert_eq!(Staking::free_balance(&20), 70);
+		assert!(Staking::forcing_new_era().is_none());
+	});
+}
+
+#[test]
+fn note_missed_proposal_force_unstake_session_change_should_work() {
+	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
+		Staking::set_free_balance(&10, 70);
+		Staking::set_free_balance(&20, 70);
+		assert_ok!(Staking::stake(&10));
+		assert_ok!(Staking::stake(&20));
+		assert_ok!(Staking::stake(&1));
+		
+		assert_eq!(Staking::slash_count(&10), 0);
+		assert_eq!(Staking::free_balance(&10), 70);
+		assert_eq!(Staking::intentions(), vec![10, 20, 1]);
+		assert_eq!(Session::validators(), vec![10, 20]);
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
+		assert_eq!(Staking::free_balance(&10), 50);
+		assert_eq!(Staking::slash_count(&10), 1);
+		assert_eq!(Staking::intentions(), vec![10, 20, 1]);
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0]));
+		assert_eq!(Staking::intentions(), vec![1, 20]);
+		assert_eq!(Staking::free_balance(&10), 10);
+		assert!(Staking::forcing_new_era().is_some());
+	});
+}
+
+#[test]
+fn note_missed_proposal_auto_unstake_session_change_should_work() {
+	with_externalities(&mut new_test_ext(0, 3, 3, 0, true, 10), || {
+		Staking::set_free_balance(&10, 7000);
+		Staking::set_free_balance(&20, 7000);
+		assert_ok!(Staking::stake(&10));
+		assert_ok!(Staking::stake(&20));
+		assert_ok!(Staking::register_slash_preference(&10, 0, SlashPreference { unstake_threshold: 1 }));
+		
+		assert_eq!(Staking::intentions(), vec![10, 20]);
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0, 1]));
+		assert_eq!(Staking::free_balance(&10), 6980);
+		assert_eq!(Staking::free_balance(&20), 6980);
+		assert_eq!(Staking::intentions(), vec![10, 20]);
+		assert!(Staking::forcing_new_era().is_none());
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![0, 1]));
+		assert_eq!(Staking::free_balance(&10), 6940);
+		assert_eq!(Staking::free_balance(&20), 6940);
+		assert_eq!(Staking::intentions(), vec![20]);
+		assert!(Staking::forcing_new_era().is_some());
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![1]));
+		assert_eq!(Staking::free_balance(&10), 6940);
+		assert_eq!(Staking::free_balance(&20), 6860);
+		assert_eq!(Staking::intentions(), vec![20]);
+
+		assert_ok!(Staking::note_missed_proposal(&Default::default(), vec![1]));
+		assert_eq!(Staking::free_balance(&10), 6940);
+		assert_eq!(Staking::free_balance(&20), 6700);
+		assert_eq!(Staking::intentions(), vec![0u64; 0]);
 	});
 }
 


### PR DESCRIPTION
Redesigns the slashing subsystem to make incremental slashing more sensible, offers a way out for validators that want a fail-safe and provides more scope for fail-overs (especially when done in combination with a weighted leader-selection algorithm).

- validators can set preferences;
- force-unstake when balance too low;
- auto-unstake after N slashes according to validator's preferences;
- exponential (base 2) slashing;
- don't early-terminate session/era unless validator becomes unstaked;
- offline grace period before punishment;
- introduced support for the new inherent extrinsic into the block-authoring subsystem.

Still to do:
- [x] A few runtime tests;
- [x] fix `validator_offline` test.