### PR TITLE
Attempt to make `Client` generic over Hasher/NodeCodec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519 0.1.0",
  "environmental 0.1.0",
+ "hashdb 0.2.1 (git+https://github.com/paritytech/parity-common)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-codec 0.1.0",
  "substrate-primitives 0.1.0",

--- a/substrate/client/src/client.rs
+++ b/substrate/client/src/client.rs
@@ -23,7 +23,10 @@ use primitives::AuthorityId;
 use runtime_primitives::{bft::Justification, generic::{BlockId, SignedBlock, Block as RuntimeBlock}};
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Zero, One, As, NumberFor};
 use runtime_primitives::BuildStorage;
-use primitives::{KeccakHasher, RlpCodec};
+use hashdb::Hasher;
+use heapsize::HeapSizeOf;
+use patricia_trie::NodeCodec;
+use rlp::Encodable;
 use primitives::storage::{StorageKey, StorageData};
 use codec::Decode;
 use state_machine::{
@@ -37,12 +40,13 @@ use call_executor::{CallExecutor, LocalCallExecutor};
 use executor::{RuntimeVersion, RuntimeInfo};
 use notifications::{StorageNotifications, StorageEventStream};
 use {error, in_mem, block_builder, runtime_io, bft, genesis};
+use std::marker::PhantomData;
 
 /// Type that implements `futures::Stream` of block import events.
 pub type BlockchainEventStream<Block> = mpsc::UnboundedReceiver<BlockImportNotification<Block>>;
 
 /// Substrate Client
-pub struct Client<B, E, Block> where Block: BlockT {
+pub struct Client<B, E, Block, H, C> where Block: BlockT {
 	backend: Arc<B>,
 	executor: E,
 	storage_notifications: Mutex<StorageNotifications<Block>>,
@@ -50,6 +54,8 @@ pub struct Client<B, E, Block> where Block: BlockT {
 	import_lock: Mutex<()>,
 	importing_block: RwLock<Option<Block::Hash>>, // holds the block hash currently being imported. TODO: replace this with block queue
 	execution_strategy: ExecutionStrategy,
+	_hasher: PhantomData<H>, // TODO: feels like these shouldn't be necesseary
+	_codec: PhantomData<C>,
 }
 
 /// A source of blockchain evenets.
@@ -161,24 +167,35 @@ impl<Block: BlockT> JustifiedHeader<Block> {
 }
 
 /// Create an instance of in-memory client.
-pub fn new_in_mem<E, Block, S>(
+pub fn new_in_mem<E, Block, S, H, C>(
 	executor: E,
 	genesis_storage: S,
-) -> error::Result<Client<in_mem::Backend<Block, KeccakHasher, RlpCodec>, LocalCallExecutor<in_mem::Backend<Block, KeccakHasher, RlpCodec>, E, KeccakHasher, RlpCodec>, Block>>
+) -> error::Result<Client<
+		in_mem::Backend<Block, H, C>,
+		LocalCallExecutor<in_mem::Backend<Block, H, C>, E, H, C>,
+		Block,
+		H,
+		C>>
 	where
-		E: CodeExecutor<KeccakHasher> + RuntimeInfo<KeccakHasher>,
+		E: CodeExecutor<H> + RuntimeInfo<H>,
 		S: BuildStorage,
 		Block: BlockT,
+		H: Hasher,
+		H::Out: Ord + Encodable + HeapSizeOf,
+		C: NodeCodec<H> + Send + Sync,
 {
 	let backend = Arc::new(in_mem::Backend::new());
 	let executor = LocalCallExecutor::new(backend.clone(), executor);
 	Client::new(backend, executor, genesis_storage, ExecutionStrategy::NativeWhenPossible)
 }
 
-impl<B, E, Block> Client<B, E, Block> where
-	B: backend::Backend<Block, KeccakHasher, RlpCodec>,
-	E: CallExecutor<Block, KeccakHasher, RlpCodec>,
+impl<B, E, Block, H, C> Client<B, E, Block, H, C> where
+	B: backend::Backend<Block, H, C>,
+	E: CallExecutor<Block, H, C>,
 	Block: BlockT,
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
 {
 	/// Creates new Substrate Client with given blockchain and code executor.
 	pub fn new<S: BuildStorage>(
@@ -204,6 +221,8 @@ impl<B, E, Block> Client<B, E, Block> where
 			import_lock: Default::default(),
 			importing_block: Default::default(),
 			execution_strategy,
+			_hasher: PhantomData,
+			_codec: PhantomData,
 		})
 	}
 
@@ -285,14 +304,14 @@ impl<B, E, Block> Client<B, E, Block> where
 	}
 
 	/// Create a new block, built on the head of the chain.
-	pub fn new_block(&self) -> error::Result<block_builder::BlockBuilder<B, E, Block, KeccakHasher, RlpCodec>>
+	pub fn new_block(&self) -> error::Result<block_builder::BlockBuilder<B, E, Block, H, C>>
 	where E: Clone
 	{
 		block_builder::BlockBuilder::new(self)
 	}
 
 	/// Create a new block, built on top of `parent`.
-	pub fn new_block_at(&self, parent: &BlockId<Block>) -> error::Result<block_builder::BlockBuilder<B, E, Block, KeccakHasher, RlpCodec>>
+	pub fn new_block_at(&self, parent: &BlockId<Block>) -> error::Result<block_builder::BlockBuilder<B, E, Block, H, C>>
 	where E: Clone
 	{
 		block_builder::BlockBuilder::at_block(parent, &self)
@@ -507,11 +526,14 @@ impl<B, E, Block> Client<B, E, Block> where
 	}
 }
 
-impl<B, E, Block> bft::BlockImport<Block> for Client<B, E, Block>
-	where
-		B: backend::Backend<Block, KeccakHasher, RlpCodec>,
-		E: CallExecutor<Block, KeccakHasher, RlpCodec>,
-		Block: BlockT,
+impl<B, E, Block, H, C> bft::BlockImport<Block> for Client<B, E, Block, H, C>
+where
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
+	B: backend::Backend<Block, H, C>,
+	E: CallExecutor<Block, H, C>,
+	Block: BlockT,
 {
 	fn import_block(
 		&self,
@@ -530,11 +552,14 @@ impl<B, E, Block> bft::BlockImport<Block> for Client<B, E, Block>
 	}
 }
 
-impl<B, E, Block> bft::Authorities<Block> for Client<B, E, Block>
-	where
-		B: backend::Backend<Block, KeccakHasher, RlpCodec>,
-		E: CallExecutor<Block, KeccakHasher, RlpCodec>,
-		Block: BlockT,
+impl<B, E, Block, H, C> bft::Authorities<Block> for Client<B, E, Block, H, C>
+where
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
+	B: backend::Backend<Block, H, C>,
+	E: CallExecutor<Block, H, C>,
+	Block: BlockT,
 {
 	fn authorities(&self, at: &BlockId<Block>) -> Result<Vec<AuthorityId>, bft::Error> {
 		let on_chain_version: Result<_, bft::Error> = self.runtime_version_at(at)
@@ -553,9 +578,12 @@ impl<B, E, Block> bft::Authorities<Block> for Client<B, E, Block>
 	}
 }
 
-impl<B, E, Block> BlockchainEvents<Block> for Client<B, E, Block>
+impl<B, E, Block, H, C> BlockchainEvents<Block> for Client<B, E, Block, H, C>
 where
-	E: CallExecutor<Block, KeccakHasher, RlpCodec>,
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
+	E: CallExecutor<Block, H, C>,
 	Block: BlockT,
 {
 	/// Get block import event stream.
@@ -571,10 +599,13 @@ where
 	}
 }
 
-impl<B, E, Block> ChainHead<Block> for Client<B, E, Block>
+impl<B, E, Block, H, C> ChainHead<Block> for Client<B, E, Block, H, C>
 where
-	B: backend::Backend<Block, KeccakHasher, RlpCodec>,
-	E: CallExecutor<Block, KeccakHasher, RlpCodec>,
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
+	B: backend::Backend<Block, H, C>,
+	E: CallExecutor<Block, H, C>,
 	Block: BlockT,
 {
 	fn best_block_header(&self) -> error::Result<<Block as BlockT>::Header> {
@@ -582,11 +613,14 @@ where
 	}
 }
 
-impl<B, E, Block> BlockBody<Block> for Client<B, E, Block>
-	where
-		B: backend::Backend<Block, KeccakHasher, RlpCodec>,
-		E: CallExecutor<Block, KeccakHasher, RlpCodec>,
-		Block: BlockT,
+impl<B, E, Block, H, C> BlockBody<Block> for Client<B, E, Block, H, C>
+where
+	H: Hasher,
+	H::Out: Ord + Encodable + HeapSizeOf,
+	C: NodeCodec<H>,
+	B: backend::Backend<Block, H, C>,
+	E: CallExecutor<Block, H, C>,
+	Block: BlockT,
 {
 	fn block_body(&self, id: &BlockId<Block>) -> error::Result<Option<Vec<<Block as BlockT>::Extrinsic>>> {
 		self.body(id)

--- a/substrate/client/src/client.rs
+++ b/substrate/client/src/client.rs
@@ -164,9 +164,9 @@ impl<Block: BlockT> JustifiedHeader<Block> {
 pub fn new_in_mem<E, Block, S>(
 	executor: E,
 	genesis_storage: S,
-) -> error::Result<Client<in_mem::Backend<Block, KeccakHasher, RlpCodec>, LocalCallExecutor<in_mem::Backend<Block, KeccakHasher, RlpCodec>, E>, Block>>
+) -> error::Result<Client<in_mem::Backend<Block, KeccakHasher, RlpCodec>, LocalCallExecutor<in_mem::Backend<Block, KeccakHasher, RlpCodec>, E, KeccakHasher, RlpCodec>, Block>>
 	where
-		E: CodeExecutor<KeccakHasher> + RuntimeInfo,
+		E: CodeExecutor<KeccakHasher> + RuntimeInfo<KeccakHasher>,
 		S: BuildStorage,
 		Block: BlockT,
 {

--- a/substrate/client/src/light/call_executor.rs
+++ b/substrate/client/src/light/call_executor.rs
@@ -28,7 +28,6 @@ use primitives::H256;
 use patricia_trie::NodeCodec;
 use hashdb::Hasher;
 use rlp::Encodable;
-use primitives::{KeccakHasher, RlpCodec};
 
 use blockchain::Backend as ChainBackend;
 use call_executor::{CallExecutor, CallResult};
@@ -37,26 +36,32 @@ use light::fetcher::{Fetcher, RemoteCallRequest};
 use executor::RuntimeVersion;
 use codec::Decode;
 use heapsize::HeapSizeOf;
+use std::marker::PhantomData;
 
 /// Call executor that executes methods on remote node, querying execution proof
 /// and checking proof by re-executing locally.
-pub struct RemoteCallExecutor<B, F> {
+pub struct RemoteCallExecutor<B, F, H, C> {
 	blockchain: Arc<B>,
 	fetcher: Arc<F>,
+	_hasher: PhantomData<H>,
+	_codec: PhantomData<C>,
 }
 
-impl<B, F> RemoteCallExecutor<B, F> {
+impl<B, F, H, C> RemoteCallExecutor<B, F, H, C> {
 	/// Creates new instance of remote call executor.
 	pub fn new(blockchain: Arc<B>, fetcher: Arc<F>) -> Self {
-		RemoteCallExecutor { blockchain, fetcher }
+		RemoteCallExecutor { blockchain, fetcher, _hasher: PhantomData, _codec: PhantomData }
 	}
 }
 
-impl<B, F, Block> CallExecutor<Block, KeccakHasher, RlpCodec> for RemoteCallExecutor<B, F>
-	where
-		Block: BlockT,
-		B: ChainBackend<Block>,
-		F: Fetcher<Block>,
+impl<B, F, Block, H, C> CallExecutor<Block, H, C> for RemoteCallExecutor<B, F, H, C>
+where
+	Block: BlockT,
+	B: ChainBackend<Block>,
+	F: Fetcher<Block>,
+	H: Hasher,
+	H::Out: Ord + Encodable,
+	C: NodeCodec<H>
 {
 	type Error = ClientError;
 
@@ -83,7 +88,7 @@ impl<B, F, Block> CallExecutor<Block, KeccakHasher, RlpCodec> for RemoteCallExec
 	}
 
 	fn call_at_state<
-		S: StateBackend<KeccakHasher, RlpCodec>,
+		S: StateBackend<H, C>,
 		FF: FnOnce(Result<Vec<u8>, Self::Error>, Result<Vec<u8>, Self::Error>) -> Result<Vec<u8>, Self::Error>
 	>(&self,
 		_state: &S,
@@ -95,7 +100,7 @@ impl<B, F, Block> CallExecutor<Block, KeccakHasher, RlpCodec> for RemoteCallExec
 		Err(ClientErrorKind::NotAvailableOnLightClient.into())
 	}
 
-	fn prove_at_state<S: StateBackend<KeccakHasher, RlpCodec>>(
+	fn prove_at_state<S: StateBackend<H, C>>(
 		&self,
 		_state: S,
 		_changes: &mut OverlayedChanges,

--- a/substrate/client/src/light/mod.rs
+++ b/substrate/client/src/light/mod.rs
@@ -23,6 +23,7 @@ pub mod fetcher;
 
 use std::sync::Arc;
 
+use primitives::{KeccakHasher, RlpCodec};
 use runtime_primitives::BuildStorage;
 use runtime_primitives::traits::Block as BlockT;
 use state_machine::{CodeExecutor, ExecutionStrategy};
@@ -52,7 +53,7 @@ pub fn new_light<B, S, F, GS>(
 	backend: Arc<Backend<S, F>>,
 	fetcher: Arc<F>,
 	genesis_storage: GS,
-) -> ClientResult<Client<Backend<S, F>, RemoteCallExecutor<Blockchain<S, F>, F>, B>>
+) -> ClientResult<Client<Backend<S, F>, RemoteCallExecutor<Blockchain<S, F>, F, KeccakHasher, RlpCodec>, B>>
 	where
 		B: BlockT,
 		S: BlockchainStorage<B>,

--- a/substrate/client/src/light/mod.rs
+++ b/substrate/client/src/light/mod.rs
@@ -53,7 +53,7 @@ pub fn new_light<B, S, F, GS>(
 	backend: Arc<Backend<S, F>>,
 	fetcher: Arc<F>,
 	genesis_storage: GS,
-) -> ClientResult<Client<Backend<S, F>, RemoteCallExecutor<Blockchain<S, F>, F, KeccakHasher, RlpCodec>, B>>
+) -> ClientResult<Client<Backend<S, F>, RemoteCallExecutor<Blockchain<S, F>, F, KeccakHasher, RlpCodec>, B, KeccakHasher, RlpCodec>>
 	where
 		B: BlockT,
 		S: BlockchainStorage<B>,

--- a/substrate/executor/src/lib.rs
+++ b/substrate/executor/src/lib.rs
@@ -76,15 +76,15 @@ pub use native_executor::{with_native_environment, NativeExecutor, NativeExecuti
 pub use state_machine::Externalities;
 pub use runtime_version::RuntimeVersion;
 pub use codec::Codec;
-use primitives::KeccakHasher;
+use hashdb::Hasher;
 
 /// Provides runtime information.
-pub trait RuntimeInfo {
+pub trait RuntimeInfo<H: Hasher> {
 	/// Native runtime information if any.
 	const NATIVE_VERSION: Option<RuntimeVersion>;
 
 	/// Extract RuntimeVersion of given :code block
-	fn runtime_version<E: Externalities<KeccakHasher>> (
+	fn runtime_version<E: Externalities<H>> (
 		&self,
 		ext: &mut E,
 		code: &[u8]

--- a/substrate/executor/src/native_executor.rs
+++ b/substrate/executor/src/native_executor.rs
@@ -149,7 +149,7 @@ impl<D: NativeExecutionDispatch> Clone for NativeExecutor<D> {
 	}
 }
 
-impl<D: NativeExecutionDispatch> RuntimeInfo for NativeExecutor<D> {
+impl<D: NativeExecutionDispatch> RuntimeInfo<KeccakHasher> for NativeExecutor<D> {
 	const NATIVE_VERSION: Option<RuntimeVersion> = Some(D::VERSION);
 
 	fn runtime_version<E: Externalities<KeccakHasher>>(

--- a/substrate/runtime-io/Cargo.toml
+++ b/substrate/runtime-io/Cargo.toml
@@ -15,6 +15,7 @@ substrate-primitives = { path = "../primitives", default_features = false }
 substrate-codec = { path = "../codec", default_features = false }
 triehash = { version = "0.1.2", optional = true }
 ed25519 = { path = "../ed25519", optional = true }
+hashdb = { git = "https://github.com/paritytech/parity-common", optional = true }
 
 [features]
 default = ["std"]
@@ -26,6 +27,7 @@ std = [
 	"substrate-codec/std",
 	"substrate-runtime-std/std",
 	"ed25519",
+	"hashdb"
 ]
 nightly = []
 strict = []

--- a/substrate/runtime-io/with_std.rs
+++ b/substrate/runtime-io/with_std.rs
@@ -23,6 +23,7 @@ extern crate substrate_primitives as primitives;
 extern crate substrate_state_machine;
 extern crate triehash;
 extern crate ed25519;
+extern crate hashdb;
 
 #[doc(hidden)]
 pub extern crate substrate_codec as codec;
@@ -30,6 +31,7 @@ pub extern crate substrate_codec as codec;
 pub use primitives::{blake2_256, twox_128, twox_256};
 
 pub use primitives::KeccakHasher;
+use hashdb::Hasher;
 // Switch to this after PoC-3
 // pub use primitives::BlakeHasher;
 pub use substrate_state_machine::{Externalities, TestExternalities};
@@ -130,8 +132,8 @@ pub fn ed25519_verify<P: AsRef<[u8]>>(sig: &[u8; 64], msg: &[u8], pubkey: P) -> 
 /// Execute the given closure with global function available whose functionality routes into the
 /// externalities `ext`. Forwards the value that the closure returns.
 // NOTE: need a concrete hasher here due to limitations of the `environmental!` macro, otherwise a type param would have been fine I think.
-pub fn with_externalities<R, F: FnOnce() -> R>(ext: &mut Externalities<KeccakHasher>, f: F) -> R {
-	ext::using(ext, f)
+pub fn with_externalities<R, H: Hasher, F: FnOnce() -> R>(ext: &mut Externalities<H>, f: F) -> R {
+	ext::using(ext, f) // REVIEW: this is where the limitations of the `environmental!` macro comes in. Any way to get around this?
 }
 
 /// Trait for things which can be printed.

--- a/substrate/test-client/src/lib.rs
+++ b/substrate/test-client/src/lib.rs
@@ -53,7 +53,12 @@ pub use local_executor::LocalExecutor;
 pub type Backend = client::in_mem::Backend<runtime::Block, KeccakHasher, RlpCodec>;
 
 /// Test client executor.
-pub type Executor = client::LocalCallExecutor<Backend, executor::NativeExecutor<LocalExecutor>>;
+pub type Executor = client::LocalCallExecutor<
+		Backend,
+		executor::NativeExecutor<LocalExecutor>,
+		KeccakHasher,
+		RlpCodec
+	>;
 
 /// Creates new client instance used for tests.
 pub fn new() -> client::Client<Backend, Executor, runtime::Block> {


### PR DESCRIPTION
This PR is more of a question/illustration of a problem I've had on previous PRs. The attempt to make `Client` generic over `Hasher`/`NodeCodec` hits a problem when calling [`runtime_io::with_externalities`](https://github.com/paritytech/substrate/pull/574/files#diff-8676d22639686f518b914ccd4dcb4b7eR135https://github.com/paritytech/substrate/pull/574/files#diff-8676d22639686f518b914ccd4dcb4b7eR135) ([example callsite](https://github.com/paritytech/substrate/pull/574/files#diff-76964ec8de481638ce29d022262cfc53L284)) as the `Externalities` cannot be generic due to the limitations of
`environmental`. Can this be solved somehow?