### PR TITLE
Allow specifying listening multiaddresses

### DIFF
--- a/substrate/cli/src/cli.yml
+++ b/substrate/cli/src/cli.yml
@@ -41,10 +41,16 @@ args:
       long: dev
       help: Run in development mode; implies --chain=dev --validator --key Alice
       takes_value: false
+  - listen-addr:
+      long: listen-addr
+      value_name: LISTEN_ADDR
+      help: Listen on this multiaddress
+      takes_value: true
+      multiple: true
   - port:
       long: port
       value_name: PORT
-      help: Specify p2p protocol TCP port
+      help: Specify p2p protocol TCP port. Only used if --listen-addr is not specified.
       takes_value: true
   - rpc-external:
       long: rpc-external

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -287,15 +287,25 @@ where
 			config.network.non_reserved_mode = NonReservedPeerMode::Deny;
 		}
 
-		let port = match matches.value_of("port") {
-			Some(port) => port.parse().map_err(|_| "Invalid p2p port value specified.")?,
-			None => 30333,
-		};
+		config.network.listen_addresses = Vec::new();
+		for addr in matches.values_of("listen-addr").unwrap_or_default() {
+			let addr = addr.parse().map_err(|_| "Invalid listen multiaddress")?;
+			config.network.listen_addresses.push(addr);
+		}
+		if config.network.listen_addresses.is_empty() {
+			let port = match matches.value_of("port") {
+				Some(port) => port.parse().map_err(|_| "Invalid p2p port value specified.")?,
+				None => 30333,
+			};
+			config.network.listen_addresses = vec![
+				iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
+					.chain(iter::once(AddrComponent::TCP(port)))
+					.collect()
+			];
+		}
 
-		config.network.listen_address = iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-			.chain(iter::once(AddrComponent::TCP(port)))
-			.collect();
-		config.network.public_address = None;
+		config.network.public_addresses = Vec::new();
+
 		config.network.client_version = config.client_id();
 		config.network.use_secret = match matches.value_of("node-key").map(|s| s.parse()) {
 			Some(Ok(secret)) => Some(secret),

--- a/substrate/network-libp2p/src/traits.rs
+++ b/substrate/network-libp2p/src/traits.rs
@@ -104,10 +104,10 @@ pub struct NetworkConfiguration {
 	pub config_path: Option<String>,
 	/// Directory path to store network-specific configuration. None means nothing will be saved
 	pub net_config_path: Option<String>,
-	/// IP address to listen for incoming connections. Listen to all connections by default
-	pub listen_address: Multiaddr,
-	/// IP address to advertise. Detected automatically if none.
-	pub public_address: Option<Multiaddr>,
+	/// Multiaddresses to listen for incoming connections.
+	pub listen_addresses: Vec<Multiaddr>,
+	/// Multiaddresses to advertise. Detected automatically if empty.
+	pub public_addresses: Vec<Multiaddr>,
 	/// List of initial node addresses
 	pub boot_nodes: Vec<String>,
 	/// Use provided node key instead of default
@@ -136,10 +136,12 @@ impl NetworkConfiguration {
 		NetworkConfiguration {
 			config_path: None,
 			net_config_path: None,
-			listen_address: iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-				.chain(iter::once(AddrComponent::TCP(30333)))
-				.collect(),
-			public_address: None,
+			listen_addresses: vec![
+				iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
+					.chain(iter::once(AddrComponent::TCP(30333)))
+					.collect()
+			],
+			public_addresses: Vec::new(),
 			boot_nodes: Vec::new(),
 			use_secret: None,
 			min_peers: 25,
@@ -153,9 +155,11 @@ impl NetworkConfiguration {
 	/// Create new default configuration for localhost-only connection with random port (useful for testing)
 	pub fn new_local() -> NetworkConfiguration {
 		let mut config = NetworkConfiguration::new();
-		config.listen_address = iter::once(AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)))
-			.chain(iter::once(AddrComponent::TCP(0)))
-			.collect();
+		config.listen_addresses = vec![
+			iter::once(AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)))
+				.chain(iter::once(AddrComponent::TCP(0)))
+				.collect()
+		];
 		config
 	}
 }


### PR DESCRIPTION
Allows the user to specify a multiaddress for listening, and listening on multiple addresses at once by passing the option multiple times.

Right now only the `/ip4/.../tcp/...`, `/ip6/.../tcp/...`, and `.../ws` schemes are supported in substrate.

This makes the `--port` option a bit redundant. I kept it for backward compatibility, but we ideally it would be removed.