### PR TITLE
Fix runtime version cache

### DIFF
--- a/substrate/codec/derive/src/lib.rs
+++ b/substrate/codec/derive/src/lib.rs
@@ -17,7 +17,7 @@
 //! Derives serialization and deserialization codec for complex structs for simple marshalling.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
+//#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 extern crate proc_macro;
 extern crate proc_macro2;


### PR DESCRIPTION
- Use blake2 instead of xxhash for guaranteed safety
- Simplify by caching the version rather than the compatibility (this makes it possible to provide logs to debug any potential problems)
- Additional logging
- Remove an `.expect`