### PR TITLE
Time-based transaction banning

### DIFF
--- a/polkadot/transaction-pool/src/error.rs
+++ b/polkadot/transaction-pool/src/error.rs
@@ -55,6 +55,11 @@ error_chain! {
 			description("Unrecognised address in extrinsic"),
 			display("Unrecognised address in extrinsic: {}", who),
 		}
+		/// Temporarily banned
+		TemporarilyBanned {
+			description("Extrinsic is temporarily banned"),
+			display("Extrinsic is temporarily banned"),
+		}
 	}
 }
 

--- a/polkadot/transaction-pool/src/lib.rs
+++ b/polkadot/transaction-pool/src/lib.rs
@@ -41,6 +41,7 @@ use std::{
 	collections::HashMap,
 	ops::Deref,
 	sync::Arc,
+	time::{Duration, Instant},
 };
 
 use codec::{Decode, Encode};
@@ -51,6 +52,7 @@ use extrinsic_pool::{
 	Pool,
 	Listener,
 };
+use parking_lot::RwLock;
 use polkadot_api::PolkadotApi;
 use primitives::{AccountId, BlockId, Hash, Index, UncheckedExtrinsic as FutureProofUncheckedExtrinsic};
 use runtime::{Address, UncheckedExtrinsic};
@@ -58,6 +60,11 @@ use substrate_runtime_primitives::traits::{Bounded, Checkable, Hash as HashT, Bl
 
 pub use extrinsic_pool::txpool::{Options, Status, LightStatus, VerifiedTransaction as VerifiedTransactionOps};
 pub use error::{Error, ErrorKind, Result};
+
+/// Maximum time the transaction will be kept in the pool.
+///
+/// Transactions that don't get included within the limit are removed from the pool.
+const POOL_TIME: Duration = Duration::from_secs(60 * 5);
 
 /// Type alias for convenience.
 pub type CheckedExtrinsic = <UncheckedExtrinsic as Checkable<fn(Address) -> std::result::Result<AccountId, &'static str>>>::Checked;
@@ -70,6 +77,7 @@ pub struct VerifiedTransaction {
 	sender: Option<AccountId>,
 	hash: Hash,
 	encoded_size: usize,
+	valid_till: Instant,
 }
 
 impl VerifiedTransaction {
@@ -187,17 +195,21 @@ impl txpool::Scoring<VerifiedTransaction> for Scoring {
 pub struct Ready<'a, A: 'a + PolkadotApi> {
 	at_block: BlockId,
 	api: &'a A,
+	rotator: &'a PoolRotator,
 	known_nonces: HashMap<AccountId, ::primitives::Index>,
+	now: Instant,
 }
 
 impl<'a, A: 'a + PolkadotApi> Ready<'a, A> {
 	/// Create a new readiness evaluator at the given block. Requires that
 	/// the ID has already been checked for local corresponding and available state.
-	fn create(at: BlockId, api: &'a A) -> Self {
+	fn create(at: BlockId, api: &'a A, rotator: &'a PoolRotator) -> Self {
 		Ready {
 			at_block: at,
 			api,
-			known_nonces: HashMap::new(),
+			rotator,
+			known_nonces: Default::default(),
+			now: Instant::now(),
 		}
 	}
 }
@@ -207,7 +219,9 @@ impl<'a, T: 'a + PolkadotApi> Clone for Ready<'a, T> {
 		Ready {
 			at_block: self.at_block.clone(),
 			api: self.api,
+			rotator: self.rotator,
 			known_nonces: self.known_nonces.clone(),
+			now: self.now.clone(),
 		}
 	}
 }
@@ -230,6 +244,11 @@ impl<'a, A: 'a + PolkadotApi> txpool::Ready<VerifiedTransaction> for Ready<'a, A
 
 		trace!(target: "transaction-pool", "Next index for sender is {}; xt index is {}", next_index, xt.original.extrinsic.index);
 
+		if self.rotator.ban_if_stale(&self.now, xt) {
+			debug!(target: "transaction-pool", "[{}] Banning as stale.", xt.hash);
+			return Readiness::Stale;
+		}
+
 		let result = match xt.original.extrinsic.index.cmp(&next_index) {
 			// TODO: this won't work perfectly since accounts can now be killed, returning the nonce
 			// to zero.
@@ -251,11 +270,12 @@ impl<'a, A: 'a + PolkadotApi> txpool::Ready<VerifiedTransaction> for Ready<'a, A
 
 pub struct Verifier<'a, A: 'a> {
 	api: &'a A,
+	rotator: &'a PoolRotator,
 	at_block: BlockId,
 }
 
 impl<'a, A> Verifier<'a, A> where
-	A: 'a + PolkadotApi,
+A: 'a + PolkadotApi,
 {
 	const NO_ACCOUNT: &'static str = "Account not found.";
 
@@ -289,6 +309,11 @@ impl<'a, A> txpool::Verifier<UncheckedExtrinsic> for Verifier<'a, A> where
 
 		debug!(target: "transaction-pool", "Transaction submitted: {}", ::substrate_primitives::hexdisplay::HexDisplay::from(&encoded));
 
+		if self.rotator.is_banned(&hash) {
+			debug!(target: "transaction-pool", "[{}] Transaction is temporarily banned", hash);
+			bail!(ErrorKind::TemporarilyBanned);
+		}
+
 		let inner = match uxt.clone().check_with(|a| self.lookup(a)) {
 			Ok(xt) => Some(xt),
 			// keep the transaction around in the future pool and attempt to promote it later.
@@ -298,9 +323,9 @@ impl<'a, A> txpool::Verifier<UncheckedExtrinsic> for Verifier<'a, A> where
 		let sender = inner.as_ref().map(|x| x.signed.clone());
 
 		if encoded_size < 1024 {
-			debug!(target: "transaction-pool", "Transaction verified: {} => {:?}", hash, uxt);
+			debug!(target: "transaction-pool", "[{}] Transaction verified: {:?}", hash, uxt);
 		} else {
-			debug!(target: "transaction-pool", "Transaction verified: {} ({} bytes is too large to display)", hash, encoded_size);
+			debug!(target: "transaction-pool", "[{}] Transaction verified: ({} bytes is too large to display)", hash, encoded_size);
 		}
 
 		Ok(VerifiedTransaction {
@@ -308,8 +333,66 @@ impl<'a, A> txpool::Verifier<UncheckedExtrinsic> for Verifier<'a, A> where
 			inner,
 			sender,
 			hash,
-			encoded_size
+			encoded_size,
+			valid_till: Instant::now() + POOL_TIME,
 		})
+	}
+}
+
+/// Pool rotator is responsible to only keep fresh transactions in the pool.
+///
+/// Transactions that occupy the pool for too long are culled and temporarily banned from entering
+/// the pool again.
+struct PoolRotator {
+	/// How long the transaction is banned for.
+	ban_time: Duration,
+	/// Currently banned transactions.
+	banned_until: RwLock<HashMap<Hash, Instant>>,
+}
+
+impl Default for PoolRotator {
+	fn default() -> Self {
+		PoolRotator {
+			ban_time: Duration::from_secs(60 * 30),
+			banned_until: Default::default(),
+		}
+	}
+}
+
+impl PoolRotator {
+	/// Returns `true` if transaction hash is currently banned.
+	pub fn is_banned(&self, hash: &Hash) -> bool {
+		self.banned_until.read().contains_key(hash)
+	}
+
+	/// Bans transaction if it's stale.
+	///
+	/// Returns `true` if transaction is stale and got banned.
+	pub fn ban_if_stale(&self, now: &Instant, tx: &VerifiedTransaction) -> bool {
+		if &tx.valid_till > now {
+			return false;
+		}
+
+		self.banned_until.write().insert(*tx.hash(), *now + self.ban_time);
+		true
+	}
+
+	/// Removes timed bans.
+	pub fn clear_timeouts(&self, now: &Instant) {
+		let to_remove = {
+			self.banned_until.read()
+				.iter()
+				.filter_map(|(k, v)| if v < now {
+					Some(*k)
+				} else {
+					None
+				}).collect::<Vec<_>>()
+		};
+
+		let mut banned = self.banned_until.write();
+		for k in to_remove {
+			banned.remove(&k);
+		}
 	}
 }
 
@@ -319,16 +402,18 @@ impl<'a, A> txpool::Verifier<UncheckedExtrinsic> for Verifier<'a, A> where
 pub struct TransactionPool<A> {
 	inner: Pool<Hash, VerifiedTransaction, Scoring, Error>,
 	api: Arc<A>,
+	rotator: PoolRotator,
 }
 
 impl<A> TransactionPool<A> where
-	A: PolkadotApi,
+A: PolkadotApi,
 {
 	/// Create a new transaction pool.
 	pub fn new(options: Options, api: Arc<A>) -> Self {
 		TransactionPool {
 			inner: Pool::new(options, Scoring),
 			api,
+			rotator: Default::default(),
 		}
 	}
 
@@ -337,6 +422,7 @@ impl<A> TransactionPool<A> where
 		let verifier = Verifier {
 			api: &*self.api,
 			at_block: block,
+			rotator: &self.rotator,
 		};
 		self.inner.submit(verifier, vec![uxt]).map(|mut v| v.swap_remove(0))
 	}
@@ -347,6 +433,7 @@ impl<A> TransactionPool<A> where
 		let verifier = Verifier {
 			api: &*self.api,
 			at_block: block,
+			rotator: &self.rotator,
 		};
 
 		self.inner.submit(verifier, to_reverify.into_iter().map(|tx| tx.original.clone()))?;
@@ -372,7 +459,9 @@ impl<A> TransactionPool<A> where
 
 	/// Cull old transactions from the queue.
 	pub fn cull(&self, block: BlockId) -> Result<usize> {
-		let ready = Ready::create(block, &*self.api);
+		self.rotator.clear_timeouts(&Instant::now());
+
+		let ready = Ready::create(block, &*self.api, &self.rotator);
 		Ok(self.inner.cull(None, ready))
 	}
 
@@ -380,7 +469,8 @@ impl<A> TransactionPool<A> where
 	pub fn cull_and_get_pending<F, T>(&self, block: BlockId, f: F) -> Result<T> where
 		F: FnOnce(txpool::PendingIterator<VerifiedTransaction, Ready<A>, Scoring, Listener<Hash>>) -> T,
 	{
-		let ready = Ready::create(block, &*self.api);
+		self.rotator.clear_timeouts(&Instant::now());
+		let ready = Ready::create(block, &*self.api, &self.rotator);
 		self.inner.cull(None, ready.clone());
 		Ok(self.inner.pending(ready, f))
 	}
@@ -424,6 +514,7 @@ impl<A> ExtrinsicPool<FutureProofUncheckedExtrinsic, BlockId, Hash> for Transact
 
 		let verifier = Verifier {
 			api: &*self.api,
+			rotator: &self.rotator,
 			at_block: block,
 		};
 

--- a/polkadot/transaction-pool/src/lib.rs
+++ b/polkadot/transaction-pool/src/lib.rs
@@ -148,8 +148,8 @@ impl txpool::Scoring<VerifiedTransaction> for Scoring {
 		if old.is_fully_verified() {
 			assert!(new.is_fully_verified(), "Scoring::choose called with transactions from different senders");
 			if old.index() == new.index() {
-				// TODO [ToDr] Do we allow replacement? If yes then it should be Choice::ReplaceOld
-				return Choice::RejectNew;
+				// Allow replacing transactions so that we never fail to import to the pool.
+				return Choice::ReplaceOld;
 			}
 		}
 

--- a/polkadot/transaction-pool/src/rotator.rs
+++ b/polkadot/transaction-pool/src/rotator.rs
@@ -1,0 +1,165 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Rotate extrinsic inside the pool.
+//!
+//! Keeps only recent extrinsic and discard the ones kept for a significant amount of time.
+//! Discarded extrinsics are banned so that they don't get re-imported again.
+
+use std::{
+	collections::HashMap,
+	time::{Duration, Instant},
+};
+use parking_lot::RwLock;
+use primitives::Hash;
+use VerifiedTransaction;
+
+/// Pool rotator is responsible to only keep fresh extrinsics in the pool.
+///
+/// Extrinsics that occupy the pool for too long are culled and temporarily banned from entering
+/// the pool again.
+pub struct PoolRotator {
+	/// How long the extrinsic is banned for.
+	ban_time: Duration,
+	/// Currently banned extrinsics.
+	banned_until: RwLock<HashMap<Hash, Instant>>,
+}
+
+impl Default for PoolRotator {
+	fn default() -> Self {
+		PoolRotator {
+			ban_time: Duration::from_secs(60 * 30),
+			banned_until: Default::default(),
+		}
+	}
+}
+
+impl PoolRotator {
+	/// Returns `true` if extrinsic hash is currently banned.
+	pub fn is_banned(&self, hash: &Hash) -> bool {
+		self.banned_until.read().contains_key(hash)
+	}
+
+	/// Bans extrinsic if it's stale.
+	///
+	/// Returns `true` if extrinsic is stale and got banned.
+	pub fn ban_if_stale(&self, now: &Instant, tx: &VerifiedTransaction) -> bool {
+		if &tx.valid_till > now {
+			return false;
+		}
+
+		self.banned_until.write().insert(*tx.hash(), *now + self.ban_time);
+		true
+	}
+
+	/// Removes timed bans.
+	pub fn clear_timeouts(&self, now: &Instant) {
+		let to_remove = {
+			self.banned_until.read()
+				.iter()
+				.filter_map(|(k, v)| if v < now {
+					Some(*k)
+				} else {
+					None
+				}).collect::<Vec<_>>()
+		};
+
+		let mut banned = self.banned_until.write();
+		for k in to_remove {
+			banned.remove(&k);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use runtime::{Extrinsic, Call, TimestampCall, UncheckedExtrinsic};
+
+	fn rotator() -> PoolRotator {
+		PoolRotator {
+			ban_time: Duration::from_millis(10),
+			..Default::default()
+		}
+	}
+
+	fn tx() -> (Hash, VerifiedTransaction) {
+		let hash: Hash = 5.into();
+		let tx = VerifiedTransaction {
+			original: UncheckedExtrinsic::new(
+				Extrinsic {
+					function: Call::Timestamp(TimestampCall::set(100_000_000)),
+					signed: Default::default(),
+					index: Default::default(),
+				},
+				Default::default(),
+			),
+			inner: None,
+			sender: None,
+			hash: hash.clone(),
+			encoded_size: 1024,
+			valid_till: Instant::now(),
+		};
+
+		(hash, tx)
+	}
+
+	#[test]
+	fn should_not_ban_if_not_stale() {
+		// given
+		let (hash, tx) = tx();
+		let rotator = rotator();
+		assert!(!rotator.is_banned(&hash));
+		let past = Instant::now() - Duration::from_millis(1000);
+
+		// when
+		assert!(!rotator.ban_if_stale(&past, &tx));
+
+		// then
+		assert!(!rotator.is_banned(&hash));
+	}
+
+	#[test]
+	fn should_ban_stale_extrinsic() {
+		// given
+		let (hash, tx) = tx();
+		let rotator = rotator();
+		assert!(!rotator.is_banned(&hash));
+
+		// when
+		assert!(rotator.ban_if_stale(&Instant::now(), &tx));
+
+		// then
+		assert!(rotator.is_banned(&hash));
+	}
+
+
+	#[test]
+	fn should_clear_banned() {
+		// given
+		let (hash, tx) = tx();
+		let rotator = rotator();
+		assert!(rotator.ban_if_stale(&Instant::now(), &tx));
+		assert!(rotator.is_banned(&hash));
+
+		// when
+		let future = Instant::now() + rotator.ban_time + rotator.ban_time;
+		rotator.clear_timeouts(&future);
+
+		// then
+		assert!(!rotator.is_banned(&hash));
+	}
+}

--- a/polkadot/transaction-pool/src/rotator.rs
+++ b/polkadot/transaction-pool/src/rotator.rs
@@ -68,7 +68,7 @@ impl PoolRotator {
 		banned.insert(*tx.hash(), *now + self.ban_time);
 		if banned.len() > 2 * EXPECTED_SIZE {
 			while banned.len() > EXPECTED_SIZE {
-				if let Ok(key) = banned.keys().next().cloned() {
+				if let Some(key) = banned.keys().next().cloned() {
 					banned.remove(&key);
 				}
 			}
@@ -79,17 +79,16 @@ impl PoolRotator {
 
 	/// Removes timed bans.
 	pub fn clear_timeouts(&self, now: &Instant) {
-		let to_remove = {
-			self.banned_until.read()
-				.iter()
-				.filter_map(|(k, v)| if v < now {
-					Some(*k)
-				} else {
-					None
-				}).collect::<Vec<_>>()
-		};
-
 		let mut banned = self.banned_until.write();
+
+		let to_remove = banned
+			.iter()
+			.filter_map(|(k, v)| if v < now {
+				Some(*k)
+			} else {
+				None
+			}).collect::<Vec<_>>();
+
 		for k in to_remove {
 			banned.remove(&k);
 		}


### PR DESCRIPTION
If the pool occupies the queue for more than 5 minutes:
1. Remove it from the pool
2. Ban for next 30 minutes