### PR TITLE
Minor fixes for nightly 2018-08-18

### DIFF
--- a/substrate/executor/wasm/build.sh
+++ b/substrate/executor/wasm/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-RUSTFLAGS="-C link-arg=--export-table" cargo +nightly build --target=wasm32-unknown-unknown --release
+cargo +nightly build --target=wasm32-unknown-unknown --release
 for i in test
 do
 	wasm-gc target/wasm32-unknown-unknown/release/runtime_$i.wasm target/wasm32-unknown-unknown/release/runtime_$i.compact.wasm

--- a/substrate/runtime-std/src/lib.rs
+++ b/substrate/runtime-std/src/lib.rs
@@ -21,7 +21,6 @@
 #![cfg_attr(not(feature = "std"), feature(panic_implementation))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
-#![cfg_attr(not(feature = "std"), feature(use_extern_macros))]
 
 #![cfg_attr(feature = "std", doc = "Polkadot runtime standard library as compiled when linked with Rust's standard library.")]
 #![cfg_attr(not(feature = "std"), doc = "Polkadot's runtime standard library as compiled without Rust's standard library.")]


### PR DESCRIPTION
- LLD flag `--export-table` for wasm has been turned on by default rust-lang/rust#53237
- `feature(use_extern_macros)` has been stabilized in the latest nightlies
