### PR TITLE
Minor change to allow docker builds.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,9 +4,12 @@ set -e
 
 echo "*** Initialising WASM build environment"
 
-rustup update nightly
+if [ -z $CI_PROJECT_NAME ] ; then
+   rustup update nightly
+   rustup update stable
+fi
+
 rustup target add wasm32-unknown-unknown --toolchain nightly
-rustup update stable
 
 # Install wasm-gc. It's useful for stripping slimming down wasm binaries.
 command -v wasm-gc || \


### PR DESCRIPTION
Do not attempt to rustup if in CI. This is taken care of by the base image and will cause a crosslink error.