### PR TITLE
Backport removing mplex buffer in libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,11 +257,11 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1131,26 +1131,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1160,20 +1160,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1181,12 +1181,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1194,60 +1194,60 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1255,35 +1255,35 @@ dependencies = [
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,14 +1292,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1309,11 +1309,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1322,37 +1322,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1360,12 +1360,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1373,10 +1373,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1384,13 +1384,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1399,11 +1399,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1539,10 +1539,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1557,7 +1557,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1567,14 +1567,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
 ]
 
 [[package]]
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1829,7 +1829,7 @@ dependencies = [
  "polkadot-service 0.2.2",
  "polkadot-transaction-pool 0.1.0",
  "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-cli 0.2.7",
+ "substrate-cli 0.2.8",
  "substrate-client 0.1.0",
  "substrate-codec 0.1.0",
  "substrate-extrinsic-pool 0.1.0",
@@ -2356,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2814,7 +2814,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3723,6 +3723,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "varint"
+version = "0.1.0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,7 +3939,7 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3943,7 +3956,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4012,22 +4025,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4043,10 +4056,10 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4108,7 +4121,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4191,6 +4204,7 @@ dependencies = [
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
+"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", branch = "polkadot-2", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "cc79d91706e7f1ce40a3a30626e192539ae993c0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"


### PR DESCRIPTION
Removes the mplex buffer size limit, which is too quickly reached now.
This should remove some random disconnects, provided nodes upgrade.