### PR TITLE
Avoid Ext calls from outside of runtime

### DIFF
--- a/substrate/state-machine/src/ext.rs
+++ b/substrate/state-machine/src/ext.rs
@@ -126,8 +126,9 @@ where
 	H::Out: Ord + Encodable
 {
 	fn storage(&self, key: &[u8]) -> Option<Vec<u8>> {
-		self.overlay.storage(key).map(|x| x.map(|x| x.to_vec())).unwrap_or_else(||
-			self.backend.storage(key).expect("Externalities not allowed to fail within runtime"))
+		use {try_read_overlay_value};
+		try_read_overlay_value(self.overlay, self.backend, key)
+			.expect("Externalities not allowed to fail within runtime")
 	}
 
 	fn exists_storage(&self, key: &[u8]) -> bool {

--- a/substrate/state-machine/src/ext.rs
+++ b/substrate/state-machine/src/ext.rs
@@ -126,7 +126,7 @@ where
 	H::Out: Ord + Encodable
 {
 	fn storage(&self, key: &[u8]) -> Option<Vec<u8>> {
-		use {try_read_overlay_value};
+		use try_read_overlay_value;
 		try_read_overlay_value(self.overlay, self.backend, key)
 			.expect("Externalities not allowed to fail within runtime")
 	}

--- a/substrate/state-machine/src/proving_backend.rs
+++ b/substrate/state-machine/src/proving_backend.rs
@@ -126,7 +126,7 @@ mod tests {
 	use primitives::{KeccakHasher, RlpCodec};
 
 	fn test_proving() -> ProvingBackend<KeccakHasher, RlpCodec> {
-		ProvingBackend::new(test_trie())
+		ProvingBackend::new(test_trie(true))
 	}
 
 	#[test]
@@ -148,7 +148,7 @@ mod tests {
 
 	#[test]
 	fn passes_throgh_backend_calls() {
-		let trie_backend = test_trie();
+		let trie_backend = test_trie(true);
 		let proving_backend = test_proving();
 		assert_eq!(trie_backend.storage(b"key").unwrap(), proving_backend.storage(b"key").unwrap());
 		assert_eq!(trie_backend.pairs(), proving_backend.pairs());


### PR DESCRIPTION
Alternative fix of this panic:
```
thread '<unnamed>' panicked at 'Externalities not allowed to fail within runtime: "Trie lookup error: Invalid state root: 0x609a�~@�3f5a"', libcore/result.rs:945:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:467
   5: std::panicking::begin_panic_fmt
             at libstd/panicking.rs:350
   6: rust_begin_unwind
             at libstd/panicking.rs:328
   7: core::panicking::panic_fmt
             at libcore/panicking.rs:71
   8: core::result::unwrap_failed
   9: <substrate_state_machine::ext::Ext<'a, B> as substrate_state_machine::Externalities>::storage
  10: substrate_state_machine::prove_execution
  11: <substrate_client::call_executor::LocalCallExecutor<B, E> as substrate_client::call_executor::CallExecutor<Block>>::prove_at_state
  12: <substrate_client::client::Client<B, E, Block> as substrate_network::chain::Client<Block>>::execution_proof
  13: <substrate_network::protocol::Protocol<B, S>>::handle_packet
  14: <substrate_network::service::ProtocolHandler<B, S> as substrate_network_libp2p::traits::NetworkProtocolHandler>::read
```

It should be fixed as @arkpar suggested - by checking if the state is not pruned (he's preparing PR). However, calling 'unsafe' `Ext` methods (`storage` && `exists_storage`) from outside of runtime should be avoided (since `Ext` **expect-s** backend calls to succeed) => this PR removes temporary `Ext` creation for those calls.