### PR TITLE
Backport the current networking to v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,11 +257,11 @@ dependencies = [
 [[package]]
 name = "cid"
 version = "0.2.3"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -569,14 +569,6 @@ dependencies = [
 [[package]]
 name = "environmental"
 version = "0.1.0"
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "error-chain"
@@ -1131,26 +1123,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1160,20 +1152,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1181,12 +1173,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1194,96 +1186,96 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,15 +1284,15 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1309,11 +1301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1322,37 +1314,37 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1360,12 +1352,13 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1373,10 +1366,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1384,13 +1377,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
- "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1399,11 +1392,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
@@ -1539,10 +1532,10 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1557,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1567,14 +1560,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1618,15 +1611,6 @@ dependencies = [
 name = "nodrop"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num-integer"
@@ -1688,6 +1672,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "parity-bytes"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/parity-common.git#613d1420f91cc5660c1d9983447ce32b41fcfe28"
 
 [[package]]
 name = "parity-wasm"
@@ -1784,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1829,7 +1818,7 @@ dependencies = [
  "polkadot-service 0.2.2",
  "polkadot-transaction-pool 0.1.0",
  "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-cli 0.2.9",
+ "substrate-cli 0.2.10",
  "substrate-client 0.1.0",
  "substrate-codec 0.1.0",
  "substrate-extrinsic-pool 0.1.0",
@@ -2171,7 +2160,7 @@ dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2356,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c#4ff16806970cad950619af8735d934f4b326996c"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2615,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-cli"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2710,7 +2699,7 @@ dependencies = [
  "hex-literal 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2806,7 +2795,6 @@ dependencies = [
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-bytes 0.1.0 (git+https://github.com/paritytech/parity.git)",
  "ethcore-io 1.12.0 (git+https://github.com/paritytech/parity.git)",
  "ethcore-logger 1.12.0 (git+https://github.com/paritytech/parity.git)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2814,14 +2802,15 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common.git)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)",
+ "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3358,6 +3347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tk-listen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,6 +3690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsigned-varint"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,32 +3718,6 @@ dependencies = [
 name = "utf8-ranges"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "varint"
-version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2#725f9f78ebeddc038941316f120a99daaebc9231"
-dependencies = [
- "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "varint"
-version = "0.1.0"
-source = "git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0#cc79d91706e7f1ce40a3a30626e192539ae993c0"
-dependencies = [
- "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "vcpkg"
@@ -3939,7 +3923,7 @@ dependencies = [
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chashmap 2.2.1 (git+https://github.com/redox-os/tfs)" = "<none>"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
-"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum cid 0.2.3 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
@@ -3956,7 +3940,7 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -3964,7 +3948,6 @@ dependencies = [
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4851b005ef16de812ea9acdb7bece2f0a40dd86c07b85631d7dafa54537bb"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)" = "<none>"
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
@@ -4025,22 +4008,22 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
-"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4056,16 +4039,15 @@ dependencies = [
 "checksum mime 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0b28683d0b09bbc20be1c9b3f6f24854efb1356ffcffee08ea3f6e65596e85fa"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum multibase 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
-"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 "checksum num-integer 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac0ea58d64a89d9d6b7688031b3be9358d6c919badcf7fbb0527ccfd891ee45"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
@@ -4073,6 +4055,7 @@ dependencies = [
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+"checksum parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common.git)" = "<none>"
 "checksum parity-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1c91199d14bd5b78ecade323d4a891d094799749c1b9e82d9c590c2e2849a40"
 "checksum parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0dec124478845b142f68b446cbee953d14d4b41f1bc0425024417720dce693"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
@@ -4121,7 +4104,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=4ff16806970cad950619af8735d934f4b326996c)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4165,6 +4148,7 @@ dependencies = [
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
 "checksum timer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
+"checksum tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dec7ba6a80b7695fc2abb21af18bed445a362ffd80b64704771ce142d6d2151d"
 "checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
 "checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
 "checksum tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "aeeffbbb94209023feaef3c196a41cbcdafa06b4a6f893f68779bb5e53796f71"
@@ -4200,11 +4184,10 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5c1441164e5da61f00acd15f5a9e61939693c2c6e8b9fae36a220b82de7e212"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?branch=polkadot-2)" = "<none>"
-"checksum varint 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=cc79d91706e7f1ce40a3a30626e192539ae993c0)" = "<none>"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -294,10 +294,12 @@ where
 			None => 30333,
 		};
 
-		config.network.listen_address = iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-			.chain(iter::once(AddrComponent::TCP(port)))
-			.collect();
-		config.network.public_address = None;
+		config.network.listen_addresses = vec![
+			iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
+				.chain(iter::once(AddrComponent::TCP(port)))
+				.collect()
+		];
+		config.network.public_addresses = Vec::new();
 		config.network.client_version = config.client_id();
 		config.network.use_secret = match matches.value_of("node-key").map(|s| s.parse()) {
 			Some(Ok(secret)) => Some(secret),

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "cc79d91706e7f1ce40a3a30626e192539ae993c0", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "4ff16806970cad950619af8735d934f4b326996c", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"
@@ -22,10 +22,10 @@ rand = "0.5.0"
 tokio = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2"
-varint = { git = "https://github.com/tomaka/libp2p-rs", branch = "polkadot-2" }
+unsigned-varint = { version = "0.1", features = ["codec"] }
 
 [dev-dependencies]
 assert_matches = "1.2"
-ethcore-bytes = { git = "https://github.com/paritytech/parity.git" }
+parity-bytes = { git = "https://github.com/paritytech/parity-common.git" }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethcore-logger = { git = "https://github.com/paritytech/parity.git" }

--- a/substrate/network-libp2p/src/custom_proto.rs
+++ b/substrate/network-libp2p/src/custom_proto.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use bytes::{Bytes, BytesMut};
 use ProtocolId;
@@ -23,7 +23,7 @@ use std::vec::IntoIter as VecIntoIter;
 use futures::{future, Future, stream, Stream, Sink};
 use futures::sync::mpsc;
 use tokio_io::{AsyncRead, AsyncWrite};
-use varint::VarintCodec;
+use unsigned_varint::codec::UviBytes;
 
 /// Connection upgrade for a single protocol.
 ///
@@ -157,7 +157,7 @@ where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
 		}
 
 		let (sink, stream) = {
-			let framed = AsyncRead::framed(socket, VarintCodec::default());
+			let framed = AsyncRead::framed(socket, UviBytes::default());
 			let msg_rx = msg_rx.map(Message::SendReq)
 				.map_err(|()| unreachable!("mpsc::UnboundedReceiver never errors"));
 			let (sink, stream) = framed.split();

--- a/substrate/network-libp2p/src/lib.rs
+++ b/substrate/network-libp2p/src/lib.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 #![recursion_limit="128"]
 #![type_length_limit = "268435456"]
@@ -28,7 +28,7 @@ extern crate libc;
 extern crate libp2p;
 extern crate rand;
 extern crate bytes;
-extern crate varint;
+extern crate unsigned_varint;
 
 extern crate ethcore_io as io;
 extern crate ethereum_types;

--- a/substrate/network-libp2p/src/network_state.rs
+++ b/substrate/network-libp2p/src/network_state.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use bytes::Bytes;
 use fnv::{FnvHashMap, FnvHashSet};
@@ -677,7 +677,7 @@ impl NetworkState {
 	}
 
 	/// Disables a peer for `PEER_DISABLE_DURATION`. This adds the peer to the
-	/// list of disabled peers, and  drops any existing connections if
+	/// list of disabled peers, and drops any existing connections if
 	/// necessary (ie. drops the sender that was stored in the `UniqueConnec`
 	/// of `custom_proto`).
 	pub fn ban_peer(&self, who: NodeIndex, reason: &str) {
@@ -838,7 +838,7 @@ fn parse_and_add_to_node_store(
 
 	let mut addr = addr_str.to_multiaddr().map_err(|_| ErrorKind::AddressParse)?;
 	let who = match addr.pop() {
-		Some(AddrComponent::P2P(key)) | Some(AddrComponent::IPFS(key)) =>
+		Some(AddrComponent::P2P(key)) =>
 			PeerId::from_bytes(key).map_err(|_| ErrorKind::AddressParse)?,
 		_ => return Err(ErrorKind::AddressParse.into()),
 	};

--- a/substrate/network-libp2p/src/timeouts.rs
+++ b/substrate/network-libp2p/src/timeouts.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use futures::{Async, future, Future, Poll, stream, Stream, sync::mpsc};
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};

--- a/substrate/network-libp2p/src/traits.rs
+++ b/substrate/network-libp2p/src/traits.rs
@@ -104,10 +104,10 @@ pub struct NetworkConfiguration {
 	pub config_path: Option<String>,
 	/// Directory path to store network-specific configuration. None means nothing will be saved
 	pub net_config_path: Option<String>,
-	/// IP address to listen for incoming connections. Listen to all connections by default
-	pub listen_address: Multiaddr,
-	/// IP address to advertise. Detected automatically if none.
-	pub public_address: Option<Multiaddr>,
+	/// Multiaddresses to listen for incoming connections.
+	pub listen_addresses: Vec<Multiaddr>,
+	/// Multiaddresses to advertise. Detected automatically if empty.
+	pub public_addresses: Vec<Multiaddr>,
 	/// List of initial node addresses
 	pub boot_nodes: Vec<String>,
 	/// Use provided node key instead of default
@@ -136,10 +136,12 @@ impl NetworkConfiguration {
 		NetworkConfiguration {
 			config_path: None,
 			net_config_path: None,
-			listen_address: iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-				.chain(iter::once(AddrComponent::TCP(30333)))
-				.collect(),
-			public_address: None,
+			listen_addresses: vec![
+				iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
+					.chain(iter::once(AddrComponent::TCP(30333)))
+					.collect()
+			],
+			public_addresses: Vec::new(),
 			boot_nodes: Vec::new(),
 			use_secret: None,
 			min_peers: 25,
@@ -153,9 +155,11 @@ impl NetworkConfiguration {
 	/// Create new default configuration for localhost-only connection with random port (useful for testing)
 	pub fn new_local() -> NetworkConfiguration {
 		let mut config = NetworkConfiguration::new();
-		config.listen_address = iter::once(AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)))
-			.chain(iter::once(AddrComponent::TCP(0)))
-			.collect();
+		config.listen_addresses = vec![
+			iter::once(AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)))
+				.chain(iter::once(AddrComponent::TCP(0)))
+				.collect()
+		];
 		config
 	}
 }

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -12,7 +12,7 @@
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.?
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use libp2p::{self, Transport, mplex, secio, yamux};
 use libp2p::core::{MuxedTransport, either, upgrade};
@@ -55,7 +55,9 @@ pub fn build_transport(
 			upgrade::map(mplex::MplexConfig::new(), either::EitherOutput::First),
 			upgrade::map(yamux::Config::default(), either::EitherOutput::Second),
 		))
-		.into_connection_reuse();
+		.map(|out, _| ((), out))
+		.into_connection_reuse()
+		.map(|((), out), _| out);
 
 	TransportTimeout::new(base, Duration::from_secs(20))
 }

--- a/substrate/network-libp2p/tests/tests.rs
+++ b/substrate/network-libp2p/tests/tests.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate parking_lot;
-extern crate ethcore_bytes;
+extern crate parity_bytes;
 extern crate ethcore_io as io;
 extern crate ethcore_logger;
 extern crate substrate_network_libp2p;
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::*;
 use parking_lot::Mutex;
-use ethcore_bytes::Bytes;
+use parity_bytes::Bytes;
 use substrate_network_libp2p::*;
 use ethkey::{Random, Generator};
 use io::TimerToken;


### PR DESCRIPTION
Backports the networking from master to v0.2, so that it is identical.
This supposedly doesn't fix much, but at least we will have a unique version of libp2p everywhere.

I just copy-pasted the content of `network-libp2p` from master to v0.2, and updated the CLI crate.

Also includes a small libp2p fix.