### PR TITLE
Backport: Upgrade to libp2p master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1160,27 +1160,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1190,20 +1190,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1211,12 +1211,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1224,16 +1224,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1245,15 +1245,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1264,20 +1264,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1291,12 +1291,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1307,13 +1307,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1322,14 +1322,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1339,11 +1339,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1352,14 +1352,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1370,32 +1370,34 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,10 +1406,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1415,25 +1417,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1442,11 +1444,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1593,19 +1595,19 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1615,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2405,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69#02576eecf140a06134519ed9438d061d99bb2e69"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88#e2960b4317b22d64c4fca7fa77c6124a44a92f88"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2870,7 +2872,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (git+https://github.com/paritytech/parity-common.git)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3688,6 +3690,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "twofish"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,7 +4044,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4100,23 +4112,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4133,9 +4145,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4198,7 +4210,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=02576eecf140a06134519ed9438d061d99bb2e69)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4267,6 +4279,7 @@ dependencies = [
 "checksum triehash 0.1.0 (git+https://github.com/paritytech/parity.git?rev=202c54d42398fc4b49d67ffbf9070522e38f9360)" = "<none>"
 "checksum triehash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2033893a813c70e7d8a739ca6c36dc0a7a2c913ec718d7cbf84a3837bbe3c7ce"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
+"checksum twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eef327f05b0d0ec1b9d7d119d8f4d9f602ceee37e0540aff8071e8e66c2e22e"
 "checksum twox-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "475352206e7a290c5fccc27624a163e8d0d115f7bb60ca18a64fc9ce056d7435"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -943,7 +943,7 @@ dependencies = [
  "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1052,7 +1052,7 @@ dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc.git)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ dependencies = [
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1218,7 +1218,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1238,7 +1238,7 @@ dependencies = [
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1257,7 +1257,7 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1283,7 +1283,7 @@ dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1300,7 +1300,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1333,7 +1333,7 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ dependencies = [
  "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1363,7 +1363,7 @@ dependencies = [
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1384,7 +1384,7 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1399,8 +1399,8 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1437,7 +1437,7 @@ dependencies = [
  "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1451,7 +1451,7 @@ dependencies = [
  "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa77c6124a44a92f88)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
 ]
 
@@ -1623,7 +1623,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2222,7 +2222,7 @@ dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2411,7 +2411,7 @@ source = "git+https://github.com/libp2p/rust-libp2p?rev=e2960b4317b22d64c4fca7fa
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2881,7 +2881,7 @@ dependencies = [
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3427,7 +3427,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3439,9 +3439,9 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3454,7 +3454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3470,7 +3470,7 @@ dependencies = [
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3509,13 +3509,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3536,7 +3536,7 @@ dependencies = [
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3550,7 +3550,7 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3563,14 +3563,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tcp"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3606,7 +3606,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3618,7 +3618,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3634,7 +3634,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3904,7 +3904,7 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3985,7 +3985,7 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -4263,11 +4263,11 @@ dependencies = [
 "checksum tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb9bf62ca2c53bf2f2faec3e48a98b6d8c9577c27011cb0203a4beacdc8ab328"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
-"checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
+"checksum tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6cc2de7725863c86ac71b0b9068476fec50834f055a243558ef1655bbd34cb"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
+"checksum tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4c329b47f071eb8a746040465fa751bd95e4716e98daef6a9b4e434c17d565"
 "checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
 "checksum tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d03fa701f9578a01b7014f106b47f0a363b4727a7f3f75d666e312ab7acbbf1c"
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "02576eecf140a06134519ed9438d061d99bb2e69", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "e2960b4317b22d64c4fca7fa77c6124a44a92f88", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git", rev = "202c54d42398fc4b49d67ffbf9070522e38f9360" }
 ethkey = { git = "https://github.com/paritytech/parity.git", rev = "202c54d42398fc4b49d67ffbf9070522e38f9360" }
 ethereum-types = "0.3"


### PR DESCRIPTION
#660 backported to v0.2.

I included a commit that upgrades tokio in the Cargo.lock to latest versions.