### PR TITLE
Backport: Reduce max backoff to 60 seconds

### DIFF
--- a/substrate/network-libp2p/src/topology.rs
+++ b/substrate/network-libp2p/src/topology.rs
@@ -46,7 +46,7 @@ const FIRST_CONNECT_FAIL_BACKOFF: Duration = Duration::from_secs(2);
 /// Every time we fail to connect to an address, multiply the backoff by this constant.
 const FAIL_BACKOFF_MULTIPLIER: u32 = 2;
 /// We need a maximum value for the backoff, overwise we risk an overflow.
-const MAX_BACKOFF: Duration = Duration::from_secs(30 * 60);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
 // TODO: should be merged with the Kademlia k-buckets
 


### PR DESCRIPTION
Even if a node doesn't respond, we try dialing it again after 1 minute, as opposed to 30 minutes before.
This is a temporary change to hopefully improve the network.