### PR TITLE
Remove requirement of function indices for decl_module!

### DIFF
--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -177,26 +177,26 @@ impl_outer_dispatch! {
 	#[derive(Clone, PartialEq, Eq)]
 	#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 	pub enum Call where aux: <Runtime as system::Trait>::PublicAux {
-		Consensus = 0,
-		Balances = 1,
-		Session = 2,
-		Staking = 3,
-		Timestamp = 4,
-		Democracy = 5,
-		Council = 6,
-		CouncilVoting = 7,
+		Consensus,
+		Balances,
+		Session,
+		Staking,
+		Timestamp,
+		Democracy,
+		Council,
+		CouncilVoting,
 	}
 
 	#[derive(Clone, PartialEq, Eq)]
 	#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 	pub enum PrivCall {
-		Consensus = 0,
-		Balances = 1,
-		Session = 2,
-		Staking = 3,
-		Democracy = 4,
-		Council = 5,
-		CouncilVoting = 6,
+		Consensus,
+		Balances,
+		Session,
+		Staking,
+		Democracy,
+		Council,
+		CouncilVoting,
 	}
 }
 

--- a/substrate/runtime/balances/src/lib.rs
+++ b/substrate/runtime/balances/src/lib.rs
@@ -136,12 +136,12 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn transfer(aux, dest: RawAddress<T::AccountId, T::AccountIndex>, value: T::Balance) -> Result = 0;
+		fn transfer(aux, dest: RawAddress<T::AccountId, T::AccountIndex>, value: T::Balance) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_balance(who: RawAddress<T::AccountId, T::AccountIndex>, free: T::Balance, reserved: T::Balance) -> Result = 0;
+		fn set_balance(who: RawAddress<T::AccountId, T::AccountIndex>, free: T::Balance, reserved: T::Balance) -> Result;
 	}
 }
 

--- a/substrate/runtime/consensus/src/lib.rs
+++ b/substrate/runtime/consensus/src/lib.rs
@@ -84,15 +84,15 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn report_misbehavior(aux, report: MisbehaviorReport<T::Hash, T::BlockNumber>) -> Result = 0;
-		fn note_offline(aux, offline_val_indices: Vec<u32>) -> Result = 1;
-		fn remark(aux, remark: Vec<u8>) -> Result = 2;
+		fn report_misbehavior(aux, report: MisbehaviorReport<T::Hash, T::BlockNumber>) -> Result;
+		fn note_offline(aux, offline_val_indices: Vec<u32>) -> Result;
+		fn remark(aux, remark: Vec<u8>) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_code(new: Vec<u8>) -> Result = 0;
-		fn set_storage(items: Vec<KeyValue>) -> Result = 1;
+		fn set_code(new: Vec<u8>) -> Result;
+		fn set_storage(items: Vec<KeyValue>) -> Result;
 	}
 }
 

--- a/substrate/runtime/contract/src/lib.rs
+++ b/substrate/runtime/contract/src/lib.rs
@@ -130,7 +130,7 @@ decl_module! {
 			value: T::Balance,
 			gas_limit: T::Gas,
 			data: Vec<u8>
-		) -> Result = 0;
+		) -> Result;
 
 		fn create(
 			aux,
@@ -138,7 +138,7 @@ decl_module! {
 			gas_limit: T::Gas,
 			ctor: Vec<u8>,
 			data: Vec<u8>
-		) -> Result = 1;
+		) -> Result;
 	}
 }
 

--- a/substrate/runtime/council/src/lib.rs
+++ b/substrate/runtime/council/src/lib.rs
@@ -110,19 +110,19 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn set_approvals(aux, votes: Vec<bool>, index: VoteIndex) -> Result = 0;
-		fn reap_inactive_voter(aux, signed_index: u32, who: Address<T::AccountId, T::AccountIndex>, who_index: u32, assumed_vote_index: VoteIndex) -> Result = 1;
-		fn retract_voter(aux, index: u32) -> Result = 2;
-		fn submit_candidacy(aux, slot: u32) -> Result = 3;
-		fn present_winner(aux, candidate: Address<T::AccountId, T::AccountIndex>, total: T::Balance, index: VoteIndex) -> Result = 4;
+		fn set_approvals(aux, votes: Vec<bool>, index: VoteIndex) -> Result;
+		fn reap_inactive_voter(aux, signed_index: u32, who: Address<T::AccountId, T::AccountIndex>, who_index: u32, assumed_vote_index: VoteIndex) -> Result;
+		fn retract_voter(aux, index: u32) -> Result;
+		fn submit_candidacy(aux, slot: u32) -> Result;
+		fn present_winner(aux, candidate: Address<T::AccountId, T::AccountIndex>, total: T::Balance, index: VoteIndex) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_desired_seats(count: u32) -> Result = 0;
-		fn remove_member(who: Address<T::AccountId, T::AccountIndex>) -> Result = 1;
-		fn set_presentation_duration(count: T::BlockNumber) -> Result = 2;
-		fn set_term_duration(count: T::BlockNumber) -> Result = 3;
+		fn set_desired_seats(count: u32) -> Result;
+		fn remove_member(who: Address<T::AccountId, T::AccountIndex>) -> Result;
+		fn set_presentation_duration(count: T::BlockNumber) -> Result;
+		fn set_term_duration(count: T::BlockNumber) -> Result;
 	}
 }
 
@@ -625,8 +625,8 @@ mod tests {
 	impl_outer_dispatch! {
 		#[derive(Debug, Clone, Eq, Serialize, Deserialize, PartialEq)]
 		pub enum Proposal {
-			Balances = 0,
-			Democracy = 1,
+			Balances,
+			Democracy,
 		}
 	}
 

--- a/substrate/runtime/council/src/voting.rs
+++ b/substrate/runtime/council/src/voting.rs
@@ -30,15 +30,15 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn propose(aux, proposal: Box<T::Proposal>) -> Result = 0;
-		fn vote(aux, proposal: T::Hash, approve: bool) -> Result = 1;
-		fn veto(aux, proposal_hash: T::Hash) -> Result = 2;
+		fn propose(aux, proposal: Box<T::Proposal>) -> Result;
+		fn vote(aux, proposal: T::Hash, approve: bool) -> Result;
+		fn veto(aux, proposal_hash: T::Hash) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_cooloff_period(blocks: T::BlockNumber) -> Result = 0;
-		fn set_voting_period(blocks: T::BlockNumber) -> Result = 1;
+		fn set_cooloff_period(blocks: T::BlockNumber) -> Result;
+		fn set_voting_period(blocks: T::BlockNumber) -> Result;
 	}
 }
 

--- a/substrate/runtime/democracy/src/lib.rs
+++ b/substrate/runtime/democracy/src/lib.rs
@@ -67,15 +67,15 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn propose(aux, proposal: Box<T::Proposal>, value: T::Balance) -> Result = 0;
-		fn second(aux, proposal: PropIndex) -> Result = 1;
-		fn vote(aux, ref_index: ReferendumIndex, approve_proposal: bool) -> Result = 2;
+		fn propose(aux, proposal: Box<T::Proposal>, value: T::Balance) -> Result;
+		fn second(aux, proposal: PropIndex) -> Result;
+		fn vote(aux, ref_index: ReferendumIndex, approve_proposal: bool) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn start_referendum(proposal: Box<T::Proposal>, vote_threshold: VoteThreshold) -> Result = 0;
-		fn cancel_referendum(ref_index: ReferendumIndex) -> Result = 1;
+		fn start_referendum(proposal: Box<T::Proposal>, vote_threshold: VoteThreshold) -> Result;
+		fn cancel_referendum(ref_index: ReferendumIndex) -> Result;
 	}
 }
 
@@ -357,8 +357,8 @@ mod tests {
 	impl_outer_dispatch! {
 		#[derive(Debug, Clone, Eq, Serialize, Deserialize, PartialEq)]
 		pub enum Proposal {
-			Balances = 0,
-			Democracy = 1,
+			Balances,
+			Democracy,
 		}
 	}
 

--- a/substrate/runtime/example/src/lib.rs
+++ b/substrate/runtime/example/src/lib.rs
@@ -100,7 +100,7 @@ decl_module! {
 	pub enum Call where aux: T::PublicAux {
 		// This is just a simple example of how to interact with the module from the external
 		// world.
-		fn accumulate_dummy(aux, increase_by: T::Balance) -> Result = 0;
+		fn accumulate_dummy(aux, increase_by: T::Balance) -> Result;
 	}
 
 	// The priviledged entry points. These are provided to allow any governance modules in 
@@ -111,7 +111,7 @@ decl_module! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
 		// A priviledged call; in this case it resets our dummy value to something new.
-		fn set_dummy(new_dummy: T::Balance) -> Result = 0;
+		fn set_dummy(new_dummy: T::Balance) -> Result;
 	}
 }
 

--- a/substrate/runtime/session/src/lib.rs
+++ b/substrate/runtime/session/src/lib.rs
@@ -79,13 +79,13 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn set_key(aux, key: T::SessionKey) -> Result = 0;
+		fn set_key(aux, key: T::SessionKey) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_length(new: T::BlockNumber) -> Result = 0;
-		fn force_new_session(apply_rewards: bool) -> Result = 1;
+		fn set_length(new: T::BlockNumber) -> Result;
+		fn force_new_session(apply_rewards: bool) -> Result;
 	}
 }
 

--- a/substrate/runtime/staking/src/lib.rs
+++ b/substrate/runtime/staking/src/lib.rs
@@ -109,20 +109,20 @@ decl_module! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	#[cfg_attr(feature = "std", serde(bound(deserialize = "T::Balance: ::serde::de::DeserializeOwned")))]
 	pub enum Call where aux: T::PublicAux {
-		fn stake(aux) -> Result = 0;
-		fn unstake(aux, intentions_index: u32) -> Result = 1;
-		fn nominate(aux, target: Address<T::AccountId, T::AccountIndex>) -> Result = 2;
-		fn unnominate(aux, target_index: u32) -> Result = 3;
-		fn register_preferences(aux, intentions_index: u32, prefs: ValidatorPrefs<T::Balance>) -> Result = 4;
+		fn stake(aux) -> Result;
+		fn unstake(aux, intentions_index: u32) -> Result;
+		fn nominate(aux, target: Address<T::AccountId, T::AccountIndex>) -> Result;
+		fn unnominate(aux, target_index: u32) -> Result;
+		fn register_preferences(aux, intentions_index: u32, prefs: ValidatorPrefs<T::Balance>) -> Result;
 	}
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
-		fn set_sessions_per_era(new: T::BlockNumber) -> Result = 0;
-		fn set_bonding_duration(new: T::BlockNumber) -> Result = 1;
-		fn set_validator_count(new: u32) -> Result = 2;
-		fn force_new_era(apply_rewards: bool) -> Result = 3;
-		fn set_offline_slash_grace(new: u32) -> Result = 4;
+		fn set_sessions_per_era(new: T::BlockNumber) -> Result;
+		fn set_bonding_duration(new: T::BlockNumber) -> Result;
+		fn set_validator_count(new: u32) -> Result;
+		fn force_new_era(apply_rewards: bool) -> Result;
+		fn set_offline_slash_grace(new: u32) -> Result;
 	}
 }
 

--- a/substrate/runtime/timestamp/src/lib.rs
+++ b/substrate/runtime/timestamp/src/lib.rs
@@ -56,7 +56,7 @@ decl_module! {
 
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum Call where aux: T::PublicAux {
-		fn set(aux, now: T::Moment) -> Result = 0;
+		fn set(aux, now: T::Moment) -> Result;
 	}
 }
 

--- a/substrate/runtime/treasury/src/lib.rs
+++ b/substrate/runtime/treasury/src/lib.rs
@@ -70,7 +70,7 @@ decl_module! {
 		// Put forward a suggestion for spending. A deposit proportional to the value
 		// is reserved and slashed if the proposal is rejected. It is returned once the
 		// proposal is awarded.
-		fn propose_spend(aux, value: T::Balance, beneficiary: T::AccountId) -> Result = 0;
+		fn propose_spend(aux, value: T::Balance, beneficiary: T::AccountId) -> Result;
 	}
 
 	// The priviledged entry points. These are provided to allow any governance modules in 
@@ -81,17 +81,17 @@ decl_module! {
 	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 	pub enum PrivCall {
 		// Set the balance of funds available to spend.
-		fn set_pot(new_pot: T::Balance) -> Result = 0;
+		fn set_pot(new_pot: T::Balance) -> Result;
 
 		// (Re-)configure this module.
-		fn configure(proposal_bond: Permill, proposal_bond_minimum: T::Balance, spend_period: T::BlockNumber, burn: Permill) -> Result = 1;
+		fn configure(proposal_bond: Permill, proposal_bond_minimum: T::Balance, spend_period: T::BlockNumber, burn: Permill) -> Result;
 
 		// Reject a proposed spend. The original deposit will be slashed.
-		fn reject_proposal(proposal_id: ProposalIndex) -> Result = 2;
+		fn reject_proposal(proposal_id: ProposalIndex) -> Result;
 
 		// Approve a proposal. At a later time, the proposal will be allocated to the beneficiary
 		// and the original deposit will be returned.
-		fn approve_proposal(proposal_id: ProposalIndex) -> Result = 3;
+		fn approve_proposal(proposal_id: ProposalIndex) -> Result;
 	}
 }
 


### PR DESCRIPTION
With this patch, the `decl_module!` macro does not require function indices.
This implementation has two drawbacks:
1. The json function id looks like `"0 + 1 + 1"` for the second index. Its not that huge problem, as the sum should be easily implementable in javascript.
2. The encoder and decoder implementations switch from using `match` to `if`s. This could have some impact on the performance.