### PR TITLE
Update to latest libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -436,7 +436,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -942,7 +942,7 @@ dependencies = [
  "relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1051,7 +1051,7 @@ dependencies = [
  "jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc.git)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1139,160 +1139,160 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-uds 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,92 +1301,94 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1394,41 +1396,41 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
 ]
 
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.1.0 (git+https://github.com/paritytech/yamux)",
 ]
 
@@ -1570,19 +1572,19 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1592,14 +1594,14 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2145,11 +2147,11 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e#a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e"
+source = "git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5#8ac9b65e669ebbd9deeffa9d4566c95f631cfed5"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2622,7 +2624,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)",
+ "libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2631,9 +2633,9 @@ dependencies = [
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3264,7 +3266,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3276,9 +3278,9 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3291,7 +3293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3307,7 +3309,7 @@ dependencies = [
  "scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3346,13 +3348,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3373,7 +3375,7 @@ dependencies = [
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3387,7 +3389,7 @@ dependencies = [
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3400,14 +3402,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tcp"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3443,7 +3445,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3455,7 +3457,7 @@ dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3471,7 +3473,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3513,6 +3515,16 @@ dependencies = [
 name = "try-lock"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "twofish"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "twox-hash"
@@ -3608,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "unsigned-varint"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3711,7 +3723,28 @@ dependencies = [
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "websocket"
+version = "0.20.3"
+source = "git+https://github.com/tomaka/rust-websocket?branch=send#28ea5eb82b573bf3ace2fc75c36d791bcedf08b1"
+dependencies = [
+ "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3792,7 +3825,7 @@ dependencies = [
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -3850,7 +3883,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
@@ -3916,23 +3949,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -3949,9 +3982,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4015,7 +4048,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=a6c82e6ca17ba5afc6e0aa849acb54bbb32d7e8e)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/tomaka/libp2p-rs?rev=8ac9b65e669ebbd9deeffa9d4566c95f631cfed5)" = "<none>"
 "checksum safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f7bf422d23a88c16d5090d455f182bc99c60af4df6a345c63428acf5129e347"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
@@ -4069,11 +4102,11 @@ dependencies = [
 "checksum tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb9bf62ca2c53bf2f2faec3e48a98b6d8c9577c27011cb0203a4beacdc8ab328"
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
-"checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
+"checksum tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6cc2de7725863c86ac71b0b9068476fec50834f055a243558ef1655bbd34cb"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
+"checksum tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b4c329b47f071eb8a746040465fa751bd95e4716e98daef6a9b4e434c17d565"
 "checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
 "checksum tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d03fa701f9578a01b7014f106b47f0a363b4727a7f3f75d666e312ab7acbbf1c"
 "checksum tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "772f4b04e560117fe3b0a53e490c16ddc8ba6ec437015d91fa385564996ed913"
@@ -4084,6 +4117,7 @@ dependencies = [
 "checksum transaction-pool 1.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fdb8870eea404a57e2f62056ac45067a53a6207fd31866122356481d3c2e1a30"
 "checksum triehash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3da77dc2c88bac48769c53f2c7675d99d522a7fc8130da3fadf29d7c6f94c9ac"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
+"checksum twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eef327f05b0d0ec1b9d7d119d8f4d9f602ceee37e0540aff8071e8e66c2e22e"
 "checksum twox-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "475352206e7a290c5fccc27624a163e8d0d115f7bb60ca18a64fc9ce056d7435"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
@@ -4097,7 +4131,7 @@ dependencies = [
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum unsigned-varint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9d184b340077c4fdf63bc884a71c3c7d01e905167daf9003eb8131aaddb605"
+"checksum unsigned-varint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8abc4b7d8158bdfbbaaccc35331ed3c30c2673e99000d7ae665a2eb6576f4"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
@@ -4110,6 +4144,7 @@ dependencies = [
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum wasmi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "522fe3fdd44a56f25cd5ddcd8ccdb1cf2e982ceb28fcb00f41d8a018ae5245a8"
 "checksum websocket 0.20.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eb277e7f4c23dc49176f74ae200e77651764efb2c25f56ad2d22623b63826369"
+"checksum websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "e2960b4317b22d64c4fca7fa77c6124a44a92f88", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/tomaka/libp2p-rs", rev = "8ac9b65e669ebbd9deeffa9d4566c95f631cfed5", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 ethkey = { git = "https://github.com/paritytech/parity.git" }
 ethereum-types = "0.3"
@@ -25,7 +25,7 @@ serde_json = "1.0.24"
 tokio = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2"
-unsigned-varint = { version = "0.2", features = ["codec"] }
+unsigned-varint = { version = "0.2.1", features = ["codec"] }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/substrate/network-libp2p/src/custom_proto.rs
+++ b/substrate/network-libp2p/src/custom_proto.rs
@@ -64,7 +64,7 @@ pub struct RegisteredProtocolOutput<T> {
 
 	/// Stream where incoming messages are received. The stream ends whenever
 	/// either side is closed.
-	pub incoming: Box<Stream<Item = (PacketId, Bytes), Error = IoError>>,
+	pub incoming: Box<Stream<Item = (PacketId, Bytes), Error = IoError> + Send>,
 }
 
 impl<T> RegisteredProtocol<T> {
@@ -101,8 +101,8 @@ impl<T> RegisteredProtocol<T> {
 
 // `Maf` is short for `MultiaddressFuture`
 impl<T, C, Maf> ConnectionUpgrade<C, Maf> for RegisteredProtocol<T>
-where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
-	Maf: Future<Item = Multiaddr, Error = IoError> + 'static,		// TODO: 'static :(
+where C: AsyncRead + AsyncWrite + Send + 'static,		// TODO: 'static :-/
+	Maf: Future<Item = Multiaddr, Error = IoError> + Send + 'static,		// TODO: 'static :(
 {
 	type NamesIter = VecIntoIter<(Bytes, Self::UpgradeIdentifier)>;
 	type UpgradeIdentifier = u8;		// Protocol version
@@ -252,8 +252,8 @@ impl<T> Default for RegisteredProtocols<T> {
 }
 
 impl<T, C, Maf> ConnectionUpgrade<C, Maf> for RegisteredProtocols<T>
-where C: AsyncRead + AsyncWrite + 'static,		// TODO: 'static :-/
-	Maf: Future<Item = Multiaddr, Error = IoError> + 'static,		// TODO: 'static :(
+where C: AsyncRead + AsyncWrite + Send + 'static,		// TODO: 'static :-/
+	Maf: Future<Item = Multiaddr, Error = IoError> + Send + 'static,		// TODO: 'static :(
 {
 	type NamesIter = VecIntoIter<(Bytes, Self::UpgradeIdentifier)>;
 	type UpgradeIdentifier = (usize,

--- a/substrate/network-libp2p/src/transport.rs
+++ b/substrate/network-libp2p/src/transport.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use libp2p::{self, PeerId, Transport, mplex, secio, yamux};
-use libp2p::core::{MuxedTransport, either, upgrade};
+use libp2p::core::{either, upgrade, transport::BoxedMuxed};
 use libp2p::transport_timeout::TransportTimeout;
 use std::time::Duration;
 use std::usize;
@@ -24,7 +24,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 /// Builds the transport that serves as a common ground for all connections.
 pub fn build_transport(
 	local_private_key: secio::SecioKeyPair
-) -> impl MuxedTransport<Output = (PeerId, impl AsyncRead + AsyncWrite)> + Clone {
+) -> BoxedMuxed<(PeerId, impl AsyncRead + AsyncWrite)> {
 	let mut mplex_config = mplex::MplexConfig::new();
 	mplex_config.max_buffer_len_behaviour(mplex::MaxBufferBehaviour::Block);
 	mplex_config.max_buffer_len(usize::MAX);
@@ -46,4 +46,5 @@ pub fn build_transport(
 		.map(|(key, substream), _| (key.into_peer_id(), substream));
 
 	TransportTimeout::new(base, Duration::from_secs(20))
+		.boxed_muxed()
 }


### PR DESCRIPTION
There are a lot of changes because we now require `Send` everywhere.
Eventually these `Send` requirements will disappear again once libp2p gets more work.

Note that since the master branch doesn't compile anymore on my machine, I'm a bit blind.
However the same changes ported to branch v0.2 worked.