### PR TITLE
Contracts: return arbitrary sized buffers

### DIFF
--- a/srml/contract/src/exec.rs
+++ b/srml/contract/src/exec.rs
@@ -24,13 +24,13 @@ use runtime_primitives::traits::{Zero, CheckedAdd, CheckedSub};
 use runtime_support::{StorageMap, StorageValue};
 use balances::{self, EnsureAccountLiquid};
 
+// TODO: Add logs
 pub struct CreateReceipt<T: Trait> {
 	pub address: T::AccountId,
 }
 
-pub struct CallReceipt {
-	pub return_data: Vec<u8>,
-}
+// TODO: Add logs.
+pub struct CallReceipt;
 
 pub struct ExecutionContext<'a, T: Trait + 'a> {
 	// typically should be dest
@@ -48,6 +48,7 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 		value: T::Balance,
 		gas_meter: &mut GasMeter<T>,
 		data: &[u8],
+		output_data: &mut Vec<u8>,
 	) -> Result<CallReceipt, &'static str> {
 		if self.depth == <MaxDepth<T>>::get() as usize {
 			return Err("reached maximum depth, cannot make a call");
@@ -60,7 +61,7 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 
 		let dest_code = <CodeOf<T>>::get(&dest);
 
-		let (exec_result, change_set) = {
+		let change_set = {
 			let mut overlay = OverlayAccountDb::new(&self.overlay);
 
 			if value > T::Balance::zero() {
@@ -79,31 +80,26 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 				self_account: dest.clone(),
 				depth: self.depth + 1,
 			};
-			let exec_result = if !dest_code.is_empty() {
+
+			if !dest_code.is_empty() {
 				vm::execute(
 					&dest_code,
 					data,
+					output_data,
 					&mut CallContext {
 						ctx: &mut nested,
 						_caller: caller,
 					},
 					gas_meter,
-				).map_err(|_| "vm execute returned error while call")?
-			} else {
-				// that was a plain transfer
-				vm::ExecutionResult {
-					return_data: Vec::new(),
-				}
-			};
+				).map_err(|_| "vm execute returned error while call")?;
+			}
 
-			(exec_result, nested.overlay.into_change_set())
+			nested.overlay.into_change_set()
 		};
 
 		self.overlay.commit(change_set);
 
-		Ok(CallReceipt {
-			return_data: exec_result.return_data,
-		})
+		Ok(CallReceipt)
 	}
 
 	pub fn create(
@@ -148,19 +144,20 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 				self_account: dest.clone(),
 				depth: self.depth + 1,
 			};
-			let exec_result = {
-				vm::execute(
-					ctor,
-					data,
-					&mut CallContext {
-						ctx: &mut nested,
-						_caller: caller,
-					},
-					gas_meter,
-				).map_err(|_| "vm execute returned error while create")?
-			};
 
-			nested.overlay.set_code(&dest, exec_result.return_data);
+			let mut contract_code = Vec::new();
+			vm::execute(
+				ctor,
+				data,
+				&mut contract_code,
+				&mut CallContext {
+					ctx: &mut nested,
+					_caller: caller,
+				},
+				gas_meter,
+			).map_err(|_| "vm execute returned error while create")?;
+
+			nested.overlay.set_code(&dest, contract_code);
 			nested.overlay.into_change_set()
 		};
 
@@ -257,10 +254,12 @@ impl<'a, 'b: 'a, T: Trait + 'b> vm::Ext for CallContext<'a, 'b, T> {
 		value: T::Balance,
 		gas_meter: &mut GasMeter<T>,
 		data: &[u8],
-	) -> Result<CallReceipt, ()> {
+		output_data: &mut Vec<u8>,
+	) -> Result<(), ()> {
 		let caller = self.ctx.self_account.clone();
 		self.ctx
-			.call(caller, to.clone(), value, gas_meter, data)
+			.call(caller, to.clone(), value, gas_meter, data, output_data)
 			.map_err(|_| ())
+			.map(|_| ())
 	}
 }

--- a/srml/contract/src/exec.rs
+++ b/srml/contract/src/exec.rs
@@ -107,7 +107,7 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 		caller: T::AccountId,
 		endowment: T::Balance,
 		gas_meter: &mut GasMeter<T>,
-		ctor: &[u8],
+		init_code: &[u8],
 		data: &[u8],
 	) -> Result<CreateReceipt<T>, &'static str> {
 		if self.depth == <MaxDepth<T>>::get() as usize {
@@ -119,7 +119,7 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 			return Err("not enough gas to pay base create fee");
 		}
 
-		let dest = T::DetermineContractAddress::contract_address_for(ctor, data, &self.self_account);
+		let dest = T::DetermineContractAddress::contract_address_for(init_code, data, &self.self_account);
 		if <CodeOf<T>>::exists(&dest) {
 			// TODO: Is it enough?
 			return Err("contract already exists");
@@ -147,7 +147,7 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 
 			let mut contract_code = Vec::new();
 			vm::execute(
-				ctor,
+				init_code,
 				data,
 				&mut contract_code,
 				&mut CallContext {

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -163,7 +163,7 @@ decl_module! {
 			origin,
 			value: T::Balance,
 			gas_limit: T::Gas,
-			ctor: Vec<u8>,
+			init_code: Vec<u8>,
 			data: Vec<u8>
 		) -> Result;
 	}

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -227,7 +227,9 @@ impl<T: Trait> Module<T> {
 			depth: 0,
 			overlay: OverlayAccountDb::<T>::new(&account_db::DirectAccountDb),
 		};
-		let result = ctx.call(origin.clone(), dest, value, &mut gas_meter, &data);
+
+		let mut output_data = Vec::new();
+		let result = ctx.call(origin.clone(), dest, value, &mut gas_meter, &data, &mut output_data);
 
 		if let Ok(_) = result {
 			// Commit all changes that made it thus far into the persistant storage.

--- a/srml/contract/src/tests.rs
+++ b/srml/contract/src/tests.rs
@@ -414,7 +414,7 @@ fn top_level_create() {
 		));
 
 		// 11 - value sent with the transaction
-		// (3 * 129) - gas spent by the ctor
+		// (3 * 129) - gas spent by the init_code.
 		// (3 * 175) - base gas fee for create (175) (top level) multipled by gas price (3)
 		// ((21 / 3) * 3) - price for contract creation
 		assert_eq!(

--- a/srml/contract/src/vm/mod.rs
+++ b/srml/contract/src/vm/mod.rs
@@ -116,7 +116,6 @@ pub enum Error {
 /// In this runtime traps used not only for signaling about errors but also
 /// to just terminate quickly in some cases.
 enum SpecialTrap {
-	// TODO: Can we pass wrapped memory instance instead of copying?
 	/// Signals that trap was generated in response to call `ext_return` host function.
 	Return,
 }

--- a/srml/contract/src/vm/mod.rs
+++ b/srml/contract/src/vm/mod.rs
@@ -17,10 +17,10 @@
 //! This module provides a means for executing contracts
 //! represented in wasm.
 
-use exec::{CallReceipt, CreateReceipt};
+use exec::{CreateReceipt};
 use gas::{GasMeter, GasMeterResult};
 use rstd::prelude::*;
-use runtime_primitives::traits::{As, CheckedMul};
+use runtime_primitives::traits::As;
 use {sandbox, balances, system};
 use Trait;
 
@@ -67,7 +67,8 @@ pub trait Ext {
 		value: BalanceOf<Self::T>,
 		gas_meter: &mut GasMeter<Self::T>,
 		data: &[u8],
-	) -> Result<CallReceipt, ()>;
+		output_data: &mut Vec<u8>,
+	) -> Result<(), ()>;
 }
 
 /// Error that can occur while preparing or executing wasm smart-contract.
@@ -117,12 +118,13 @@ pub enum Error {
 enum SpecialTrap {
 	// TODO: Can we pass wrapped memory instance instead of copying?
 	/// Signals that trap was generated in response to call `ext_return` host function.
-	Return(Vec<u8>),
+	Return,
 }
 
 pub(crate) struct Runtime<'a, 'data, E: Ext + 'a> {
 	ext: &'a mut E,
 	input_data: &'data [u8],
+	output_data: &'data mut Vec<u8>,
 	scratch_buf: Vec<u8>,
 	config: &'a Config<E::T>,
 	memory: sandbox::Memory,
@@ -133,68 +135,35 @@ impl<'a, 'data, E: Ext + 'a> Runtime<'a, 'data, E> {
 	fn memory(&self) -> &sandbox::Memory {
 		&self.memory
 	}
-	/// Save a data buffer as a result of the execution.
-	///
-	/// This function also charges gas for the returning.
-	///
-	/// Returns `Err` if there is not enough gas.
-	fn store_return_data(&mut self, data: Vec<u8>) -> Result<(), ()> {
-		let data_len = <<<E as Ext>::T as Trait>::Gas as As<u64>>::sa(data.len() as u64);
-		let price = (self.config.return_data_per_byte_cost)
-			.checked_mul(&data_len)
-			.ok_or_else(|| ())?;
-
-		match self.gas_meter.charge(price) {
-			GasMeterResult::Proceed => {
-				self.special_trap = Some(SpecialTrap::Return(data));
-				Ok(())
-			}
-			GasMeterResult::OutOfGas => Err(()),
-		}
-	}
 }
 
 fn to_execution_result<E: Ext>(
 	runtime: Runtime<E>,
 	run_err: Option<sandbox::Error>,
-) -> Result<ExecutionResult, Error> {
+) -> Result<(), Error> {
 	// Check the exact type of the error. It could be plain trap or
 	// special runtime trap the we must recognize.
-	let return_data = match (run_err, runtime.special_trap) {
+	match (run_err, runtime.special_trap) {
 		// No traps were generated. Proceed normally.
-		(None, None) => Vec::new(),
+		(None, None) => Ok(()),
 		// Special case. The trap was the result of the execution `return` host function.
-		(Some(sandbox::Error::Execution), Some(SpecialTrap::Return(rd))) => rd,
+		(Some(sandbox::Error::Execution), Some(SpecialTrap::Return)) => Ok(()),
 		// Any other kind of a trap should result in a failure.
-		(Some(_), _) => return Err(Error::Invoke),
+		(Some(_), _) => Err(Error::Invoke),
 		// Any other case (such as special trap flag without actual trap) signifies
 		// a logic error.
 		_ => unreachable!(),
-	};
-
-	Ok(ExecutionResult { return_data })
-}
-
-/// The result of execution of a smart-contract.
-#[derive(PartialEq, Eq)]
-#[cfg_attr(feature = "std", derive(Debug))]
-pub struct ExecutionResult {
-	/// The result produced by the execution of the contract.
-	///
-	/// The contract can designate some buffer at the execution time via a special function.
-	/// If contract called this function with non-empty buffer it will be copied here.
-	///
-	/// Note that gas is already charged for returning the data.
-	pub return_data: Vec<u8>,
+	}
 }
 
 /// Execute the given code as a contract.
 pub fn execute<'a, E: Ext>(
 	code: &[u8],
 	input_data: &[u8],
+	output_data: &mut Vec<u8>,
 	ext: &'a mut E,
 	gas_meter: &mut GasMeter<E::T>,
-) -> Result<ExecutionResult, Error> {
+) -> Result<(), Error> {
 	let config = Config::default();
 	let env = env_def::init_env();
 
@@ -212,6 +181,7 @@ pub fn execute<'a, E: Ext>(
 	let mut runtime = Runtime {
 		ext,
 		input_data,
+		output_data,
 		config: &config,
 		scratch_buf: Vec::new(),
 		memory,
@@ -324,7 +294,8 @@ mod tests {
 			value: u64,
 			gas_meter: &mut GasMeter<Test>,
 			data: &[u8],
-		) -> Result<CallReceipt, ()> {
+			_output_data: &mut Vec<u8>,
+		) -> Result<(), ()> {
 			self.transfers.push(TransferEntry {
 				to: *to,
 				value,
@@ -333,9 +304,7 @@ mod tests {
 			});
 			// Assume for now that it was just a plain transfer.
 			// TODO: Add tests for different call outcomes.
-			Ok(CallReceipt {
-				return_data: Vec::new(),
-			})
+			Ok(())
 		}
 	}
 
@@ -384,6 +353,7 @@ mod tests {
 		execute(
 			&code_transfer,
 			&[],
+			&mut Vec::new(),
 			&mut mock_ext,
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();
@@ -445,6 +415,7 @@ mod tests {
 		execute(
 			&code_create,
 			&[],
+			&mut Vec::new(),
 			&mut mock_ext,
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();
@@ -483,6 +454,7 @@ mod tests {
 			execute(
 				&code_mem,
 				&[],
+				&mut Vec::new(),
 				&mut mock_ext,
 				&mut GasMeter::with_limit(100_000, 1)
 			),
@@ -535,6 +507,7 @@ mod tests {
 		execute(
 			&code_transfer,
 			&[],
+			&mut Vec::new(),
 			&mut mock_ext,
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();

--- a/srml/contract/src/vm/mod.rs
+++ b/srml/contract/src/vm/mod.rs
@@ -48,7 +48,6 @@ pub trait Ext {
 	/// Sets the storage entry by the given key to the specified value.
 	fn set_storage(&mut self, key: &[u8], value: Option<Vec<u8>>);
 
-	// TODO: Return the address of the created contract.
 	/// Create a new account for a contract.
 	///
 	/// The newly created account will be associated with the `code`. `value` specifies the amount of value
@@ -124,6 +123,7 @@ enum SpecialTrap {
 pub(crate) struct Runtime<'a, 'data, E: Ext + 'a> {
 	ext: &'a mut E,
 	input_data: &'data [u8],
+	scratch_buf: Vec<u8>,
 	config: &'a Config<E::T>,
 	memory: sandbox::Memory,
 	gas_meter: &'a mut GasMeter<E::T>,
@@ -213,6 +213,7 @@ pub fn execute<'a, E: Ext>(
 		ext,
 		input_data,
 		config: &config,
+		scratch_buf: Vec::new(),
 		memory,
 		gas_meter,
 		special_trap: None,


### PR DESCRIPTION
Several contract runtime functions require to return arbitrary sized buffers. These functions are:

1. `ext_get_storage`. This PR lifts the limitation on the storage value size. Now it can be arbitrary long. Thus, the length of the buffer that `ext_get_storage` returns needs to be arbitrary long too.
2. `ext_call`. Callee can return a buffer of arbitrary size.
3. `ext_create`. Returns the address (or rather `T::AccountId`) of the created contract. Typically, it is of fixed sized, but we still have to treat it as of arbitrary size since the value depends on the result of `T::AccountId::encode` (after all, nothing prevents it from returning vectors of different sizes).

so, there is a clearly need for returning arbitrary sized buffers from the contract runtime functions. I reviewed a few possible approaches how to implement this pattern but settled on this one. It goes like this:

1. Add a buffer to the execution context of the contract, let's call it `scratch_buf`.
2. Expose functions for reading contents of `scratch_buf`: `ext_scratch_size` and `ext_scratch_copy`.
3. Each function that needs to return an arbitrary sized buffer writes it's result to the `scratch_buf`.

After executing a function that returns arbitrary sized buffer the contract can copy the buffer to the contract's memory calling `ext_scratch_copy`.

Also, this PR makes an optimization: the return buffer returned with `ext_return` now is written to the designated buffer (instead of allocating a new one). `ext_call` passes `ctx.scratch_buf` as a designated buffer, so there is no intermediate buffer.
