### PR TITLE
Check if `cargo` already from nighlty in wasm build scripts

### DIFF
--- a/core/executor/wasm/build.sh
+++ b/core/executor/wasm/build.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-cargo +nightly build --target=wasm32-unknown-unknown --release
+if cargo --version | grep -q "nightly"; then
+	CARGO_CMD="cargo"
+else
+	CARGO_CMD="cargo +nightly"
+fi
+$CARGO_CMD build --target=wasm32-unknown-unknown --release
 for i in test
 do
 	wasm-gc target/wasm32-unknown-unknown/release/runtime_$i.wasm target/wasm32-unknown-unknown/release/runtime_$i.compact.wasm

--- a/core/test-runtime/wasm/build.sh
+++ b/core/test-runtime/wasm/build.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-cargo +nightly build --target=wasm32-unknown-unknown --release
+if cargo --version | grep -q "nightly"; then
+	CARGO_CMD="cargo"
+else
+	CARGO_CMD="cargo +nightly"
+fi
+$CARGO_CMD build --target=wasm32-unknown-unknown --release
 for i in substrate_test_runtime
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm

--- a/node/runtime/wasm/build.sh
+++ b/node/runtime/wasm/build.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-cargo +nightly build --target=wasm32-unknown-unknown --release
+if cargo --version | grep -q "nightly"; then
+	CARGO_CMD="cargo"
+else
+	CARGO_CMD="cargo +nightly"
+fi
+$CARGO_CMD build --target=wasm32-unknown-unknown --release
 for i in node_runtime
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm


### PR DESCRIPTION
This is required for environments where `rust` is not installed via `rustup`.
In my case, I work in such an environment and get the following error for `cargo +nightly`:
`error: no such subcommand:  +nightly`