### PR TITLE
bugfix: balances::transfer for new_account issue#722

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,11 +305,6 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "crossbeam"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +387,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -423,11 +418,6 @@ dependencies = [
 [[package]]
 name = "dtoa"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "edit-distance"
-version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -487,49 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethcore-crypto"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#4145be863bec10038fc0ac5d36a41365b5087344"
-dependencies = [
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethcore-io"
-version = "1.12.0"
-source = "git+https://github.com/paritytech/parity.git#4145be863bec10038fc0ac5d36a41365b5087344"
-dependencies = [
- "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "timer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethcore-logger"
-version = "1.12.0"
-source = "git+https://github.com/paritytech/parity.git#4145be863bec10038fc0ac5d36a41365b5087344"
-dependencies = [
- "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ethereum-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,28 +509,6 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethkey"
-version = "0.3.0"
-source = "git+https://github.com/paritytech/parity.git#4145be863bec10038fc0ac5d36a41365b5087344"
-dependencies = [
- "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
- "ethcore-crypto 0.1.0 (git+https://github.com/paritytech/parity.git)",
- "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "mem 0.1.0 (git+https://github.com/paritytech/parity.git)",
- "parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -831,14 +756,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,27 +903,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,20 +933,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1037,12 +954,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1050,16 +967,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1071,15 +988,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1090,20 +1007,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1117,12 +1034,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1133,13 +1050,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1148,14 +1065,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1165,11 +1082,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1178,14 +1095,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,19 +1113,19 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1216,12 +1133,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1230,10 +1147,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1241,25 +1158,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
@@ -1268,11 +1185,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1323,11 +1240,6 @@ dependencies = [
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "mem"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/parity.git#4145be863bec10038fc0ac5d36a41365b5087344"
 
 [[package]]
 name = "memchr"
@@ -1417,19 +1329,19 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "integer-encoding 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1439,7 +1351,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1814,16 +1726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-wordlist"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346#304e9c72c88bc97824f2734dc19d1b5f4556d346"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de#5980a4538ef6fc8af450893acb01290eaed136de"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2790,6 +2692,7 @@ dependencies = [
  "substrate-client 0.1.0",
  "substrate-network 0.1.0",
  "substrate-network-libp2p 0.1.0",
+ "substrate-primitives 0.1.0",
  "substrate-service 0.3.0",
  "substrate-telemetry 0.3.0",
  "sysinfo 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2942,7 +2845,6 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-io 1.12.0 (git+https://github.com/paritytech/parity.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2965,14 +2867,11 @@ dependencies = [
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-io 1.12.0 (git+https://github.com/paritytech/parity.git)",
- "ethcore-logger 1.12.0 (git+https://github.com/paritytech/parity.git)",
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethkey 0.3.0 (git+https://github.com/paritytech/parity.git)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3272,14 +3171,6 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3900,7 +3791,6 @@ dependencies = [
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
-"checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -3910,25 +3800,20 @@ dependencies = [
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "630391922b1b893692c6334369ff528dcc3a9d8061ccf4c803aa8f83cb13db5e"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum edit-distance 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3bd26878c3d921f89797a4e1a1711919f999a9f6946bb6f5a4ffda126d297b7e"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum elastic-array 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4851b005ef16de812ea9acdb7bece2f0a40dd86c07b85631d7dafa54537bb"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)" = "<none>"
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
-"checksum ethcore-crypto 0.1.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
-"checksum ethcore-io 1.12.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
-"checksum ethcore-logger 1.12.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
 "checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
 "checksum ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "35b3c5a18bc5e73a32a110ac743ec04b02bbbcd3b71d3118d40a6113d509378a"
 "checksum ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac59a21a9ce98e188f3dace9eb67a6c4a3c67ec7fbc7218cb827852679dc002"
-"checksum ethkey 0.3.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
 "checksum etrace 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5a3eb49b4ae7e88cc23caa812e8072c9f83a3e202e0b789ff4f9319cf796d8ca"
 "checksum exit-future 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa7b56cef68c4182db7212dece19cc9f6e2916cf9412e57e6cea53ec02f316d"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -3959,7 +3844,6 @@ dependencies = [
 "checksum integer-sqrt 0.1.0 (git+https://github.com/paritytech/integer-sqrt-rs.git)" = "<none>"
 "checksum interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum jsonrpc-core 8.0.2 (git+https://github.com/paritytech/jsonrpc.git)" = "<none>"
 "checksum jsonrpc-http-server 8.0.1 (git+https://github.com/paritytech/jsonrpc.git)" = "<none>"
@@ -3976,30 +3860,29 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
-"checksum mem 0.1.0 (git+https://github.com/paritytech/parity.git)" = "<none>"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
@@ -4009,9 +3892,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4031,7 +3914,6 @@ dependencies = [
 "checksum parity-rocksdb-sys 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae07d4bfb2759541957c19f471996b807fc09ef3a5bdce14409b57f038de49f"
 "checksum parity-snappy-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c2086caac40c79289cb70d7e1c64f5888e1c53f5d38399d3e95101493739f423"
 "checksum parity-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1c91199d14bd5b78ecade323d4a891d094799749c1b9e82d9c590c2e2849a40"
-"checksum parity-wordlist 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0dec124478845b142f68b446cbee953d14d4b41f1bc0425024417720dce693"
 "checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 "checksum parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4d05f1349491390b1730afba60bb20d55761bef489a954546b58b4b34e1e2ac"
 "checksum parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "901d6514273469bb17380c1ac3f51fb3ce54be1f960e51a6f04901eba313ab8d"
@@ -4075,7 +3957,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=304e9c72c88bc97824f2734dc19d1b5f4556d346)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=5980a4538ef6fc8af450893acb01290eaed136de)" = "<none>"
 "checksum safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f7bf422d23a88c16d5090d455f182bc99c60af4df6a345c63428acf5129e347"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
@@ -4118,7 +4000,6 @@ dependencies = [
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum timer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
 "checksum tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e9175261fbdb60781fcd388a4d6cc7e14764a2b629a7ad94abb439aed223a44f"
 "checksum tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dec7ba6a80b7695fc2abb21af18bed445a362ffd80b64704771ce142d6d2151d"
 "checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -27,6 +27,7 @@ substrate-client = { path = "../../core/client" }
 substrate-network = { path = "../../core/network" }
 substrate-network-libp2p = { path = "../../core/network-libp2p" }
 sr-primitives = { path = "../../core/sr-primitives" }
+substrate-primitives = { path = "../../core/primitives" }
 substrate-service = { path = "../../core/service" }
 substrate-telemetry = { path = "../../core/telemetry" }
 names = "0.11.0"

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -39,6 +39,7 @@ extern crate substrate_network as network;
 extern crate substrate_network_libp2p as network_libp2p;
 extern crate sr_primitives as runtime_primitives;
 extern crate substrate_service as service;
+extern crate substrate_primitives as primitives;
 #[macro_use]
 extern crate slog;	// needed until we can reexport `slog_info` from `substrate_telemetry`
 #[macro_use]
@@ -64,6 +65,7 @@ use service::{
 	FactoryGenesis, PruningMode, ChainSpec,
 };
 use network::NonReservedPeerMode;
+use primitives::H256;
 
 use std::io::{Write, Read, stdin, stdout};
 use std::iter;
@@ -71,6 +73,7 @@ use std::fs;
 use std::fs::File;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use names::{Generator, Name};
 use regex::Regex;
 
@@ -311,8 +314,8 @@ where
 		config.network.public_addresses = Vec::new();
 
 		config.network.client_version = config.client_id();
-		config.network.use_secret = match matches.value_of("node-key").map(|s| s.parse()) {
-			Some(Ok(secret)) => Some(secret),
+		config.network.use_secret = match matches.value_of("node-key").map(H256::from_str) {
+			Some(Ok(secret)) => Some(secret.into()),
 			Some(Err(err)) => return Err(format!("Error parsing node key: {}", err).into()),
 			None => None,
 		};

--- a/core/network-libp2p/Cargo.toml
+++ b/core/network-libp2p/Cargo.toml
@@ -11,9 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "304e9c72c88bc97824f2734dc19d1b5f4556d346", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
-ethcore-io = { git = "https://github.com/paritytech/parity.git" }
-ethkey = { git = "https://github.com/paritytech/parity.git" }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "5980a4538ef6fc8af450893acb01290eaed136de", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethereum-types = "0.3"
 parking_lot = "0.5"
 libc = "0.2"
@@ -30,5 +28,3 @@ unsigned-varint = { version = "0.2.1", features = ["codec"] }
 [dev-dependencies]
 assert_matches = "1.2"
 parity-bytes = "0.1"
-ethcore-io = { git = "https://github.com/paritytech/parity.git" }
-ethcore-logger = { git = "https://github.com/paritytech/parity.git" }

--- a/core/network-libp2p/src/error.rs
+++ b/core/network-libp2p/src/error.rs
@@ -16,8 +16,6 @@
 
 use std::{io, net, fmt};
 use libc::{ENFILE, EMFILE};
-use io::IoError;
-use ethkey;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DisconnectReason
@@ -82,10 +80,6 @@ impl fmt::Display for DisconnectReason {
 }
 
 error_chain! {
-	foreign_links {
-		SocketIo(IoError) #[doc = "Socket IO error."];
-	}
-
 	errors {
 		#[doc = "Error concerning the network address parsing subsystem."]
 		AddressParse {
@@ -171,17 +165,6 @@ impl From<io::Error> for Error {
 	}
 }
 
-impl From<ethkey::Error> for Error {
-	fn from(_err: ethkey::Error) -> Self {
-		ErrorKind::Auth.into()
-	}
-}
-
-impl From<ethkey::crypto::Error> for Error {
-	fn from(_err: ethkey::crypto::Error) -> Self {
-		ErrorKind::Auth.into()
-	}
-}
 
 impl From<net::AddrParseError> for Error {
 	fn from(_err: net::AddrParseError) -> Self { ErrorKind::AddressParse.into() }

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -27,7 +27,6 @@ extern crate futures;
 extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_timer;
-extern crate ethkey;
 extern crate libc;
 extern crate libp2p;
 extern crate rand;
@@ -38,7 +37,6 @@ extern crate serde_json;
 extern crate bytes;
 extern crate unsigned_varint;
 
-extern crate ethcore_io as io;
 extern crate ethereum_types;
 
 #[macro_use]
@@ -49,10 +47,11 @@ extern crate log;
 extern crate assert_matches;
 
 pub use connection_filter::{ConnectionFilter, ConnectionDirection};
-pub use io::TimerToken;
 pub use error::{Error, ErrorKind, DisconnectReason};
 pub use libp2p::{Multiaddr, multiaddr::AddrComponent};
 pub use traits::*;
+
+pub type TimerToken = usize;
 
 mod connection_filter;
 mod custom_proto;

--- a/core/network-libp2p/src/traits.rs
+++ b/core/network-libp2p/src/traits.rs
@@ -20,10 +20,9 @@ use std::iter;
 use std::net::Ipv4Addr;
 use std::str;
 use std::time::Duration;
-use io::TimerToken;
+use TimerToken;
 use libp2p::{multiaddr::AddrComponent, Multiaddr};
 use error::Error;
-use ethkey::Secret;
 use ethereum_types::H512;
 
 /// Protocol handler level packet id
@@ -36,6 +35,9 @@ pub type NodeId = H512;
 
 /// Local (temporary) peer session ID.
 pub type NodeIndex = usize;
+
+/// secio secret key;
+pub type Secret = [u8; 32];
 
 /// Shared session information
 #[derive(Debug, Clone)]

--- a/core/network-libp2p/src/transport.rs
+++ b/core/network-libp2p/src/transport.rs
@@ -30,9 +30,7 @@ pub fn build_transport(
 	mplex_config.max_buffer_len(usize::MAX);
 
 	let base = libp2p::CommonTransport::new()
-		.with_upgrade(secio::SecioConfig {
-			key: local_private_key,
-		})
+		.with_upgrade(secio::SecioConfig::new(local_private_key))
 		.and_then(move |out, endpoint, client_addr| {
 			let upgrade = upgrade::or(
 				upgrade::map(mplex_config, either::EitherOutput::First),

--- a/core/network-libp2p/tests/tests.rs
+++ b/core/network-libp2p/tests/tests.rs
@@ -16,10 +16,7 @@
 
 extern crate parking_lot;
 extern crate parity_bytes;
-extern crate ethcore_io as io;
-extern crate ethcore_logger;
 extern crate substrate_network_libp2p;
-extern crate ethkey;
 
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::sync::Arc;
@@ -28,8 +25,7 @@ use std::time::*;
 use parking_lot::Mutex;
 use parity_bytes::Bytes;
 use substrate_network_libp2p::*;
-use ethkey::{Random, Generator};
-use io::TimerToken;
+use TimerToken;
 
 pub struct TestProtocol {
 	drop_session: bool,
@@ -102,9 +98,7 @@ fn net_service() {
 #[test]
 #[ignore]		// TODO: how is this test even supposed to work?
 fn net_disconnect() {
-	let key1 = Random.generate().unwrap();
 	let mut config1 = NetworkConfiguration::new_local();
-	config1.use_secret = Some(key1.secret().clone());
 	config1.boot_nodes = vec![ ];
 	let handler1 = Arc::new(TestProtocol::new(false));
 	let service1 = NetworkService::new(config1, vec![(handler1.clone(), *b"tst", &[(42u8, 1), (43u8, 1)])]).unwrap();

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -15,7 +15,6 @@ bitflags = "1.0"
 futures = "0.1.17"
 linked-hash-map = "0.5"
 rustc-hex = "1.0"
-ethcore-io = { git = "https://github.com/paritytech/parity.git" }
 substrate-primitives = { path = "../../core/primitives" }
 substrate-client = { path = "../../core/client" }
 sr-primitives = { path = "../../core/sr-primitives" }

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -22,7 +22,6 @@
 //! Allows attachment of an optional subprotocol for chain-specific requests.
 // end::description[]
 
-extern crate ethcore_io as core_io;
 extern crate linked_hash_map;
 extern crate parking_lot;
 extern crate substrate_primitives as primitives;

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -22,7 +22,6 @@ use futures::sync::{oneshot, mpsc};
 use network_libp2p::{NetworkProtocolHandler, NetworkContext, NodeIndex, ProtocolId,
 NetworkConfiguration , NonReservedPeerMode, ErrorKind};
 use network_libp2p::{NetworkService};
-use core_io::{TimerToken};
 use io::NetSyncIo;
 use protocol::{Protocol, ProtocolContext, Context, ProtocolStatus, PeerInfo as ProtocolPeerInfo};
 use config::{ProtocolConfig};
@@ -38,6 +37,8 @@ use runtime_primitives::traits::{Block as BlockT};
 pub type FetchFuture = oneshot::Receiver<Vec<u8>>;
 /// Type that represents bft messages stream.
 pub type BftMessageStream<B> = mpsc::UnboundedReceiver<LocalizedBftMessage<B>>;
+
+type TimerToken = usize;
 
 const TICK_TOKEN: TimerToken = 0;
 const TICK_TIMEOUT: Duration = Duration::from_millis(1000);

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -121,6 +121,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![70u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]
@@ -141,6 +142,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![70u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]
@@ -485,6 +487,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![70u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]
@@ -506,6 +509,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -161,6 +161,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]
@@ -185,6 +186,7 @@ mod tests {
 			twox_128(<balances::TransactionBaseFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransactionByteFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::ExistentialDeposit<Runtime>>::key()).to_vec() => vec![0u8; 8],
+			twox_128(<balances::CreationFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::TransferFee<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(<balances::NextEnumSet<Runtime>>::key()).to_vec() => vec![0u8; 8],
 			twox_128(&<system::BlockHash<Runtime>>::key_for(0)).to_vec() => vec![0u8; 32]

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -284,7 +284,8 @@ impl<T: Trait> Module<T> {
 
 		let dest = Self::lookup(dest)?;
 		let from_balance = Self::free_balance(&transactor);
-		let would_create = from_balance.is_zero();
+		let to_balance = Self::free_balance(&dest);
+		let would_create = to_balance.is_zero();
 		let fee = if would_create { Self::creation_fee() } else { Self::transfer_fee() };
 		let liability = value + fee;
 
@@ -297,7 +298,6 @@ impl<T: Trait> Module<T> {
 		}
 		T::EnsureAccountLiquid::ensure_account_liquid(&transactor)?;
 
-		let to_balance = Self::free_balance(&dest);
 		// NOTE: total stake being stored in the same type means that this could never overflow
 		// but better to be safe than sorry.
 		let new_to_balance = match to_balance.checked_add(&value) {

--- a/srml/balances/src/mock.rs
+++ b/srml/balances/src/mock.rs
@@ -73,5 +73,28 @@ pub fn new_test_ext(ext_deposit: u64, monied: bool) -> runtime_io::TestExternali
 	t.into()
 }
 
+pub fn new_test_ext2(ext_deposit: u64, monied: bool) -> runtime_io::TestExternalities<Blake2Hasher> {
+	let mut t = system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+	let balance_factor = if ext_deposit > 0 {
+		256
+	} else {
+		1
+	};
+	t.extend(GenesisConfig::<Runtime>{
+		balances: if monied {
+			vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor)]
+		} else {
+			vec![(10, balance_factor), (20, balance_factor)]
+		},
+		transaction_base_fee: 0,
+		transaction_byte_fee: 0,
+		existential_deposit: ext_deposit,
+		transfer_fee: 10,  // transfer_fee not zero
+		creation_fee: 50, // creation_fee not zero
+		reclaim_rebate: 0,
+	}.build_storage().unwrap());
+	t.into()
+}
+
 pub type System = system::Module<Runtime>;
 pub type Balances = Module<Runtime>;

--- a/srml/contract/src/exec.rs
+++ b/srml/contract/src/exec.rs
@@ -172,6 +172,18 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 	}
 }
 
+/// Transfer some funds from `transactor` to `dest`.
+///
+/// All balance changes are performed in the `overlay`.
+///
+/// This function also handles charging the fee. The fee depends
+/// on whether the transfer happening because of contract creation
+/// (transfering endowment), specified by `contract_create` flag,
+/// or because of a transfer via `call`.
+///
+/// Note, that the fee is denominated in `T::Balance` units, but
+/// charged in `T::Gas` from the provided `gas_meter`. This means
+/// that the actual amount charged might differ.
 fn transfer<T: Trait>(
 	gas_meter: &mut GasMeter<T>,
 	contract_create: bool,
@@ -180,7 +192,7 @@ fn transfer<T: Trait>(
 	value: T::Balance,
 	overlay: &mut OverlayAccountDb<T>,
 ) -> Result<(), &'static str> {
-	let would_create = overlay.get_balance(transactor).is_zero();
+	let would_create = overlay.get_balance(dest).is_zero();
 
 	let fee: T::Balance = if contract_create {
 		<Module<T>>::contract_fee()

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -63,6 +63,8 @@ mod hashable;
 mod event;
 #[macro_use]
 pub mod metadata;
+#[macro_use]
+mod origin;
 
 pub use self::storage::{StorageVec, StorageList, StorageValue, StorageMap};
 pub use self::hashable::Hashable;
@@ -120,73 +122,3 @@ macro_rules! assert_ok {
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum Void {}
-
-#[macro_export]
-macro_rules! impl_outer_origin {
-	($(#[$attr:meta])* pub enum $name:ident for $trait:ident where system = $system:ident { $( $module:ident ),* }) => {
-		// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-		#[derive(Clone, PartialEq, Eq)]
-		#[cfg_attr(feature = "std", derive(Debug))]
-		$(#[$attr])*
-		#[allow(non_camel_case_types)]
-		pub enum $name {
-			system($system::Origin<$trait>),
-			$(
-				$module($module::Origin),
-			)*
-			#[allow(dead_code)]
-			Void($crate::Void)
-		}
-		#[allow(dead_code)]
-		impl $name {
-			pub const INHERENT: Self = $name::system($system::RawOrigin::Inherent);
-			pub const ROOT: Self = $name::system($system::RawOrigin::Root);
-			pub fn signed(by: <$trait as $system::Trait>::AccountId) -> Self {
-				$name::system($system::RawOrigin::Signed(by))
-			}
-		}
-		impl From<$system::Origin<$trait>> for $name {
-			fn from(x: $system::Origin<$trait>) -> Self {
-				$name::system(x)
-			}
-		}
-		impl Into<Option<$system::Origin<$trait>>> for $name {
-			fn into(self) -> Option<$system::Origin<$trait>> {
-				if let $name::system(l) = self {
-					Some(l)
-				} else {
-					None
-				}
-			}
-		}
-		impl From<Option<<$trait as $system::Trait>::AccountId>> for $name {
-			fn from(x: Option<<$trait as $system::Trait>::AccountId>) -> Self {
-				<$system::Origin<$trait>>::from(x).into()
-			}
-		}
-		$(
-			impl From<$module::Origin> for $name {
-				fn from(x: $module::Origin) -> Self {
-					$name::$module(x)
-				}
-			}
-			impl Into<Option<$module::Origin>> for $name {
-				fn into(self) -> Option<$module::Origin> {
-					if let $name::$module(l) = self {
-						Some(l)
-					} else {
-						None
-					}
-				}
-			}
-		)*
-	};
-	($(#[$attr:meta])* pub enum $name:ident for $trait:ident { $( $module:ident ),* }) => {
-		impl_outer_origin! {
-			$(#[$attr])*
-			pub enum $name for $trait where system = system {
-				$( $module ),*
-			}
-		}
-	}
-}

--- a/srml/support/src/origin.rs
+++ b/srml/support/src/origin.rs
@@ -1,0 +1,260 @@
+// Copyright 2018 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+#[macro_export]
+macro_rules! impl_outer_origin {
+	(
+		$(#[$attr:meta])*
+		pub enum $name:ident for $runtime:ident {
+			$( $module:ident $( <$generic:ident> )* ),* $(,)*
+		}
+	) => {
+		impl_outer_origin! {
+			$(#[$attr])*
+			pub enum $name for $runtime where system = system {
+				$( $module $( <$generic> )*, )*
+			}
+		}
+	};
+	(
+		$(#[$attr:meta])*
+		pub enum $name:ident for $runtime:ident where system = $system:ident {}
+	) => {
+		impl_outer_origin!(
+			$( #[$attr] )*;
+			$name;
+			$runtime;
+			$system;
+			Modules { };
+			;
+		);
+	};
+	(
+		$(#[$attr:meta])*
+		pub enum $name:ident for $runtime:ident where system = $system:ident {
+			$module:ident,
+			$( $rest_module:ident $( <$rest_generic:ident> )* ),* $(,)*
+		}
+	) => {
+		impl_outer_origin!(
+			$( #[$attr] )*;
+			$name;
+			$runtime;
+			$system;
+			Modules { $( $rest_module $( <$rest_generic> )*, )* };
+			$module;
+		);
+	};
+	(
+		$(#[$attr:meta])*
+		pub enum $name:ident for $runtime:ident where system = $system:ident {
+			$module:ident<T>,
+			$( $rest_module:ident $( <$rest_generic:ident> )* ),* $(,)*
+		}
+	) => {
+		impl_outer_origin!(
+			$( #[$attr] )*;
+			$name;
+			$runtime;
+			$system;
+			Modules { $( $rest_module $( <$rest_generic> )*, )* };
+			$module<$runtime>;
+		);
+	};
+	(
+		$(#[$attr:meta])*;
+		$name:ident;
+		$runtime:ident;
+		$system:ident;
+		Modules {
+			$module:ident,
+			$( $rest_module:ident $( <$rest_generic:ident> )*, )*
+		};
+		$( $parsed_module:ident $( <$generic_param:ident> )* ),*;
+	) => {
+		impl_outer_origin!(
+			$( #[$attr] )*;
+			$name;
+			$runtime;
+			$system;
+			Modules { $( $rest_module $( <$rest_generic> )*, )* };
+			$( $parsed_module $( <$generic_param> )* ),*, $module;
+		);
+	};
+	(
+		$(#[$attr:meta])*;
+		$name:ident;
+		$runtime:ident;
+		$system:ident;
+		Modules {
+			$module:ident<T>,
+			$( $rest_module:ident $( <$rest_generic:ident> )*, )*
+		};
+		$( $parsed_module:ident $( <$generic_param:ident> )* ),*;
+	) => {
+		impl_outer_origin!(
+			$( #[$attr] )*;
+			$name;
+			$runtime;
+			$system;
+			Modules { $( $rest_module $( <$rest_generic> )*, )* };
+			$( $parsed_module $( <$generic_param> )* ),*, $module<$runtime>;
+		);
+	};
+	(
+		$(#[$attr:meta])*;
+		$name:ident;
+		$runtime:ident;
+		$system:ident;
+		Modules {};
+		$( $module:ident $( <$generic_param:ident> )* ),*;
+	) => {
+		// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
+		#[derive(Clone, PartialEq, Eq)]
+		#[cfg_attr(feature = "std", derive(Debug))]
+		$(#[$attr])*
+		#[allow(non_camel_case_types)]
+		pub enum $name {
+			system($system::Origin<$runtime>),
+			$(
+				$module($module::Origin $( <$generic_param> )* ),
+			)*
+			#[allow(dead_code)]
+			Void($crate::Void)
+		}
+		#[allow(dead_code)]
+		impl $name {
+			pub const INHERENT: Self = $name::system($system::RawOrigin::Inherent);
+			pub const ROOT: Self = $name::system($system::RawOrigin::Root);
+			pub fn signed(by: <$runtime as $system::Trait>::AccountId) -> Self {
+				$name::system($system::RawOrigin::Signed(by))
+			}
+		}
+		impl From<$system::Origin<$runtime>> for $name {
+			fn from(x: $system::Origin<$runtime>) -> Self {
+				$name::system(x)
+			}
+		}
+		impl Into<Option<$system::Origin<$runtime>>> for $name {
+			fn into(self) -> Option<$system::Origin<$runtime>> {
+				if let $name::system(l) = self {
+					Some(l)
+				} else {
+					None
+				}
+			}
+		}
+		impl From<Option<<$runtime as $system::Trait>::AccountId>> for $name {
+			fn from(x: Option<<$runtime as $system::Trait>::AccountId>) -> Self {
+				<$system::Origin<$runtime>>::from(x).into()
+			}
+		}
+		$(
+			impl From<$module::Origin $( <$generic_param> )*> for $name {
+				fn from(x: $module::Origin $( <$generic_param> )*) -> Self {
+					$name::$module(x)
+				}
+			}
+			impl Into<Option<$module::Origin $( <$generic_param> )*>> for $name {
+				fn into(self) -> Option<$module::Origin $( <$generic_param> )*> {
+					if let $name::$module(l) = self {
+						Some(l)
+					} else {
+						None
+					}
+				}
+			}
+		)*
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	mod system {
+		pub trait Trait {
+			type AccountId;
+		}
+
+		#[derive(Clone, PartialEq, Eq, Debug)]
+		pub enum RawOrigin<AccountId> {
+			Root,
+			Signed(AccountId),
+			Inherent,
+		}
+
+		impl<AccountId> From<Option<AccountId>> for RawOrigin<AccountId> {
+			fn from(s: Option<AccountId>) -> RawOrigin<AccountId> {
+				match s {
+					Some(who) => RawOrigin::Signed(who),
+					None => RawOrigin::Inherent,
+				}
+			}
+		}
+
+		pub type Origin<T> = RawOrigin<<T as Trait>::AccountId>;
+	}
+
+	mod origin_without_generic {
+		#[derive(Clone, PartialEq, Eq, Debug)]
+		pub struct Origin;
+	}
+
+	mod origin_with_generic {
+		#[derive(Clone, PartialEq, Eq, Debug)]
+		pub struct Origin<T> {
+			t: T
+		}
+	}
+
+	#[derive(Clone, PartialEq, Eq, Debug)]
+	pub struct TestRuntime;
+
+	impl system::Trait for TestRuntime {
+		type AccountId = u32;
+	}
+
+	impl_outer_origin!(
+		pub enum OriginWithoutSystem for TestRuntime {
+			origin_without_generic,
+			origin_with_generic<T>,
+		}
+	);
+
+	impl_outer_origin!(
+		pub enum OriginWithoutSystem2 for TestRuntime {
+			origin_with_generic<T>,
+			origin_without_generic
+		}
+	);
+
+	impl_outer_origin!(
+		pub enum OriginWithSystem for TestRuntime where system = system {
+			origin_without_generic,
+			origin_with_generic<T>
+		}
+	);
+
+	impl_outer_origin!(
+		pub enum OriginWithSystem2 for TestRuntime where system = system {
+			origin_with_generic<T>,
+			origin_without_generic,
+		}
+	);
+
+	impl_outer_origin!(
+		pub enum OriginEmpty for TestRuntime where system = system {}
+	);
+}


### PR DESCRIPTION
[issue:#722](https://github.com/paritytech/substrate/issues/722)
would_create flag should depend on dest, not origin.
change 
```rust
let would_create = from_balance.is_zero();
```
to 
```rust
    let to_balance = Self::free_balance(&dest); 
    let would_create = to_balance.is_zero(); 
```
in the other hand, provide `fn new_test_ext2()` and let `transfer_fee=10`, `creation_fee=50` for test case