### PR TITLE
Fix error handling in sandboxing/contracts modules

### DIFF
--- a/core/executor/src/sandbox.rs
+++ b/core/executor/src/sandbox.rs
@@ -342,7 +342,7 @@ pub enum InstantiationError {
 	EnvironmentDefintionCorrupted,
 	/// Provided module isn't recognized as a valid webassembly binary.
 	ModuleDecoding,
-	/// Module is well-formed webassembly binary but could not be instantiated. This could
+	/// Module is a well-formed webassembly binary but could not be instantiated. This could
 	/// happen because, e.g. the module imports entries not provided by the environment.
 	Instantiation,
 	/// Module is well-formed, instantiated and linked, but while executing the start function

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -337,7 +337,14 @@ impl_function_executor!(this: FunctionExecutor<'e, E>,
 			5
 		})
 	},
-	ext_sandbox_instantiate(dispatch_thunk_idx: usize, wasm_ptr: *const u8, wasm_len: usize, imports_ptr: *const u8, imports_len: usize, state: usize) -> u32 => {
+	ext_sandbox_instantiate(
+		dispatch_thunk_idx: usize,
+		wasm_ptr: *const u8,
+		wasm_len: usize,
+		imports_ptr: *const u8,
+		imports_len: usize,
+		state: usize
+	) -> u32 => {
 		let wasm = this.memory.get(wasm_ptr, wasm_len as usize).map_err(|_| UserError("Sandbox error"))?;
 		let raw_env_def = this.memory.get(imports_ptr, imports_len as usize).map_err(|_| UserError("Sandbox error"))?;
 
@@ -350,9 +357,14 @@ impl_function_executor!(this: FunctionExecutor<'e, E>,
 				.clone()
 		};
 
-		let instance_idx = sandbox::instantiate(this, dispatch_thunk, &wasm, &raw_env_def, state)?;
+		let instance_idx_or_err_code =
+			match sandbox::instantiate(this, dispatch_thunk, &wasm, &raw_env_def, state) {
+				Ok(instance_idx) => instance_idx,
+				Err(sandbox::InstantiationError::StartTrapped) => sandbox_primitives::ERR_EXECUTION,
+				Err(_) => sandbox_primitives::ERR_MODULE,
+			};
 
-		Ok(instance_idx as u32)
+		Ok(instance_idx_or_err_code as u32)
 	},
 	ext_sandbox_instance_teardown(instance_idx: u32) => {
 		this.sandbox_store.instance_teardown(instance_idx)?;

--- a/core/executor/wasm/src/lib.rs
+++ b/core/executor/wasm/src/lib.rs
@@ -81,6 +81,16 @@ impl_stubs!(
 		);
 		let ok = if let Ok(sandbox::ReturnValue::Value(sandbox::TypedValue::I32(0x1337))) = result { true } else { false };
 		[ok as u8].to_vec()
+	},
+	test_sandbox_instantiate NO_DECODE => |code: &[u8]| {
+		let env_builder = sandbox::EnvironmentDefinitionBuilder::new();
+		let code = match sandbox::Instance::new(code, &env_builder, &mut ()) {
+			Ok(_) => 0,
+			Err(sandbox::Error::Module) => 1,
+			Err(sandbox::Error::Execution) => 2,
+			Err(sandbox::Error::OutOfBounds) => 3,
+		};
+		[code].to_vec()
 	}
 );
 

--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -190,7 +190,12 @@ pub struct Instance<T> {
 }
 
 impl<T> Instance<T> {
-	/// Instantiate a module with the given [`EnvironmentDefinitionBuilder`].
+	/// Instantiate a module with the given [`EnvironmentDefinitionBuilder`]. It will
+	/// run the `start` function with the given `state`.
+	///
+	/// Returns `Err(Error::Module)` if this module can't be instantiated with the given
+	/// environment. If execution of `start` function generated a trap, then `Err(Error::Execution)` will
+	/// be returned.
 	///
 	/// [`EnvironmentDefinitionBuilder`]: struct.EnvironmentDefinitionBuilder.html
 	pub fn new(code: &[u8], env_def_builder: &EnvironmentDefinitionBuilder<T>, state: &mut T) -> Result<Instance<T>, Error> {

--- a/core/sr-sandbox/with_std.rs
+++ b/core/sr-sandbox/with_std.rs
@@ -271,7 +271,7 @@ impl<T> Instance<T> {
 				state,
 				defined_host_functions: &defined_host_functions,
 			};
-			let instance = not_started_instance.run_start(&mut externals).map_err(|_| Error::Module)?;
+			let instance = not_started_instance.run_start(&mut externals).map_err(|_| Error::Execution)?;
 			instance
 		};
 

--- a/core/sr-sandbox/without_std.rs
+++ b/core/sr-sandbox/without_std.rs
@@ -253,6 +253,7 @@ impl<T> Instance<T> {
 		};
 		let instance_idx = match result {
 			sandbox_primitives::ERR_MODULE => return Err(Error::Module),
+			sandbox_primitives::ERR_EXECUTION => return Err(Error::Execution),
 			instance_idx => instance_idx,
 		};
 		Ok(Instance {


### PR DESCRIPTION
A few errors were found while analysing contracts module for running time and memory consumption characteristics.

