### PR TITLE
Update libp2p and increase listeners slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,35 @@
 [[package]]
+name = "aes-ctr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aes-soft 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aesni 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aesni"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +217,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -384,6 +423,15 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ctr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ctrlc"
 version = "1.1.1"
 source = "git+https://github.com/paritytech/rust-ctrlc.git#b523017108bb2d571a7a69bd97bc406e63bc7a9d"
@@ -396,7 +444,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1072,27 +1120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1102,20 +1150,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1125,12 +1173,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1138,16 +1186,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,15 +1207,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1178,20 +1226,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1205,12 +1253,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1221,13 +1269,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1236,14 +1284,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,11 +1301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1266,14 +1314,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1284,32 +1332,34 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
+ "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1318,10 +1368,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1329,25 +1379,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
@@ -1356,11 +1406,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1502,11 +1552,11 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1514,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1524,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1605,6 +1655,11 @@ dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
@@ -2299,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4#2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab#3e53a9dcc728d2e932d731bf90a8e81e0e4257ab"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2521,6 +2576,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "stream-cipher"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -2754,7 +2817,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3575,6 +3638,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "twofish"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3893,6 +3966,9 @@ dependencies = [
 ]
 
 [metadata]
+"checksum aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f65958ff3692041c36fc009261ccd63f24cd8e0dc1164266f068c2387e8b4e4f"
+"checksum aes-soft 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67cc03b0a090a05cb01e96998a01905d7ceedce1bc23b756c0bb7faa0682ccb1"
+"checksum aesni 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6810b7fb9f2bb4f76f05ac1c170b8dde285b6308955dc3afd89710268c958d9e"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)" = "<none>"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
@@ -3917,6 +3993,7 @@ dependencies = [
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum block-cipher-trait 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "370424437b9459f3dfd68428ed9376ddfe03d8b70ede29cc533b3557df186ab4"
 "checksum bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e6ea4851598d7433fbdba71fa2509d9b0df68124b9c0effe7588f5149692d9f"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
@@ -3942,8 +4019,9 @@ dependencies = [
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+"checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4007,23 +4085,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4039,9 +4117,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4051,6 +4129,7 @@ dependencies = [
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
+"checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
@@ -4102,7 +4181,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=3e53a9dcc728d2e932d731bf90a8e81e0e4257ab)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -4132,6 +4211,7 @@ dependencies = [
 "checksum snappy-sys 0.1.0 (git+https://github.com/paritytech/rust-snappy)" = "<none>"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
+"checksum stream-cipher 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30dc6118470d69ce0fdcf7e6f95e95853f7f4f72f80d835d4519577c323814ab"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum subtle 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc7f6353c2ee5407358d063a14cccc1630804527090a6fb5a9489ce4924280fb"
 "checksum syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfd71b2be5a58ee30a6f8ea355ba8290d397131c00dfa55c3d34e6e13db5101"
@@ -4170,6 +4250,7 @@ dependencies = [
 "checksum triehash 0.1.0 (git+https://github.com/paritytech/parity.git?rev=202c54d42398fc4b49d67ffbf9070522e38f9360)" = "<none>"
 "checksum triehash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2033893a813c70e7d8a739ca6c36dc0a7a2c913ec718d7cbf84a3837bbe3c7ce"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
+"checksum twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eef327f05b0d0ec1b9d7d119d8f4d9f602ceee37e0540aff8071e8e66c2e22e"
 "checksum twox-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "475352206e7a290c5fccc27624a163e8d0d115f7bb60ca18a64fc9ce056d7435"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "2a7a48b4962cd01095ed634f7d0fb4dd2bddb7e4", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "3e53a9dcc728d2e932d731bf90a8e81e0e4257ab", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethereum-types = "0.3"
 parking_lot = "0.5"
 libc = "0.2"

--- a/substrate/network-libp2p/src/traits.rs
+++ b/substrate/network-libp2p/src/traits.rs
@@ -147,7 +147,7 @@ impl NetworkConfiguration {
 			boot_nodes: Vec::new(),
 			use_secret: None,
 			min_peers: 25,
-			max_peers: 50,
+			max_peers: 100,
 			reserved_nodes: Vec::new(),
 			non_reserved_mode: NonReservedPeerMode::Accept,
 			client_version: "Parity-network".into(),		// TODO: meh


### PR DESCRIPTION
Incorporates https://github.com/libp2p/rust-libp2p/pull/483, which should fix https://github.com/paritytech/polkadot/issues/21

Also hard-code an increase in the listeners slots, so that the bootstrap nodes accept more nodes.