### PR TITLE
Change to running a development chain/node in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -156,7 +156,7 @@ cargo test --all
 You can start a development chain with:
 
 [source, shell]
-cargo run -- --dev
+cargo run --manifest-path node/Cargo.toml -- --dev
 
 include::doc/packages/packages.adoc[]
 


### PR DESCRIPTION
Existing command failed with:
`error: manifest path {path} is a virtual manifest, but this command requires running against an actual package in this workspace`