### PR TITLE
Dont punish peers when no peers respond

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -395,8 +395,11 @@ impl<B: BlockT, S: Specialization<B>, H: ExHashT> Protocol<B, S, H> {
 		}
 
 		self.specialization.write().maintain_peers(&mut ProtocolContext::new(&self.context_data, io));
-		for p in aborting {
-			io.report_peer(p, Severity::Timeout);
+
+		if aborting.len() < self.context_data.peers.len() {
+			for p in aborting {
+				io.report_peer(p, Severity::Timeout);
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue: https://github.com/paritytech/substrate/issues/736

@tomaka Let me know your thoughts on this small change.

This was the only place I have found so far that punishes peers regardless of whether any of them respond. I also want to keep it short since I'm new to this project and a rust codebase of this size.