### PR TITLE
Extract well known keys into a single place

### DIFF
--- a/core/client/src/call_executor.rs
+++ b/core/client/src/call_executor.rs
@@ -27,6 +27,7 @@ use rlp::Encodable;
 use memorydb::MemoryDB;
 use codec::Decode;
 use primitives::{Blake2Hasher, RlpCodec};
+use primitives::storage::well_known_keys;
 
 use backend;
 use error;
@@ -144,11 +145,11 @@ where
 		let mut overlay = OverlayedChanges::default();
 		let state = self.backend.state_at(*id)?;
 		use state_machine::Backend;
-		let code = state.storage(b":code")
+		let code = state.storage(well_known_keys::CODE)
 			.map_err(|e| error::ErrorKind::Execution(Box::new(e)))?
 			.ok_or(error::ErrorKind::VersionInvalid)?
 			.to_vec();
-		let heap_pages = state.storage(b":heappages")
+		let heap_pages = state.storage(well_known_keys::HEAP_PAGES)
 			.map_err(|e| error::ErrorKind::Execution(Box::new(e)))?
 			.and_then(|v| u64::decode(&mut &v[..]))
 			.unwrap_or(8) as usize;

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -26,6 +26,7 @@ use runtime_primitives::BuildStorage;
 use substrate_metadata::JsonMetadataDecodable;
 use primitives::{Blake2Hasher, RlpCodec, H256};
 use primitives::storage::{StorageKey, StorageData};
+use primitives::storage::well_known_keys;
 use codec::{Encode, Decode};
 use state_machine::{
 	Backend as StateBackend, CodeExecutor,
@@ -228,7 +229,7 @@ impl<B, E, Block> Client<B, E, Block> where
 
 	/// Get the code at a given block.
 	pub fn code_at(&self, id: &BlockId<Block>) -> error::Result<Vec<u8>> {
-		Ok(self.storage(id, &StorageKey(b":code".to_vec()))?
+		Ok(self.storage(id, &StorageKey(well_known_keys::CODE.to_vec()))?
 			.expect("None is returned if there's no value stored for the given key; ':code' key is always defined; qed").0)
 	}
 

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -188,6 +188,7 @@ pub mod tests {
 	use light::fetcher::{Fetcher, FetchChecker, LightDataChecker,
 		RemoteCallRequest, RemoteHeaderRequest};
 	use primitives::{Blake2Hasher, RlpCodec};
+	use primitives::storage::well_known_keys;
 	use runtime_primitives::generic::BlockId;
 	use state_machine::Backend;
 	use super::*;
@@ -225,7 +226,7 @@ pub mod tests {
 
 		// 'fetch' read proof from remote node
 		let authorities_len = remote_client.authorities_at(&remote_block_id).unwrap().len();
-		let remote_read_proof = remote_client.read_proof(&remote_block_id, b":auth:len").unwrap();
+		let remote_read_proof = remote_client.read_proof(&remote_block_id, well_known_keys::AUTHORITY_COUNT).unwrap();
 
 		// check remote read proof locally
 		let local_storage = InMemoryBlockchain::<Block>::new();
@@ -269,7 +270,7 @@ pub mod tests {
 		assert_eq!((&local_checker as &FetchChecker<Block>).check_read_proof(&RemoteReadRequest::<Header> {
 			block: remote_block_header.hash(),
 			header: remote_block_header,
-			key: b":auth:len".to_vec(),
+			key: well_known_keys::AUTHORITY_COUNT.to_vec(),
 			retry_count: None,
 		}, remote_read_proof).unwrap().unwrap()[0], authorities_len as u8);
 	}

--- a/core/primitives/src/storage.rs
+++ b/core/primitives/src/storage.rs
@@ -42,3 +42,34 @@ pub struct StorageChangeSet<Hash> {
 	)>,
 }
 
+/// List of all well known keys and prefixes in storage.
+pub mod well_known_keys {
+
+	/// Wasm code of the runtime.
+	///
+	/// Required by substrate. Stored as a raw byte vector.
+	pub const CODE: &'static [u8] = b":code";
+
+	/// Number of wasm linear memory pages required for execution of the runtime.
+	///
+	/// The type of this value is encoded `u64`.
+	pub const HEAP_PAGES: &'static [u8] = b":heappages";
+
+	/// Number of authorities. Required by substrate.
+	///
+	/// The type of this value is encoded `u32`.
+	pub const AUTHORITY_COUNT: &'static [u8] = b":auth:len";
+
+	/// Prefix under which authorities are storied.
+	///
+	/// The full key for N-th authority is generated as:
+	///
+	/// `(n as u32).to_keyed_vec(AUTHORITY_PREFIX)`.
+	pub const AUTHORITY_PREFIX: &'static [u8] = b":auth:";
+
+	/// Current extrinsic index (u32) is stored under this key.
+	pub const EXTRINSIC_INDEX: &'static [u8] = b":extrinsic_index";
+
+	/// Changes trie configuration is stored under this key.
+	pub const CHANGES_TRIE_CONFIG: &'static [u8] = b":changes_trie";
+}

--- a/core/primitives/src/storage.rs
+++ b/core/primitives/src/storage.rs
@@ -47,7 +47,7 @@ pub mod well_known_keys {
 
 	/// Wasm code of the runtime.
 	///
-	/// Required by substrate. Stored as a raw byte vector.
+	/// Stored as a raw byte vector. Required by substrate.
 	pub const CODE: &'static [u8] = b":code";
 
 	/// Number of wasm linear memory pages required for execution of the runtime.
@@ -55,9 +55,9 @@ pub mod well_known_keys {
 	/// The type of this value is encoded `u64`.
 	pub const HEAP_PAGES: &'static [u8] = b":heappages";
 
-	/// Number of authorities. Required by substrate.
+	/// Number of authorities.
 	///
-	/// The type of this value is encoded `u32`.
+	/// The type of this value is encoded `u32`. Required by substrate.
 	pub const AUTHORITY_COUNT: &'static [u8] = b":auth:len";
 
 	/// Prefix under which authorities are storied.

--- a/core/state-machine/src/changes_trie/build.rs
+++ b/core/state-machine/src/changes_trie/build.rs
@@ -148,6 +148,7 @@ fn prepare_digest_input<'a, S, H, C>(
 mod test {
 	use codec::Encode;
 	use primitives::{Blake2Hasher, RlpCodec};
+	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
 	use backend::InMemory;
 	use changes_trie::storage::InMemoryStorage;
 	use overlayed_changes::OverlayedValue;
@@ -208,7 +209,7 @@ mod test {
 				}),
 			].into_iter().collect(),
 			committed: vec![
-				(b":extrinsic_index".to_vec(), OverlayedValue {
+				(EXTRINSIC_INDEX.to_vec(), OverlayedValue {
 					value: Some(3u32.encode()),
 					extrinsics: None,
 				}),

--- a/core/state-machine/src/ext.rs
+++ b/core/state-machine/src/ext.rs
@@ -229,6 +229,7 @@ where
 mod tests {
 	use codec::Encode;
 	use primitives::{Blake2Hasher, RlpCodec};
+	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
 	use backend::InMemory;
 	use changes_trie::{Configuration as ChangesTrieConfiguration,
 		InMemoryStorage as InMemoryChangesTrieStorage};
@@ -242,7 +243,7 @@ mod tests {
 	fn prepare_overlay_with_changes() -> OverlayedChanges {
 		OverlayedChanges {
 			prospective: vec![
-				(b":extrinsic_index".to_vec(), OverlayedValue {
+				(EXTRINSIC_INDEX.to_vec(), OverlayedValue {
 					value: Some(3u32.encode()),
 					extrinsics: Some(vec![1].into_iter().collect())
 				}),

--- a/core/state-machine/src/lib.rs
+++ b/core/state-machine/src/lib.rs
@@ -44,6 +44,7 @@ use patricia_trie::NodeCodec;
 use rlp::Encodable;
 use heapsize::HeapSizeOf;
 use codec::Decode;
+use primitives::storage::well_known_keys;
 
 pub mod backend;
 mod changes_trie;
@@ -260,11 +261,11 @@ where
 	let strategy: ExecutionStrategy = (&manager).into();
 
 	// make a copy.
-	let code = try_read_overlay_value(overlay, backend, b":code")?
+	let code = try_read_overlay_value(overlay, backend, well_known_keys::CODE)?
 		.ok_or_else(|| Box::new(ExecutionError::CodeEntryDoesNotExist) as Box<Error>)?
 		.to_vec();
 
-	let heap_pages = try_read_overlay_value(overlay, backend, b":heappages")?
+	let heap_pages = try_read_overlay_value(overlay, backend, well_known_keys::HEAP_PAGES)?
 		.and_then(|v| u64::decode(&mut &v[..])).unwrap_or(8) as usize;
 
 	// read changes trie configuration. The reason why we're doing it here instead of the
@@ -272,7 +273,11 @@ where
 	// proof-of-execution on light clients. And the proof is recorded by the backend which
 	// is created after OverlayedChanges
 
-	let changes_trie_config = try_read_overlay_value(overlay, backend, b":changes_trie")?;
+	let changes_trie_config = try_read_overlay_value(
+		overlay,
+		backend,
+		well_known_keys::CHANGES_TRIE_CONFIG
+	)?;
 	set_changes_trie_config(overlay, changes_trie_config)?;
 
 	let result = {

--- a/core/state-machine/src/overlayed_changes.rs
+++ b/core/state-machine/src/overlayed_changes.rs
@@ -19,6 +19,7 @@
 use std::collections::{HashMap, HashSet};
 use codec::Decode;
 use changes_trie::{NO_EXTRINSIC_INDEX, Configuration as ChangesTrieConfig};
+use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
 
 /// The overlayed changes to state to be queried on top of the backend.
 ///
@@ -168,7 +169,7 @@ impl OverlayedChanges {
 	#[cfg(test)]
 	pub(crate) fn set_extrinsic_index(&mut self, extrinsic_index: u32) {
 		use codec::Encode;
-		self.prospective.insert(b":extrinsic_index".to_vec(), OverlayedValue {
+		self.prospective.insert(EXTRINSIC_INDEX.to_vec(), OverlayedValue {
 			value: Some(extrinsic_index.encode()),
 			extrinsics: None,
 		});
@@ -183,7 +184,7 @@ impl OverlayedChanges {
 	fn extrinsic_index(&self) -> Option<u32> {
 		match self.changes_trie_config.is_some() {
 			true => Some(
-				self.storage(b":extrinsic_index")
+				self.storage(EXTRINSIC_INDEX)
 					.and_then(|idx| idx.and_then(|idx| Decode::decode(&mut &*idx)))
 					.unwrap_or(NO_EXTRINSIC_INDEX)),
 			false => None,
@@ -201,6 +202,7 @@ impl From<Option<Vec<u8>>> for OverlayedValue {
 #[cfg(test)]
 mod tests {
 	use primitives::{Blake2Hasher, RlpCodec, H256};
+	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
 	use backend::InMemory;
 	use changes_trie::InMemoryStorage as InMemoryChangesTrieStorage;
 	use ext::Ext;
@@ -209,7 +211,7 @@ mod tests {
 
 	fn strip_extrinsic_index(map: &HashMap<Vec<u8>, OverlayedValue>) -> HashMap<Vec<u8>, OverlayedValue> {
 		let mut clone = map.clone();
-		clone.remove(&b":extrinsic_index".to_vec());
+		clone.remove(&EXTRINSIC_INDEX.to_vec());
 		clone
 	}
 

--- a/core/state-machine/src/testing.rs
+++ b/core/state-machine/src/testing.rs
@@ -25,6 +25,7 @@ use rlp::Encodable;
 use triehash::trie_root;
 use backend::InMemory;
 use changes_trie::{compute_changes_trie_root, InMemoryStorage as ChangesTrieInMemoryStorage};
+use primitives::storage::well_known_keys::CHANGES_TRIE_CONFIG;
 use super::{Externalities, OverlayedChanges};
 
 /// Simple HashMap-based Externalities impl.
@@ -41,7 +42,7 @@ impl<H: Hasher, C: NodeCodec<H>> TestExternalities<H, C> where H::Out: HeapSizeO
 		let mut overlay = OverlayedChanges::default();
 		super::set_changes_trie_config(
 			&mut overlay,
-			inner.get(&b":changes_trie".to_vec()).cloned())
+			inner.get(&CHANGES_TRIE_CONFIG.to_vec()).cloned())
 			.expect("changes trie configuration is correct in test env; qed");
 
 		TestExternalities {

--- a/core/test-runtime/src/genesismap.rs
+++ b/core/test-runtime/src/genesismap.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use runtime_io::twox_128;
 use codec::{KeyedVec, Joiner};
 use primitives::AuthorityId;
+use primitives::storage::well_known_keys;
 use runtime_primitives::traits::Block;
 
 /// Configuration of a general Substrate test genesis block.
@@ -42,13 +43,13 @@ impl GenesisConfig {
 			.map(|&(account, balance)| (account.to_keyed_vec(b"balance:"), vec![].and(&balance)))
 			.map(|(k, v)| (twox_128(&k[..])[..].to_vec(), v.to_vec()))
 			.chain(vec![
-				(b":code"[..].into(), wasm_runtime),
-				(b":heappages"[..].into(), vec![].and(&(16 as u64))),
-				(b":auth:len"[..].into(), vec![].and(&(self.authorities.len() as u32))),
+				(well_known_keys::CODE.into(), wasm_runtime),
+				(well_known_keys::HEAP_PAGES.into(), vec![].and(&(16 as u64))),
+				(well_known_keys::AUTHORITY_COUNT.into(), vec![].and(&(self.authorities.len() as u32))),
 			].into_iter())
 			.chain(self.authorities.iter()
 				.enumerate()
-				.map(|(i, account)| ((i as u32).to_keyed_vec(b":auth:"), vec![].and(account)))
+				.map(|(i, account)| ((i as u32).to_keyed_vec(well_known_keys::AUTHORITY_PREFIX), vec![].and(account)))
 			)
 			.collect()
 	}

--- a/srml/consensus/src/lib.rs
+++ b/srml/consensus/src/lib.rs
@@ -48,18 +48,14 @@ use runtime_support::storage::StorageValue;
 use runtime_support::storage::unhashed::StorageVec;
 use primitives::traits::{MaybeSerializeDebug, OnFinalise, Member};
 use primitives::bft::MisbehaviorReport;
+use substrate_primitives::storage::well_known_keys;
 use system::{ensure_signed, ensure_inherent};
-
-pub const AUTHORITY_AT: &'static [u8] = b":auth:";
-pub const AUTHORITY_COUNT: &'static [u8] = b":auth:len";
 
 struct AuthorityStorageVec<S: codec::Codec + Default>(rstd::marker::PhantomData<S>);
 impl<S: codec::Codec + Default> StorageVec for AuthorityStorageVec<S> {
 	type Item = S;
-	const PREFIX: &'static [u8] = AUTHORITY_AT;
+	const PREFIX: &'static [u8] = well_known_keys::AUTHORITY_PREFIX;
 }
-
-pub const CODE: &'static [u8] = b":code";
 
 pub type KeyValue = (Vec<u8>, Vec<u8>);
 
@@ -142,7 +138,7 @@ impl<T: Trait> Module<T> {
 
 	/// Set the new code.
 	fn set_code(new: Vec<u8>) -> Result {
-		storage::unhashed::put_raw(CODE, &new);
+		storage::unhashed::put_raw(well_known_keys::CODE, &new);
 		Ok(())
 	}
 
@@ -175,7 +171,7 @@ impl<T: Trait> Module<T> {
 		for validator_index in offline_val_indices.into_iter() {
 			T::OnOfflineValidator::on_offline_validator(validator_index as usize);
 		}
-		
+
 		Ok(())
 	}
 
@@ -253,10 +249,10 @@ impl<T: Trait> primitives::BuildStorage for GenesisConfig<T>
 		use codec::{Encode, KeyedVec};
 		let auth_count = self.authorities.len() as u32;
 		let mut r: primitives::StorageMap = self.authorities.into_iter().enumerate().map(|(i, v)|
-			((i as u32).to_keyed_vec(AUTHORITY_AT), v.encode())
+			((i as u32).to_keyed_vec(well_known_keys::AUTHORITY_PREFIX), v.encode())
 		).collect();
-		r.insert(AUTHORITY_COUNT.to_vec(), auth_count.encode());
-		r.insert(CODE.to_vec(), self.code);
+		r.insert(well_known_keys::AUTHORITY_COUNT.to_vec(), auth_count.encode());
+		r.insert(well_known_keys::CODE.to_vec(), self.code);
 		Ok(r.into())
 	}
 }

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -45,6 +45,7 @@ extern crate safe_mix;
 use rstd::prelude::*;
 use primitives::traits::{self, CheckEqual, SimpleArithmetic, SimpleBitOps, Zero, One, Bounded,
 	Hash, Member, MaybeDisplay, EnsureOrigin, Digest as DigestT, As};
+use substrate_primitives::storage::well_known_keys::{EXTRINSIC_INDEX, CHANGES_TRIE_CONFIG};
 use runtime_support::{storage, StorageValue, StorageMap, Parameter};
 use safe_mix::TripletMix;
 
@@ -56,11 +57,6 @@ use runtime_io::{twox_128, TestExternalities, Blake2Hasher, RlpCodec};
 
 #[cfg(any(feature = "std", test))]
 use substrate_primitives::ChangesTrieConfiguration;
-
-/// Current extrinsic index (u32) is stored under this key.
-pub const EXTRINSIC_INDEX: &'static [u8] = b":extrinsic_index";
-/// Changes trie configuration is stored under this key.
-pub const CHANGES_TRIE_CONFIG: &'static [u8] = b":changes_trie";
 
 /// Compute the extrinsics root of a list of extrinsics.
 pub fn extrinsics_root<H: Hash, E: codec::Encode>(extrinsics: &[E]) -> H::Output {

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -45,7 +45,7 @@ extern crate safe_mix;
 use rstd::prelude::*;
 use primitives::traits::{self, CheckEqual, SimpleArithmetic, SimpleBitOps, Zero, One, Bounded,
 	Hash, Member, MaybeDisplay, EnsureOrigin, Digest as DigestT, As};
-use substrate_primitives::storage::well_known_keys::{EXTRINSIC_INDEX, CHANGES_TRIE_CONFIG};
+use substrate_primitives::storage::well_known_keys;
 use runtime_support::{storage, StorageValue, StorageMap, Parameter};
 use safe_mix::TripletMix;
 
@@ -240,13 +240,13 @@ pub fn ensure_inherent<OuterOrigin, AccountId>(o: OuterOrigin) -> Result<(), &'s
 impl<T: Trait> Module<T> {
 	/// Gets the index of extrinsic that is currenty executing.
 	pub fn extrinsic_index() -> Option<u32> {
-		storage::unhashed::get(EXTRINSIC_INDEX)
+		storage::unhashed::get(well_known_keys::EXTRINSIC_INDEX)
 	}
 
 	/// Start the execution of a particular block.
 	pub fn initialise(number: &T::BlockNumber, parent_hash: &T::Hash, txs_root: &T::Hash) {
 		// populate environment.
-		storage::unhashed::put(EXTRINSIC_INDEX, &0u32);
+		storage::unhashed::put(well_known_keys::EXTRINSIC_INDEX, &0u32);
 		<Number<T>>::put(number);
 		<ParentHash<T>>::put(parent_hash);
 		<BlockHash<T>>::insert(*number - One::one(), parent_hash);
@@ -330,7 +330,7 @@ impl<T: Trait> Module<T> {
 	/// Sets the index of extrinsic that is currenty executing.
 	#[cfg(any(feature = "std", test))]
 	pub fn set_extrinsic_index(extrinsic_index: u32) {
-		storage::unhashed::put(EXTRINSIC_INDEX, &extrinsic_index)
+		storage::unhashed::put(well_known_keys::EXTRINSIC_INDEX, &extrinsic_index)
 	}
 
 	/// Set the parent hash number to something in particular. Can be used as an alternative to
@@ -366,13 +366,13 @@ impl<T: Trait> Module<T> {
 		}.into());
 
 		let next_extrinsic_index = Self::extrinsic_index().unwrap_or_default() + 1u32;
-		storage::unhashed::put(EXTRINSIC_INDEX, &next_extrinsic_index);
+		storage::unhashed::put(well_known_keys::EXTRINSIC_INDEX, &next_extrinsic_index);
 	}
 
 	/// To be called immediately after `note_applied_extrinsic` of the last extrinsic of the block
 	/// has been called.
 	pub fn note_finished_extrinsics() {
-		let extrinsic_index: u32 = storage::unhashed::take(EXTRINSIC_INDEX).unwrap_or_default();
+		let extrinsic_index: u32 = storage::unhashed::take(well_known_keys::EXTRINSIC_INDEX).unwrap_or_default();
 		<ExtrinsicCount<T>>::put(extrinsic_index);
 	}
 
@@ -418,11 +418,11 @@ impl<T: Trait> primitives::BuildStorage for GenesisConfig<T>
 			Self::hash(<RandomSeed<T>>::key()).to_vec() => [0u8; 32].encode()
 		];
 
-		storage.insert(EXTRINSIC_INDEX.to_vec(), 0u32.encode());
+		storage.insert(well_known_keys::EXTRINSIC_INDEX.to_vec(), 0u32.encode());
 
 		if let Some(changes_trie_config) = self.changes_trie_config {
 			storage.insert(
-				CHANGES_TRIE_CONFIG.to_vec(),
+				well_known_keys::CHANGES_TRIE_CONFIG.to_vec(),
 				changes_trie_config.encode());
 		}
 


### PR DESCRIPTION
We adding more and more keys that is native code should be aware of. However, there is no list of what currently keys substrate can expect from the runtime, what their types are, and whether they are required or not. Also, it's hard to attach documentation to literals.

This change proposes to move all known to date keys into a single place, in substrate-primitives, and maintain this list from now on, adding new keys as needed.

As a downside, this will require adding dependency on `substrate-primitives` even if these constants are all of only needed. OTOH, it didn't require to add new dependencies since `substrate-primitives` is already used as a dependency.