### PR TITLE
Various networking fixes for v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1120,27 +1120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1150,20 +1150,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1173,12 +1173,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1186,16 +1186,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1207,15 +1207,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,20 +1226,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,12 +1253,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,13 +1269,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1284,14 +1284,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,11 +1301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1314,14 +1314,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,12 +1340,12 @@ dependencies = [
  "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1354,12 +1354,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1368,10 +1368,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1379,25 +1379,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
@@ -1406,11 +1406,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1552,11 +1552,11 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2#ee9ff643a547f45113793315eaad7a4ed7fcb9b2"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2822,7 +2822,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4027,7 +4027,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4091,23 +4091,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4123,9 +4123,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4188,7 +4188,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=ee9ff643a547f45113793315eaad7a4ed7fcb9b2)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1120,27 +1120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1150,20 +1150,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1173,12 +1173,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1186,16 +1186,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1207,15 +1207,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,20 +1226,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,12 +1253,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,13 +1269,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1284,14 +1284,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,11 +1301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1314,14 +1314,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,12 +1340,12 @@ dependencies = [
  "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1354,12 +1354,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1368,10 +1368,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1379,25 +1379,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
@@ -1406,11 +1406,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1552,11 +1552,11 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef#f2a5eee5e8363b5cf567206ab2c01c564943d2ef"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2822,7 +2822,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4027,7 +4027,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4091,23 +4091,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4123,9 +4123,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4188,7 +4188,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=f2a5eee5e8363b5cf567206ab2c01c564943d2ef)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "base64 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chashmap 2.2.1 (git+https://github.com/redox-os/tfs)",
@@ -1120,27 +1120,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libp2p"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1150,20 +1150,20 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "smallvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1173,12 +1173,12 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1186,16 +1186,16 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1207,15 +1207,15 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,20 +1226,20 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,12 +1253,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1269,13 +1269,13 @@ dependencies = [
 [[package]]
 name = "libp2p-peerstore"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1284,14 +1284,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1301,11 +1301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-ratelimit"
 version = "0.1.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "aio-limited 0.1.0 (git+https://github.com/paritytech/aio-limited.git)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1314,14 +1314,14 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1332,7 +1332,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "aes-ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "asn1_der 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,12 +1340,12 @@ dependencies = [
  "ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1354,12 +1354,12 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp-transport"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "tk-listen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1368,10 +1368,10 @@ dependencies = [
 [[package]]
 name = "libp2p-transport-timeout"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1379,25 +1379,25 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "tokio-uds 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
- "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
+ "rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)",
@@ -1406,11 +1406,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1552,11 +1552,11 @@ dependencies = [
 [[package]]
 name = "multiaddr"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bs58 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "multihash"
 version = "0.8.1-pre"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "sha1 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79#1969bde4fe2f35507074b19583c4ba565e7a5d79"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b#4d8da24c64689c92dad64cc648ff474d4d9cef6b"
 dependencies = [
  "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2822,7 +2822,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)",
+ "libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4027,7 +4027,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum ctr 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50ac3add446ec1f8fe3dc007cd838f5b22bbf33186394feac505451ecc43c018"
 "checksum ctrlc 1.1.1 (git+https://github.com/paritytech/rust-ctrlc.git)" = "<none>"
-"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum datastore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum digest 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3cae2388d706b52f2f2f9afe280f9d768be36544bd71d1b8120cb34ea6450b55"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -4091,23 +4091,23 @@ dependencies = [
 "checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum libp2p 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-core 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-dns 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-floodsub 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-identify 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-kad 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-mplex 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-peerstore 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-ping 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-ratelimit 0.1.1 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-relay 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-secio 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-tcp-transport 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-transport-timeout 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-uds 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-websocket 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum libp2p-yamux 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
@@ -4123,9 +4123,9 @@ dependencies = [
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
-"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum multiaddr 0.3.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum multihash 0.8.1-pre (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
+"checksum multistream-select 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
 "checksum names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 "checksum nan-preserving-float 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d4f00fcc2f4c9efa8cc971db0da9e28290e28e97af47585e48691ef10ff31f"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
@@ -4188,7 +4188,7 @@ dependencies = [
 "checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
-"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=1969bde4fe2f35507074b19583c4ba565e7a5d79)" = "<none>"
+"checksum rw-stream-sink 0.1.0 (git+https://github.com/libp2p/rust-libp2p?rev=4d8da24c64689c92dad64cc648ff474d4d9cef6b)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"

--- a/substrate/cli/src/lib.rs
+++ b/substrate/cli/src/lib.rs
@@ -56,7 +56,7 @@ pub mod error;
 pub mod informant;
 mod panic_hook;
 
-use network_libp2p::AddrComponent;
+use network_libp2p::Protocol;
 use runtime_primitives::traits::As;
 use service::{
 	ServiceFactory, FactoryFullConfiguration, RuntimeGenesis,
@@ -298,8 +298,8 @@ where
 		};
 
 		config.network.listen_addresses = vec![
-			iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-				.chain(iter::once(AddrComponent::TCP(port)))
+			iter::once(Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)))
+				.chain(iter::once(Protocol::Tcp(port)))
 				.collect()
 		];
 		config.network.public_addresses = Vec::new();

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "4d8da24c64689c92dad64cc648ff474d4d9cef6b", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "ee9ff643a547f45113793315eaad7a4ed7fcb9b2", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethereum-types = "0.3"
 parking_lot = "0.5"
 libc = "0.2"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "1969bde4fe2f35507074b19583c4ba565e7a5d79", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "4d8da24c64689c92dad64cc648ff474d4d9cef6b", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethereum-types = "0.3"
 parking_lot = "0.5"
 libc = "0.2"

--- a/substrate/network-libp2p/Cargo.toml
+++ b/substrate/network-libp2p/Cargo.toml
@@ -11,7 +11,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "f2a5eee5e8363b5cf567206ab2c01c564943d2ef", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", rev = "1969bde4fe2f35507074b19583c4ba565e7a5d79", default-features = false, features = ["libp2p-secio", "libp2p-secio-secp256k1"] }
 ethereum-types = "0.3"
 parking_lot = "0.5"
 libc = "0.2"

--- a/substrate/network-libp2p/src/lib.rs
+++ b/substrate/network-libp2p/src/lib.rs
@@ -53,7 +53,7 @@ use libp2p::PeerId;
 
 pub use connection_filter::{ConnectionFilter, ConnectionDirection};
 pub use error::{Error, ErrorKind, DisconnectReason};
-pub use libp2p::{Multiaddr, multiaddr::AddrComponent};
+pub use libp2p::{Multiaddr, multiaddr::Protocol};
 pub use traits::*;
 
 pub type TimerToken = usize;
@@ -87,7 +87,7 @@ pub fn validate_node_url(url: &str) -> Result<(), Error> {
 pub(crate) fn parse_str_addr(addr_str: &str) -> Result<(PeerId, Multiaddr), Error> {
 	let mut addr: Multiaddr = addr_str.parse().map_err(|_| ErrorKind::AddressParse)?;
 	let who = match addr.pop() {
-		Some(AddrComponent::P2P(key)) =>
+		Some(Protocol::P2p(key)) =>
 			PeerId::from_multihash(key).map_err(|_| ErrorKind::AddressParse)?,
 		_ => return Err(ErrorKind::AddressParse.into()),
 	};

--- a/substrate/network-libp2p/src/node_handler.rs
+++ b/substrate/network-libp2p/src/node_handler.rs
@@ -475,7 +475,8 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 		let proto = match self.custom_protocols_substreams.iter().find(|p| p.protocol_id == protocol) {
 			Some(proto) => proto,
 			None => {
-				error!(target: "sub-libp2p", "Protocol {:?} isn't open", protocol);
+				// We are processing a message event before we could report to the outside that
+				// we disconnected from the protocol. This is not an error.
 				return
 			},
 		};

--- a/substrate/network-libp2p/src/service_task.rs
+++ b/substrate/network-libp2p/src/service_task.rs
@@ -751,10 +751,9 @@ impl Service {
 			SwarmEvent::NodeInfos { node_index, client_version, listen_addrs } => {
 				let peer_id = self.swarm.peer_id_of_node(node_index)
 					.expect("the swarm always produces events containing valid node indices");
-				// TODO: wrong function name
-				self.topology.add_kademlia_discovered_addrs(
+				self.topology.add_self_reported_listen_addrs(
 					peer_id,
-					listen_addrs.into_iter().map(|a| (a, false))
+					listen_addrs.into_iter()
 				);
 				Some(ServiceEvent::NodeInfos {
 					node_index,

--- a/substrate/network-libp2p/src/service_task.rs
+++ b/substrate/network-libp2p/src/service_task.rs
@@ -108,8 +108,8 @@ pub fn start_service(
 				// If the format of the bootstrap node is not a multiaddr, try to parse it as
 				// a `SocketAddr`. This corresponds to the format `IP:PORT`.
 				let addr = match bootnode.parse::<SocketAddr>() { 
-					Ok(SocketAddr::V4(socket)) => multiaddr![IP4(*socket.ip()), TCP(socket.port())],
-					Ok(SocketAddr::V6(socket)) => multiaddr![IP6(*socket.ip()), TCP(socket.port())],
+					Ok(SocketAddr::V4(socket)) => multiaddr![Ip4(*socket.ip()), Tcp(socket.port())],
+					Ok(SocketAddr::V6(socket)) => multiaddr![Ip6(*socket.ip()), Tcp(socket.port())],
 					_ => {
 						warn!(target: "sub-libp2p", "Not a valid bootnode address: {}", bootnode);
 						continue;

--- a/substrate/network-libp2p/src/service_task.rs
+++ b/substrate/network-libp2p/src/service_task.rs
@@ -863,7 +863,7 @@ impl Service {
 			}
 		}
 
-		// Poll the future that fires when we need to perform a random Kademlia query.
+		// Poll the future that fires when we need to reply to a Kademlia query.
 		loop {
 			match self.kad_new_ctrl_req_rx.poll() {
 				Ok(Async::NotReady) => break,

--- a/substrate/network-libp2p/src/service_task.rs
+++ b/substrate/network-libp2p/src/service_task.rs
@@ -265,6 +265,8 @@ pub struct Service {
 	max_outgoing_connections: usize,
 
 	/// For each node we're connected to, its address if known.
+	///
+	/// This is used purely to report disconnections to the topology.
 	nodes_addresses: FnvHashMap<NodeIndex, Multiaddr>,
 
 	/// If true, only reserved peers can connect.
@@ -707,10 +709,6 @@ impl Service {
 				None
 			},
 			SwarmEvent::NodeAddress { node_index, address } => {
-				let peer_id = self.swarm.peer_id_of_node(node_index)
-					.expect("the swarm always produces events containing valid node indices");
-				self.topology.report_connected(&address, &peer_id);
-				self.nodes_addresses.insert(node_index, address.clone());
 				Some(ServiceEvent::NodeAddress {
 					node_index,
 					address,

--- a/substrate/network-libp2p/src/swarm.rs
+++ b/substrate/network-libp2p/src/swarm.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use custom_proto::RegisteredProtocols;
 use fnv::FnvHashMap;
 use futures::{prelude::*, Stream};
-use libp2p::{Multiaddr, multiaddr::AddrComponent, PeerId};
+use libp2p::{Multiaddr, multiaddr::Protocol, PeerId};
 use libp2p::core::{muxing, Endpoint, PublicKey};
 use libp2p::core::nodes::node::Substream;
 use libp2p::core::nodes::swarm::{ConnectedPoint, Swarm as Libp2pSwarm, HandlerFactory};
@@ -267,7 +267,7 @@ impl<TUserData> Swarm<TUserData>
 	pub fn listen_on(&mut self, addr: Multiaddr) -> Result<Multiaddr, Multiaddr> {
 		match self.swarm.listen_on(addr) {
 			Ok(mut addr) => {
-				addr.append(AddrComponent::P2P(self.local_peer_id.clone().into()));
+				addr.append(Protocol::P2p(self.local_peer_id.clone().into()));
 				info!(target: "sub-libp2p", "Local node address is: {}", addr);
 				Ok(addr)
 			},
@@ -457,7 +457,7 @@ impl<TUserData> Swarm<TUserData>
 			);
 
 			self.listening_addrs.push(addr.clone());
-			addr.append(AddrComponent::P2P(self.local_peer_id.clone().into()));
+			addr.append(Protocol::P2p(self.local_peer_id.clone().into()));
 			info!(target: "sub-libp2p", "New external node address: {}", addr);
 		}
 	}

--- a/substrate/network-libp2p/src/swarm.rs
+++ b/substrate/network-libp2p/src/swarm.rs
@@ -523,9 +523,8 @@ impl<TUserData> Swarm<TUserData>
 				});
 			}
 			Libp2pSwarmEvent::Replaced { peer_id, endpoint, .. } => {
-				let node_index = self.next_node_index.clone();
-				self.next_node_index += 1;
-				debug_assert_eq!(self.node_by_peer.get(&peer_id), Some(&node_index));
+				let node_index = *self.node_by_peer.get(&peer_id)
+					.expect("node_by_peer is always kept in sync with the inner swarm");
 				let infos = self.nodes_info.get_mut(&node_index)
 					.expect("nodes_info is always kept in sync with the swarm");
 				debug_assert_eq!(infos.peer_id, peer_id);

--- a/substrate/network-libp2p/src/topology.rs
+++ b/substrate/network-libp2p/src/topology.rs
@@ -240,6 +240,7 @@ impl NetTopology {
 	/// Adds addresses that a node says it is listening on.
 	///
 	/// The addresses are most likely to be valid.
+	#[inline]
 	pub fn add_self_reported_listen_addrs<I>(
 		&mut self,
 		peer_id: &PeerId,
@@ -254,6 +255,7 @@ impl NetTopology {
 	///
 	/// For each address, incorporates a boolean. If true, that means we have some sort of hint
 	/// that this address can be reached.
+	#[inline]
 	pub fn add_kademlia_discovered_addrs<I>(
 		&mut self,
 		peer_id: &PeerId,

--- a/substrate/network-libp2p/src/topology.rs
+++ b/substrate/network-libp2p/src/topology.rs
@@ -366,8 +366,11 @@ impl NetTopology {
 	/// If we were indeed connected to this addr, then we can find out which peer ID it is.
 	pub fn report_disconnected(&mut self, addr: &Multiaddr, reason: DisconnectReason) {
 		let score_diff = match reason {
-			DisconnectReason::ClosedGracefully => -1,
-			DisconnectReason::Banned => -1,
+			DisconnectReason::NoSlot => -1,
+			DisconnectReason::FoundBetterAddr => -5,
+			DisconnectReason::RemoteClosed => -5,
+			DisconnectReason::Useless => -5,
+			DisconnectReason::Banned => -5,
 		};
 
 		for info in self.store.values_mut() {
@@ -419,9 +422,17 @@ impl NetTopology {
 }
 
 /// Reason why we disconnected from a peer.
+#[derive(Debug)]
 pub enum DisconnectReason {
-	/// The disconnection was graceful.
-	ClosedGracefully,
+	/// No slot available locally anymore for this peer.
+	NoSlot,
+	/// A better way to connect to this peer has been found, therefore we disconnect from
+	/// the old one.
+	FoundBetterAddr,
+	/// The remote closed the connection.
+	RemoteClosed,
+	/// This node is considered useless for our needs. This includes time outs.
+	Useless,
 	/// The peer has been banned.
 	Banned,
 }

--- a/substrate/network-libp2p/src/traits.rs
+++ b/substrate/network-libp2p/src/traits.rs
@@ -21,7 +21,7 @@ use std::net::Ipv4Addr;
 use std::str;
 use std::time::Duration;
 use TimerToken;
-use libp2p::{multiaddr::AddrComponent, Multiaddr};
+use libp2p::{multiaddr::Protocol, Multiaddr};
 use error::Error;
 use ethereum_types::H512;
 
@@ -139,8 +139,8 @@ impl NetworkConfiguration {
 			config_path: None,
 			net_config_path: None,
 			listen_addresses: vec![
-				iter::once(AddrComponent::IP4(Ipv4Addr::new(0, 0, 0, 0)))
-					.chain(iter::once(AddrComponent::TCP(30333)))
+				iter::once(Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)))
+					.chain(iter::once(Protocol::Tcp(30333)))
 					.collect()
 			],
 			public_addresses: Vec::new(),
@@ -158,8 +158,8 @@ impl NetworkConfiguration {
 	pub fn new_local() -> NetworkConfiguration {
 		let mut config = NetworkConfiguration::new();
 		config.listen_addresses = vec![
-			iter::once(AddrComponent::IP4(Ipv4Addr::new(127, 0, 0, 1)))
-				.chain(iter::once(AddrComponent::TCP(0)))
+			iter::once(Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)))
+				.chain(iter::once(Protocol::Tcp(0)))
 				.collect()
 		];
 		config


### PR DESCRIPTION
- Should hopefully fix all the panics.
- Some reputation score adjustments: we give higher priority to addresses that nodes we are connected to report for themselves, and don't decrease the reputation if we disconnect nodes because are full or because reserved mode has been enabled.
- No longer register the dialing port in the topology (cc #747)

The bug where syncing doesn't work is not really improved by these changes, but I think it's because we keep bouncing between nodes that refuse us because they are full, and because we have random disconnects. Both problems were fixed by unreleased PRs. Once this code has been deployed to more than a few nodes, syncing should hopefully work reliably again.