### PR TITLE
Removed From<H256> bound

### DIFF
--- a/core/client/db/src/light.rs
+++ b/core/client/db/src/light.rs
@@ -28,7 +28,7 @@ use client::cht;
 use client::error::{ErrorKind as ClientErrorKind, Result as ClientResult};
 use client::light::blockchain::Storage as LightBlockchainStorage;
 use codec::{Decode, Encode};
-use primitives::{AuthorityId, H256, Blake2Hasher};
+use primitives::{AuthorityId, Blake2Hasher};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT,
 	Zero, One, As, NumberFor};
@@ -183,7 +183,7 @@ impl<Block> BlockchainHeaderBackend<Block> for LightStorage<Block>
 	}
 }
 
-impl<Block: BlockT> LightStorage<Block> where Block::Hash: From<H256> {
+impl<Block: BlockT> LightStorage<Block> {
 	// note that a block is finalized. ensure that best chain contains the finalized
 	// block number first.
 	fn note_finalized(&self, transaction: &mut DBTransaction, header: &Block::Header, hash: Block::Hash) -> ClientResult<()> {
@@ -212,7 +212,7 @@ impl<Block: BlockT> LightStorage<Block> where Block::Hash: From<H256> {
 		let mut build_cht = |header: &Block::Header| -> ClientResult<()> {
 			if let Some(new_cht_number) = cht::is_build_required(cht::SIZE, *header.number()) {
 				let new_cht_start: NumberFor<Block> = cht::start_number(cht::SIZE, new_cht_number);
-				let new_cht_root: Option<Block::Hash> = cht::compute_root::<Block::Header, Blake2Hasher, _>(
+				let new_cht_root = cht::compute_root::<Block::Header, Blake2Hasher, _>(
 					cht::SIZE, new_cht_number, (new_cht_start.as_()..)
 					.map(|num| self.hash(As::sa(num)).unwrap_or_default())
 				);
@@ -262,7 +262,6 @@ impl<Block: BlockT> LightStorage<Block> where Block::Hash: From<H256> {
 impl<Block> LightBlockchainStorage<Block> for LightStorage<Block>
 	where
 		Block: BlockT,
-		Block::Hash: From<H256>,
 {
 	fn import_header(
 		&self,

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -18,7 +18,6 @@
 
 use futures::IntoFuture;
 
-use primitives::H256;
 use hashdb::Hasher;
 use patricia_trie::NodeCodec;
 use rlp::Encodable;
@@ -134,11 +133,10 @@ impl<E, H, C> LightDataChecker<E, H, C> {
 impl<E, Block, H, C> FetchChecker<Block> for LightDataChecker<E, H, C>
 	where
 		Block: BlockT,
-		Block::Hash: Into<H::Out> + From<H256>,
 		E: CodeExecutor<H>,
 		H: Hasher,
 		C: NodeCodec<H> + Sync + Send,
-		H::Out: Ord + Encodable + HeapSizeOf + From<Block::Hash> + From<H256>,
+		H::Out: Ord + Encodable + HeapSizeOf,
 {
 	fn check_header_proof(
 		&self,
@@ -162,8 +160,9 @@ impl<E, Block, H, C> FetchChecker<Block> for LightDataChecker<E, H, C>
 		request: &RemoteReadRequest<Block::Header>,
 		remote_proof: Vec<Vec<u8>>
 	) -> ClientResult<Option<Vec<u8>>> {
-		let local_state_root = request.header.state_root().clone();
-		read_proof_check::<H, C>(local_state_root.into(), remote_proof, &request.key).map_err(Into::into)
+		let mut root: H::Out = Default::default();
+		root.as_mut().copy_from_slice(request.header.state_root().as_ref());
+		read_proof_check::<H, C>(root, remote_proof, &request.key).map_err(Into::into)
 	}
 
 	fn check_execution_proof(

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -29,7 +29,7 @@ use substrate_executor::{NativeExecutor, NativeExecutionDispatch};
 use transaction_pool::{self, Options as TransactionPoolOptions, Pool as TransactionPool};
 use runtime_primitives::{traits::Block as BlockT, traits::Header as HeaderT, BuildStorage};
 use config::Configuration;
-use primitives::{Blake2Hasher, RlpCodec, H256};
+use primitives::{Blake2Hasher, RlpCodec};
 
 // Type aliases.
 // These exist mainly to avoid typing `<F as Factory>::Foo` all over the code.
@@ -214,11 +214,7 @@ pub struct LightComponents<Factory: ServiceFactory> {
 	_factory: PhantomData<Factory>,
 }
 
-impl<Factory: ServiceFactory> Components for LightComponents<Factory>
-	where
-		<<Factory as ServiceFactory>::Block as BlockT>::Hash: From<H256>,
-		H256: From<<<Factory as ServiceFactory>::Block as BlockT>::Hash>,
-{
+impl<Factory: ServiceFactory> Components for LightComponents<Factory> {
 	type Factory = Factory;
 	type Executor = LightExecutor<Factory>;
 	type Backend = LightBackend<Factory>;


### PR DESCRIPTION
This removes the `From<H256>` bound for `Hash` that needs to be specified everywhere the `Service` is used.