### PR TITLE
Contracts: Add transfer event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec-derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -174,6 +174,7 @@ impl treasury::Trait for Runtime {
 impl contract::Trait for Runtime {
 	type Gas = u64;
 	type DetermineContractAddress = contract::SimpleAddressDeterminator<Runtime>;
+	type Event = Event;
 }
 
 impl DigestItem for Log {
@@ -208,7 +209,7 @@ construct_runtime!(
 		CouncilVoting: council_voting::{Module, Call, Storage, Event<T>},
 		CouncilMotions: council_motions::{Module, Call, Storage, Event<T>, Origin},
 		Treasury: treasury,
-		Contract: contract::{Module, Call, Config},
+		Contract: contract::{Module, Call, Config, Event<T>},
 	}
 );
 

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -661,6 +661,7 @@ name = "srml-contract"
 version = "0.1.0"
 dependencies = [
  "parity-codec 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec-derive 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/srml/contract/Cargo.toml
+++ b/srml/contract/Cargo.toml
@@ -7,7 +7,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 serde = { version = "1.0", default_features = false }
 serde_derive = { version = "1.0", optional = true }
 pwasm-utils = { version = "0.3", default_features = false }
-parity-codec = { version = "2.0", default_features = false }
+parity-codec = { version = "~2.0.1", default_features = false }
+parity-codec-derive = { version = "~2.0.1", default-features = false }
 parity-wasm = { version = "0.31", default_features = false }
 substrate-primitives = { path = "../../core/primitives", default_features = false }
 sr-primitives = { path = "../../core/sr-primitives", default_features = false }
@@ -28,6 +29,7 @@ std = [
 	"serde_derive",
 	"serde/std",
 	"parity-codec/std",
+	"parity-codec-derive/std",
 	"substrate-primitives/std",
 	"sr-primitives/std",
 	"sr-io/std",

--- a/srml/contract/src/exec.rs
+++ b/srml/contract/src/exec.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
-use super::{CodeOf, MaxDepth, ContractAddressFor, Module, Trait};
+use super::{CodeOf, MaxDepth, ContractAddressFor, Module, Trait, Event, RawEvent};
 use account_db::{AccountDb, OverlayAccountDb};
 use gas::GasMeter;
 use vm;
@@ -37,6 +37,7 @@ pub struct ExecutionContext<'a, T: Trait + 'a> {
 	pub self_account: T::AccountId,
 	pub overlay: OverlayAccountDb<'a, T>,
 	pub depth: usize,
+	pub events: Vec<Event<T>>,
 }
 
 impl<'a, T: Trait> ExecutionContext<'a, T> {
@@ -61,8 +62,15 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 
 		let dest_code = <CodeOf<T>>::get(&dest);
 
-		let change_set = {
+		let (change_set, events) = {
 			let mut overlay = OverlayAccountDb::new(&self.overlay);
+
+			let mut nested = ExecutionContext {
+				overlay: overlay,
+				self_account: dest.clone(),
+				depth: self.depth + 1,
+				events: Vec::new(),
+			};
 
 			if value > T::Balance::zero() {
 				transfer(
@@ -71,15 +79,9 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 					&self.self_account,
 					&dest,
 					value,
-					&mut overlay,
+					&mut nested,
 				)?;
 			}
-
-			let mut nested = ExecutionContext {
-				overlay: overlay,
-				self_account: dest.clone(),
-				depth: self.depth + 1,
-			};
 
 			if !dest_code.is_empty() {
 				vm::execute(
@@ -95,10 +97,11 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 				).map_err(|_| "vm execute returned error while call")?;
 			}
 
-			nested.overlay.into_change_set()
+			(nested.overlay.into_change_set(), nested.events)
 		};
 
 		self.overlay.commit(change_set);
+		self.events.extend(events);
 
 		Ok(CallReceipt)
 	}
@@ -126,8 +129,15 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 			return Err("contract already exists");
 		}
 
-		let change_set = {
+		let (change_set, events) = {
 			let mut overlay = OverlayAccountDb::new(&self.overlay);
+
+			let mut nested = ExecutionContext {
+				overlay: overlay,
+				self_account: dest.clone(),
+				depth: self.depth + 1,
+				events: Vec::new(),
+			};
 
 			if endowment > T::Balance::zero() {
 				transfer(
@@ -136,15 +146,9 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 					&self.self_account,
 					&dest,
 					endowment,
-					&mut overlay,
+					&mut nested,
 				)?;
 			}
-
-			let mut nested = ExecutionContext {
-				overlay: overlay,
-				self_account: dest.clone(),
-				depth: self.depth + 1,
-			};
 
 			let mut contract_code = Vec::new();
 			vm::execute(
@@ -160,10 +164,11 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 			).map_err(|_| "vm execute returned error while create")?;
 
 			nested.overlay.set_code(&dest, contract_code);
-			nested.overlay.into_change_set()
+			(nested.overlay.into_change_set(), nested.events)
 		};
 
 		self.overlay.commit(change_set);
+		self.events.extend(events);
 
 		Ok(CreateReceipt {
 			address: dest,
@@ -183,15 +188,15 @@ impl<'a, T: Trait> ExecutionContext<'a, T> {
 /// Note, that the fee is denominated in `T::Balance` units, but
 /// charged in `T::Gas` from the provided `gas_meter`. This means
 /// that the actual amount charged might differ.
-fn transfer<T: Trait>(
+fn transfer<'a, T: Trait>(
 	gas_meter: &mut GasMeter<T>,
 	contract_create: bool,
 	transactor: &T::AccountId,
 	dest: &T::AccountId,
 	value: T::Balance,
-	overlay: &mut OverlayAccountDb<T>,
+	ctx: &mut ExecutionContext<'a, T>,
 ) -> Result<(), &'static str> {
-	let would_create = overlay.get_balance(dest).is_zero();
+	let would_create = ctx.overlay.get_balance(dest).is_zero();
 
 	let fee: T::Balance = if contract_create {
 		<Module<T>>::contract_fee()
@@ -207,7 +212,7 @@ fn transfer<T: Trait>(
 		return Err("not enough gas to pay transfer fee");
 	}
 
-	let from_balance = overlay.get_balance(transactor);
+	let from_balance = ctx.overlay.get_balance(transactor);
 	let new_from_balance = match from_balance.checked_sub(&value) {
 		Some(b) => b,
 		None => return Err("balance too low to send value"),
@@ -217,15 +222,16 @@ fn transfer<T: Trait>(
 	}
 	<T as balances::Trait>::EnsureAccountLiquid::ensure_account_liquid(transactor)?;
 
-	let to_balance = overlay.get_balance(dest);
+	let to_balance = ctx.overlay.get_balance(dest);
 	let new_to_balance = match to_balance.checked_add(&value) {
 		Some(b) => b,
 		None => return Err("destination balance too high to receive value"),
 	};
 
 	if transactor != dest {
-		overlay.set_balance(transactor, new_from_balance);
-		overlay.set_balance(dest, new_to_balance);
+		ctx.overlay.set_balance(transactor, new_from_balance);
+		ctx.overlay.set_balance(dest, new_to_balance);
+		ctx.events.push(RawEvent::Transfer(transactor.clone(), dest.clone(), value));
 	}
 
 	Ok(())


### PR DESCRIPTION
Closes #696 

Deposits the `Transfer` event each time some amount of value is transfered (initiated either by message-call or create). Events are deposited only at the top-level in case of successful execution. Events from nested contexts are only accrued if the nested context finished successfully.

