### PR TITLE
cli: add --dev to all subcommands

### DIFF
--- a/core/cli/src/cli.yml
+++ b/core/cli/src/cli.yml
@@ -138,6 +138,10 @@ subcommands:
             value_name: CHAIN_SPEC
             help: Specify the chain specification (one of krummelanke, dev, local or staging)
             takes_value: true
+        - dev:
+            long: dev
+            help: Specify the development chain
+            takes_value: false
   - export-blocks:
       about: Export blocks to a file
       args:
@@ -150,6 +154,10 @@ subcommands:
               value_name: CHAIN_SPEC
               help: Specify the chain specification.
               takes_value: true
+          - dev:
+              long: dev
+              help: Specify the development chain
+              takes_value: false
           - base-path:
               long: base-path
               short: d
@@ -182,6 +190,10 @@ subcommands:
               value_name: CHAIN_SPEC
               help: Specify the chain specification.
               takes_value: true
+          - dev:
+              long: dev
+              help: Specify the development chain
+              takes_value: false
           - base-path:
               long: base-path
               short: d
@@ -207,6 +219,10 @@ subcommands:
               value_name: CHAIN_SPEC
               help: Specify the chain specification.
               takes_value: true
+          - dev:
+              long: dev
+              help: Specify the development chain
+              takes_value: false
           - base-path:
               long: base-path
               short: d
@@ -221,6 +237,10 @@ subcommands:
               value_name: CHAIN_SPEC
               help: Specify the chain specification.
               takes_value: true
+          - dev:
+              long: dev
+              help: Specify the development chain
+              takes_value: false
           - base-path:
               long: base-path
               short: d


### PR DESCRIPTION
adds a shortcut to #803 to just use `./substrate purge-chain --dev` instead of `./substrate purge-chain --chain dev`.

Add `--dev` to other subcommands as well, as they all have the `--chain` option.