### PR TITLE
Introduce ExtBuilder in balances tests

### DIFF
--- a/srml/balances/src/mock.rs
+++ b/srml/balances/src/mock.rs
@@ -51,50 +51,61 @@ impl Trait for Runtime {
 	type Event = ();
 }
 
-pub fn new_test_ext(ext_deposit: u64, monied: bool) -> runtime_io::TestExternalities<Blake2Hasher> {
-	let mut t = system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
-	let balance_factor = if ext_deposit > 0 {
-		256
-	} else {
-		1
-	};
-	t.extend(GenesisConfig::<Runtime>{
-		balances: if monied {
-			vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor)]
-		} else {
-			vec![(10, balance_factor), (20, balance_factor)]
-		},
-		transaction_base_fee: 0,
-		transaction_byte_fee: 0,
-		existential_deposit: ext_deposit,
-		transfer_fee: 0,
-		creation_fee: 0,
-		reclaim_rebate: 0,
-	}.build_storage().unwrap());
-	t.into()
+pub struct ExtBuilder {
+	existential_deposit: u64,
+	transfer_fee: u64,
+	creation_fee: u64,
+	monied: bool,
 }
-
-pub fn new_test_ext2(ext_deposit: u64, monied: bool) -> runtime_io::TestExternalities<Blake2Hasher> {
-	let mut t = system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
-	let balance_factor = if ext_deposit > 0 {
-		256
-	} else {
-		1
-	};
-	t.extend(GenesisConfig::<Runtime>{
-		balances: if monied {
-			vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor)]
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		Self {
+			existential_deposit: 0,
+			transfer_fee: 0,
+			creation_fee: 0,
+			monied: false,
+		}
+	}
+}
+impl ExtBuilder {
+	pub fn existential_deposit(mut self, existential_deposit: u64) -> Self {
+		self.existential_deposit = existential_deposit;
+		self
+	}
+	pub fn transfer_fee(mut self, transfer_fee: u64) -> Self {
+		self.transfer_fee = transfer_fee;
+		self
+	}
+	pub fn creation_fee(mut self, creation_fee: u64) -> Self {
+		self.creation_fee = creation_fee;
+		self
+	}
+	pub fn monied(mut self, monied: bool) -> Self {
+		self.monied = monied;
+		self
+	}
+	pub fn build(self) -> runtime_io::TestExternalities<Blake2Hasher> {
+		let mut t = system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
+		let balance_factor = if self.existential_deposit > 0 {
+			256
 		} else {
-			vec![(10, balance_factor), (20, balance_factor)]
-		},
-		transaction_base_fee: 0,
-		transaction_byte_fee: 0,
-		existential_deposit: ext_deposit,
-		transfer_fee: 10,  // transfer_fee not zero
-		creation_fee: 50, // creation_fee not zero
-		reclaim_rebate: 0,
-	}.build_storage().unwrap());
-	t.into()
+			1
+		};
+		t.extend(GenesisConfig::<Runtime> {
+			balances: if self.monied {
+				vec![(1, 10 * balance_factor), (2, 20 * balance_factor), (3, 30 * balance_factor), (4, 40 * balance_factor)]
+			} else {
+				vec![(10, balance_factor), (20, balance_factor)]
+			},
+			transaction_base_fee: 0,
+			transaction_byte_fee: 0,
+			existential_deposit: self.existential_deposit,
+			transfer_fee: self.transfer_fee,
+			creation_fee: self.creation_fee,
+			reclaim_rebate: 0,
+		}.build_storage().unwrap());
+		t.into()
+	}
 }
 
 pub type System = system::Module<Runtime>;

--- a/srml/balances/src/tests.rs
+++ b/srml/balances/src/tests.rs
@@ -19,12 +19,12 @@
 #![cfg(test)]
 
 use super::*;
+use mock::{Balances, ExtBuilder, Runtime, System};
 use runtime_io::with_externalities;
-use mock::{Balances, System, Runtime, new_test_ext, new_test_ext2};
 
 #[test]
 fn reward_should_work() {
-	with_externalities(&mut new_test_ext(0, true), || {
+	with_externalities(&mut ExtBuilder::default().monied(true).build(), || {
 		assert_eq!(Balances::total_balance(&1), 10);
 		assert_ok!(Balances::reward(&1, 10));
 		assert_eq!(Balances::total_balance(&1), 20);
@@ -34,165 +34,231 @@ fn reward_should_work() {
 
 #[test]
 fn indexing_lookup_should_work() {
-	with_externalities(&mut new_test_ext(10, true), || {
-		assert_eq!(Balances::lookup_index(0), Some(1));
-		assert_eq!(Balances::lookup_index(1), Some(2));
-		assert_eq!(Balances::lookup_index(2), Some(3));
-		assert_eq!(Balances::lookup_index(3), Some(4));
-		assert_eq!(Balances::lookup_index(4), None);
-	});
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(10)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(0), Some(1));
+			assert_eq!(Balances::lookup_index(1), Some(2));
+			assert_eq!(Balances::lookup_index(2), Some(3));
+			assert_eq!(Balances::lookup_index(3), Some(4));
+			assert_eq!(Balances::lookup_index(4), None);
+		},
+	);
 }
 
 #[test]
 fn default_indexing_on_new_accounts_should_work() {
-	with_externalities(&mut new_test_ext(10, true), || {
-		assert_eq!(Balances::lookup_index(4), None);
-		assert_ok!(Balances::transfer(Some(1).into(), 5.into(), 10));
-		assert_eq!(Balances::lookup_index(4), Some(5));
-	});
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(10)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(4), None);
+			assert_ok!(Balances::transfer(Some(1).into(), 5.into(), 10));
+			assert_eq!(Balances::lookup_index(4), Some(5));
+		},
+	);
 }
 
 #[test]
 fn default_indexing_on_new_accounts_should_work2() {
-	with_externalities(&mut new_test_ext2(10, true), || {
-		assert_eq!(Balances::lookup_index(4), None);
-		// account 1 has 256 * 10 = 2560, account 5 is not exist, ext_deposit is 10, value is 10
-		assert_ok!(Balances::transfer(Some(1).into(), 5.into(), 10));
-		assert_eq!(Balances::lookup_index(4), Some(5));
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(10)
+			.creation_fee(50)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(4), None);
+			// account 1 has 256 * 10 = 2560, account 5 is not exist, ext_deposit is 10, value is 10
+			assert_ok!(Balances::transfer(Some(1).into(), 5.into(), 10));
+			assert_eq!(Balances::lookup_index(4), Some(5));
 
-		assert_eq!(Balances::free_balance(&1), 256 * 10 - 10 - 50); // 10 is value, 50 is creation_free
-	});
+			assert_eq!(Balances::free_balance(&1), 256 * 10 - 10 - 50); // 10 is value, 50 is creation_free
+		},
+	);
 }
 
 #[test]
 fn default_indexing_on_new_accounts_should_not_work2() {
-	with_externalities(&mut new_test_ext2(10, true), || {
-		assert_eq!(Balances::lookup_index(4), None);
-		// account 1 has 256 * 10 = 2560, account 5 is not exist, ext_deposit is 10, value is 9, not satisfies for ext_deposit
-		assert_noop!(Balances::transfer(Some(1).into(), 5.into(), 9), "value too low to create account");
-		assert_eq!(Balances::lookup_index(4), None); // account 5 should not exist
-		assert_eq!(Balances::free_balance(&1), 256 * 10);
-	});
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(10)
+			.creation_fee(50)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(4), None);
+			// account 1 has 256 * 10 = 2560, account 5 is not exist, ext_deposit is 10, value is 9, not satisfies for ext_deposit
+			assert_noop!(
+				Balances::transfer(Some(1).into(), 5.into(), 9),
+				"value too low to create account"
+			);
+			assert_eq!(Balances::lookup_index(4), None); // account 5 should not exist
+			assert_eq!(Balances::free_balance(&1), 256 * 10);
+		},
+	);
 }
 
 #[test]
 fn dust_account_removal_should_work() {
-	with_externalities(&mut new_test_ext(256 * 10, true), || {
-		System::inc_account_nonce(&2);
-		assert_eq!(System::account_nonce(&2), 1);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 10)
+			.monied(true)
+			.build(),
+		|| {
+			System::inc_account_nonce(&2);
+			assert_eq!(System::account_nonce(&2), 1);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
 
-		assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 10 + 1));	// index 1 (account 2) becomes zombie
-		assert_eq!(Balances::total_balance(&2), 0);
-		assert_eq!(Balances::total_balance(&5), 256 * 10 + 1);
-		assert_eq!(System::account_nonce(&2), 0);
-	});
+			assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 10 + 1)); // index 1 (account 2) becomes zombie
+			assert_eq!(Balances::total_balance(&2), 0);
+			assert_eq!(Balances::total_balance(&5), 256 * 10 + 1);
+			assert_eq!(System::account_nonce(&2), 0);
+		},
+	);
 }
 
 #[test]
 fn dust_account_removal_should_work2() {
-	with_externalities(&mut new_test_ext2(256 * 10, true), || {
-		System::inc_account_nonce(&2);
-		assert_eq!(System::account_nonce(&2), 1);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
-		assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 10));	// index 1 (account 2) becomes zombie for 256*10 + 50(fee) < 256 * 10 (ext_deposit)
-		assert_eq!(Balances::total_balance(&2), 0);
-		assert_eq!(Balances::total_balance(&5), 256 * 10);
-		assert_eq!(System::account_nonce(&2), 0);
-	});
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 10)
+			.creation_fee(50)
+			.monied(true)
+			.build(),
+		|| {
+			System::inc_account_nonce(&2);
+			assert_eq!(System::account_nonce(&2), 1);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
+			assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 10)); // index 1 (account 2) becomes zombie for 256*10 + 50(fee) < 256 * 10 (ext_deposit)
+			assert_eq!(Balances::total_balance(&2), 0);
+			assert_eq!(Balances::total_balance(&5), 256 * 10);
+			assert_eq!(System::account_nonce(&2), 0);
+		},
+	);
 }
 
 #[test]
 fn reclaim_indexing_on_new_accounts_should_work() {
-	with_externalities(&mut new_test_ext(256 * 1, true), || {
-		assert_eq!(Balances::lookup_index(1), Some(2));
-		assert_eq!(Balances::lookup_index(4), None);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 1)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(1), Some(2));
+			assert_eq!(Balances::lookup_index(4), None);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
 
-		assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 20));	// account 2 becomes zombie freeing index 1 for reclaim)
-		assert_eq!(Balances::total_balance(&2), 0);
+			assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 20)); // account 2 becomes zombie freeing index 1 for reclaim)
+			assert_eq!(Balances::total_balance(&2), 0);
 
-		assert_ok!(Balances::transfer(Some(5).into(), 6.into(), 256 * 1 + 0x69));	// account 6 takes index 1.
-		assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(6));
-	});
+			assert_ok!(Balances::transfer(Some(5).into(), 6.into(), 256 * 1 + 0x69)); // account 6 takes index 1.
+			assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(6));
+		},
+	);
 }
 
 #[test]
 fn reclaim_indexing_on_new_accounts_should_work2() {
-	with_externalities(&mut new_test_ext2(256 * 1, true), || {
-		assert_eq!(Balances::lookup_index(1), Some(2));
-		assert_eq!(Balances::lookup_index(4), None);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 1)
+			.monied(true)
+			.build(),
+		|| {
+			assert_eq!(Balances::lookup_index(1), Some(2));
+			assert_eq!(Balances::lookup_index(4), None);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
 
-		assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 20 - 50));	// account 2 becomes zombie freeing index 1 for reclaim) 50 is creation fee
-		assert_eq!(Balances::total_balance(&2), 0);
+			assert_ok!(Balances::transfer(Some(2).into(), 5.into(), 256 * 20 - 50)); // account 2 becomes zombie freeing index 1 for reclaim) 50 is creation fee
+			assert_eq!(Balances::total_balance(&2), 0);
 
-		assert_ok!(Balances::transfer(Some(5).into(), 6.into(), 256 * 1 + 0x69));	// account 6 takes index 1.
-		assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(6));
-	});
+			assert_ok!(Balances::transfer(Some(5).into(), 6.into(), 256 * 1 + 0x69)); // account 6 takes index 1.
+			assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(6));
+		},
+	);
 }
 
 #[test]
 fn reserved_balance_should_prevent_reclaim_count() {
-	with_externalities(&mut new_test_ext(256 * 1, true), || {
-		System::inc_account_nonce(&2);
-		assert_eq!(Balances::lookup_index(1), Some(2));
-		assert_eq!(Balances::lookup_index(4), None);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 1)
+			.monied(true)
+			.build(),
+		|| {
+			System::inc_account_nonce(&2);
+			assert_eq!(Balances::lookup_index(1), Some(2));
+			assert_eq!(Balances::lookup_index(4), None);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
 
-		assert_ok!(Balances::reserve(&2, 256 * 19 + 1));					// account 2 becomes mostly reserved
-		assert_eq!(Balances::free_balance(&2), 0);						// "free" account deleted."
-		assert_eq!(Balances::total_balance(&2), 256 * 19 + 1);			// reserve still exists.
-		assert_eq!(System::account_nonce(&2), 1);
+			assert_ok!(Balances::reserve(&2, 256 * 19 + 1)); // account 2 becomes mostly reserved
+			assert_eq!(Balances::free_balance(&2), 0); // "free" account deleted."
+			assert_eq!(Balances::total_balance(&2), 256 * 19 + 1); // reserve still exists.
+			assert_eq!(System::account_nonce(&2), 1);
 
-		assert_ok!(Balances::transfer(Some(4).into(), 5.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 for account 5.
-		assert_eq!(Balances::total_balance(&5), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(2));					// but fails.
-		assert_eq!(System::account_nonce(&2), 1);
+			assert_ok!(Balances::transfer(Some(4).into(), 5.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 for account 5.
+			assert_eq!(Balances::total_balance(&5), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(2)); // but fails.
+			assert_eq!(System::account_nonce(&2), 1);
 
-		assert_eq!(Balances::slash(&2, 256 * 18 + 2), None);				// account 2 gets slashed
-		assert_eq!(Balances::total_balance(&2), 0);						// "free" account deleted."
-		assert_eq!(System::account_nonce(&2), 0);
+			assert_eq!(Balances::slash(&2, 256 * 18 + 2), None); // account 2 gets slashed
+			assert_eq!(Balances::total_balance(&2), 0); // "free" account deleted."
+			assert_eq!(System::account_nonce(&2), 0);
 
-		assert_ok!(Balances::transfer(Some(4).into(), 6.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 again for account 6.
-		assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(6));					// and succeeds.
-	});
+			assert_ok!(Balances::transfer(Some(4).into(), 6.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 again for account 6.
+			assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(6)); // and succeeds.
+		},
+	);
 }
 
 #[test]
 fn reserved_balance_should_prevent_reclaim_count2() {
-	with_externalities(&mut new_test_ext2(256 * 1, true), || {
-		System::inc_account_nonce(&2);
-		assert_eq!(Balances::lookup_index(1), Some(2));
-		assert_eq!(Balances::lookup_index(4), None);
-		assert_eq!(Balances::total_balance(&2), 256 * 20);
+	with_externalities(
+		&mut ExtBuilder::default()
+			.existential_deposit(256 * 1)
+			.monied(true)
+			.build(),
+		|| {
+			System::inc_account_nonce(&2);
+			assert_eq!(Balances::lookup_index(1), Some(2));
+			assert_eq!(Balances::lookup_index(4), None);
+			assert_eq!(Balances::total_balance(&2), 256 * 20);
 
-		assert_ok!(Balances::reserve(&2, 256 * 19 + 1));					// account 2 becomes mostly reserved
-		assert_eq!(Balances::free_balance(&2), 0);						// "free" account deleted."
-		assert_eq!(Balances::total_balance(&2), 256 * 19 + 1);			// reserve still exists.
-		assert_eq!(System::account_nonce(&2), 1);
+			assert_ok!(Balances::reserve(&2, 256 * 19 + 1)); // account 2 becomes mostly reserved
+			assert_eq!(Balances::free_balance(&2), 0); // "free" account deleted."
+			assert_eq!(Balances::total_balance(&2), 256 * 19 + 1); // reserve still exists.
+			assert_eq!(System::account_nonce(&2), 1);
 
-		assert_ok!(Balances::transfer(Some(4).into(), 5.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 for account 5.
-		assert_eq!(Balances::total_balance(&5), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(2));					// but fails.
-		assert_eq!(System::account_nonce(&2), 1);
+			assert_ok!(Balances::transfer(Some(4).into(), 5.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 for account 5.
+			assert_eq!(Balances::total_balance(&5), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(2)); // but fails.
+			assert_eq!(System::account_nonce(&2), 1);
 
-		assert_eq!(Balances::slash(&2, 256 * 18 + 2), None);				// account 2 gets slashed
-		assert_eq!(Balances::total_balance(&2), 0);						// "free" account deleted."
-		assert_eq!(System::account_nonce(&2), 0);
+			assert_eq!(Balances::slash(&2, 256 * 18 + 2), None); // account 2 gets slashed
+			assert_eq!(Balances::total_balance(&2), 0); // "free" account deleted."
+			assert_eq!(System::account_nonce(&2), 0);
 
-		assert_ok!(Balances::transfer(Some(4).into(), 6.into(), 256 * 1 + 0x69));	// account 4 tries to take index 1 again for account 6.
-		assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
-		assert_eq!(Balances::lookup_index(1), Some(6));					// and succeeds.
-	});
+			assert_ok!(Balances::transfer(Some(4).into(), 6.into(), 256 * 1 + 0x69)); // account 4 tries to take index 1 again for account 6.
+			assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
+			assert_eq!(Balances::lookup_index(1), Some(6)); // and succeeds.
+		},
+	);
 }
 
 #[test]
 fn balance_works() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 42);
 		assert_eq!(Balances::free_balance(&1), 42);
 		assert_eq!(Balances::reserved_balance(&1), 0);
@@ -205,7 +271,7 @@ fn balance_works() {
 
 #[test]
 fn balance_transfer_works() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		Balances::increase_total_stake_by(111);
 		assert_ok!(Balances::transfer(Some(1).into(), 2.into(), 69));
@@ -216,7 +282,7 @@ fn balance_transfer_works() {
 
 #[test]
 fn reserving_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 
 		assert_eq!(Balances::total_balance(&1), 111);
@@ -233,7 +299,7 @@ fn reserving_balance_should_work() {
 
 #[test]
 fn balance_transfer_when_reserved_should_not_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		assert_ok!(Balances::reserve(&1, 69));
 		assert_noop!(Balances::transfer(Some(1).into(), 2.into(), 69), "balance too low to send value");
@@ -242,7 +308,7 @@ fn balance_transfer_when_reserved_should_not_work() {
 
 #[test]
 fn deducting_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		assert_ok!(Balances::reserve(&1, 69));
 		assert_eq!(Balances::free_balance(&1), 42);
@@ -251,7 +317,7 @@ fn deducting_balance_should_work() {
 
 #[test]
 fn refunding_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 42);
 		Balances::set_reserved_balance(&1, 69);
 		Balances::unreserve(&1, 69);
@@ -262,7 +328,7 @@ fn refunding_balance_should_work() {
 
 #[test]
 fn slashing_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		Balances::increase_total_stake_by(111);
 		assert_ok!(Balances::reserve(&1, 69));
@@ -275,7 +341,7 @@ fn slashing_balance_should_work() {
 
 #[test]
 fn slashing_incomplete_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 42);
 		Balances::increase_total_stake_by(42);
 		assert_ok!(Balances::reserve(&1, 21));
@@ -288,7 +354,7 @@ fn slashing_incomplete_balance_should_work() {
 
 #[test]
 fn unreserving_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		assert_ok!(Balances::reserve(&1, 111));
 		Balances::unreserve(&1, 42);
@@ -299,7 +365,7 @@ fn unreserving_balance_should_work() {
 
 #[test]
 fn slashing_reserved_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		Balances::increase_total_stake_by(111);
 		assert_ok!(Balances::reserve(&1, 111));
@@ -312,7 +378,7 @@ fn slashing_reserved_balance_should_work() {
 
 #[test]
 fn slashing_incomplete_reserved_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		Balances::increase_total_stake_by(111);
 		assert_ok!(Balances::reserve(&1, 42));
@@ -325,7 +391,7 @@ fn slashing_incomplete_reserved_balance_should_work() {
 
 #[test]
 fn transferring_reserved_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 110);
 		Balances::set_free_balance(&2, 1);
 		assert_ok!(Balances::reserve(&1, 110));
@@ -339,7 +405,7 @@ fn transferring_reserved_balance_should_work() {
 
 #[test]
 fn transferring_reserved_balance_to_nonexistent_should_fail() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 111);
 		assert_ok!(Balances::reserve(&1, 111));
 		assert_noop!(Balances::repatriate_reserved(&1, &2, 42), "beneficiary account must pre-exist");
@@ -348,7 +414,7 @@ fn transferring_reserved_balance_to_nonexistent_should_fail() {
 
 #[test]
 fn transferring_incomplete_reserved_balance_should_work() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		Balances::set_free_balance(&1, 110);
 		Balances::set_free_balance(&2, 1);
 		assert_ok!(Balances::reserve(&1, 41));
@@ -362,7 +428,7 @@ fn transferring_incomplete_reserved_balance_should_work() {
 
 #[test]
 fn transferring_too_high_value_should_not_panic() {
-	with_externalities(&mut new_test_ext(0, false), || {
+	with_externalities(&mut ExtBuilder::default().build(), || {
 		<FreeBalance<Runtime>>::insert(1, u64::max_value());
 		<FreeBalance<Runtime>>::insert(2, 1);
 
@@ -373,32 +439,35 @@ fn transferring_too_high_value_should_not_panic() {
 
 		assert_eq!(Balances::free_balance(&1), u64::max_value());
 		assert_eq!(Balances::free_balance(&2), 1);
-		});
+	});
 }
 
 #[test]
 fn account_removal_on_free_too_low() {
-	with_externalities(&mut new_test_ext(100, false), || {
-		// Setup two accounts with free balance above the exsistential threshold.
-		{
-			Balances::set_free_balance(&1, 110);
-			Balances::increase_total_stake_by(110);
+	with_externalities(
+		&mut ExtBuilder::default().existential_deposit(100).build(),
+		|| {
+			// Setup two accounts with free balance above the exsistential threshold.
+			{
+				Balances::set_free_balance(&1, 110);
+				Balances::increase_total_stake_by(110);
 
-			Balances::set_free_balance(&2, 110);
-			Balances::increase_total_stake_by(110);
+				Balances::set_free_balance(&2, 110);
+				Balances::increase_total_stake_by(110);
 
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 732);
-		}
+				assert_eq!(<TotalIssuance<Runtime>>::get(), 732);
+			}
 
-		// Transfer funds from account 1 of such amount that after this transfer
-		// the balance of account 1 will be below the exsistential threshold.
-		// This should lead to the removal of all balance of this account.
-		assert_ok!(Balances::transfer(Some(1).into(), 2.into(), 20));
+			// Transfer funds from account 1 of such amount that after this transfer
+			// the balance of account 1 will be below the exsistential threshold.
+			// This should lead to the removal of all balance of this account.
+			assert_ok!(Balances::transfer(Some(1).into(), 2.into(), 20));
 
-		// Verify free balance removal of account 1.
-		assert_eq!(Balances::free_balance(&1), 0);
-		
-		// Verify that TotalIssuance tracks balance removal when free balance is too low.
-		assert_eq!(<TotalIssuance<Runtime>>::get(), 642);
-	});
+			// Verify free balance removal of account 1.
+			assert_eq!(Balances::free_balance(&1), 0);
+
+			// Verify that TotalIssuance tracks balance removal when free balance is too low.
+			assert_eq!(<TotalIssuance<Runtime>>::get(), 642);
+		},
+	);
 }


### PR DESCRIPTION
Instead of using `new_test_ext`/`new_test_ext2` this change proposes to use a builder pattern. IMO this makes code more readable, although a bit more verbose.

For example, it converts 

```rust
new_test_ext2(10, true)
```

to

```rust
&mut ExtBuilder::default()
    .existential_deposit(10)
    .creation_fee(50)
    .monied(true)
    .build()
```

This PR does **NOT** change behavior, although there is some formatting was done to keep lines
reasonably long.
