### PR TITLE
Prevent exploiting overflow in Balances::transfer

### DIFF
--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -287,7 +287,10 @@ impl<T: Trait> Module<T> {
 		let to_balance = Self::free_balance(&dest);
 		let would_create = to_balance.is_zero();
 		let fee = if would_create { Self::creation_fee() } else { Self::transfer_fee() };
-		let liability = value + fee;
+		let liability = match value.checked_add(&fee) {
+			Some(l) => l,
+			None => return Err("got overflow after adding a fee to value"),
+		};
 
 		let new_from_balance = match from_balance.checked_sub(&liability) {
 			Some(b) => b,

--- a/srml/balances/src/tests.rs
+++ b/srml/balances/src/tests.rs
@@ -471,3 +471,19 @@ fn account_removal_on_free_too_low() {
 		},
 	);
 }
+
+#[test]
+fn transfer_overflow_isnt_exploitable() {
+	with_externalities(
+		&mut ExtBuilder::default().creation_fee(50).build(),
+		|| {
+			// Craft a value that will overflow if summed with `creation_fee`.
+			let evil_value = u64::max_value() - 49;
+
+			assert_err!(
+				Balances::transfer(Some(1).into(), 5.into(), evil_value),
+				"got overflow after adding a fee to value"
+			);
+		}
+	);
+}


### PR DESCRIPTION
Based on #822 

An user can make a call to `transfer` with such `value`, that overflows and wraps when added with `fee`. If it passes `balance too low` and `destination balance too high to receive value` checks then it could be used to create value from the thin air.