### PR TITLE
Clean up the "custom protocol" code

### DIFF
--- a/core/network-libp2p/src/custom_proto.rs
+++ b/core/network-libp2p/src/custom_proto.rs
@@ -145,6 +145,12 @@ impl<TSubstream> RegisteredProtocolSubstream<TSubstream> {
 		message.extend_from_slice(&data);
 		self.send_queue.push_back(message);
 
+		// If the length of the queue goes over a certain arbitrary threshold, we print a warning.
+		if self.send_queue.len() >= 128 {
+			warn!(target: "sub-libp2p", "Queue of packets to send over substream is pretty \
+				large: {}", self.send_queue.len());
+		}
+
 		if let Some(task) = self.to_notify.take() {
 			task.notify();
 		}

--- a/core/network-libp2p/src/custom_proto.rs
+++ b/core/network-libp2p/src/custom_proto.rs
@@ -146,7 +146,8 @@ impl<TSubstream> RegisteredProtocolSubstream<TSubstream> {
 		self.send_queue.push_back(message);
 
 		// If the length of the queue goes over a certain arbitrary threshold, we print a warning.
-		if self.send_queue.len() >= 128 {
+		// TODO: figure out a good threshold
+		if self.send_queue.len() >= 2048 {
 			warn!(target: "sub-libp2p", "Queue of packets to send over substream is pretty \
 				large: {}", self.send_queue.len());
 		}

--- a/core/network-libp2p/src/custom_proto.rs
+++ b/core/network-libp2p/src/custom_proto.rs
@@ -206,9 +206,8 @@ where TSubstream: AsyncRead + AsyncWrite,
 
 		// Flushing if necessary.
 		if self.requires_poll_complete {
-			match self.inner.poll_complete()? {
-				Async::Ready(()) => self.requires_poll_complete = false,
-				Async::NotReady => (),
+			if let Async::Ready(()) = self.inner.poll_complete()? {
+				self.requires_poll_complete = false;
 			}
 		}
 

--- a/core/network-libp2p/src/node_handler.rs
+++ b/core/network-libp2p/src/node_handler.rs
@@ -396,6 +396,11 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 	fn shutdown(&mut self) {
 		// TODO: close gracefully
 		self.is_shutting_down = true;
+
+		for custom_proto in &mut self.custom_protocols_substreams {
+			custom_proto.shutdown();
+		}
+
 		if let Some(to_notify) = self.to_notify.take() {
 			to_notify.notify();
 		}
@@ -403,6 +408,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 
 	fn poll(&mut self) -> Poll<Option<NodeHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>>, IoError> {
 		if self.is_shutting_down {
+			// TODO: finish only when everything is closed
 			return Ok(Async::Ready(None));
 		}
 


### PR DESCRIPTION
Right now for each substrate substream we're creating two channels, and the incoming and outgoing packets are transmitted over those channels.
This PR changes this so that we use a "flat" structure that simply polls a `CustomProtocolSubstream` struct for incoming packets, and calls a method for outgoing packets.