### PR TITLE
Remove `serde_json` stuff from the metadata RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,6 @@ dependencies = [
  "parity-codec 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0",
  "sr-version 0.1.0",
  "substrate-client 0.1.0",

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -18,7 +18,6 @@ substrate-primitives = { path = "../primitives" }
 sr-primitives = { path = "../sr-primitives" }
 sr-version = { path = "../sr-version" }
 tokio = "0.1.7"
-serde_json = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -30,7 +30,6 @@ extern crate substrate_primitives as primitives;
 extern crate sr_primitives as runtime_primitives;
 extern crate sr_version as runtime_version;
 extern crate tokio;
-extern crate serde_json;
 
 #[macro_use]
 extern crate error_chain;

--- a/core/rpc/src/state/error.rs
+++ b/core/rpc/src/state/error.rs
@@ -19,15 +19,9 @@ use rpc;
 
 use errors;
 
-use serde_json;
-
 error_chain! {
 	links {
 		Client(client::error::Error, client::error::ErrorKind) #[doc = "Client error"];
-	}
-
-	foreign_links {
-		Json(serde_json::Error);
 	}
 
 	errors {

--- a/core/rpc/src/state/mod.rs
+++ b/core/rpc/src/state/mod.rs
@@ -33,7 +33,6 @@ use rpc::futures::{stream, Future, Sink, Stream};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header};
 use tokio::runtime::TaskExecutor;
-use serde_json;
 
 use subscriptions::Subscriptions;
 
@@ -66,7 +65,7 @@ build_rpc_trait! {
 
 		/// Returns the runtime metadata as JSON.
 		#[rpc(name = "state_getMetadata")]
-		fn metadata(&self, Trailing<Hash>) -> Result<serde_json::Value>;
+		fn metadata(&self, Trailing<Hash>) -> Result<Vec<u8>>;
 
 		/// Query historical storage entries (by key) starting from a block given as the second parameter.
 		///
@@ -143,10 +142,9 @@ impl<B, E, Block> StateApi<Block::Hash> for State<B, E, Block> where
 		Ok(self.storage(key, block)?.map(|x| x.0.len() as u64))
 	}
 
-	fn metadata(&self, block: Trailing<Block::Hash>) -> Result<serde_json::Value> {
+	fn metadata(&self, block: Trailing<Block::Hash>) -> Result<Vec<u8>> {
 		let block = self.unwrap_or_best(block)?;
-		let metadata = self.client.metadata(&BlockId::Hash(block))?;
-		serde_json::to_value(metadata).map_err(Into::into)
+		self.client.metadata(&BlockId::Hash(block)).map_err(Into::into)
 	}
 
 	fn query_storage(&self, keys: Vec<StorageKey>, from: Block::Hash, to: Trailing<Block::Hash>) -> Result<Vec<StorageChangeSet<Block::Hash>>> {


### PR DESCRIPTION
The metadata call does not work anymore with JSON and just returns an
opaque blob.