### PR TITLE
Limit gossip for non-authorities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,6 +2991,7 @@ dependencies = [
  "parity-codec 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0",
  "substrate-client 0.1.0",

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -15,6 +15,7 @@ bitflags = "1.0"
 futures = "0.1.17"
 linked-hash-map = "0.5"
 rustc-hex = "1.0"
+rand = "0.5"
 substrate-primitives = { path = "../../core/primitives" }
 substrate-client = { path = "../../core/client" }
 sr-primitives = { path = "../../core/sr-primitives" }

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -31,6 +31,7 @@ extern crate substrate_network_libp2p as network_libp2p;
 extern crate parity_codec as codec;
 extern crate futures;
 extern crate rustc_hex;
+extern crate rand;
 #[macro_use] extern crate log;
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate error_chain;

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -296,11 +296,11 @@ impl<B: BlockT> ChainSync<B> {
 				if !self.is_known_or_already_downloading(protocol, header.parent_hash()) {
 					trace!(target: "sync", "Ignoring unknown stale block announce from {}: {} {:?}", who, hash, header);
 				} else {
-					trace!(target: "sync", "Downloading new stale block announced from {}: {} {:?}", who, hash, header);
+					trace!(target: "sync", "Considering new stale block announced from {}: {} {:?}", who, hash, header);
 					self.download_stale(protocol, who, &hash);
 				}
 			} else {
-				trace!(target: "sync", "Downloading new block announced from {}: {} {:?}", who, hash, header);
+				trace!(target: "sync", "Considering new block announced from {}: {} {:?}", who, hash, header);
 				self.download_new(protocol, who);
 			}
 		} else {
@@ -371,6 +371,7 @@ impl<B: BlockT> ChainSync<B> {
 			let import_status = self.import_queue.status();
 			// when there are too many blocks in the queue => do not try to download new blocks
 			if import_status.importing_count > MAX_IMPORTING_BLOCKS {
+				trace!(target: "sync", "Too many blocks in the queue.");
 				return;
 			}
 			// we should not download already queued blocks
@@ -395,7 +396,7 @@ impl<B: BlockT> ChainSync<B> {
 						trace!(target: "sync", "Nothing to request");
 					}
 				},
-				_ => (),
+				_ => trace!(target: "sync", "Peer {} is busy", who),
 			}
 		}
 	}


### PR DESCRIPTION
Send gossip messages to `sqrt()` peers on average. Authorities still get all messages unconditionally.