### PR TITLE
Take and return Bytes in state_call

### DIFF
--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -43,7 +43,7 @@ fn should_call_contract() {
 	let client = State::new(client, core.executor());
 
 	assert_matches!(
-		client.call("balanceOf".into(), vec![1,2,3], Some(genesis_hash).into()),
+		client.call("balanceOf".into(), Bytes(vec![1,2,3]), Some(genesis_hash).into()),
 		Err(Error(ErrorKind::Client(client::error::ErrorKind::Execution(_)), _))
 	)
 }


### PR DESCRIPTION
This PR changes serialization and deserialization of `data` and result of `state_call` to `Bytes` rather than `Vec<u8>`. It allows us to use `0x0020` notation rather than `[0, 32]`, e.g.:

```
$ curl \
    -H 'Content-Type: application/json'\
    -d '{"jsonrpc": "2.0", "method":"state_call", "params":["account_nonce", "0xf295940fa750df68a686fcf4abd4111c8a9c5a5a5a83c4c8639c451a94a7adfd"], "id":1}' \
    -s http://localhost:9933/ | jq '.'

{
  "jsonrpc": "2.0",
  "result": "0x0000000000000000",
  "id": 1
}
```
