### PR TITLE
Remove `#![feature(panic_handler)]`

### DIFF
--- a/core/executor/wasm/src/lib.rs
+++ b/core/executor/wasm/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(panic_handler)]
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 #![feature(alloc)]

--- a/core/sr-io/src/lib.rs
+++ b/core/sr-io/src/lib.rs
@@ -20,7 +20,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(lang_items))]
-#![cfg_attr(not(feature = "std"), feature(panic_handler))]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]

--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -39,7 +39,6 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(panic_handler))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 

--- a/core/sr-std/src/lib.rs
+++ b/core/sr-std/src/lib.rs
@@ -20,7 +20,6 @@
 // end::description[]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(panic_handler))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 


### PR DESCRIPTION
This PR fixes the following warning in the CI build

```
warning: the feature `panic_handler` has been stable since 1.30.0 and no longer requires an attribute to enable
  --> /home/gitlab-runner/builds/133083f6/1/parity/substrate/core/sr-std/src/lib.rs:23:43
   |
23 | #![cfg_attr(not(feature = "std"), feature(panic_handler))]
   |                                           ^^^^^^^^^^^^^
   |
   = note: #[warn(stable_features)] on by default
```
