### PR TITLE
Drew.debug_bft - Add debug statements throughout BFT / consensus logic

### DIFF
--- a/core/bft/Cargo.toml
+++ b/core/bft/Cargo.toml
@@ -13,7 +13,7 @@ tokio = "0.1.7"
 parking_lot = "0.4"
 error-chain = "0.12"
 log = "0.4"
-rhododendron = "0.3"
+rhododendron = "0.3.4"
 
 [dev-dependencies]
 substrate-keyring = { path = "../keyring" }

--- a/core/bft/Cargo.toml
+++ b/core/bft/Cargo.toml
@@ -13,7 +13,7 @@ tokio = "0.1.7"
 parking_lot = "0.4"
 error-chain = "0.12"
 log = "0.4"
-rhododendron = "0.3.4"
+rhododendron = "0.3"
 
 [dev-dependencies]
 substrate-keyring = { path = "../keyring" }

--- a/core/bft/src/lib.rs
+++ b/core/bft/src/lib.rs
@@ -323,7 +323,7 @@ impl<B: Block, P: Proposer<B>> rhododendron::Context for BftInstance<B, P>
 		debug!(target: "bft", "Voting authorities: {:?}",
 			collect_pubkeys(accumulator.voters()));
 		debug!(target: "bft", "Round {} should end in at most {} seconds from now", next_round, round_timeout.as_secs());
-
+		debug!(target: "bfg", "Proposer: {}", self.proposer);
 		self.update_round_cache(next_round);
 
 		if let AdvanceRoundReason::Timeout = reason {

--- a/core/bft/src/lib.rs
+++ b/core/bft/src/lib.rs
@@ -323,7 +323,9 @@ impl<B: Block, P: Proposer<B>> rhododendron::Context for BftInstance<B, P>
 		debug!(target: "bft", "Voting authorities: {:?}",
 			collect_pubkeys(accumulator.voters()));
 		debug!(target: "bft", "Round {} should end in at most {} seconds from now", next_round, round_timeout.as_secs());
-		debug!(target: "bfg", "Proposer: {}", self.proposer);
+
+		// let proposer_id = accumulator.round_proposer();
+		// debug!(target: "bfg", "Proposer: {}", ed25519::Public::from_raw(proposer_id.0));
 		self.update_round_cache(next_round);
 
 		if let AdvanceRoundReason::Timeout = reason {

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -276,7 +276,7 @@ impl<B: BlockT> ConsensusGossip<B> where B::Header: HeaderT<Number=u64> {
 					if let Err(e) = sink.unbounded_send(message.clone()) {
 						trace!(target:"gossip", "Error broadcasting message notification: {:?}", e);
 					} else {
-						debug!(target: "gossip", "Pushed message into sink: {}", message.clone());
+						debug!(target: "gossip", "Pushed message into sink: {:?}", message.clone());
 					}
 				}
 

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -119,12 +119,12 @@ impl<B: BlockT> ConsensusGossip<B> where B::Header: HeaderT<Number=u64> {
 		for (id, ref mut peer) in self.peers.iter_mut() {
 			if peer.is_authority {
 				if peer.known_messages.insert(hash.clone()) {
-					trace!(target:"gossip", "Propagating to authority {}: {:?}", id, message);
+					debug!(target:"gossip", "Propagating to authority {}: {:?}", id, message);
 					protocol.send_message(*id, message.clone());
 				}
 			}
 			else if non_authorities.contains(&id) {
-				trace!(target:"gossip", "Propagating to {}: {:?}", id, message);
+				debug!(target:"gossip", "Propagating to {}: {:?}", id, message);
 				peer.known_messages.insert(hash.clone());
 				protocol.send_message(*id, message.clone());
 			}
@@ -275,6 +275,8 @@ impl<B: BlockT> ConsensusGossip<B> where B::Header: HeaderT<Number=u64> {
 					debug!(target: "gossip", "Pushing relevant consensus message to sink.");
 					if let Err(e) = sink.unbounded_send(message.clone()) {
 						trace!(target:"gossip", "Error broadcasting message notification: {:?}", e);
+					} else {
+						debug!(target: "gossip", "Pushed message into sink: {}", message.clone());
 					}
 				}
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -404,6 +404,12 @@ impl<C> bft::Proposer<<C as AuthoringApi>::Block> for Proposer<C> where
 			}
 		};
 
+		debug!(target: "bft", "Evaluating block proposal [number: {}; hash: {}; parent_hash: {}]",
+			proposal.header().number(),
+			<<C as AuthoringApi>::Block as BlockT>::Hash::from(proposal.header().hash()),
+			proposal.header().parent_hash()
+		);
+
 		let vote_delays = {
 			let now = Instant::now();
 

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -406,7 +406,7 @@ impl<C> bft::Proposer<<C as AuthoringApi>::Block> for Proposer<C> where
 
 		debug!(target: "bft", "Evaluating block proposal [number: {}; hash: {}; parent_hash: {}]",
 			proposal.header().number(),
-			<<C as AuthoringApi>::Block as BlockT>::Hash::from(proposal.header().hash()),
+			proposal.header().hash(),
 			proposal.header().parent_hash()
 		);
 


### PR DESCRIPTION
This is to address the issue: https://github.com/paritytech/substrate/issues/604
It is still a work in progress. As a matter of fact, I believe this has led me to discover another issue stemming from overriding? a private field with a public method, indicated below. I am unable to grab the currently round's proposer for debug logging since it is only exposed through the accumulator.

```
error[E0599]: no method named `round_proposer` found for type `&rhododendron::Accumulator<B, <B as runtime_primitives::traits::Block>::Hash, primitives::AuthorityId, primitives::ed25519::LocalizedSignature>` in the current scope
   --> core/bft/src/lib.rs:327:33
    |
327 |         let proposer_id = accumulator.round_proposer();
    |                                       ^^^^^^^^^^^^^^ private field, not a method
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `round_proposer`, perhaps you need to implement it:
            candidate #1: `Proposer`

error: aborting due to previous error
```
@rphmeier Does this sound correct?