### PR TITLE
The NodeId is always available in the session info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,6 @@ dependencies = [
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 0.1.0",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/network-libp2p/Cargo.toml
+++ b/core/network-libp2p/Cargo.toml
@@ -23,7 +23,6 @@ tokio = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }
-substrate-primitives = { path = "../primitives" }
 
 [dev-dependencies]
 assert_matches = "1.2"

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -34,7 +34,6 @@ extern crate rand;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-extern crate substrate_primitives as primitives;
 extern crate bytes;
 extern crate unsigned_varint;
 
@@ -45,11 +44,9 @@ extern crate log;
 #[cfg(test)] #[macro_use]
 extern crate assert_matches;
 
-use libp2p::PeerId;
-
 pub use connection_filter::{ConnectionFilter, ConnectionDirection};
 pub use error::{Error, ErrorKind, DisconnectReason};
-pub use libp2p::{Multiaddr, multiaddr::Protocol};
+pub use libp2p::{Multiaddr, multiaddr::Protocol, PeerId};
 pub use traits::*;
 
 pub type TimerToken = usize;

--- a/core/network-libp2p/src/service.rs
+++ b/core/network-libp2p/src/service.rs
@@ -552,7 +552,7 @@ impl NetworkContext for NetworkContextImpl {
 		};
 
 		Some(SessionInfo {
-			id: None,						// TODO: ???? what to do??? wrong format!
+			id: info.id.clone(),
 			client_version: info.client_version.clone().take().unwrap_or(String::new()),
 			protocol_version: From::from(protocol_version),
 			capabilities: Vec::new(),		// TODO: list of supported protocols ; hard

--- a/core/network-libp2p/src/traits.rs
+++ b/core/network-libp2p/src/traits.rs
@@ -21,9 +21,8 @@ use std::net::Ipv4Addr;
 use std::str;
 use std::time::Duration;
 use TimerToken;
-use libp2p::{multiaddr::Protocol, Multiaddr};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use error::Error;
-use primitives::hash::H512;
 
 /// Protocol handler level packet id
 pub type PacketId = u8;
@@ -31,7 +30,7 @@ pub type PacketId = u8;
 pub type ProtocolId = [u8; 3];
 
 /// Node public key
-pub type NodeId = H512;
+pub type NodeId = PeerId;
 
 /// Local (temporary) peer session ID.
 pub type NodeIndex = usize;
@@ -43,7 +42,7 @@ pub type Secret = [u8; 32];
 #[derive(Debug, Clone)]
 pub struct SessionInfo {
 	/// Peer public key
-	pub id: Option<NodeId>,
+	pub id: NodeId,
 	/// Peer client ID
 	pub client_version: String,
 	/// Peer RLPx protocol version

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -500,10 +500,8 @@ impl<B: BlockT, S: Specialization<B>, H: ExHashT> Protocol<B, S, H> {
 				.unzip();
 
 			if !to_send.is_empty() {
-				let node_id = io.peer_session_info(*who).map(|info| match info.id {
-					Some(id) => format!("{}@{:x}", info.remote_address, id),
-					None => info.remote_address.clone(),
-				});
+				let node_id = io.peer_session_info(*who)
+					.map(|info| format!("{}@{:?}", info.remote_address, info.id));
 
 				if let Some(id) = node_id {
 					for hash in hashes {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use futures::sync::{oneshot, mpsc};
 use network_libp2p::{NetworkProtocolHandler, NetworkContext, NodeIndex, ProtocolId,
 NetworkConfiguration , NonReservedPeerMode, ErrorKind};
-use network_libp2p::{NetworkService};
+use network_libp2p::{NetworkService, PeerId};
 use io::NetSyncIo;
 use protocol::{Protocol, ProtocolContext, Context, ProtocolStatus, PeerInfo as ProtocolPeerInfo};
 use config::{ProtocolConfig};
@@ -122,7 +122,7 @@ struct ProtocolHandler<B: BlockT, S: Specialization<B>, H: ExHashT> {
 #[derive(Debug)]
 pub struct PeerInfo<B: BlockT> {
 	/// Public node id
-	pub id: Option<String>,
+	pub id: PeerId,
 	/// Node client ID
 	pub client_version: String,
 	/// Capabilities
@@ -264,7 +264,7 @@ impl<B: BlockT + 'static, S: Specialization<B>, H: ExHashT> SyncProvider<B> for 
 				};
 
 				Some(PeerInfo {
-					id: session_info.id.map(|id| format!("{:x}", id)),
+					id: session_info.id,
 					client_version: session_info.client_version,
 					capabilities: session_info.peer_capabilities.into_iter().map(|c| c.to_string()).collect(),
 					remote_address: session_info.remote_address,


### PR DESCRIPTION
cc @tomusdrw 

Makes the node ID always available when querying information about a peer.