### PR TITLE
Use transfer for sandboxed memory get/set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
  "sr-std 0.1.0",
  "substrate-primitives 0.1.0",
  "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2931,7 +2931,7 @@ dependencies = [
  "substrate-state-machine 0.1.0",
  "substrate-trie 0.4.0",
  "wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "twox-hash 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmi 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4376,7 +4376,7 @@ dependencies = [
 "checksum wabt 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "182ae543249ccf2705f324d233891c1176fca142e137b55ba43d9dbfe93f18a2"
 "checksum wabt-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca77c6b934a2b32618941b2f565aac43b8cb7141378c3b4fba4d8fcdcd57da3"
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
-"checksum wasmi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "522fe3fdd44a56f25cd5ddcd8ccdb1cf2e982ceb28fcb00f41d8a018ae5245a8"
+"checksum wasmi 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d184c4b7081f30316f74f8d73c197314dcb56ea7af9323522b42a2fa9cb19453"
 "checksum websocket 0.20.3 (git+https://github.com/tomaka/rust-websocket?branch=send)" = "<none>"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -14,7 +14,7 @@ substrate-state-machine = { path = "../state-machine"  }
 sr-version = { path = "../sr-version" }
 serde = "1.0"
 serde_derive = "1.0"
-wasmi = "0.4"
+wasmi = { version = "0.4.1" }
 byteorder = "1.1"
 lazy_static = "1.0"
 parking_lot = "*"

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -421,33 +421,33 @@ impl_function_executor!(this: FunctionExecutor<'e, E>,
 		let mem_idx = this.sandbox_store.new_memory(initial, maximum)?;
 		Ok(mem_idx)
 	},
-	ext_sandbox_memory_get(memory_idx: u32, offset: u32, buf_ptr: *mut u8, buf_len: usize) -> u32 => {
-		let dst_memory = this.sandbox_store.memory(memory_idx)?;
+	ext_sandbox_memory_get(memory_idx: u32, offset: u32, buf_ptr: *mut u8, buf_len: u32) -> u32 => {
+		let sandboxed_memory = this.sandbox_store.memory(memory_idx)?;
 
-		let data: Vec<u8> = match dst_memory.get(offset, buf_len as usize) {
-			Ok(data) => data,
-			Err(_) => return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
-		};
-		match this.memory.set(buf_ptr, &data) {
-			Err(_) => return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
-			_ => {},
+		match MemoryInstance::transfer(
+			&sandboxed_memory,
+			offset as usize,
+			&this.memory,
+			buf_ptr as usize,
+			buf_len as usize,
+		) {
+			Ok(()) => Ok(sandbox_primitives::ERR_OK),
+			Err(_) => Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
 		}
-
-		Ok(sandbox_primitives::ERR_OK)
 	},
-	ext_sandbox_memory_set(memory_idx: u32, offset: u32, val_ptr: *const u8, val_len: usize) -> u32 => {
-		let dst_memory = this.sandbox_store.memory(memory_idx)?;
+	ext_sandbox_memory_set(memory_idx: u32, offset: u32, val_ptr: *const u8, val_len: u32) -> u32 => {
+		let sandboxed_memory = this.sandbox_store.memory(memory_idx)?;
 
-		let data = match this.memory.get(val_ptr, val_len as usize) {
-			Ok(data) => data,
-			Err(_) => return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
-		};
-		match dst_memory.set(offset, &data) {
-			Err(_) => return Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
-			_ => {},
+		match MemoryInstance::transfer(
+			&this.memory,
+			val_ptr as usize,
+			&sandboxed_memory,
+			offset as usize,
+			val_len as usize,
+		) {
+			Ok(()) => Ok(sandbox_primitives::ERR_OK),
+			Err(_) => Ok(sandbox_primitives::ERR_OUT_OF_BOUNDS),
 		}
-
-		Ok(sandbox_primitives::ERR_OK)
 	},
 	ext_sandbox_memory_teardown(memory_idx: u32) => {
 		this.sandbox_store.memory_teardown(memory_idx)?;

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = { version = "1.0", optional = true }
 uint = { version = "0.4.1", default-features = false }
 twox-hash = { version = "1.1.0", optional = true }
 byteorder = { version = "1.1", default-features = false }
-wasmi = { version = "0.4", optional = true }
+wasmi = { version = "0.4.1", optional = true }
 hash-db = { git = "https://github.com/paritytech/trie", default-features = false }
 hash256-std-hasher = { git = "https://github.com/paritytech/trie", default-features = false }
 ring = { version = "0.12", optional = true }

--- a/core/sr-sandbox/Cargo.toml
+++ b/core/sr-sandbox/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 rustc_version = "0.2"
 
 [dependencies]
-wasmi = { version = "0.4", optional = true }
+wasmi = { version = "0.4.1", optional = true }
 substrate-primitives = { path = "../primitives", default-features = false }
 sr-std = { path = "../sr-std", default-features = false }
 parity-codec = { version = "2.0", default-features = false }


### PR DESCRIPTION
This change makes copy to not require intermediate buffer. 