### PR TITLE
Compare digests item-by-item

### DIFF
--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -108,7 +108,7 @@ impl<Hash, AuthorityId> DigestItem<Hash, AuthorityId> {
 	}
 }
 
-impl<Hash: Member, AuthorityId: Member> traits::DigestItem for DigestItem<Hash, AuthorityId> {
+impl<Hash: Codec + Member, AuthorityId: Codec + Member> traits::DigestItem for DigestItem<Hash, AuthorityId> {
 	type Hash = Hash;
 	type AuthorityId = AuthorityId;
 

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -333,6 +333,24 @@ impl CheckEqual for substrate_primitives::H256 {
 	}
 }
 
+impl<I> CheckEqual for I where I: DigestItem {
+	#[cfg(feature = "std")]
+	fn check_equal(&self, other: &Self) {
+		if self != other {
+			println!("DigestItem: given={:?}, expected={:?}", self, other);
+		}
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn check_equal(&self, other: &Self) {
+		if self != other {
+			runtime_io::print("DigestItem not equal");
+			runtime_io::print(&Encode::encode(self)[..]);
+			runtime_io::print(&Encode::encode(other)[..]);
+		}
+	}
+}
+
 #[cfg(feature = "std")]
 pub trait MaybeSerializeDebugButNotDeserialize: Serialize + Debug {}
 #[cfg(feature = "std")]
@@ -491,7 +509,7 @@ pub trait Digest: Member + Default {
 /// for casting member to 'system' log items, known to substrate.
 ///
 /// If the runtime does not supports some 'system' items, use `()` as a stub.
-pub trait DigestItem: Member {
+pub trait DigestItem: Codec + Member {
 	type Hash: Member;
 	type AuthorityId: Member;
 

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -50,7 +50,7 @@ use rstd::prelude::*;
 use rstd::marker::PhantomData;
 use rstd::result;
 use primitives::traits::{self, Header, Zero, One, Checkable, Applyable, CheckEqual, OnFinalise,
-	MakePayment, Hash, As};
+	MakePayment, Hash, As, Digest};
 use runtime_support::Dispatchable;
 use codec::{Codec, Encode};
 use system::extrinsics_root;
@@ -205,9 +205,16 @@ impl<
 		let new_header = <system::Module<System>>::finalise();
 
 		// check digest. uncomment next two lines to figure out next digest hash for tests.
-//		runtime_io::print(&header.digest().encode()[..]);
-//		runtime_io::print(&new_header.digest().encode()[..]);
-		assert!(header.digest() == new_header.digest());
+		assert_eq!(
+			header.digest().logs().len(),
+			new_header.digest().logs().len(),
+			"Number of digest items must match that calculated."
+		);
+		let items_zip = header.digest().logs().iter().zip(new_header.digest().logs().iter());
+		for (header_item, computed_item) in items_zip {
+			header_item.check_equal(&computed_item);
+			assert!(header_item == computed_item, "Digest item must match that calculated.");
+		}
 
 		// check storage root.
 		let storage_root = System::Hashing::storage_root();

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -204,7 +204,7 @@ impl<
 		// remove temporaries.
 		let new_header = <system::Module<System>>::finalise();
 
-		// check digest. uncomment next two lines to figure out next digest hash for tests.
+		// check digest.
 		assert_eq!(
 			header.digest().logs().len(),
 			new_header.digest().logs().len(),


### PR DESCRIPTION
To avoid commenting/uncommenting print-s in runtime. Shouldn't be a big overhead.

The only important addition is that `DigestItem` is now `Codec`, but looks like this has been the original intention, according to [this comment](https://github.com/paritytech/substrate/blob/master/core/sr-primitives/src/traits.rs#L478).