### PR TITLE
Fix CPU metrics on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,7 +2855,7 @@ dependencies = [
  "substrate-primitives 0.1.0",
  "substrate-service 0.3.0",
  "substrate-telemetry 0.3.0",
- "sysinfo 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sysinfo 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.5.7"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4309,7 +4309,7 @@ dependencies = [
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
-"checksum sysinfo 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "394abcf30852ac00878ab01642b13668db48d166d945f250c7bdbb9e12d75ad0"
+"checksum sysinfo 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "11c5f6e8a7a7146f26ffed9a5ff8bab2706f1ac8a413a415e1d211b819d5c24d"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -22,7 +22,7 @@ tokio = "0.1.7"
 futures = "0.1.17"
 fdlimit = "0.1"
 exit-future = "0.1"
-sysinfo = "0.5.7"
+sysinfo = "0.6.2"
 substrate-client = { path = "../../core/client" }
 substrate-network = { path = "../../core/network" }
 substrate-network-libp2p = { path = "../../core/network-libp2p" }


### PR DESCRIPTION
Just a version bump to the `sysinfo` crate. [More info in the issue](https://github.com/GuillaumeGomez/sysinfo/issues/143).

Closes #870.