### PR TITLE
remove unused nodecode in impl_stubs

### DIFF
--- a/core/executor/wasm/src/lib.rs
+++ b/core/executor/wasm/src/lib.rs
@@ -16,9 +16,9 @@ use runtime_io::{
 };
 
 macro_rules! impl_stubs {
-	( $( $new_name:ident $($nodecode:ident)* => $invoke:expr ),* ) => {
+	( $( $new_name:ident => $invoke:expr ),* ) => {
 		$(
-			impl_stubs!(@METHOD $new_name $($nodecode)* => $invoke);
+			impl_stubs!(@METHOD $new_name => $invoke);
 		)*
 	};
 	( @METHOD $new_name:ident => $invoke:expr ) => {


### PR DESCRIPTION
trivial fix.
it looks like `impl_stubs` is not important anymore, but still the `nodecode` should be removed for clarity. 

@bkchr 