### PR TITLE
fix the ignored tests in doc test

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -20,7 +20,7 @@ case $TARGET in
 		sudo apt-get -y update
 		sudo apt-get install -y cmake pkg-config libssl-dev
 
-		cargo test --all --locked
+		cargo test --all --release --locked
 		;;
 
 	"wasm")

--- a/core/client/src/blockchain.rs
+++ b/core/client/src/blockchain.rs
@@ -121,7 +121,7 @@ pub struct RouteEntry<Block: BlockT> {
 /// The ancestry sets will include the given blocks, and thus the tree-route is
 /// never empty.
 ///
-/// ```ignore
+/// ```text
 /// Tree route from R1 to E2. Retracted is [R1, R2, R3], Common is C, enacted [E1, E2]
 ///   <- R3 <- R2 <- R1
 ///  /
@@ -129,7 +129,7 @@ pub struct RouteEntry<Block: BlockT> {
 ///  \-> E1 -> E2
 /// ```
 ///
-/// ```ignore
+/// ```text
 /// Tree route from C to E2. Retracted empty. Common is C, enacted [E1, E2]
 /// C -> E1 -> E2
 /// ```

--- a/core/executor/src/wasm_utils.rs
+++ b/core/executor/src/wasm_utils.rs
@@ -107,7 +107,7 @@ macro_rules! unmarshall_args {
 
 /// Since we can't specify the type of closure directly at binding site:
 ///
-/// ```rust,ignore
+/// ```nocompile
 /// let f: FnOnce() -> Result<<u32 as ConvertibleToWasm>::NativeType, _> = || { /* ... */ };
 /// ```
 ///

--- a/srml/contract/src/vm/env_def/macros.rs
+++ b/srml/contract/src/vm/env_def/macros.rs
@@ -68,7 +68,7 @@ macro_rules! unmarshall_then_body {
 
 /// Since we can't specify the type of closure directly at binding site:
 ///
-/// ```rust,ignore
+/// ```nocompile
 /// let f: FnOnce() -> Result<<u32 as ConvertibleToWasm>::NativeType, _> = || { /* ... */ };
 /// ```
 ///


### PR DESCRIPTION
I would like to put the long running tests into ignored tests. these three take too long... It speeds up my dev and testing process.

Now the ci would run both ignored and non ignored ones.

**EDIT**: after discussion, I'll just fix the ignored tests in doc test, move them to either `text` or `nocompile`. After this fix, the `cargo test -- --ignored` can run properly. 