### PR TITLE
Pool: Longevity handling.

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -395,7 +395,7 @@ impl<C: Components> network::TransactionPool<ComponentExHash<C>, ComponentBlock<
 		self.pool.ready(|pending| pending
 			.map(|t| {
 				let hash = t.hash.clone();
-				let ex: ComponentExtrinsic<C> = t.data.raw.clone();
+				let ex: ComponentExtrinsic<C> = t.data.clone();
 				(hash, ex)
 			})
 			.collect())

--- a/core/transaction-pool/graph/src/future.rs
+++ b/core/transaction-pool/graph/src/future.rs
@@ -169,6 +169,11 @@ impl<Hash: hash::Hash + Eq + Clone, Ex> FutureTransactions<Hash, Ex> {
 		removed
 	}
 
+	/// Returns iterator over all future transactions
+	pub fn all(&self) -> impl Iterator<Item=&Transaction<Hash, Ex>> {
+		self.waiting.values().map(|waiting| &waiting.transaction)
+	}
+
 	/// Returns number of transactions in the Future queue.
 	pub fn len(&self) -> usize {
 		self.waiting.len()

--- a/core/transaction-pool/graph/src/lib.rs
+++ b/core/transaction-pool/graph/src/lib.rs
@@ -23,7 +23,6 @@
 //! graph in the correct order taking into account priorities and dependencies.
 //!
 //! TODO [ToDr]
-//! - [ ] Longevity handling (remove obsolete transactions periodically)
 //! - [ ] Multi-threading (getting ready transactions should not block the pool)
 // end::description[]
 

--- a/core/transaction-pool/src/tests.rs
+++ b/core/transaction-pool/src/tests.rs
@@ -109,7 +109,7 @@ fn submission_should_work() {
 	assert_eq!(209, index(&BlockId::number(0)));
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 209)).unwrap();
 
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, vec![209]);
 }
 
@@ -119,7 +119,7 @@ fn multiple_submission_should_work() {
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 209)).unwrap();
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 210)).unwrap();
 
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, vec![209, 210]);
 }
 
@@ -128,7 +128,7 @@ fn early_nonce_should_be_culled() {
 	let pool = pool();
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 208)).unwrap();
 
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, Vec::<Index>::new());
 }
 
@@ -137,11 +137,11 @@ fn late_nonce_should_be_queued() {
 	let pool = pool();
 
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 210)).unwrap();
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, Vec::<Index>::new());
 
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 209)).unwrap();
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, vec![209, 210]);
 }
 
@@ -151,12 +151,12 @@ fn prune_tags_should_work() {
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 209)).unwrap();
 	pool.submit_one(&BlockId::number(0), uxt(Alice, 210)).unwrap();
 
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, vec![209, 210]);
 
 	pool.prune_tags(&BlockId::number(1), vec![vec![209]]).unwrap();
 
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, vec![210]);
 }
 
@@ -169,7 +169,7 @@ fn should_ban_invalid_transactions() {
 	pool.submit_one(&BlockId::number(0), uxt.clone()).unwrap_err();
 
 	// when
-	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.raw.transfer.nonce).collect());
+	let pending: Vec<_> = pool.ready(|p| p.map(|a| a.data.transfer.nonce).collect());
 	assert_eq!(pending, Vec::<Index>::new());
 
 	// then

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -314,10 +314,10 @@ impl<C, A> bft::Proposer<<C as AuthoringApi>::Block> for Proposer<C, A> where
 					let mut pending_size = 0;
 					for pending in pending_iterator {
 						// TODO [ToDr] Probably get rid of it, and validate in runtime.
-						let encoded_size = pending.data.raw.encode().len();
+						let encoded_size = pending.data.encode().len();
 						if pending_size + encoded_size >= MAX_TRANSACTIONS_SIZE { break }
 
-						match block_builder.push_extrinsic(pending.data.raw.clone()) {
+						match block_builder.push_extrinsic(pending.data.clone()) {
 							Ok(()) => {
 								pending_size += encoded_size;
 							}


### PR DESCRIPTION
Currently it's `O(n)` to remove stale transactions - we could optimize this bucketing transactions into eras (like every 64 blocks) and then just considering transactions in a particular era (that would add another mapping to the queue `(era -> transaction)` that would have to be kept in sync though)