### PR TITLE
Silence Telemetry WS errors

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -517,7 +517,7 @@ fn init_logger(pattern: &str) {
 
 	let mut builder = env_logger::Builder::new();
 	// Disable info logging by default for some modules:
-	builder.filter(Some("ws"), log::LevelFilter::Warn);
+	builder.filter(Some("ws"), log::LevelFilter::Off);
 	builder.filter(Some("hyper"), log::LevelFilter::Warn);
 	// Enable info for others.
 	builder.filter(None, log::LevelFilter::Info);

--- a/core/telemetry/src/lib.rs
+++ b/core/telemetry/src/lib.rs
@@ -126,6 +126,8 @@ impl TelemetryWriter {
 				trace!(target: "telemetry", "Connecting to Telemetry...");
 
 				let _ = ws::connect(config.url.as_str(), |out| Connection::new(out, &*out_sync, &config));
+
+				thread::sleep(time::Duration::from_millis(5000));
 			}
 		});
 


### PR DESCRIPTION
+ Turns off all log levels for the `ws` crate used by Telemetry. (Do we use it elsewhere? Do we need error logs from it?)
+ Adds a 5s timer after failed connection due to DNS lookup (source of the spam when the node is offline).