### PR TITLE
Pool: A bunch of tests and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,7 @@ dependencies = [
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0",
+ "substrate-test-runtime 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,6 +3304,7 @@ dependencies = [
 name = "substrate-transaction-graph"
 version = "0.1.0"
 dependencies = [
+ "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3304,7 +3304,7 @@ dependencies = [
 name = "substrate-transaction-graph"
 version = "0.1.0"
 dependencies = [
- "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/transaction-pool/graph/Cargo.toml
+++ b/core/transaction-pool/graph/Cargo.toml
@@ -11,3 +11,6 @@ parking_lot = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 sr-primitives = { path = "../../sr-primitives" }
+
+[dev-dependencies]
+substrate-test-runtime = { path = "../../test-runtime" }

--- a/core/transaction-pool/graph/Cargo.toml
+++ b/core/transaction-pool/graph/Cargo.toml
@@ -13,4 +13,5 @@ serde_derive = "1.0"
 sr-primitives = { path = "../../sr-primitives" }
 
 [dev-dependencies]
+assert_matches = "1.1"
 substrate-test-runtime = { path = "../../test-runtime" }

--- a/core/transaction-pool/graph/src/lib.rs
+++ b/core/transaction-pool/graph/src/lib.rs
@@ -37,6 +37,9 @@ extern crate sr_primitives;
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_derive;
 
+#[cfg(test)]
+extern crate substrate_test_runtime as test_runtime;
+
 mod future;
 mod listener;
 mod pool;

--- a/core/transaction-pool/graph/src/lib.rs
+++ b/core/transaction-pool/graph/src/lib.rs
@@ -39,6 +39,9 @@ extern crate sr_primitives;
 
 #[cfg(test)]
 extern crate substrate_test_runtime as test_runtime;
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
 
 mod future;
 mod listener;

--- a/core/transaction-pool/graph/src/listener.rs
+++ b/core/transaction-pool/graph/src/listener.rs
@@ -64,13 +64,15 @@ impl<H: hash::Hash + traits::Member, H2: Clone> Listener<H, H2> {
 
 	/// New transaction was added to the ready pool or promoted from the future pool.
 	pub fn ready(&mut self, tx: &H, old: Option<&H>) {
+		self.fire(tx, |watcher| watcher.ready());
 		if let Some(old) = old {
 			self.fire(old, |watcher| watcher.usurped(tx.clone()));
 		}
 	}
 
 	/// New transaction was added to the future pool.
-	pub fn future(&mut self, _tx: &H) {
+	pub fn future(&mut self, tx: &H) {
+		self.fire(tx, |watcher| watcher.future());
 	}
 
 	/// Transaction was dropped from the pool because of the limit.

--- a/core/transaction-pool/graph/src/listener.rs
+++ b/core/transaction-pool/graph/src/listener.rs
@@ -53,8 +53,8 @@ impl<H: hash::Hash + traits::Member, H2: Clone> Listener<H, H2> {
 	///
 	/// The watcher can be used to subscribe to lifecycle events of that extrinsic.
 	pub fn create_watcher(&mut self, hash: H) -> watcher::Watcher<H, H2> {
-		let sender = self.watchers.entry(hash).or_insert_with(watcher::Sender::default);
-		sender.new_watcher()
+		let sender = self.watchers.entry(hash.clone()).or_insert_with(watcher::Sender::default);
+		sender.new_watcher(hash)
 	}
 
 	/// Notify the listeners about extrinsic broadcast.
@@ -83,14 +83,10 @@ impl<H: hash::Hash + traits::Member, H2: Clone> Listener<H, H2> {
 		})
 	}
 
-	/// Transaction was rejected from the pool.
-	pub fn rejected(&mut self, tx: &H, is_invalid: bool) {
-		warn!(target: "transaction-pool", "Extrinsic rejected ({}): {:?}", is_invalid, tx);
-	}
-
 	/// Transaction was removed as invalid.
 	pub fn invalid(&mut self, tx: &H) {
 		warn!(target: "transaction-pool", "Extrinsic invalid: {:?}", tx);
+		self.fire(tx, |watcher| watcher.invalid());
 	}
 
 	/// Transaction was pruned from the pool.

--- a/core/transaction-pool/graph/src/watcher.rs
+++ b/core/transaction-pool/graph/src/watcher.rs
@@ -22,7 +22,7 @@ use futures::{
 };
 
 /// Possible extrinsic status events
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Status<H, H2> {
 	/// Extrinsic is part of the future queue.
@@ -81,6 +81,16 @@ impl<H: Clone, H2: Clone> Sender<H, H2> {
 		Watcher {
 			receiver,
 		}
+	}
+
+	/// Transaction became ready.
+	pub fn ready(&mut self) {
+		self.send(Status::Ready)
+	}
+
+	/// Transaction was moved to future.
+	pub fn future(&mut self) {
+		self.send(Status::Future)
 	}
 
 	/// Some state change (perhaps another extrinsic was included) rendered this extrinsic invalid.


### PR DESCRIPTION
- Make sure that the watcher contains initial notifications (i.e. importing to Ready/Future)
- Don't trigger `rejected` notifications, as it's obvious from the return type.
- Don't trigger `import_notification` in case we import to `Future` (this is used to trigger repropagation in the network)