### PR TITLE
Fix build error for panic_handler

### DIFF
--- a/core/sr-io/src/lib.rs
+++ b/core/sr-io/src/lib.rs
@@ -18,6 +18,7 @@
 //! This is part of the Substrate runtime.
 // end::description[]
 
+#![cfg_attr(not(feature = "std"), feature(panic_handler))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(lang_items))]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]


### PR DESCRIPTION
https://www.google.com/search?client=safari&rls=en&q=Fix+build+error(about+rust+no_std+panic_handler)&ie=UTF-8&oe=UTF-8