### PR TITLE
Moved DigestItem impl to impl_outer_log

### DIFF
--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -205,17 +205,14 @@ println!("=== connectivity4");
 println!("=== connectivity5");
 			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES as u32, 0, vec![], 30400);
 			info!("Checking linked topology");
-println!("=== connectivity6");
 			let mut address = network.full_nodes[0].1.network().node_id().expect("No node address");
 			for (_, service) in network.full_nodes.iter().skip(1) {
 				service.network().add_reserved_peer(address.clone()).expect("Error adding reserved peer");
 				address = service.network().node_id().expect("No node address");
 			}
-println!("=== connectivity7");
 			network.run_until_all_full(|_index, service| {
 				service.network().status().num_peers == NUM_NODES as usize - 1
 			});
-println!("=== connectivity8");
 		}
 		temp.close().expect("Error removing temp dir");
 	}

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -181,33 +181,41 @@ impl<F: ServiceFactory> TestNet<F> {
 pub fn connectivity<F: ServiceFactory>(spec: FactoryChainSpec<F>) {
 	const NUM_NODES: u32 = 10;
 	{
+println!("=== connectivity1");
 		let temp = TempDir::new("substrate-connectivity-test").expect("Error creating test dir");
 		{
 			let mut network = TestNet::<F>::new(&temp, spec.clone(), NUM_NODES, 0, vec![], 30400);
 			info!("Checking star topology");
+println!("=== connectivity2");
 			let first_address = network.full_nodes[0].1.network().node_id().expect("No node address");
 			for (_, service) in network.full_nodes.iter().skip(1) {
 				service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
 			}
+println!("=== connectivity3");
 			network.run_until_all_full(|_index, service|
 				service.network().status().num_peers == NUM_NODES as usize - 1
 			);
+println!("=== connectivity4");
 		}
 		temp.close().expect("Error removing temp dir");
 	}
 	{
 		let temp = TempDir::new("substrate-connectivity-test").expect("Error creating test dir");
 		{
+println!("=== connectivity5");
 			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES as u32, 0, vec![], 30400);
 			info!("Checking linked topology");
+println!("=== connectivity6");
 			let mut address = network.full_nodes[0].1.network().node_id().expect("No node address");
 			for (_, service) in network.full_nodes.iter().skip(1) {
 				service.network().add_reserved_peer(address.clone()).expect("Error adding reserved peer");
 				address = service.network().node_id().expect("No node address");
 			}
+println!("=== connectivity7");
 			network.run_until_all_full(|_index, service| {
 				service.network().status().num_peers == NUM_NODES as usize - 1
 			});
+println!("=== connectivity8");
 		}
 		temp.close().expect("Error removing temp dir");
 	}

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -181,28 +181,23 @@ impl<F: ServiceFactory> TestNet<F> {
 pub fn connectivity<F: ServiceFactory>(spec: FactoryChainSpec<F>) {
 	const NUM_NODES: u32 = 10;
 	{
-println!("=== connectivity1");
 		let temp = TempDir::new("substrate-connectivity-test").expect("Error creating test dir");
 		{
 			let mut network = TestNet::<F>::new(&temp, spec.clone(), NUM_NODES, 0, vec![], 30400);
 			info!("Checking star topology");
-println!("=== connectivity2");
 			let first_address = network.full_nodes[0].1.network().node_id().expect("No node address");
 			for (_, service) in network.full_nodes.iter().skip(1) {
 				service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
 			}
-println!("=== connectivity3");
 			network.run_until_all_full(|_index, service|
 				service.network().status().num_peers == NUM_NODES as usize - 1
 			);
-println!("=== connectivity4");
 		}
 		temp.close().expect("Error removing temp dir");
 	}
 	{
 		let temp = TempDir::new("substrate-connectivity-test").expect("Error creating test dir");
 		{
-println!("=== connectivity5");
 			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES as u32, 0, vec![], 30400);
 			info!("Checking linked topology");
 			let mut address = network.full_nodes[0].1.network().node_id().expect("No node address");

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -113,17 +113,11 @@ impl<Hash: Codec + Member, AuthorityId: Codec + Member> traits::DigestItem for D
 	type AuthorityId = AuthorityId;
 
 	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
-		match *self {
-			DigestItem::AuthoritiesChange(ref authorities) => Some(authorities),
-			_ => None,
-		}
+		self.dref().as_authorities_change()
 	}
 
 	fn as_changes_trie_root(&self) -> Option<&Hash> {
-		match *self {
-			DigestItem::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
-			_ => None,
-		}
+		self.dref().as_changes_trie_root()
 	}
 }
 
@@ -146,6 +140,22 @@ impl<Hash: Decode, AuthorityId: Decode> Decode for DigestItem<Hash, AuthorityId>
 			DigestItemType::Other => Some(DigestItem::Other(
 				Decode::decode(input)?,
 			)),
+		}
+	}
+}
+
+impl<'a, Hash: Codec + Member, AuthorityId: Codec + Member> DigestItemRef<'a, Hash, AuthorityId> {
+	pub fn as_authorities_change(&self) -> Option<&'a [AuthorityId]> {
+		match *self {
+			DigestItemRef::AuthoritiesChange(ref authorities) => Some(authorities),
+			_ => None,
+		}
+	}
+
+	pub fn as_changes_trie_root(&self) -> Option<&'a Hash> {
+		match *self {
+			DigestItemRef::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
+			_ => None,
 		}
 	}
 }

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -113,11 +113,17 @@ impl<Hash: Codec + Member, AuthorityId: Codec + Member> traits::DigestItem for D
 	type AuthorityId = AuthorityId;
 
 	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
-		self.dref().as_authorities_change()
+		match *self {
+			DigestItem::AuthoritiesChange(ref authorities) => Some(authorities),
+			_ => None,
+		}
 	}
 
 	fn as_changes_trie_root(&self) -> Option<&Hash> {
-		self.dref().as_changes_trie_root()
+		match *self {
+			DigestItem::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
+			_ => None,
+		}
 	}
 }
 
@@ -140,22 +146,6 @@ impl<Hash: Decode, AuthorityId: Decode> Decode for DigestItem<Hash, AuthorityId>
 			DigestItemType::Other => Some(DigestItem::Other(
 				Decode::decode(input)?,
 			)),
-		}
-	}
-}
-
-impl<'a, Hash: Codec + Member, AuthorityId: Codec + Member> DigestItemRef<'a, Hash, AuthorityId> {
-	pub fn as_authorities_change(&self) -> Option<&'a [AuthorityId]> {
-		match *self {
-			DigestItemRef::AuthoritiesChange(ref authorities) => Some(authorities),
-			_ => None,
-		}
-	}
-
-	pub fn as_changes_trie_root(&self) -> Option<&'a Hash> {
-		match *self {
-			DigestItemRef::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
-			_ => None,
 		}
 	}
 }

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -326,7 +326,7 @@ macro_rules! impl_outer_log {
 	(
 		$(#[$attr:meta])*
 		pub enum $name:ident ($internal:ident: DigestItem<$( $genarg:ty ),*>) for $trait:ident {
-			$( $module:ident($( $item:ident ),*) ),*
+			$( $module:ident( $( $sitem:ident ),* ) ),*
 		}
 	) => {
 		/// Wrapper for all possible log entries for the `$trait` runtime. Provides binary-compatible
@@ -335,17 +335,34 @@ macro_rules! impl_outer_log {
 		#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 		$(#[$attr])*
 		#[allow(non_camel_case_types)]
-		pub struct $name($internal);
+		pub struct $name($internal::InternalLog);
 
-		/// All possible log entries for the `$trait` runtime. `Encode`/`Decode` implementations
-		/// are auto-generated => it is not binary-compatible with `generic::DigestItem`.
-		#[derive(Clone, PartialEq, Eq, Encode, Decode)]
-		#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-		$(#[$attr])*
-		#[allow(non_camel_case_types)]
-		enum $internal {
+		#[allow(non_snake_case)]
+		mod $internal {
+			use super::*;
+
+			/// Type alias for corresponding generic::DigestItem.
+			pub type GenericDigestItem = $crate::generic::DigestItem<$($genarg),*>;
+
+			/// All possible log entries for the `$trait` runtime. `Encode`/`Decode` implementations
+			/// are auto-generated => it is not binary-compatible with `generic::DigestItem`.
+			#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+			#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+			$(#[$attr])*
+			#[allow(non_camel_case_types)]
+			pub enum InternalLog {
+				$(
+					$module($module::Log<$trait>),
+				)*
+			}
+
 			$(
-				$module($module::Log<$trait>),
+				impl From<$module::Log<$trait>> for InternalLog {
+					/// Converts single module log item into `$internal`.
+					fn from(x: $module::Log<$trait>) -> Self {
+						InternalLog::$module(x)
+					}
+				}
 			)*
 		}
 
@@ -357,11 +374,24 @@ macro_rules! impl_outer_log {
 			fn dref<'a>(&'a self) -> Option<$crate::generic::DigestItemRef<'a, $($genarg),*>> {
 				match self.0 {
 					$($(
-					$internal::$module($module::RawLog::$item(ref v)) =>
-						Some($crate::generic::DigestItemRef::$item(v)),
+					$internal::InternalLog::$module($module::RawLog::$sitem(ref v)) =>
+						Some($crate::generic::DigestItemRef::$sitem(v)),
 					)*)*
 					_ => None,
 				}
+			}
+		}
+
+		impl $crate::traits::DigestItem for $name {
+			type Hash = <$internal::GenericDigestItem as $crate::traits::DigestItem>::Hash;
+			type AuthorityId = <$internal::GenericDigestItem as $crate::traits::DigestItem>::AuthorityId;
+
+			fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
+				self.dref().and_then(|dref| dref.as_authorities_change())
+			}
+
+			fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
+				self.dref().and_then(|dref| dref.as_changes_trie_root())
 			}
 		}
 
@@ -375,8 +405,8 @@ macro_rules! impl_outer_log {
 			fn from(gen: $crate::generic::DigestItem<$($genarg),*>) -> Self {
 				match gen {
 					$($(
-					$crate::generic::DigestItem::$item(value) =>
-						$name($internal::$module($module::RawLog::$item(value))),
+					$crate::generic::DigestItem::$sitem(value) =>
+						$name($internal::InternalLog::$module($module::RawLog::$sitem(value))),
 					)*)*
 					_ => gen.as_other()
 						.and_then(|value| $crate::codec::Decode::decode(&mut &value[..]))
@@ -416,13 +446,6 @@ macro_rules! impl_outer_log {
 					$name(x.into())
 				}
 			}
-
-			impl From<$module::Log<$trait>> for $internal {
-				/// Converts single module log item into `$internal`.
-				fn from(x: $module::Log<$trait>) -> Self {
-					$internal::$module(x)
-				}
-			}
 		)*
 	};
 }
@@ -431,6 +454,7 @@ macro_rules! impl_outer_log {
 mod tests {
 	use substrate_primitives::hash::H256;
 	use codec::{Encode as EncodeHidden, Decode as DecodeHidden};
+	use traits::DigestItem;
 
 	pub trait RuntimeT {
 		type AuthorityId;
@@ -442,31 +466,31 @@ mod tests {
 		type AuthorityId = u64;
 	}
 
+	mod a {
+		use super::RuntimeT;
+		pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
+
+		#[derive(Serialize, Deserialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
+		pub enum RawLog<AuthorityId> { A1(AuthorityId), AuthoritiesChange(Vec<AuthorityId>), A3(AuthorityId) }
+	}
+
+	mod b {
+		use super::RuntimeT;
+		pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
+
+		#[derive(Serialize, Deserialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
+		pub enum RawLog<AuthorityId> { B1(AuthorityId), B2(AuthorityId) }
+	}
+
+	// TODO try to avoid redundant brackets: a(AuthoritiesChange), b
+	impl_outer_log! {
+		pub enum Log(InternalLog: DigestItem<H256, u64>) for Runtime {
+			a(AuthoritiesChange), b()
+		}
+	}
+
 	#[test]
 	fn impl_outer_log_works() {
-		mod a {
-			use super::RuntimeT;
-			pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
-
-			#[derive(Serialize, Deserialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
-			pub enum RawLog<AuthorityId> { A1(AuthorityId), AuthoritiesChange(Vec<AuthorityId>), A3(AuthorityId) }
-		}
-
-		mod b {
-			use super::RuntimeT;
-			pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
-
-			#[derive(Serialize, Deserialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
-			pub enum RawLog<AuthorityId> { B1(AuthorityId), B2(AuthorityId) }
-		}
-
-		// TODO try to avoid redundant brackets: a(AuthoritiesChange), b
-		impl_outer_log! {
-			pub enum Log(InternalLog: DigestItem<H256, u64>) for Runtime {
-				a(AuthoritiesChange), b()
-			}
-		}
-
 		// encode/decode regular item
 		let b1: Log = b::RawLog::B1::<u64>(777).into();
 		let encoded_b1 = b1.encode();
@@ -492,5 +516,11 @@ mod tests {
 			super::generic::DigestItem::AuthoritiesChange::<H256, u64>(authorities) => assert_eq!(authorities, vec![100, 200, 300]),
 			_ => panic!("unexpected generic_auth_change: {:?}", generic_auth_change),
 		}
+
+		// check that as-style methods are working with system items
+		assert!(auth_change.as_authorities_change().is_some());
+
+		// check that as-style methods are not working with regular items
+		assert!(b1.as_authorities_change().is_none());
 	}
 }

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -335,17 +335,34 @@ macro_rules! impl_outer_log {
 		#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 		$(#[$attr])*
 		#[allow(non_camel_case_types)]
-		pub struct $name($internal);
+		pub struct $name($internal::InternalLog);
 
-		/// All possible log entries for the `$trait` runtime. `Encode`/`Decode` implementations
-		/// are auto-generated => it is not binary-compatible with `generic::DigestItem`.
-		#[derive(Clone, PartialEq, Eq, Encode, Decode)]
-		#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-		$(#[$attr])*
-		#[allow(non_camel_case_types)]
-		pub enum InternalLog {
+		#[allow(non_snake_case)]
+		mod $internal {
+			use super::*;
+
+			/// Type alias for corresponding generic::DigestItem.
+			pub type GenericDigestItem = $crate::generic::DigestItem<$($genarg),*>;
+
+			/// All possible log entries for the `$trait` runtime. `Encode`/`Decode` implementations
+			/// are auto-generated => it is not binary-compatible with `generic::DigestItem`.
+			#[derive(Clone, PartialEq, Eq, Encode, Decode)]
+			#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+			$(#[$attr])*
+			#[allow(non_camel_case_types)]
+			pub enum InternalLog {
+				$(
+					$module($module::Log<$trait>),
+				)*
+			}
+
 			$(
-				$module($module::Log<$trait>),
+				impl From<$module::Log<$trait>> for InternalLog {
+					/// Converts single module log item into `$internal`.
+					fn from(x: $module::Log<$trait>) -> Self {
+						InternalLog::$module(x)
+					}
+				}
 			)*
 		}
 
@@ -357,7 +374,7 @@ macro_rules! impl_outer_log {
 			fn dref<'a>(&'a self) -> Option<$crate::generic::DigestItemRef<'a, $($genarg),*>> {
 				match self.0 {
 					$($(
-					$internal::$module($module::RawLog::$sitem(ref v)) =>
+					$internal::InternalLog::$module($module::RawLog::$sitem(ref v)) =>
 						Some($crate::generic::DigestItemRef::$sitem(v)),
 					)*)*
 					_ => None,
@@ -366,8 +383,8 @@ macro_rules! impl_outer_log {
 		}
 
 		impl $crate::traits::DigestItem for $name {
-			type Hash = <$crate::generic::DigestItem<$($genarg),*> as $crate::traits::DigestItem>::Hash;
-			type AuthorityId = <$crate::generic::DigestItem<$($genarg),*> as $crate::traits::DigestItem>::AuthorityId;
+			type Hash = <$internal::GenericDigestItem as $crate::traits::DigestItem>::Hash;
+			type AuthorityId = <$internal::GenericDigestItem as $crate::traits::DigestItem>::AuthorityId;
 
 			fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
 				self.dref().and_then(|dref| dref.as_authorities_change())
@@ -389,7 +406,7 @@ macro_rules! impl_outer_log {
 				match gen {
 					$($(
 					$crate::generic::DigestItem::$sitem(value) =>
-						$name($internal::$module($module::RawLog::$sitem(value))),
+						$name($internal::InternalLog::$module($module::RawLog::$sitem(value))),
 					)*)*
 					_ => gen.as_other()
 						.and_then(|value| $crate::codec::Decode::decode(&mut &value[..]))
@@ -427,13 +444,6 @@ macro_rules! impl_outer_log {
 				/// Converts single module log item into `$name`.
 				fn from(x: $module::Log<$trait>) -> Self {
 					$name(x.into())
-				}
-			}
-
-			impl From<$module::Log<$trait>> for InternalLog {
-				/// Converts single module log item into `$internal`.
-				fn from(x: $module::Log<$trait>) -> Self {
-					InternalLog::$module(x)
 				}
 			}
 		)*

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -534,14 +534,10 @@ pub trait DigestItem: Codec + Member {
 	type AuthorityId: Member;
 
 	/// Returns Some if the entry is the `AuthoritiesChange` entry.
-	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
-		None
-	}
+	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]>;
 
 	/// Returns Some if the entry is the `ChangesTrieRoot` entry.
-	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
-		None
-	}
+	fn as_changes_trie_root(&self) -> Option<&Self::Hash>;
 }
 
 /// Something that provides an inherent for a runtime.

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -534,10 +534,14 @@ pub trait DigestItem: Codec + Member {
 	type AuthorityId: Member;
 
 	/// Returns Some if the entry is the `AuthoritiesChange` entry.
-	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]>;
+	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
+		None
+	}
 
 	/// Returns Some if the entry is the `ChangesTrieRoot` entry.
-	fn as_changes_trie_root(&self) -> Option<&Self::Hash>;
+	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
+		None
+	}
 }
 
 /// Something that provides an inherent for a runtime.

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -40,7 +40,6 @@ extern crate substrate_primitives;
 #[macro_use]
 extern crate parity_codec_derive;
 
-#[cfg_attr(not(feature = "std"), macro_use)]
 extern crate sr_std as rstd;
 extern crate srml_balances as balances;
 extern crate srml_consensus as consensus;
@@ -67,7 +66,7 @@ use runtime_api::runtime::*;
 use runtime_primitives::ApplyResult;
 use runtime_primitives::transaction_validity::TransactionValidity;
 use runtime_primitives::generic;
-use runtime_primitives::traits::{Convert, BlakeTwo256, DigestItem, Block as BlockT};
+use runtime_primitives::traits::{Convert, BlakeTwo256, Block as BlockT};
 use version::{RuntimeVersion, ApiId};
 use council::{motions as council_motions, voting as council_voting};
 #[cfg(feature = "std")]
@@ -190,25 +189,6 @@ impl contract::Trait for Runtime {
 	type Gas = u64;
 	type DetermineContractAddress = contract::SimpleAddressDeterminator<Runtime>;
 	type Event = Event;
-}
-
-impl DigestItem for Log {
-	type Hash = Hash;
-	type AuthorityId = SessionKey;
-
-	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
-		match self.0 {
-			InternalLog::consensus(ref item) => item.as_authorities_change(),
-			_ => None,
-		}
-	}
-
-	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
-		match self.0 {
-			InternalLog::system(ref item) => item.as_changes_trie_root(),
-			_ => None,
-		}
-	}
 }
 
 construct_runtime!(

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -40,6 +40,7 @@ extern crate substrate_primitives;
 #[macro_use]
 extern crate parity_codec_derive;
 
+#[cfg_attr(not(feature = "std"), macro_use)]
 extern crate sr_std as rstd;
 extern crate srml_balances as balances;
 extern crate srml_consensus as consensus;
@@ -66,7 +67,7 @@ use runtime_api::runtime::*;
 use runtime_primitives::ApplyResult;
 use runtime_primitives::transaction_validity::TransactionValidity;
 use runtime_primitives::generic;
-use runtime_primitives::traits::{Convert, BlakeTwo256, Block as BlockT};
+use runtime_primitives::traits::{Convert, BlakeTwo256, DigestItem, Block as BlockT};
 use version::{RuntimeVersion, ApiId};
 use council::{motions as council_motions, voting as council_voting};
 #[cfg(feature = "std")]
@@ -189,6 +190,25 @@ impl contract::Trait for Runtime {
 	type Gas = u64;
 	type DetermineContractAddress = contract::SimpleAddressDeterminator<Runtime>;
 	type Event = Event;
+}
+
+impl DigestItem for Log {
+	type Hash = Hash;
+	type AuthorityId = SessionKey;
+
+	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]> {
+		match self.0 {
+			InternalLog::consensus(ref item) => item.as_authorities_change(),
+			_ => None,
+		}
+	}
+
+	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
+		match self.0 {
+			InternalLog::system(ref item) => item.as_changes_trie_root(),
+			_ => None,
+		}
+	}
 }
 
 construct_runtime!(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -208,10 +208,10 @@ pub fn new_client(config: Configuration)
 mod tests {
 	use {service_test, Factory, chain_spec};
 
-	#[test]
+/*	#[test]
 	fn test_connectivity() {
 		service_test::connectivity::<Factory>(chain_spec::integration_test_config());
-	}
+	}*/
 
 	#[test]
 	#[cfg(feature = "rhd")]

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -208,10 +208,10 @@ pub fn new_client(config: Configuration)
 mod tests {
 	use {service_test, Factory, chain_spec};
 
-/*	#[test]
+	#[test]
 	fn test_connectivity() {
 		service_test::connectivity::<Factory>(chain_spec::integration_test_config());
-	}*/
+	}
 
 	#[test]
 	#[cfg(feature = "rhd")]


### PR DESCRIPTION
closes #926 

Brief overview:
1) moved `impl DigestImpl for Log` from runtime to `impl_outer_log` macro, so that it is implemented by `construct_runtime` macro
2) removed default impls of `DigestItem::as_*` methods to make sure when methods are adding, `impl_outer_log` macro is also updated