### PR TITLE
mutate returns a value

### DIFF
--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -253,7 +253,10 @@ impl<T: Trait> Module<T> {
 
 		let prev = <Foo<T>>::get();
 		// Because Foo has 'default', the type of 'foo' in closure is the raw type instead of an Option<> type.
-		let result = <Foo<T>>::mutate(|foo| *foo = *foo + increase_by);
+		let result = <Foo<T>>::mutate(|foo| {
+			*foo = *foo + increase_by;
+			*foo
+		});
 		assert!(prev + increase_by == result);
 
 		Ok(())

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -251,8 +251,10 @@ impl<T: Trait> Module<T> {
 	fn accumulate_foo(origin: T::Origin, increase_by: T::Balance) -> Result {
 		let _sender = ensure_signed(origin)?;
 
+		let prev = <Foo<T>>::get();
 		// Because Foo has 'default', the type of 'foo' in closure is the raw type instead of an Option<> type.
-		<Foo<T>>::mutate(|foo| *foo = *foo + increase_by);
+		let result = <Foo<T>>::mutate(|foo| *foo = *foo + increase_by);
+		assert!(prev + increase_by == result);
 
 		Ok(())
 	}

--- a/srml/support/src/storage/generator.rs
+++ b/srml/support/src/storage/generator.rs
@@ -119,7 +119,7 @@ pub trait StorageValue<T: codec::Codec> {
 	}
 
 	/// Mutate this value
-	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(f: F, storage: &S) -> Self::Query;
+	fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: Storage>(f: F, storage: &S) -> R;
 
 	/// Clear the storage value.
 	fn kill<S: Storage>(storage: &S) {
@@ -190,7 +190,7 @@ pub trait StorageMap<K: codec::Codec, V: codec::Codec> {
 	}
 
 	/// Mutate the value under a key.
-	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(key: &K, f: F, storage: &S) -> Self::Query;
+	fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: Storage>(key: &K, f: F, storage: &S) -> R;
 }
 
 // TODO: Remove this in favour of `decl_storage` macro.
@@ -342,10 +342,10 @@ macro_rules! __storage_items_internal {
 			}
 
 			/// Mutate this value.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) -> Self::Query {
+			fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: $crate::GenericStorage>(f: F, storage: &S) -> R {
 				let mut val = <Self as $crate::storage::generator::StorageValue<$ty>>::get(storage);
 
-				f(&mut val);
+				let ret = f(&mut val);
 
 				__handle_wrap_internal!($wraptype {
 					// raw type case
@@ -358,7 +358,7 @@ macro_rules! __storage_items_internal {
 					}
 				});
 
-				val
+				ret
 			}
 		}
 	};
@@ -400,10 +400,10 @@ macro_rules! __storage_items_internal {
 			}
 
 			/// Mutate the value under a key.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> Self::Query {
+			fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> R {
 				let mut val = <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::take(key, storage);
 
-				f(&mut val);
+				let ret = f(&mut val);
 
 				__handle_wrap_internal!($wraptype {
 					// raw type case
@@ -416,7 +416,7 @@ macro_rules! __storage_items_internal {
 					}
 				});
 
-				val
+				ret
 			}
 		}
 	};
@@ -1904,10 +1904,10 @@ macro_rules! __decl_storage_item {
 			}
 
 			/// Mutate the value under a key
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> Self::Query {
+			fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> R {
 				let mut val = <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::take(key, storage);
 
-				f(&mut val);
+				let ret = f(&mut val);
 
 				__handle_wrap_internal!($wraptype {
 					// raw type case
@@ -1920,7 +1920,7 @@ macro_rules! __decl_storage_item {
 					}
 				});
 
-				val
+				ret
 			}
 		}
 	};
@@ -1965,10 +1965,10 @@ macro_rules! __decl_storage_item {
 			}
 
 			/// Mutate the value under a key.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) -> Self::Query {
+			fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: $crate::GenericStorage>(f: F, storage: &S) -> R {
 				let mut val = <Self as $crate::storage::generator::StorageValue<$ty>>::get(storage);
 
-				f(&mut val);
+				let ret = f(&mut val);
 
 				__handle_wrap_internal!($wraptype {
 					// raw type case
@@ -1981,7 +1981,7 @@ macro_rules! __decl_storage_item {
 					}
 				});
 
-				val
+				ret
 			}
 		}
 	};

--- a/srml/support/src/storage/generator.rs
+++ b/srml/support/src/storage/generator.rs
@@ -119,7 +119,7 @@ pub trait StorageValue<T: codec::Codec> {
 	}
 
 	/// Mutate this value
-	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(f: F, storage: &S);
+	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(f: F, storage: &S) -> Self::Query;
 
 	/// Clear the storage value.
 	fn kill<S: Storage>(storage: &S) {
@@ -190,7 +190,7 @@ pub trait StorageMap<K: codec::Codec, V: codec::Codec> {
 	}
 
 	/// Mutate the value under a key.
-	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(key: &K, f: F, storage: &S);
+	fn mutate<F: FnOnce(&mut Self::Query), S: Storage>(key: &K, f: F, storage: &S) -> Self::Query;
 }
 
 // TODO: Remove this in favour of `decl_storage` macro.
@@ -342,7 +342,7 @@ macro_rules! __storage_items_internal {
 			}
 
 			/// Mutate this value.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) {
+			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) -> Self::Query {
 				let mut val = <Self as $crate::storage::generator::StorageValue<$ty>>::get(storage);
 
 				f(&mut val);
@@ -353,10 +353,12 @@ macro_rules! __storage_items_internal {
 				} {
 					// Option<> type case
 					match val {
-						Some(val) => <Self as $crate::storage::generator::StorageValue<$ty>>::put(&val, storage),
+						Some(ref val) => <Self as $crate::storage::generator::StorageValue<$ty>>::put(&val, storage),
 						None => <Self as $crate::storage::generator::StorageValue<$ty>>::kill(storage),
 					}
 				});
+
+				val
 			}
 		}
 	};
@@ -398,7 +400,7 @@ macro_rules! __storage_items_internal {
 			}
 
 			/// Mutate the value under a key.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) {
+			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> Self::Query {
 				let mut val = <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::take(key, storage);
 
 				f(&mut val);
@@ -409,10 +411,12 @@ macro_rules! __storage_items_internal {
 				} {
 					// Option<> type case
 					match val {
-						Some(val) => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::insert(key, &val, storage),
+						Some(ref val) => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::insert(key, &val, storage),
 						None => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::remove(key, storage),
 					}
 				});
+
+				val
 			}
 		}
 	};
@@ -1900,7 +1904,7 @@ macro_rules! __decl_storage_item {
 			}
 
 			/// Mutate the value under a key
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) {
+			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(key: &$kty, f: F, storage: &S) -> Self::Query {
 				let mut val = <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::take(key, storage);
 
 				f(&mut val);
@@ -1911,10 +1915,12 @@ macro_rules! __decl_storage_item {
 				} {
 					// Option<> type case
 					match val {
-						Some(val) => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::insert(key, &val, storage),
+						Some(ref val) => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::insert(key, &val, storage),
 						None => <Self as $crate::storage::generator::StorageMap<$kty, $ty>>::remove(key, storage),
 					}
 				});
+
+				val
 			}
 		}
 	};
@@ -1959,7 +1965,7 @@ macro_rules! __decl_storage_item {
 			}
 
 			/// Mutate the value under a key.
-			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) {
+			fn mutate<F: FnOnce(&mut Self::Query), S: $crate::GenericStorage>(f: F, storage: &S) -> Self::Query {
 				let mut val = <Self as $crate::storage::generator::StorageValue<$ty>>::get(storage);
 
 				f(&mut val);
@@ -1970,10 +1976,12 @@ macro_rules! __decl_storage_item {
 				} {
 					// Option<> type case
 					match val {
-						Some(val) => <Self as $crate::storage::generator::StorageValue<$ty>>::put(&val, storage),
+						Some(ref val) => <Self as $crate::storage::generator::StorageValue<$ty>>::put(&val, storage),
 						None => <Self as $crate::storage::generator::StorageValue<$ty>>::kill(storage),
 					}
 				});
+
+				val
 			}
 		}
 	};

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -169,7 +169,7 @@ pub trait StorageValue<T: Codec> {
 	fn put<Arg: Borrow<T>>(val: Arg);
 
 	/// Mutate the value
-	fn mutate<F: FnOnce(&mut Self::Query)>(f: F) -> Self::Query;
+	fn mutate<R, F: FnOnce(&mut Self::Query) -> R>(f: F) -> R;
 
 	/// Clear the storage value.
 	fn kill();
@@ -193,7 +193,7 @@ impl<T: Codec, U> StorageValue<T> for U where U: generator::StorageValue<T> {
 	fn put<Arg: Borrow<T>>(val: Arg) {
 		U::put(val.borrow(), &RuntimeStorage)
 	}
-	fn mutate<F: FnOnce(&mut Self::Query)>(f: F) -> Self::Query {
+	fn mutate<R, F: FnOnce(&mut Self::Query) -> R>(f: F) -> R {
 		U::mutate(f, &RuntimeStorage)
 	}
 	fn kill() {
@@ -296,7 +296,7 @@ pub trait StorageMap<K: Codec, V: Codec> {
 	fn remove<KeyArg: Borrow<K>>(key: KeyArg);
 
 	/// Mutate the value under a key.
-	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F) -> Self::Query;
+	fn mutate<KeyArg: Borrow<K>, R, F: FnOnce(&mut Self::Query) -> R>(key: KeyArg, f: F) -> R;
 
 	/// Take the value under a key.
 	fn take<KeyArg: Borrow<K>>(key: KeyArg) -> Self::Query;
@@ -329,7 +329,7 @@ impl<K: Codec, V: Codec, U> StorageMap<K, V> for U where U: generator::StorageMa
 		U::remove(key.borrow(), &RuntimeStorage)
 	}
 
-	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F) -> Self::Query {
+	fn mutate<KeyArg: Borrow<K>, R, F: FnOnce(&mut Self::Query) -> R>(key: KeyArg, f: F) -> R {
 		U::mutate(key.borrow(), f, &RuntimeStorage)
 	}
 

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -169,7 +169,7 @@ pub trait StorageValue<T: Codec> {
 	fn put<Arg: Borrow<T>>(val: Arg);
 
 	/// Mutate the value
-	fn mutate<F: FnOnce(&mut Self::Query)>(f: F);
+	fn mutate<F: FnOnce(&mut Self::Query)>(f: F) -> Self::Query;
 
 	/// Clear the storage value.
 	fn kill();
@@ -193,7 +193,7 @@ impl<T: Codec, U> StorageValue<T> for U where U: generator::StorageValue<T> {
 	fn put<Arg: Borrow<T>>(val: Arg) {
 		U::put(val.borrow(), &RuntimeStorage)
 	}
-	fn mutate<F: FnOnce(&mut Self::Query)>(f: F) {
+	fn mutate<F: FnOnce(&mut Self::Query)>(f: F) -> Self::Query {
 		U::mutate(f, &RuntimeStorage)
 	}
 	fn kill() {
@@ -296,7 +296,7 @@ pub trait StorageMap<K: Codec, V: Codec> {
 	fn remove<KeyArg: Borrow<K>>(key: KeyArg);
 
 	/// Mutate the value under a key.
-	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F);
+	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F) -> Self::Query;
 
 	/// Take the value under a key.
 	fn take<KeyArg: Borrow<K>>(key: KeyArg) -> Self::Query;
@@ -329,7 +329,7 @@ impl<K: Codec, V: Codec, U> StorageMap<K, V> for U where U: generator::StorageMa
 		U::remove(key.borrow(), &RuntimeStorage)
 	}
 
-	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F) {
+	fn mutate<KeyArg: Borrow<K>, F: FnOnce(&mut Self::Query)>(key: KeyArg, f: F) -> Self::Query {
 		U::mutate(key.borrow(), f, &RuntimeStorage)
 	}
 


### PR DESCRIPTION
This is an attempt to fix #921

However, this doesn't quite follow the exact the requirement in that issue, we could have some discussion here:

1. Should this also be applied to StorageMap's mutate? In this commit, I converted it too.
2. Because for mutate's FnOnce, we're passing the "mut ref" down, so I don't think we should pass another value out, that would be a bit inconvenient, unless we make the signature look like this `FnOnce(Self::Query) -> Self::Query`.

@gavofyork @snd 

