### PR TITLE
Fix build error in no_std env

### DIFF
--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -55,6 +55,7 @@ extern crate srml_system as system;
 use runtime_support::{StorageValue, StorageMap, dispatch::Result, Parameter};
 use primitives::traits::{Member, SimpleArithmetic, Zero};
 use system::ensure_signed;
+use sr_std::prelude::Vec;
 
 pub trait Trait: system::Trait {
 	/// The overarching event type.


### PR DESCRIPTION
99  | / decl_storage! {
100 | |     trait Store for Module<T: Trait> as Assets {
101 | |         /// The number of units of assets held by any given account.
102 | |         Balances: map (AssetId, T::AccountId) => T::Balance;
...   |
105 | |     }
106 | | }
Vec not found in this scope