### PR TITLE
docs: Fix broken link to License in Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -321,6 +321,5 @@ The code block annotations in the `# Example` section may be used as https://doc
 ** Documentation as tests examples are included when running `cargo test`
 
 == License
-----
+
 https://github.com/paritytech/substrate/blob/master/LICENSE[LICENSE]
-----

--- a/README.adoc
+++ b/README.adoc
@@ -322,5 +322,5 @@ The code block annotations in the `# Example` section may be used as https://doc
 
 == License
 ----
-include::LICENSE[]
+https://github.com/paritytech/substrate/blob/master/LICENSE[LICENSE]
 ----


### PR DESCRIPTION
Note: Alternative may have been to rename LICENSE to LICENSE.adoc so it would be recognised as an AsciiDoc file and modify to be `include::LICENSE.adoc[]`  https://github.com/asciidoctor/asciidoctor.org/blob/master/docs/_includes/include-directive.adoc