### PR TITLE
docs: Relates to Issue #995. Fix links in existing documentation

### DIFF
--- a/core/client/db/README.adoc
+++ b/core/client/db/README.adoc
@@ -1,0 +1,13 @@
+
+= Client DB
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/client/src/lib.rs
+++ b/core/client/src/lib.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! Substrate Client and associated logic.
+// end::description[]
 
 #![warn(missing_docs)]
 #![recursion_limit="128"]

--- a/core/consensus/common/README.adoc
+++ b/core/consensus/common/README.adoc
@@ -1,0 +1,12 @@
+= Consensus Common
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/consensus/common/src/lib.rs
+++ b/core/consensus/common/src/lib.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate Consensus Common.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! Tracks offline validators.
+// end::description[]
+
 #![allow(dead_code)]
 
 #![cfg(feature="rhd")]

--- a/core/consensus/rhd/README.adoc
+++ b/core/consensus/rhd/README.adoc
@@ -1,0 +1,12 @@
+= Consensus Rhododendron (RHD)
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/consensus/rhd/src/lib.rs
+++ b/core/consensus/rhd/src/lib.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! BFT Agreement based on a rotating proposer in different rounds.
 //!
 //! Where this crate refers to input stream, should never logically conclude.
@@ -29,6 +30,7 @@
 //! conclude without having witnessed the conclusion.
 //! In general, this future should be pre-empted by the import of a justification
 //! set for this block height.
+// end::description[]
 
 #![cfg(feature = "rhd")]
 

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -24,7 +24,7 @@
 //! - execute_block(bytes)
 //! - init_block(PrevBlock?) -> InProgressBlock
 //! - add_transaction(InProgressBlock) -> InProgressBlock
-//! I leave it as is for now as it might be removed before this is ever done.
+//! It is left as is for now as it might be removed before this is ever done.
 // end::description[]
 
 #![warn(missing_docs)]

--- a/core/finality-grandpa/README.adoc
+++ b/core/finality-grandpa/README.adoc
@@ -1,0 +1,12 @@
+= Finality GRANDPA (aka SHAFT)
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! Integration of the GRANDPA finality gadget into substrate.
 //!
 //! This is a long-running future that produces finality notifications.
+// end::description[]
 
 extern crate finality_grandpa as grandpa;
 extern crate futures;

--- a/core/keyring/src/lib.rs
+++ b/core/keyring/src/lib.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 // tag::description[]
-//! Support code for the runtime.
+//! Support code for the runtime. A set of test accounts.
 // end::description[]
 
 #[macro_use] extern crate hex_literal;

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 // tag::description[]
-//! Substrate service. Starts a thread that spins the network, the client and the extrinsic pool.
+//! Substrate service. Starts a thread that spins up the network, client, and extrinsic pool.
 //! Manages communication between them.
 // end::description[]
 

--- a/core/sr-api/README.adoc
+++ b/core/sr-api/README.adoc
@@ -1,0 +1,12 @@
+= Runtime API
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/sr-api/src/lib.rs
+++ b/core/sr-api/src/lib.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! API's for interfacing with the runtime via native/wasm.
+// end::description[]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/core/sr-primitives/README.adoc
+++ b/core/sr-primitives/README.adoc
@@ -1,0 +1,12 @@
+= Runtime Primitives
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+// tag::description[]
 //! System manager: Handles all of the top-level stuff; executing block/transaction, setting code
 //! and depositing logs.
+// end::description[]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -15,25 +15,25 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 // tag::description[]
-//! This crate provides means of instantiation and execution of wasm modules.
+//! This crate provides means to instantiate and execute wasm modules.
 //!
-//! It works even when the user of this library is itself executes
-//! inside the wasm VM. In this case same VM is used for execution
+//! It works even when the user of this library executes from
+//! inside the wasm VM. In this case the same VM is used for execution
 //! of both the sandbox owner and the sandboxed module, without compromising security
-//! and without performance penalty of full wasm emulation inside wasm.
+//! and without the performance penalty of full wasm emulation inside wasm.
 //!
-//! This is achieved by using bindings to wasm VM which are published by the host API.
-//! This API is thin and consists of only handful functions. It contains functions for instantiating
-//! modules and executing them and for example doesn't contain functions for inspecting the module
-//! structure. The user of this library is supposed to read wasm module by it's own means.
+//! This is achieved by using bindings to the wasm VM, which are published by the host API.
+//! This API is thin and consists of only a handful functions. It contains functions for instantiating
+//! modules and executing them, but doesn't contain functions for inspecting the module
+//! structure. The user of this library is supposed to read the wasm module.
 //!
-//! When this crate is used in `std` environment all these functions are implemented by directly
-//! calling wasm VM.
+//! When this crate is used in the `std` environment all these functions are implemented by directly
+//! calling the wasm VM.
 //!
-//! Example of possible use-cases for this library are following:
+//! Example of possible use-cases for this library are the following:
 //!
-//! - implementing smart-contract runtimes which uses wasm for contract code
-//! - executing wasm substrate runtime inside of a wasm parachain
+//! - implementing smart-contract runtimes that use wasm for contract code
+//! - executing a wasm substrate runtime inside of a wasm parachain
 //! - etc
 // end::description[]
 

--- a/core/sr-version/README.adoc
+++ b/core/sr-version/README.adoc
@@ -1,0 +1,13 @@
+
+= Runtime Version
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/sr-version/src/lib.rs
+++ b/core/sr-version/src/lib.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Version module for runtime; Provide a function that returns runtime version.
+// tag::description[]
+//! Version module for the Substrate runtime; Provides a function that returns the runtime version.
+// end::description[]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/core/telemetry/src/lib.rs
+++ b/core/telemetry/src/lib.rs
@@ -17,7 +17,7 @@
 // tag::description[]
 //! Telemetry utils.
 //!
-//! `telemetry` macro be used from whereever in the Substrate codebase
+//! `telemetry` macro may be used anywhere in the Substrate codebase
 //! in order to send real-time logging information to the telemetry
 //! server (if there is one). We use the async drain adapter of `slog`
 //! so that the logging thread doesn't get held up at all.

--- a/core/transaction-pool/README.adoc
+++ b/core/transaction-pool/README.adoc
@@ -1,0 +1,13 @@
+
+= Transaction Pool
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/trie/README.adoc
+++ b/core/trie/README.adoc
@@ -1,0 +1,12 @@
+= Substrate Trie
+
+.Summary
+[source, toml]
+----
+include::Cargo.toml[lines=2..5]
+----
+
+.Description
+----
+include::src/lib.rs[tag=description]
+----

--- a/core/trie/README.md
+++ b/core/trie/README.md
@@ -1,1 +1,0 @@
-This crate provides utility functions to interact with Substrate's Modified Merkle Patricia tree ("trie").

--- a/core/trie/src/lib.rs
+++ b/core/trie/src/lib.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Substrate-format Base-16 Modified Merkle Patricia Tree (Trie).
+// tag::description[]
+//! Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
+// end::description[]
 
 // TODO: no_std
 

--- a/doc/packages/misc.adoc
+++ b/doc/packages/misc.adoc
@@ -3,8 +3,6 @@
 
 :leveloffset: +3
 
-include::../../safe-mix/README.adoc[]
-
 include::../../subkey/README.adoc[]
 
 :leveloffset: -3

--- a/doc/packages/substrate.adoc
+++ b/doc/packages/substrate.adoc
@@ -1,35 +1,33 @@
 
 == Substrate Packages
 
+=== Substrate Core
+
 :leveloffset: +3
-
-include::../../core/bft/README.adoc[]
-
-include::../../core/cli/README.adoc[]
 
 include::../../core/client/README.adoc[]
 
-include::../../codec/README.adoc[]
+include::../../core/test-client/README.adoc[]
 
-include::../../environmental/README.adoc[]
+include::../../core/client/db/README.adoc[]
+
+include::../../core/state-db/README.adoc[]
+
+include::../../core/consensus/common/README.adoc[]
+
+include::../../core/consensus/rhd/README.adoc[]
 
 include::../../core/executor/README.adoc[]
+
+include::../../core/finality-grandpa/README.adoc[]
 
 include::../../core/transaction-pool/README.adoc[]
 
 include::../../core/keyring/README.adoc[]
 
-include::../../core/keystore/README.adoc[]
-
-include::../../core/misbehavior-check/README.adoc[]
-
 include::../../core/network/README.adoc[]
 
 include::../../core/network-libp2p/README.adoc[]
-
-include::../../core/primitives/README.adoc[]
-
-include::../../pwasm-alloc/README.adoc[]
 
 include::../../core/rpc/README.adoc[]
 
@@ -37,26 +35,32 @@ include::../../core/rpc-servers/README.adoc[]
 
 include::../../srml/README.adoc[]
 
+include::../../core/sr-api/README.adoc[]
+
 include::../../core/sr-io/README.adoc[]
+
+include::../../core/sr-primitives/README.adoc[]
 
 include::../../core/sr-sandbox/README.adoc[]
 
 include::../../core/sr-std/README.adoc[]
 
-include::../../core/runtime-support/README.adoc[]
-
-include::../../core/serializer/README.adoc[]
-
-include::../../core/service/README.adoc[]
-
-include::../../core/state-db/README.adoc[]
-
 include::../../core/state-machine/README.adoc[]
+
+include::../../core/test-runtime/README.adoc[]
 
 include::../../core/telemetry/README.adoc[]
 
-include::../../core/test-client/README.adoc[]
+include::../../core/cli/README.adoc[]
 
-include::../../core/test-srml/README.adoc[]
+include::../../core/service/README.adoc[]
+
+include::../../core/trie/README.adoc[]
+
+include::../../core/keystore/README.adoc[]
+
+include::../../core/primitives/README.adoc[]
+
+include::../../core/serializer/README.adoc[]
 
 :leveloffset: -3


### PR DESCRIPTION
* Add missing README.adoc to substrate/core packages
* Add missing description tag to lib.rs so README.adoc may interpret
* Remove deprecated substrate/core packages from substrate.adoc