### PR TITLE
docker: use alpine to slim down images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,35 @@
-FROM phusion/baseimage:0.10.1 as builder
-LABEL maintainer "chevdor@gmail.com"
+FROM frolvlad/alpine-glibc AS builder
+LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."
+
+RUN apk add build-base \
+    cmake \
+    linux-headers \
+    openssl-dev && \
+    apk add --repository http://nl.alpinelinux.org/alpine/edge/community cargo
 
 ARG PROFILE=release
 WORKDIR /substrate
 
-RUN apt-get update && \
-	apt-get upgrade -y && \
-	apt-get install -y cmake pkg-config libssl-dev git
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
 COPY . /substrate
 
-RUN export PATH=$PATH:$HOME/.cargo/bin && cargo build --$PROFILE
+RUN cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 
-FROM phusion/baseimage:0.10.0
-LABEL maintainer "chevdor@gmail.com"
+FROM alpine:3.8
+LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 ARG PROFILE=release
 COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
 
-RUN mv /usr/share/ca* /tmp && \
-	rm -rf /usr/share/*  && \
-	mv /tmp/ca-certificates /usr/share/ && \
-	rm -rf /usr/lib/python* && \
+RUN apk add --no-cache ca-certificates \
+    libstdc++ \
+    openssl
+
+RUN rm -rf /usr/lib/python* && \
 	mkdir -p /root/.local/share/Substrate && \
 	ln -s /root/.local/share/Substrate /data
-
-RUN	rm -rf /usr/bin /usr/sbin
 
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]


### PR DESCRIPTION
reduces the image size by ~25%. this is motivated by wanting to reduce the memory footprint of a container in the case of testing many nodes at once. i can also include this as a separate dockerfile if we don't want to default to alpine/musl.

``` 
$ docker stats --no-stream --format "table {{.Name}}\t{{.MemUsage}}"
NAME                        MEM USAGE / LIMIT
substrate:alpine            37.23MiB / 31.3GiB
substrate:phusion           48.18MiB / 31.3GiB

$ docker images --filter=reference='substrate' --format="table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
REPOSITORY          TAG                 SIZE
substrate           alpine              41.8MB
substrate           phusion             241MB
```
@chevdor @gavofyork 