### PR TITLE
Suggest `sh` instead of `bash`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ To get going as fast as possible, there is a simple script that installs all req
 
 [source, shell]
 ----
-curl getsubstrate.io -sSf | bash
+curl getsubstrate.io -sSf | sh
 ----
 
 You can start a local Substrate development chain with running `substrate --dev`.


### PR DESCRIPTION
Since the getsubstrate.io script doesn't use any bashisms, we can safely suggest `sh` instead. It's generally good practice to recommend `sh` over `bash` since you can't guarantee to have `bash` installed on any given system but `sh` will _always_ point to something useful.