### PR TITLE
Simplify onboarding when using `subkey restore`

### DIFF
--- a/subkey/src/cli.yml
+++ b/subkey/src/cli.yml
@@ -3,7 +3,7 @@ author: "Parity Team <admin@parity.io>"
 about: A substrate key utility
 subcommands:
   - restore:
-      about: Gets a SS58 public key from the provided seed phrase
+      about: Gets a public key and a SS58 address from the provided seed phrase
       args:
         - seed:
             index: 1

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
 			seed[..len].copy_from_slice(&raw_seed[..len]);
 			let pair = Pair::from_seed(&seed);
 
-			println!("Seed 0x{} is account:\n    Hex: 0x{}\n    SS58: {}",
+			println!("Seed 0x{} is account:\n    Public key (hex): 0x{}\n    Address (SS58): {}",
 				HexDisplay::from(&seed),
 				HexDisplay::from(&pair.public().0),
 				pair.public().to_ss58check()

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -58,10 +58,10 @@ fn main() {
 			seed[..len].copy_from_slice(&raw_seed[..len]);
 			let pair = Pair::from_seed(&seed);
 
-			println!("Seed 0x{} is account:\n    SS58: {}\n    Hex: 0x{}",
+			println!("Seed 0x{} is account:\n    Hex: 0x{}\n    SS58: {}",
 				HexDisplay::from(&seed),
-				pair.public().to_ss58check(),
-				HexDisplay::from(&pair.public().0)
+				HexDisplay::from(&pair.public().0),
+				pair.public().to_ss58check()
 			);
 		},
 		_ => print_usage(&matches),


### PR DESCRIPTION
Some small improvementes that help understanding key derivation