### PR TITLE
refactor: Fixes #1083. Rename ApplyExtrinsicFailed method without typo

### DIFF
--- a/core/client/src/block_builder.rs
+++ b/core/client/src/block_builder.rs
@@ -103,7 +103,7 @@ where
 					}
 					Err(e) => {
 						self.changes.discard_prospective();
-						Err(error::ErrorKind::ApplyExtinsicFailed(e).into())
+						Err(error::ErrorKind::ApplyExtrinsicFailed(e).into())
 					}
 				}
 			}

--- a/core/client/src/error.rs
+++ b/core/client/src/error.rs
@@ -41,7 +41,7 @@ error_chain! {
 		}
 
 		/// Applying extrinsic error.
-		ApplyExtinsicFailed(e: ApplyError) {
+		ApplyExtrinsicFailed(e: ApplyError) {
 			description("Extrinsic error"),
 			display("Extrinsic error: {:?}", e),
 		}


### PR DESCRIPTION
Rename method name since it is missing the letter `r`. i.e. ApplyExt**r**insicFailed instead of  ApplyExtinsicFailed