### PR TITLE
docker: build dependencies separately

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 doc
 target
 .idea/
-Dockerfile
 .dockerignore
+.git/
+docker/

--- a/docker/Deps.dockerfile
+++ b/docker/Deps.dockerfile
@@ -1,0 +1,29 @@
+FROM frolvlad/alpine-glibc
+
+ARG PROFILE=release
+
+RUN apk add --no-cache build-base \
+    cmake \
+    linux-headers \
+    openssl-dev \
+    bash \
+    wget && \
+    apk add --repository http://nl.alpinelinux.org/alpine/edge/community cargo
+
+# Need nightly cargo for build-deps
+WORKDIR /tmp
+RUN wget -q https://static.rust-lang.org/dist/2018-11-07/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz
+RUN tar xf cargo-nightly-x86_64-unknown-linux-gnu.tar.xz
+RUN mv cargo-nightly-x86_64-unknown-linux-gnu/cargo/bin/cargo /usr/bin/cargo
+RUN rm -r cargo-nightly-x86_64-unknown-linux-gnu
+
+RUN cargo install cargo-build-deps \
+    --git https://github.com/azban/cargo-build-deps \
+    --rev 0a83ffef78d559548cba7a30d6dabc83223c5e93
+
+COPY docker/touch_libs.sh /tmp
+
+WORKDIR /substrate
+COPY . /substrate
+RUN /tmp/touch_libs.sh
+RUN cargo build-deps --$PROFILE

--- a/docker/Substrate.dockerfile
+++ b/docker/Substrate.dockerfile
@@ -1,18 +1,11 @@
-FROM frolvlad/alpine-glibc AS builder
+FROM substrate-deps as builder
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."
 
-RUN apk add build-base \
-    cmake \
-    linux-headers \
-    openssl-dev && \
-    apk add --repository http://nl.alpinelinux.org/alpine/edge/community cargo
-
 ARG PROFILE=release
+
 WORKDIR /substrate
-
 COPY . /substrate
-
 RUN cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
@@ -20,6 +13,7 @@ RUN cargo build --$PROFILE
 FROM alpine:3.8
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
+
 ARG PROFILE=release
 COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+(cd ../ && tar c docker/Deps.dockerfile docker/touch_libs.sh $(find . -name "Cargo.lock") $(find . -name "Cargo.toml") $(find . -name "bench.rs") | docker build -t substrate-deps -f docker/Deps.dockerfile -)
+(cd ../ && docker build -f docker/Substrate.dockerfile .)

--- a/docker/touch_libs.sh
+++ b/docker/touch_libs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+for manifest in $(find . -mindepth 2 -name "Cargo.toml")
+do
+    mkdir $(dirname ${manifest})/src
+    touch $(dirname ${manifest})/src/lib.rs
+done


### PR DESCRIPTION
@chevdor @gavofyork 
this change optimizes build times after the initial build by building only dependencies first, and then building local packages later.

previously, every build took ~15 minutes for any code change. 
with these changes, the first build takes ~17 minutes and subsequent builds for code changes take ~4.5 minutes.