### PR TITLE
docker: use build kit to allow for incremental builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ target
 .idea/
 Dockerfile
 .dockerignore
+**/target
+!**/wasm/target
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile-upstream:experimental
+
 FROM frolvlad/alpine-glibc AS builder
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."
@@ -8,20 +10,27 @@ RUN apk add build-base \
     openssl-dev && \
     apk add --repository http://nl.alpinelinux.org/alpine/edge/community cargo
 
-ARG PROFILE=release
 WORKDIR /substrate
-
 COPY . /substrate
 
-RUN cargo build --$PROFILE
+# Build with mounted cache
+ENV CARGO_HOME=/usr/local/cargo
+ENV CARGO_TARGET_DIR=/tmp/target
+RUN --mount=type=cache,target=/tmp/target \
+    --mount=type=cache,target=/usr/local/cargo \
+    ["cargo", "build", "--release"]
+
+# Copy binaries into normal layers
+RUN --mount=type=cache,target=/tmp/target \
+    ["cp", "/tmp/target/release/substrate", "/usr/local/bin/substrate"]
 
 # ===== SECOND STAGE ======
 
 FROM alpine:3.8
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
-ARG PROFILE=release
-COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
+
+COPY --from=builder /usr/local/bin/substrate /usr/local/bin
 
 RUN apk add --no-cache ca-certificates \
     libstdc++ \


### PR DESCRIPTION
this change allows for incremental builds via docker. this utilizes BuildKit which allows you to specify cache mounts for individual directories per `RUN` command. 

this requires `docker-ce` 18.09, which was released today (11/9/18), and won't be available on stable Docker for Mac for some time. i don't know how we want to decide between this and https://github.com/paritytech/substrate/pull/1085, which is less optimal but is currently more compatible across platforms.

note: setting `DOCKER_BUILDKIT=1` is required when running `docker build`.