### PR TITLE
RPC: expose chain spec `properties` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,7 @@ dependencies = [
  "parity-codec 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 0.1.0",
  "sr-version 0.1.0",
  "substrate-client 0.1.0",

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -11,6 +11,7 @@ jsonrpc-pubsub = { git="https://github.com/paritytech/jsonrpc.git" }
 log = "0.4"
 parking_lot = "0.4"
 parity-codec = "2.1"
+serde_json = "1.0"
 substrate-client = { path = "../client" }
 substrate-executor = { path = "../executor" }
 substrate-transaction-pool = { path = "../transaction-pool" }

--- a/core/rpc/src/system/error.rs
+++ b/core/rpc/src/system/error.rs
@@ -27,13 +27,25 @@ error_chain! {
 			description("not yet implemented"),
 			display("Method Not Implemented"),
 		}
+		/// Invalid system properties config
+		InvalidPropertiesConfig(v: serde_json::Value) {
+			description("invalid system properties config, expected JSON object"),
+			display("Invalid system properties config '{:?}', expected JSON object", v),
+		}
 	}
 }
+
+const ERROR: i64 = 4000;
 
 impl From<Error> for rpc::Error {
 	fn from(e: Error) -> Self {
 		match e {
 			Error(ErrorKind::Unimplemented, _) => errors::unimplemented(),
+			Error(ErrorKind::InvalidPropertiesConfig(v), _) => rpc::Error {
+				code: rpc::ErrorCode::ServerError(ERROR + 1),
+				message: format!("Invalid system properties config '{:?}', expected JSON object.", v),
+				data: None,
+			},
 			e => errors::internal(e),
 		}
 	}

--- a/core/rpc/src/system/error.rs
+++ b/core/rpc/src/system/error.rs
@@ -27,25 +27,13 @@ error_chain! {
 			description("not yet implemented"),
 			display("Method Not Implemented"),
 		}
-		/// Invalid system properties config
-		InvalidPropertiesConfig(v: serde_json::Value) {
-			description("invalid system properties config, expected JSON object"),
-			display("Invalid system properties config '{:?}', expected JSON object", v),
-		}
 	}
 }
-
-const ERROR: i64 = 4000;
 
 impl From<Error> for rpc::Error {
 	fn from(e: Error) -> Self {
 		match e {
 			Error(ErrorKind::Unimplemented, _) => errors::unimplemented(),
-			Error(ErrorKind::InvalidPropertiesConfig(v), _) => rpc::Error {
-				code: rpc::ErrorCode::ServerError(ERROR + 1),
-				message: format!("Invalid system properties config '{:?}', expected JSON object.", v),
-				data: None,
-			},
 			e => errors::internal(e),
 		}
 	}

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -37,5 +37,9 @@ build_rpc_trait! {
 		/// Get the chain's type. Given as a string identifier.
 		#[rpc(name = "system_chain")]
 		fn system_chain(&self) -> Result<String>;
+
+        /// Get a custom set of properties as a JSON object, defined in the chain spec.
+		#[rpc(name = "system_properties")]
+		fn system_properties(&self) -> Result<serde_json::map::Map<String, serde_json::Value>>;
 	}
 }

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -38,7 +38,7 @@ build_rpc_trait! {
 		#[rpc(name = "system_chain")]
 		fn system_chain(&self) -> Result<String>;
 
-        /// Get a custom set of properties as a JSON object, defined in the chain spec.
+		/// Get a custom set of properties as a JSON object, defined in the chain spec.
 		#[rpc(name = "system_properties")]
 		fn system_properties(&self) -> Result<serde_json::map::Map<String, serde_json::Value>>;
 	}

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -27,6 +27,9 @@ impl SystemApi for () {
 	fn system_chain(&self) -> Result<String> {
 		Ok("testchain".into())
 	}
+	fn system_properties(&self) -> Result<serde_json::Value> {
+		Ok(serde_json::Value::Object(serde_json::map::Map::new()))
+	}
 }
 
 #[test]
@@ -50,5 +53,13 @@ fn system_chain_works() {
 	assert_eq!(
 		SystemApi::system_chain(&()).unwrap(),
 		"testchain".to_owned()
+	);
+}
+
+#[test]
+fn system_properties_works() {
+	assert_eq!(
+		SystemApi::system_properties(&()).unwrap(),
+		serde_json::Value::Object(serde_json::map::Map::new())
 	);
 }

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -27,8 +27,8 @@ impl SystemApi for () {
 	fn system_chain(&self) -> Result<String> {
 		Ok("testchain".into())
 	}
-	fn system_properties(&self) -> Result<serde_json::Value> {
-		Ok(serde_json::Value::Object(serde_json::map::Map::new()))
+	fn system_properties(&self) -> Result<serde_json::map::Map<String, serde_json::Value>> {
+		Ok(serde_json::map::Map::new())
 	}
 }
 
@@ -60,6 +60,6 @@ fn system_chain_works() {
 fn system_properties_works() {
 	assert_eq!(
 		SystemApi::system_properties(&()).unwrap(),
-		serde_json::Value::Object(serde_json::map::Map::new())
+		serde_json::map::Map::new()
 	);
 }

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -177,7 +177,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 			telemetry_url: telemetry_url.map(str::to_owned),
 			protocol_id: protocol_id.map(str::to_owned),
 			consensus_engine: consensus_engine.map(str::to_owned),
-			properties: properties,
+			properties,
 		};
 		ChainSpec {
 			spec,

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -88,7 +88,7 @@ struct ChainSpecFile {
 	pub telemetry_url: Option<String>,
 	pub protocol_id: Option<String>,
 	pub consensus_engine: Option<String>,
-	pub properties: Option<String>,
+	pub properties: Option<json::Value>,
 }
 
 /// A configuration of a chain. Can be used to build a genesis block.
@@ -131,8 +131,9 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		self.spec.consensus_engine.as_ref().map(String::as_str)
 	}
 
-	pub fn properties(&self) -> Option<&str> {
-		self.spec.properties.as_ref().map(String::as_str)
+	pub fn properties(&self) -> &json::Value {
+		// Return an empty JSON object if 'properties' not defined in config
+		self.spec.properties.as_ref().unwrap_or(&json::Value::Object(json::map::Map::new()))
 	}
 
 	/// Parse json content into a `ChainSpec`
@@ -163,7 +164,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		telemetry_url: Option<&str>,
 		protocol_id: Option<&str>,
 		consensus_engine: Option<&str>,
-		properties: Option<&str>,
+		properties: Option<serde_json::Value>,
 	) -> Self
 	{
 		let spec = ChainSpecFile {
@@ -173,7 +174,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 			telemetry_url: telemetry_url.map(str::to_owned),
 			protocol_id: protocol_id.map(str::to_owned),
 			consensus_engine: consensus_engine.map(str::to_owned),
-			properties: properties.map(str::to_owned),
+			properties: properties,
 		};
 		ChainSpec {
 			spec,

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -88,7 +88,7 @@ struct ChainSpecFile {
 	pub telemetry_url: Option<String>,
 	pub protocol_id: Option<String>,
 	pub consensus_engine: Option<String>,
-	pub properties: Option<json::Value>,
+	pub properties: Option<json::map::Map<String, json::Value>>,
 }
 
 /// A configuration of a chain. Can be used to build a genesis block.
@@ -131,9 +131,9 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		self.spec.consensus_engine.as_ref().map(String::as_str)
 	}
 
-	pub fn properties(&self) -> &json::Value {
+	pub fn properties(&self) -> json::map::Map<String, json::Value> {
 		// Return an empty JSON object if 'properties' not defined in config
-		self.spec.properties.as_ref().unwrap_or(&json::Value::Object(json::map::Map::new()))
+		self.spec.properties.as_ref().unwrap_or(&json::map::Map::new()).clone()
 	}
 
 	/// Parse json content into a `ChainSpec`
@@ -164,7 +164,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		telemetry_url: Option<&str>,
 		protocol_id: Option<&str>,
 		consensus_engine: Option<&str>,
-		properties: Option<serde_json::Value>,
+		properties: Option<serde_json::map::Map<String, serde_json::Value>>,
 	) -> Self
 	{
 		let spec = ChainSpecFile {

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -88,6 +88,7 @@ struct ChainSpecFile {
 	pub telemetry_url: Option<String>,
 	pub protocol_id: Option<String>,
 	pub consensus_engine: Option<String>,
+	pub properties: Option<String>,
 }
 
 /// A configuration of a chain. Can be used to build a genesis block.
@@ -130,6 +131,10 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		self.spec.consensus_engine.as_ref().map(String::as_str)
 	}
 
+	pub fn properties(&self) -> Option<&str> {
+		self.spec.properties.as_ref().map(String::as_str)
+	}
+
 	/// Parse json content into a `ChainSpec`
 	pub fn from_embedded(json: &'static [u8]) -> Result<Self, String> {
 		let spec = json::from_slice(json).map_err(|e| format!("Error parsing spec file: {}", e))?;
@@ -158,6 +163,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		telemetry_url: Option<&str>,
 		protocol_id: Option<&str>,
 		consensus_engine: Option<&str>,
+		properties: Option<&str>,
 	) -> Self
 	{
 		let spec = ChainSpecFile {
@@ -167,6 +173,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 			telemetry_url: telemetry_url.map(str::to_owned),
 			protocol_id: protocol_id.map(str::to_owned),
 			consensus_engine: consensus_engine.map(str::to_owned),
+			properties: properties.map(str::to_owned),
 		};
 		ChainSpec {
 			spec,

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -88,8 +88,11 @@ struct ChainSpecFile {
 	pub telemetry_url: Option<String>,
 	pub protocol_id: Option<String>,
 	pub consensus_engine: Option<String>,
-	pub properties: Option<json::map::Map<String, json::Value>>,
+	pub properties: Option<Properties>,
 }
+
+/// Arbitrary properties defined in chain spec as a JSON object
+pub type Properties = json::map::Map<String, json::Value>;
 
 /// A configuration of a chain. Can be used to build a genesis block.
 pub struct ChainSpec<G: RuntimeGenesis> {
@@ -131,7 +134,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		self.spec.consensus_engine.as_ref().map(String::as_str)
 	}
 
-	pub fn properties(&self) -> json::map::Map<String, json::Value> {
+	pub fn properties(&self) -> Properties {
 		// Return an empty JSON object if 'properties' not defined in config
 		self.spec.properties.as_ref().unwrap_or(&json::map::Map::new()).clone()
 	}
@@ -164,7 +167,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		telemetry_url: Option<&str>,
 		protocol_id: Option<&str>,
 		consensus_engine: Option<&str>,
-		properties: Option<serde_json::map::Map<String, serde_json::Value>>,
+		properties: Option<Properties>,
 	) -> Self
 	{
 		let spec = ChainSpecFile {

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -381,7 +381,7 @@ fn maybe_start_server<T, F>(address: Option<SocketAddr>, start: F) -> Result<Opt
 #[derive(Clone)]
 struct RpcConfig {
 	chain_name: String,
-	properties: serde_json::Value,
+	properties: serde_json::map::Map<String, json::Value>,
 	impl_name: &'static str,
 	impl_version: &'static str,
 }
@@ -400,10 +400,7 @@ impl substrate_rpc::system::SystemApi for RpcConfig {
 	}
 
 	fn system_properties(&self) -> substrate_rpc::system::error::Result<json::map::Map<String, json::Value>> {
-		match self.properties {
-			serde_json::Value::Object(ref map) => Ok(map.clone()),
-			ref v => bail!(substrate_rpc::system::error::ErrorKind::InvalidPropertiesConfig(v.clone())),
-		}
+		Ok(self.properties.clone())
 	}
 }
 

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -70,7 +70,6 @@ use keystore::Store as Keystore;
 use client::BlockchainEvents;
 use runtime_primitives::traits::{Header, As};
 use runtime_primitives::generic::BlockId;
-use serde_json as json;
 use exit_future::Signal;
 #[doc(hidden)]
 pub use tokio::runtime::TaskExecutor;
@@ -79,7 +78,7 @@ use codec::{Encode, Decode};
 
 pub use self::error::{ErrorKind, Error};
 pub use config::{Configuration, Roles, PruningMode};
-pub use chain_spec::ChainSpec;
+pub use chain_spec::{ChainSpec, Properties};
 pub use transaction_pool::txpool::{self, Pool as TransactionPool, Options as TransactionPoolOptions, ChainApi, IntoPoolError};
 pub use client::ExecutionStrategy;
 
@@ -381,7 +380,7 @@ fn maybe_start_server<T, F>(address: Option<SocketAddr>, start: F) -> Result<Opt
 #[derive(Clone)]
 struct RpcConfig {
 	chain_name: String,
-	properties: serde_json::map::Map<String, json::Value>,
+	properties: Properties,
 	impl_name: &'static str,
 	impl_version: &'static str,
 }
@@ -399,7 +398,7 @@ impl substrate_rpc::system::SystemApi for RpcConfig {
 		Ok(self.chain_name.clone())
 	}
 
-	fn system_properties(&self) -> substrate_rpc::system::error::Result<json::map::Map<String, json::Value>> {
+	fn system_properties(&self) -> substrate_rpc::system::error::Result<Properties> {
 		Ok(self.properties.clone())
 	}
 }

--- a/node/cli/res/bbq-birch.json
+++ b/node/cli/res/bbq-birch.json
@@ -1,6 +1,9 @@
 {
 	"name": "BBQ Birch",
 	"id": "bbq-birch",
+	"properties": {
+		"tokenSymbol": "BBQ"
+	},
 	"telemetryUrl": "wss://telemetry.polkadot.io/submit/",
 	"protocolId": null,
 	"bootNodes": [

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -140,6 +140,7 @@ pub fn staging_testnet_config() -> ChainSpec {
 		Some(STAGING_TELEMETRY_URL.into()),
 		None,
 		None,
+		None,
 	)
 }
 
@@ -240,7 +241,7 @@ fn development_config_genesis() -> GenesisConfig {
 
 /// Development config (single validator Alice)
 pub fn development_config() -> ChainSpec {
-	ChainSpec::from_genesis("Development", "development", development_config_genesis, vec![], None, None, None)
+	ChainSpec::from_genesis("Development", "development", development_config_genesis, vec![], None, None, None, None)
 }
 
 fn local_testnet_genesis() -> GenesisConfig {
@@ -254,7 +255,7 @@ fn local_testnet_genesis() -> GenesisConfig {
 
 /// Local testnet config (multivalidator Alice + Bob)
 pub fn local_testnet_config() -> ChainSpec {
-	ChainSpec::from_genesis("Local Testnet", "local_testnet", local_testnet_genesis, vec![], None, None, None)
+	ChainSpec::from_genesis("Local Testnet", "local_testnet", local_testnet_genesis, vec![], None, None, None, None)
 }
 
 #[cfg(test)]
@@ -271,7 +272,7 @@ mod tests {
 
 	/// Local testnet config (multivalidator Alice + Bob)
 	pub fn integration_test_config() -> ChainSpec {
-		ChainSpec::from_genesis("Integration Test", "test", local_testnet_genesis_instant, vec![], None, None, None)
+		ChainSpec::from_genesis("Integration Test", "test", local_testnet_genesis_instant, vec![], None, None, None, None)
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #918 

Adds an RPC method `system_properties` which returns the top level `properties` from chain spec (must be a valid JSON object). It is optional, if not specified the RPC will return an empty json object `{ }`.