### PR TITLE
Introduce a `PhantomData` field in `GenesisConfig`

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -59,6 +59,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 		consensus: Some(ConsensusConfig {
 			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),    // TODO change
 			authorities: initial_authorities.clone(),
+			_genesis_phantom_data: Default::default(),
 		}),
 		system: None,
 		balances: Some(BalancesConfig {
@@ -69,10 +70,12 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			transfer_fee: 1 * CENTS,
 			creation_fee: 1 * CENTS,
 			reclaim_rebate: 1 * CENTS,
+			_genesis_phantom_data: Default::default(),
 		}),
 		session: Some(SessionConfig {
 			validators: initial_authorities.iter().cloned().map(Into::into).collect(),
 			session_length: 5 * MINUTES,
+			_genesis_phantom_data: Default::default(),
 		}),
 		staking: Some(StakingConfig {
 			current_era: 0,
@@ -86,11 +89,13 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			bonding_duration: 1 * DAYS,
 			offline_slash_grace: 4,
 			minimum_validator_count: 4,
+			_genesis_phantom_data: Default::default(),
 		}),
 		democracy: Some(DemocracyConfig {
 			launch_period: 5 * MINUTES,    // 1 day per public referendum
 			voting_period: 5 * MINUTES,    // 3 days to discuss & vote on an active referendum
 			minimum_deposit: 50 * DOLLARS,    // 12000 as the minimum deposit for a referendum
+			_genesis_phantom_data: Default::default(),
 		}),
 		council_seats: Some(CouncilSeatsConfig {
 			active_council: vec![],
@@ -103,19 +108,23 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			term_duration: 28 * DAYS,
 			desired_seats: 0,
 			inactive_grace_period: 1,    // one additional vote should go by before an inactive voter can be reaped.
+			_genesis_phantom_data: Default::default(),
 		}),
 		council_voting: Some(CouncilVotingConfig {
 			cooloff_period: 4 * DAYS,
 			voting_period: 1 * DAYS,
+			_genesis_phantom_data: Default::default(),
 		}),
 		timestamp: Some(TimestampConfig {
 			period: SECS_PER_BLOCK,
+			_genesis_phantom_data: Default::default(),
 		}),
 		treasury: Some(TreasuryConfig {
 			proposal_bond: Permill::from_percent(5),
 			proposal_bond_minimum: 1 * DOLLARS,
 			spend_period: 1 * DAYS,
 			burn: Permill::from_percent(50),
+			_genesis_phantom_data: Default::default(),
 		}),
 		contract: Some(ContractConfig {
 			contract_fee: 1 * CENTS,
@@ -125,9 +134,11 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			max_depth: 1024,
 			block_gas_limit: 10_000_000,
 			current_schedule: Default::default(),
+			_genesis_phantom_data: Default::default(),
 		}),
 		upgrade_key: Some(UpgradeKeyConfig {
 			key: endowed_accounts[0].clone(),
+			_genesis_phantom_data: Default::default(),
 		}),
 	}
 }
@@ -175,6 +186,7 @@ pub fn testnet_genesis(
 		consensus: Some(ConsensusConfig {
 			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),
 			authorities: initial_authorities.clone(),
+			_genesis_phantom_data: Default::default(),
 		}),
 		system: None,
 		balances: Some(BalancesConfig {
@@ -185,10 +197,12 @@ pub fn testnet_genesis(
 			creation_fee: 0,
 			reclaim_rebate: 0,
 			balances: endowed_accounts.iter().map(|&k| (k.into(), (1 << 60))).collect(),
+			_genesis_phantom_data: Default::default(),
 		}),
 		session: Some(SessionConfig {
 			validators: initial_authorities.iter().cloned().map(Into::into).collect(),
 			session_length: 10,
+			_genesis_phantom_data: Default::default(),
 		}),
 		staking: Some(StakingConfig {
 			current_era: 0,
@@ -202,11 +216,13 @@ pub fn testnet_genesis(
 			current_offline_slash: 0,
 			current_session_reward: 0,
 			offline_slash_grace: 0,
+			_genesis_phantom_data: Default::default(),
 		}),
 		democracy: Some(DemocracyConfig {
 			launch_period: 9,
 			voting_period: 18,
 			minimum_deposit: 10,
+			_genesis_phantom_data: Default::default(),
 		}),
 		council_seats: Some(CouncilSeatsConfig {
 			active_council: endowed_accounts.iter()
@@ -221,19 +237,23 @@ pub fn testnet_genesis(
 			term_duration: 1000000,
 			desired_seats: (endowed_accounts.len() - initial_authorities.len()) as u32,
 			inactive_grace_period: 1,
+			_genesis_phantom_data: Default::default(),
 		}),
 		council_voting: Some(CouncilVotingConfig {
 			cooloff_period: 75,
 			voting_period: 20,
+			_genesis_phantom_data: Default::default(),
 		}),
 		timestamp: Some(TimestampConfig {
 			period: 5,                    // 5 second block time.
+			_genesis_phantom_data: Default::default(),
 		}),
 		treasury: Some(TreasuryConfig {
 			proposal_bond: Permill::from_percent(5),
 			proposal_bond_minimum: 1_000_000,
 			spend_period: 12 * 60 * 24,
 			burn: Permill::from_percent(50),
+			_genesis_phantom_data: Default::default(),
 		}),
 		contract: Some(ContractConfig {
 			contract_fee: 21,
@@ -243,9 +263,11 @@ pub fn testnet_genesis(
 			max_depth: 1024,
 			block_gas_limit: 10_000_000,
 			current_schedule: Default::default(),
+			_genesis_phantom_data: Default::default(),
 		}),
 		upgrade_key: Some(UpgradeKeyConfig {
 			key: upgrade_key,
+			_genesis_phantom_data: Default::default(),
 		}),
 	}
 }
@@ -289,7 +311,7 @@ mod tests {
 
 	fn local_testnet_genesis_instant() -> GenesisConfig {
 		let mut genesis = local_testnet_genesis();
-		genesis.timestamp = Some(TimestampConfig { period: 0 });
+		genesis.timestamp = Some(TimestampConfig { period: 0, _genesis_phantom_data: Default::default() });
 		genesis
 	}
 

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -230,10 +230,12 @@ mod tests {
 				transfer_fee: 0,
 				creation_fee: 0,
 				reclaim_rebate: 0,
+				_genesis_phantom_data: Default::default(),
 			}),
 			session: Some(SessionConfig {
 				session_length: 2,
 				validators: vec![One.to_raw_public().into(), Two.to_raw_public().into(), three],
+				_genesis_phantom_data: Default::default(),
 			}),
 			staking: Some(StakingConfig {
 				sessions_per_era: 2,
@@ -247,6 +249,7 @@ mod tests {
 				current_offline_slash: 0,
 				current_session_reward: 0,
 				offline_slash_grace: 0,
+				_genesis_phantom_data: Default::default(),
 			}),
 			democracy: Some(Default::default()),
 			council_seats: Some(Default::default()),

--- a/srml/balances/src/mock.rs
+++ b/srml/balances/src/mock.rs
@@ -104,6 +104,7 @@ impl ExtBuilder {
 			transfer_fee: self.transfer_fee,
 			creation_fee: self.creation_fee,
 			reclaim_rebate: 0,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.into()
 	}

--- a/srml/consensus/src/mock.rs
+++ b/srml/consensus/src/mock.rs
@@ -54,6 +54,7 @@ pub fn new_test_ext(authorities: Vec<u64>) -> runtime_io::TestExternalities<Blak
 	t.extend(GenesisConfig::<Test>{
 		code: vec![],
 		authorities,
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	t.into()
 }

--- a/srml/contract/src/tests.rs
+++ b/srml/contract/src/tests.rs
@@ -131,6 +131,7 @@ impl ExtBuilder {
 				transfer_fee: self.transfer_fee,
 				creation_fee: self.creation_fee,
 				reclaim_rebate: 0,
+				_genesis_phantom_data: Default::default(),
 			}.build_storage()
 			.unwrap().0,
 		);
@@ -143,6 +144,7 @@ impl ExtBuilder {
 				max_depth: 100,
 				block_gas_limit: self.block_gas_limit,
 				current_schedule: Default::default(),
+				_genesis_phantom_data: Default::default(),
 			}.build_storage()
 			.unwrap().0,
 		);

--- a/srml/council/src/lib.rs
+++ b/srml/council/src/lib.rs
@@ -122,11 +122,13 @@ mod tests {
 			transfer_fee: 0,
 			creation_fee: 0,
 			reclaim_rebate: 0,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(democracy::GenesisConfig::<Test>{
 			launch_period: 1,
 			voting_period: 3,
 			minimum_deposit: 1,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(seats::GenesisConfig::<Test> {
 			candidacy_bond: 9,
@@ -143,10 +145,12 @@ mod tests {
 			presentation_duration: 2,
 			desired_seats: 2,
 			term_duration: 5,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(voting::GenesisConfig::<Test> {
 			cooloff_period: 2,
 			voting_period: 1,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		runtime_io::TestExternalities::new(t)
 	}

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -358,11 +358,13 @@ mod tests {
 			transfer_fee: 0,
 			creation_fee: 0,
 			reclaim_rebate: 0,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(GenesisConfig::<Test>{
 			launch_period: 1,
 			voting_period: 1,
 			minimum_deposit: 1,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		runtime_io::TestExternalities::new(t)
 	}

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -313,6 +313,7 @@ mod tests {
 		t.extend(GenesisConfig::<Test>{
 			dummy: 42,
 			foo: 24,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.into()
 	}

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -327,6 +327,7 @@ mod tests {
 			transfer_fee: 0,
 			creation_fee: 0,
 			reclaim_rebate: 0,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		let xt = primitives::testing::TestXt(Some(1), 0, Call::transfer(2.into(), 69.into()));
 		let mut t = runtime_io::TestExternalities::<Blake2Hasher>::new(t);

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -270,13 +270,16 @@ mod tests {
 		t.extend(consensus::GenesisConfig::<Test>{
 			code: vec![],
 			authorities: vec![1, 2, 3],
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(timestamp::GenesisConfig::<Test>{
 			period: 5,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(GenesisConfig::<Test>{
 			session_length: 2,
 			validators: vec![1, 2, 3],
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		runtime_io::TestExternalities::new(t)
 	}

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -88,10 +88,12 @@ pub fn new_test_ext(
 	t.extend(consensus::GenesisConfig::<Test>{
 		code: vec![],
 		authorities: vec![],
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	t.extend(session::GenesisConfig::<Test>{
 		session_length,
 		validators: vec![10, 20],
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	t.extend(balances::GenesisConfig::<Test>{
 		balances: if monied {
@@ -109,6 +111,7 @@ pub fn new_test_ext(
 		transfer_fee: 0,
 		creation_fee: 0,
 		reclaim_rebate: 0,
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	t.extend(GenesisConfig::<Test>{
 		sessions_per_era,
@@ -122,9 +125,11 @@ pub fn new_test_ext(
 		current_session_reward: reward,
 		current_offline_slash: 20,
 		offline_slash_grace: 0,
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	t.extend(timestamp::GenesisConfig::<Test>{
-		period: 5
+		period: 5,
+		_genesis_phantom_data: Default::default(),
 	}.build_storage().unwrap().0);
 	runtime_io::TestExternalities::new(t)
 }

--- a/srml/support/src/storage/generator.rs
+++ b/srml/support/src/storage/generator.rs
@@ -627,6 +627,8 @@ macro_rules! __generate_genesis_config {
 		#[serde(rename_all = "camelCase")]
 		#[serde(deny_unknown_fields)]
 		pub struct GenesisConfig<$traitinstance: $traittype> {
+			#[serde(skip)]
+			pub _genesis_phantom_data: $crate::storage::generator::PhantomData<$traitinstance>,
 			$(pub $fieldname : $fieldtype ,)*
 			$( $(#[$attr])* pub $extrafieldname : $extrafieldty ,)*
 		}
@@ -635,6 +637,7 @@ macro_rules! __generate_genesis_config {
 		impl<$traitinstance: $traittype> Default for GenesisConfig<$traitinstance> {
 			fn default() -> Self {
 				GenesisConfig {
+					_genesis_phantom_data: Default::default(),
 					$($fieldname : $fielddefault ,)*
 					$($extrafieldname : $extrafielddefault ,)*
 				}

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -201,7 +201,6 @@ decl_storage! {
 	}
 	add_extra_genesis {
 		config(changes_trie_config): Option<ChangesTrieConfiguration>;
-		config(_phantom): ::std::marker::PhantomData<T>;
 
 		build(|storage: &mut primitives::StorageMap, _: &mut primitives::ChildrenStorageMap, config: &GenesisConfig<T>| {
 			use codec::Encode;

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -211,7 +211,10 @@ mod tests {
 	#[test]
 	fn timestamp_works() {
 		let mut t = system::GenesisConfig::<Test>::default().build_storage().unwrap().0;
-		t.extend(GenesisConfig::<Test> { period: 0 }.build_storage().unwrap().0);
+		t.extend(GenesisConfig::<Test> {
+			period: 5,
+			_genesis_phantom_data: Default::default()
+		}.build_storage().unwrap().0);
 
 		with_externalities(&mut TestExternalities::new(t), || {
 			Timestamp::set_timestamp(42);
@@ -224,7 +227,10 @@ mod tests {
 	#[should_panic(expected = "Timestamp must be updated only once in the block")]
 	fn double_timestamp_should_fail() {
 		let mut t = system::GenesisConfig::<Test>::default().build_storage().unwrap().0;
-		t.extend(GenesisConfig::<Test> { period: 5 }.build_storage().unwrap().0);
+		t.extend(GenesisConfig::<Test> {
+			period: 5,
+			_genesis_phantom_data: Default::default()
+		}.build_storage().unwrap().0);
 
 		with_externalities(&mut TestExternalities::new(t), || {
 			Timestamp::set_timestamp(42);
@@ -237,7 +243,10 @@ mod tests {
 	#[should_panic(expected = "Timestamp must increment by at least <BlockPeriod> between sequential blocks")]
 	fn block_period_is_enforced() {
 		let mut t = system::GenesisConfig::<Test>::default().build_storage().unwrap().0;
-		t.extend(GenesisConfig::<Test> { period: 5 }.build_storage().unwrap().0);
+		t.extend(GenesisConfig::<Test> {
+			period: 5,
+			_genesis_phantom_data: Default::default()
+		}.build_storage().unwrap().0);
 
 		with_externalities(&mut TestExternalities::new(t), || {
 			Timestamp::set_timestamp(42);

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -330,12 +330,14 @@ mod tests {
 			creation_fee: 0,
 			existential_deposit: 0,
 			reclaim_rebate: 0,
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.extend(GenesisConfig::<Test>{
 			proposal_bond: Permill::from_percent(5),
 			proposal_bond_minimum: 1,
 			spend_period: 2,
 			burn: Permill::from_percent(50),
+			_genesis_phantom_data: Default::default(),
 		}.build_storage().unwrap().0);
 		t.into()
 	}


### PR DESCRIPTION
This makes it possible to support `GenesisConfig`s that to do not use
generic parameter.