### PR TITLE
Update SRML Council: prevent excess votes/computation

### DIFF
--- a/srml/council/src/seats.rs
+++ b/srml/council/src/seats.rs
@@ -360,7 +360,8 @@ decl_storage! {
 		pub VoteCount get(vote_index): VoteIndex;
 
 		// persistent state (always relevant, changes constantly)
-		/// A voters list of votes for the last cleared vote index that this voter was last active at.
+		/// A list of votes for each voter, respecting the last cleared vote index that this voter was
+		/// last active at.
 		pub ApprovalsOf get(approvals_of): map T::AccountId => Vec<bool>;
 		/// The vote index and list slot that the candidate `who` was registered or `None` if they are not
 		/// currently registered.

--- a/srml/council/src/seats.rs
+++ b/srml/council/src/seats.rs
@@ -354,7 +354,7 @@ decl_storage! {
 		/// The current council. When there's a vote going on, this should still be used for executive
 		/// matters. The block number (second element in the tuple) is the block that their position is
 		/// active until (calculated by the sum of the block number when the council member was elected
-		/// and their term duration.
+		/// and their term duration).
 		pub ActiveCouncil get(active_council) config(): Vec<(T::AccountId, T::BlockNumber)>;
 		/// The total number of votes that have happened or are in progress.
 		pub VoteCount get(vote_index): VoteIndex;


### PR DESCRIPTION
* Add assertion and associated tests to prevent a vote from voters that provide a list of votes with a length that exceeds the amount of candidates, since otherwise an attacker may be able to submit a very long list of `votes` that far exceeds the amount of candidates and waste more computation than a reasonable voting bond would cover. Added additional associated test that may be run with `cargo test -p srml-council`

* Add assertion and associated tests so that amount of candidates must be greater than zero when calling `set_approvals` for a list of votes to be made by a voter 

* Update comment to refer to `reporter` instead of `who` (target of inactivity), since the origin is the `reporter`

* Update comment to refer more specifically to how many vote indexes, since `InactiveGracePeriod` is measured in vote indexes

* Update comment for `ApprovalsOf` since previously the comment was a duplicate of the comment for `LastActiveOf`'s

* Create variable to refer to `retaining_seats` to improve readability

* Reference Notes: https://hackmd.io/nr6kPD2sR4urmljtvHs0CQ