### PR TITLE
Clean up CLI params

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -338,17 +338,17 @@ where
 	init_logger(log_pattern);
 	fdlimit::raise_fd_limit();
 
-	if let Some(matches) = matches.subcommand_matches("build_spec") {
+	if let Some(matches) = matches.subcommand_matches("build-spec") {
 		build_spec::<F>(matches, spec)?;
 		return Ok(Action::ExecutedInternally);
 	}
 
-	if let Some(matches) = matches.subcommand_matches("export_blocks") {
+	if let Some(matches) = matches.subcommand_matches("export-blocks") {
 		export_blocks::<F, _>(matches, spec, exit.into_exit())?;
 		return Ok(Action::ExecutedInternally);
 	}
 
-	if let Some(matches) = matches.subcommand_matches("import_blocks") {
+	if let Some(matches) = matches.subcommand_matches("import-blocks") {
 		import_blocks::<F, _>(matches, spec, exit.into_exit())?;
 		return Ok(Action::ExecutedInternally);
 	}

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -394,7 +394,7 @@ fn export_blocks<F, E>(matches: &clap::ArgMatches, spec: ChainSpec<FactoryGenesi
 	};
 	let json = matches.is_present("json");
 
-	let file: Box<Write> = match matches.value_of("OUTPUT") {
+	let file: Box<Write> = match matches.value_of("output") {
 		Some(filename) => Box::new(File::create(filename)?),
 		None => Box::new(stdout()),
 	};
@@ -427,7 +427,7 @@ fn import_blocks<F, E>(matches: &clap::ArgMatches, spec: ChainSpec<FactoryGenesi
 		};
 	}
 
-	let file: Box<Read> = match matches.value_of("INPUT") {
+	let file: Box<Read> = match matches.value_of("input") {
 		Some(filename) => Box::new(File::open(filename)?),
 		None => Box::new(stdin()),
 	};
@@ -442,7 +442,7 @@ fn revert_chain<F>(matches: &clap::ArgMatches, spec: ChainSpec<FactoryGenesis<F>
 	let mut config = service::Configuration::default_with_spec(spec);
 	config.database_path = db_path(&base_path, config.chain_spec.id()).to_string_lossy().into();
 
-	let blocks = match matches.value_of("NUM") {
+	let blocks = match matches.value_of("num") {
 		Some(v) => v.parse().map_err(|_| "Invalid block count specified")?,
 		None => 256,
 	};

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -19,90 +19,120 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "Substrate")]
+/// CLI Parameters provided by default
 pub struct CoreParams {
-    #[structopt(short = "l", long = "log", value_name = "LOG_PATTERN", help = "Sets a custom logging filter")]
+    ///Sets a custom logging filter
+    #[structopt(short = "l", long = "log", value_name = "LOG_PATTERN")]
     log: Option<String>,
 
-    #[structopt(long = "base-path", short = "d", value_name = "PATH", help = "Specify custom base path", parse(from_os_str))]
+    #[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
+    /// Specify custom base path
     base_path: Option<PathBuf>,
 
-    #[structopt(long = "keystore-path", value_name = "PATH", help = "Specify custom keystore path", parse(from_os_str))]
+    #[structopt(long = "keystore-path", value_name = "PATH", parse(from_os_str))]
+    /// Specify custom keystore path
     keystore_path: Option<PathBuf>,
 
-    #[structopt(long = "key", value_name = "STRING", help = "Specify additional key seed")]
+    #[structopt(long = "key", value_name = "STRING")]
+    /// Specify additional key seed
     key: Option<String>,
 
-    #[structopt(long = "node-key", value_name = "KEY", help = "Specify node secret key (64-character hex string)")]
+    #[structopt(long = "node-key", value_name = "KEY")]
+    /// Specify node secret key (64-character hex string)
     node_key: Option<String>,
     
-    #[structopt(long = "validator",help = "Enable validator mode")]
+    #[structopt(long = "validator")]
+    /// Enable validator mode
     validator: bool,
 
-    #[structopt(long = "light", help = "Run in light client mode")]
+    #[structopt(long = "light")]
+    /// Run in light client mode
     light: bool,
   
-    #[structopt(long = "dev", help = "Run in development mode; implies --chain=dev --validator --key Alice")]
+    #[structopt(long = "dev")]
+    /// Run in development mode; implies --chain=dev --validator --key Alice
     dev: bool,
   
-    #[structopt(long = "listen-addr", value_name = "LISTEN_ADDR", help = "Listen on this multiaddress")]
+    #[structopt(long = "listen-addr", value_name = "LISTEN_ADDR")]
+    /// Listen on this multiaddress
     listen_addr: Vec<String>,
   
-    #[structopt(long = "port", value_name = "PORT", help = "Specify p2p protocol TCP port. Only used if --listen-addr is not specified.")]
+    #[structopt(long = "port", value_name = "PORT")]
+    /// Specify p2p protocol TCP port. Only used if --listen-addr is not specified.
     port: Option<u32>,
   
-    #[structopt(long = "rpc-external", help = "Listen to all RPC interfaces (default is local)")]
+    #[structopt(long = "rpc-external")]
+    /// Listen to all RPC interfaces (default is local)
     rpc_external: bool,
   
-    #[structopt(long = "ws-external", help = "Listen to all Websocket interfaces (default is local)")]
+    #[structopt(long = "ws-external")]
+    /// Listen to all Websocket interfaces (default is local)
     ws_external: bool,
   
-    #[structopt(long = "rpc-port", value_name = "PORT", help = "Specify HTTP RPC server TCP port")]
+    #[structopt(long = "rpc-port", value_name = "PORT")]
+    /// Specify HTTP RPC server TCP port
     rpc_port: Option<u32>,
   
-    #[structopt(long = "ws-port", value_name = "PORT", help = "Specify WebSockets RPC server TCP port")]
+    #[structopt(long = "ws-port", value_name = "PORT")]
+    /// Specify WebSockets RPC server TCP port
     ws_port: Option<u32>,
   
-    #[structopt(long = "bootnodes", value_name = "URL", help = "Specify a list of bootnodes")]
+    #[structopt(long = "bootnodes", value_name = "URL")]
+    /// Specify a list of bootnodes
     bootnodes: Vec<String>,
   
-    #[structopt(long = "reserved-nodes", value_name = "URL", help = "Specify a list of reserved node addresses")]
+    #[structopt(long = "reserved-nodes", value_name = "URL")]
+    /// Specify a list of reserved node addresses
     reserved_nodes: Vec<String>,
   
-    #[structopt(long = "out-peers", value_name = "OUT_PEERS", help = "Specify the number of outgoing connections we're trying to maintain")]
+    #[structopt(long = "out-peers", value_name = "OUT_PEERS")]
+    /// Specify the number of outgoing connections we're trying to maintain
     out_peers: Option<u8>,
   
-    #[structopt(long = "in-peers", value_name = "IN_PEERS", help = "Specify the maximum number of incoming connections we're accepting")]
+    #[structopt(long = "in-peers", value_name = "IN_PEERS")]
+    /// Specify the maximum number of incoming connections we're accepting
     in_peers: Option<u8>,
   
-    #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification (one of dev, local or staging)")]
+    #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+    /// Specify the chain specification (one of dev, local or staging)
     chain: Option<String>,
   
-    #[structopt(long = "pruning", value_name = "PRUNING_MODE", help = "Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.")]
+    #[structopt(long = "pruning", value_name = "PRUNING_MODE")]
+    /// Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.
     pruning: Option<u32>,
   
-    #[structopt(long = "name", value_name = "NAME", help = "The human-readable name for this node, as reported to the telemetry server, if enabled")]
+    #[structopt(long = "name", value_name = "NAME")]
+    /// The human-readable name for this node, as reported to the telemetry server, if enabled
     name: Option<String>,
   
-    #[structopt(short = "t", long = "telemetry", help = "Should connect to the Substrate telemetry server (telemetry is off by default on local chains)")]
+    #[structopt(short = "t", long = "telemetry")]
+    /// Should connect to the Substrate telemetry server (telemetry is off by default on local chains)
     telemetry: bool,
   
-    #[structopt(long = "no-telemetry", help = "Should not connect to the Substrate telemetry server (telemetry is on by default on global chains)")]
+    #[structopt(long = "no-telemetry")]
+    /// Should not connect to the Substrate telemetry server (telemetry is on by default on global chains)
     no_telemetry: bool,
   
-    #[structopt(long = "telemetry-url", value_name = "TELEMETRY_URL", help = "The URL of the telemetry server. Implies --telemetry")]
+    #[structopt(long = "telemetry-url", value_name = "TELEMETRY_URL")]
+    /// The URL of the telemetry server. Implies --telemetry
     telemetry_url: Option<String>,
 
-    #[structopt(long = "execution", value_name = "STRATEGY", help = "The means of execution used when calling into the runtime. Can be either wasm, native or both.")]
+    #[structopt(long = "execution", value_name = "STRATEGY")]
+    /// The means of execution used when calling into the runtime. Can be either wasm, native or both.
     execution: Option<ExecutionStrategy>,
 
     #[structopt(subcommand)]
     cmds: Option<CoreCommands>,
 }
 
+/// How to execute blocks
 #[derive(Debug, StructOpt)]
 pub enum ExecutionStrategy {
+    /// Execute native only
     Native,
+    /// Execute wasm only
     Wasm,
+    /// Execute natively when possible, wasm otherwise
     Both,
 }
 
@@ -125,92 +155,121 @@ impl std::str::FromStr for ExecutionStrategy {
     }
 }
 
+/// Subcommands provided by Default
 #[derive(Debug, StructOpt)]
 pub enum CoreCommands {
-    #[structopt(name = "build-spec", about = "Build a spec.json file, outputing to stdout")]
+    #[structopt(name = "build-spec")]
+    /// Build a spec.json file, outputing to stdout
     BuildSpec {
-        #[structopt(long = "raw", help = "Force raw genesis storage output.")]  
+        #[structopt(long = "raw")]
+        /// Force raw genesis storage output.
         raw: bool,
         
-        #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification (one of dev, local or staging)")]
+        #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+        /// Specify the chain specification (one of dev, local or staging)
         chain: Option<String>,
         
-        #[structopt(long = "dev", help = "Specify the development chain")]
+        #[structopt(long = "dev")]
+        /// Specify the development chain
         dev: bool,
     },
 
-    #[structopt(name = "export-blocks", about = "Export blocks to a file")]
+    #[structopt(name = "export-blocks")]
+    /// Export blocks to a file
     ExportBlocks {
-        #[structopt(help = "Output file name or stdout if unspecified.", parse(from_os_str))]    
-        OUTPUT: Option<PathBuf>,
+        #[structopt(parse(from_os_str))]
+        /// Output file name or stdout if unspecified.
+        output: Option<PathBuf>,
         
-        #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification.")]
+        #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+        /// Specify the chain specification.
         chain: Option<String>,
         
-        #[structopt(long = "dev", help = "Specify the development chain")]
+        #[structopt(long = "dev")]
+        /// Specify the development chain
         dev: bool,
         
-        #[structopt(long = "base-path", short = "d", value_name = "PATH", help = "Specify custom base path.")]
+        #[structopt(long = "base-path", short = "d", value_name = "PATH")]
+        /// Specify custom base path.
         base_path: Option<String>,
         
-        #[structopt(long = "from", value_name = "BLOCK", help = "Specify starting block number. 1 by default.")]
+        #[structopt(long = "from", value_name = "BLOCK")]
+        /// Specify starting block number. 1 by default.
         from: Option<u128>,
         
-        #[structopt(long = "to", value_name = "BLOCK", help = "Specify last block number. Best block by default.")]
+        #[structopt(long = "to", value_name = "BLOCK")]
+        /// Specify last block number. Best block by default.
         to: Option<u128>,
         
-        #[structopt(long = "json", help = "Use JSON output rather than binary.")]
+        #[structopt(long = "json")]
+        /// Use JSON output rather than binary.
         json: bool,
     },
 
-    #[structopt(name = "import-blocks", about = "Import blocks from file.")]
+    #[structopt(name = "import-blocks")]
+    /// Import blocks from file.
     ImportBlocks {
-        #[structopt(help = "Input file or stdin if unspecified.", parse(from_os_str))]    
-        INPUT: Option<PathBuf>,
+        #[structopt(parse(from_os_str))]
+        /// Input file or stdin if unspecified.
+        input: Option<PathBuf>,
         
-        #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification.")]
+        #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+        /// Specify the chain specification.
         chain: Option<String>,
           
-        #[structopt(long = "dev", help = "Specify the development chain")]
+        #[structopt(long = "dev")]
+        /// Specify the development chain
         dev: bool,
         
-        #[structopt(long = "base-path", short = "d", value_name = "PATH", help = "Specify custom base path.", parse(from_os_str))]
+        #[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
+        /// Specify custom base path.
         base_path: Option<PathBuf>,
         
-        #[structopt(long = "execution", value_name = "STRATEGY", help = "The means of execution used when executing blocks. Can be either wasm, native or both.")]
+        #[structopt(long = "execution", value_name = "STRATEGY")]
+        /// The means of execution used when executing blocks. Can be either wasm, native or both.
         execution: ExecutionStrategy,
         
-        #[structopt(long = "api-execution", value_name = "STRATEGY", help = "The means of execution used when calling into the runtime. Can be either wasm, native or both.")]
+        #[structopt(long = "api-execution", value_name = "STRATEGY")]
+        /// The means of execution used when calling into the runtime. Can be either wasm, native or both.
         api_execution: ExecutionStrategy,
         
-        #[structopt(long = "max-heap-pages", value_name = "COUNT", help = "The maximum number of 64KB pages to ever allocate for Wasm execution. Don't alter this unless you know what you're doing.")]
+        #[structopt(long = "max-heap-pages", value_name = "COUNT")]
+        /// The maximum number of 64KB pages to ever allocate for Wasm execution. Don't alter this unless you know what you're doing.
         max_heap_pages: Option<u32>,
     },
 
-    #[structopt(name = "revert", about = "Revert chain to the previous state")]
+    #[structopt(name = "revert")]
+    ///Revert chain to the previous state
     Revert {
-        #[structopt(help = "Number of blocks to revert. Default is 256.")]    
-        NUM: Option<u32>,
+        /// Number of blocks to revert. Default is 256.
+        num: Option<u32>,
         
-        #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification.")]
+        #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+        /// Specify the chain specification.
         chain: Option<String>,
         
-        #[structopt(long = "dev", help = "Specify the development chain")]
+        #[structopt(long = "dev")]
+        /// Specify the development chain
         dev: bool,
         
-        #[structopt(long = "base-path", short = "d", value_name = "PATH", help = "Specify custom base path.", parse(from_os_str))]
+        #[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
+        /// Specify custom base path.
         base_path: Option<PathBuf>,
     },
 
-    #[structopt(name = "purge-chain", about = "Remove the whole chain data.")]
+    /// Remove the whole chain data.
+    #[structopt(name = "purge-chain")]
     PurgeChain {
-        #[structopt(long = "chain", value_name = "CHAIN_SPEC", help = "Specify the chain specification.")]    
+        /// Specify the chain specification.
+        #[structopt(long = "chain", value_name = "CHAIN_SPEC")]
         chain: Option<String>,
         
-        #[structopt(long = "dev", help = "Specify the development chain")]
+        /// Specify the development chain
+        #[structopt(long = "dev")]
         dev: bool,
         
-        #[structopt(long = "base-path", short = "d", value_name = "PATH", help = "Specify custom base path.", parse(from_os_str))]
+        /// Specify custom base path.
+        #[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
         base_path: Option<PathBuf>
     }
 }

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -14,12 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-#[macro_use]
 extern crate clap;
-
 extern crate substrate_cli as cli;
-
-#[macro_use]
 extern crate structopt;
 
 use std::fs;

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -43,7 +43,6 @@ extern crate substrate_keystore;
 
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate structopt;
 
 pub use cli::error;


### PR DESCRIPTION
there. This PR cleans them up:

 - [x] Move help into doc to fix `docsmissing` compile error
 - [x] Rename uppercase to snake case variables as compiler suggests
 - [x] remove unused `macro_use`
 - [x] fix snake case usage of kebab cased commands