### PR TITLE
Simplify consensus message sending

### DIFF
--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -259,10 +259,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_message(&self, round: u64, set_id: u64, message: Vec<u8>) {
 		let topic = message_topic::<B>(round, set_id);
-		let gossip = self.service.consensus_gossip();
-		self.service.with_spec(move |_s, context|{
-			gossip.write().multicast(context, topic, message);
-		});
+		self.service.send_consensus_message(topic, message);
 	}
 
 	fn drop_messages(&self, round: u64, set_id: u64) {

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -259,7 +259,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_message(&self, round: u64, set_id: u64, message: Vec<u8>) {
 		let topic = message_topic::<B>(round, set_id);
-		self.service.send_consensus_message(topic, message);
+		self.service.gossip_consensus_message(topic, message);
 	}
 
 	fn drop_messages(&self, round: u64, set_id: u64) {
@@ -273,10 +273,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_commit(&self, set_id: u64, message: Vec<u8>) {
 		let topic = commit_topic::<B>(set_id);
-		let gossip = self.service.consensus_gossip();
-		self.service.with_spec(move |_s, context|{
-			gossip.write().multicast(context, topic, message);
-		});
+		self.service.gossip_consensus_message(topic, message);
 	}
 }
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -296,10 +296,10 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		send_message::<B, H>(&self.context_data.peers, io, who, message)
 	}
 
-	pub fn send_consensus_message(&self, io: &mut SyncIo, topic: B::Hash, data: Vec<u8>) {
+	pub fn gossip_consensus_message(&self, io: &mut SyncIo, topic: B::Hash, message: Vec<u8>) {
 		let gossip = self.consensus_gossip();
 		self.with_spec(io, move |_s, context|{
-			gossip.write().multicast(context, topic, data);
+			gossip.write().multicast(context, topic, message);
 		});
 	}
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -224,7 +224,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		&self.sync
 	}
 
-
 	pub(crate) fn consensus_gossip<'a>(&'a self) -> &'a RwLock<ConsensusGossip<B>> {
 		&self.consensus_gossip
 	}
@@ -295,6 +294,13 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 
 	pub fn send_message(&self, io: &mut SyncIo, who: NodeIndex, message: Message<B>) {
 		send_message::<B, H>(&self.context_data.peers, io, who, message)
+	}
+
+	pub fn send_consensus_message(&self, io: &mut SyncIo, topic: B::Hash, data: Vec<u8>) {
+		let gossip = self.consensus_gossip();
+		self.with_spec(io, move |_s, context|{
+			gossip.write().multicast(context, topic, data);
+		});
 	}
 
 	/// Called when a new peer is connected

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -127,8 +127,11 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Service<B, S,
 	}
 
 	/// Send a consensus message through the gossip
-	pub fn send_consensus_message(&self, topic: B::Hash, message: Vec<u8>) {
-		self.handler.send_consensus_message(&mut NetSyncIo::new(&self.network, self.protocol_id), topic, message)
+	pub fn gossip_consensus_message(&self, topic: B::Hash, message: Vec<u8>) {
+		self.handler.gossip_consensus_message(
+			&mut NetSyncIo::new(&self.network, self.protocol_id),
+			topic,
+			message)
 	}
 	/// Execute a closure with the chain-specific network specialization.
 	pub fn with_spec<F, U>(&self, f: F) -> U

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -126,6 +126,10 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Service<B, S,
 		self.handler.propagate_extrinsics(&mut NetSyncIo::new(&self.network, self.protocol_id));
 	}
 
+	/// Send a consensus message through the gossip
+	pub fn send_consensus_message(&self, topic: B::Hash, message: Vec<u8>) {
+		self.handler.send_consensus_message(&mut NetSyncIo::new(&self.network, self.protocol_id), topic, message)
+	}
 	/// Execute a closure with the chain-specific network specialization.
 	pub fn with_spec<F, U>(&self, f: F) -> U
 		where F: FnOnce(&mut S, &mut Context<B>) -> U

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -229,10 +229,7 @@ impl<V: 'static + Verifier<Block>, D> Peer<V, D> {
 	/// Push a message into the gossip network and relay to peers.
 	/// `TestNet::sync_step` needs to be called to ensure it's propagated.
 	pub fn gossip_message(&self, topic: Hash, data: Vec<u8>) {
-		let gossip = self.sync.consensus_gossip();
-		self.sync.with_spec(&mut TestIo::new(&self.queue, None), move |_s, context|{
-			gossip.write().multicast(context, topic, data);
-		});
+		self.sync.send_consensus_message(&mut TestIo::new(&self.queue, None), topic, data);
 	}
 
 	/// Add blocks to the peer -- edit the block before adding

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -229,7 +229,7 @@ impl<V: 'static + Verifier<Block>, D> Peer<V, D> {
 	/// Push a message into the gossip network and relay to peers.
 	/// `TestNet::sync_step` needs to be called to ensure it's propagated.
 	pub fn gossip_message(&self, topic: Hash, data: Vec<u8>) {
-		self.sync.send_consensus_message(&mut TestIo::new(&self.queue, None), topic, data);
+		self.sync.gossip_consensus_message(&mut TestIo::new(&self.queue, None), topic, data);
 	}
 
 	/// Add blocks to the peer -- edit the block before adding


### PR DESCRIPTION
We keep repeating the `with_spec`-block everywhere anyone wants to send a consensus message, however this is internal behavior of the protocol and shouldn't be necessary to have knowledge of from the outside in order to send a message.

This PR changes that by providing a new `send_consensus_message` on `service` which encapsulates this entire setup and consequentially moves `consensus_gossip` a little more into the interior.