### PR TITLE
Remove Proposer from Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "substrate-cli 0.3.0",
  "substrate-client 0.1.0",
  "substrate-consensus-aura 0.1.0",
+ "substrate-consensus-common 0.1.0",
  "substrate-finality-grandpa 0.1.0",
  "substrate-keystore 0.1.0",
  "substrate-network 0.1.0",

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -63,7 +63,7 @@ use std::collections::HashMap;
 #[doc(hidden)]
 pub use std::{ops::Deref, result::Result, sync::Arc};
 use futures::prelude::*;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 use keystore::Store as Keystore;
 use client::BlockchainEvents;
 use runtime_primitives::traits::{Header, As};
@@ -80,7 +80,6 @@ pub use chain_spec::{ChainSpec, Properties};
 pub use transaction_pool::txpool::{self, Pool as TransactionPool, Options as TransactionPoolOptions, ChainApi, IntoPoolError};
 pub use client::ExecutionStrategy;
 
-use consensus_common::offline_tracker::OfflineTracker;
 pub use consensus::ProposerFactory;
 pub use components::{ServiceFactory, FullBackend, FullExecutor, LightBackend,
 	LightExecutor, Components, PoolApi, ComponentClient,

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -24,6 +24,7 @@ substrate-service = { path = "../../core/service" }
 substrate-transaction-pool = { path = "../../core/transaction-pool" }
 substrate-network = { path = "../../core/network" }
 substrate-consensus-aura = { path = "../../core/consensus/aura" }
+substrate-consensus-common = { path = "../../core/consensus/common" }
 substrate-finality-grandpa = { path = "../../core/finality-grandpa" }
 sr-primitives = { path = "../../core/sr-primitives" }
 node-executor = { path = "../executor" }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -33,6 +33,7 @@ extern crate substrate_transaction_pool as transaction_pool;
 #[macro_use]
 extern crate substrate_network as network;
 extern crate substrate_consensus_aura as consensus;
+extern crate substrate_consensus_common as consensus_common;
 extern crate substrate_client as client;
 extern crate substrate_finality_grandpa as grandpa;
 extern crate node_primitives;
@@ -44,6 +45,7 @@ extern crate substrate_keystore;
 #[macro_use]
 extern crate log;
 extern crate structopt;
+extern crate parking_lot;
 
 pub use cli::error;
 pub mod chain_spec;


### PR DESCRIPTION
The smallest possible patch to get #1158 ready for poc-3: Remove the - otherwise not needed - `ProposerFactory` from `service` and let this happen within the consensus setup itself, thus allowing the polkadot consensus framework to bring their own.

However, this does not yet offer to have this as an external crate, nor does it move the glue out of the service crate. Both could be tackled nicely in a bigger refactor with #1021.

