### PR TITLE
docs: Fixes ordering of command-line arguments for dumping chainspec to file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,7 +135,7 @@ First let's get a template chainspec that you can edit. We'll use the "staging" 
 
 [source, shell]
 ----
-substrate build-spec --chain=staging > ~/chainspec.json
+substrate --chain=staging build-spec > ~/chainspec.json
 ----
 
 Now, edit `~/chainspec.json` in your editor. There are a lot of individual fields for each module, and one very large one which contains the Webassembly code blob for this chain. The easiest field to edit is the block `period`. Change it to 10 (seconds):


### PR DESCRIPTION
Fixes ordering of command-line arguments. `substrate --help` shows usage as substrate `[FLAGS] [OPTIONS] [SUBCOMMAND]`, where `--chain=staging` is one of the possible OPTIONS, and `build-spec` is a possible SUBCOMMAND.
The ordering should be `substrate --chain=staging build-spec` instead.

Relates to issue raised by user attente in Riot https://matrix.to/#/!HzySYSaIhtyWrwiwEV:matrix.org/$154385734133299JuBZU:matrix.parity.io