### PR TITLE
Fix Double BlockRequest

### DIFF
--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -392,7 +392,7 @@ impl<B: BlockT> ChainSync<B> {
 				return;
 			}
 			// we should not download already queued blocks
-			let common_number = ::std::cmp::max(peer.common_number, import_status.best_importing_number);
+			let common_number = ::std::cmp::max(peer.common_number, self.best_queued_number);
 
 			trace!(target: "sync", "Considering new block download from {}, common block is {}, best is {:?}", who, common_number, peer.best_number);
 			match peer.state {


### PR DESCRIPTION
While investigating the CPU spikes at import, I noticed that we are requesting a block _twice_ after it as announced. Turns out that we are tracking the `queue_best_number` twice, once in the importqueue itself and once prior to that and because of the order in items are called, they are not in sync at that particular moment after we have received the latest block and before the handover to the importqueue - but exactly at that moment do we check whether we should download further blocks against the importqueue, which doesn't yet know of the new block. And we happen to request the same block again - but only twice because right after the request we successfully import the block and the next response is actually ignored. 

The fix is simple: we need to check the local value not the remote value. This PR does that and the logs show no double imports or requests anymore.