### PR TITLE
Move create network folder structure to top level of start_service

### DIFF
--- a/core/network-libp2p/src/secret.rs
+++ b/core/network-libp2p/src/secret.rs
@@ -35,8 +35,6 @@ pub fn obtain_private_key(
 
 	} else {
 		if let Some(ref path) = config.net_config_path {
-			fs::create_dir_all(Path::new(path))?;
-
 			// Try fetch the key from a the file containing the secret.
 			let secret_path = Path::new(path).join(SECRET_FILE);
 			match load_private_key_from_file(&secret_path) {

--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -27,6 +27,7 @@ use libp2p::kad::{KadConnectionType, KadQueryEvent};
 use parking_lot::Mutex;
 use rand;
 use secret::obtain_private_key;
+use std::fs;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::iter;
 use std::net::SocketAddr;
@@ -52,6 +53,11 @@ pub fn start_service<TProtos>(
 	registered_custom: TProtos,
 ) -> Result<Service, Error>
 where TProtos: IntoIterator<Item = RegisteredProtocol> {
+
+	if let Some(ref path) = config.net_config_path {
+	    fs::create_dir_all(Path::new(path))?;
+	}
+
 	// Private and public keys configuration.
 	let local_private_key = obtain_private_key(&config)?;
 	let local_public_key = local_private_key.to_public_key();


### PR DESCRIPTION
Fixes issue where the network folder is not created when node is run with `--node-key` arg

This causes the network toplogy to fail during `flush_to_disk()`as the "chains/target_chain/network" folder hasn't been created yet.

Example error log
```
2018-12-06 00:22:13 tokio-runtime-worker-1 WARN sub-libp2p Failed to flush topology: Os

{ code: 2, kind: NotFound, message: "No such file or directory" }
````