### PR TITLE
Fix syncing issue

### DIFF
--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -239,6 +239,13 @@ impl<B: BlockT> ChainSync<B> {
 							}
 						},
 						None => {
+							if n > As::sa(0) {
+								trace!(target:"sync", "Ancestry block not found for peer {}: block #{}", who, n);
+								let n = n - As::sa(1);
+								peer.state = PeerSyncState::AncestorSearch(n);
+								Self::request_ancestry(protocol, who, n);
+								return None;
+							}
 							trace!(target:"sync", "Invalid response when searching for ancestor from {}", who);
 							protocol.report_peer(who, Severity::Bad("Invalid response when searching for ancestor"));
 							return None;


### PR DESCRIPTION
A block request can result an empty response if the requested hight is too high, which shouldn't resulting the peer get banned just because it is behind

I have a 3 node network setup running for two days, today one of the node is lagging behind and it is not able to catch up. Some logs:
```
018-12-06 01:19:12 Starting consensus session on top of parent 0x88ddfc295c254e6f645e44a82dd11473fb8740775d99e0702b0518f2cb510648
2018-12-06 01:19:12 Rejected connection from disabled peer: PeerId(QmbADoJzP16EoAudVusknELEsbm4FAYQWgWkNjPuEYTWwz)
2018-12-06 01:19:12 Proposing block [number: 15518; hash: 0xab16…e845; parent_hash: 0x88dd…0648; extrinsics: [0xbd4e…e1f0, 0x7b4e…2d59]]
2018-12-06 01:19:12 Imported #15518 (0xeb2e…9fef)
2018-12-06 01:19:14 Rejected connection from disabled peer: PeerId(QmbADoJzP16EoAudVusknELEsbm4FAYQWgWkNjPuEYTWwz)
2018-12-06 01:19:14 Purposefully dropping 10513 ; reason: Bad("Peer is on different chain (our genesis: 0x23de…6e62 theirs: 0x03a1…8353)")
2018-12-06 01:19:14 Banned PeerId(QmXboRGHd5ZG51LMGwqGnbocXZGnTwbp3eoUkZqBJYaEfM)
2018-12-06 01:19:16 Rejected connection from disabled peer: PeerId(QmbADoJzP16EoAudVusknELEsbm4FAYQWgWkNjPuEYTWwz)
2018-12-06 01:19:16 Idle (3 peers), best: #15518 (0xeb2e…9fef)
2018-12-06 01:19:18 Rejected connection from disabled peer: PeerId(QmbADoJzP16EoAudVusknELEsbm4FAYQWgWkNjPuEYTWwz)
2018-12-06 01:19:21 Rejected connection from disabled peer: PeerId(QmbADoJzP16EoAudVusknELEsbm4FAYQWgWkNjPuEYTWwz)
```