### PR TITLE
Allow spaces in types for decl_storage proc_macro

### DIFF
--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -49,7 +49,6 @@ macro_rules! try_tok(( $expre : expr ) => {
 pub fn decl_storage_impl(input: TokenStream) -> TokenStream {
 	let def = parse_macro_input!(input as StorageDefinition);
 
-	// old macro naming convention (s replaces $)
 	let StorageDefinition {
 		hidden_crate,
 		visibility,
@@ -578,7 +577,7 @@ fn store_functions_to_metadata (
 		let is_option = extracted_opt.is_some();
 		let typ = extracted_opt.unwrap_or(quote!( #gettype ));
 		let stype = if is_simple {
-			let styp = typ.to_string().replace(" ","");
+			let styp = typ.to_string();
 			quote!{
 				#scrate::storage::generator::StorageFunctionType::Plain(
 					#scrate::storage::generator::DecodeDifferent::Encode(#styp),
@@ -587,7 +586,7 @@ fn store_functions_to_metadata (
 		} else {
 			let kty = stk.expect("is not simple; qed");
 			let kty = quote!(#kty).to_string();
-			let styp = typ.to_string().replace(" ","");
+			let styp = typ.to_string();
 			quote!{
 				#scrate::storage::generator::StorageFunctionType::Map {
 					key: #scrate::storage::generator::DecodeDifferent::Encode(#kty),


### PR DESCRIPTION
Fix #1244
Switching to procedural macro introduces additional spaces at some places (this is valid rust code).  

The output of metadata is not rust code which makes `quote` output invalid. 

First attempt was to run an hacky space removal, it was a bad idea (my assumption that types does not contain space was wrong for some cases).

This PR remove those space removals in favor of a javascript process for allowing/removing those spaces).