### PR TITLE
Do not compute storage root when proving execution/checking proof

### DIFF
--- a/core/client/src/call_executor.rs
+++ b/core/client/src/call_executor.rs
@@ -235,7 +235,14 @@ where
 			method,
 			call_data,
 			manager,
-		).map_err(Into::into)
+			true,
+		)
+		.map(|(result, storage_tx, changes_tx)| (
+			result,
+			storage_tx.expect("storage_tx is always computed when compute_tx is true; qed"),
+			changes_tx,
+		))
+		.map_err(Into::into)
 	}
 
 	fn prove_at_trie_state<S: state_machine::TrieBackendStorage<Blake2Hasher>>(


### PR DESCRIPTION
Following #1213 

When full node generates execution proof AND when light node checks this proof, both storage root and (if enabled) changes trie root is computed. These are immediately dropped, but cause warnings in light client logs. So I have removed calculation in this PR. But...

If we ever need roots calculation on the light node, proof should also include proof-of-touch for all modified storage items (like if we have smth like `<Events<T>>::kill();` - events are not read => execution proof doesn't have any events footprints). Not sure if we need it => extracted this change into separate PR to have separate discussion.