### PR TITLE
Use `dev` as id in `development_config_genesis`

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -272,7 +272,7 @@ fn development_config_genesis() -> GenesisConfig {
 
 /// Development config (single validator Alice)
 pub fn development_config() -> ChainSpec {
-	ChainSpec::from_genesis("Development", "development", development_config_genesis, vec![], None, None, None, None)
+	ChainSpec::from_genesis("Development", "dev", development_config_genesis, vec![], None, None, None, None)
 }
 
 fn local_testnet_genesis() -> GenesisConfig {


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/1258