### PR TITLE
Remove grandpa liveness oracle

### DIFF
--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -266,7 +266,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_message(&self, round: u64, set_id: u64, message: Vec<u8>) {
 		let topic = message_topic::<B>(round, set_id);
-		self.service.gossip_consensus_message(topic, message);
+		self.service.gossip_consensus_message(topic, message, false);
 	}
 
 	fn drop_messages(&self, round: u64, set_id: u64) {
@@ -280,7 +280,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_commit(&self, set_id: u64, message: Vec<u8>) {
 		let topic = commit_topic::<B>(set_id);
-		self.service.gossip_consensus_message(topic, message);
+		self.service.gossip_consensus_message(topic, message, true);
 	}
 }
 

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -840,7 +840,6 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA> BlockImport<Block>
 		-> Result<ImportResult, Self::Error>
 	{
 		use authorities::PendingChange;
-		use client::blockchain::Backend;
 
 		let hash = block.post_header().hash();
 		let number = block.header.number().clone();

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -192,7 +192,7 @@ impl Network for MessageRouting {
 
 	fn send_message(&self, round: u64, set_id: u64, message: Vec<u8>) {
 		let mut inner = self.inner.lock();
-		inner.peer(self.peer_id).gossip_message(make_topic(round, set_id), message);
+		inner.peer(self.peer_id).gossip_message(make_topic(round, set_id), message, false);
 		inner.route_until_complete();
 	}
 
@@ -223,7 +223,7 @@ impl Network for MessageRouting {
 
 	fn send_commit(&self, set_id: u64, message: Vec<u8>) {
 		let mut inner = self.inner.lock();
-		inner.peer(self.peer_id).gossip_message(make_commit_topic(set_id), message);
+		inner.peer(self.peer_id).gossip_message(make_commit_topic(set_id), message, true);
 		inner.route_until_complete();
 	}
 }

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -368,7 +368,7 @@ fn finalize_3_voters_no_observers() {
 		);
 		fn assert_send<T: Send>(_: &T) { }
 
-		let (voter, oracle) = run_grandpa(
+		let voter = run_grandpa(
 			Config {
 				gossip_duration: TEST_GOSSIP_DURATION,
 				local_key: Some(Arc::new(key.clone().into())),
@@ -380,7 +380,6 @@ fn finalize_3_voters_no_observers() {
 
 		assert_send(&voter);
 
-		runtime.spawn(oracle);
 		runtime.spawn(voter);
 	}
 
@@ -429,7 +428,7 @@ fn finalize_3_voters_1_observer() {
 				.take_while(|n| Ok(n.header.number() < &20))
 				.for_each(move |_| Ok(()))
 		);
-		let (voter, oracle) = run_grandpa(
+		let voter = run_grandpa(
 			Config {
 				gossip_duration: TEST_GOSSIP_DURATION,
 				local_key,
@@ -439,7 +438,6 @@ fn finalize_3_voters_1_observer() {
 			MessageRouting::new(net.clone(), peer_id),
 		).expect("all in order with client and network");
 
-		runtime.spawn(oracle);
 		runtime.spawn(voter);
 	}
 
@@ -508,7 +506,6 @@ fn transition_3_voters_twice_1_observer() {
 			transitions.lock().insert(parent_hash, change);
 		};
 		let peers_c = peers_c.clone();
-		let executor = runtime.executor().clone();
 
 		// wait for blocks to be finalized before generating new ones
 		let block_production = client.finality_notification_stream()
@@ -533,34 +530,18 @@ fn transition_3_voters_twice_1_observer() {
 						net.lock().peer(0).push_blocks(5, false);
 					},
 					20 => {
-						let net = net.clone();
-						let add_transition = add_transition.clone();
-
 						// at block 21 we do another transition, but this time instant.
 						// add more until we have 30.
-						let generate_blocks = move || {
-							net.lock().peer(0).generate_blocks(1, BlockOrigin::File, |builder| {
-								let block = builder.bake().unwrap();
-								add_transition(*block.header.parent_hash(), ScheduledChange {
-									next_authorities: make_ids(&peers_c),
-									delay: 0,
-								});
-
-								block
+						net.lock().peer(0).generate_blocks(1, BlockOrigin::File, |builder| {
+							let block = builder.bake().unwrap();
+							add_transition(*block.header.parent_hash(), ScheduledChange {
+								next_authorities: make_ids(&peers_c),
+								delay: 0,
 							});
-							net.lock().peer(0).push_blocks(9, false);
-						};
 
-						// delay block generation for a bit for the liveness tracker to be
-						// able to update due to the authority set change
-						let delay_generate = Delay::new(Instant::now() + Duration::from_millis(5000))
-							.and_then(move |_| {
-								generate_blocks();
-								Ok(())
-							})
-							.map_err(|_| ());
-
-						executor.spawn(delay_generate);
+							block
+						});
+						net.lock().peer(0).push_blocks(9, false);
 					},
 					_ => {},
 				}
@@ -603,7 +584,7 @@ fn transition_3_voters_twice_1_observer() {
 					assert!(set.pending_changes().is_empty());
 				})
 		);
-		let (voter, oracle) = run_grandpa(
+		let voter = run_grandpa(
 			Config {
 				gossip_duration: TEST_GOSSIP_DURATION,
 				local_key,
@@ -613,7 +594,6 @@ fn transition_3_voters_twice_1_observer() {
 			MessageRouting::new(net.clone(), peer_id),
 		).expect("all in order with client and network");
 
-		runtime.spawn(oracle);
 		runtime.spawn(voter);
 	}
 

--- a/core/network/src/message.rs
+++ b/core/network/src/message.rs
@@ -173,7 +173,7 @@ pub mod generic {
 		/// Transactions.
 		Transactions(Transactions<Extrinsic>),
 		/// Consensus protocol message.
-		Consensus(Hash, ConsensusMessage), // topic, opaque Vec<u8>
+		Consensus(Hash, ConsensusMessage, bool), // topic, opaque Vec<u8>, broadcast
 		/// Remote method call request.
 		RemoteCallRequest(RemoteCallRequest<Hash>),
 		/// Remote method call response.

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -285,8 +285,8 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			GenericMessage::RemoteHeaderResponse(response) => self.on_remote_header_response(io, who, response),
 			GenericMessage::RemoteChangesRequest(request) => self.on_remote_changes_request(io, who, request),
 			GenericMessage::RemoteChangesResponse(response) => self.on_remote_changes_response(io, who, response),
-			GenericMessage::Consensus(topic, msg) => {
-				self.consensus_gossip.write().on_incoming(&mut ProtocolContext::new(&self.context_data, io), who, topic, msg);	
+			GenericMessage::Consensus(topic, msg, broadcast) => {
+				self.consensus_gossip.write().on_incoming(&mut ProtocolContext::new(&self.context_data, io), who, topic, msg, broadcast);
 			},
 			other => self.specialization.write().on_message(&mut ProtocolContext::new(&self.context_data, io), who, &mut Some(other)),
 		}
@@ -296,10 +296,10 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		send_message::<B, H>(&self.context_data.peers, io, who, message)
 	}
 
-	pub fn gossip_consensus_message(&self, io: &mut SyncIo, topic: B::Hash, message: Vec<u8>) {
+	pub fn gossip_consensus_message(&self, io: &mut SyncIo, topic: B::Hash, message: Vec<u8>, broadcast: bool) {
 		let gossip = self.consensus_gossip();
 		self.with_spec(io, move |_s, context|{
-			gossip.write().multicast(context, topic, message);
+			gossip.write().multicast(context, topic, message, broadcast);
 		});
 	}
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -127,11 +127,13 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Service<B, S,
 	}
 
 	/// Send a consensus message through the gossip
-	pub fn gossip_consensus_message(&self, topic: B::Hash, message: Vec<u8>) {
+	pub fn gossip_consensus_message(&self, topic: B::Hash, message: Vec<u8>, broadcast: bool) {
 		self.handler.gossip_consensus_message(
 			&mut NetSyncIo::new(&self.network, self.protocol_id),
 			topic,
-			message)
+			message,
+			broadcast,
+		)
 	}
 	/// Execute a closure with the chain-specific network specialization.
 	pub fn with_spec<F, U>(&self, f: F) -> U

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -229,8 +229,8 @@ impl<V: 'static + Verifier<Block>, D> Peer<V, D> {
 
 	/// Push a message into the gossip network and relay to peers.
 	/// `TestNet::sync_step` needs to be called to ensure it's propagated.
-	pub fn gossip_message(&self, topic: Hash, data: Vec<u8>) {
-		self.sync.gossip_consensus_message(&mut TestIo::new(&self.queue, None), topic, data);
+	pub fn gossip_message(&self, topic: Hash, data: Vec<u8>, broadcast: bool) {
+		self.sync.gossip_consensus_message(&mut TestIo::new(&self.queue, None), topic, data, broadcast);
 	}
 
 	/// Add blocks to the peer -- edit the block before adding

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -578,11 +578,8 @@ macro_rules! construct_service_factory {
 			) -> Result<Self::FullService, $crate::Error>
 			{
 				( $( $full_service_init )* ) (config, executor.clone()).and_then(|service| {
-					if let Some(key) = (&service).authority_key() {
-						($( $authority_setup )*)(service, executor, Arc::new(key))
-					} else {
-						Ok(service)
-					}
+					let key = (&service).authority_key().map(Arc::new);
+					($( $authority_setup )*)(service, executor, key)
 				})
 			}
 		}

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -204,7 +204,7 @@ pub fn connectivity<F: ServiceFactory, Inherent>(spec: FactoryChainSpec<F>) wher
 	{
 		let temp = TempDir::new("substrate-connectivity-test").expect("Error creating test dir");
 		{
-			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES as u32, 0, vec![], 30400);
+			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES, 0, vec![], 30500);
 			info!("Checking linked topology");
 			let mut address = network.full_nodes[0].1.network().node_id().expect("No node address");
 			for (_, service) in network.full_nodes.iter().skip(1) {

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -309,7 +309,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_connectiviy() {
+	fn test_connectivity() {
 		service_test::connectivity::<Factory, node_primitives::InherentData>(integration_test_config());
 	}
 }

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -83,7 +83,7 @@ construct_service_factory! {
 
 				if service.config.custom.grandpa_authority {
 					info!("Running Grandpa session as Authority {}", key.public());
-					let (voter, oracle) = grandpa::run_grandpa(
+					let voter = grandpa::run_grandpa(
 						grandpa::Config {
 							gossip_duration: Duration::new(4, 0), // FIXME: make this available through chainspec?
 							local_key: Some(key.clone()),
@@ -93,9 +93,9 @@ construct_service_factory! {
 						grandpa::NetworkBridge::new(service.network()),
 					)?;
 
-					executor.spawn(oracle);
 					executor.spawn(voter);
 				}
+
 				if !service.config.custom.grandpa_authority_only {
 					info!("Using authority key {}", key.public());
 					let proposer = Arc::new(substrate_service::ProposerFactory {

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -77,42 +77,51 @@ construct_service_factory! {
 			{ |config: FactoryFullConfiguration<Self>, executor: TaskExecutor|
 				FullComponents::<Factory>::new(config, executor) },
 		AuthoritySetup = {
-			|mut service: Self::FullService, executor: TaskExecutor, key: Arc<Pair>| {
+			|mut service: Self::FullService, executor: TaskExecutor, key: Option<Arc<Pair>>| {
 				let (block_import, link_half) = service.config.custom.grandpa_import_setup.take()
 					.expect("Link Half and Block Import are present for Full Services or setup failed before. qed");
 
-				if service.config.custom.grandpa_authority {
-					info!("Running Grandpa session as Authority {}", key.public());
-					let voter = grandpa::run_grandpa(
-						grandpa::Config {
-							gossip_duration: Duration::new(4, 0), // FIXME: make this available through chainspec?
-							local_key: Some(key.clone()),
-							name: Some(service.config.name.clone())
-						},
-						link_half,
-						grandpa::NetworkBridge::new(service.network()),
-					)?;
+				let local_key = if let Some(key) = key {
+					if !service.config.custom.grandpa_authority_only {
+						info!("Using authority key {}", key.public());
+						let proposer = Arc::new(substrate_service::ProposerFactory {
+							client: service.client(),
+							transaction_pool: service.transaction_pool(),
+						});
 
-					executor.spawn(voter);
-				}
+						let client = service.client();
+						executor.spawn(start_aura(
+							SlotDuration::get_or_compute(&*client)?,
+							key.clone(),
+							client,
+							block_import.clone(),
+							proposer,
+							service.network(),
+						));
+					}
 
-				if !service.config.custom.grandpa_authority_only {
-					info!("Using authority key {}", key.public());
-					let proposer = Arc::new(substrate_service::ProposerFactory {
-						client: service.client(),
-						transaction_pool: service.transaction_pool(),
-					});
+					if service.config.custom.grandpa_authority {
+						info!("Running Grandpa session as Authority {}", key.public());
+						Some(key)
+					} else {
+						None
+					}
+				} else {
+					None
+				};
 
-					let client = service.client();
-					executor.spawn(start_aura(
-						SlotDuration::get_or_compute(&*client)?,
-						key,
-						client,
-						block_import.clone(),
-						proposer,
-						service.network(),
-					));
-				}
+				let voter = grandpa::run_grandpa(
+					grandpa::Config {
+						local_key,
+						gossip_duration: Duration::new(4, 0), // FIXME: make this available through chainspec?
+						name: Some(service.config.name.clone())
+					},
+					link_half,
+					grandpa::NetworkBridge::new(service.network()),
+				)?;
+
+				executor.spawn(voter);
+
 				Ok(service)
 			}
 		},


### PR DESCRIPTION
Fix #1265.

The grandpa liveness oracle was a bit flaky and could easily report false negatives. This PR removes the liveness oracle and instead always imports unjustified change blocks, this is currently safe to do since we guarantee that we won't import multiple pending change blocks for the same fork, although it could lead to stalls if the block isn't finalized in the future. I also changed the consensus gossip so that grandpa commit messages are broadcast to all peers (rather than just all authorities). The full node now always runs the grandpa voter.

In a future PR this will be extended with a sync protocol to request block justifications.