### PR TITLE
Add additional Charred Cherry chain specification properties

### DIFF
--- a/node/cli/res/charred-cherry.json
+++ b/node/cli/res/charred-cherry.json
@@ -2,6 +2,8 @@
 	"name": "Charred Cherry",
 	"id": "charred-cherry",
 	"properties": {
+		"networkId": 68,
+		"tokenDecimals": 15,
 		"tokenSymbol": "CHR"
 	},
 	"telemetryUrl": "wss://telemetry.polkadot.io/submit/",


### PR DESCRIPTION
Add additional properties to the `properties` section of the chain specification -

- `networkId` - useful for determining the prefix id used in address encoding (API middleware and UI). Set to `68`, aligning with BBQ
- `tokenDecimals` - useful for user inputs e.g. Balance in UIs. Set to `15`, aligning with BBQ (naming of this property aligning with already-existing `tokenSymbol`)