### PR TITLE
node: remove grandpa authority flags

### DIFF
--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -120,20 +120,9 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 			Err(e) => e.exit(),
 		};
 
-	let (spec, mut config) = cli::parse_matches::<service::Factory, _>(
+	let (spec, config) = cli::parse_matches::<service::Factory, _>(
 		load_spec, version, "substrate-node", &matches
 	)?;
-
-	if matches.is_present("grandpa_authority_only") {
-		config.custom.grandpa_authority = true;
-		config.custom.grandpa_authority_only = true;
-		// Authority Setup is only called if validator is set as true
-		config.roles = ServiceRoles::AUTHORITY;
-	} else if matches.is_present("grandpa_authority") {
-		config.custom.grandpa_authority = true;
-		// Authority Setup is only called if validator is set as true
-		config.roles = ServiceRoles::AUTHORITY;
-	}
 
 	match cli::execute_default::<service::Factory, _>(spec, exit, &matches, &config)? {
 		cli::Action::ExecutedInternally => (),

--- a/node/cli/src/params.rs
+++ b/node/cli/src/params.rs
@@ -20,14 +20,6 @@ use cli::CoreParams;
 /// Extend params for Node
 #[derive(Debug, StructOpt)]
 pub struct Params {
-	/// Should run as a GRANDPA authority node
-	#[structopt(long = "grandpa-authority", help = "Run Node as a GRANDPA authority, implies --validator")]
-	grandpa_authority: bool,
-
-	/// Should run as a GRANDPA authority node only
-	#[structopt(long = "grandpa-authority-only", help = "Run Node as a GRANDPA authority only, don't as a usual validator, implies --grandpa-authority")]
-	grandpa_authority_only: bool,
-
 	#[structopt(flatten)]
 	core: CoreParams
 }


### PR DESCRIPTION
The full node always runs the grandpa voter. If `--validator` is passed the node is started as an authority for both aura and grandpa (both validator sets are linked right now).