### PR TITLE
typo: Hash -> Self::Hash

### DIFF
--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -133,7 +133,7 @@ impl<
 		self.dref().as_authorities_change()
 	}
 
-	fn as_changes_trie_root(&self) -> Option<&Hash> {
+	fn as_changes_trie_root(&self) -> Option<&Self::Hash> {
 		self.dref().as_changes_trie_root()
 	}
 }


### PR DESCRIPTION
While both works, it just looks inconsistent.