### PR TITLE
fix params pruning type

### DIFF
--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -91,7 +91,7 @@ pub struct CoreParams {
 
 	/// Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.
 	#[structopt(long = "pruning", value_name = "PRUNING_MODE")]
-	pruning: Option<u32>,
+	pruning: Option<String>,
 
 	/// The human-readable name for this node, as reported to the telemetry server, if enabled
 	#[structopt(long = "name", value_name = "NAME")]


### PR DESCRIPTION
The parameter pruning is handled by core/cli/src/lib.rs. The params type should be String.