### PR TITLE
fix bug for revert block command

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -422,7 +422,7 @@ where
 	} else if let Some(sub_matches) = matches.subcommand_matches("revert") {
 		revert_chain::<F>(
 			get_db_path_for_subcommand(matches, sub_matches)?,
-			matches,
+			sub_matches,
 			spec
 		)?;
 		return Ok(Action::ExecutedInternally);


### PR DESCRIPTION
* must pass sub_matches to function, so that could get `<num>` in revert
* revert should del current best index block, not prev block