### PR TITLE
Improve ondemand request dispatch

### DIFF
--- a/core/network/src/on_demand.rs
+++ b/core/network/src/on_demand.rs
@@ -414,15 +414,23 @@ impl<B, E> OnDemandCore<B, E> where
 		};
 
 		let mut last_peer = self.idle_peers.back().cloned();
-		while !self.pending_requests.is_empty() {
+		let mut unhandled_requests = VecDeque::new();
+
+		loop {
 			let peer = match self.idle_peers.pop_front() {
 				Some(peer) => peer,
-				None => return,
+				None => break,
 			};
 
 			// check if request can (optimistically) be processed by the peer
 			let can_be_processed_by_peer = {
-				let request = self.pending_requests.front().expect("checked in loop condition; qed");
+				let request = match self.pending_requests.front() {
+					Some(r) => r,
+					None => {
+						self.idle_peers.push_front(peer);
+						break;
+					},
+				};
 				let peer_best_block = self.best_blocks.get(&peer)
 					.expect("entries are inserted into best_blocks when peer is connected;
 						entries are removed from best_blocks when peer is disconnected;
@@ -436,7 +444,9 @@ impl<B, E> OnDemandCore<B, E> where
 
 				// we have enumerated all peers and noone can handle request
 				if Some(peer) == last_peer {
-					break;
+					let request = self.pending_requests.pop_front().expect("checked in loop condition; qed");
+					unhandled_requests.push_back(request);
+					last_peer = self.idle_peers.back().cloned();
 				}
 
 				continue;
@@ -451,6 +461,8 @@ impl<B, E> OnDemandCore<B, E> where
 			service.execute_in_context(|ctx| ctx.send_message(peer, request.message()));
 			self.active_peers.insert(peer, request);
 		}
+
+		self.pending_requests.append(&mut unhandled_requests);
 	}
 }
 
@@ -956,6 +968,29 @@ pub mod tests {
 		on_demand.on_connect(3, Roles::FULL, 250);
 
 		assert_eq!(vec![1, 2], on_demand.core.lock().idle_peers.iter().cloned().collect::<Vec<_>>());
+		assert_eq!(on_demand.core.lock().pending_requests.len(), 1);
+	}
+
+	#[test]
+	fn tries_to_send_all_pending_requests() {
+		let (_x, on_demand) = dummy(true);
+		let queue = RwLock::new(VecDeque::new());
+		let mut network = TestIo::new(&queue, None);
+
+		on_demand.remote_header(RemoteHeaderRequest {
+			cht_root: Default::default(),
+			block: 300,
+			retry_count: None,
+		});
+		on_demand.remote_header(RemoteHeaderRequest {
+			cht_root: Default::default(),
+			block: 250,
+			retry_count: None,
+		});
+
+		on_demand.on_connect(1, Roles::FULL, 250);
+
+		assert!(on_demand.core.lock().idle_peers.iter().cloned().collect::<Vec<_>>().is_empty());
 		assert_eq!(on_demand.core.lock().pending_requests.len(), 1);
 	}
 }


### PR DESCRIPTION
Fix a bug where the ondemand dispatch function would loop forever. Improved the loop so that we try to dispatch as much requests as we can (currently we stop on the first request we can't dispatch).