### PR TITLE
expose peer information via rpc

### DIFF
--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -53,7 +53,7 @@ mod transport;
 
 pub use custom_proto::RegisteredProtocol;
 pub use error::{Error, ErrorKind, DisconnectReason};
-pub use libp2p::{Multiaddr, multiaddr::{Protocol}, multiaddr, PeerId};
+pub use libp2p::{Multiaddr, multiaddr::{Protocol}, multiaddr, PeerId, core::PublicKey};
 pub use secret::obtain_private_key;
 pub use service_task::{start_service, Service, ServiceEvent};
 pub use traits::{NetworkConfiguration, NodeIndex, NodeId, NonReservedPeerMode};

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -69,7 +69,7 @@ pub use protocol::{ProtocolStatus, PeerInfo, Context};
 pub use sync::{Status as SyncStatus, SyncState};
 pub use network_libp2p::{
     NodeIndex, ProtocolId, Severity, Protocol, Multiaddr,
-    obtain_private_key, multiaddr,
+    obtain_private_key, multiaddr, PeerId, PublicKey
 };
 pub use message::{generic as generic_message, RequestId, Status as StatusMessage};
 pub use error::Error;

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -240,6 +240,20 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		}
 	}
 
+	pub fn peers(&self) -> Vec<(NodeIndex, PeerInfo<B>)> {
+		self.context_data.peers.read().iter().map(|(idx, p)| {
+			(
+				*idx,
+				PeerInfo {
+					roles: p.roles,
+					protocol_version: p.protocol_version,
+					best_hash: p.best_hash,
+					best_number: p.best_number,
+				}
+			)
+		}).collect()
+	}
+
 	pub fn handle_packet(&self, io: &mut SyncIo, who: NodeIndex, mut data: &[u8]) {
 		let message: Message<B> = match Decode::decode(&mut data) {
 			Some(m) => m,

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -45,6 +45,7 @@ const PROPAGATE_TIMEOUT: Duration = Duration::from_millis(5000);
 pub trait SyncProvider<B: BlockT>: Send + Sync {
 	/// Get sync status
 	fn status(&self) -> ProtocolStatus<B>;
+	/// Get currently connected peers
 	fn peers(&self) -> Vec<(NodeIndex, Option<PeerId>, PeerInfo<B>)>;
 }
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -232,7 +232,7 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> SyncProvider<
 	}
 
 	fn peers(&self) -> Vec<(NodeIndex, Option<PeerId>, PeerInfo<B>)> {
-		let mut peers = self.handler.peers();
+		let peers = self.handler.peers();
 		let network = self.network.lock();
 		peers.into_iter().map(|(idx, info)| {
 			(idx, network.peer_id_of_node(idx).map(|p| p.clone()), info)

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -26,7 +26,7 @@ use network_libp2p::{RegisteredProtocol, parse_str_addr, Protocol as Libp2pProto
 use io::NetSyncIo;
 use consensus::import_queue::{ImportQueue, Link};
 use consensus_gossip::ConsensusGossip;
-use protocol::{self, Protocol, ProtocolContext, Context, ProtocolStatus};
+use protocol::{self, Protocol, ProtocolContext, Context, ProtocolStatus, PeerInfo};
 use config::Params;
 use error::Error;
 use specialization::NetworkSpecialization;
@@ -45,6 +45,7 @@ const PROPAGATE_TIMEOUT: Duration = Duration::from_millis(5000);
 pub trait SyncProvider<B: BlockT>: Send + Sync {
 	/// Get sync status
 	fn status(&self) -> ProtocolStatus<B>;
+	fn peers(&self) -> Vec<(NodeIndex, Option<PeerId>, PeerInfo<B>)>;
 }
 
 /// Minimum Requirements for a Hash within Networking
@@ -227,6 +228,14 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> SyncProvider<
 	/// Get sync status
 	fn status(&self) -> ProtocolStatus<B> {
 		self.handler.status()
+	}
+
+	fn peers(&self) -> Vec<(NodeIndex, Option<PeerId>, PeerInfo<B>)> {
+		let mut peers = self.handler.peers();
+		let network = self.network.lock();
+		peers.into_iter().map(|(idx, info)| {
+			(idx, network.peer_id_of_node(idx).map(|p| p.clone()), info)
+		}).collect::<Vec<_>>()
 	}
 }
 

--- a/core/rpc-servers/src/lib.rs
+++ b/core/rpc-servers/src/lib.rs
@@ -53,7 +53,7 @@ pub fn rpc_handler<Block: BlockT, ExHash, S, C, A, Y>(
 	S: apis::state::StateApi<Block::Hash, Metadata=Metadata>,
 	C: apis::chain::ChainApi<Block::Hash, Block::Header, NumberFor<Block>, SignedBlock<Block>, Metadata=Metadata>,
 	A: apis::author::AuthorApi<ExHash, Block::Hash, Metadata=Metadata>,
-	Y: apis::system::SystemApi,
+	Y: apis::system::SystemApi<Block::Hash, NumberFor<Block>>,
 {
 	let mut io = pubsub::PubSubHandler::default();
 	io.extend_with(state.to_delegate());

--- a/core/rpc/src/system/helpers.rs
+++ b/core/rpc/src/system/helpers.rs
@@ -47,7 +47,7 @@ pub struct Health {
 
 /// Network Peer information
 #[derive(Debug, PartialEq, Serialize)]
-pub struct PeerInfo {
+pub struct PeerInfo<Hash, Number> {
 	/// Peer Node Index
 	pub index: usize,
 	/// Peer ID
@@ -57,9 +57,9 @@ pub struct PeerInfo {
 	/// Protocol version
 	pub protocol_version: u32,
 	/// Peer best block hash
-	pub best_hash: String,
+	pub best_hash: Hash,
 	/// Peer best block number
-	pub best_number: String,
+	pub best_number: Number,
 }
 
 impl fmt::Display for Health {

--- a/core/rpc/src/system/helpers.rs
+++ b/core/rpc/src/system/helpers.rs
@@ -45,6 +45,23 @@ pub struct Health {
 	pub is_syncing: bool,
 }
 
+/// Network Peer information
+#[derive(Debug, PartialEq, Serialize)]
+pub struct PeerInfo {
+	/// Peer Node Index
+	pub index: usize,
+	/// Peer ID
+	pub peer_id: String,
+	/// Roles
+	pub roles: String,
+	/// Protocol version
+	pub protocol_version: u32,
+	/// Peer best block hash
+	pub best_hash: String,
+	/// Peer best block number
+	pub best_number: String,
+}
+
 impl fmt::Display for Health {
 	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
 		write!(fmt, "{} peers ({})", self.peers, if self.is_syncing {

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -123,7 +123,7 @@ impl<B: traits::Block> SystemApi<B::Hash, <B::Header as HeaderT>::Number> for Sy
 	fn system_peers(&self) -> Result<Vec<PeerInfo<B::Hash, <B::Header as HeaderT>::Number>>> {
 		Ok(self.sync.peers().into_iter().map(|(idx, peer_id, p)| PeerInfo {
 			index: idx,
-			peer_id: peer_id.map_or("".into(), |p| p.to_base58()),
+			peer_id: peer_id.map_or_else(Default::default, |p| p.to_base58()),
 			roles: format!("{:?}", p.roles),
 			protocol_version: p.protocol_version,
 			best_hash: p.best_hash,

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -27,7 +27,7 @@ use network;
 use runtime_primitives::traits;
 
 use self::error::Result;
-pub use self::helpers::{Properties, SystemInfo, Health};
+pub use self::helpers::{Properties, SystemInfo, Health, PeerInfo};
 
 build_rpc_trait! {
 	/// Substrate system RPC API
@@ -55,6 +55,10 @@ build_rpc_trait! {
 		/// - not performing a major sync
 		#[rpc(name = "system_health")]
 		fn system_health(&self) -> Result<Health>;
+
+		/// get peers
+		#[rpc(name = "system_peers")]
+		fn system_peers(&self) -> Result<Vec<PeerInfo>>;
 	}
 }
 
@@ -114,5 +118,16 @@ impl<B: traits::Block> SystemApi for System<B> {
 		} else {
 			Ok(health)
 		}
+	}
+
+	fn system_peers(&self) -> Result<Vec<PeerInfo>> {
+		Ok(self.sync.peers().into_iter().map(|(idx, peer_id, p)| PeerInfo {
+			index: idx as usize,
+			peer_id: peer_id.map_or("".into(), |p| p.to_base58()),
+			roles: format!("{:?}", p.roles),
+			protocol_version: p.protocol_version,
+			best_hash: format!("{:?}", p.best_hash),
+			best_number: format!("{}", p.best_number),
+		}).collect())
 	}
 }

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -56,7 +56,7 @@ build_rpc_trait! {
 		#[rpc(name = "system_health")]
 		fn system_health(&self) -> Result<Health>;
 
-		/// get peers
+		/// Returns currently connected peers
 		#[rpc(name = "system_peers")]
 		fn system_peers(&self) -> Result<Vec<PeerInfo>>;
 	}

--- a/core/rpc/src/system/mod.rs
+++ b/core/rpc/src/system/mod.rs
@@ -122,7 +122,7 @@ impl<B: traits::Block> SystemApi for System<B> {
 
 	fn system_peers(&self) -> Result<Vec<PeerInfo>> {
 		Ok(self.sync.peers().into_iter().map(|(idx, peer_id, p)| PeerInfo {
-			index: idx as usize,
+			index: idx,
 			peer_id: peer_id.map_or("".into(), |p| p.to_base58()),
 			roles: format!("{:?}", p.roles),
 			protocol_version: p.protocol_version,

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -16,7 +16,8 @@
 
 use super::*;
 
-use network::{self, SyncState, SyncStatus, ProtocolStatus};
+use network::{self, SyncState, SyncStatus, ProtocolStatus, NodeIndex, PeerId, PeerInfo as NetworkPeerInfo, PublicKey};
+use network::config::Roles;
 use test_client::runtime::Block;
 
 #[derive(Default)]
@@ -36,6 +37,15 @@ impl network::SyncProvider<Block> for Status {
 			num_peers: self.peers,
 			num_active_peers: 0,
 		}
+	}
+
+	fn peers(&self) -> Vec<(NodeIndex, Option<PeerId>, NetworkPeerInfo<Block>)> {
+		vec![(1, Some(PublicKey::Ed25519((0 .. 32).collect::<Vec<u8>>()).into()), NetworkPeerInfo {
+			roles: Roles::FULL,
+			protocol_version: 1,
+			best_hash: Default::default(),
+			best_number: 1
+		})]
 	}
 }
 
@@ -127,5 +137,21 @@ fn system_health() {
 			peers: 0,
 			is_syncing: false,
 		}
+	);
+}
+
+#[test]
+fn system_peers() {
+
+	assert_eq!(
+		api(None).system_peers().unwrap(),
+		vec![PeerInfo {
+			index: 1,
+			peer_id: "QmS5oyTmdjwBowwAH1D9YQnoe2HyWpVemH8qHiU5RqWPh4".into(),
+			roles: "FULL".into(),
+			protocol_version: 1,
+			best_hash: "0x0000000000000000000000000000000000000000000000000000000000000000".into(),
+			best_number: "1".into(),
+		}]
 	);
 }

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -16,7 +16,6 @@
 
 use super::*;
 
-use std::str::FromStr;
 use network::{self, SyncState, SyncStatus, ProtocolStatus, NodeIndex, PeerId, PeerInfo as NetworkPeerInfo, PublicKey};
 use network::config::Roles;
 use test_client::runtime::Block;
@@ -144,7 +143,6 @@ fn system_health() {
 
 #[test]
 fn system_peers() {
-
 	assert_eq!(
 		api(None).system_peers().unwrap(),
 		vec![PeerInfo {

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -16,9 +16,11 @@
 
 use super::*;
 
+use std::str::FromStr;
 use network::{self, SyncState, SyncStatus, ProtocolStatus, NodeIndex, PeerId, PeerInfo as NetworkPeerInfo, PublicKey};
 use network::config::Roles;
 use test_client::runtime::Block;
+use primitives::H256;
 
 #[derive(Default)]
 struct Status {
@@ -150,8 +152,8 @@ fn system_peers() {
 			peer_id: "QmS5oyTmdjwBowwAH1D9YQnoe2HyWpVemH8qHiU5RqWPh4".into(),
 			roles: "FULL".into(),
 			protocol_version: 1,
-			best_hash: "0x0000000000000000000000000000000000000000000000000000000000000000".into(),
-			best_number: "1".into(),
+			best_hash: Default::default(),
+			best_number: 1u64,
 		}]
 	);
 }


### PR DESCRIPTION
I want to investigate some networking issues (#1335, #1346) but figuring out the current node status only via logs is hard. So I want to have some RPC methods to expose internal information for diagnostic purpose.

I am planning to include more details about dropped/banned peers, maybe behind a diagnostic mode flag.

Example output:

```
$ curl -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "method":"system_peers", "params":[], "id": 1 }' http://localhost:9933/ | jq '.'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   745  100   678  100    67  45888   4534 --:--:-- --:--:-- --:--:-- 48428
{
  "jsonrpc": "2.0",
  "result": [
    {
      "best_hash": "0x771a8de21d7a77374425b1dcf8694b039290b9c630d9112f95978e152f0f1359",
      "best_number": "1736",
      "index": 1,
      "peer_id": "QmXiB3jqqn2rpiKU7k1h7NJYeBg8WNSx9DiTRKz9ti2KSK",
      "protocol_version": 1,
      "roles": "AUTHORITY"
    },
    {
      "best_hash": "0x771a8de21d7a77374425b1dcf8694b039290b9c630d9112f95978e152f0f1359",
      "best_number": "1736",
      "index": 0,
      "peer_id": "QmYcHeEWuqtr6Gb5EbK7zEhnaCm5p6vA2kWcVjFKbhApaC",
      "protocol_version": 1,
      "roles": "AUTHORITY"
    },
    {
      "best_hash": "0x771a8de21d7a77374425b1dcf8694b039290b9c630d9112f95978e152f0f1359",
      "best_number": "1736",
      "index": 2,
      "peer_id": "QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN",
      "protocol_version": 1,
      "roles": "AUTHORITY"
    }
  ],
  "id": 1
}
```