### PR TITLE
Expose all authorship APIs

### DIFF
--- a/core/basic-authorship/src/lib.rs
+++ b/core/basic-authorship/src/lib.rs
@@ -31,4 +31,4 @@ extern crate log;
 
 mod basic_authorship;
 
-pub use basic_authorship::ProposerFactory;
+pub use basic_authorship::{ProposerFactory, BlockBuilder, AuthoringApi, Proposer};


### PR DESCRIPTION
Makes it possible to extend it and to reference those traits.