### PR TITLE
drew.tupletimestamp - Add tuple macro for timestamps too, break macro out into support

### DIFF
--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -42,6 +42,7 @@ use primitives::traits::{As, Zero, One, Convert};
 use codec::HasCompact;
 use runtime_support::{StorageValue, StorageMap};
 use runtime_support::dispatch::Result;
+use runtime_support::for_each_tuple;
 use system::ensure_signed;
 use rstd::ops::Mul;
 

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -51,17 +51,6 @@ pub trait OnSessionChange<T> {
 	fn on_session_change(time_elapsed: T, should_reward: bool);
 }
 
-macro_rules! for_each_tuple {
-	($m:ident) => {
-		for_each_tuple! { @IMPL $m !! A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, }
-	};
-	(@IMPL $m:ident !!) => { $m! { } };
-	(@IMPL $m:ident !! $h:ident, $($t:ident,)*) => {
-		$m! { $h $($t)* }
-		for_each_tuple! { @IMPL $m !! $($t,)* }
-	}
-}
-
 macro_rules! impl_session_change {
 	() => (
 		impl<T> OnSessionChange<T> for () {
@@ -79,7 +68,6 @@ macro_rules! impl_session_change {
 }
 
 for_each_tuple!(impl_session_change);
-
 
 pub trait Trait: timestamp::Trait {
 	type ConvertAccountIdToSessionKey: Convert<Self::AccountId, Self::SessionKey>;

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -134,3 +134,16 @@ pub use mashup::*;
 #[cfg(feature = "std")]
 #[doc(hidden)]
 pub use serde_derive::*;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! for_each_tuple {
+	($m:ident) => {
+		for_each_tuple! { @IMPL $m !! A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, }
+	};
+	(@IMPL $m:ident !!) => { $m! { } };
+	(@IMPL $m:ident !! $h:ident, $($t:ident,)*) => {
+		$m! { $h $($t)* }
+		for_each_tuple! { @IMPL $m !! $($t,)* }
+	}
+}

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -135,8 +135,10 @@ pub use mashup::*;
 #[doc(hidden)]
 pub use serde_derive::*;
 
+/// Programatically create derivations for tuples of up to 19 elements. You provide a second macro
+/// which is called once per tuple size, along with a number of identifiers, one for each element
+/// of the tuple.
 #[macro_export]
-#[doc(hidden)]
 macro_rules! for_each_tuple {
 	($m:ident) => {
 		for_each_tuple! { @IMPL $m !! A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, }

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -59,7 +59,7 @@ use runtime_support::for_each_tuple;
 
 /// A trait which is called when the timestamp is set.
 pub trait OnTimestampSet<Moment> {
-    fn on_timestamp_set(moment: Moment);
+	fn on_timestamp_set(moment: Moment);
 }
 
 macro_rules! impl_timestamp_set {

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -55,24 +55,30 @@ use runtime_primitives::traits::{
 };
 use system::ensure_inherent;
 use rstd::{result, ops::{Mul, Div}, vec::Vec};
+use runtime_support::for_each_tuple;
 
 /// A trait which is called when the timestamp is set.
 pub trait OnTimestampSet<Moment> {
-	fn on_timestamp_set(moment: Moment);
+    fn on_timestamp_set(moment: Moment);
 }
 
-impl<Moment> OnTimestampSet<Moment> for () {
-	fn on_timestamp_set(_moment: Moment) { }
-}
+macro_rules! impl_timestamp_set {
+	() => (
+		impl<Moment> OnTimestampSet<Moment> for () {
+			fn on_timestamp_set(_: Moment) {}
+		}
+	);
 
-impl<A, B, Moment: Clone> OnTimestampSet<Moment> for (A, B)
-	where A: OnTimestampSet<Moment>, B: OnTimestampSet<Moment>
-{
-	fn on_timestamp_set(moment: Moment) {
-		A::on_timestamp_set(moment.clone());
-		B::on_timestamp_set(moment);
+	( $($t:ident)* ) => {
+		impl<Moment: Clone, $($t: OnTimestampSet<Moment>),*> OnTimestampSet<Moment> for ($($t,)*) {
+			fn on_timestamp_set(moment: Moment) {
+				$($t::on_timestamp_set(moment.clone());)*
+			}
+		}
 	}
 }
+
+for_each_tuple!(impl_timestamp_set);
 
 pub trait Trait: consensus::Trait + system::Trait {
 	/// The position of the required timestamp-set extrinsic.


### PR DESCRIPTION
Moves the tuple macro into support so that it can be used be other modules easily.