### PR TITLE
Properly log sealing and the newly created proposal hash from aura

### DIFF
--- a/core/basic-authorship/src/basic_authorship.rs
+++ b/core/basic-authorship/src/basic_authorship.rs
@@ -232,15 +232,16 @@ impl<Block, C, A> Proposer<Block, C, A>	where
 				self.transaction_pool.remove_invalid(&unqueue_invalid);
 			})?;
 
-		info!("Proposing block [number: {}; hash: {}; parent_hash: {}; extrinsics: [{}]]",
-			  block.header().number(),
-			  <<C as AuthoringApi>::Block as BlockT>::Hash::from(block.header().hash()),
-			  block.header().parent_hash(),
-			  block.extrinsics().iter()
-			  .map(|xt| format!("{}", BlakeTwo256::hash_of(xt)))
-			  .collect::<Vec<_>>()
-			  .join(", ")
-			 );
+		info!("Prepared block for proposing at {} [hash: {:?}; parent_hash: {}; extrinsics: [{}]]",
+			block.header().number(),
+			<<C as AuthoringApi>::Block as BlockT>::Hash::from(block.header().hash()),
+			block.header().parent_hash(),
+			block.extrinsics()
+				.iter()
+				.map(|xt| format!("{}", BlakeTwo256::hash_of(xt)))
+				.collect::<Vec<_>>()
+				.join(", ")
+		);
 
 		let substrate_block = Decode::decode(&mut block.encode().as_slice())
 			.expect("blocks are defined to serialize to substrate blocks correctly; qed");

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -317,7 +317,7 @@ pub fn start_aura<B, C, E, I, SO, Error>(
 							signature,
 						);
 
-						let import_block : ImportBlock<B> = ImportBlock {
+						let import_block: ImportBlock<B> = ImportBlock {
 							origin: BlockOrigin::Own,
 							header,
 							justification: None,

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -304,6 +304,7 @@ pub fn start_aura<B, C, E, I, SO, Error>(
 						}
 
 						let (header, body) = b.deconstruct();
+						let header_num = header.number().clone();
 						let pre_hash = header.hash();
 						let parent_hash = header.parent_hash().clone();
 
@@ -316,7 +317,7 @@ pub fn start_aura<B, C, E, I, SO, Error>(
 							signature,
 						);
 
-						let import_block = ImportBlock {
+						let import_block : ImportBlock<B> = ImportBlock {
 							origin: BlockOrigin::Own,
 							header,
 							justification: None,
@@ -326,6 +327,12 @@ pub fn start_aura<B, C, E, I, SO, Error>(
 							auxiliary: Vec::new(),
 							fork_choice: ForkChoiceStrategy::LongestChain,
 						};
+
+						info!("Pre-sealed block for proposal at {}. Hash now {:?}, previously {:?}.",
+							header_num,
+							import_block.post_header().hash(),
+							pre_hash
+						);
 
 						if let Err(e) = block_import.import_block(import_block, None) {
 							warn!(target: "aura", "Error with block built on {:?}: {:?}",


### PR DESCRIPTION
Fixes #1138.

I opted for keeping the mentioned message but rephrase it slightly, because it still contains other useful information and is a good 
default in non-aura cases. Instead I added another message post pre-sealing in aura to announce the hash change, that felt more explicit 
and cleaner to me.

Run with `RUST_LOG=info node` now announces them as:
```
2019-01-11 13:50:41 Prepared block for proposing at 1 [hash: 0xe07f9bcda5e8cdf4d1d2cd5ed5787b8a7d471cf4a269b5f32dfdd6871bdb5904; 
parent_hash: 0x7171…78a8; extrinsics: [0xad52…0fdd]]
2019-01-11 13:50:41 Pre-sealed block for proposal at 1. Hash now 0x9923b1c5cc870c25175c65dd32caeb5661c36e74f1a92c7becf171e98bb74c08, 
previously 0xe07f9bcda5e8cdf4d1d2cd5ed5787b8a7d471cf4a269b5f32dfdd6871bdb5904.

```