### PR TITLE
Update links, labels and process in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,16 +14,23 @@ There are a few basic ground-rules for contributors (including the maintainer(s)
 . **Non-master branches**, prefixed with a short name moniker (e.g. `gav-my-feature`) must be used for ongoing work.
 . **All modifications** must be made in a **pull-request** to solicit feedback from other contributors.
 . A pull-request *must not be merged until CI* has finished successfully.
-. Contributors should adhere to the https://github.com/paritytech/polkadot/wiki/Style-Guide[house coding style].
+. Contributors should adhere to the https://wiki.parity.io/Substrate-Style-Guide[house coding style].
+
+
+== Merge Process
 
 Merging pull requests once CI is successful:
 
-. A pull request that does not alter any logic (e.g. comments, dependencies, docs) may be tagged https://github.com/paritytech/core/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3AA2-insubstantial[`insubstantial`] and merged by its author.
-. A pull request with no large change to logic that is an urgent fix may be merged after a non-author contributor has reviewed it well.
-. All other PRs should sit for 48 hours with the https://github.com/paritytech/core/pulls?q=is%3Apr+is%3Aopen+label%3AA0-pleasereview[`pleasereview`] tag in order to garner feedback.
+. A PR needs to be reviewed and approved by project maintainers unless:
+	- it does not alter any logic (e.g. comments, dependencies, docs), then it may be tagged https://github.com/paritytech/substrate/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3AA2-insubstantial[`insubstantial`] and merged by its author.
+  - it is an urgent fix withiut a no large change to logic, then it may be merged after a non-author contributor has approved the review.
+
+. Once a PR is ready for review please add the https://github.com/paritytech/substrate/pulls?q=is%3Apr+is%3Aopen+label%3AA0-pleasereview[`pleasereview`] label. Generally PRs should sit with this label for 48 hours in order to garner feedback. It may be merged before if all relevant parties had a look at it.
+. PRs that break the external API must be tagged with https://github.com/paritytech/substrate/labels/B2-breaksapi[`breaksapi`], when it changes the SRML or consensus of running system with https://github.com/paritytech/substrate/labels/B3-breaksconsensus[`breaksconsensus`]
 . No PR should be merged until all reviews' comments are addressed.
 
-.Reviewing pull requests:
+*Reviewing pull requests*:
+
 When reviewing a pull request, the end-goal is to suggest useful changes to the author. Reviews should finish with approval unless there are issues that would result in:
 
 . Buggy behaviour.
@@ -33,9 +40,14 @@ When reviewing a pull request, the end-goal is to suggest useful changes to the 
 . Feature reduction (i.e. it removes some aspect of functionality that a significant minority of users rely on).
 . Uselessness (i.e. it does not strictly add a feature or fix a known issue).
 
-.Reviews may not be used as an effective veto for a PR because:
+*Reviews may not be used as an effective veto for a PR because*:
+
 . There exists a somewhat cleaner/better/faster way of accomplishing the same feature/fix.
 . It does not fit well with some other contributors' longer-term vision for the project.
+
+== Helping out
+
+We use https://github.com/paritytech/substrate/labels[labels] to manage PRs and issues and communicate state of a PR. Please familiarize yourself with them. Further more we are organising issues in https://github.com/paritytech/substrate/milestones[milestones]. Best way to get started is to a pick a ticket from the current milestone tagged https://github.com/paritytech/substrate/issues?q=is%3Aissue+is%3Aopen+label%3AQ2-easy[`easy`] or https://github.com/paritytech/substrate/issues?q=is%3Aissue+is%3Aopen+label%3AQ3-medium[`medium`] and get going or https://github.com/paritytech/substrate/issues?q=is%3Aissue+is%3Aopen+label%3AX1-mentor[`mentor`] and get in contact with the mentor offering their support on that larger task.  
 
 == Releases
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -22,8 +22,8 @@ There are a few basic ground-rules for contributors (including the maintainer(s)
 Merging pull requests once CI is successful:
 
 . A PR needs to be reviewed and approved by project maintainers unless:
-	- it does not alter any logic (e.g. comments, dependencies, docs), then it may be tagged https://github.com/paritytech/substrate/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3AA2-insubstantial[`insubstantial`] and merged by its author.
-  - it is an urgent fix withiut a no large change to logic, then it may be merged after a non-author contributor has approved the review.
+	- it does not alter any logic (e.g. comments, dependencies, docs), then it may be tagged https://github.com/paritytech/substrate/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+label%3AA2-insubstantial[`insubstantial`] and merged by its author once CI is complete.
+  - it is an urgent fix with no large change to logic, then it may be merged after a non-author contributor has approved the review once CI is complete.
 
 . Once a PR is ready for review please add the https://github.com/paritytech/substrate/pulls?q=is%3Apr+is%3Aopen+label%3AA0-pleasereview[`pleasereview`] label. Generally PRs should sit with this label for 48 hours in order to garner feedback. It may be merged before if all relevant parties had a look at it.
 . PRs that break the external API must be tagged with https://github.com/paritytech/substrate/labels/B2-breaksapi[`breaksapi`], when it changes the SRML or consensus of running system with https://github.com/paritytech/substrate/labels/B3-breaksconsensus[`breaksconsensus`]


### PR DESCRIPTION
Fix broken links to labels, update link to style guide. Add breaksapi and breaksconsensus and add a section on easy, medium and mentor ticket to get started. Slight rephrasing to clarify current process.