### PR TITLE
Clean up TODO & FIXME comments

### DIFF
--- a/core/basic-authorship/src/basic_authorship.rs
+++ b/core/basic-authorship/src/basic_authorship.rs
@@ -214,7 +214,7 @@ impl<Block, C, A> Proposer<Block, C, A>	where
 				let pending_iterator = self.transaction_pool.ready();
 
 				for pending in pending_iterator {
-					// TODO [ToDr] Probably get rid of it, and validate in runtime.
+					// FIXME [ToDr] Probably get rid of it, and validate in runtime.
 					let encoded_size = pending.data.encode().len();
 					if pending_size + encoded_size >= MAX_TRANSACTIONS_SIZE { break }
 

--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -330,7 +330,7 @@ where Block: BlockT<Hash=H256>,
 	}
 
 	fn reset_storage(&mut self, mut top: StorageMap, children: ChildrenStorageMap) -> Result<H256, client::error::Error> {
-		// TODO: wipe out existing trie.
+		// FIXME: wipe out existing trie.
 
 		if top.iter().any(|(k, _)| well_known_keys::is_child_storage_key(k)) {
 			return Err(client::error::ErrorKind::GenesisInvalid.into());
@@ -402,7 +402,7 @@ struct DbGenesisStorage(pub H256);
 impl DbGenesisStorage {
 	pub fn new() -> Self {
 		let mut root = H256::default();
-		let mut mdb = MemoryDB::<Blake2Hasher>::default();	// TODO: use new() to make it more correct
+		let mut mdb = MemoryDB::<Blake2Hasher>::default();	// FIXME: use new() to make it more correct
 		state_machine::TrieDBMut::<Blake2Hasher>::new(&mut mdb, &mut root);
 		DbGenesisStorage(root)
 	}
@@ -803,7 +803,7 @@ impl<Block> client::backend::Backend<Block, Blake2Hasher> for Backend<Block> whe
 			};
 
 			if finalized {
-				// TODO: ensure best chain contains this block.
+				// FIXME: ensure best chain contains this block.
 				self.note_finalized(&mut transaction, &pending_block.header, hash)?;
 			} else {
 				// canonicalize blocks which are old enough, regardless of finality.
@@ -856,7 +856,7 @@ impl<Block> client::backend::Backend<Block, Blake2Hasher> for Backend<Block> whe
 
 		if let Some(header) = ::client::blockchain::HeaderBackend::header(&self.blockchain, block)? {
 			let mut transaction = DBTransaction::new();
-			// TODO: ensure best chain contains this block.
+			// FIXME: ensure best chain contains this block.
 			let hash = header.hash();
 			self.note_finalized(&mut transaction, &header, hash.clone())?;
 			if let Some(justification) = justification {
@@ -970,7 +970,7 @@ mod tests {
 
 	fn prepare_changes(changes: Vec<(Vec<u8>, Vec<u8>)>) -> (H256, MemoryDB<Blake2Hasher>) {
 		let mut changes_root = H256::default();
-		let mut changes_trie_update = MemoryDB::<Blake2Hasher>::default();		// TODO: change to new() to make more correct
+		let mut changes_trie_update = MemoryDB::<Blake2Hasher>::default();		// FIXME: change to new() to make more correct
 		{
 			let mut trie = TrieDBMut::<Blake2Hasher>::new(
 				&mut changes_trie_update,

--- a/core/client/db/src/light.rs
+++ b/core/client/db/src/light.rs
@@ -340,7 +340,7 @@ impl<Block> LightBlockchainStorage<Block> for LightStorage<Block>
 					// update block number to hash lookup entries.
 					for retracted in tree_route.retracted() {
 						if retracted.hash == meta.finalized_hash {
-							// TODO: can we recover here?
+							// FIXME: can we recover here?
 							warn!("Safety failure: reverting finalized block {:?}",
 								(&retracted.number, &retracted.hash));
 						}
@@ -437,7 +437,7 @@ impl<Block> LightBlockchainStorage<Block> for LightStorage<Block>
 	fn finalize_header(&self, id: BlockId<Block>) -> ClientResult<()> {
 		if let Some(header) = self.header(id)? {
 			let mut transaction = DBTransaction::new();
-			// TODO: ensure best chain contains this block.
+			// FIXME: ensure best chain contains this block.
 			let hash = header.hash();
 			let number = *header.number();
 			self.note_finalized(&mut transaction, &header, hash.clone())?;

--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -44,7 +44,7 @@ pub type SharedCache<B, H> = Arc<Mutex<Cache<B, H>>>;
 
 /// Create new shared cache instance with given max memory usage.
 pub fn new_shared_cache<B: Block, H: Hasher>(shared_cache_size: usize) -> SharedCache<B, H> {
-	let cache_items = shared_cache_size / 100; // Estimated average item size. TODO: more accurate tracking
+	let cache_items = shared_cache_size / 100; // Estimated average item size. FIXME: more accurate tracking
 	Arc::new(Mutex::new(Cache {
 		storage: LruCache::new(cache_items),
 		hashes: LruCache::new(cache_items),

--- a/core/client/src/block_builder/block_builder.rs
+++ b/core/client/src/block_builder/block_builder.rs
@@ -101,7 +101,7 @@ where
 			})
 		}
 
-		//FIXME: Please NLL, help me!
+		//FIXME: Replace with NLL as soon as we've switched to 2018: https://github.com/paritytech/substrate/issues/1413
 		impl_push(&mut self.api, &self.block_id, xt, &mut self.extrinsics)
 	}
 

--- a/core/client/src/call_executor.rs
+++ b/core/client/src/call_executor.rs
@@ -184,7 +184,7 @@ where
 		manager: ExecutionManager<EM>,
 	) -> Result<Vec<u8>, error::Error> where ExecutionManager<EM>: Clone {
 		let state = self.backend.state_at(*at)?;
-		//TODO: Find a better way to prevent double block initialization
+		//FIXME: Find a better way to prevent double block initialization
 		if method != "Core_initialise_block" && initialised_block.map(|id| id != *at).unwrap_or(true) {
 			let header = prepare_environment_block()?;
 			state_machine::execute_using_consensus_failure_handler(

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -64,7 +64,7 @@ pub struct Client<B, E, Block, RA> where Block: BlockT {
 	import_notification_sinks: Mutex<Vec<mpsc::UnboundedSender<BlockImportNotification<Block>>>>,
 	finality_notification_sinks: Mutex<Vec<mpsc::UnboundedSender<FinalityNotification<Block>>>>,
 	import_lock: Mutex<()>,
-	importing_block: RwLock<Option<Block::Hash>>, // holds the block hash currently being imported. TODO: replace this with block queue
+	importing_block: RwLock<Option<Block::Hash>>, // holds the block hash currently being imported. FIXME: replace this with block queue
 	block_execution_strategy: ExecutionStrategy,
 	api_execution_strategy: ExecutionStrategy,
 	_phantom: PhantomData<RA>,
@@ -102,7 +102,7 @@ pub trait BlockBody<Block: BlockT> {
 }
 
 /// Client info
-// TODO: split queue info from chain info and amalgamate into single struct.
+// FIXME: split queue info from chain info and amalgamate into single struct.
 #[derive(Debug)]
 pub struct ClientInfo<Block: BlockT> {
 	/// Best block hash.
@@ -296,7 +296,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 	/// Get the RuntimeVersion at a given block.
 	pub fn runtime_version_at(&self, id: &BlockId<Block>) -> error::Result<RuntimeVersion> {
-		// TODO: Post Poc-2 return an error if version is missing
+		// FIXME: Post Poc-2 return an error if version is missing
 		self.executor.runtime_version(id)
 	}
 
@@ -612,7 +612,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 			None => (None, None, None)
 		};
 
-		// TODO: non longest-chain rule.
+		// FIXME: non longest-chain rule.
 		let is_new_best = finalized || match fork_choice {
 			ForkChoiceStrategy::LongestChain => import_headers.post().number() > &last_best_number,
 			ForkChoiceStrategy::Custom(v) => v,
@@ -652,7 +652,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 		if make_notifications {
 			if let Some(storage_changes) = storage_changes {
-				// TODO [ToDr] How to handle re-orgs? Should we re-emit all storage changes?
+				// FIXME [ToDr] How to handle re-orgs? Should we re-emit all storage changes?
 				self.storage_notifications.lock()
 					.trigger(&hash, storage_changes.into_iter());
 			}
@@ -717,7 +717,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		// if the block is not a direct ancestor of the current best chain,
 		// then some other block is the common ancestor.
 		if route_from_best.common_block().hash != block {
-			// TODO: reorganize best block to be the best chain containing
+			// FIXME: reorganize best block to be the best chain containing
 			// `block`.
 		}
 
@@ -782,7 +782,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 	/// Get block status.
 	pub fn block_status(&self, id: &BlockId<Block>) -> error::Result<BlockStatus> {
-		// TODO: more efficient implementation
+		// FIXME: more efficient implementation
 		if let BlockId::Hash(ref h) = id {
 			if self.importing_block.read().as_ref().map_or(false, |importing| h == importing) {
 				return Ok(BlockStatus::Queued);
@@ -831,9 +831,9 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	/// If `maybe_max_block_number` is `Some(max_block_number)`
 	/// the search is limited to block `numbers <= max_block_number`.
 	/// in other words as if there were no blocks greater `max_block_number`.
-	/// TODO [snd] possibly implement this on blockchain::Backend and just redirect here
+	/// FIXME [snd] possibly implement this on blockchain::Backend and just redirect here
 	/// Returns `Ok(None)` if `target_hash` is not found in search space.
-	/// TODO [snd] write down time complexity
+	/// FIXME [snd] write down time complexity
 	pub fn best_containing(&self, target_hash: Block::Hash, maybe_max_number: Option<NumberFor<Block>>)
 		-> error::Result<Option<Block::Hash>>
 	{
@@ -893,7 +893,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 			// waiting until we are <= max_number
 			if let Some(max_number) = maybe_max_number {
 				loop {
-					// TODO [snd] this should be a panic
+					// FIXME [snd] this should be a panic
 					let current_header = self.backend.blockchain().header(BlockId::Hash(current_hash.clone()))?
 						.ok_or_else(|| error::Error::from(format!("failed to get header for hash {}", current_hash)))?;
 
@@ -913,7 +913,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 					return Ok(Some(best_hash));
 				}
 
-				// TODO [snd] this should be a panic
+				// FIXME [snd] this should be a panic
 				let current_header = self.backend.blockchain().header(BlockId::Hash(current_hash.clone()))?
 					.ok_or_else(|| error::Error::from(format!("failed to get header for hash {}", current_hash)))?;
 

--- a/core/client/src/error.rs
+++ b/core/client/src/error.rs
@@ -144,7 +144,7 @@ error_chain! {
 	}
 }
 
-// TODO [ToDr] Temporary, state_machine::Error should be a regular error not Box.
+// FIXME [ToDr] Temporary, state_machine::Error should be a regular error not Box.
 impl From<Box<state_machine::Error>> for Error {
 	fn from(e: Box<state_machine::Error>) -> Self {
 		ErrorKind::Execution(e).into()

--- a/core/client/src/light/blockchain.rs
+++ b/core/client/src/light/blockchain.rs
@@ -141,7 +141,7 @@ impl<S, F, Block> BlockchainHeaderBackend<Block> for Blockchain<S, F> where Bloc
 
 impl<S, F, Block> BlockchainBackend<Block> for Blockchain<S, F> where Block: BlockT, S: Storage<Block>, F: Fetcher<Block> {
 	fn body(&self, _id: BlockId<Block>) -> ClientResult<Option<Vec<Block::Extrinsic>>> {
-		// TODO [light]: fetch from remote node
+		// FIXME [light]: fetch from remote node
 		Ok(None)
 	}
 

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -379,7 +379,7 @@ pub fn import_single_block<B: BlockT, V: Verifier<B>>(
 			} else {
 				debug!(target: "sync", "Header {} was not provided ", block.hash);
 			}
-			return Err(BlockImportError::IncompleteHeader(peer)) //TODO: use persistent ID
+			return Err(BlockImportError::IncompleteHeader(peer)) //FIXME: use persistent ID
 		},
 	};
 
@@ -415,7 +415,7 @@ pub fn import_single_block<B: BlockT, V: Verifier<B>>(
 		},
 		Ok(ImportResult::KnownBad) => {
 			debug!(target: "sync", "Peer gave us a bad block {}: {:?}", number, hash);
-			Err(BlockImportError::BadBlock(peer)) //TODO: use persistent ID
+			Err(BlockImportError::BadBlock(peer)) //FIXME: use persistent ID
 		}
 		Err(e) => {
 			debug!(target: "sync", "Error importing block {}: {:?}: {:?}", number, hash, e);

--- a/core/consensus/rhd/src/lib.rs
+++ b/core/consensus/rhd/src/lib.rs
@@ -460,7 +460,7 @@ impl<B, P, I, InStream, OutSink> Drop for BftFuture<B, P, I, InStream, OutSink> 
 	OutSink: Sink<SinkItem=Communication<B>, SinkError=Error>,
 {
 	fn drop(&mut self) {
-		// TODO: have a trait member to pass misbehavior reports into.
+		// FIXME: have a trait member to pass misbehavior reports into.
 		let misbehavior = self.inner.drain_misbehavior().collect::<Vec<_>>();
 		self.inner.context().proposer.import_misbehavior(misbehavior);
 	}
@@ -494,7 +494,7 @@ pub struct BftService<B: Block, P, I> {
 	live_agreement: Mutex<Option<(B::Header, AgreementHandle)>>,
 	round_cache: Arc<Mutex<RoundCache<B::Hash>>>,
 	round_timeout_multiplier: u64,
-	key: Arc<ed25519::Pair>, // TODO: key changing over time.
+	key: Arc<ed25519::Pair>, // FIXME: key changing over time.
 	factory: P,
 }
 
@@ -516,14 +516,14 @@ impl<B, P, I> BftService<B, P, I>
 				start_round: 0,
 			})),
 			round_timeout_multiplier: 10,
-			key: key, // TODO: key changing over time.
+			key: key, // FIXME: key changing over time.
 			factory,
 		}
 	}
 
 	/// Get the local Authority ID.
 	pub fn local_id(&self) -> AuthorityId {
-		// TODO: based on a header and some keystore.
+		// FIXME: based on a header and some keystore.
 		self.key.public().into()
 	}
 
@@ -1112,7 +1112,7 @@ impl<C, A> BaseProposer<<C as AuthoringApi>::Block> for Proposer<C, A> where
 				self.transaction_pool.ready(|pending_iterator| {
 					let mut pending_size = 0;
 					for pending in pending_iterator {
-						// TODO [ToDr] Probably get rid of it, and validate in runtime.
+						// FIXME [ToDr] Probably get rid of it, and validate in runtime.
 						let encoded_size = pending.data.encode().len();
 						if pending_size + encoded_size >= MAX_TRANSACTIONS_SIZE { break }
 

--- a/core/executor/src/native_executor.rs
+++ b/core/executor/src/native_executor.rs
@@ -219,7 +219,7 @@ macro_rules! native_executor_instance {
 		native_executor_instance!(IMPL $name, $dispatcher, $version, $code);
 	};
 	(IMPL $name:ident, $dispatcher:path, $version:path, $code:expr) => {
-		// TODO: this is not so great – I think I should go back to have dispatch take a type param and modify this macro to accept a type param and then pass it in from the test-client instead
+		// FIXME: this is not so great – I think I should go back to have dispatch take a type param and modify this macro to accept a type param and then pass it in from the test-client instead
 		use primitives::Blake2Hasher as _Blake2Hasher;
 		impl $crate::NativeExecutionDispatch for $name {
 			fn native_equivalent() -> &'static [u8] {

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -138,7 +138,7 @@ impl ReadPrimitive<u32> for MemoryInstance {
 	}
 }
 
-// TODO: this macro does not support `where` clauses and that seems somewhat tricky to add
+// FIXME: this macro does not support `where` clauses and that seems somewhat tricky to add
 impl_function_executor!(this: FunctionExecutor<'e, E>,
 	ext_print_utf8(utf8_data: *const u8, utf8_len: u32) => {
 		if let Ok(utf8) = this.memory.get(utf8_data, utf8_len as usize) {

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -517,7 +517,7 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 		let prevote_timer = Delay::new(now + self.config.gossip_duration * 2);
 		let precommit_timer = Delay::new(now + self.config.gossip_duration * 4);
 
-		// TODO: dispatch this with `mpsc::spawn`.
+		// FIXME: dispatch this with `mpsc::spawn`.
 		let incoming = ::communication::checked_message_stream::<Block, _>(
 			round,
 			self.set_id,

--- a/core/keystore/src/lib.rs
+++ b/core/keystore/src/lib.rs
@@ -66,7 +66,7 @@ pub struct InvalidPassword;
 struct EncryptedKey {
 	mac: [u8; 32],
 	salt: [u8; 32],
-	ciphertext: Vec<u8>, // TODO: switch to fixed-size when serde supports
+	ciphertext: Vec<u8>, // FIXME: switch to fixed-size when serde supports
 	iv: [u8; 16],
 	iterations: u32,
 }

--- a/core/network-libp2p/src/node_handler.rs
+++ b/core/network-libp2p/src/node_handler.rs
@@ -159,7 +159,7 @@ pub enum SubstrateOutEvent<TSubstream> {
 	/// The remote wants us to answer a Kademlia `FIND_NODE` request.
 	///
 	/// The `responder` should be used to answer that query.
-	// FIXME: this API with the "responder" is bad, but changing it requires modifications in libp2p
+	// TODO: this API with the "responder" is bad, but changing it requires modifications in libp2p
 	KadFindNode {
 		/// The value being searched.
 		searched: PeerId,
@@ -203,7 +203,7 @@ impl<TSubstream> IdentificationRequest<TSubstream> {
 		listen_addrs: Vec<Multiaddr>,
 		remote_addr: &Multiaddr
 	) where TSubstream: AsyncRead + AsyncWrite + Send + 'static {
-		// FIXME: what to return for `protocol_version` and `agent_version`?
+		// TODO: what to return for `protocol_version` and `agent_version`?
 		let sender = self.sender.send(
 			identify::IdentifyInfo {
 				public_key: local_key,
@@ -233,7 +233,7 @@ pub enum SubstrateInEvent {
 	},
 
 	/// Requests to open a Kademlia substream.
-	// FIXME: document better
+	// TODO: document better
 	OpenKademlia,
 }
 
@@ -247,7 +247,7 @@ macro_rules! listener_upgrade {
 			upgrade::map(KadConnecConfig::new(), move |(c, s)| FinalUpgrade::Kad(c, s))),
 			upgrade::map(ping::protocol::Ping::default(), move |p| FinalUpgrade::from(p))),
 			upgrade::map(identify::IdentifyProtocolConfig, move |i| FinalUpgrade::from(i)))
-			// FIXME: meh for cloning a Vec here
+			// TODO: meh for cloning a Vec here
 	)
 }
 
@@ -321,7 +321,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 		match purpose {
 			UpgradePurpose::Custom(id) => {
 				let wanted = if let Some(proto) = self.registered_custom.find_protocol(id) {
-					// FIXME: meh for cloning
+					// TODO: meh for cloning
 					upgrade::map(proto.clone(), move |c| FinalUpgrade::Custom(c))
 				} else {
 					error!(target: "sub-libp2p", "Logic error: wrong custom protocol id for \
@@ -370,13 +370,13 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 			},
 			SubstrateInEvent::OpenKademlia => self.open_kademlia(),
 			SubstrateInEvent::Accept => {
-				// FIXME: implement
+				// TODO: implement
 			},
 		}
 	}
 
 	fn shutdown(&mut self) {
-		// FIXME: close gracefully
+		// TODO: close gracefully
 		self.is_shutting_down = true;
 
 		for custom_proto in &mut self.custom_protocols_substreams {
@@ -390,7 +390,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 
 	fn poll(&mut self) -> Poll<Option<NodeHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>>, IoError> {
 		if self.is_shutting_down {
-			// FIXME: finish only when everything is closed
+			// TODO: finish only when everything is closed
 			return Ok(Async::Ready(None));
 		}
 
@@ -645,7 +645,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 				Ok(Async::NotReady) =>
 					self.upgrades_in_progress_dial.push((purpose, in_progress)),
 				Err(err) => {
-					// FIXME: dispatch depending on actual error ; right now we assume that
+					// TODO: dispatch depending on actual error ; right now we assume that
 					// error == not supported, which is not necessarily true in theory
 					if let UpgradePurpose::Custom(_) = purpose {
 						return Ok(Async::Ready(Some(SubstrateOutEvent::Useless)));

--- a/core/network-libp2p/src/node_handler.rs
+++ b/core/network-libp2p/src/node_handler.rs
@@ -159,7 +159,7 @@ pub enum SubstrateOutEvent<TSubstream> {
 	/// The remote wants us to answer a Kademlia `FIND_NODE` request.
 	///
 	/// The `responder` should be used to answer that query.
-	// TODO: this API with the "responder" is bad, but changing it requires modifications in libp2p
+	// FIXME: this API with the "responder" is bad, but changing it requires modifications in libp2p
 	KadFindNode {
 		/// The value being searched.
 		searched: PeerId,
@@ -203,7 +203,7 @@ impl<TSubstream> IdentificationRequest<TSubstream> {
 		listen_addrs: Vec<Multiaddr>,
 		remote_addr: &Multiaddr
 	) where TSubstream: AsyncRead + AsyncWrite + Send + 'static {
-		// TODO: what to return for `protocol_version` and `agent_version`?
+		// FIXME: what to return for `protocol_version` and `agent_version`?
 		let sender = self.sender.send(
 			identify::IdentifyInfo {
 				public_key: local_key,
@@ -233,7 +233,7 @@ pub enum SubstrateInEvent {
 	},
 
 	/// Requests to open a Kademlia substream.
-	// TODO: document better
+	// FIXME: document better
 	OpenKademlia,
 }
 
@@ -247,7 +247,7 @@ macro_rules! listener_upgrade {
 			upgrade::map(KadConnecConfig::new(), move |(c, s)| FinalUpgrade::Kad(c, s))),
 			upgrade::map(ping::protocol::Ping::default(), move |p| FinalUpgrade::from(p))),
 			upgrade::map(identify::IdentifyProtocolConfig, move |i| FinalUpgrade::from(i)))
-			// TODO: meh for cloning a Vec here
+			// FIXME: meh for cloning a Vec here
 	)
 }
 
@@ -321,7 +321,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 		match purpose {
 			UpgradePurpose::Custom(id) => {
 				let wanted = if let Some(proto) = self.registered_custom.find_protocol(id) {
-					// TODO: meh for cloning
+					// FIXME: meh for cloning
 					upgrade::map(proto.clone(), move |c| FinalUpgrade::Custom(c))
 				} else {
 					error!(target: "sub-libp2p", "Logic error: wrong custom protocol id for \
@@ -370,13 +370,13 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 			},
 			SubstrateInEvent::OpenKademlia => self.open_kademlia(),
 			SubstrateInEvent::Accept => {
-				// TODO: implement
+				// FIXME: implement
 			},
 		}
 	}
 
 	fn shutdown(&mut self) {
-		// TODO: close gracefully
+		// FIXME: close gracefully
 		self.is_shutting_down = true;
 
 		for custom_proto in &mut self.custom_protocols_substreams {
@@ -390,7 +390,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 
 	fn poll(&mut self) -> Poll<Option<NodeHandlerEvent<Self::OutboundOpenInfo, Self::OutEvent>>, IoError> {
 		if self.is_shutting_down {
-			// TODO: finish only when everything is closed
+			// FIXME: finish only when everything is closed
 			return Ok(Async::Ready(None));
 		}
 
@@ -645,7 +645,7 @@ where TSubstream: AsyncRead + AsyncWrite + Send + 'static,
 				Ok(Async::NotReady) =>
 					self.upgrades_in_progress_dial.push((purpose, in_progress)),
 				Err(err) => {
-					// TODO: dispatch depending on actual error ; right now we assume that
+					// FIXME: dispatch depending on actual error ; right now we assume that
 					// error == not supported, which is not necessarily true in theory
 					if let UpgradePurpose::Custom(_) = purpose {
 						return Ok(Async::Ready(Some(SubstrateOutEvent::Useless)));

--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -144,7 +144,7 @@ where TProtos: IntoIterator<Item = RegisteredProtocol> {
 				}
 			},
 			Err(_) =>
-				// TODO: also handle the `IP:PORT` format ; however we need to somehow add the
+				// FIXME: also handle the `IP:PORT` format ; however we need to somehow add the
 				// reserved ID to `reserved_peers` at some point
 				warn!(target: "sub-libp2p", "Not a valid reserved node address: {}", reserved),
 		}
@@ -257,13 +257,13 @@ pub struct Service {
 	topology: NetTopology,
 
 	/// Handles the Kademlia queries.
-	// TODO: put the kbuckets in the topology instead
+	// FIXME: put the kbuckets in the topology instead
 	kad_system: KadSystem,
 
 	/// List of Kademlia controller we want to open.
 	///
 	/// A clone of tihs `Arc` is stored in each Kademlia query stream.
-	// TODO: use a better container?
+	// FIXME: use a better container?
 	kad_pending_ctrls: Arc<Mutex<FnvHashMap<PeerId, Vec<oneshot::Sender<KadConnecController>>>>>,
 
 	/// Sender whenever we inserted an entry in `kad_pending_ctrls`, so that we can process it.
@@ -374,7 +374,7 @@ impl Service {
 	}
 
 	/// Sends a message to a peer using the custom protocol.
-	// TODO: report invalid node index or protocol?
+	// FIXME: report invalid node index or protocol?
 	pub fn send_custom_message(
 		&mut self,
 		node_index: NodeIndex,
@@ -418,7 +418,7 @@ impl Service {
 	) {
 		let peer_id = match self.swarm.peer_id_of_node(node_index) {
 			Some(pid) => pid.clone(),
-			None => return,		// TODO: report?
+			None => return,		// FIXME: report?
 		};
 
 		// Kill the node from the swarm, and inject an event about it.
@@ -563,7 +563,7 @@ impl Service {
 					}
 				}
 			})
-			// TODO: we really want to remove nodes with no multiaddress from
+			// FIXME: we really want to remove nodes with no multiaddress from
 			// the results, but a flaw in the Kad protocol of libp2p makes it
 			// impossible to return empty results ; therefore we must at least
 			// return ourselves
@@ -846,7 +846,7 @@ impl Service {
 					}
 				Ok(Async::NotReady) => return Ok(Async::NotReady),
 				Ok(Async::Ready(None)) => unreachable!("The Swarm stream never ends"),
-				// TODO: this `Err` contains a `Void` ; remove variant when Rust allows that
+				// FIXME: this `Err` contains a `Void` ; remove variant when Rust allows that
 				Err(_) => unreachable!("The Swarm stream never errors"),
 			}
 		}

--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -144,7 +144,7 @@ where TProtos: IntoIterator<Item = RegisteredProtocol> {
 				}
 			},
 			Err(_) =>
-				// FIXME: also handle the `IP:PORT` format ; however we need to somehow add the
+				// TODO: also handle the `IP:PORT` format ; however we need to somehow add the
 				// reserved ID to `reserved_peers` at some point
 				warn!(target: "sub-libp2p", "Not a valid reserved node address: {}", reserved),
 		}
@@ -257,13 +257,13 @@ pub struct Service {
 	topology: NetTopology,
 
 	/// Handles the Kademlia queries.
-	// FIXME: put the kbuckets in the topology instead
+	// TODO: put the kbuckets in the topology instead
 	kad_system: KadSystem,
 
 	/// List of Kademlia controller we want to open.
 	///
 	/// A clone of tihs `Arc` is stored in each Kademlia query stream.
-	// FIXME: use a better container?
+	// TODO: use a better container?
 	kad_pending_ctrls: Arc<Mutex<FnvHashMap<PeerId, Vec<oneshot::Sender<KadConnecController>>>>>,
 
 	/// Sender whenever we inserted an entry in `kad_pending_ctrls`, so that we can process it.
@@ -374,7 +374,7 @@ impl Service {
 	}
 
 	/// Sends a message to a peer using the custom protocol.
-	// FIXME: report invalid node index or protocol?
+	// TODO: report invalid node index or protocol?
 	pub fn send_custom_message(
 		&mut self,
 		node_index: NodeIndex,
@@ -418,7 +418,7 @@ impl Service {
 	) {
 		let peer_id = match self.swarm.peer_id_of_node(node_index) {
 			Some(pid) => pid.clone(),
-			None => return,		// FIXME: report?
+			None => return,		// TODO: report?
 		};
 
 		// Kill the node from the swarm, and inject an event about it.
@@ -563,7 +563,7 @@ impl Service {
 					}
 				}
 			})
-			// FIXME: we really want to remove nodes with no multiaddress from
+			// TODO: we really want to remove nodes with no multiaddress from
 			// the results, but a flaw in the Kad protocol of libp2p makes it
 			// impossible to return empty results ; therefore we must at least
 			// return ourselves
@@ -846,7 +846,7 @@ impl Service {
 					}
 				Ok(Async::NotReady) => return Ok(Async::NotReady),
 				Ok(Async::Ready(None)) => unreachable!("The Swarm stream never ends"),
-				// FIXME: this `Err` contains a `Void` ; remove variant when Rust allows that
+				// TODO: this `Err` contains a `Void` ; remove variant when Rust allows that
 				Err(_) => unreachable!("The Swarm stream never errors"),
 			}
 		}

--- a/core/network-libp2p/src/swarm.rs
+++ b/core/network-libp2p/src/swarm.rs
@@ -155,7 +155,7 @@ pub enum SwarmEvent {
 	},
 
 	/// Opened a Kademlia substream with the node.
-	// TODO: the controller API is bad, but we need to make changes in libp2p to improve that
+	// FIXME: the controller API is bad, but we need to make changes in libp2p to improve that
 	KadOpen {
 		/// Index of the node.
 		node_index: NodeIndex,
@@ -166,7 +166,7 @@ pub enum SwarmEvent {
 	/// The remote wants us to answer a Kademlia `FIND_NODE` request.
 	///
 	/// The `responder` should be used to answer that query.
-	// TODO: this API with the "responder" is bad, but changing it requires modifications in libp2p
+	// FIXME: this API with the "responder" is bad, but changing it requires modifications in libp2p
 	KadFindNode {
 		/// Index of the node that wants an answer.
 		node_index: NodeIndex,
@@ -285,7 +285,7 @@ impl Swarm {
 	}
 
 	/// Sends a message to a peer using the custom protocol.
-	// TODO: report invalid node index or protocol?
+	// FIXME: report invalid node index or protocol?
 	pub fn send_custom_message(
 		&mut self,
 		node_index: NodeIndex,
@@ -346,7 +346,7 @@ impl Swarm {
 	///
 	/// Returns an error if the node index is invalid, or if it was already accepted.
 	pub fn accept_node(&mut self, node_index: NodeIndex) -> Result<(), ()> {
-		// TODO: detect if already accepted?
+		// FIXME: detect if already accepted?
 		let peer_id = match self.nodes_info.get(&node_index) {
 			Some(info) => &info.peer_id,
 			None => return Err(())

--- a/core/network-libp2p/src/swarm.rs
+++ b/core/network-libp2p/src/swarm.rs
@@ -155,7 +155,7 @@ pub enum SwarmEvent {
 	},
 
 	/// Opened a Kademlia substream with the node.
-	// FIXME: the controller API is bad, but we need to make changes in libp2p to improve that
+	// TODO: the controller API is bad, but we need to make changes in libp2p to improve that
 	KadOpen {
 		/// Index of the node.
 		node_index: NodeIndex,
@@ -166,7 +166,7 @@ pub enum SwarmEvent {
 	/// The remote wants us to answer a Kademlia `FIND_NODE` request.
 	///
 	/// The `responder` should be used to answer that query.
-	// FIXME: this API with the "responder" is bad, but changing it requires modifications in libp2p
+	// TODO: this API with the "responder" is bad, but changing it requires modifications in libp2p
 	KadFindNode {
 		/// Index of the node that wants an answer.
 		node_index: NodeIndex,
@@ -285,7 +285,7 @@ impl Swarm {
 	}
 
 	/// Sends a message to a peer using the custom protocol.
-	// FIXME: report invalid node index or protocol?
+	// TODO: report invalid node index or protocol?
 	pub fn send_custom_message(
 		&mut self,
 		node_index: NodeIndex,
@@ -346,7 +346,7 @@ impl Swarm {
 	///
 	/// Returns an error if the node index is invalid, or if it was already accepted.
 	pub fn accept_node(&mut self, node_index: NodeIndex) -> Result<(), ()> {
-		// FIXME: detect if already accepted?
+		// TODO: detect if already accepted?
 		let peer_id = match self.nodes_info.get(&node_index) {
 			Some(info) => &info.peer_id,
 			None => return Err(())

--- a/core/network-libp2p/src/topology.rs
+++ b/core/network-libp2p/src/topology.rs
@@ -58,7 +58,7 @@ const FAIL_BACKOFF_MULTIPLIER: u32 = 2;
 /// We need a maximum value for the backoff, overwise we risk an overflow.
 const MAX_BACKOFF: Duration = Duration::from_secs(30 * 60);
 
-// FIXME: should be merged with the Kademlia k-buckets
+// TODO: should be merged with the Kademlia k-buckets
 
 /// Stores information about the topology of the network.
 #[derive(Debug)]
@@ -111,7 +111,7 @@ impl NetTopology {
 		};
 
 		let file = fs::File::create(path)?;
-		// FIXME: the capacity of the BufWriter is kind of arbitrary ; decide better
+		// TODO: the capacity of the BufWriter is kind of arbitrary ; decide better
 		serialize(BufWriter::with_capacity(1024 * 1024, file), &self.store)
 	}
 
@@ -142,7 +142,7 @@ impl NetTopology {
 		let peer = if let Some(peer) = self.store.get(peer) {
 			peer
 		} else {
-			// FIXME: use an EitherIterator or something
+			// TODO: use an EitherIterator or something
 			return Vec::new().into_iter();
 		};
 
@@ -158,7 +158,7 @@ impl NetTopology {
 			}
 		}).collect::<Vec<_>>();
 		list.sort_by(|a, b| a.0.cmp(&b.0));
-		// FIXME: meh, optimize
+		// TODO: meh, optimize
 		let l = list.into_iter().map(|(_, connec, addr)| (addr, connec)).collect::<Vec<_>>();
 		l.into_iter()
 	}
@@ -171,7 +171,7 @@ impl NetTopology {
 	/// the earlier known time when a new entry will be added automatically to
 	/// the list.
 	pub fn addrs_to_attempt(&self) -> (impl Iterator<Item = (&PeerId, &Multiaddr)>, Instant) {
-		// FIXME: optimize
+		// TODO: optimize
 		let now = Instant::now();
 		let now_systime = SystemTime::now();
 		let mut instant = now + Duration::from_secs(3600);
@@ -367,7 +367,7 @@ impl NetTopology {
 					continue;
 				}
 
-				// FIXME: a else block would be better, but we get borrowck errors
+				// TODO: a else block would be better, but we get borrowck errors
 				info_in_store.addrs.push(Addr {
 					addr: addr.clone(),
 					expires: SystemTime::now() + EXPIRATION_PUSH_BACK_CONNEC,
@@ -469,7 +469,7 @@ pub enum DisconnectReason {
 }
 
 fn peer_access<'a>(store: &'a mut FnvHashMap<PeerId, PeerInfo>, peer: &PeerId) -> &'a mut PeerInfo {
-	// FIXME: should be optimizable if HashMap gets a better API
+	// TODO: should be optimizable if HashMap gets a better API
 	store.entry(peer.clone()).or_insert_with(Default::default)
 }
 
@@ -586,7 +586,7 @@ impl Addr {
 }
 
 /// Divides a `Duration` with a `Duration`. This exists in the stdlib but isn't stable yet.
-// FIXME: remove this function once stable
+// TODO: remove this function once stable
 fn div_dur_with_dur(a: Duration, b: Duration) -> u32 {
 	let a_ms = a.as_secs() * 1_000_000 + (a.subsec_nanos() / 1_000) as u64;
 	let b_ms = b.as_secs() * 1_000_000 + (b.subsec_nanos() / 1_000) as u64;
@@ -628,7 +628,7 @@ fn try_load(path: impl AsRef<Path>) -> FnvHashMap<PeerId, PeerInfo> {
 	}
 
 	let mut file = match fs::File::open(path) {
-		// FIXME: the capacity of the BufReader is kind of arbitrary ; decide better
+		// TODO: the capacity of the BufReader is kind of arbitrary ; decide better
 		Ok(f) => BufReader::with_capacity(1024 * 1024, f),
 		Err(err) => {
 			warn!(target: "sub-libp2p", "Failed to open peer storage file: {:?}", err);
@@ -647,7 +647,7 @@ fn try_load(path: impl AsRef<Path>) -> FnvHashMap<PeerId, PeerInfo> {
 	let num_read = match file.read(&mut first_byte) {
 		Ok(f) => f,
 		Err(err) => {
-			// FIXME: DRY
+			// TODO: DRY
 			warn!(target: "sub-libp2p", "Failed to read peer storage file: {:?}", err);
 			info!(target: "sub-libp2p", "Deleting peer storage file {:?}", path);
 			let _ = fs::remove_file(path);

--- a/core/network-libp2p/src/topology.rs
+++ b/core/network-libp2p/src/topology.rs
@@ -58,7 +58,7 @@ const FAIL_BACKOFF_MULTIPLIER: u32 = 2;
 /// We need a maximum value for the backoff, overwise we risk an overflow.
 const MAX_BACKOFF: Duration = Duration::from_secs(30 * 60);
 
-// TODO: should be merged with the Kademlia k-buckets
+// FIXME: should be merged with the Kademlia k-buckets
 
 /// Stores information about the topology of the network.
 #[derive(Debug)]
@@ -111,7 +111,7 @@ impl NetTopology {
 		};
 
 		let file = fs::File::create(path)?;
-		// TODO: the capacity of the BufWriter is kind of arbitrary ; decide better
+		// FIXME: the capacity of the BufWriter is kind of arbitrary ; decide better
 		serialize(BufWriter::with_capacity(1024 * 1024, file), &self.store)
 	}
 
@@ -142,7 +142,7 @@ impl NetTopology {
 		let peer = if let Some(peer) = self.store.get(peer) {
 			peer
 		} else {
-			// TODO: use an EitherIterator or something
+			// FIXME: use an EitherIterator or something
 			return Vec::new().into_iter();
 		};
 
@@ -158,7 +158,7 @@ impl NetTopology {
 			}
 		}).collect::<Vec<_>>();
 		list.sort_by(|a, b| a.0.cmp(&b.0));
-		// TODO: meh, optimize
+		// FIXME: meh, optimize
 		let l = list.into_iter().map(|(_, connec, addr)| (addr, connec)).collect::<Vec<_>>();
 		l.into_iter()
 	}
@@ -171,7 +171,7 @@ impl NetTopology {
 	/// the earlier known time when a new entry will be added automatically to
 	/// the list.
 	pub fn addrs_to_attempt(&self) -> (impl Iterator<Item = (&PeerId, &Multiaddr)>, Instant) {
-		// TODO: optimize
+		// FIXME: optimize
 		let now = Instant::now();
 		let now_systime = SystemTime::now();
 		let mut instant = now + Duration::from_secs(3600);
@@ -367,7 +367,7 @@ impl NetTopology {
 					continue;
 				}
 
-				// TODO: a else block would be better, but we get borrowck errors
+				// FIXME: a else block would be better, but we get borrowck errors
 				info_in_store.addrs.push(Addr {
 					addr: addr.clone(),
 					expires: SystemTime::now() + EXPIRATION_PUSH_BACK_CONNEC,
@@ -469,7 +469,7 @@ pub enum DisconnectReason {
 }
 
 fn peer_access<'a>(store: &'a mut FnvHashMap<PeerId, PeerInfo>, peer: &PeerId) -> &'a mut PeerInfo {
-	// TODO: should be optimizable if HashMap gets a better API
+	// FIXME: should be optimizable if HashMap gets a better API
 	store.entry(peer.clone()).or_insert_with(Default::default)
 }
 
@@ -586,7 +586,7 @@ impl Addr {
 }
 
 /// Divides a `Duration` with a `Duration`. This exists in the stdlib but isn't stable yet.
-// TODO: remove this function once stable
+// FIXME: remove this function once stable
 fn div_dur_with_dur(a: Duration, b: Duration) -> u32 {
 	let a_ms = a.as_secs() * 1_000_000 + (a.subsec_nanos() / 1_000) as u64;
 	let b_ms = b.as_secs() * 1_000_000 + (b.subsec_nanos() / 1_000) as u64;
@@ -628,7 +628,7 @@ fn try_load(path: impl AsRef<Path>) -> FnvHashMap<PeerId, PeerInfo> {
 	}
 
 	let mut file = match fs::File::open(path) {
-		// TODO: the capacity of the BufReader is kind of arbitrary ; decide better
+		// FIXME: the capacity of the BufReader is kind of arbitrary ; decide better
 		Ok(f) => BufReader::with_capacity(1024 * 1024, f),
 		Err(err) => {
 			warn!(target: "sub-libp2p", "Failed to open peer storage file: {:?}", err);
@@ -647,7 +647,7 @@ fn try_load(path: impl AsRef<Path>) -> FnvHashMap<PeerId, PeerInfo> {
 	let num_read = match file.read(&mut first_byte) {
 		Ok(f) => f,
 		Err(err) => {
-			// TODO: DRY
+			// FIXME: DRY
 			warn!(target: "sub-libp2p", "Failed to read peer storage file: {:?}", err);
 			info!(target: "sub-libp2p", "Deleting peer storage file {:?}", path);
 			let _ = fs::remove_file(path);

--- a/core/network-libp2p/src/traits.rs
+++ b/core/network-libp2p/src/traits.rs
@@ -80,7 +80,7 @@ impl NetworkConfiguration {
 			out_peers: 75,
 			reserved_nodes: Vec::new(),
 			non_reserved_mode: NonReservedPeerMode::Accept,
-			client_version: "Parity-network".into(),		// FIXME: meh
+			client_version: "Parity-network".into(),		// TODO: meh
 		}
 	}
 

--- a/core/network-libp2p/src/traits.rs
+++ b/core/network-libp2p/src/traits.rs
@@ -80,7 +80,7 @@ impl NetworkConfiguration {
 			out_peers: 75,
 			reserved_nodes: Vec::new(),
 			non_reserved_mode: NonReservedPeerMode::Accept,
-			client_version: "Parity-network".into(),		// TODO: meh
+			client_version: "Parity-network".into(),		// FIXME: meh
 		}
 	}
 

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -75,7 +75,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 		if roles.intersects(Roles::AUTHORITY) {
 			trace!(target:"gossip", "Registering {:?} {}", roles, who);
 			// Send out all known messages to authorities.
-			// TODO: limit by size
+			// FIXME: limit by size
 			let mut known_messages = HashSet::new();
 			for entry in self.messages.iter() {
 				known_messages.insert((entry.topic, entry.message_hash));

--- a/core/network/src/on_demand.rs
+++ b/core/network/src/on_demand.rs
@@ -213,7 +213,7 @@ impl<B, E> OnDemandService<B> for OnDemand<B, E> where
 	B::Header: HeaderT,
 {
 	fn on_connect(&self, peer: NodeIndex, role: Roles, best_number: NumberFor<B>) {
-		if !role.intersects(Roles::FULL | Roles::AUTHORITY) { // TODO: correct?
+		if !role.intersects(Roles::FULL | Roles::AUTHORITY) { // FIXME: correct?
 			return;
 		}
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -357,7 +357,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			message::FromBlock::Number(n) => BlockId::Number(n),
 		};
 		let max = cmp::min(request.max.unwrap_or(u32::max_value()), MAX_BLOCK_DATA_RESPONSE) as usize;
-		// TODO: receipts, etc.
+		// FIXME: receipts, etc.
 		let get_header = request.fields.contains(message::BlockAttributes::HEADER);
 		let get_body = request.fields.contains(message::BlockAttributes::BODY);
 		let get_justification = request.fields.contains(message::BlockAttributes::JUSTIFICATION);
@@ -396,7 +396,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	}
 
 	fn on_block_response(&self, io: &mut SyncIo, peer: NodeIndex, request: message::BlockRequest<B>, response: message::BlockResponse<B>) {
-		// TODO: validate response
+		// FIXME: validate response
 		let blocks_range = match (
 				response.blocks.first().and_then(|b| b.header.as_ref().map(|h| h.number())),
 				response.blocks.last().and_then(|b| b.header.as_ref().map(|h| h.number())),

--- a/core/primitives/src/changes_trie.rs
+++ b/core/primitives/src/changes_trie.rs
@@ -49,7 +49,7 @@ impl ChangesTrieConfiguration {
 			return 1;
 		}
 
-		// TODO: use saturating_pow when available
+		// FIXME: use saturating_pow when available
 		let mut max_digest_interval = self.digest_interval;
 		for _ in 1..self.digest_levels {
 			max_digest_interval = match max_digest_interval.checked_mul(self.digest_interval) {

--- a/core/primitives/src/ed25519.rs
+++ b/core/primitives/src/ed25519.rs
@@ -240,7 +240,7 @@ impl Pair {
 	}
 
 	/// Derive a child key. Probably unsafe and broken.
-	// TODO: proper HD derivation https://cardanolaunch.com/assets/Ed25519_BIP.pdf
+	// FIXME: proper HD derivation https://cardanolaunch.com/assets/Ed25519_BIP.pdf
 	pub fn derive_child_probably_bad(&self, chain_data: &[u8]) -> Pair {
 		let sig = self.sign(chain_data);
 		let mut seed = [0u8; 32];

--- a/core/rpc/src/chain/number.rs
+++ b/core/rpc/src/chain/number.rs
@@ -41,7 +41,7 @@ impl<Number: traits::As<u64>> NumberOrHex<Number> {
 		match self {
 			NumberOrHex::Number(n) => Ok(n),
 			NumberOrHex::Hex(h) => {
-				// TODO [ToDr] this only supports `u64` since `BlockNumber` is `As<u64>` we could possibly go with `u128`. (#1377)
+				// FIXME [ToDr] this only supports `u64` since `BlockNumber` is `As<u64>` we could possibly go with `u128`. (#1377)
 				let l = h.low_u64();
 				if U256::from(l) != h {
 					Err(format!("`{}` does not fit into the block number type.", h))

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -233,7 +233,7 @@ impl<C: Components> MaintainTransactionPool<Self> for C where
 	ComponentClient<C>: ProvideRuntimeApi<Api = C::RuntimeApi>,
 	C::RuntimeApi: TaggedTransactionQueue<ComponentBlock<C>>,
 {
-	// TODO [ToDr] Optimize and re-use tags from the pool.
+	// FIXME [ToDr] Optimize and re-use tags from the pool.
 	fn on_block_imported(
 		id: &BlockId<ComponentBlock<C>>,
 		client: &ComponentClient<C>,
@@ -283,7 +283,7 @@ pub trait ServiceFactory: 'static + Sized {
 	/// ImportQueue for light clients
 	type LightImportQueue: consensus_common::import_queue::ImportQueue<Self::Block> + 'static;
 
-	//TODO: replace these with a constructor trait. that TransactionPool implements. (#1242)
+	//FIXME: replace these with a constructor trait. that TransactionPool implements. (#1242)
 	/// Extrinsic pool constructor for the full client.
 	fn build_full_transaction_pool(config: TransactionPoolOptions, client: Arc<FullClient<Self>>)
 		-> Result<TransactionPool<Self::FullTransactionPoolApi>, error::Error>;
@@ -345,7 +345,7 @@ pub trait Components: Sized + 'static {
 	type RuntimeApi: Send + Sync;
 	/// A type that can start the RPC.
 	type RPC: StartRPC<Self>;
-	// TODO [ToDr] Traitify transaction pool and allow people to implement their own. (#1242)
+	// FIXME [ToDr] Traitify transaction pool and allow people to implement their own. (#1242)
 	/// A type that can maintain transaction pool.
 	type TransactionPool: MaintainTransactionPool<Self>;
 	/// Extrinsic pool type.

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -226,7 +226,7 @@ impl<Components: components::Components> Service<Components> {
 			// extrinsic notifications
 			let network = Arc::downgrade(&network);
 			let events = transaction_pool.import_notification_stream()
-				// TODO [ToDr] Consider throttling?
+				// FIXME [ToDr] Consider throttling?
 				.for_each(move |_| {
 					if let Some(network) = network.upgrade() {
 						network.trigger_repropagate();

--- a/core/sr-io/with_std.rs
+++ b/core/sr-io/with_std.rs
@@ -37,7 +37,7 @@ use primitives::hexdisplay::HexDisplay;
 use primitives::H256;
 use hash_db::Hasher;
 
-// TODO: use the real error, not NoError.
+// FIXME: use the real error, not NoError.
 
 environmental!(ext: trait Externalities<Blake2Hasher>);
 

--- a/core/sr-io/without_std.rs
+++ b/core/sr-io/without_std.rs
@@ -315,7 +315,7 @@ pub fn trie_root<
 	B: AsRef<[u8]>,
 >(_input: I) -> [u8; 32] {
 	unimplemented!()
-	// TODO Maybe implement (though probably easier/cleaner to have blake2 be the only thing
+	// FIXME Maybe implement (though probably easier/cleaner to have blake2 be the only thing
 	// implemneted natively and compile the trie logic as wasm).
 }
 
@@ -326,7 +326,7 @@ pub fn ordered_trie_root<
 	A: AsRef<[u8]>
 >(_input: I) -> [u8; 32] {
 	unimplemented!()
-	// TODO Maybe implement (though probably easier/cleaner to have blake2 be the only thing
+	// FIXME Maybe implement (though probably easier/cleaner to have blake2 be the only thing
 	// implemneted natively and compile the trie logic as wasm).
 }
 

--- a/core/sr-primitives/src/generic/unchecked_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_extrinsic.rs
@@ -156,7 +156,7 @@ impl<Address: Codec, Index: HasCompact + Codec, Signature: Codec, Call: Encode> 
 	}
 }
 
-/// TODO: use derive when possible.
+/// FIXME: use derive when possible.
 #[cfg(feature = "std")]
 impl<Address, Index, Signature, Call> fmt::Debug
 	for UncheckedExtrinsic<Address, Index, Call, Signature>

--- a/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
@@ -168,7 +168,7 @@ impl<Address: Encode, Index, Signature: Encode, Call: Encode> serde::Serialize
 	}
 }
 
-/// TODO: use derive when possible.
+/// FIXME: use derive when possible.
 #[cfg(feature = "std")]
 impl<Address, Index, Call, Signature> fmt::Debug for UncheckedMortalCompactExtrinsic<Address, Index, Call, Signature> where
 	Address: fmt::Debug,

--- a/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
@@ -166,7 +166,7 @@ impl<Address: Encode, Index: Encode, Signature: Encode, Call: Encode> serde::Ser
 	}
 }
 
-/// TODO: use derive when possible.
+/// FIXME: use derive when possible.
 #[cfg(feature = "std")]
 impl<Address, Index, Call, Signature> fmt::Debug for UncheckedMortalExtrinsic<Address, Index, Call, Signature> where
 	Address: fmt::Debug,

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -116,10 +116,10 @@ impl BuildStorage for StorageMap {
 #[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq)]
 pub struct Permill(u32);
 
-// TODO: impl Mul<Permill> for N where N: As<usize>
+// FIXME: impl Mul<Permill> for N where N: As<usize>
 impl Permill {
 	pub fn times<N: traits::As<u64> + ::rstd::ops::Mul<N, Output=N> + ::rstd::ops::Div<N, Output=N>>(self, b: N) -> N {
-		// TODO: handle overflows
+		// FIXME: handle overflows
 		b * <N as traits::As<u64>>::sa(self.0 as u64) / <N as traits::As<u64>>::sa(1000000)
 	}
 
@@ -151,11 +151,11 @@ impl From<f32> for Permill {
 #[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq)]
 pub struct Perbill(u32);
 
-// TODO: impl Mul<Perbill> for N where N: As<usize>
+// FIXME: impl Mul<Perbill> for N where N: As<usize>
 impl Perbill {
 	/// Attenuate `b` by self.
 	pub fn times<N: traits::As<u64> + ::rstd::ops::Mul<N, Output=N> + ::rstd::ops::Div<N, Output=N>>(self, b: N) -> N {
-		// TODO: handle overflows
+		// FIXME: handle overflows
 		b * <N as traits::As<u64>>::sa(self.0 as u64) / <N as traits::As<u64>>::sa(1_000_000_000)
 	}
 
@@ -474,7 +474,7 @@ macro_rules! impl_outer_log {
 	};
 }
 
-//TODO: https://github.com/paritytech/substrate/issues/1022
+//FIXME: https://github.com/paritytech/substrate/issues/1022
 /// Basic Inherent data to include in a block; used by simple runtimes.
 #[derive(Encode, Decode)]
 pub struct BasicInherentData {
@@ -497,7 +497,7 @@ impl BasicInherentData {
 	}
 }
 
-//TODO: https://github.com/paritytech/substrate/issues/1022
+//FIXME: https://github.com/paritytech/substrate/issues/1022
 /// Error type used while checking inherents.
 #[derive(Encode)]
 #[cfg_attr(feature = "std", derive(Decode))]
@@ -576,7 +576,7 @@ mod tests {
 		pub enum RawLog<AuthorityId> { B1(AuthorityId), B2(AuthorityId) }
 	}
 
-	// TODO try to avoid redundant brackets: a(AuthoritiesChange), b
+	// FIXME try to avoid redundant brackets: a(AuthoritiesChange), b
 	impl_outer_log! {
 		pub enum Log(InternalLog: DigestItem<H256, u64>) for Runtime {
 			a(AuthoritiesChange), b()

--- a/core/state-db/src/noncanonical.rs
+++ b/core/state-db/src/noncanonical.rs
@@ -220,7 +220,7 @@ impl<BlockHash: Hash, Key: Hash> NonCanonicalOverlay<BlockHash, Key> {
 				commit.data.inserted = self.last_canonicalized_overlay.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 				commit.data.deleted = overlay.deleted;
 			} else {
-				// TODO: borrow checker won't allow us to split out mutable references
+				// FIXME: borrow checker won't allow us to split out mutable references
 				// required for recursive processing. A more efficient implementation
 				// that does not require converting to vector is possible
 				let mut vec: Vec<_> = self.levels.drain(..).collect();

--- a/core/state-machine/src/backend.rs
+++ b/core/state-machine/src/backend.rs
@@ -118,7 +118,7 @@ impl<H: Hasher> Consolidate for MemoryDB<H> {
 }
 
 /// Error impossible.
-// TODO: use `!` type when stabilized.
+// FIXME: use `!` type when stabilized.
 #[derive(Debug)]
 pub enum Void {}
 
@@ -291,7 +291,7 @@ impl<H: Hasher> Backend<H> for InMemory<H> where H::Out: HeapSizeOf {
 	}
 
 	fn try_into_trie_backend(self) -> Option<TrieBackend<Self::TrieBackendStorage, H>> {
-		let mut mdb = MemoryDB::default();	// TODO: should be more correct and use ::new()
+		let mut mdb = MemoryDB::default();	// FIXME: should be more correct and use ::new()
 		let mut root = None;
 		for (storage_key, map) in self.inner {
 			if storage_key != None {

--- a/core/state-machine/src/changes_trie/changes_iterator.rs
+++ b/core/state-machine/src/changes_trie/changes_iterator.rs
@@ -102,7 +102,7 @@ pub fn key_changes_proof_check<S: RootsStorage<H>, H: Hasher>(
 	max: u64,
 	key: &[u8]
 ) -> Result<Vec<(u64, u32)>, String> where H::Out: HeapSizeOf {
-	let mut proof_db = MemoryDB::<H>::default();	// TODO: use new for correctness
+	let mut proof_db = MemoryDB::<H>::default();	// FIXME: use new for correctness
 	for item in proof {
 		proof_db.insert(&item);
 	}

--- a/core/state-machine/src/changes_trie/prune.rs
+++ b/core/state-machine/src/changes_trie/prune.rs
@@ -46,7 +46,7 @@ pub fn prune<S: Storage<H>, H: Hasher, F: FnMut(H::Out)>(
 	};
 
 	// delete changes trie for every block in range
-	// TODO: limit `max_digest_interval` so that this cycle won't involve huge ranges
+	// FIXME: limit `max_digest_interval` so that this cycle won't involve huge ranges
 	for block in first..last+1 {
 		let root = match storage.root(current_block, block) {
 			Ok(Some(root)) => root,

--- a/core/state-machine/src/ext.rs
+++ b/core/state-machine/src/ext.rs
@@ -302,7 +302,7 @@ where
 		);
 		let root_and_tx = root_and_tx.map(|(root, changes)| {
 			let mut calculated_root = Default::default();
-			let mut mdb = MemoryDB::default();	// TODO: use new for correctness
+			let mut mdb = MemoryDB::default();	// FIXME: use new for correctness
 			{
 				let mut trie = TrieDBMut::<H>::new(&mut mdb, &mut calculated_root);
 				for (key, value) in changes {

--- a/core/state-machine/src/proving_backend.rs
+++ b/core/state-machine/src/proving_backend.rs
@@ -195,7 +195,7 @@ where
 	H: Hasher,
 	H::Out: HeapSizeOf,
 {
-	let mut db = MemoryDB::default();	// TODO: use new for correctness
+	let mut db = MemoryDB::default();	// FIXME: use new for correctness
 	for item in proof {
 		db.insert(&item);
 	}

--- a/core/state-machine/src/trie_backend.rs
+++ b/core/state-machine/src/trie_backend.rs
@@ -82,7 +82,7 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 	}
 
 	fn pairs(&self) -> Vec<(Vec<u8>, Vec<u8>)> {
-		let mut read_overlay = MemoryDB::default();	// TODO: use new for correctness
+		let mut read_overlay = MemoryDB::default();	// FIXME: use new for correctness
 		let eph = Ephemeral::new(self.essence.backend_storage(), &mut read_overlay);
 
 		let collect_all = || -> Result<_, Box<TrieError<H::Out>>> {
@@ -106,7 +106,7 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 	}
 
 	fn keys(&self, prefix: &Vec<u8>) -> Vec<Vec<u8>> {
-		let mut read_overlay = MemoryDB::default();	// TODO: use new for correctness
+		let mut read_overlay = MemoryDB::default();	// FIXME: use new for correctness
 		let eph = Ephemeral::new(self.essence.backend_storage(), &mut read_overlay);
 
 		let collect_all = || -> Result<_, Box<TrieError<H::Out>>> {
@@ -193,7 +193,7 @@ pub mod tests {
 
 	fn test_db() -> (MemoryDB<Blake2Hasher>, H256) {
 		let mut root = H256::default();
-		let mut mdb = MemoryDB::<Blake2Hasher>::default();	// TODO: use new() to be more correct
+		let mut mdb = MemoryDB::<Blake2Hasher>::default();	// FIXME: use new() to be more correct
 		{
 			let mut trie = TrieDBMut::new(&mut mdb, &mut root);
 			trie.insert(b"key", b"value").expect("insert failed");
@@ -230,7 +230,7 @@ pub mod tests {
 	#[test]
 	fn pairs_are_empty_on_empty_storage() {
 		assert!(TrieBackend::<MemoryDB<Blake2Hasher>, Blake2Hasher>::new(
-			MemoryDB::default(),	// TODO: use new() to be more correct
+			MemoryDB::default(),	// FIXME: use new() to be more correct
 			Default::default(),
 		).pairs().is_empty());
 	}

--- a/core/state-machine/src/trie_backend_essence.rs
+++ b/core/state-machine/src/trie_backend_essence.rs
@@ -176,7 +176,7 @@ impl<'a,
 	where H::Out: HeapSizeOf
 {
 	fn keys(&self) -> HashMap<H::Out, i32> {
-		self.overlay.keys() // TODO: iterate backing
+		self.overlay.keys() // FIXME: iterate backing
 	}
 
 	fn get(&self, key: &H::Out) -> Option<DBValue> {

--- a/core/test-client/src/lib.rs
+++ b/core/test-client/src/lib.rs
@@ -49,7 +49,7 @@ use keyring::Keyring;
 mod local_executor {
 	#![allow(missing_docs)]
 	use super::runtime;
-	// TODO: change the macro and pass in the `BlakeHasher` that dispatch needs from here instead
+	// FIXME: change the macro and pass in the `BlakeHasher` that dispatch needs from here instead
 	native_executor_instance!(pub LocalExecutor, runtime::api::dispatch, runtime::native_version, include_bytes!("../../test-runtime/wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm"));
 }
 

--- a/core/transaction-pool/graph/src/lib.rs
+++ b/core/transaction-pool/graph/src/lib.rs
@@ -21,7 +21,7 @@
 //! The pool is able to return an iterator that traverses transaction
 //! graph in the correct order taking into account priorities and dependencies.
 //!
-//! TODO [ToDr]
+//! FIXME [ToDr]
 //! - [ ] Multi-threading (getting ready transactions should not block the pool)
 
 #![warn(missing_docs)]

--- a/core/transaction-pool/graph/src/pool.rs
+++ b/core/transaction-pool/graph/src/pool.rs
@@ -226,7 +226,7 @@ impl<B: ChainApi> Pool<B> {
 
 impl<B: ChainApi> Pool<B> {
 	/// Create a new transaction pool.
-	/// TODO [ToDr] Options
+	/// FIXME [ToDr] Options
 	pub fn new(_options: Options, api: B) -> Self {
 		Pool {
 			api,

--- a/core/transaction-pool/src/api.rs
+++ b/core/transaction-pool/src/api.rs
@@ -67,7 +67,7 @@ impl<T, Block> txpool::ChainApi for ChainApi<T, Block> where
 		Ok(self.client.runtime_api().validate_transaction(at, uxt)?)
 	}
 
-	// TODO [toDr] Use proper lbock number type
+	// FIXME [toDr] Use proper lbock number type
 	fn block_id_to_number(&self, at: &BlockId<Self::Block>) -> error::Result<Option<txpool::NumberFor<Self>>> {
 		Ok(self.client.block_number_from_id(at)?)
 	}

--- a/core/trie/src/lib.rs
+++ b/core/trie/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
 
-// TODO: no_std
+// FIXME: no_std
 
 extern crate trie_root;
 extern crate parity_codec as codec;
@@ -85,7 +85,7 @@ pub fn delta_trie_root<H: Hasher, I, A, B>(db: &mut HashDB<H>, mut root: H::Out,
 		for (key, change) in delta {
 			match change {
 				Some(val) => trie.insert(key.as_ref(), val.as_ref())?,
-				None => trie.remove(key.as_ref())?, // TODO: archive mode
+				None => trie.remove(key.as_ref())?, // FIXME: archive mode
 			};
 		}
 	}
@@ -164,7 +164,7 @@ pub fn child_delta_trie_root<H: Hasher, I, A, B>(_storage_key: &[u8], db: &mut H
 		for (key, change) in delta {
 			match change {
 				Some(val) => trie.insert(key.as_ref(), val.as_ref())?,
-				None => trie.remove(key.as_ref())?, // TODO: archive mode
+				None => trie.remove(key.as_ref())?, // FIXME: archive mode
 			};
 		}
 	}

--- a/core/trie/src/node_codec.rs
+++ b/core/trie/src/node_codec.rs
@@ -95,14 +95,14 @@ impl<H: Hasher> trie_db::NodeCodec<H> for NodeCodec<H> {
 		vec![EMPTY_TRIE]
 	}
 
-	// TODO: refactor this so that `partial` isn't already encoded with HPE. Should just be an `impl Iterator<Item=u8>`.
+	// FIXME: refactor this so that `partial` isn't already encoded with HPE. Should just be an `impl Iterator<Item=u8>`.
 	fn leaf_node(partial: &[u8], value: &[u8]) -> Vec<u8> {
 		let mut output = partial_to_key(partial, LEAF_NODE_OFFSET, LEAF_NODE_BIG);
 		value.encode_to(&mut output);
 		output
 	}
 
-	// TODO: refactor this so that `partial` isn't already encoded with HPE. Should just be an `impl Iterator<Item=u8>`.
+	// FIXME: refactor this so that `partial` isn't already encoded with HPE. Should just be an `impl Iterator<Item=u8>`.
 	fn ext_node(partial: &[u8], child: ChildReference<H::Out>) -> Vec<u8> {
 		let mut output = partial_to_key(partial, EXTENSION_NODE_OFFSET, EXTENSION_NODE_BIG);
 		match child {

--- a/core/trie/src/trie_stream.rs
+++ b/core/trie/src/trie_stream.rs
@@ -94,7 +94,7 @@ impl trie_root::TrieStream for TrieStream {
 			_ => {
 //				println!("[append_substream] would have hashed, because data.len() = {}", data.len());
 //				data.encode_to(&mut self.buffer)
-				// TODO: re-enable hashing before merging
+				// FIXME: re-enable hashing before merging
 				H::hash(&data).as_ref().encode_to(&mut self.buffer)
 			}
 		}

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -57,7 +57,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
-			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),    // TODO change
+			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),    // FIXME change
 			authorities: initial_authorities.clone(),
 		}),
 		system: None,

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -168,7 +168,7 @@ fn run_until_exit<T, C, E>(
 	let _telemetry = service.telemetry();
 	drop(service);
 
-	// TODO [andre]: timeout this future #1318
+	// FIXME [andre]: timeout this future #1318
 	let _ = runtime.shutdown_on_idle().wait();
 
 	Ok(())

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -135,7 +135,7 @@ impl<T: Trait> Module<T> {
 
 	/// Verify an inherent slot that is used in a block seal against a timestamp
 	/// extracted from the block.
-	// TODO: ensure `ProvideInherent` can deal with dependencies like this.
+	// FIXME: ensure `ProvideInherent` can deal with dependencies like this.
 	// https://github.com/paritytech/substrate/issues/1228
 	pub fn verify_inherent(timestamp: T::Moment, seal_slot: u64) -> Result {
 		let timestamp_based_slot = timestamp.as_() / Self::slot_duration();

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -399,7 +399,7 @@ impl<T: Trait> Module<T> {
 		// account is reaped).
 		// NOTE: This is orthogonal to the `Bondage` value that an account has, a high
 		// value of which makes even the `free_balance` unspendable.
-		// TODO: enforce this for the other balance-altering functions.
+		// FIXME: enforce this for the other balance-altering functions.
 		if balance < ed {
 			Self::set_free_balance(who, balance);
 			UpdateBalanceOutcome::AccountKilled

--- a/srml/consensus/src/lib.rs
+++ b/srml/consensus/src/lib.rs
@@ -199,7 +199,7 @@ decl_module! {
 		/// Report some misbehaviour.
 		fn report_misbehavior(origin, _report: Vec<u8>) {
 			ensure_signed(origin)?;
-			// TODO: requires extension trait.
+			// FIXME: requires extension trait.
 		}
 
 		/// Note the previous block's validator missed their opportunity to propose a block.

--- a/srml/contract/src/exec.rs
+++ b/srml/contract/src/exec.rs
@@ -23,12 +23,12 @@ use rstd::prelude::*;
 use runtime_primitives::traits::{Zero, CheckedAdd, CheckedSub};
 use balances::{self, EnsureAccountLiquid};
 
-// TODO: Add logs
+// FIXME: Add logs
 pub struct CreateReceipt<T: Trait> {
 	pub address: T::AccountId,
 }
 
-// TODO: Add logs.
+// FIXME: Add logs.
 pub struct CallReceipt;
 
 pub struct ExecutionContext<'a, T: Trait + 'a> {

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -147,7 +147,7 @@ decl_module! {
 	/// Contracts module.
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event<T>() = default;
-		// TODO: Change AccountId to staking::Address
+		// FIXME: Change AccountId to staking::Address
 		/// Make a call to a specified account, optionally transferring some balance.
 		/// Make a call to a specified account, optionally transferring some balance.
 		fn call(
@@ -290,16 +290,16 @@ decl_storage! {
 		/// Current cost schedule for contracts.
 		CurrentSchedule get(current_schedule) config(): Schedule<T::Gas> = Schedule::default();
 		/// The code associated with an account.
-		pub CodeOf: map T::AccountId => Vec<u8>;	// TODO Vec<u8> values should be optimised to not do a length prefix.
+		pub CodeOf: map T::AccountId => Vec<u8>;	// FIXME Vec<u8> values should be optimised to not do a length prefix.
 	}
 }
 
-// TODO: consider storing upper-bound for contract's gas limit in fixed-length runtime
+// FIXME: consider storing upper-bound for contract's gas limit in fixed-length runtime
 // code in contract itself and use that.
 
 /// The storage items associated with an account/key.
 ///
-/// TODO: keys should also be able to take AsRef<KeyType> to ensure Vec<u8>s can be passed as &[u8]
+/// FIXME: keys should also be able to take AsRef<KeyType> to ensure Vec<u8>s can be passed as &[u8]
 pub(crate) struct StorageOf<T>(::rstd::marker::PhantomData<T>);
 impl<T: Trait> StorageDoubleMap for StorageOf<T> {
 	const PREFIX: &'static [u8] = b"con:sto:";

--- a/srml/contract/src/vm/mod.rs
+++ b/srml/contract/src/vm/mod.rs
@@ -225,7 +225,7 @@ mod tests {
 				gas_left: gas_meter.gas_left(),
 			});
 			// Assume for now that it was just a plain transfer.
-			// TODO: Add tests for different call outcomes.
+			// FIXME: Add tests for different call outcomes.
 			Ok(())
 		}
 		fn caller(&self) -> &u64 {

--- a/srml/contract/src/vm/runtime.rs
+++ b/srml/contract/src/vm/runtime.rs
@@ -159,7 +159,7 @@ fn write_sandbox_memory<T: Trait>(
 // * AFTER MAKING A CHANGE MAKE SURE TO UPDATE COMPLEXITY.MD *
 // ***********************************************************
 
-// TODO: ext_balance, ext_address, ext_callvalue, etc.
+// FIXME: ext_balance, ext_address, ext_callvalue, etc.
 
 // Define a function `fn init_env<E: Ext>() -> HostFunctionSet<E>` that returns
 // a function set which can be imported by an executed contract.

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -181,7 +181,7 @@ decl_module! {
 		/// Report some misbehaviour.
 		fn report_misbehavior(origin, _report: Vec<u8>) {
 			ensure_signed(origin)?;
-			// TODO: https://github.com/paritytech/substrate/issues/1112
+			// FIXME: https://github.com/paritytech/substrate/issues/1112
 		}
 
 		fn on_finalise(block_number: T::BlockNumber) {
@@ -259,7 +259,7 @@ impl<T: Trait> Module<T> where Ed25519AuthorityId: core::convert::From<<T as Tra
 /// sets should be.
 pub struct SyncedAuthorities<T>(::rstd::marker::PhantomData<T>);
 
-// TODO: remove when https://github.com/rust-lang/rust/issues/26925 is fixed
+// FIXME: remove when https://github.com/rust-lang/rust/issues/26925 is fixed
 impl<T> Default for SyncedAuthorities<T> {
 	fn default() -> Self {
 		SyncedAuthorities(::rstd::marker::PhantomData)

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -140,7 +140,7 @@ decl_storage! {
 impl<T: Trait> Module<T> {
 	/// The number of validators currently.
 	pub fn validator_count() -> u32 {
-		<Validators<T>>::get().len() as u32	// TODO: can probably optimised
+		<Validators<T>>::get().len() as u32	// FIXME: can probably optimised
 	}
 
 	/// The last length change, if there was one, zero if not.
@@ -160,7 +160,7 @@ impl<T: Trait> Module<T> {
 	/// Called by `staking::new_era()` only. `next_session` should be called after this in order to
 	/// update the session keys to the next validator set.
 	pub fn set_validators(new: &[T::AccountId]) {
-		<Validators<T>>::put(&new.to_vec());			// TODO: optimise.
+		<Validators<T>>::put(&new.to_vec());			// FIXME: optimise.
 		<consensus::Module<T>>::set_authorities(
 			&new.iter().cloned().map(T::ConvertAccountIdToSessionKey::convert).collect::<Vec<_>>()
 		);

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -72,7 +72,7 @@ pub enum LockStatus<BlockNumber: Parameter> {
 /// Preference of what happens on a slash event.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct ValidatorPrefs<Balance: HasCompact + Copy> { // TODO: @bkchr shouldn't need this Copy but derive(Encode) breaks otherwise
+pub struct ValidatorPrefs<Balance: HasCompact + Copy> { // FIXME: @bkchr shouldn't need this Copy but derive(Encode) breaks otherwise
 	/// Validator should ensure this many more slashes than is necessary before being unstaked.
 	#[codec(compact)]
 	pub unstake_threshold: u32,
@@ -362,7 +362,7 @@ impl<T: Trait> Module<T> {
 			let noms = Self::current_nominators_for(v);
 			let total = noms.iter().map(<balances::Module<T>>::total_balance).fold(T::Balance::zero(), |acc, x| acc + x);
 			if !total.is_zero() {
-				let safe_mul_rational = |b| b * rem / total;// TODO: avoid overflow
+				let safe_mul_rational = |b| b * rem / total;// FIXME: avoid overflow
 				for n in noms.iter() {
 					let _ = <balances::Module<T>>::slash(n, safe_mul_rational(<balances::Module<T>>::total_balance(n)));	// best effort - not much that can be done on fail.
 				}
@@ -383,7 +383,7 @@ impl<T: Trait> Module<T> {
 				.map(<balances::Module<T>>::total_balance)
 				.fold(<balances::Module<T>>::total_balance(who), |acc, x| acc + x)
 				.max(One::one());
-			let safe_mul_rational = |b| b * reward / total;// TODO: avoid overflow
+			let safe_mul_rational = |b| b * reward / total;// FIXME: avoid overflow
 			for n in noms.iter() {
 				let _ = <balances::Module<T>>::reward(n, safe_mul_rational(<balances::Module<T>>::total_balance(n)));
 			}
@@ -461,7 +461,7 @@ impl<T: Trait> Module<T> {
 		// combination of validators, then use session::internal::set_validators().
 		// for now, this just orders would-be stakers by their balances and chooses the top-most
 		// <ValidatorCount<T>>::get() of them.
-		// TODO: this is not sound. this should be moved to an off-chain solution mechanism.
+		// FIXME: this is not sound. this should be moved to an off-chain solution mechanism.
 		let mut intentions = Self::intentions()
 			.into_iter()
 			.map(|v| (Self::slashable_balance(&v), v))

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -416,7 +416,7 @@ fn nominating_slashes_should_work() {
 		assert_eq!(Balances::total_balance(&2), 20);		//not slashed
 		assert_eq!(Balances::total_balance(&3), 10);		//slashed
 		assert_eq!(Balances::total_balance(&4), 30);		//slashed
-		// TODO: change slash % to something sensible.
+		// FIXME: change slash % to something sensible.
 	});
 }
 

--- a/srml/support/procedural/src/storage/mod.rs
+++ b/srml/support/procedural/src/storage/mod.rs
@@ -74,7 +74,7 @@ struct AddExtraGenesisLine {
 	pub extra_field: ext::Parens<Ident>,
 	pub coldot_token: Token![:],
 	pub extra_type: syn::Type,
-	// TODO use a custom ext::Option instead (syn option on '=' fails)
+	// FIXME use a custom ext::Option instead (syn option on '=' fails)
 	pub default_value: ext::Seq<DeclStorageDefault>,
 }
 
@@ -91,7 +91,7 @@ struct DeclStorageLine {
 	pub build: Option<DeclStorageBuild>,
 	pub coldot_token: Token![:],
 	pub storage_type: DeclStorageType,
-	// TODO use a custom ext::Option instead (syn option on '=' fails)
+	// FIXME use a custom ext::Option instead (syn option on '=' fails)
 	pub default_value: ext::Seq<DeclStorageDefault>,
 }
 

--- a/srml/support/procedural/tools/src/lib.rs
+++ b/srml/support/procedural/tools/src/lib.rs
@@ -57,7 +57,7 @@ macro_rules! custom_keyword {
 }
 
 
-// TODO following functions are copied from sr-api-macros : do a merge to get a unique procedural
+// FIXME following functions are copied from sr-api-macros : do a merge to get a unique procedural
 // macro tooling crate (this crate path does not look good for it)
 
 use proc_macro2::{TokenStream, Span};

--- a/srml/support/src/dispatch.rs
+++ b/srml/support/src/dispatch.rs
@@ -449,7 +449,7 @@ macro_rules! decl_module {
 		// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
 		#[derive(Clone, Copy, PartialEq, Eq)]
 		#[cfg_attr(feature = "std", derive(Debug))]
-		// TODO: switching based on std feature is because of an issue in
+		// FIXME: switching based on std feature is because of an issue in
 		// serde-derive for when we attempt to derive `Deserialize` on these types,
 		// in a situation where we've imported `srml_support` as another name.
 		#[cfg(feature = "std")]

--- a/srml/support/src/storage/generator.rs
+++ b/srml/support/src/storage/generator.rs
@@ -194,7 +194,7 @@ pub trait StorageMap<K: codec::Codec, V: codec::Codec> {
 	fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: Storage>(key: &K, f: F, storage: &S) -> R;
 }
 
-// TODO: Remove this in favour of `decl_storage` macro.
+// FIXME: Remove this in favour of `decl_storage` macro.
 /// Declares strongly-typed wrappers around codec-compatible types in storage.
 #[macro_export]
 macro_rules! storage_items {
@@ -445,7 +445,7 @@ macro_rules! __storage_items_internal {
 			}
 
 			/// Get the key used to put the length field.
-			// TODO: concat macro should accept byte literals.
+			// FIXME: concat macro should accept byte literals.
 			fn len_key() -> $crate::rstd::vec::Vec<u8> {
 				let mut key = $prefix.to_vec();
 				key.extend(b"len");
@@ -513,7 +513,7 @@ macro_rules! __handle_wrap_internal {
 	};
 }
 
-// TODO: revisit this idiom once we get `type`s in `impl`s.
+// FIXME: revisit this idiom once we get `type`s in `impl`s.
 /*impl<T: Trait> Module<T> {
 	type Now = super::Now<T>;
 }*/

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -24,7 +24,7 @@ use codec::{Codec, Decode, KeyedVec, Input};
 #[macro_use]
 pub mod generator;
 
-// TODO: consider using blake256 to avoid possible preimage attack.
+// FIXME: consider using blake256 to avoid possible preimage attack.
 
 struct IncrementalInput<'a> {
 	key: &'a [u8],

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -321,9 +321,9 @@ impl<T: Trait> Module<T> {
 	#[cfg(any(feature = "std", test))]
 	pub fn externalities() -> TestExternalities<Blake2Hasher> {
 		TestExternalities::new(map![
-			twox_128(&<BlockHash<T>>::key_for(T::BlockNumber::zero())).to_vec() => [69u8; 32].encode(),	// TODO: replace with Hash::default().encode
+			twox_128(&<BlockHash<T>>::key_for(T::BlockNumber::zero())).to_vec() => [69u8; 32].encode(),	// FIXME: replace with Hash::default().encode
 			twox_128(<Number<T>>::key()).to_vec() => T::BlockNumber::one().encode(),
-			twox_128(<ParentHash<T>>::key()).to_vec() => [69u8; 32].encode(),	// TODO: replace with Hash::default().encode
+			twox_128(<ParentHash<T>>::key()).to_vec() => [69u8; 32].encode(),	// FIXME: replace with Hash::default().encode
 			twox_128(<RandomSeed<T>>::key()).to_vec() => T::Hash::default().encode()
 		])
 	}


### PR DESCRIPTION
Clean up the substrate code base as per our latest rule:
 - no FIXME without the link to corresponding issue, explaining what is missing for an implementation here
 - replace all TODO with either FIXME as prior rule or convert into a proper ticket, if it is just a future task, and remove the comment.

Tracking.