### PR TITLE
Document how to build substrate on Windows (#1343)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -178,6 +178,9 @@ build it. Ensure you have Rust and the support software installed:
 [source, shell]
 ----
 curl https://sh.rustup.rs -sSf | sh
+# on Windows download and run rustup-init.exe
+# from https://rustup.rs instead
+
 rustup update nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 rustup update stable
@@ -193,6 +196,28 @@ sudo apt install cmake pkg-config libssl-dev git clang libclang-dev
  - Mac:
 [source, shell]
 brew install cmake pkg-config openssl git llvm
+
+ - Windows (PowerShell):
++
+[source, shell]
+----
+# Install LLVM
+# Download and install the Pre Build Windows binaries
+# of LLVM  from http://releases.llvm.org/download.html
+
+# Install OpenSSL (through vcpkg)
+mkdir \Tools
+cd \Tools
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg.exe install openssl:x64-windows-static
+
+$env:OPENSSL_DIR = 'C:\Tools\vcpkg\installed\x64-windows-static'
+$env:OPENSSL_STATIC = 'Yes'
+[System.Environment]::SetEnvironmentVariable('OPENSSL_DIR', $env:OPENSSL_DIR, [System.EnvironmentVariableTarget]::User)
+[System.Environment]::SetEnvironmentVariable('OPENSSL_STATIC', $env:OPENSSL_STATIC, [System.EnvironmentVariableTarget]::User)
+----
 
 Then, grab the Substrate source code:
 


### PR DESCRIPTION
Hi.

Here's my attempt to document how to build substrate on Windows and to finish #1343. 
To build substrate one has to install the following tools:

1. Build Tools for Visual Studio 2017 
    - The Rust Installer throws an error if no Build Tools for Visual Studio are installed so I did not document how to install it explicitly. Maybe we want to make it explicit?
2. Rust
3. LLVM
4. OpenSSL

The shell files like `scripts/build.sh` can be executed with the Git Bash which I also left out for the moment.

Cheers,
Fabian