### PR TITLE
Allow implementation to provide AppInfo to figure out default paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,7 @@ dependencies = [
 name = "node-cli"
 version = "0.1.0"
 dependencies = [
+ "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -13,6 +13,7 @@ exit-future = "0.1"
 substrate-cli = { path = "../../core/cli" }
 parity-codec = { version = "2.2" }
 slog = "^2"
+app_dirs = "1.2"
 sr-io = { path = "../../core/sr-io" }
 substrate-client = { path = "../../core/client" }
 substrate-primitives = { path = "../../core/primitives" }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -20,6 +20,7 @@
 #![warn(unused_extern_crates)]
 
 extern crate tokio;
+extern crate app_dirs;
 
 extern crate substrate_cli as cli;
 extern crate substrate_primitives as primitives;
@@ -57,6 +58,13 @@ use substrate_service::{ServiceFactory, Roles as ServiceRoles};
 use params::{Params as NodeParams};
 use structopt::StructOpt;
 use std::ops::Deref;
+use app_dirs::AppInfo;
+
+
+const APP_INFO: AppInfo = AppInfo {
+	name: "Substrate Node",
+	author: "Parity Technologies"
+};
 
 /// The chain specification option.
 #[derive(Clone, Debug)]
@@ -122,15 +130,15 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 		};
 
 	let (spec, config) = cli::parse_matches::<service::Factory, _>(
-		load_spec, version, "substrate-node", &matches
+		load_spec, version, "substrate-node", &matches, &APP_INFO
 	)?;
 
-	match cli::execute_default::<service::Factory, _>(spec, exit, &matches, &config)? {
+	match cli::execute_default::<service::Factory, _>(spec, exit, &matches, &config, &APP_INFO)? {
 		cli::Action::ExecutedInternally => (),
 		cli::Action::RunService(exit) => {
-			info!("Substrate Node");
+			info!("{}", APP_INFO.name);
 			info!("  version {}", config.full_version());
-			info!("  by Parity Technologies, 2017, 2018");
+			info!("  by {}, 2017, 2018", APP_INFO.author);
 			info!("Chain specification: {}", config.chain_spec.name());
 			info!("Node name: {}", config.name);
 			info!("Roles: {:?}", config.roles);


### PR DESCRIPTION
rather than always falling back to "substrate" path, which might conflict with other implementations.

fixes #1465 