### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN rm -rf /usr/lib/python* && \
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
 
-CMD ["/usr/local/bin/substrate"]
+ENTRYPOINT ["/usr/local/bin/substrate"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add build-base \
     cmake \
     linux-headers \
     openssl-dev \
+    clang-dev \
     cargo
 
 ARG PROFILE=release


### PR DESCRIPTION
Rocksdb now depends on bindgen, which depends on libclang.