### PR TITLE
remove unneeded iterator bound on ordered_trie_root

### DIFF
--- a/core/trie/src/lib.rs
+++ b/core/trie/src/lib.rs
@@ -116,10 +116,11 @@ pub fn unhashed_trie<H: Hasher, I, A, B>(input: I) -> Vec<u8> where
 /// compact-encoded index (using `parity-codec` crate).
 pub fn ordered_trie_root<H: Hasher, I, A>(input: I) -> H::Out
 where
-	I: IntoIterator<Item = A> + Iterator<Item = A>,
+	I: IntoIterator<Item = A>,
 	A: AsRef<[u8]>,
 {
 	trie_root::<H, _, _, _>(input
+		.into_iter()
 		.enumerate()
 		.map(|(i, v)| (codec::Encode::encode(&codec::Compact(i as u32)), v))
 	)


### PR DESCRIPTION
Generally functions of this form, like all others in the crate, should use `IntoIterator` instead of `Iterator`. `Iterator` already implies `IntoIterator`, so this is backwards compatible.