### PR TITLE
Verify that contracts cannot use float operations

### DIFF
--- a/srml/contract/src/wasm/prepare.rs
+++ b/srml/contract/src/wasm/prepare.rs
@@ -342,6 +342,22 @@ mod tests {
 		};
 	}
 
+	prepare_test!(no_floats,
+		r#"
+		(module
+			(func (export "call")
+				(drop
+					(f32.add
+						(f32.const 0)
+						(f32.const 1)
+					)
+				)
+			)
+			(func (export "deploy"))
+		)"#,
+		Err("gas instrumentation failed")
+	);
+
 	mod memories {
 		use super::*;
 


### PR DESCRIPTION
This test should have been added there long time ago.