### PR TITLE
Camel case types returned from RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,7 @@ dependencies = [
 name = "sr-version"
 version = "0.1.0"
 dependencies = [
+ "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/primitives/src/storage.rs
+++ b/core/primitives/src/storage.rs
@@ -32,6 +32,7 @@ pub struct StorageData(#[cfg_attr(feature = "std", serde(with="bytes"))] pub Vec
 
 /// Storage change set
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug, PartialEq, Eq))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct StorageChangeSet<Hash> {
 	/// Block hash
 	pub block: Hash,

--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -220,6 +220,11 @@ fn should_return_runtime_version() {
 		api.runtime_version(None.into()),
 		Ok(ref ver) if ver == &runtime::VERSION
 	);
+
+	assert_eq!(
+		::serde_json::to_string(&api.runtime_version(None.into()).unwrap()).unwrap(),
+		r#"{"specName":"test","implName":"parity-test","authoringVersion":1,"specVersion":1,"implVersion":1,"apis":[["0xdf6acb689907609b",1],["0x37e397fc7c91f5e4",1],["0xd2bc9897eed08f15",1],["0x40fe3ad401f8959a",1],["0xc6e9a76309f39b09",1],["0xdd718d5cc53262d4",1]]}"#
+	);
 }
 
 #[test]

--- a/core/rpc/src/system/helpers.rs
+++ b/core/rpc/src/system/helpers.rs
@@ -38,17 +38,21 @@ pub struct SystemInfo {
 
 /// Health struct returned by the RPC
 #[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Health {
 	/// Number of connected peers
 	pub peers: usize,
 	/// Is the node syncing
 	pub is_syncing: bool,
 	/// Should this node have any peers
+	///
+	/// Might be false for local chains or when running without discovery.
 	pub should_have_peers: bool,
 }
 
 /// Network Peer information
 #[derive(Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PeerInfo<Hash, Number> {
 	/// Peer Node Index
 	pub index: usize,
@@ -69,5 +73,37 @@ impl fmt::Display for Health {
 		write!(fmt, "{} peers ({})", self.peers, if self.is_syncing {
 			"syncing"
 		} else { "idle" })
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_serialize_health() {
+		assert_eq!(
+			::serde_json::to_string(&Health {
+				peers: 1,
+				is_syncing: false,
+				should_have_peers: true,
+			}).unwrap(),
+			r#"{"peers":1,"isSyncing":false,"shouldHavePeers":true}"#,
+		);
+	}
+
+	#[test]
+	fn should_serialize_peer_info() {
+		assert_eq!(
+			::serde_json::to_string(&PeerInfo {
+				index: 1,
+				peer_id: "2".into(),
+				roles: "a".into(),
+				protocol_version: 2,
+				best_hash: 5u32,
+				best_number: 6u32,
+			}).unwrap(),
+			r#"{"index":1,"peerId":"2","roles":"a","protocolVersion":2,"bestHash":5,"bestNumber":6}"#,
+		);
 	}
 }

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -19,7 +19,6 @@ use super::*;
 use network::{self, SyncState, SyncStatus, ProtocolStatus, NodeIndex, PeerId, PeerInfo as NetworkPeerInfo, PublicKey};
 use network::config::Roles;
 use test_client::runtime::Block;
-use primitives::H256;
 
 #[derive(Default)]
 struct Status {

--- a/core/sr-version/Cargo.toml
+++ b/core/sr-version/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+impl-serde = { version = "0.1", optional = true }
 serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "2.2", default-features = false }
@@ -14,6 +15,7 @@ sr-primitives = { path = "../sr-primitives", default-features = false }
 [features]
 default = ["std"]
 std = [
+	"impl-serde",
 	"serde/std",
 	"serde_derive",
 	"parity-codec/std",


### PR DESCRIPTION
- Also encode `RuntimeVersion` Apis as hex.