### PR TITLE
core: revert grandpa authorities unless imported blocked is queued

### DIFF
--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -1104,18 +1104,24 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA> BlockImport<Block>
 		// we don't want to finalize on `inner.import_block`
 		let justification = block.justification.take();
 		let enacts_consensus_change = new_authorities.is_some();
-		let import_result = self.inner.import_block(block, new_authorities).map_err(|e| {
-			if let Some((old_set, mut authorities)) = just_in_case {
-				debug!(target: "afg", "Restoring old set after block import error: {:?}", e);
-				*authorities = old_set;
-			}
-			e
-		});
+		let import_result = self.inner.import_block(block, new_authorities);
+
+		let revert_authorities = || if let Some((old_set, mut authorities)) = just_in_case {
+			*authorities = old_set;
+		};
 
 		let import_result = match import_result {
 			Ok(ImportResult::Queued) => ImportResult::Queued,
-			Ok(r) => return Ok(r),
-			Err(e) => return Err(ConsensusErrorKind::ClientImport(e.to_string()).into()),
+			Ok(r) => {
+				debug!(target: "afg", "Restoring old authority set after block import result: {:?}", r);
+				revert_authorities();
+				return Ok(r);
+			},
+			Err(e) => {
+				debug!(target: "afg", "Restoring old authority set after block import error: {:?}", e);
+				revert_authorities();
+				return Err(ConsensusErrorKind::ClientImport(e.to_string()).into());
+			},
 		};
 
 		let enacts_change = self.authority_set.inner().read().enacts_change(number, |canon_number| {


### PR DESCRIPTION
`GrandpaBlockImport` could be given an already imported change block and it would duplicate the authority set changes. Instead, we must revert any authority set changes unless the block is successfully `Queued`.