### PR TITLE
use compact Permill in methods

### DIFF
--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -98,10 +98,10 @@ decl_module! {
 
 		/// (Re-)configure this module.
 		fn configure(
-			proposal_bond: Permill,
+			#[compact] proposal_bond: Permill,
 			#[compact] proposal_bond_minimum: T::Balance,
 			#[compact] spend_period: T::BlockNumber,
-			burn: Permill
+			#[compact] burn: Permill
 		) {
 			<ProposalBond<T>>::put(proposal_bond);
 			<ProposalBondMinimum<T>>::put(proposal_bond_minimum);


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/1405

any params of type Permill and Perbill in runtime dispatched functions are switched to the compact variants.