### PR TITLE
Report to sync layer when peer is clogged

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -160,6 +160,14 @@ pub enum BehaviourOut {
 		data: Bytes,
 	},
 
+	/// A substream with a remote is clogged. We should avoid sending more data to it if possible.
+	Clogged {
+		/// Id of the peer the message came from.
+		peer_id: PeerId,
+		/// Protocol which generated the message.
+		protocol_id: ProtocolId,
+	},
+
 	/// We have obtained debug information from a peer.
 	Identified {
 		/// Id of the peer that has been identified.
@@ -174,13 +182,16 @@ impl From<CustomProtosOut> for BehaviourOut {
 		match other {
 			CustomProtosOut::CustomProtocolOpen { protocol_id, version, peer_id, endpoint } => {
 				BehaviourOut::CustomProtocolOpen { protocol_id, version, peer_id, endpoint }
-			},
+			}
 			CustomProtosOut::CustomProtocolClosed { protocol_id, peer_id, result } => {
 				BehaviourOut::CustomProtocolClosed { protocol_id, peer_id, result }
-			},
+			}
 			CustomProtosOut::CustomMessage { protocol_id, peer_id, data } => {
 				BehaviourOut::CustomMessage { protocol_id, peer_id, data }
-			},
+			}
+			CustomProtosOut::Clogged { protocol_id, peer_id } => {
+				BehaviourOut::Clogged { protocol_id, peer_id }
+			}
 		}
 	}
 }

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -107,6 +107,15 @@ pub enum CustomProtosOut {
 		/// Data that has been received.
 		data: Bytes,
 	},
+
+	/// The substream used by the protocol is pretty large. We should print avoid sending more
+	/// data on it if possible.
+	Clogged {
+		/// Id of the peer which is clogged.
+		peer_id: PeerId,
+		/// Protocol which has a problem.
+		protocol_id: ProtocolId,
+	},
 }
 
 impl<TSubstream> CustomProtos<TSubstream> {
@@ -435,6 +444,14 @@ where
 				};
 
 				self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+			}
+			CustomProtosHandlerOut::Clogged { protocol_id } => {
+				warn!(target: "sub-libp2p", "Queue of packets to send to {:?} (protocol: {:?}) is \
+					pretty large", source, protocol_id);
+				self.events.push(NetworkBehaviourAction::GenerateEvent(CustomProtosOut::Clogged {
+					peer_id: source,
+					protocol_id,
+				}));
 			}
 		}
 	}

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -351,6 +351,18 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		}
 	}
 
+	/// Called as a back-pressure mechanism if the networking detects that the peer cannot process
+	/// our messaging rate fast enough.
+	pub fn on_clogged_peer(&self, io: &mut SyncIo, who: NodeIndex) {
+		// We don't do anything but print some diagnostics for now.
+		if let Some(peer) = self.context_data.peers.read().get(&who) {
+			debug!(target: "sync", "Clogged peer {} (protocol_version: {:?}; roles: {:?}; \
+				known_extrinsics: {:?}; known_blocks: {:?}; best_hash: {:?}; best_number: {:?})",
+				who, peer.protocol_version, peer.roles, peer.known_extrinsics, peer.known_blocks,
+				peer.best_hash, peer.best_number);
+		}
+	}
+
 	fn on_block_request(&self, io: &mut SyncIo, peer: NodeIndex, request: message::BlockRequest<B>) {
 		trace!(target: "sync", "BlockRequest {} from {} with fields {:?}: from {:?} to {:?} max {:?}",
 			request.id,

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -401,6 +401,9 @@ fn run_thread<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT>(
 			NetworkServiceEvent::CustomMessage { node_index, data, .. } => {
 				protocol.handle_packet(&mut net_sync, node_index, &data);
 			}
+			NetworkServiceEvent::Clogged { node_index, .. } => {
+				protocol.on_clogged_peer(&mut net_sync, node_index);
+			}
 		};
 
 		Ok(())


### PR DESCRIPTION
Adds a `Clogged` diagnostic message from the libp2p layer to the sync layer, so that the sync layer can print some debug information when that happens. May help diagnose #1414.

Another possible change would be to dump the content of the send queue to the logs, or to clone the content of the queue back to the sync layer for more analysis (as only sync is capable of decoding messages), but that would make us a very easy target to DoS attacks.

Eventually #1517 should clean up this by merging some parts of `network` and `network-libp2p`.
