### PR TITLE
Migrate basic-authorship, cli and client-db crates to 2018 edition

### DIFF
--- a/core/basic-authorship/Cargo.toml
+++ b/core/basic-authorship/Cargo.toml
@@ -2,14 +2,15 @@
 name = "substrate-basic-authorship"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 log = "0.4"
-parity-codec = "2.2"
-sr-primitives = { path = "../sr-primitives" }
-substrate-client = { path = "../client" }
-substrate-consensus-aura-primitives = { path = "../consensus/aura/primitives" }
-substrate-consensus-common = { path = "../consensus/common" }
-substrate-primitives = { path = "../primitives" }
-substrate-inherents = { path = "../inherents" }
-substrate-transaction-pool = { path = "../transaction-pool" }
+codec = { package = "parity-codec", version = "2.2" }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives" }
+client = { package = "substrate-client", path = "../../core/client" }
+aura_primitives = { package = "substrate-consensus-aura-primitives", path = "../../core/consensus/aura/primitives" }
+consensus_common = { package = "substrate-consensus-common", path = "../../core/consensus/common" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
+inherents = { package = "substrate-inherents", path = "../inherents" }
+transaction_pool = { package = "substrate-transaction-pool", path = "../../core/transaction-pool" }

--- a/core/basic-authorship/src/basic_authorship.rs
+++ b/core/basic-authorship/src/basic_authorship.rs
@@ -20,6 +20,8 @@
 
 use std::{sync::Arc, self};
 
+use log::{info, trace};
+
 use client::{
 	self, error, Client as SubstrateClient, CallExecutor,
 	block_builder::api::BlockBuilder as BlockBuilderApi, runtime_api::{Core, ApiExt}

--- a/core/basic-authorship/src/lib.rs
+++ b/core/basic-authorship/src/lib.rs
@@ -18,17 +18,6 @@
 
 #![warn(unused_extern_crates)]
 
-extern crate substrate_primitives as primitives;
-extern crate sr_primitives as runtime_primitives;
-extern crate substrate_consensus_common as consensus_common;
-extern crate substrate_client as client;
-extern crate parity_codec as codec;
-extern crate substrate_transaction_pool as transaction_pool;
-extern crate substrate_inherents as inherents;
-
-#[macro_use]
-extern crate log;
-
 mod basic_authorship;
 
-pub use basic_authorship::{ProposerFactory, BlockBuilder, AuthoringApi, Proposer};
+pub use crate::basic_authorship::{ProposerFactory, BlockBuilder, AuthoringApi, Proposer};

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-cli"
 version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate CLI interface."
+edition = "2018"
 
 [dependencies]
 clap = "~2.32"
@@ -22,11 +23,11 @@ futures = "0.1.17"
 fdlimit = "0.1"
 exit-future = "0.1"
 sysinfo = "0.7"
-substrate-client = { path = "../../core/client" }
-substrate-network = { path = "../../core/network" }
-sr-primitives = { path = "../../core/sr-primitives" }
-substrate-primitives = { path = "../../core/primitives" }
-substrate-service = { path = "../../core/service" }
+client = { package = "substrate-client", path = "../../core/client" }
+network = { package = "substrate-network", path = "../../core/network" }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
+service = { package = "substrate-service", path = "../../core/service" }
 substrate-telemetry = { path = "../../core/telemetry" }
 names = "0.11.0"
 structopt = "0.2.13"

--- a/core/cli/src/error.rs
+++ b/core/cli/src/error.rs
@@ -17,6 +17,8 @@
 //! Initialization errors.
 
 use client;
+use error_chain::{error_chain, error_chain_processing, impl_error_chain_processed,
+	impl_extract_backtrace, impl_error_chain_kind};
 
 error_chain! {
 	foreign_links {

--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -25,6 +25,9 @@ use tokio::timer::Interval;
 use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 use network::{SyncState, SyncProvider};
 use client::{backend::Backend, BlockchainEvents};
+use substrate_telemetry::telemetry;
+use log::{debug, info, warn};
+use slog::slog_info;
 
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Header, As};

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -19,39 +19,6 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
-extern crate app_dirs;
-extern crate env_logger;
-extern crate atty;
-extern crate ansi_term;
-extern crate regex;
-extern crate time;
-extern crate fdlimit;
-extern crate futures;
-extern crate tokio;
-extern crate names;
-extern crate backtrace;
-extern crate sysinfo;
-
-extern crate substrate_client as client;
-extern crate substrate_network as network;
-extern crate sr_primitives as runtime_primitives;
-extern crate substrate_service as service;
-extern crate substrate_primitives as primitives;
-#[macro_use]
-extern crate slog;	// needed until we can reexport `slog_info` from `substrate_telemetry`
-#[macro_use]
-extern crate substrate_telemetry;
-extern crate exit_future;
-
-#[macro_use]
-extern crate lazy_static;
-extern crate clap;
-#[macro_use]
-extern crate error_chain;
-#[macro_use]
-extern crate log;
-extern crate structopt;
-
 mod params;
 pub mod error;
 pub mod informant;
@@ -80,6 +47,9 @@ use regex::Regex;
 use structopt::StructOpt;
 pub use params::{CoreParams, CoreCommands, ExecutionStrategy};
 use app_dirs::{AppInfo, AppDataType};
+use error_chain::bail;
+use log::info;
+use lazy_static::lazy_static;
 
 use futures::Future;
 

--- a/core/client/db/Cargo.toml
+++ b/core/client/db/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-client-db"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 parking_lot = "0.7.1"
@@ -11,17 +12,17 @@ kvdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c
 kvdb-rocksdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 lru-cache = "0.1"
 hash-db = { version = "0.9" }
-substrate-primitives = { path = "../../primitives" }
-sr-primitives = { path = "../../sr-primitives" }
-substrate-client = { path = "../../client" }
-substrate-state-machine = { path = "../../state-machine" }
+primitives = { package = "substrate-primitives", path = "../../primitives" }
+runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
+client = { package = "substrate-client", path = "../../client" }
+state-machine = { package = "substrate-state-machine", path = "../../state-machine" }
 parity-codec = "2.2"
 parity-codec-derive = "2.1"
-substrate-executor = { path = "../../executor" }
-substrate-state-db = { path = "../../state-db" }
-substrate-trie = { path = "../../trie" }
+executor = { package = "substrate-executor", path = "../../executor" }
+state_db = { package = "substrate-state-db", path = "../../state-db" }
+trie = { package = "substrate-trie", path = "../../trie" }
 
 [dev-dependencies]
 kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 substrate-keyring = { path = "../../keyring" }
-substrate-test-client = { path = "../../test-client" }
+test-client = { package = "substrate-test-client", path = "../../test-client" }

--- a/core/client/db/src/cache/list_cache.rs
+++ b/core/client/db/src/cache/list_cache.rs
@@ -41,12 +41,14 @@
 
 use std::collections::BTreeSet;
 
+use log::warn;
+
 use client::error::{ErrorKind as ClientErrorKind, Result as ClientResult};
 use runtime_primitives::traits::{Block as BlockT, NumberFor, As, Zero};
 
-use cache::{CacheItemT, ComplexBlockId};
-use cache::list_entry::{Entry, StorageEntry};
-use cache::list_storage::{Storage, StorageTransaction, Metadata};
+use crate::cache::{CacheItemT, ComplexBlockId};
+use crate::cache::list_entry::{Entry, StorageEntry};
+use crate::cache::list_storage::{Storage, StorageTransaction, Metadata};
 
 /// List-based cache.
 pub struct ListCache<Block: BlockT, T: CacheItemT, S: Storage<Block, T>> {
@@ -585,7 +587,7 @@ fn read_forks<Block: BlockT, T: CacheItemT, S: Storage<Block, T>>(
 pub mod tests {
 	use runtime_primitives::testing::{Header, Block as RawBlock, ExtrinsicWrapper};
 	use runtime_primitives::traits::Header as HeaderT;
-	use cache::list_storage::tests::{DummyStorage, FaultyStorage, DummyTransaction};
+	use crate::cache::list_storage::tests::{DummyStorage, FaultyStorage, DummyTransaction};
 	use super::*;
 
 	type Block = RawBlock<ExtrinsicWrapper<u64>>;

--- a/core/client/db/src/cache/list_entry.rs
+++ b/core/client/db/src/cache/list_entry.rs
@@ -18,9 +18,10 @@
 
 use client::error::Result as ClientResult;
 use runtime_primitives::traits::{Block as BlockT, NumberFor};
+use parity_codec_derive::{Encode, Decode};
 
-use cache::{CacheItemT, ComplexBlockId};
-use cache::list_storage::{Storage};
+use crate::cache::{CacheItemT, ComplexBlockId};
+use crate::cache::list_storage::{Storage};
 
 /// Single list-based cache entry.
 #[derive(Debug)]
@@ -112,8 +113,8 @@ impl<Block: BlockT, T: CacheItemT> StorageEntry<Block, T> {
 
 #[cfg(test)]
 mod tests {
-	use cache::list_cache::tests::test_id;
-	use cache::list_storage::tests::{DummyStorage, FaultyStorage};
+	use crate::cache::list_cache::tests::test_id;
+	use crate::cache::list_storage::tests::{DummyStorage, FaultyStorage};
 	use super::*;
 
 	#[test]

--- a/core/client/db/src/cache/list_storage.rs
+++ b/core/client/db/src/cache/list_storage.rs
@@ -21,14 +21,14 @@ use std::sync::Arc;
 use kvdb::{KeyValueDB, DBTransaction};
 
 use client::error::{Error as ClientError, ErrorKind as ClientErrorKind, Result as ClientResult};
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor};
-use utils::{self, db_err, meta_keys};
+use crate::utils::{self, db_err, meta_keys};
 
-use cache::{CacheItemT, ComplexBlockId};
-use cache::list_cache::{CommitOperation, Fork};
-use cache::list_entry::{Entry, StorageEntry};
+use crate::cache::{CacheItemT, ComplexBlockId};
+use crate::cache::list_cache::{CommitOperation, Fork};
+use crate::cache::list_entry::{Entry, StorageEntry};
 
 /// Single list-cache metadata.
 #[derive(Debug)]

--- a/core/client/db/src/cache/mod.rs
+++ b/core/client/db/src/cache/mod.rs
@@ -23,10 +23,11 @@ use kvdb::{KeyValueDB, DBTransaction};
 
 use client::blockchain::Cache as BlockchainCache;
 use client::error::Result as ClientResult;
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
+use parity_codec_derive::{Encode, Decode};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor, As, AuthorityIdFor};
-use utils::{self, COLUMN_META};
+use crate::utils::{self, COLUMN_META};
 
 use self::list_cache::ListCache;
 

--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -23,6 +23,7 @@ use lru_cache::LruCache;
 use hash_db::Hasher;
 use runtime_primitives::traits::{Block, Header};
 use state_machine::{backend::Backend as StateBackend, TrieBackend};
+use log::trace;
 
 const STATE_CACHE_BLOCKS: usize = 12;
 

--- a/core/client/db/src/utils.rs
+++ b/core/client/db/src/utils.rs
@@ -22,13 +22,14 @@ use std::io;
 
 use kvdb::{KeyValueDB, DBTransaction};
 use kvdb_rocksdb::{Database, DatabaseConfig};
+use log::debug;
 
 use client;
-use codec::Decode;
+use parity_codec::Decode;
 use trie::DBValue;
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, Zero};
-use DatabaseSettings;
+use crate::DatabaseSettings;
 
 /// Number of columns in the db. Must be the same for both full && light dbs.
 /// Otherwise RocksDb will fail to open database && check its type.


### PR DESCRIPTION
Part of #1415: in order to simplify merge I decided to split migration into several pull requests.