### PR TITLE
Remove TODO comment about unboxing state_machine error

### DIFF
--- a/core/client/src/error.rs
+++ b/core/client/src/error.rs
@@ -145,7 +145,6 @@ error_chain! {
 	}
 }
 
-// TODO [ToDr] Temporary, state_machine::Error should be a regular error not Box.
 impl From<Box<state_machine::Error>> for Error {
 	fn from(e: Box<state_machine::Error>) -> Self {
 		ErrorKind::Execution(e).into()


### PR DESCRIPTION
The reasons for removing the message are:
- `error_chain` doesn't support generic parameters, so either we would need to have a different "host" error type for every state_machine or rewrite the error type without `error_chain`.
- There is little reason to handle different low-level `state_machine` errors specifically.
- With `Box` we cannot match on concrete errors, but it is also true for generic errors.
- The blokchain error is boxed too.

Closes #1422.