### PR TITLE
Migrate node (cli, executor, primitives and runtime) to the 2018 edition

### DIFF
--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -4,35 +4,36 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 build = "build.rs"
+edition = "2018"
 
 [dependencies]
 log = "0.4"
 tokio = "0.1.7"
 futures = "0.1"
 exit-future = "0.1"
-substrate-cli = { path = "../../core/cli" }
+cli = { package = "substrate-cli", path = "../../core/cli" }
 parity-codec = { version = "3.0" }
 slog = "^2"
 sr-io = { path = "../../core/sr-io" }
-substrate-client = { path = "../../core/client" }
-substrate-primitives = { path = "../../core/primitives" }
-substrate-inherents = { path = "../../core/inherents" }
+client = { package = "substrate-client", path = "../../core/client" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
+inherents = { package = "substrate-inherents", path = "../../core/inherents" }
 node-runtime = { path = "../runtime" }
 node-primitives = { path = "../primitives" }
 hex-literal = "0.1"
 substrate-basic-authorship = { path = "../../core/basic-authorship" }
 substrate-service = { path = "../../core/service" }
-substrate-transaction-pool = { path = "../../core/transaction-pool" }
-substrate-network = { path = "../../core/network" }
-substrate-consensus-aura = { path = "../../core/consensus/aura" }
-substrate-finality-grandpa = { path = "../../core/finality-grandpa" }
+transaction_pool = { package = "substrate-transaction-pool", path = "../../core/transaction-pool" }
+network = { package = "substrate-network", path = "../../core/network" }
+consensus = { package = "substrate-consensus-aura", path = "../../core/consensus/aura" }
+grandpa = { package = "substrate-finality-grandpa", path = "../../core/finality-grandpa" }
 sr-primitives = { path = "../../core/sr-primitives" }
 node-executor = { path = "../executor" }
 substrate-keystore = { path = "../../core/keystore" }
 
 [dev-dependencies]
-substrate-service-test = { path = "../../core/service/test" }
+service-test = { package = "substrate-service-test", path = "../../core/service/test" }
 
 [build-dependencies]
-substrate-cli = { path = "../../core/cli" }
+cli = { package = "substrate-cli", path = "../../core/cli" }
 structopt = "0.2"

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate substrate_cli as cli;
-extern crate structopt;
-
 use cli::{NoCustom, CoreParams};
 
 use std::{fs, env, path::Path};

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -23,6 +23,7 @@ use node_runtime::{ConsensusConfig, CouncilSeatsConfig, CouncilVotingConfig, Dem
 	SudoConfig, ContractConfig, GrandpaConfig, IndicesConfig, Permill, Perbill};
 pub use node_runtime::GenesisConfig;
 use substrate_service;
+use hex_literal::{hex, hex_impl};
 
 use substrate_keystore::pad_seed;
 
@@ -303,7 +304,7 @@ pub fn local_testnet_config() -> ChainSpec {
 mod tests {
 	use super::*;
 	use service_test;
-	use service::Factory;
+	use crate::service::Factory;
 
 	fn local_testnet_genesis_instant() -> GenesisConfig {
 		let mut genesis = local_testnet_genesis();

--- a/node/cli/src/error.rs
+++ b/node/cli/src/error.rs
@@ -17,6 +17,9 @@
 //! Initialization errors.
 
 use client;
+use error_chain::{
+	error_chain, error_chain_processing, impl_error_chain_processed
+};
 
 error_chain! {
 	foreign_links {

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -19,32 +19,6 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
-extern crate tokio;
-
-extern crate substrate_cli as cli;
-extern crate substrate_primitives as primitives;
-extern crate node_runtime;
-extern crate exit_future;
-#[macro_use]
-extern crate hex_literal;
-#[cfg(test)]
-extern crate substrate_service_test as service_test;
-extern crate substrate_transaction_pool as transaction_pool;
-#[macro_use]
-extern crate substrate_network as network;
-extern crate substrate_consensus_aura as consensus;
-extern crate substrate_client as client;
-extern crate substrate_finality_grandpa as grandpa;
-extern crate node_primitives;
-#[macro_use]
-extern crate substrate_service;
-extern crate node_executor;
-extern crate substrate_keystore;
-extern crate substrate_inherents as inherents;
-
-#[macro_use]
-extern crate log;
-
 pub use cli::error;
 pub mod chain_spec;
 mod service;
@@ -54,6 +28,7 @@ use tokio::runtime::Runtime;
 pub use cli::{VersionInfo, IntoExit, NoCustom};
 use substrate_service::{ServiceFactory, Roles as ServiceRoles};
 use std::ops::Deref;
+use log::info;
 
 /// The chain specification option.
 #[derive(Clone, Debug)]

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -34,6 +34,9 @@ use substrate_service::{
 };
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use inherents::InherentDataProviders;
+use network::construct_simple_protocol;
+use substrate_service::construct_service_factory;
+use log::info;
 
 construct_simple_protocol! {
 	/// Demo protocol attachment for substrate.

--- a/node/executor/Cargo.toml
+++ b/node/executor/Cargo.toml
@@ -3,33 +3,34 @@ name = "node-executor"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
+edition = "2018"
 
 [dependencies]
 hex-literal = "0.1"
 trie-root = "0.9"
 parity-codec = "3.0"
-sr-io = { path = "../../core/sr-io" }
-substrate-state-machine = { path = "../../core/state-machine" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+state_machine = { package = "substrate-state-machine", path = "../../core/state-machine" }
 substrate-executor = { path = "../../core/executor" }
-substrate-primitives = { path = "../../core/primitives" }
-substrate-trie = { path = "../../core/trie" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
+trie = { package = "substrate-trie", path = "../../core/trie" }
 node-primitives = { path = "../primitives" }
 node-runtime = { path = "../runtime" }
 
 [dev-dependencies]
-substrate-keyring = { path = "../../core/keyring" }
-sr-primitives = { path = "../../core/sr-primitives" }
-srml-support = { path = "../../srml/support" }
-srml-balances = { path = "../../srml/balances" }
-srml-session = { path = "../../srml/session" }
-srml-staking = { path = "../../srml/staking" }
-srml-system = { path = "../../srml/system" }
-srml-consensus = { path = "../../srml/consensus" }
-srml-timestamp = { path = "../../srml/timestamp" }
-srml-treasury = { path = "../../srml/treasury" }
-srml-contract = { path = "../../srml/contract" }
-srml-grandpa = { path = "../../srml/grandpa" }
-srml-indices = { path = "../../srml/indices" }
+keyring = { package = "substrate-keyring", path = "../../core/keyring" }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives" }
+runtime_support = { package = "srml-support", path = "../../srml/support" }
+balances = { package = "srml-balances", path = "../../srml/balances" }
+session = { package = "srml-session", path = "../../srml/session" }
+staking = { package = "srml-staking", path = "../../srml/staking" }
+system = { package = "srml-system", path = "../../srml/system" }
+consensus = { package = "srml-consensus", path = "../../srml/consensus" }
+timestamp = { package = "srml-timestamp", path = "../../srml/timestamp" }
+treasury = { package = "srml-treasury", path = "../../srml/treasury" }
+contract = { package = "srml-contract", path = "../../srml/contract" }
+grandpa = { package = "srml-grandpa", path = "../../srml/grandpa" }
+indices = { package = "srml-indices", path = "../../srml/indices" }
 wabt = "~0.7.4"
 
 [features]

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -19,34 +19,10 @@
 
 #![cfg_attr(feature = "benchmarks", feature(test))]
 
-extern crate node_runtime;
-#[macro_use] extern crate substrate_executor;
-#[cfg_attr(test, macro_use)] extern crate substrate_primitives as primitives;
-
 #[cfg(feature = "benchmarks")] extern crate test;
 
-#[cfg(test)] extern crate substrate_keyring as keyring;
-#[cfg(test)] extern crate sr_primitives as runtime_primitives;
-#[cfg(test)] extern crate srml_support as runtime_support;
-#[cfg(test)] extern crate srml_balances as balances;
-#[cfg(test)] extern crate srml_session as session;
-#[cfg(test)] extern crate srml_staking as staking;
-#[cfg(test)] extern crate srml_system as system;
-#[cfg(test)] extern crate srml_consensus as consensus;
-#[cfg(test)] extern crate srml_timestamp as timestamp;
-#[cfg(test)] extern crate srml_treasury as treasury;
-#[cfg(test)] extern crate srml_contract as contract;
-#[cfg(test)] extern crate srml_grandpa as grandpa;
-#[cfg(test)] extern crate srml_indices as indices;
-#[cfg(test)] extern crate node_primitives;
-#[cfg(test)] extern crate parity_codec as codec;
-#[cfg(test)] extern crate sr_io as runtime_io;
-#[cfg(test)] extern crate substrate_trie as trie;
-#[cfg(test)] extern crate substrate_state_machine as state_machine;
-#[cfg(test)] #[macro_use] extern crate hex_literal;
-#[cfg(test)] extern crate wabt;
-
 pub use substrate_executor::NativeExecutor;
+use substrate_executor::native_executor_instance;
 native_executor_instance!(pub Executor, node_runtime::api::dispatch, node_runtime::native_version, include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm"));
 
 #[cfg(test)]
@@ -54,7 +30,7 @@ mod tests {
 	use runtime_io;
 	use super::Executor;
 	use substrate_executor::{WasmExecutor, NativeExecutionDispatch};
-	use codec::{Encode, Decode, Joiner};
+	use parity_codec::{Encode, Decode, Joiner};
 	use keyring::Keyring;
 	use runtime_support::{Hashable, StorageValue, StorageMap};
 	use state_machine::{CodeExecutor, Externalities, TestExternalities};
@@ -71,6 +47,8 @@ mod tests {
 		BuildStorage, GenesisConfig, BalancesConfig, SessionConfig, StakingConfig, System,
 		SystemConfig, GrandpaConfig, IndicesConfig, Event, Log};
 	use wabt;
+	use hex_literal::{hex, hex_impl};
+	use primitives::map;
 
 	const BLOATY_CODE: &[u8] = include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.wasm");
 	const COMPACT_CODE: &[u8] = include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm");

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -2,15 +2,16 @@
 name = "node-primitives"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-sr-std = { path = "../../core/sr-std", default-features = false }
-sr-primitives = { path = "../../core/sr-primitives", default-features = false }
+primitives = { package = "substrate-primitives", path = "../../core/primitives", default-features = false }
+rstd = { package = "sr-std", path = "../../core/sr-std", default-features = false }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives", default-features = false }
 
 [dev-dependencies]
 substrate-serializer = { path = "../../core/serializer" }
@@ -21,9 +22,9 @@ default = ["std"]
 std = [
 	"parity-codec-derive/std",
 	"parity-codec/std",
-	"substrate-primitives/std",
-	"sr-std/std",
-	"sr-primitives/std",
+	"primitives/std",
+	"rstd/std",
+	"runtime_primitives/std",
 	"serde_derive",
 	"serde/std",
 ]

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -21,15 +21,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg(feature = "std")]
-extern crate serde;
-
-extern crate parity_codec as codec;
-
-extern crate sr_std as rstd;
-extern crate sr_primitives as runtime_primitives;
-extern crate substrate_primitives as primitives;
-
 use runtime_primitives::generic;
 use runtime_primitives::{OpaqueExtrinsic, traits::BlakeTwo256};
 

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "node-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 integer-sqrt = { version = "0.1.2" }
@@ -10,28 +11,28 @@ parity-codec-derive = { version = "3.0" }
 parity-codec = { version = "3.0", default-features = false }
 substrate-primitives = { path = "../../core/primitives", default-features = false }
 substrate-client = { path = "../../core/client", default-features = false }
-sr-std = { path = "../../core/sr-std", default-features = false }
-sr-primitives = { path = "../../core/sr-primitives", default-features = false }
-sr-version = { path = "../../core/sr-version", default-features = false }
+rstd = { package = "sr-std", path = "../../core/sr-std", default-features = false }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives", default-features = false }
+version = { package = "sr-version", path = "../../core/sr-version", default-features = false }
 srml-support = { path = "../../srml/support", default-features = false }
-srml-aura = { path = "../../srml/aura", default-features = false }
-srml-balances = { path = "../../srml/balances", default-features = false }
-srml-consensus = { path = "../../srml/consensus", default-features = false }
-srml-contract = { path = "../../srml/contract", default-features = false }
-srml-council = { path = "../../srml/council", default-features = false }
-srml-democracy = { path = "../../srml/democracy", default-features = false }
-srml-executive = { path = "../../srml/executive", default-features = false }
-srml-grandpa = { path = "../../srml/grandpa", default-features = false }
-srml-indices = { path = "../../srml/indices", default-features = false }
-srml-session = { path = "../../srml/session", default-features = false }
-srml-staking = { path = "../../srml/staking", default-features = false }
-srml-system = { path = "../../srml/system", default-features = false }
-srml-timestamp = { path = "../../srml/timestamp", default-features = false }
-srml-treasury = { path = "../../srml/treasury", default-features = false }
-srml-sudo = { path = "../../srml/sudo", default-features = false }
+aura = { package = "srml-aura", path = "../../srml/aura", default-features = false }
+balances = { package = "srml-balances", path = "../../srml/balances", default-features = false }
+consensus = { package = "srml-consensus", path = "../../srml/consensus", default-features = false }
+contract = { package = "srml-contract", path = "../../srml/contract", default-features = false }
+council = { package = "srml-council", path = "../../srml/council", default-features = false }
+democracy = { package = "srml-democracy", path = "../../srml/democracy", default-features = false }
+executive = { package = "srml-executive", path = "../../srml/executive", default-features = false }
+grandpa = { package = "srml-grandpa", path = "../../srml/grandpa", default-features = false }
+indices = { package = "srml-indices", path = "../../srml/indices", default-features = false }
+session = { package = "srml-session", path = "../../srml/session", default-features = false }
+staking = { package = "srml-staking", path = "../../srml/staking", default-features = false }
+system = { package = "srml-system", path = "../../srml/system", default-features = false }
+timestamp = { package = "srml-timestamp", path = "../../srml/timestamp", default-features = false }
+treasury = { package = "srml-treasury", path = "../../srml/treasury", default-features = false }
+sudo = { package = "srml-sudo", path = "../../srml/sudo", default-features = false }
 srml-upgrade-key = { path = "../../srml/upgrade-key", default-features = false }
 node-primitives = { path = "../primitives", default-features = false }
-substrate-consensus-aura-primitives = { path = "../../core/consensus/aura/primitives", default-features = false }
+consensus_aura = { package = "substrate-consensus-aura-primitives", path = "../../core/consensus/aura/primitives", default-features = false }
 rustc-hex = { version = "2.0", optional = true }
 hex-literal = { version = "0.1.0", optional = true }
 serde = { version = "1.0", optional = true }
@@ -42,30 +43,30 @@ default = ["std"]
 std = [
 	"parity-codec/std",
 	"substrate-primitives/std",
-	"sr-std/std",
-	"sr-primitives/std",
+	"rstd/std",
+	"runtime_primitives/std",
 	"srml-support/std",
-	"srml-balances/std",
-	"srml-consensus/std",
-	"srml-contract/std",
-	"srml-council/std",
-	"srml-democracy/std",
-	"srml-executive/std",
-	"srml-grandpa/std",
-	"srml-indices/std",
-	"srml-session/std",
-	"srml-staking/std",
-	"srml-system/std",
-	"srml-timestamp/std",
-	"srml-treasury/std",
-	"srml-sudo/std",
+	"balances/std",
+	"consensus/std",
+	"contract/std",
+	"council/std",
+	"democracy/std",
+	"executive/std",
+	"grandpa/std",
+	"indices/std",
+	"session/std",
+	"staking/std",
+	"system/std",
+	"timestamp/std",
+	"treasury/std",
+	"sudo/std",
 	"srml-upgrade-key/std",
-	"sr-version/std",
+	"version/std",
 	"node-primitives/std",
 	"serde/std",
 	"safe-mix/std",
 	"substrate-client/std",
-	"substrate-consensus-aura-primitives/std",
+	"consensus_aura/std",
 	"rustc-hex",
 	"hex-literal",
 	"serde",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -22,48 +22,20 @@
 
 #[macro_use]
 extern crate srml_support;
-
 #[macro_use]
-extern crate sr_primitives as runtime_primitives;
-
-extern crate substrate_primitives;
-
-#[macro_use]
-extern crate substrate_client as client;
-
-#[macro_use]
-extern crate parity_codec_derive;
-
-extern crate parity_codec as codec;
-
-extern crate sr_std as rstd;
-extern crate srml_aura as aura;
-extern crate srml_balances as balances;
-extern crate srml_consensus as consensus;
-extern crate srml_contract as contract;
-extern crate srml_council as council;
-extern crate srml_democracy as democracy;
-extern crate srml_executive as executive;
-extern crate srml_grandpa as grandpa;
-extern crate srml_indices as indices;
-extern crate srml_session as session;
-extern crate srml_staking as staking;
-extern crate srml_sudo as sudo;
-extern crate srml_system as system;
-extern crate srml_timestamp as timestamp;
-extern crate srml_treasury as treasury;
-#[macro_use]
-extern crate sr_version as version;
-extern crate node_primitives;
-extern crate substrate_consensus_aura_primitives as consensus_aura;
+extern crate runtime_primitives;
 
 use rstd::prelude::*;
+use parity_codec_derive::{Encode, Decode};
+#[cfg(feature = "std")]
+use srml_support::{Serialize, Deserialize};
 use substrate_primitives::u32_trait::{_2, _4};
 use node_primitives::{
 	AccountId, AccountIndex, Balance, BlockNumber, Hash, Index, SessionKey, Signature
 };
 use grandpa::fg_primitives::{self, ScheduledChange};
-use client::{
+use substrate_client::impl_runtime_apis;
+use substrate_client::{
 	block_builder::api::{self as block_builder_api, InherentData, CheckInherentsResult},
 	runtime_api as client_api,
 };

--- a/node/runtime/wasm/Cargo.toml
+++ b/node/runtime/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "node-runtime-wasm"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [lib]
 name = "node_runtime"

--- a/node/runtime/wasm/src/lib.rs
+++ b/node/runtime/wasm/src/lib.rs
@@ -18,5 +18,4 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate node_runtime;
 pub use node_runtime::*;


### PR DESCRIPTION
Part of #1415.