### PR TITLE
Migrate subkey and chain-spec-builder to the 2018 edition

### DIFF
--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -2,6 +2,7 @@
 name = "subkey"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 substrate-primitives = { version = "*", path = "../core/primitives" }

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -17,12 +17,8 @@
 #![cfg_attr(feature = "bench", feature(test))]
 #[cfg(feature = "bench")]
 extern crate test;
-extern crate substrate_primitives;
-extern crate rand;
 
-#[macro_use]
-extern crate clap;
-
+use clap::load_yaml;
 use rand::{RngCore, rngs::OsRng};
 use substrate_primitives::{ed25519::Pair, hexdisplay::HexDisplay};
 

--- a/test-utils/chain-spec-builder/Cargo.toml
+++ b/test-utils/chain-spec-builder/Cargo.toml
@@ -2,6 +2,7 @@
 name = "chain-spec-builder"
 version = "0.1.0"
 authors = ["haydn dufrene <haydn.dufrene@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 clap = { version = "~2.32", features = ["yaml"] }

--- a/test-utils/chain-spec-builder/src/main.rs
+++ b/test-utils/chain-spec-builder/src/main.rs
@@ -1,11 +1,4 @@
-#[macro_use]
-extern crate clap;
-
-use clap::App;
-
-extern crate node_cli;
-extern crate substrate_service;
-extern crate substrate_primitives;
+use clap::{App, load_yaml};
 
 use node_cli::chain_spec;
 use substrate_service::chain_ops::build_spec;


### PR DESCRIPTION
Part of the #1415 issue.