### PR TITLE
harden permill perbill and impl Mul

### DIFF
--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -494,8 +494,8 @@ impl<T: Trait> Module<T> {
 		<session::Module<T>>::set_validators(vals);
 
 		// Update the balances for slashing/rewarding according to the stakes.
-		<CurrentOfflineSlash<T>>::put(Self::offline_slash().times(stake_range.1));
-		<CurrentSessionReward<T>>::put(Self::session_reward().times(stake_range.1));
+		<CurrentOfflineSlash<T>>::put(Self::offline_slash() * stake_range.1);
+		<CurrentSessionReward<T>>::put(Self::session_reward() * stake_range.1);
 	}
 
 	/// Call when a validator is determined to be offline. `count` is the

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -201,7 +201,7 @@ impl<T: Trait> Module<T> {
 
 	/// The needed bond for a proposal whose spend is `value`.
 	fn calculate_bond(value: T::Balance) -> T::Balance {
-		Self::proposal_bond_minimum().max(Self::proposal_bond().times(value))
+		Self::proposal_bond_minimum().max(Self::proposal_bond() * value)
 	}
 
 	// Spend some money!
@@ -238,7 +238,7 @@ impl<T: Trait> Module<T> {
 
 		if !missed_any {
 			// burn some proportion of the remaining budget if we run a surplus.
-			let burn = Self::burn().times(budget_remaining).min(budget_remaining);
+			let burn = (Self::burn() * budget_remaining).min(budget_remaining);
 			budget_remaining -= burn;
 			Self::deposit_event(RawEvent::Burnt(burn))
 		}


### PR DESCRIPTION
related to https://github.com/paritytech/substrate/issues/1577

This PR impl Mul for Perbill and a type that is `As<u64>`

To avoid overflow we use the saturating mul method on u64. So Perbill and the other factor are converted to u64 and multiplication is made.

Previously Perbill was converted to the other factor using As.

note: we could also have used From and Into instead of As.

