### PR TITLE
Make --port CLI option work again

### DIFF
--- a/core/network-libp2p/src/traits.rs
+++ b/core/network-libp2p/src/traits.rs
@@ -70,11 +70,7 @@ impl NetworkConfiguration {
 		NetworkConfiguration {
 			config_path: None,
 			net_config_path: None,
-			listen_addresses: vec![
-				iter::once(Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)))
-					.chain(iter::once(Protocol::Tcp(30333)))
-					.collect()
-			],
+			listen_addresses: Vec::new(),
 			public_addresses: Vec::new(),
 			boot_nodes: Vec::new(),
 			use_secret: None,


### PR DESCRIPTION
Right now when I'm starting two local nodes like that:
```bash
rm -rf db.alice && ./substrate --chain=local --node-key 0000000000000000000000000000000000000000000000000000000000000002 --key Alice --validator --port=30333 --bootnodes /ip4/127.0.0.1/tcp/30334/p2p/QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN -d db.alice --rpc-port=11010 --ws-port=11011 2>&1 | gawk '{ print strftime("Alice: [%Y-%m-%d %H:%M:%S]"), $0 }'
rm -rf db.bob && ./substrate --chain=local --node-key 0000000000000000000000000000000000000000000000000000000000000001 --key Bob --validator --port 30334 --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/QmXiB3jqqn2rpiKU7k1h7NJYeBg8WNSx9DiTRKz9ti2KSK -d db.bob --rpc-port=11012 --ws-port=11013 2>&1 | gawk '{ print strftime("Bob  : [%Y-%m-%d %H:%M:%S]"), $0 }'
```
I keep getting "Port already in use" for one of nodes. That's because `--port` option [here](https://github.com/paritytech/substrate/blob/master/core/cli/src/lib.rs#L262) is used only when `listen_addresses` are empty && they're not empty in default `NetworkConfiguration`. This PR removes default value for `NetworkConfiguration::listen_addresses`