### PR TITLE
Migrate state-db, state-machine, telemetry, test-client and test-runtime to the 2018 edition

### DIFF
--- a/core/state-db/Cargo.toml
+++ b/core/state-db/Cargo.toml
@@ -2,11 +2,12 @@
 name = "substrate-state-db"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 parking_lot = "0.7.1"
 log = "0.4"
-substrate-primitives = { path = "../../core/primitives" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
 

--- a/core/state-db/src/lib.rs
+++ b/core/state-db/src/lib.rs
@@ -29,23 +29,18 @@
 //! See `RefWindow` for pruning algorithm details. `StateDb` prunes on each canonicalization until pruning
 //! constraints are satisfied.
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate parity_codec_derive;
-extern crate parking_lot;
-extern crate parity_codec as codec;
-#[cfg(test)]
-extern crate substrate_primitives as primitives;
-
 mod noncanonical;
 mod pruning;
 #[cfg(test)] mod test;
 
 use std::fmt;
 use parking_lot::RwLock;
+use parity_codec as codec;
 use codec::Codec;
 use std::collections::HashSet;
 use noncanonical::NonCanonicalOverlay;
 use pruning::RefWindow;
+use log::trace;
 
 /// Database value type.
 pub type DBValue = Vec<u8>;
@@ -61,7 +56,6 @@ pub trait MetaDb {
 	/// Get meta value, such as the journal.
 	fn get_meta(&self, key: &[u8]) -> Result<Option<DBValue>, Self::Error>;
 }
-
 
 /// Backend database trait. Read-only.
 pub trait HashDb {
@@ -353,8 +347,8 @@ impl<BlockHash: Hash, Key: Hash> StateDb<BlockHash, Key> {
 mod tests {
 	use std::io;
 	use primitives::H256;
-	use {StateDb, PruningMode, Constraints};
-	use test::{make_db, make_changeset, TestDb};
+	use crate::{StateDb, PruningMode, Constraints};
+	use crate::test::{make_db, make_changeset, TestDb};
 
 	fn make_test_db(settings: PruningMode) -> (TestDb, StateDb<H256, H256>) {
 		let mut db = make_db(&[91, 921, 922, 93, 94]);

--- a/core/state-db/src/noncanonical.rs
+++ b/core/state-db/src/noncanonical.rs
@@ -23,7 +23,9 @@
 use std::fmt;
 use std::collections::{HashMap, VecDeque};
 use super::{Error, DBValue, ChangeSet, CommitSet, MetaDb, Hash, to_meta_key};
-use codec::{Decode, Encode};
+use crate::codec::{Decode, Encode};
+use parity_codec_derive::{Decode, Encode};
+use log::trace;
 
 const NON_CANONICAL_JOURNAL: &[u8] = b"noncanonical_journal";
 const LAST_CANONICAL: &[u8] = b"last_canonical";
@@ -270,9 +272,9 @@ impl<BlockHash: Hash, Key: Hash> NonCanonicalOverlay<BlockHash, Key> {
 mod tests {
 	use std::io;
 	use super::NonCanonicalOverlay;
-	use {ChangeSet};
+	use crate::ChangeSet;
 	use primitives::H256;
-	use test::{make_db, make_changeset};
+	use crate::test::{make_db, make_changeset};
 
 	fn contains(overlay: &NonCanonicalOverlay<H256, H256>, key: u64) -> bool {
 		overlay.get(&H256::from_low_u64_be(key)) == Some(H256::from_low_u64_be(key).as_bytes().to_vec())

--- a/core/state-db/src/pruning.rs
+++ b/core/state-db/src/pruning.rs
@@ -23,8 +23,10 @@
 //! The changes are journaled in the DB.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use codec::{Encode, Decode};
-use {CommitSet, Error, MetaDb, to_meta_key, Hash};
+use crate::codec::{Encode, Decode};
+use parity_codec_derive::{Encode, Decode};
+use crate::{CommitSet, Error, MetaDb, to_meta_key, Hash};
+use log::trace;
 
 const LAST_PRUNED: &[u8] = b"last_pruned";
 const PRUNING_JOURNAL: &[u8] = b"pruning_journal";
@@ -158,8 +160,8 @@ impl<BlockHash: Hash, Key: Hash> RefWindow<BlockHash, Key> {
 mod tests {
 	use super::RefWindow;
 	use primitives::H256;
-	use {CommitSet};
-	use test::{make_db, make_commit, TestDb};
+	use crate::CommitSet;
+	use crate::test::{make_db, make_commit, TestDb};
 
 	fn check_journal(pruning: &RefWindow<H256, H256>, db: &TestDb) {
 		let restored: RefWindow<H256, H256> = RefWindow::new(db).unwrap();

--- a/core/state-db/src/test.rs
+++ b/core/state-db/src/test.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 use primitives::H256;
-use {DBValue, ChangeSet, CommitSet, MetaDb, HashDb};
+use crate::{DBValue, ChangeSet, CommitSet, MetaDb, HashDb};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct TestDb {

--- a/core/state-machine/Cargo.toml
+++ b/core/state-machine/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-state-machine"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate State Machine"
+edition = "2018"
 
 [dependencies]
 hex-literal = "0.1.0"
@@ -12,6 +13,6 @@ heapsize = "0.4"
 hash-db = "0.9"
 trie-db = "0.9"
 trie-root = "0.9"
-substrate-trie = { path = "../trie" }
-substrate-primitives = { path = "../primitives" }
+trie = { package = "substrate-trie", path = "../trie" }
+primitives = { package = "substrate-primitives", path = "../primitives" }
 parity-codec = "3.0"

--- a/core/state-machine/src/backend.rs
+++ b/core/state-machine/src/backend.rs
@@ -20,10 +20,11 @@ use std::{error, fmt};
 use std::cmp::Ord;
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use log::warn;
 use hash_db::Hasher;
-use trie_backend::TrieBackend;
-use trie_backend_essence::TrieBackendStorage;
-use substrate_trie::{TrieDBMut, TrieMut, MemoryDB, trie_root, child_trie_root, default_child_trie_root};
+use crate::trie_backend::TrieBackend;
+use crate::trie_backend_essence::TrieBackendStorage;
+use trie::{TrieDBMut, TrieMut, MemoryDB, trie_root, child_trie_root, default_child_trie_root};
 use heapsize::HeapSizeOf;
 
 /// A state backend is used to read state data and can have changes committed

--- a/core/state-machine/src/changes_trie/build.rs
+++ b/core/state-machine/src/changes_trie/build.rs
@@ -17,15 +17,15 @@
 //! Structures and functions required to build changes trie for given block.
 
 use std::collections::{BTreeMap, BTreeSet};
-use codec::Decode;
+use parity_codec::Decode;
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
-use backend::Backend;
-use overlayed_changes::OverlayedChanges;
-use trie_backend_essence::{TrieBackendStorage, TrieBackendEssence};
-use changes_trie::build_iterator::digest_build_iterator;
-use changes_trie::input::{InputKey, InputPair, DigestIndex, ExtrinsicIndex};
-use changes_trie::{AnchorBlockId, Configuration, Storage};
+use crate::backend::Backend;
+use crate::overlayed_changes::OverlayedChanges;
+use crate::trie_backend_essence::{TrieBackendStorage, TrieBackendEssence};
+use crate::changes_trie::build_iterator::digest_build_iterator;
+use crate::changes_trie::input::{InputKey, InputPair, DigestIndex, ExtrinsicIndex};
+use crate::changes_trie::{AnchorBlockId, Configuration, Storage};
 
 /// Prepare input pairs for building a changes trie of given block.
 ///
@@ -142,12 +142,12 @@ fn prepare_digest_input<'a, S, H>(
 
 #[cfg(test)]
 mod test {
-	use codec::Encode;
+	use parity_codec::Encode;
 	use primitives::Blake2Hasher;
 	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
-	use backend::InMemory;
-	use changes_trie::storage::InMemoryStorage;
-	use overlayed_changes::OverlayedValue;
+	use crate::backend::InMemory;
+	use crate::changes_trie::storage::InMemoryStorage;
+	use crate::overlayed_changes::OverlayedValue;
 	use super::*;
 
 	fn prepare_for_build() -> (InMemory<Blake2Hasher>, InMemoryStorage<Blake2Hasher>, OverlayedChanges) {

--- a/core/state-machine/src/changes_trie/build_iterator.rs
+++ b/core/state-machine/src/changes_trie/build_iterator.rs
@@ -17,7 +17,7 @@
 //! Structures and functions to return blocks whose changes are to be included
 //! in given block' changes trie.
 
-use changes_trie::Configuration;
+use crate::changes_trie::Configuration;
 
 /// Returns iterator of OTHER blocks that are required for inclusion into
 /// changes trie of given block.

--- a/core/state-machine/src/changes_trie/changes_iterator.rs
+++ b/core/state-machine/src/changes_trie/changes_iterator.rs
@@ -19,15 +19,15 @@
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use codec::{Decode, Encode};
+use parity_codec::{Decode, Encode};
 use hash_db::{HashDB, Hasher};
 use heapsize::HeapSizeOf;
-use substrate_trie::{Recorder, MemoryDB};
-use changes_trie::{AnchorBlockId, Configuration, RootsStorage, Storage};
-use changes_trie::input::{DigestIndex, ExtrinsicIndex, DigestIndexValue, ExtrinsicIndexValue};
-use changes_trie::storage::{TrieBackendAdapter, InMemoryStorage};
-use proving_backend::ProvingBackendEssence;
-use trie_backend_essence::{TrieBackendEssence};
+use trie::{Recorder, MemoryDB};
+use crate::changes_trie::{AnchorBlockId, Configuration, RootsStorage, Storage};
+use crate::changes_trie::input::{DigestIndex, ExtrinsicIndex, DigestIndexValue, ExtrinsicIndexValue};
+use crate::changes_trie::storage::{TrieBackendAdapter, InMemoryStorage};
+use crate::proving_backend::ProvingBackendEssence;
+use crate::trie_backend_essence::{TrieBackendEssence};
 
 /// Return changes of given key at given blocks range.
 /// `max` is the number of best known block.
@@ -383,8 +383,8 @@ fn lower_bound_max_digest(
 mod tests {
 	use std::iter::FromIterator;
 	use primitives::Blake2Hasher;
-	use changes_trie::input::InputPair;
-	use changes_trie::storage::InMemoryStorage;
+	use crate::changes_trie::input::InputPair;
+	use crate::changes_trie::storage::InMemoryStorage;
 	use super::*;
 
 	fn prepare_for_drilldown() -> (Configuration, InMemoryStorage<Blake2Hasher>) {

--- a/core/state-machine/src/changes_trie/input.rs
+++ b/core/state-machine/src/changes_trie/input.rs
@@ -16,7 +16,7 @@
 
 //! Different types of changes trie input pairs.
 
-use codec::{Decode, Encode, Input, Output};
+use parity_codec::{Decode, Encode, Input, Output};
 
 /// Key of { changed key => set of extrinsic indices } mapping.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/core/state-machine/src/changes_trie/mod.rs
+++ b/core/state-machine/src/changes_trie/mod.rs
@@ -48,11 +48,11 @@ pub use self::prune::{prune, oldest_non_pruned_trie};
 
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
-use backend::Backend;
+use crate::backend::Backend;
 use primitives;
-use changes_trie::build::prepare_input;
-use overlayed_changes::OverlayedChanges;
-use trie_backend_essence::TrieBackendStorage;
+use crate::changes_trie::build::prepare_input;
+use crate::overlayed_changes::OverlayedChanges;
+use crate::trie_backend_essence::TrieBackendStorage;
 use trie::{DBValue, trie_root};
 
 /// Changes that are made outside of extrinsics are marked with this index;

--- a/core/state-machine/src/changes_trie/prune.rs
+++ b/core/state-machine/src/changes_trie/prune.rs
@@ -18,11 +18,12 @@
 
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
-use substrate_trie::Recorder;
-use proving_backend::ProvingBackendEssence;
-use trie_backend_essence::TrieBackendEssence;
-use changes_trie::{AnchorBlockId, Configuration, Storage};
-use changes_trie::storage::TrieBackendAdapter;
+use trie::Recorder;
+use log::warn;
+use crate::proving_backend::ProvingBackendEssence;
+use crate::trie_backend_essence::TrieBackendEssence;
+use crate::changes_trie::{AnchorBlockId, Configuration, Storage};
+use crate::changes_trie::storage::TrieBackendAdapter;
 
 /// Get number of oldest block for which changes trie is not pruned
 /// given changes trie configuration, pruning parameter and number of
@@ -152,8 +153,8 @@ mod tests {
 	use std::collections::HashSet;
 	use trie::MemoryDB;
 	use primitives::Blake2Hasher;
-	use backend::insert_into_memory_db;
-	use changes_trie::storage::InMemoryStorage;
+	use crate::backend::insert_into_memory_db;
+	use crate::changes_trie::storage::InMemoryStorage;
 	use super::*;
 
 	fn config(interval: u64, levels: u32) -> Configuration {

--- a/core/state-machine/src/changes_trie/storage.rs
+++ b/core/state-machine/src/changes_trie/storage.rs
@@ -22,15 +22,15 @@ use trie::DBValue;
 use heapsize::HeapSizeOf;
 use trie::MemoryDB;
 use parking_lot::RwLock;
-use changes_trie::{AnchorBlockId, RootsStorage, Storage};
-use trie_backend_essence::TrieBackendStorage;
+use crate::changes_trie::{AnchorBlockId, RootsStorage, Storage};
+use crate::trie_backend_essence::TrieBackendStorage;
 
 #[cfg(test)]
 use std::collections::HashSet;
 #[cfg(test)]
-use backend::insert_into_memory_db;
+use crate::backend::insert_into_memory_db;
 #[cfg(test)]
-use changes_trie::input::InputPair;
+use crate::changes_trie::input::InputPair;
 
 /// In-memory implementation of changes trie storage.
 pub struct InMemoryStorage<H: Hasher> where H::Out: HeapSizeOf {

--- a/core/state-machine/src/ext.rs
+++ b/core/state-machine/src/ext.rs
@@ -17,12 +17,13 @@
 //! Conrete externalities implementation.
 
 use std::{error, fmt, cmp::Ord};
-use backend::{Backend, Consolidate};
-use changes_trie::{AnchorBlockId, Storage as ChangesTrieStorage, compute_changes_trie_root};
-use {Externalities, OverlayedChanges};
+use log::warn;
+use crate::backend::{Backend, Consolidate};
+use crate::changes_trie::{AnchorBlockId, Storage as ChangesTrieStorage, compute_changes_trie_root};
+use crate::{Externalities, OverlayedChanges};
 use hash_db::Hasher;
 use primitives::storage::well_known_keys::is_child_storage_key;
-use substrate_trie::{MemoryDB, TrieDBMut, TrieMut, default_child_trie_root, is_child_trie_key_valid};
+use trie::{MemoryDB, TrieDBMut, TrieMut, default_child_trie_root, is_child_trie_key_valid};
 use heapsize::HeapSizeOf;
 
 const EXT_NOT_ALLOWED_TO_FAIL: &'static str = "Externalities not allowed to fail within runtime";
@@ -320,13 +321,14 @@ where
 
 #[cfg(test)]
 mod tests {
-	use codec::Encode;
+	use hex_literal::{hex, hex_impl};
+	use parity_codec::Encode;
 	use primitives::{Blake2Hasher};
 	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
-	use backend::InMemory;
-	use changes_trie::{Configuration as ChangesTrieConfiguration,
+	use crate::backend::InMemory;
+	use crate::changes_trie::{Configuration as ChangesTrieConfiguration,
 		InMemoryStorage as InMemoryChangesTrieStorage};
-	use overlayed_changes::OverlayedValue;
+	use crate::overlayed_changes::OverlayedValue;
 	use super::*;
 
 	type TestBackend = InMemory<Blake2Hasher>;

--- a/core/state-machine/src/lib.rs
+++ b/core/state-machine/src/lib.rs
@@ -18,27 +18,11 @@
 
 #![warn(missing_docs)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
-
-#[macro_use]
-extern crate log;
-
-extern crate hash_db;
-extern crate substrate_trie;
-
-extern crate parking_lot;
-extern crate heapsize;
-#[cfg_attr(test, macro_use)]
-extern crate substrate_primitives as primitives;
-extern crate parity_codec as codec;
-extern crate substrate_trie as trie;
-
 use std::{fmt, panic::UnwindSafe};
+use log::warn;
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
-use codec::{Decode, Encode};
+use parity_codec::{Decode, Encode};
 use primitives::{storage::well_known_keys, NativeOrEncoded, NeverNativeValue};
 
 pub mod backend;
@@ -343,7 +327,7 @@ where
 	init_overlay(overlay, false)?;
 
 	let result = {
-		let mut orig_prospective = overlay.prospective.clone();
+		let orig_prospective = overlay.prospective.clone();
 
 		let (result, was_native, storage_delta, changes_delta) = {
 			let ((result, was_native), (storage_delta, changes_delta)) = {
@@ -616,7 +600,7 @@ where
 #[cfg(test)]
 mod tests {
 	use std::collections::HashMap;
-	use codec::Encode;
+	use parity_codec::Encode;
 	use overlayed_changes::OverlayedValue;
 	use super::*;
 	use super::backend::InMemory;
@@ -625,7 +609,7 @@ mod tests {
 		InMemoryStorage as InMemoryChangesTrieStorage,
 		Configuration as ChangesTrieConfig,
 	};
-	use primitives::Blake2Hasher;
+	use primitives::{Blake2Hasher, map};
 
 	struct DummyCodeExecutor {
 		change_changes_trie_config: bool,

--- a/core/state-machine/src/overlayed_changes.rs
+++ b/core/state-machine/src/overlayed_changes.rs
@@ -18,8 +18,8 @@
 
 #[cfg(test)] use std::iter::FromIterator;
 use std::collections::{HashMap, HashSet};
-use codec::Decode;
-use changes_trie::{NO_EXTRINSIC_INDEX, Configuration as ChangesTrieConfig};
+use parity_codec::Decode;
+use crate::changes_trie::{NO_EXTRINSIC_INDEX, Configuration as ChangesTrieConfig};
 use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
 
 /// The overlayed changes to state to be queried on top of the backend.
@@ -276,7 +276,7 @@ impl OverlayedChanges {
 	/// Inserts storage entry responsible for current extrinsic index.
 	#[cfg(test)]
 	pub(crate) fn set_extrinsic_index(&mut self, extrinsic_index: u32) {
-		use codec::Encode;
+		use parity_codec::Encode;
 		self.prospective.top.insert(EXTRINSIC_INDEX.to_vec(), OverlayedValue {
 			value: Some(extrinsic_index.encode()),
 			extrinsics: None,
@@ -309,12 +309,13 @@ impl From<Option<Vec<u8>>> for OverlayedValue {
 
 #[cfg(test)]
 mod tests {
+	use hex_literal::{hex, hex_impl};
 	use primitives::{Blake2Hasher, H256};
 	use primitives::storage::well_known_keys::EXTRINSIC_INDEX;
-	use backend::InMemory;
-	use changes_trie::InMemoryStorage as InMemoryChangesTrieStorage;
-	use ext::Ext;
-	use {Externalities};
+	use crate::backend::InMemory;
+	use crate::changes_trie::InMemoryStorage as InMemoryChangesTrieStorage;
+	use crate::ext::Ext;
+	use crate::Externalities;
 	use super::*;
 
 	fn strip_extrinsic_index(map: &HashMap<Vec<u8>, OverlayedValue>) -> HashMap<Vec<u8>, OverlayedValue> {

--- a/core/state-machine/src/proving_backend.rs
+++ b/core/state-machine/src/proving_backend.rs
@@ -17,13 +17,14 @@
 //! Proving state machine backend.
 
 use std::cell::RefCell;
+use log::debug;
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
 use hash_db::HashDB;
 use trie::{Recorder, MemoryDB, TrieError, default_child_trie_root, read_trie_value_with, read_child_trie_value_with, record_all_keys};
-use trie_backend::TrieBackend;
-use trie_backend_essence::{Ephemeral, TrieBackendEssence, TrieBackendStorage};
-use {Error, ExecutionError, Backend};
+use crate::trie_backend::TrieBackend;
+use crate::trie_backend_essence::{Ephemeral, TrieBackendEssence, TrieBackendStorage};
+use crate::{Error, ExecutionError, Backend};
 
 /// Patricia trie-based backend essence which also tracks all touched storage trie values.
 /// These can be sent to remote node and used as a proof of execution.
@@ -204,8 +205,8 @@ where
 
 #[cfg(test)]
 mod tests {
-	use backend::{InMemory};
-	use trie_backend::tests::test_trie;
+	use crate::backend::{InMemory};
+	use crate::trie_backend::tests::test_trie;
 	use super::*;
 	use primitives::{Blake2Hasher};
 

--- a/core/state-machine/src/testing.rs
+++ b/core/state-machine/src/testing.rs
@@ -21,10 +21,10 @@ use std::iter::FromIterator;
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
 use trie::trie_root;
-use backend::InMemory;
-use changes_trie::{compute_changes_trie_root, InMemoryStorage as ChangesTrieInMemoryStorage, AnchorBlockId};
+use crate::backend::InMemory;
+use crate::changes_trie::{compute_changes_trie_root, InMemoryStorage as ChangesTrieInMemoryStorage, AnchorBlockId};
 use primitives::storage::well_known_keys::{CHANGES_TRIE_CONFIG, CODE, HEAP_PAGES};
-use codec::Encode;
+use parity_codec::Encode;
 use super::{Externalities, OverlayedChanges};
 
 /// Simple HashMap-based Externalities impl.
@@ -163,6 +163,7 @@ impl<H: Hasher> Externalities<H> for TestExternalities<H> where H::Out: Ord + He
 mod tests {
 	use super::*;
 	use primitives::{Blake2Hasher, H256};
+	use hex_literal::{hex, hex_impl};
 
 	#[test]
 	fn commit_should_work() {

--- a/core/state-machine/src/trie_backend.rs
+++ b/core/state-machine/src/trie_backend.rs
@@ -16,11 +16,12 @@
 
 //! Trie-based state machine backend.
 
+use log::{warn, debug};
 use hash_db::Hasher;
 use heapsize::HeapSizeOf;
 use trie::{TrieDB, TrieError, Trie, MemoryDB, delta_trie_root, default_child_trie_root, child_delta_trie_root};
-use trie_backend_essence::{TrieBackendEssence, TrieBackendStorage, Ephemeral};
-use {Backend};
+use crate::trie_backend_essence::{TrieBackendEssence, TrieBackendStorage, Ephemeral};
+use crate::Backend;
 
 /// Patricia trie-based backend. Transaction type is an overlay of changes to commit.
 pub struct TrieBackend<S: TrieBackendStorage<H>, H: Hasher> {

--- a/core/state-machine/src/trie_backend_essence.rs
+++ b/core/state-machine/src/trie_backend_essence.rs
@@ -20,10 +20,11 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
+use log::{debug, warn};
 use hash_db::{self, Hasher};
 use heapsize::HeapSizeOf;
 use trie::{TrieDB, Trie, MemoryDB, DBValue, TrieError, default_child_trie_root, read_trie_value, read_child_trie_value, for_keys_in_child_trie};
-use changes_trie::Storage as ChangesTrieStorage;
+use crate::changes_trie::Storage as ChangesTrieStorage;
 
 /// Patricia trie-based storage trait.
 pub trait Storage<H: Hasher>: Send + Sync {

--- a/core/telemetry/Cargo.toml
+++ b/core/telemetry/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-telemetry"
 version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Telemetry utils"
+edition = "2018"
 
 [dependencies]
 parking_lot = "0.7.1"

--- a/core/telemetry/src/lib.rs
+++ b/core/telemetry/src/lib.rs
@@ -21,20 +21,11 @@
 //! server (if there is one). We use the async drain adapter of `slog`
 //! so that the logging thread doesn't get held up at all.
 
-extern crate parking_lot;
-extern crate ws;
-extern crate slog_async;
-extern crate slog_json;
-#[macro_use]
-extern crate log;
-#[macro_use(o)]
-extern crate slog;
-extern crate slog_scope;
-
 use std::{io, time, thread};
 use std::sync::Arc;
 use parking_lot::Mutex;
-use slog::Drain;
+use slog::{Drain, o};
+use log::trace;
 pub use slog_scope::with_logger;
 
 /// Configuration for telemetry.

--- a/core/test-client/Cargo.toml
+++ b/core/test-client/Cargo.toml
@@ -2,14 +2,15 @@
 name = "substrate-test-client"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
-substrate-client = { path = "../client" }
+client = { package = "substrate-client", path = "../client" }
 parity-codec = "3.0"
-substrate-executor = { path = "../executor" }
-substrate-consensus-common = { path = "../consensus/common" }
-substrate-keyring = { path = "../../core/keyring" }
-substrate-primitives = { path = "../primitives" }
-substrate-state-machine = { path = "../state-machine" }
-substrate-test-runtime = { path = "../test-runtime" }
-sr-primitives = { path = "../sr-primitives" }
+executor = { package = "substrate-executor", path = "../executor" }
+consensus = { package = "substrate-consensus-common", path = "../consensus/common" }
+keyring = { package = "substrate-keyring", path = "../../core/keyring" }
+primitives = { package = "substrate-primitives", path = "../primitives" }
+state_machine = { package = "substrate-state-machine", path = "../state-machine" }
+runtime = { package = "substrate-test-runtime", path = "../test-runtime" }
+runtime_primitives = { package = "sr-primitives", path = "../sr-primitives" }

--- a/core/test-client/src/block_builder_ext.rs
+++ b/core/test-client/src/block_builder_ext.rs
@@ -16,7 +16,6 @@
 
 //! Block Builder extensions for tests.
 
-use codec;
 use client;
 use keyring;
 use runtime;
@@ -41,7 +40,7 @@ impl<'a, A> BlockBuilderExt for client::block_builder::BlockBuilder<'a, runtime:
 fn sign_tx(transfer: runtime::Transfer) -> runtime::Extrinsic {
 	let signature = keyring::Keyring::from_raw_public(transfer.from.to_fixed_bytes())
 		.unwrap()
-		.sign(&codec::Encode::encode(&transfer))
+		.sign(&parity_codec::Encode::encode(&transfer))
 		.into();
 	runtime::Extrinsic::Transfer(transfer, signature)
 }

--- a/core/test-client/src/lib.rs
+++ b/core/test-client/src/lib.rs
@@ -18,26 +18,19 @@
 
 #![warn(missing_docs)]
 
-extern crate parity_codec as codec;
-extern crate substrate_primitives as primitives;
-extern crate sr_primitives as runtime_primitives;
-#[macro_use] extern crate substrate_executor as executor;
-
-pub extern crate substrate_client as client;
-pub extern crate substrate_keyring as keyring;
-pub extern crate substrate_test_runtime as runtime;
-pub extern crate substrate_consensus_common as consensus;
-extern crate substrate_state_machine as state_machine;
-
 pub mod client_ext;
 pub mod trait_tests;
 mod block_builder_ext;
 
 pub use client_ext::TestClient;
 pub use block_builder_ext::BlockBuilderExt;
+pub use client;
 pub use client::blockchain;
 pub use client::backend;
 pub use executor::NativeExecutor;
+pub use keyring;
+pub use runtime;
+pub use consensus;
 
 use std::sync::Arc;
 use primitives::Blake2Hasher;
@@ -48,7 +41,8 @@ use keyring::Keyring;
 
 mod local_executor {
 	#![allow(missing_docs)]
-	use super::runtime;
+	use runtime;
+	use executor::native_executor_instance;
 	// FIXME #1576 change the macro and pass in the `BlakeHasher` that dispatch needs from here instead
 	native_executor_instance!(
 		pub LocalExecutor,

--- a/core/test-client/src/trait_tests.rs
+++ b/core/test-client/src/trait_tests.rs
@@ -23,11 +23,11 @@ use std::sync::Arc;
 use keyring::Keyring;
 use consensus::BlockOrigin;
 use primitives::Blake2Hasher;
-use ::TestClient;
+use crate::TestClient;
 use runtime_primitives::traits::Block as BlockT;
-use backend;
-use blockchain::{Backend as BlockChainBackendT, HeaderBackend};
-use ::BlockBuilderExt;
+use crate::backend;
+use crate::blockchain::{Backend as BlockChainBackendT, HeaderBackend};
+use crate::{BlockBuilderExt, new_with_backend};
 use runtime::{self, Transfer};
 use runtime_primitives::generic::BlockId;
 
@@ -41,7 +41,7 @@ pub fn test_leaves_for_backend<B: 'static>(backend: Arc<B>) where
 	//			  B2 -> C3
 	//		A1 -> D2
 
-	let client = ::new_with_backend(backend.clone(), false);
+	let client = new_with_backend(backend.clone(), false);
 
 	let genesis_hash = client.info().unwrap().chain.genesis_hash;
 
@@ -153,7 +153,7 @@ pub fn test_blockchain_query_by_number_gets_canonical<B: 'static>(backend: Arc<B
 	//		A1 -> B2 -> B3 -> B4
 	//			  B2 -> C3
 	//		A1 -> D2
-	let client = ::new_with_backend(backend, false);
+	let client = new_with_backend(backend, false);
 
 	// G -> A1
 	let a1 = client.new_block().unwrap().bake().unwrap();

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-test-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 log = { version = "0.4", optional = true }
@@ -10,15 +11,15 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
-substrate-keyring = { path = "../keyring", optional = true }
+keyring = { package = "substrate-keyring", path = "../keyring", optional = true }
 substrate-client = { path = "../client", default-features = false }
-substrate-primitives = { path = "../primitives", default-features = false }
-substrate-inherents = { path = "../inherents", default-features = false }
-substrate-consensus-aura-primitives = { path = "../consensus/aura/primitives", default-features = false }
-sr-std = { path = "../sr-std", default-features = false }
-sr-io = { path = "../sr-io", default-features = false }
-sr-primitives = { path = "../sr-primitives", default-features = false }
-sr-version = { path = "../sr-version", default-features = false }
+primitives = { package = "substrate-primitives", path = "../primitives", default-features = false }
+inherents = { package = "substrate-inherents", path = "../inherents", default-features = false }
+consensus_aura = { package = "substrate-consensus-aura-primitives", path = "../consensus/aura/primitives", default-features = false }
+rstd = { package = "sr-std", path = "../sr-std", default-features = false }
+runtime_io = { package = "sr-io", path = "../sr-io", default-features = false }
+runtime_primitives = { package = "sr-primitives", path = "../sr-primitives", default-features = false }
+runtime_version = { package = "sr-version", path = "../sr-version", default-features = false }
 srml-support = { path = "../../srml/support", default-features = false }
 
 [dev-dependencies]
@@ -32,14 +33,14 @@ std = [
 	"serde",
 	"serde_derive",
 	"substrate-client/std",
-	"substrate-keyring",
+	"keyring",
 	"parity-codec/std",
-	"sr-std/std",
-	"sr-io/std",
+	"rstd/std",
+	"runtime_io/std",
 	"srml-support/std",
-	"substrate-primitives/std",
-	"substrate-inherents/std",
-	"sr-primitives/std",
-	"sr-version/std",
-	"substrate-consensus-aura-primitives/std",
+	"primitives/std",
+	"inherents/std",
+	"runtime_primitives/std",
+	"runtime_version/std",
+	"consensus_aura/std",
 ]

--- a/core/test-runtime/src/genesismap.rs
+++ b/core/test-runtime/src/genesismap.rs
@@ -18,8 +18,8 @@
 
 use std::collections::HashMap;
 use runtime_io::twox_128;
-use codec::{Encode, KeyedVec, Joiner};
-use primitives::{Ed25519AuthorityId, ChangesTrieConfiguration};
+use parity_codec::{Encode, KeyedVec, Joiner};
+use primitives::{Ed25519AuthorityId, ChangesTrieConfiguration, map};
 use primitives::storage::well_known_keys;
 use runtime_primitives::traits::Block;
 
@@ -68,7 +68,7 @@ impl GenesisConfig {
 	}
 }
 
-pub fn additional_storage_with_genesis(genesis_block: &::Block) -> HashMap<Vec<u8>, Vec<u8>> {
+pub fn additional_storage_with_genesis(genesis_block: &crate::Block) -> HashMap<Vec<u8>, Vec<u8>> {
 	map![
 		twox_128(&b"latest"[..]).to_vec() => genesis_block.hash().as_fixed_bytes().to_vec()
 	]

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -18,45 +18,22 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate serde;
-
-extern crate sr_std as rstd;
-extern crate parity_codec as codec;
-extern crate sr_primitives as runtime_primitives;
-extern crate substrate_inherents as inherents;
-extern crate substrate_consensus_aura_primitives as consensus_aura;
-
-#[macro_use]
-extern crate substrate_client as client;
-
 #[macro_use]
 extern crate srml_support as runtime_support;
-#[macro_use]
-extern crate parity_codec_derive;
-extern crate sr_io as runtime_io;
-#[macro_use]
-extern crate sr_version as runtime_version;
-
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
-#[cfg(test)]
-extern crate substrate_keyring as keyring;
-#[cfg_attr(any(feature = "std", test), macro_use)]
-extern crate substrate_primitives as primitives;
-
-#[cfg(test)] extern crate substrate_executor;
 
 #[cfg(feature = "std")] pub mod genesismap;
 pub mod system;
 
 use rstd::prelude::*;
-use codec::{Encode, Decode};
+use parity_codec::{Encode, Decode};
+use parity_codec_derive::{Encode, Decode};
 
-use client::{runtime_api as client_api, block_builder::api as block_builder_api};
+use substrate_client::{runtime_api as client_api, block_builder::api as block_builder_api,
+	decl_runtime_apis, impl_runtime_apis,
+};
 use runtime_primitives::{
 	ApplyResult, Ed25519Signature, transaction_validity::TransactionValidity,
+	create_runtime_str,
 	traits::{
 		BlindCheckable, BlakeTwo256, Block as BlockT, Extrinsic as ExtrinsicT,
 		GetNodeBlockType, GetRuntimeBlockType

--- a/core/test-runtime/src/system.rs
+++ b/core/test-runtime/src/system.rs
@@ -23,7 +23,7 @@ use runtime_support::storage::{self, StorageValue, StorageMap};
 use runtime_primitives::traits::{Hash as HashT, BlakeTwo256, Digest as DigestT};
 use runtime_primitives::generic;
 use runtime_primitives::{ApplyError, ApplyOutcome, ApplyResult, transaction_validity::TransactionValidity};
-use codec::{KeyedVec, Encode};
+use parity_codec::{KeyedVec, Encode};
 use super::{AccountId, BlockNumber, Extrinsic, Transfer, H256 as Hash, Block, Header, Digest};
 use primitives::{Ed25519AuthorityId, Blake2Hasher};
 use primitives::storage::well_known_keys;
@@ -256,12 +256,13 @@ mod tests {
 	use super::*;
 
 	use runtime_io::{with_externalities, twox_128, TestExternalities};
-	use codec::{Joiner, KeyedVec};
+	use parity_codec::{Joiner, KeyedVec};
 	use keyring::Keyring;
-	use ::{Header, Digest, Extrinsic, Transfer};
-	use primitives::{Blake2Hasher};
+	use crate::{Header, Digest, Extrinsic, Transfer};
+	use primitives::{Blake2Hasher, map};
 	use primitives::storage::well_known_keys;
 	use substrate_executor::WasmExecutor;
+	use hex_literal::{hex, hex_impl};
 
 	const WASM_CODE: &'static [u8] =
 			include_bytes!("../wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm");

--- a/core/test-runtime/wasm/Cargo.toml
+++ b/core/test-runtime/wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-test-runtime-wasm"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [lib]
 name = "substrate_test_runtime"

--- a/core/test-runtime/wasm/src/lib.rs
+++ b/core/test-runtime/wasm/src/lib.rs
@@ -18,5 +18,4 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate substrate_test_runtime;
 pub use substrate_test_runtime::*;


### PR DESCRIPTION
Part of the #1415 issue.