### PR TITLE
Fix minor error in chain-spec generation command in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,7 @@ First let's get a template chainspec that you can edit. We'll use the "staging" 
 
 [source, shell]
 ----
-substrate --chain=staging build-spec > ~/chainspec.json
+substrate build-spec --chain=staging spec > ~/chainspec.json
 ----
 
 Now, edit `~/chainspec.json` in your editor. There are a lot of individual fields for each module, and one very large one which contains the Webassembly code blob for this chain. The easiest field to edit is the block `period`. Change it to 10 (seconds):

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,7 @@ First let's get a template chainspec that you can edit. We'll use the "staging" 
 
 [source, shell]
 ----
-substrate build-spec --chain=staging spec > ~/chainspec.json
+substrate build-spec --chain=staging > ~/chainspec.json
 ----
 
 Now, edit `~/chainspec.json` in your editor. There are a lot of individual fields for each module, and one very large one which contains the Webassembly code blob for this chain. The easiest field to edit is the block `period`. Change it to 10 (seconds):


### PR DESCRIPTION
This minor pr fixes a mistake in the command to generate a chain spec in the substrate readme. Fix taken from https://github.com/paritytech/substrate/issues/1643