### PR TITLE
Reduce consensus spam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -231,7 +231,10 @@ pub trait Network<Block: BlockT>: Clone {
 	fn send_message(&self, round: u64, set_id: u64, message: Vec<u8>);
 
 	/// Clean up messages for a round.
-	fn drop_messages(&self, round: u64, set_id: u64);
+	fn drop_round_messages(&self, round: u64, set_id: u64);
+
+	/// Clean up messages for a given authority set id (e.g. commit messages).
+	fn drop_set_messages(&self, set_id: u64);
 
 	/// Get a stream of commit messages for a specific set-id. This stream
 	/// should never logically conclude.
@@ -283,8 +286,13 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 		self.service.gossip_consensus_message(topic, message, false);
 	}
 
-	fn drop_messages(&self, round: u64, set_id: u64) {
+	fn drop_round_messages(&self, round: u64, set_id: u64) {
 		let topic = message_topic::<B>(round, set_id);
+		self.service.consensus_gossip().write().collect_garbage(|t| t != &topic);
+	}
+
+	fn drop_set_messages(&self, set_id: u64) {
+		let topic = commit_topic::<B>(set_id);
 		self.service.consensus_gossip().write().collect_garbage(|t| t != &topic);
 	}
 

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -288,12 +288,12 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn drop_round_messages(&self, round: u64, set_id: u64) {
 		let topic = message_topic::<B>(round, set_id);
-		self.service.consensus_gossip().write().collect_garbage(|t| t != &topic);
+		self.service.consensus_gossip().write().collect_garbage_for_topic(topic);
 	}
 
 	fn drop_set_messages(&self, set_id: u64) {
 		let topic = commit_topic::<B>(set_id);
-		self.service.consensus_gossip().write().collect_garbage(|t| t != &topic);
+		self.service.consensus_gossip().write().collect_garbage_for_topic(topic);
 	}
 
 	fn commit_messages(&self, set_id: u64) -> Self::In {

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -302,7 +302,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn send_commit(&self, _round: u64, set_id: u64, message: Vec<u8>) {
 		let topic = commit_topic::<B>(set_id);
-		self.service.gossip_consensus_message(topic, message, true);
+		self.service.gossip_consensus_message(topic, message, false);
 	}
 
 	fn announce(&self, round: u64, _set_id: u64, block: B::Hash) {

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -285,7 +285,7 @@ impl<B: BlockT, S: network::specialization::NetworkSpecialization<B>, H: ExHashT
 
 	fn drop_messages(&self, round: u64, set_id: u64) {
 		let topic = message_topic::<B>(round, set_id);
-		self.service.consensus_gossip().write().collect_garbage(|t| t == &topic);
+		self.service.consensus_gossip().write().collect_garbage(|t| t != &topic);
 	}
 
 	fn commit_messages(&self, set_id: u64) -> Self::In {

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -151,7 +151,7 @@ impl MessageRouting {
 		let peer = inner.peer(self.peer_id);
 		let mut gossip = peer.consensus_gossip().write();
 		peer.with_spec(move |_, _| {
-			gossip.collect_garbage(|t| t != &topic)
+			gossip.collect_garbage_for_topic(topic);
 		});
 	}
 }

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -226,7 +226,7 @@ impl Network<Block> for MessageRouting {
 
 	fn send_commit(&self, _round: u64, set_id: u64, message: Vec<u8>) {
 		let mut inner = self.inner.lock();
-		inner.peer(self.peer_id).gossip_message(make_commit_topic(set_id), message, true);
+		inner.peer(self.peer_id).gossip_message(make_commit_topic(set_id), message, false);
 		inner.route_until_complete();
 	}
 

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -145,6 +145,15 @@ impl MessageRouting {
 			peer_id,
 		}
 	}
+
+	fn drop_messages(&self, topic: Hash) {
+		let inner = self.inner.lock();
+		let peer = inner.peer(self.peer_id);
+		let mut gossip = peer.consensus_gossip().write();
+		peer.with_spec(move |_, _| {
+			gossip.collect_garbage(|t| t != &topic)
+		});
+	}
 }
 
 fn make_topic(round: u64, set_id: u64) -> Hash {
@@ -199,14 +208,14 @@ impl Network<Block> for MessageRouting {
 		inner.route_until_complete();
 	}
 
-	fn drop_messages(&self, round: u64, set_id: u64) {
+	fn drop_round_messages(&self, round: u64, set_id: u64) {
 		let topic = make_topic(round, set_id);
-		let inner = self.inner.lock();
-		let peer = inner.peer(self.peer_id);
-		let mut gossip = peer.consensus_gossip().write();
-		peer.with_spec(move |_, _| {
-			gossip.collect_garbage(|t| t == &topic)
-		});
+		self.drop_messages(topic);
+	}
+
+	fn drop_set_messages(&self, set_id: u64) {
+		let topic = make_commit_topic(set_id);
+		self.drop_messages(topic);
 	}
 
 	fn commit_messages(&self, set_id: u64) -> Self::In {

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -14,6 +14,7 @@ error-chain = "0.12"
 bitflags = "1.0"
 futures = "0.1.17"
 linked-hash-map = "0.5"
+lru-cache = "0.1.1"
 rustc-hex = "2.0"
 rand = "0.6"
 substrate-primitives = { path = "../../core/primitives" }

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -29,7 +29,7 @@ use protocol::Context;
 use config::Roles;
 
 // FIXME: Add additional spam/DoS attack protection: https://github.com/paritytech/substrate/issues/1115
-const MESSAGE_LIFETIME: Duration = Duration::from_secs(600);
+const MESSAGE_LIFETIME: Duration = Duration::from_secs(120);
 
 struct PeerConsensus<H> {
 	known_messages: HashSet<H>,
@@ -188,7 +188,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 		known_messages.retain(|(topic, message_hash)| {
 			message_times.get(&(*topic, *message_hash))
-				.map(|instant| *instant + (2 * MESSAGE_LIFETIME) >= now)
+				.map(|instant| *instant + (5 * MESSAGE_LIFETIME) >= now)
 				.unwrap_or(false)
 		});
 

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -188,11 +188,11 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 		known_messages.retain(|(topic, message_hash)| {
 			message_times.get(&(*topic, *message_hash))
-				.map(|instant| *instant + (2 * MESSAGE_LIFETIME) >= now && predicate(topic))
+				.map(|instant| *instant + (2 * MESSAGE_LIFETIME) >= now)
 				.unwrap_or(false)
 		});
 
-		trace!(target:"gossip", "Cleaned up {} stale messages, {} left ({} known)",
+		trace!(target: "gossip", "Cleaned up {} stale messages, {} left ({} known)",
 			before - self.messages.len(),
 			self.messages.len(),
 			known_messages.len(),

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -22,7 +22,7 @@ use futures::sync::mpsc;
 use std::time::{Instant, Duration};
 use rand::{self, seq::SliceRandom};
 use network_libp2p::NodeIndex;
-use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, Hash, HashFor};
+use runtime_primitives::traits::{Block as BlockT, Hash, HashFor};
 use runtime_primitives::generic::BlockId;
 pub use message::generic::{Message, ConsensusMessage};
 use protocol::Context;
@@ -234,21 +234,6 @@ impl<B: BlockT> ConsensusGossip<B> {
 			trace!(target:"gossip", "Ignored already known message from {} in {}", who, topic);
 			return None;
 		}
-
-		match (protocol.client().info(), protocol.client().header(&BlockId::Hash(topic))) {
-			(_, Err(e)) | (Err(e), _) => {
-				debug!(target:"gossip", "Error reading blockchain: {:?}", e);
-				return None;
-			},
-			(Ok(info), Ok(Some(header))) => {
-				if header.number() < &info.chain.best_number {
-					trace!(target:"gossip", "Ignored ancient message from {}, hash={}", who, topic);
-					return None;
-				}
-			},
-			(Ok(_), Ok(None)) => {},
-		}
-
 
 		if let Some(ref mut peer) = self.peers.get_mut(&who) {
 			use std::collections::hash_map::Entry;

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -21,6 +21,7 @@
 //! Allows attachment of an optional subprotocol for chain-specific requests.
 
 extern crate linked_hash_map;
+extern crate lru_cache;
 extern crate parking_lot;
 extern crate substrate_primitives as primitives;
 extern crate substrate_client as client;


### PR DESCRIPTION
- The predicate that was being used to clean up gossip messages was wrong, so all messages were being pruned.
- The logic for keeping known messages relied on this predicate as well, so these messages would be immediately forgotten after getting pruned.
- Right after pruning we'd get them all back from the network and import them all (20K+ messages).
- Commit topics weren't being pruned at all.
- I set the expiration-based pruning to be a bit more agressive (the higher layers already have logic for resending messages when necessary).
- Garbage collection is now done on a topic, and we ignore any further messages for that topic.
- Commit messages are no longer broadcast to all peers (this was probably a bad idea all along, sorry). This might make it so that non-authority nodes observe finality with a bit of delay (temporarily until #1272), but at least for change blocks they should request justifications through sync and therefore not get stuck waiting for finality.
- There was also old code (from RHD) that assumed that topics were header hashes (and looked it up on the DB). We should probably create an issue for this since I'm not sure whether RHD is relying on this logic.

Fix #1646. Should help with #1645.

