### PR TITLE
Lower log level of grandpa until_imported message

### DIFF
--- a/core/finality-grandpa/src/until_imported.rs
+++ b/core/finality-grandpa/src/until_imported.rs
@@ -162,7 +162,7 @@ impl<Block: BlockT, Status, I, M> Stream for UntilImported<Block, Status, I, M> 
 				} else {
 					let next_log = *last_log + LOG_PENDING_INTERVAL;
 					if Instant::now() <= next_log {
-						warn!(
+						debug!(
 							target: "afg",
 							"Waiting to import block {} before {} votes can be imported. \
 							Possible fork?",

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -24,7 +24,6 @@ use rand::{self, seq::SliceRandom};
 use lru_cache::LruCache;
 use network_libp2p::NodeIndex;
 use runtime_primitives::traits::{Block as BlockT, Hash, HashFor};
-use runtime_primitives::generic::BlockId;
 pub use message::generic::{Message, ConsensusMessage};
 use protocol::Context;
 use config::Roles;
@@ -173,6 +172,8 @@ impl<B: BlockT> ConsensusGossip<B> {
 		self.peers.remove(&who);
 	}
 
+	/// Prune all existing messages for the given topic and mark it as dead, all
+	/// new messages for the given topic are ignored.
 	pub fn collect_garbage_for_topic(&mut self, topic: B::Hash) {
 		self.known_dead_topics.insert(topic, ());
 		self.collect_garbage(|_| true);


### PR DESCRIPTION
This message is mostly useful when debugging a stalled grandpa voter. Also added missing docs on `consensus_gossip`.