### PR TITLE
Migrate sr-primitives, sr-sandbox, sr-std and sr-version to the 2018 edition.

### DIFF
--- a/core/sr-primitives/Cargo.toml
+++ b/core/sr-primitives/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sr-primitives"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
@@ -11,8 +12,8 @@ serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
 substrate-primitives = { path = "../primitives", default-features = false }
-sr-std = { path = "../sr-std", default-features = false }
-sr-io = { path = "../sr-io", default-features = false }
+rstd = { package = "sr-std", path = "../sr-std", default-features = false }
+runtime_io = { package = "sr-io", path = "../sr-io", default-features = false }
 log = {version = "0.4", optional = true }
 
 [dev-dependencies]
@@ -25,8 +26,8 @@ std = [
 	"serde",
 	"serde_derive",
 	"log",
-	"sr-std/std",
-	"sr-io/std",
+	"rstd/std",
+	"runtime_io/std",
 	"parity-codec/std",
 	"substrate-primitives/std",
 ]

--- a/core/sr-primitives/src/generic/block.rs
+++ b/core/sr-primitives/src/generic/block.rs
@@ -19,10 +19,14 @@
 #[cfg(feature = "std")]
 use std::fmt;
 
+#[cfg(feature = "std")]
+use serde_derive::Serialize;
+
 use rstd::prelude::*;
-use codec::Codec;
-use traits::{self, Member, Block as BlockT, Header as HeaderT, MaybeSerialize};
-use ::Justification;
+use parity_codec_derive::{Encode, Decode};
+use crate::codec::Codec;
+use crate::traits::{self, Member, Block as BlockT, Header as HeaderT, MaybeSerialize};
+use crate::Justification;
 
 /// Something to identify a block.
 #[derive(PartialEq, Eq, Clone)]

--- a/core/sr-primitives/src/generic/checked_extrinsic.rs
+++ b/core/sr-primitives/src/generic/checked_extrinsic.rs
@@ -17,7 +17,7 @@
 //! Generic implementation of an extrinsic that has passed the verification
 //! stage.
 
-use traits::{self, Member, SimpleArithmetic, MaybeDisplay};
+use crate::traits::{self, Member, SimpleArithmetic, MaybeDisplay};
 
 /// Definition of something that the external world might want to say; its
 /// existence implies that it has been checked and is good, particularly with

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -16,10 +16,14 @@
 
 //! Generic implementation of a digest.
 
-use rstd::prelude::*;
+#[cfg(feature = "std")]
+use serde_derive::Serialize;
 
-use codec::{Decode, Encode, Codec, Input};
-use traits::{self, Member, DigestItem as DigestItemT, MaybeHash};
+use rstd::prelude::*;
+use parity_codec_derive::{Encode, Decode};
+
+use crate::codec::{Decode, Encode, Codec, Input};
+use crate::traits::{self, Member, DigestItem as DigestItemT, MaybeHash};
 
 use substrate_primitives::hash::H512 as Signature;
 

--- a/core/sr-primitives/src/generic/era.rs
+++ b/core/sr-primitives/src/generic/era.rs
@@ -16,7 +16,10 @@
 
 //! Generic implementation of an unchecked (pre-verification) extrinsic.
 
-use codec::{Decode, Encode, Input, Output};
+#[cfg(feature = "std")]
+use serde_derive::{Serialize, Deserialize};
+
+use crate::codec::{Decode, Encode, Input, Output};
 
 pub type Period = u64;
 pub type Phase = u64;

--- a/core/sr-primitives/src/generic/header.rs
+++ b/core/sr-primitives/src/generic/header.rs
@@ -16,10 +16,12 @@
 
 //! Generic implementation of a block header.
 
-use codec::{Decode, Encode, Codec, Input, Output, HasCompact, EncodeAsRef};
-use traits::{self, Member, SimpleArithmetic, SimpleBitOps, MaybeDisplay,
+#[cfg(feature = "std")]
+use serde_derive::Serialize;
+use crate::codec::{Decode, Encode, Codec, Input, Output, HasCompact, EncodeAsRef};
+use crate::traits::{self, Member, SimpleArithmetic, SimpleBitOps, MaybeDisplay,
 	Hash as HashT, DigestItem as DigestItemT, MaybeSerializeDebug, MaybeSerializeDebugButNotDeserialize};
-use generic::Digest;
+use crate::generic::Digest;
 
 /// Abstraction over a block header for a substrate chain.
 #[derive(PartialEq, Eq, Clone)]

--- a/core/sr-primitives/src/generic/mod.rs
+++ b/core/sr-primitives/src/generic/mod.rs
@@ -38,7 +38,7 @@ pub use self::header::Header;
 pub use self::block::{Block, SignedBlock, BlockId};
 pub use self::digest::{Digest, DigestItem, DigestItemRef};
 
-use codec::Encode;
+use crate::codec::Encode;
 use rstd::prelude::*;
 
 fn encode_with_vec_prefix<T: Encode, F: Fn(&mut Vec<u8>)>(encoder: F) -> Vec<u8> {

--- a/core/sr-primitives/src/generic/tests.rs
+++ b/core/sr-primitives/src/generic/tests.rs
@@ -16,7 +16,7 @@
 
 //! Tests for the generic implementations of Extrinsic/Header/Block.
 
-use codec::{Decode, Encode};
+use crate::codec::{Decode, Encode};
 use substrate_primitives::H256;
 use super::DigestItem;
 

--- a/core/sr-primitives/src/generic/unchecked_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_extrinsic.rs
@@ -20,8 +20,9 @@
 use std::fmt;
 
 use rstd::prelude::*;
-use codec::{Decode, Encode, Codec, Input, HasCompact};
-use traits::{self, Member, SimpleArithmetic, MaybeDisplay, Lookup, Extrinsic};
+use parity_codec_derive::{Encode, Decode};
+use crate::codec::{Decode, Encode, Codec, Input, HasCompact};
+use crate::traits::{self, Member, SimpleArithmetic, MaybeDisplay, Lookup, Extrinsic};
 use super::CheckedExtrinsic;
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
@@ -92,7 +93,7 @@ where
 			Some(SignatureContent{signed, signature, index}) => {
 				let payload = (index, self.function);
 				let signed = context.lookup(signed)?;
-				if !::verify_encoded_lazy(&signature, &payload, &signed) {
+				if !crate::verify_encoded_lazy(&signature, &payload, &signed) {
 					return Err("bad signature in extrinsic")
 				}
 				CheckedExtrinsic {
@@ -172,7 +173,7 @@ where
 
 #[cfg(test)]
 mod test {
-	use codec::{Decode, Encode};
+	use crate::codec::{Decode, Encode};
 	use super::UncheckedExtrinsic;
 
 	#[test]

--- a/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
@@ -21,8 +21,8 @@ use std::fmt;
 
 use rstd::prelude::*;
 use runtime_io::blake2_256;
-use codec::{Decode, Encode, Input, Compact};
-use traits::{self, Member, SimpleArithmetic, MaybeDisplay, CurrentHeight, BlockNumberToHash, Lookup,
+use crate::codec::{Decode, Encode, Input, Compact};
+use crate::traits::{self, Member, SimpleArithmetic, MaybeDisplay, CurrentHeight, BlockNumberToHash, Lookup,
 	Checkable, Extrinsic};
 use super::{CheckedExtrinsic, Era};
 
@@ -190,6 +190,8 @@ impl<Address, Index, Call, Signature> fmt::Debug for UncheckedMortalCompactExtri
 mod tests {
 	use super::*;
 	use runtime_io::blake2_256;
+	use parity_codec_derive::{Encode, Decode};
+	use serde_derive::{Serialize, Deserialize};
 
 	struct TestContext;
 	impl Lookup for TestContext {

--- a/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
@@ -21,8 +21,8 @@ use std::fmt;
 
 use rstd::prelude::*;
 use runtime_io::blake2_256;
-use codec::{Decode, Encode, Input};
-use traits::{self, Member, SimpleArithmetic, MaybeDisplay, CurrentHeight, BlockNumberToHash, Lookup,
+use crate::codec::{Decode, Encode, Input};
+use crate::traits::{self, Member, SimpleArithmetic, MaybeDisplay, CurrentHeight, BlockNumberToHash, Lookup,
 	Checkable, Extrinsic};
 use super::{CheckedExtrinsic, Era};
 
@@ -189,6 +189,8 @@ impl<Address, Index, Call, Signature> fmt::Debug for UncheckedMortalExtrinsic<Ad
 mod tests {
 	use super::*;
 	use runtime_io::blake2_256;
+	use parity_codec_derive::{Encode, Decode};
+	use serde_derive::{Serialize, Deserialize};
 
 	struct TestContext;
 	impl Lookup for TestContext {

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -21,36 +21,18 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
-extern crate serde;
-
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate serde_derive;
-
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate log;
-
-#[macro_use]
-extern crate parity_codec_derive;
-
-extern crate num_traits;
-extern crate integer_sqrt;
-extern crate sr_std as rstd;
-extern crate sr_io as runtime_io;
 #[doc(hidden)]
-pub extern crate parity_codec as codec;
-extern crate substrate_primitives;
-
-#[cfg(test)]
-extern crate serde_json;
+pub use parity_codec as codec;
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub use serde_derive;
 
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
 use rstd::prelude::*;
 use substrate_primitives::hash::{H256, H512};
+use parity_codec_derive::{Encode, Decode};
 
 #[cfg(feature = "std")]
 use substrate_primitives::hexdisplay::ascii_format;
@@ -88,6 +70,8 @@ macro_rules! create_runtime_str {
 
 #[cfg(feature = "std")]
 pub use serde::{Serialize, de::DeserializeOwned};
+#[cfg(feature = "std")]
+use serde_derive::{Serialize, Deserialize};
 
 /// A set of key value pairs for storage.
 #[cfg(feature = "std")]
@@ -105,7 +89,7 @@ pub trait BuildStorage {
 	/// Default to xx128 hashing.
 	fn hash(data: &[u8]) -> [u8; 16] {
 		let r = runtime_io::twox_128(data);
-		trace!(target: "build_storage", "{} <= {}", substrate_primitives::hexdisplay::HexDisplay::from(&r), ascii_format(data));
+		log::trace!(target: "build_storage", "{} <= {}", substrate_primitives::hexdisplay::HexDisplay::from(&r), ascii_format(data));
 		r
 	}
 	/// Build the storage out of this builder.
@@ -423,7 +407,7 @@ macro_rules! impl_outer_log {
 		/// Wrapper for all possible log entries for the `$trait` runtime. Provides binary-compatible
 		/// `Encode`/`Decode` implementations with the corresponding `generic::DigestItem`.
 		#[derive(Clone, PartialEq, Eq)]
-		#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+		#[cfg_attr(feature = "std", derive(Debug, $crate::serde_derive::Serialize))]
 		$(#[$attr])*
 		#[allow(non_camel_case_types)]
 		pub struct $name($internal);
@@ -431,7 +415,7 @@ macro_rules! impl_outer_log {
 		/// All possible log entries for the `$trait` runtime. `Encode`/`Decode` implementations
 		/// are auto-generated => it is not binary-compatible with `generic::DigestItem`.
 		#[derive(Clone, PartialEq, Eq, Encode, Decode)]
-		#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+		#[cfg_attr(feature = "std", derive(Debug, $crate::serde_derive::Serialize))]
 		$(#[$attr])*
 		#[allow(non_camel_case_types)]
 		pub enum InternalLog {
@@ -540,7 +524,7 @@ pub struct OpaqueExtrinsic(pub Vec<u8>);
 #[cfg(feature = "std")]
 impl ::serde::Serialize for OpaqueExtrinsic {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
-		::codec::Encode::using_encoded(&self.0, |bytes| ::substrate_primitives::bytes::serialize(bytes, seq))
+		codec::Encode::using_encoded(&self.0, |bytes| ::substrate_primitives::bytes::serialize(bytes, seq))
 	}
 }
 
@@ -553,8 +537,9 @@ impl traits::Extrinsic for OpaqueExtrinsic {
 #[cfg(test)]
 mod tests {
 	use substrate_primitives::hash::H256;
-	use codec::{Encode as EncodeHidden, Decode as DecodeHidden};
-	use traits::DigestItem;
+	use crate::codec::{Encode as EncodeHidden, Decode as DecodeHidden};
+	use parity_codec_derive::{Encode, Decode};
+	use crate::traits::DigestItem;
 
 	pub trait RuntimeT {
 		type AuthorityId;
@@ -568,6 +553,8 @@ mod tests {
 
 	mod a {
 		use super::RuntimeT;
+		use parity_codec_derive::{Encode, Decode};
+		use serde_derive::Serialize;
 		pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
 
 		#[derive(Serialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
@@ -576,6 +563,8 @@ mod tests {
 
 	mod b {
 		use super::RuntimeT;
+		use parity_codec_derive::{Encode, Decode};
+		use serde_derive::Serialize;
 		pub type Log<R> = RawLog<<R as RuntimeT>::AuthorityId>;
 
 		#[derive(Serialize, Debug, Encode, Decode, PartialEq, Eq, Clone)]
@@ -633,24 +622,24 @@ mod tests {
 	fn compact_permill_perbill_encoding() {
 		let tests = [(0u32, 1usize), (63, 1), (64, 2), (16383, 2), (16384, 4), (1073741823, 4), (1073741824, 5), (u32::max_value(), 5)];
 		for &(n, l) in &tests {
-			let compact: codec::Compact<super::Permill> = super::Permill(n).into();
+			let compact: crate::codec::Compact<super::Permill> = super::Permill(n).into();
 			let encoded = compact.encode();
 			assert_eq!(encoded.len(), l);
-			let decoded = <codec::Compact<super::Permill>>::decode(&mut & encoded[..]).unwrap();
+			let decoded = <crate::codec::Compact<super::Permill>>::decode(&mut & encoded[..]).unwrap();
 			let permill: super::Permill = decoded.into();
 			assert_eq!(permill, super::Permill(n));
 
-			let compact: codec::Compact<super::Perbill> = super::Perbill(n).into();
+			let compact: crate::codec::Compact<super::Perbill> = super::Perbill(n).into();
 			let encoded = compact.encode();
 			assert_eq!(encoded.len(), l);
-			let decoded = <codec::Compact<super::Perbill>>::decode(&mut & encoded[..]).unwrap();
+			let decoded = <crate::codec::Compact<super::Perbill>>::decode(&mut & encoded[..]).unwrap();
 			let perbill: super::Perbill = decoded.into();
 			assert_eq!(perbill, super::Perbill(n));
 		}
 	}
 
 	#[derive(Encode, Decode, PartialEq, Eq, Debug)]
-	struct WithCompact<T: codec::HasCompact> {
+	struct WithCompact<T: crate::codec::HasCompact> {
 		data: T,
 	}
 

--- a/core/sr-primitives/src/testing.rs
+++ b/core/sr-primitives/src/testing.rs
@@ -17,10 +17,14 @@
 //! Testing utilities.
 
 use serde::{Serialize, Serializer, Deserialize, de::Error as DeError, Deserializer};
+use serde_derive::Serialize;
+#[cfg(feature = "std")]
+use serde_derive::Deserialize;
 use std::{fmt::Debug, ops::Deref, fmt};
-use codec::{Codec, Encode, Decode};
-use traits::{self, Checkable, Applyable, BlakeTwo256, Convert};
-use generic::DigestItem as GenDigestItem;
+use crate::codec::{Codec, Encode, Decode};
+use crate::traits::{self, Checkable, Applyable, BlakeTwo256, Convert};
+use crate::generic::DigestItem as GenDigestItem;
+use parity_codec_derive::{Encode, Decode};
 
 pub use substrate_primitives::{H256, Ed25519AuthorityId};
 use substrate_primitives::U256;

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -21,9 +21,11 @@ use rstd::{self, result, marker::PhantomData};
 use runtime_io;
 #[cfg(feature = "std")] use std::fmt::{Debug, Display};
 #[cfg(feature = "std")] use serde::{Serialize, de::DeserializeOwned};
+#[cfg(feature = "std")]
+use serde_derive::{Serialize, Deserialize};
 use substrate_primitives;
 use substrate_primitives::Blake2Hasher;
-use codec::{Codec, Encode, HasCompact};
+use crate::codec::{Codec, Encode, HasCompact};
 pub use integer_sqrt::IntegerSquareRoot;
 pub use num_traits::{Zero, One, Bounded};
 pub use num_traits::ops::checked::{
@@ -147,7 +149,7 @@ pub trait As<T> {
 	/// Convert forward (ala `Into::into`).
 	fn as_(self) -> T;
 	/// Convert backward (ala `From::from`).
-	fn sa(T) -> Self;
+	fn sa(_: T) -> Self;
 }
 
 macro_rules! impl_numerics {
@@ -518,29 +520,29 @@ pub trait Header: Clone + Send + Sync + Codec + Eq + MaybeSerializeDebugButNotDe
 	/// Returns a reference to the header number.
 	fn number(&self) -> &Self::Number;
 	/// Sets the header number.
-	fn set_number(&mut self, Self::Number);
+	fn set_number(&mut self, number: Self::Number);
 
 	/// Returns a reference to the extrinsics root.
 	fn extrinsics_root(&self) -> &Self::Hash;
 	/// Sets the extrinsic root.
-	fn set_extrinsics_root(&mut self, Self::Hash);
+	fn set_extrinsics_root(&mut self, root: Self::Hash);
 
 	/// Returns a reference to the state root.
 	fn state_root(&self) -> &Self::Hash;
 	/// Sets the state root.
-	fn set_state_root(&mut self, Self::Hash);
+	fn set_state_root(&mut self, root: Self::Hash);
 
 	/// Returns a reference to the parent hash.
 	fn parent_hash(&self) -> &Self::Hash;
 	/// Sets the parent hash.
-	fn set_parent_hash(&mut self, Self::Hash);
+	fn set_parent_hash(&mut self, hash: Self::Hash);
 
 	/// Returns a reference to the digest.
 	fn digest(&self) -> &Self::Digest;
 	/// Get a mutable reference to the digest.
 	fn digest_mut(&mut self) -> &mut Self::Digest;
 	/// Sets the digest.
-	fn set_digest(&mut self, Self::Digest);
+	fn set_digest(&mut self, digest: Self::Digest);
 
 	/// Returns the hash of the header.
 	fn hash(&self) -> Self::Hash {
@@ -676,7 +678,7 @@ pub trait DigestItem: Codec + Member + MaybeSerializeDebugButNotDeserialize {
 	/// `ChangesTrieRoot` payload.
 	type Hash: Member;
 	/// `AuthorityChange` payload.
-	type AuthorityId: Member + MaybeHash + codec::Encode + codec::Decode;
+	type AuthorityId: Member + MaybeHash + crate::codec::Encode + crate::codec::Decode;
 
 	/// Returns Some if the entry is the `AuthoritiesChange` entry.
 	fn as_authorities_change(&self) -> Option<&[Self::AuthorityId]>;

--- a/core/sr-primitives/src/transaction_validity.rs
+++ b/core/sr-primitives/src/transaction_validity.rs
@@ -17,6 +17,7 @@
 //! Transaction validity interface.
 
 use rstd::prelude::*;
+use parity_codec_derive::{Encode, Decode};
 
 /// Priority for a transaction. Additive. Higher is better.
 pub type TransactionPriority = u64;

--- a/core/sr-sandbox/Cargo.toml
+++ b/core/sr-sandbox/Cargo.toml
@@ -3,15 +3,16 @@ name = "sr-sandbox"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
+edition = "2018"
 
 [build-dependencies]
 rustc_version = "0.2"
 
 [dependencies]
 wasmi = { version = "0.4.3", optional = true }
-substrate-primitives = { path = "../primitives", default-features = false }
-sr-std = { path = "../sr-std", default-features = false }
-parity-codec = { version = "3.0", default-features = false }
+primitives = { package = "substrate-primitives", path = "../primitives", default-features = false }
+rstd = { package = "sr-std", path = "../sr-std", default-features = false }
+codec = { package = "parity-codec", version = "3.0", default-features = false }
 
 [dev-dependencies]
 wabt = "~0.7.4"
@@ -21,9 +22,9 @@ assert_matches = "1.1"
 default = ["std"]
 std = [
 	"wasmi",
-	"substrate-primitives/std",
-	"sr-std/std",
-	"parity-codec/std",
+	"primitives/std",
+	"rstd/std",
+	"codec/std",
 ]
 nightly = []
 strict = []

--- a/core/sr-sandbox/build.rs
+++ b/core/sr-sandbox/build.rs
@@ -1,6 +1,5 @@
 //! Set a nightly feature
 
-extern crate rustc_version;
 use rustc_version::{version, version_meta, Channel};
 
 fn main() {

--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -39,19 +39,6 @@
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg_attr(not(feature = "std"), macro_use)]
-extern crate sr_std as rstd;
-extern crate substrate_primitives as primitives;
-#[cfg(not(feature = "std"))]
-extern crate parity_codec as codec;
-
-#[cfg(test)]
-extern crate wabt;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-
 use rstd::prelude::*;
 
 pub use primitives::sandbox::{TypedValue, ReturnValue, HostError};

--- a/core/sr-sandbox/with_std.rs
+++ b/core/sr-sandbox/with_std.rs
@@ -14,17 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate wasmi;
-
 use rstd::collections::btree_map::BTreeMap;
 use rstd::fmt;
 
-use self::wasmi::{
+use wasmi::{
 	Externals, FuncInstance, FuncRef, GlobalDescriptor, GlobalRef, ImportResolver,
 	MemoryDescriptor, MemoryInstance, MemoryRef, Module, ModuleInstance, ModuleRef,
 	RuntimeArgs, RuntimeValue, Signature, TableDescriptor, TableRef, Trap, TrapKind
 };
-use self::wasmi::memory_units::Pages;
+use wasmi::memory_units::Pages;
 use super::{Error, TypedValue, ReturnValue, HostFuncType, HostError};
 
 #[derive(Clone)]
@@ -90,7 +88,7 @@ impl fmt::Display for DummyHostError {
 	}
 }
 
-impl self::wasmi::HostError for DummyHostError {
+impl wasmi::HostError for DummyHostError {
 }
 
 fn from_runtime_value(v: RuntimeValue) -> TypedValue {
@@ -103,7 +101,7 @@ fn from_runtime_value(v: RuntimeValue) -> TypedValue {
 }
 
 fn to_runtime_value(v: TypedValue) -> RuntimeValue {
-	use self::wasmi::nan_preserving_float::{F32, F64};
+	use wasmi::nan_preserving_float::{F32, F64};
 	match v {
 		TypedValue::I32(v) => RuntimeValue::I32(v as i32),
 		TypedValue::I64(v) => RuntimeValue::I64(v as i64),
@@ -309,7 +307,8 @@ impl<T> Instance<T> {
 #[cfg(test)]
 mod tests {
 	use wabt;
-	use ::{Error, TypedValue, ReturnValue, HostError, EnvironmentDefinitionBuilder, Instance};
+	use crate::{Error, TypedValue, ReturnValue, HostError, EnvironmentDefinitionBuilder, Instance};
+	use assert_matches::assert_matches;
 
 	fn execute_sandboxed(code: &[u8], args: &[TypedValue]) -> Result<ReturnValue, HostError> {
 		struct State {

--- a/core/sr-std/Cargo.toml
+++ b/core/sr-std/Cargo.toml
@@ -3,6 +3,7 @@ name = "sr-std"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
+edition = "2018"
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/core/sr-std/build.rs
+++ b/core/sr-std/build.rs
@@ -1,6 +1,5 @@
 //! Set a nightly feature
 
-extern crate rustc_version;
 use rustc_version::{version, version_meta, Channel};
 
 fn main() {

--- a/core/sr-std/src/lib.rs
+++ b/core/sr-std/src/lib.rs
@@ -41,13 +41,13 @@ include!("../without_std.rs");
 ///
 /// This should include only things which are in the normal std prelude.
 pub mod prelude {
-	pub use ::vec::Vec;
-	pub use ::boxed::Box;
-	pub use ::cmp::{Eq, PartialEq};
-	pub use ::clone::Clone;
+	pub use crate::vec::Vec;
+	pub use crate::boxed::Box;
+	pub use crate::cmp::{Eq, PartialEq};
+	pub use crate::clone::Clone;
 
 	// Re-export `vec!` macro here, but not in `std` mode, since
 	// std's prelude already brings `vec!` into the scope.
 	#[cfg(not(feature = "std"))]
-	pub use ::vec;
+	pub use crate::vec;
 }

--- a/core/sr-version/Cargo.toml
+++ b/core/sr-version/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sr-version"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 impl-serde = { version = "0.1", optional = true }
@@ -9,8 +10,8 @@ serde = { version = "1.0", default-features = false }
 serde_derive = { version = "1.0", optional = true }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
-sr-std = { path = "../sr-std", default-features = false }
-sr-primitives = { path = "../sr-primitives", default-features = false }
+rstd = { package = "sr-std", path = "../sr-std", default-features = false }
+runtime_primitives = { package = "sr-primitives", path = "../sr-primitives", default-features = false }
 
 [features]
 default = ["std"]
@@ -19,6 +20,6 @@ std = [
 	"serde/std",
 	"serde_derive",
 	"parity-codec/std",
-	"sr-std/std",
-	"sr-primitives/std",
+	"rstd/std",
+	"runtime_primitives/std",
 ]

--- a/core/sr-version/src/lib.rs
+++ b/core/sr-version/src/lib.rs
@@ -19,18 +19,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-#[macro_use]
-extern crate serde_derive;
-
-#[allow(unused_imports)]
-#[macro_use]
-extern crate sr_std as rstd;
-
-#[macro_use]
-extern crate parity_codec_derive;
-
-extern crate sr_primitives as runtime_primitives;
-
+use serde_derive::Serialize;
 #[cfg(feature = "std")]
 use std::fmt;
 #[cfg(feature = "std")]
@@ -70,8 +59,8 @@ macro_rules! create_apis_vec {
 /// This triplet have different semantics and mis-interpretation could cause problems.
 /// In particular: bug fixes should result in an increment of `spec_version` and possibly `authoring_version`,
 /// absolutely not `impl_version` since they change the semantics of the runtime.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Decode))]
+#[derive(Clone, PartialEq, Eq, parity_codec_derive::Encode)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, parity_codec_derive::Decode))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct RuntimeVersion {
 	/// Identifies the different Substrate runtimes. There'll be at least polkadot and node.


### PR DESCRIPTION
Part of the #1415 issue.