### PR TITLE
Migrate network, primitives and rpc to the 2018 edition

### DIFF
--- a/core/basic-authorship/src/basic_authorship.rs
+++ b/core/basic-authorship/src/basic_authorship.rs
@@ -24,7 +24,7 @@ use log::{info, debug, trace};
 
 use client::{
 	self, error, Client as SubstrateClient, CallExecutor,
-	block_builder::api::BlockBuilder as BlockBuilderApi, runtime_api::{Core, ApiExt}
+	block_builder::api::BlockBuilder as BlockBuilderApi, runtime_api::Core,
 };
 use codec::Decode;
 use consensus_common::{self, evaluation};

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -29,9 +29,6 @@
 #![recursion_limit="128"]
 
 #[macro_use]
-extern crate log;
-
-#[macro_use]
 mod wasm_utils;
 mod wasm_executor;
 #[macro_use]

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -102,7 +102,7 @@ use substrate_primitives::{ed25519, H256, Ed25519AuthorityId, Blake2Hasher};
 use grandpa::Error as GrandpaError;
 use grandpa::{voter, round::State as RoundState, BlockNumberOps, VoterSet};
 
-use network::{Service as NetworkService, ExHashT};
+use network::Service as NetworkService;
 use network::consensus_gossip::ConsensusMessage;
 use std::sync::Arc;
 use std::time::Duration;

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -4,6 +4,7 @@ name = "substrate-network"
 version = "0.1.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [lib]
 
@@ -18,24 +19,22 @@ linked-hash-map = "0.5"
 lru-cache = "0.1.1"
 rustc-hex = "2.0"
 rand = "0.6"
-substrate-primitives = { path = "../../core/primitives" }
-substrate-consensus-common = { path = "../../core/consensus/common" }
-substrate-client = { path = "../../core/client" }
-sr-primitives = { path = "../../core/sr-primitives" }
+primitives = { package = "substrate-primitives", path = "../../core/primitives" }
+consensus = { package = "substrate-consensus-common", path = "../../core/consensus/common" }
+client = { package = "substrate-client", path = "../../core/client" }
+runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives" }
 parity-codec = "3.0"
 parity-codec-derive = "3.0"
-substrate-network-libp2p = { path = "../../core/network-libp2p" }
+network_libp2p = { package = "substrate-network-libp2p", path = "../../core/network-libp2p" }
 tokio = "0.1.11"
-
-env_logger = { version = "0.6", optional = true }
-substrate-keyring = { path = "../../core/keyring", optional = true }
-substrate-test-client = { path = "../../core/test-client", optional = true }
+keyring = { package = "substrate-keyring", path = "../../core/keyring", optional = true }
+test_client = { package = "substrate-test-client", path = "../../core/test-client", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.6" }
-substrate-keyring = { path = "../../core/keyring" }
-substrate-test-client = { path = "../../core/test-client" }
+keyring = { package = "substrate-keyring", path = "../../core/keyring" }
+test_client = { package = "substrate-test-client", path = "../../core/test-client" }
 
 [features]
 default = []
-test-helpers = ["env_logger", "substrate-keyring", "substrate-test-client"]
+test-helpers = ["keyring", "test_client"]

--- a/core/network/src/blocks.rs
+++ b/core/network/src/blocks.rs
@@ -19,9 +19,10 @@ use std::cmp;
 use std::ops::Range;
 use std::collections::{HashMap, BTreeMap};
 use std::collections::hash_map::Entry;
+use log::trace;
 use network_libp2p::NodeIndex;
 use runtime_primitives::traits::{Block as BlockT, NumberFor, As};
-use message;
+use crate::message;
 
 const MAX_PARALLEL_DOWNLOADS: u32 = 1;
 
@@ -194,7 +195,7 @@ impl<B: BlockT> BlockCollection<B> {
 #[cfg(test)]
 mod test {
 	use super::{BlockCollection, BlockData, BlockRangeState};
-	use message;
+	use crate::message;
 	use runtime_primitives::testing::{Block as RawBlock, ExtrinsicWrapper};
 	use primitives::H256;
 

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -18,11 +18,12 @@
 
 pub use network_libp2p::{NonReservedPeerMode, NetworkConfiguration, Secret};
 
-use chain::Client;
-use codec;
-use on_demand::OnDemandService;
+use bitflags::bitflags;
+use crate::chain::Client;
+use parity_codec;
+use crate::on_demand::OnDemandService;
 use runtime_primitives::traits::{Block as BlockT};
-use service::{ExHashT, TransactionPool};
+use crate::service::{ExHashT, TransactionPool};
 use std::sync::Arc;
 
 /// Service initialization parameters.
@@ -70,14 +71,14 @@ bitflags! {
 	}
 }
 
-impl codec::Encode for Roles {
-	fn encode_to<T: codec::Output>(&self, dest: &mut T) {
+impl parity_codec::Encode for Roles {
+	fn encode_to<T: parity_codec::Output>(&self, dest: &mut T) {
 		dest.push_byte(self.bits())
 	}
 }
 
-impl codec::Decode for Roles {
-	fn decode<I: codec::Input>(input: &mut I) -> Option<Self> {
+impl parity_codec::Decode for Roles {
+	fn decode<I: parity_codec::Input>(input: &mut I) -> Option<Self> {
 		Self::from_bits(input.read_byte()?)
 	}
 }

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -19,14 +19,15 @@
 
 use std::collections::{HashMap, HashSet};
 use std::time::{Instant, Duration};
+use log::{trace, debug};
 use futures::sync::mpsc;
 use rand::{self, seq::SliceRandom};
 use lru_cache::LruCache;
 use network_libp2p::NodeIndex;
 use runtime_primitives::traits::{Block as BlockT, Hash, HashFor};
-pub use message::generic::{Message, ConsensusMessage};
-use protocol::Context;
-use config::Roles;
+pub use crate::message::generic::{Message, ConsensusMessage};
+use crate::protocol::Context;
+use crate::config::Roles;
 
 // FIXME: Add additional spam/DoS attack protection: https://github.com/paritytech/substrate/issues/1115
 const MESSAGE_LIFETIME: Duration = Duration::from_secs(120);

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -20,6 +20,7 @@
 // https://github.com/paritytech/substrate/issues/1547
 #![allow(deprecated)]
 
+use error_chain::*;
 use std::io::Error as IoError;
 use network_libp2p::Error as NetworkError;
 use client;

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -20,35 +20,6 @@
 //! Substrate-specific P2P networking: synchronizing blocks, propagating BFT messages.
 //! Allows attachment of an optional subprotocol for chain-specific requests.
 
-#[macro_use]
-extern crate crossbeam_channel;
-extern crate linked_hash_map;
-extern crate lru_cache;
-extern crate parking_lot;
-extern crate substrate_primitives as primitives;
-extern crate substrate_client as client;
-extern crate sr_primitives as runtime_primitives;
-extern crate substrate_network_libp2p as network_libp2p;
-extern crate substrate_consensus_common as consensus;
-extern crate parity_codec as codec;
-extern crate futures;
-extern crate rustc_hex;
-extern crate rand;
-extern crate tokio;
-#[macro_use] extern crate log;
-#[macro_use] extern crate bitflags;
-#[macro_use] extern crate error_chain;
-#[macro_use] extern crate parity_codec_derive;
-
-#[cfg(test)]
-extern crate env_logger;
-
-#[cfg(any(test, feature = "test-helpers"))]
-extern crate substrate_keyring as keyring;
-
-#[cfg(any(test, feature = "test-helpers"))]
-extern crate substrate_test_client as test_client;
-
 mod service;
 mod sync;
 #[macro_use]

--- a/core/network/src/message.rs
+++ b/core/network/src/message.rs
@@ -16,8 +16,10 @@
 
 //! Network packet message types. These get serialized and put into the lower level protocol payload.
 
+use bitflags::bitflags;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT};
-use codec::{Encode, Decode, Input, Output};
+use parity_codec::{Encode, Decode, Input, Output};
+use parity_codec_derive::{Encode, Decode};
 pub use self::generic::{
 	BlockAnnounce, RemoteCallRequest, RemoteReadRequest,
 	RemoteHeaderRequest, RemoteHeaderResponse,
@@ -124,7 +126,8 @@ pub struct RemoteReadResponse {
 /// Generic types.
 pub mod generic {
 	use runtime_primitives::Justification;
-	use config::Roles;
+	use parity_codec_derive::{Encode, Decode};
+	use crate::config::Roles;
 	use super::{
 		BlockAttributes, RemoteCallResponse, RemoteReadResponse,
 		RequestId, Transactions, Direction

--- a/core/network/src/on_demand.rs
+++ b/core/network/src/on_demand.rs
@@ -16,10 +16,11 @@
 
 //! On-demand requests service.
 
-use codec::Encode;
+use parity_codec::Encode;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Instant, Duration};
+use log::trace;
 use futures::{Async, Future, Poll};
 use futures::sync::oneshot::{channel, Receiver, Sender as OneShotSender};
 use linked_hash_map::LinkedHashMap;
@@ -28,10 +29,10 @@ use parking_lot::Mutex;
 use client::{error::{Error as ClientError, ErrorKind as ClientErrorKind}};
 use client::light::fetcher::{Fetcher, FetchChecker, RemoteHeaderRequest,
 	RemoteCallRequest, RemoteReadRequest, RemoteChangesRequest, ChangesProof};
-use message;
+use crate::message;
 use network_libp2p::{Severity, NodeIndex};
-use config::Roles;
-use service::{NetworkChan, NetworkMsg};
+use crate::config::Roles;
+use crate::service::{NetworkChan, NetworkMsg};
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 
 /// Remote request timeout.
@@ -530,10 +531,10 @@ pub mod tests {
 	use client::{error::{ErrorKind as ClientErrorKind, Result as ClientResult}};
 	use client::light::fetcher::{Fetcher, FetchChecker, RemoteHeaderRequest,
 		RemoteCallRequest, RemoteReadRequest, RemoteChangesRequest, ChangesProof};
-	use config::Roles;
-	use message;
+	use crate::config::Roles;
+	use crate::message;
 	use network_libp2p::{NodeIndex, ProtocolId, Severity};
-	use service::{network_channel, NetworkPort, NetworkMsg};
+	use crate::service::{network_channel, NetworkPort, NetworkMsg};
 	use super::{REQUEST_TIMEOUT, OnDemand, OnDemandService};
 	use test_client::runtime::{changes_trie_config, Block, Header};
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -17,20 +17,21 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::{io, thread};
+use log::{warn, debug, error, trace};
 use futures::{Async, Future, Stream, stream, sync::oneshot};
 use parking_lot::Mutex;
 use network_libp2p::{ProtocolId, PeerId, NetworkConfiguration, NodeIndex, ErrorKind, Severity};
 use network_libp2p::{start_service, parse_str_addr, Service as NetworkService, ServiceEvent as NetworkServiceEvent};
 use network_libp2p::{Protocol as Libp2pProtocol, RegisteredProtocol};
 use consensus::import_queue::{ImportQueue, Link};
-use consensus_gossip::ConsensusGossip;
-use protocol::{self, Context, Protocol, ProtocolMsg, ProtocolStatus, PeerInfo};
-use codec::Decode;
-use config::Params;
+use crate::consensus_gossip::ConsensusGossip;
+use crate::protocol::{self, Context, Protocol, ProtocolMsg, ProtocolStatus, PeerInfo};
+use parity_codec::Decode;
+use crate::config::Params;
 use crossbeam_channel::{self as channel, Receiver, Sender, TryRecvError};
-use error::Error;
+use crate::error::Error;
 use runtime_primitives::traits::{Block as BlockT, NumberFor};
-use specialization::NetworkSpecialization;
+use crate::specialization::NetworkSpecialization;
 
 use tokio::prelude::task::AtomicTask;
 use tokio::runtime::Runtime;

--- a/core/network/src/specialization.rs
+++ b/core/network/src/specialization.rs
@@ -16,9 +16,9 @@
 
 //! Specializations of the substrate network protocol to allow more complex forms of communication.
 
-use ::NodeIndex;
+use crate::NodeIndex;
 use runtime_primitives::traits::Block as BlockT;
-use protocol::Context;
+use crate::protocol::Context;
 
 /// A specialization of the substrate network protocol. Handles events and sends messages.
 pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
@@ -26,13 +26,13 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	fn status(&self) -> Vec<u8>;
 
 	/// Called when a peer successfully handshakes.
-	fn on_connect(&mut self, ctx: &mut Context<B>, who: NodeIndex, status: ::message::Status<B>);
+	fn on_connect(&mut self, ctx: &mut Context<B>, who: NodeIndex, status: crate::message::Status<B>);
 
 	/// Called when a peer is disconnected. If the peer ID is unknown, it should be ignored.
 	fn on_disconnect(&mut self, ctx: &mut Context<B>, who: NodeIndex);
 
 	/// Called when a network-specific message arrives.
-	fn on_message(&mut self, ctx: &mut Context<B>, who: NodeIndex, message: &mut Option<::message::Message<B>>);
+	fn on_message(&mut self, ctx: &mut Context<B>, who: NodeIndex, message: &mut Option<crate::message::Message<B>>);
 
 	/// Called on abort.
 	fn on_abort(&mut self) { }

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -17,18 +17,19 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use protocol::Context;
+use log::{trace, debug};
+use crate::protocol::Context;
 use network_libp2p::{Severity, NodeIndex};
 use client::{BlockStatus, ClientInfo};
 use consensus::BlockOrigin;
 use consensus::import_queue::{ImportQueue, IncomingBlock};
 use client::error::Error as ClientError;
-use blocks::BlockCollection;
+use crate::blocks::BlockCollection;
 use runtime_primitives::Justification;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, NumberFor};
 use runtime_primitives::generic::BlockId;
-use message::{self, generic::Message as GenericMessage};
-use config::Roles;
+use crate::message::{self, generic::Message as GenericMessage};
+use crate::config::Roles;
 
 // Maximum blocks to request in a single packet.
 const MAX_BLOCKS_TO_REQUEST: usize = 128;
@@ -790,7 +791,7 @@ impl<B: BlockT> ChainSync<B> {
 
 /// Get block status, taking into account import queue.
 fn block_status<B: BlockT>(
-	chain: &::chain::Client<B>,
+	chain: &crate::chain::Client<B>,
 	queue: &ImportQueue<B>,
 	hash: B::Hash) -> Result<BlockStatus, ClientError>
 {

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -26,28 +26,29 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+use log::trace;
 use client;
 use client::block_builder::BlockBuilder;
-use codec::{Decode, Encode};
-use config::ProtocolConfig;
+use parity_codec::{Decode, Encode};
+use crate::config::ProtocolConfig;
 use consensus::import_queue::{import_many_blocks, ImportQueue, ImportQueueStatus, IncomingBlock};
 use consensus::import_queue::{Link, SharedBlockImport, SharedJustificationImport, Verifier};
 use consensus::{Error as ConsensusError, ErrorKind as ConsensusErrorKind};
 use consensus::{BlockOrigin, ForkChoiceStrategy, ImportBlock, JustificationImport};
-use consensus_gossip::{ConsensusGossip, ConsensusMessage};
-use crossbeam_channel::{self as channel, Sender};
+use crate::consensus_gossip::{ConsensusGossip, ConsensusMessage};
+use crossbeam_channel::{self as channel, Sender, select};
 use futures::Future;
 use futures::sync::{mpsc, oneshot};
 use keyring::Keyring;
 use network_libp2p::{NodeIndex, ProtocolId, Severity};
 use parking_lot::Mutex;
 use primitives::{H256, Ed25519AuthorityId};
-use protocol::{Context, Protocol, ProtocolMsg, ProtocolStatus};
+use crate::protocol::{Context, Protocol, ProtocolMsg, ProtocolStatus};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{AuthorityIdFor, Block as BlockT, Digest, DigestItem, Header, Zero, NumberFor};
 use runtime_primitives::Justification;
-use service::{network_channel, NetworkChan, NetworkLink, NetworkMsg, NetworkPort, TransactionPool};
-use specialization::NetworkSpecialization;
+use crate::service::{network_channel, NetworkChan, NetworkLink, NetworkMsg, NetworkPort, TransactionPool};
+use crate::specialization::NetworkSpecialization;
 use test_client;
 
 pub use test_client::runtime::{Block, Extrinsic, Hash, Transfer};
@@ -216,7 +217,7 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		vec![]
 	}
 
-	fn on_connect(&mut self, _ctx: &mut Context<Block>, _peer_id: NodeIndex, _status: ::message::Status<Block>) {
+	fn on_connect(&mut self, _ctx: &mut Context<Block>, _peer_id: NodeIndex, _status: crate::message::Status<Block>) {
 	}
 
 	fn on_disconnect(&mut self, _ctx: &mut Context<Block>, _peer_id: NodeIndex) {
@@ -226,7 +227,7 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		&mut self,
 		_ctx: &mut Context<Block>,
 		_peer_id: NodeIndex,
-		_message: &mut Option<::message::Message<Block>>,
+		_message: &mut Option<crate::message::Message<Block>>,
 	) {
 	}
 }

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -16,10 +16,10 @@
 
 use client::backend::Backend;
 use client::blockchain::HeaderBackend as BlockchainHeaderBackend;
-use config::Roles;
+use crate::config::Roles;
 use consensus::BlockOrigin;
 use network_libp2p::NodeIndex;
-use sync::SyncState;
+use crate::sync::SyncState;
 use std::{thread, time};
 use std::collections::HashSet;
 use super::*;

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -2,9 +2,10 @@
 name = "substrate-primitives"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
-sr-std = { path = "../sr-std", default-features = false }
+rstd = { package = "sr-std", path = "../sr-std", default-features = false }
 parity-codec = { version = "3.0", default-features = false }
 parity-codec-derive = { version = "3.0", default-features = false }
 rustc-hex = { version = "2.0", default-features = false }
@@ -42,7 +43,7 @@ std = [
 	"parity-codec/std",
 	"hash256-std-hasher/std",
 	"hash-db/std",
-	"sr-std/std",
+	"rstd/std",
 	"serde/std",
 	"rustc-hex/std",
 	"twox-hash",

--- a/core/primitives/src/authority_id.rs
+++ b/core/primitives/src/authority_id.rs
@@ -16,7 +16,8 @@
 
 #[cfg(feature = "std")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use H256;
+use parity_codec_derive::{Encode, Decode};
+use crate::H256;
 
 /// An identifier for an authority in the consensus algorithm. The same size as ed25519::Public.
 #[derive(Clone, Copy, PartialEq, Eq, Default, Encode, Decode)]
@@ -25,15 +26,15 @@ pub struct Ed25519AuthorityId(pub [u8; 32]);
 #[cfg(feature = "std")]
 impl ::std::fmt::Display for Ed25519AuthorityId {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		write!(f, "{}", ::ed25519::Public(self.0).to_ss58check())
+		write!(f, "{}", crate::ed25519::Public(self.0).to_ss58check())
 	}
 }
 
 #[cfg(feature = "std")]
 impl ::std::fmt::Debug for Ed25519AuthorityId {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		let h = format!("{}", ::hexdisplay::HexDisplay::from(&self.0));
-		write!(f, "{} ({}…{})", ::ed25519::Public(self.0).to_ss58check(), &h[0..8], &h[60..])
+		let h = format!("{}", crate::hexdisplay::HexDisplay::from(&self.0));
+		write!(f, "{} ({}…{})", crate::ed25519::Public(self.0).to_ss58check(), &h[0..8], &h[60..])
 	}
 }
 
@@ -83,13 +84,13 @@ impl Into<H256> for Ed25519AuthorityId {
 #[cfg(feature = "std")]
 impl Serialize for Ed25519AuthorityId {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-		::ed25519::serialize(&self, serializer)
+		crate::ed25519::serialize(&self, serializer)
 	}
 }
 
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for Ed25519AuthorityId {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-		::ed25519::deserialize(deserializer)
+		crate::ed25519::deserialize(deserializer)
 	}
 }

--- a/core/primitives/src/changes_trie.rs
+++ b/core/primitives/src/changes_trie.rs
@@ -16,6 +16,10 @@
 
 //! Substrate changes trie configuration.
 
+#[cfg(any(feature = "std", test))]
+use serde_derive::{Serialize, Deserialize};
+use parity_codec_derive::{Encode, Decode};
+
 /// Substrate changes trie configuration.
 #[cfg_attr(any(feature = "std", test), derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Default, Encode, Decode)]

--- a/core/primitives/src/ed25519.rs
+++ b/core/primitives/src/ed25519.rs
@@ -21,8 +21,9 @@
 use untrusted;
 use blake2_rfc;
 use ring::{rand, signature, signature::KeyPair};
-use {hash::H512, Ed25519AuthorityId};
+use crate::{hash::H512, Ed25519AuthorityId};
 use base58::{ToBase58, FromBase58};
+use parity_codec_derive::{Encode, Decode};
 
 #[cfg(feature = "std")]
 use serde::{de, Serializer, Deserializer, Deserialize};
@@ -190,7 +191,7 @@ impl ::std::fmt::Display for Public {
 impl ::std::fmt::Debug for Public {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
 		let s = self.to_ss58check();
-		write!(f, "{} ({}...)", ::hexdisplay::HexDisplay::from(&self.0), &s[0..8])
+		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.0), &s[0..8])
 	}
 }
 
@@ -295,10 +296,11 @@ pub fn serialize<S, T: AsRef<[u8; 32]>>(data: &T, serializer: S) -> Result<S::Ok
 #[cfg(test)]
 mod test {
 	use super::*;
+	use hex_literal::{hex, hex_impl};
 
 	fn _test_primitives_signature_and_local_the_same() {
 		fn takes_two<T>(_: T, _: T) { }
-		takes_two(Signature::default(), ::Signature::default())
+		takes_two(Signature::default(), crate::Signature::default())
 	}
 
 	#[test]
@@ -323,7 +325,7 @@ mod test {
 
 	#[test]
 	fn seeded_pair_should_work() {
-		use ::hexdisplay::HexDisplay;
+		use crate::hexdisplay::HexDisplay;
 
 		let pair = Pair::from_seed(b"12345678901234567890123456789012");
 		let public = pair.public();

--- a/core/primitives/src/hasher.rs
+++ b/core/primitives/src/hasher.rs
@@ -18,12 +18,12 @@
 
 use hash_db::Hasher;
 use hash256_std_hasher::Hash256StdHasher;
-use hash::H256;
+use crate::hash::H256;
 
 pub mod blake2 {
 	use super::{Hasher, Hash256StdHasher, H256};
 	#[cfg(feature = "std")]
-	use hashing::blake2_256;
+	use crate::hashing::blake2_256;
 
 	#[cfg(not(feature = "std"))]
 	extern "C" {

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -21,56 +21,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
-extern crate primitive_types;
-#[macro_use]
-extern crate parity_codec_derive;
-
-extern crate rustc_hex;
-extern crate byteorder;
-extern crate parity_codec as codec;
-
-#[cfg(feature = "std")]
-extern crate serde;
-#[cfg(feature = "std")]
-extern crate twox_hash;
-
-#[cfg(feature = "std")]
-extern crate blake2_rfc;
-#[cfg(feature = "std")]
-extern crate ring;
-#[cfg(feature = "std")]
-extern crate base58;
-#[cfg(feature = "std")]
-extern crate untrusted;
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
-
-#[cfg(feature = "std")]
-extern crate impl_serde;
-
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate serde_derive;
-#[cfg(feature = "std")]
-extern crate core;
-#[cfg(feature = "std")]
-extern crate wasmi;
-extern crate hash_db;
-extern crate hash256_std_hasher;
-
-extern crate sr_std as rstd;
-
-#[cfg(test)]
-extern crate substrate_serializer;
-
-#[cfg(test)]
-extern crate heapsize;
-
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
 #[macro_export]
 macro_rules! map {
 	($( $name:expr => $value:expr ),*) => (
@@ -80,8 +30,11 @@ macro_rules! map {
 
 use rstd::prelude::*;
 use rstd::ops::Deref;
+use parity_codec_derive::{Encode, Decode};
 #[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(feature = "std")]
+use serde_derive::{Serialize, Deserialize};
 
 #[cfg(feature = "std")]
 pub use impl_serde::serialize as bytes;
@@ -168,14 +121,14 @@ pub enum NativeOrEncoded<R> {
 }
 
 #[cfg(feature = "std")]
-impl<R: codec::Encode> ::std::fmt::Debug for NativeOrEncoded<R> {
+impl<R: parity_codec::Encode> ::std::fmt::Debug for NativeOrEncoded<R> {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
 		self.as_encoded().as_ref().fmt(f)
 	}
 }
 
 #[cfg(feature = "std")]
-impl<R: codec::Encode> NativeOrEncoded<R> {
+impl<R: parity_codec::Encode> NativeOrEncoded<R> {
 	/// Return the value as the encoded format.
 	pub fn as_encoded<'a>(&'a self) -> Cow<'a, [u8]> {
 		match self {
@@ -194,13 +147,13 @@ impl<R: codec::Encode> NativeOrEncoded<R> {
 }
 
 #[cfg(feature = "std")]
-impl<R: PartialEq + codec::Decode> PartialEq for NativeOrEncoded<R> {
+impl<R: PartialEq + parity_codec::Decode> PartialEq for NativeOrEncoded<R> {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
 			(NativeOrEncoded::Native(l), NativeOrEncoded::Native(r)) => l == r,
 			(NativeOrEncoded::Native(n), NativeOrEncoded::Encoded(e)) |
 			(NativeOrEncoded::Encoded(e), NativeOrEncoded::Native(n)) =>
-				Some(n) == codec::Decode::decode(&mut &e[..]).as_ref(),
+				Some(n) == parity_codec::Decode::decode(&mut &e[..]).as_ref(),
 			(NativeOrEncoded::Encoded(l), NativeOrEncoded::Encoded(r)) => l == r,
 		}
 	}
@@ -213,7 +166,7 @@ impl<R: PartialEq + codec::Decode> PartialEq for NativeOrEncoded<R> {
 pub enum NeverNativeValue {}
 
 #[cfg(feature = "std")]
-impl codec::Encode for NeverNativeValue {
+impl parity_codec::Encode for NeverNativeValue {
 	fn encode(&self) -> Vec<u8> {
 		// The enum is not constructable, so this function should never be callable!
 		unreachable!()
@@ -221,8 +174,8 @@ impl codec::Encode for NeverNativeValue {
 }
 
 #[cfg(feature = "std")]
-impl codec::Decode for NeverNativeValue {
-	fn decode<I: codec::Input>(_: &mut I) -> Option<Self> {
+impl parity_codec::Decode for NeverNativeValue {
+	fn decode<I: parity_codec::Input>(_: &mut I) -> Option<Self> {
 		None
 	}
 }

--- a/core/primitives/src/sandbox.rs
+++ b/core/primitives/src/sandbox.rs
@@ -17,7 +17,8 @@
 //! Definition of a sandbox environment.
 
 #[cfg(test)]
-use codec::Encode;
+use parity_codec::Encode;
+use parity_codec_derive::{Encode, Decode};
 use rstd::vec::Vec;
 
 /// Error error that can be returned from host function.
@@ -185,7 +186,7 @@ pub const ERR_EXECUTION: u32 = -3i32 as u32;
 mod tests {
 	use super::*;
 	use std::fmt;
-	use codec::Codec;
+	use parity_codec::Codec;
 
 	fn roundtrip<S: Codec + PartialEq + fmt::Debug>(s: S) {
 		let encoded = s.encode();

--- a/core/primitives/src/storage.rs
+++ b/core/primitives/src/storage.rs
@@ -17,7 +17,9 @@
 //! Contract execution data.
 
 #[cfg(feature = "std")]
-use bytes;
+use serde_derive::{Serialize, Deserialize};
+#[cfg(feature = "std")]
+use crate::bytes;
 use rstd::vec::Vec;
 
 /// Contract storage key.

--- a/core/primitives/src/uint.rs
+++ b/core/primitives/src/uint.rs
@@ -21,7 +21,7 @@ pub use primitive_types::U256;
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use codec::{Encode, Decode};
+	use parity_codec::{Encode, Decode};
 	use substrate_serializer as ser;
 
 	macro_rules! test {

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "substrate-rpc"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
 
 [dependencies]
 error-chain = "0.12"
@@ -14,18 +15,18 @@ parity-codec = "3.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-substrate-client = { path = "../client" }
+client = { package = "substrate-client", path = "../client" }
 substrate-executor = { path = "../executor" }
-substrate-network = { path = "../network" }
-substrate-primitives = { path = "../primitives" }
-substrate-transaction-pool = { path = "../transaction-pool" }
-sr-primitives = { path = "../sr-primitives" }
-sr-version = { path = "../sr-version" }
+network = { package = "substrate-network", path = "../network" }
+primitives = { package = "substrate-primitives", path = "../primitives" }
+transaction_pool = { package = "substrate-transaction-pool", path = "../transaction-pool" }
+runtime_primitives = { package = "sr-primitives", path = "../sr-primitives" }
+runtime_version = { package = "sr-version", path = "../sr-version" }
 tokio = "0.1.7"
 
 [dev-dependencies]
 assert_matches = "1.1"
-substrate-test-client = { path = "../test-client" }
-substrate-consensus-common = { path = "../consensus/common" }
+test_client = { package = "substrate-test-client", path = "../test-client" }
+consensus = { package = "substrate-consensus-common", path = "../consensus/common" }
 rustc-hex = "2.0"
 hex-literal = "0.1"

--- a/core/rpc/src/author/error.rs
+++ b/core/rpc/src/author/error.rs
@@ -16,11 +16,12 @@
 
 //! Authoring RPC module errors.
 
+use error_chain::*;
 use client;
 use transaction_pool::txpool;
-use rpc;
+use crate::rpc;
 
-use errors;
+use crate::errors;
 
 error_chain! {
 	links {

--- a/core/rpc/src/author/tests.rs
+++ b/core/rpc/src/author/tests.rs
@@ -17,7 +17,9 @@
 use super::*;
 
 use std::sync::Arc;
-use codec::Encode;
+use hex_literal::{hex, hex_impl};
+use assert_matches::assert_matches;
+use parity_codec::Encode;
 use transaction_pool::{
 	txpool::Pool,
 	ChainApi,

--- a/core/rpc/src/chain/error.rs
+++ b/core/rpc/src/chain/error.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+use error_chain::*;
 use client;
-use rpc;
-
-use errors;
+use crate::rpc;
+use crate::errors;
 
 error_chain! {
 	links {

--- a/core/rpc/src/chain/number.rs
+++ b/core/rpc/src/chain/number.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+use serde_derive::Deserialize;
 use primitives::U256;
 use runtime_primitives::traits;
 

--- a/core/rpc/src/chain/tests.rs
+++ b/core/rpc/src/chain/tests.rs
@@ -15,6 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
+use assert_matches::assert_matches;
 use test_client::{self, TestClient};
 use test_client::runtime::{H256, Block, Header};
 use consensus::BlockOrigin;

--- a/core/rpc/src/errors.rs
+++ b/core/rpc/src/errors.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use rpc;
+use crate::rpc;
+use log::warn;
 
 pub fn unimplemented() -> rpc::Error {
 	rpc::Error {

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -18,41 +18,6 @@
 
 #![warn(missing_docs)]
 
-extern crate jsonrpc_core as rpc;
-extern crate jsonrpc_pubsub;
-extern crate jsonrpc_derive;
-extern crate parity_codec as codec;
-extern crate parking_lot;
-extern crate serde;
-extern crate serde_json;
-extern crate sr_primitives as runtime_primitives;
-extern crate sr_version as runtime_version;
-extern crate substrate_client as client;
-extern crate substrate_network as network;
-extern crate substrate_primitives as primitives;
-extern crate substrate_transaction_pool as transaction_pool;
-extern crate tokio;
-
-#[macro_use]
-extern crate error_chain;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-
-#[cfg(test)]
-#[macro_use]
-extern crate assert_matches;
-#[cfg(test)]
-#[macro_use]
-extern crate hex_literal;
-#[cfg(test)]
-extern crate substrate_test_client as test_client;
-#[cfg(test)]
-extern crate substrate_consensus_common as consensus;
-#[cfg(test)]
-extern crate rustc_hex;
-
 mod errors;
 mod helpers;
 mod subscriptions;
@@ -64,3 +29,5 @@ pub mod chain;
 pub mod metadata;
 pub mod state;
 pub mod system;
+
+use jsonrpc_core as rpc;

--- a/core/rpc/src/metadata.rs
+++ b/core/rpc/src/metadata.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use jsonrpc_pubsub::{Session, PubSubMetadata};
-use rpc::futures::sync::mpsc;
+use crate::rpc::futures::sync::mpsc;
 
 /// RPC Metadata.
 ///
@@ -30,7 +30,7 @@ pub struct Metadata {
 	session: Option<Arc<Session>>,
 }
 
-impl ::rpc::Metadata for Metadata {}
+impl crate::rpc::Metadata for Metadata {}
 impl PubSubMetadata for Metadata {
 	fn session(&self) -> Option<Arc<Session>> {
 		self.session.clone()

--- a/core/rpc/src/state/error.rs
+++ b/core/rpc/src/state/error.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+use error_chain::*;
 use client;
-use rpc;
-
-use errors;
+use crate::rpc;
+use crate::errors;
 
 error_chain! {
 	links {

--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -17,6 +17,7 @@
 use super::*;
 use self::error::{Error, ErrorKind};
 
+use assert_matches::assert_matches;
 use consensus::BlockOrigin;
 use rustc_hex::FromHex;
 use test_client::{self, runtime, keyring::Keyring, TestClient, BlockBuilderExt};

--- a/core/rpc/src/subscriptions.rs
+++ b/core/rpc/src/subscriptions.rs
@@ -17,10 +17,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::{self, AtomicUsize}};
 
+use log::warn;
 use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
 use parking_lot::Mutex;
-use rpc::futures::sync::oneshot;
-use rpc::futures::{Future, future};
+use crate::rpc::futures::sync::oneshot;
+use crate::rpc::futures::{Future, future};
 use tokio::runtime::TaskExecutor;
 
 type Id = u64;

--- a/core/rpc/src/system/error.rs
+++ b/core/rpc/src/system/error.rs
@@ -16,10 +16,11 @@
 
 //! System RPC module errors.
 
-use rpc;
+use error_chain::*;
 
-use errors;
-use system::helpers::Health;
+use crate::rpc;
+use crate::errors;
+use crate::system::helpers::Health;
 
 error_chain! {
 	errors {

--- a/core/rpc/src/system/tests.rs
+++ b/core/rpc/src/system/tests.rs
@@ -19,6 +19,7 @@ use super::*;
 use network::{self, SyncState, SyncStatus, ProtocolStatus, NodeIndex, PeerId, PeerInfo as NetworkPeerInfo, PublicKey};
 use network::config::Roles;
 use test_client::runtime::Block;
+use assert_matches::assert_matches;
 
 #[derive(Default)]
 struct Status {


### PR DESCRIPTION
Part of the #1415 issue.