### PR TITLE
Fix block justification response handling

### DIFF
--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -93,6 +93,8 @@ impl<B: BlockT> PendingJustifications<B> {
 			return;
 		}
 
+		let initial_pending_requests = self.pending_requests.len();
+
 		// clean up previous failed requests so we can retry again
 		for (_, requests) in self.previous_requests.iter_mut() {
 			requests.retain(|(_, instant)| instant.elapsed() < JUSTIFICATION_RETRY_WAIT);
@@ -173,6 +175,11 @@ impl<B: BlockT> PendingJustifications<B> {
 		}
 
 		self.pending_requests.append(&mut unhandled_requests);
+
+		trace!(target: "sync", "Dispatched {} justification requests ({} pending)",
+			initial_pending_requests - self.pending_requests.len(),
+			self.pending_requests.len(),
+		);
 	}
 
 	/// Queue a justification request (without dispatching it).

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -534,12 +534,12 @@ impl<B: BlockT> ChainSync<B> {
 						);
 					},
 					None => {
-						let msg = format!(
-							"Provided empty response for justification request {:?}",
+						// we might have asked the peer for a justification on a block that we thought it had
+						// (regardless of whether it had a justification for it or not).
+						trace!(target: "sync", "Peer {:?} provided empty response for justification request {:?}",
+							who,
 							hash,
 						);
-
-						protocol.report_peer(who, Severity::Useless(msg));
 						return;
 					},
 				}


### PR DESCRIPTION
We request a justification for a block from a peer with the assumption that the peer has the block in its chain (because we might have announced it to him). With this assumption, the peer should never reply with an empty response to the justification request, it should just provide a `None` for the justification. But that might not be the case, the peer might not have the block in its chain (even though we assume it had), and therefore replying with an empty response is legitimate behavior that shouldn't be reported.