### PR TITLE
Remove warning about empty list of identify addresses

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -241,10 +241,6 @@ impl<TSubstream> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<TSubs
 				if !info.protocol_version.contains("substrate") {
 					warn!(target: "sub-libp2p", "Connected to a non-Substrate node: {:?}", info);
 				}
-				if info.listen_addrs.is_empty() {
-					warn!(target: "sub-libp2p", "Received identify response with empty list of \
-						addresses");
-				}
 				if info.listen_addrs.len() > 30 {
 					warn!(target: "sub-libp2p", "Node {:?} id reported more than 30 addresses",
 						peer_id);


### PR DESCRIPTION
If a node doesn't listen on any address, its identify response will not contain any address. This is therefore not a problem.