### PR TITLE
Reduce the spam from network misbehaviours

### DIFF
--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -570,8 +570,9 @@ where
 					messages,
 				}));
 			}
-			CustomProtosHandlerOut::ProtocolError { error } => {
-				warn!(target: "sub-libp2p", "Network misbehaviour from {:?}: {:?}", source, error);
+			CustomProtosHandlerOut::ProtocolError { protocol_id, error } => {
+				warn!(target: "sub-libp2p", "Network misbehaviour from {:?} with protocol \
+					{:?}: {:?}", source, protocol_id, error);
 				self.ban_peer(source);
 			}
 		}

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -242,9 +242,14 @@ impl<TSubstream> CustomProtos<TSubstream> {
 	/// Disconnects the given peer if we are connected to it and disables it for a little while.
 	pub fn ban_peer(&mut self, peer_id: PeerId) {
 		// Peer is already banned
-		if self.banned_peers.iter().any(|(p, _)| p == &peer_id) {
-			return
+		if let Some(pos) = self.banned_peers.iter().position(|(p, _)| p == &peer_id) {
+			if self.banned_peers[pos].1 > Instant::now() {
+				return
+			} else {
+				self.banned_peers.remove(pos);
+			}
 		}
+
 		self.banned_peers.push((peer_id.clone(), Instant::now() + PEER_DISABLE_DURATION));
 		if self.enabled_peers.remove(&peer_id).is_some() {
 			self.events.push(NetworkBehaviourAction::SendEvent {
@@ -565,6 +570,10 @@ where
 					messages,
 				}));
 			}
+			CustomProtosHandlerOut::ProtocolError { error } => {
+				warn!(target: "sub-libp2p", "Network misbehaviour from {:?}: {:?}", source, error);
+				self.ban_peer(source);
+			}
 		}
 	}
 
@@ -589,7 +598,7 @@ where
 		}
 
 		// Clean up `banned_peers`
-		self.banned_peers.retain(|(_, end)| *end < Instant::now());
+		self.banned_peers.retain(|(_, end)| *end > Instant::now());
 		self.banned_peers.shrink_to_fit();
 
 		if !self.events.is_empty() {


### PR DESCRIPTION
cc #1738 

Once a node misbehaves on the network, we print a warning once and ban it for 5 minutes.

Also fixes a bug where banning didn't work because we would clear the list of banned peers every time `poll()` was called.
