### PR TITLE
Ci wasm builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@
 
 
 stages:
+  - merge-test
   - test
   - build
   - publish
@@ -35,10 +36,29 @@ cache:
 
 
 
+#### stage:                        merge-test
+
+check:merge:conflict:
+  stage:                           merge-test
+  image:                           parity/tools:latest
+  cache:                           {}
+  tags:
+    - linux-docker
+  only:
+    - /^[0-9]+$/
+  variables:
+    GITHUB_API:                    "https://api.github.com"
+    GITLAB_API:                    "https://gitlab.parity.io/api/v4"
+    GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
+  script:
+    - ./scripts/gitlab/check_merge_conflict.sh
+
+
+
 
 #### stage:                        test
 
-test:runtime:
+check:runtime:
   stage:                           test
   image:                           parity/tools:latest
   cache:                           {}
@@ -64,7 +84,6 @@ test:rust:stable:                  &test
     RUSTFLAGS: -Cdebug-assertions=y
     TARGET: native
   only:
-    - triggers
     - tags
     - master
     - schedules

--- a/scripts/gitlab/check_merge_conflict.sh
+++ b/scripts/gitlab/check_merge_conflict.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+#
+# check if there is a merge conflict with this pull request only about wasm 
+# binary blobs. if so trigger a rebuild of it and push it on the feature 
+# branch if owned by paritytech
+#
+
+set -e # fail on any error
+
+TEST_RUNTIME="core/test-runtime/wasm/target/wasm32-unknown-unknown/release/substrate_test_runtime.compact.wasm"
+NODE_RUNTIME="node/runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm"
+
+
+
+jsonfile="$(mktemp)"
+
+attemptno="1"
+while ( ! test -s ${jsonfile} ) \
+	|| ( [ "$(jq -r .mergeable ${jsonfile})" = "null" ] \
+	     && [ "${attemptno}" -lt 5 ] )
+do
+	echo "|  checking pull request status (attempt no ${attemptno})"
+	curl -sS -o ${jsonfile} -H "Accept: application/vnd.github.v3+json" \
+	  "${GITHUB_API}/repos/paritytech/substrate/pulls/${CI_COMMIT_REF_NAME}"
+	sleep 3
+	attemptno="$(( ${attemptno} + 1 ))"
+done
+
+
+
+baseref="$(jq -r .head.ref ${jsonfile})"
+baserepo="$(jq -r .head.repo.full_name ${jsonfile})"
+mergeable="$(jq -r .mergeable ${jsonfile})"
+
+rm -f ${jsonfile}
+
+
+cat <<-EOT
+|
+|  pr is of feature branch ${baseref} on ${baserepo}
+|
+|  tell me github is this branch mergeable into the master branch?
+|
+EOT
+
+test "${mergeable}" = "true" && echo "|  yes, it is." && exit 0
+
+
+cat <<-EOT
+|  not mergeable
+|
+|  github sees a conflict - check if it's only about the following wasm blobs
+|
+|	- ${TEST_RUNTIME}
+|	- ${NODE_RUNTIME}
+|
+EOT
+
+git fetch origin master
+git config --global user.email "devops-team+substrate-ci-merge-conflict@parity.io"
+git config --global user.name "I shall never commit to anything"
+
+cat <<-EOT
+|
+|  trying to merge with the master branch to see if there is a conflict about
+|  the wasm files only
+|
+EOT
+
+if git merge --no-commit --no-ff origin/master | grep '^CONFLICT ' \
+	| grep -v -e ${TEST_RUNTIME} -e ${NODE_RUNTIME}
+then
+  git merge --abort
+	echo "|  there are more conflicting files than the wasm blobs"
+	exit 1
+fi
+git merge --abort
+
+
+cat <<-EOT
+|
+|  only wasm blobs block the merge.
+|
+|  triggering rebuild of wasm blobs which will be pushed onto the feature 
+|  branch of this pull request upon success.
+| 
+|  see:
+|
+EOT
+
+
+
+curl -sS -X POST \
+	-F "token=${CI_JOB_TOKEN}" \
+	-F "ref=master" \
+	-F "variables[REBUILD_WASM]=\"${baserepo}:${baseref}\"" \
+	-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
+	${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline \
+	| jq -r .web_url
+
+# fail as there will be another commit on top of that feature branch that will
+# be tested anyway.
+exit 1
+
+
+# vim: noexpandtab

--- a/scripts/gitlab/check_runtime.sh
+++ b/scripts/gitlab/check_runtime.sh
@@ -8,12 +8,25 @@
 
 set -e # fail on any error
 
+
 # give some context
 git log --graph --oneline --decorate=short -n 10
 
 
 RUNTIME="node/runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm"
 VERSIONS_FILE="node/runtime/src/lib.rs"
+
+github_label () {
+	echo
+	echo "# run github-api job for labelling it ${1}"
+	curl -sS -X POST \
+		-F "token=${CI_JOB_TOKEN}" \
+		-F "ref=master" \
+		-F "variables[LABEL]=${1}" \
+		-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
+		${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline
+}
+
 
 
 
@@ -45,14 +58,8 @@ sub_spec_version="$(git diff origin/master...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
 # see if the version and the binary blob changed
 if [ "${add_spec_version}" != "${sub_spec_version}" ]
 then
-	echo
-	echo "# run github-api job for labelling it breaksapi"
-	curl -sS -X POST \
-		-F "token=${CI_JOB_TOKEN}" \
-		-F "ref=master" \
-		-F "variables[BREAKSAPI]=true" \
-		-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
-		${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline
+
+	github_label "B2-breaksapi"
 
 	if git diff --name-only origin/master...${CI_COMMIT_SHA} \
 		| grep -q "${RUNTIME}"
@@ -122,14 +129,7 @@ fi
 
 # dropped through. there's something wrong; mark `gotissues` and exit 1.
 
-echo
-echo "# run github-api job for labelling it gotissues"
-curl -sS -X POST \
-	-F "token=${CI_JOB_TOKEN}" \
-	-F "ref=master" \
-	-F "variables[GOTISSUES]=true" \
-	-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
-	${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline
+github_label "A4-gotissues"
 
 
 exit 1


### PR DESCRIPTION
The idea was to build the wasm files in a separate pipeline and create a pull request to the feature branches of pull requests that have changes in their source code and versions.

source code: https://gitlab.parity.io/parity/infrastructure/github-api/blob/master/.gitlab-ci.yml#L45
pipeline: https://gitlab.parity.io/parity/infrastructure/github-api/pipelines/30329

This PR can be merged safely as the corresponding pipeline will perform dry-run action only for the start.

Feel free to comment your thoughts on it.

(this is just the pr #1744 aiming at the master branch)
