### PR TITLE
Fix attempt for #1777

### DIFF
--- a/core/network-libp2p/tests/test.rs
+++ b/core/network-libp2p/tests/test.rs
@@ -187,5 +187,5 @@ fn many_nodes_connectivity() {
 		}
 	});
 
-	tokio::runtime::Runtime::new().unwrap().block_on(combined).unwrap();
+	tokio::runtime::current_thread::Runtime::new().unwrap().block_on(combined).unwrap();
 }


### PR DESCRIPTION
Fix #1777 

I've tracked down the issue to a task not being properly woken up when notified.
While I haven't had the courage to dig inside of tokio, I know that there have been issues with the multithreaded runner, and therefore this PR switches it out for the single-threaded one.

I'm not sure that this the actual cause. If the test still fails, the issue should be reopened.
