### PR TITLE
Ensure config directory exists.

### DIFF
--- a/core/network-libp2p/src/secret.rs
+++ b/core/network-libp2p/src/secret.rs
@@ -42,6 +42,7 @@ pub fn obtain_private_key(
 			.map_err(|err| IoError::new(IoErrorKind::InvalidData, err))
 	} else {
 		if let Some(ref path) = net_config_path {
+			fs::create_dir_all(Path::new(path))?;
 			// Try fetch the key from a the file containing the secret.
 			let secret_path = Path::new(path).join(SECRET_FILE);
 			match load_private_key_from_file(&secret_path) {


### PR DESCRIPTION
On a first, clean build:

```
cargo run --bin substrate -- build-spec --chain=staging > ~/.substrate/chainspec.json 
    Finished dev [unoptimized + debuginfo] target(s) in 0.54s
     Running `target/debug/substrate build-spec --chain=staging`
2019-02-14 15:57:35 Building chain spec
2019-02-14 15:57:35 Failed to store secret key in file "/home/roman/.local/share/substrate/chains/staging_testnet/network/secret" ; err = Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

It seems to be the responsibility of `obtain_private_key` to ensure the directory exists, as per the purpose of this function, otherwise it should probably state the requirement that the directory exists prominently in its documentation. I don't quite understand why the removal of that line has been approved in https://github.com/paritytech/substrate/pull/1224, as it seems to break another code path to this function where the invariant does not hold, as witnessed above.