### PR TITLE
allow build:rust:doc:release job to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,6 +140,7 @@ build:rust:linux:release:          &build
 
 build:rust:doc:release:            &build
   stage:                           build
+  allow_failure:                   true
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success
@@ -150,6 +151,7 @@ build:rust:doc:release:            &build
   tags:
     - linux-docker
   script:
+    - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
     - time cargo doc --release --verbose
     - cp -R ./target/doc ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=substrate_service/index.html>" > ./crate-docs/index.html
@@ -231,6 +233,10 @@ publish:s3:doc:
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "substrate-rustdoc"
   script:
+    - test -r ./crate-docs/index.html || (
+        echo "./crate-docs/index.html not present, build:rust:doc:release job not complete";
+        exit 1
+      )
     - aws s3 sync --delete --size-only --only-show-errors
         ./crate-docs/ s3://${BUCKET}/${PREFIX}/
   after_script:


### PR DESCRIPTION
allow doc jobs to fail due to [this bug](https://github.com/rust-lang/rust/issues/58519).