### PR TITLE
SRML staking: remove 'default-features = false' from balances dev-dependency

### DIFF
--- a/srml/assets/Cargo.toml
+++ b/srml/assets/Cargo.toml
@@ -16,9 +16,9 @@ srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-sr-std = { path = "../../core/sr-std", default-features = false }
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
+sr-std = { path = "../../core/sr-std" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 
 [features]
 default = ["std"]

--- a/srml/aura/Cargo.toml
+++ b/srml/aura/Cargo.toml
@@ -20,9 +20,9 @@ staking = { package = "srml-staking", path = "../staking", default-features = fa
 [dev-dependencies]
 lazy_static = "1.0"
 parking_lot = "0.7.1"
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
-consensus = { package = "srml-consensus", path = "../consensus", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+consensus = { package = "srml-consensus", path = "../consensus" }
 
 [features]
 default = ["std"]

--- a/srml/balances/Cargo.toml
+++ b/srml/balances/Cargo.toml
@@ -17,8 +17,8 @@ srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+substrate-primitives = { path = "../../core/primitives" }
 
 [features]
 default = ["std"]

--- a/srml/consensus/Cargo.toml
+++ b/srml/consensus/Cargo.toml
@@ -18,7 +18,7 @@ srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 
 [features]
 default = ["std"]

--- a/srml/contract/Cargo.toml
+++ b/srml/contract/Cargo.toml
@@ -26,7 +26,7 @@ fees = { package = "srml-fees", path = "../fees", default-features = false }
 wabt = "~0.7.4"
 assert_matches = "1.1"
 hex-literal = "0.1.0"
-consensus = { package = "srml-consensus", path = "../consensus", default-features = false }
+consensus = { package = "srml-consensus", path = "../consensus" }
 
 [features]
 default = ["std"]

--- a/srml/council/Cargo.toml
+++ b/srml/council/Cargo.toml
@@ -19,7 +19,7 @@ system = { package = "srml-system", path = "../system", default-features = false
 
 [dev-dependencies]
 hex-literal = "0.1.0"
-balances = { package = "srml-balances", path = "../balances", default-features = false }
+balances = { package = "srml-balances", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/srml/democracy/Cargo.toml
+++ b/srml/democracy/Cargo.toml
@@ -18,8 +18,8 @@ srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-balances = { package = "srml-balances", path = "../balances", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
+balances = { package = "srml-balances", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/srml/example/Cargo.toml
+++ b/srml/example/Cargo.toml
@@ -13,9 +13,9 @@ system = { package = "srml-system", path = "../system", default-features = false
 balances = { package = "srml-balances", path = "../balances", default-features = false }
 
 [dev-dependencies]
-sr-io = { path = "../../core/sr-io", default-features = false }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-sr-primitives = { path = "../../core/sr-primitives", default-features = false }
+sr-io = { path = "../../core/sr-io" }
+substrate-primitives = { path = "../../core/primitives" }
+sr-primitives = { path = "../../core/sr-primitives" }
 
 [features]
 default = ["std"]

--- a/srml/executive/Cargo.toml
+++ b/srml/executive/Cargo.toml
@@ -19,7 +19,7 @@ substrate-primitives = { path = "../../core/primitives" }
 srml-indices = { path = "../indices" }
 balances = { package = "srml-balances", path = "../balances" }
 fees = { package = "srml-fees", path = "../fees" }
-parity-codec-derive = { version = "3.0", default-features = false }
+parity-codec-derive = { version = "3.0" }
 
 [features]
 default = ["std"]

--- a/srml/grandpa/Cargo.toml
+++ b/srml/grandpa/Cargo.toml
@@ -19,7 +19,7 @@ system = { package = "srml-system", path = "../system", default-features = false
 session = { package = "srml-session", path = "../session", default-features = false }
 
 [dev-dependencies]
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 
 [features]
 default = ["std"]

--- a/srml/session/Cargo.toml
+++ b/srml/session/Cargo.toml
@@ -18,8 +18,8 @@ system = { package = "srml-system", path = "../system", default-features = false
 timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }
 
 [dev-dependencies]
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 
 [features]
 default = ["std"]

--- a/srml/staking/Cargo.toml
+++ b/srml/staking/Cargo.toml
@@ -19,10 +19,10 @@ system = { package = "srml-system", path = "../system", default-features = false
 session = { package = "srml-session", path = "../session", default-features = false }
 
 [dev-dependencies]
-substrate-primitives = { path = "../../core/primitives", default-features = false }
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
-timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }
-balances = { package = "srml-balances", path = "../balances", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+timestamp = { package = "srml-timestamp", path = "../timestamp" }
+balances = { package = "srml-balances", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/srml/sudo/Cargo.toml
+++ b/srml/sudo/Cargo.toml
@@ -17,7 +17,7 @@ system = { package = "srml-system", path = "../system", default-features = false
 
 [dev-dependencies]
 sr-io = { path = "../../core/sr-io", default-features = false }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
+substrate-primitives = { path = "../../core/primitives" }
 
 [features]
 default = ["std"]

--- a/srml/timestamp/Cargo.toml
+++ b/srml/timestamp/Cargo.toml
@@ -17,8 +17,8 @@ system = { package = "srml-system", path = "../system", default-features = false
 consensus = { package = "srml-consensus", path = "../consensus", default-features = false }
 
 [dev-dependencies]
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = true }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+substrate-primitives = { path = "../../core/primitives" }
 
 [features]
 default = ["std"]

--- a/srml/treasury/Cargo.toml
+++ b/srml/treasury/Cargo.toml
@@ -17,8 +17,8 @@ system = { package = "srml-system", path = "../system", default-features = false
 balances = { package = "srml-balances", path = "../balances", default-features = false }
 
 [dev-dependencies]
-runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
-substrate-primitives = { path = "../../core/primitives", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+substrate-primitives = { path = "../../core/primitives" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Previously `cargo test` gave the following error:
```rust
  --> srml/staking/src/mock.rs:97:23
   |
97 |     t.extend(::balances::GenesisConfig::<Test>{
   |                          ^^^^^^^^^^^^^ not found in `balances`
```
`cargo test --all` passes normally though.