### PR TITLE
Fix #1825

### DIFF
--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -499,12 +499,14 @@ where
 	fn inject_dial_failure(&mut self, peer_id: Option<&PeerId>, addr: &Multiaddr, error: &dyn error::Error) {
 		if let Some(peer_id) = peer_id.as_ref() {
 			debug!(target: "sub-libp2p", "Failed to reach peer {:?} through {} => {:?}", peer_id, addr, error);
-			if self.connected_peers.contains(peer_id) {
-				self.topology.set_unreachable(addr);
-			}
+			self.topology.set_unreachable(addr);
 
 			// Trigger a `connect_to_nodes` round.
 			self.next_connect_to_nodes = Delay::new(Instant::now());
+
+		} else {
+			debug!(target: "sub-libp2p", "Failed to reach {} => {:?}", addr, error);
+			self.topology.set_unreachable(addr);
 		}
 	}
 

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -505,6 +505,11 @@ where
 			self.next_connect_to_nodes = Delay::new(Instant::now());
 
 		} else {
+			// This code path is only reached if `peer_id` is None, which means that we dialed an
+			// address without knowing the `PeerId` to expect. We don't currently do that, except
+			// in one situation: for convenience, we accept bootstrap node addresses in the format
+			// `IP:PORT`.
+			// There is no reason this trigger a `connect_to_nodes` round in that situation.
 			debug!(target: "sub-libp2p", "Failed to reach {} => {:?}", addr, error);
 			self.topology.set_unreachable(addr);
 		}


### PR DESCRIPTION
I'm not sure why this `if self.connected_peers.contains(peer_id)` is there.
We want to decrease the reputation and add a fail back for the address we failed to reach even when we're not connected to the peer that's expected to be there.