### PR TITLE
Report the network PeerId to the telemetry

### DIFF
--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -565,7 +565,7 @@ fn run_thread<B: BlockT + 'static, S: NetworkSpecialization<B>>(
 		Ok(())
 	});
 
-	// Merge all futures into one.network_id
+	// Merge all futures into one.
 	let futures: Vec<Box<Future<Item = (), Error = io::Error> + Send>> = vec![
 		Box::new(protocol) as Box<_>,
 		Box::new(network) as Box<_>

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -20,7 +20,7 @@ use std::{io, thread};
 use log::{warn, debug, error, trace};
 use futures::{Async, Future, Stream, stream, sync::oneshot};
 use parking_lot::Mutex;
-use network_libp2p::{ProtocolId, PeerId, NetworkConfiguration, NodeIndex, ErrorKind, Severity};
+use network_libp2p::{ProtocolId, NetworkConfiguration, NodeIndex, ErrorKind, Severity};
 use network_libp2p::{start_service, parse_str_addr, Service as NetworkService, ServiceEvent as NetworkServiceEvent};
 use network_libp2p::{Protocol as Libp2pProtocol, RegisteredProtocol};
 use consensus::import_queue::{ImportQueue, Link};
@@ -35,6 +35,8 @@ use crate::specialization::NetworkSpecialization;
 
 use tokio::prelude::task::AtomicTask;
 use tokio::runtime::Runtime;
+
+pub use network_libp2p::PeerId;
 
 /// Type that represents fetch completion future.
 pub type FetchFuture = oneshot::Receiver<Vec<u8>>;
@@ -178,6 +180,11 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>> Service<B, S> {
 	#[inline]
 	pub fn average_upload_per_sec(&self) -> u64 {
 		self.network.lock().average_upload_per_sec()
+	}
+
+	/// Returns the network identity of the node.
+	pub fn local_peer_id(&self) -> PeerId {
+		self.network.lock().peer_id().clone()
 	}
 
 	/// Called when a new block is imported by the client.
@@ -558,7 +565,7 @@ fn run_thread<B: BlockT + 'static, S: NetworkSpecialization<B>>(
 		Ok(())
 	});
 
-	// Merge all futures into one.
+	// Merge all futures into one.network_id
 	let futures: Vec<Box<Future<Item = (), Error = io::Error> + Send>> = vec![
 		Box::new(protocol) as Box<_>,
 		Box::new(network) as Box<_>

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -271,6 +271,7 @@ impl<Components: components::Components> Service<Components> {
 		// Telemetry
 		let telemetry = config.telemetry_url.clone().map(|url| {
 			let is_authority = config.roles == Roles::AUTHORITY;
+			let network_id = network.local_peer_id().to_base58();
 			let pubkey = format!("{}", public_key);
 			let name = config.name.clone();
 			let impl_name = config.impl_name.to_owned();
@@ -286,7 +287,8 @@ impl<Components: components::Components> Service<Components> {
 						"config" => "",
 						"chain" => chain_name.clone(),
 						"pubkey" => &pubkey,
-						"authority" => is_authority
+						"authority" => is_authority,
+						"network_id" => network_id.clone()
 					);
 				}),
 			}))


### PR DESCRIPTION
cc @maciejhirsz 

Reports the network identity of the node (eg. `QmSuby4Qd3QJPCq6uu9RNwPkkCWs3EeQnftQzENVThLNvt`)
