### PR TITLE
Add names to tokio threads

### DIFF
--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -35,7 +35,7 @@ use runtime_primitives::traits::{Block as BlockT, NumberFor};
 use crate::specialization::NetworkSpecialization;
 
 use tokio::prelude::task::AtomicTask;
-use tokio::runtime::Runtime;
+use tokio::runtime::Builder as RuntimeBuilder;
 
 pub use network_libp2p::PeerId;
 
@@ -458,7 +458,7 @@ fn start_thread<B: BlockT + 'static, S: NetworkSpecialization<B>>(
 
 	let (close_tx, close_rx) = oneshot::channel();
 	let service_clone = service.clone();
-	let mut runtime = Runtime::new()?;
+	let mut runtime = RuntimeBuilder::new().name_prefix("libp2p-").build()?;
 	let thread = thread::Builder::new().name("network".to_string()).spawn(move || {
 		let fut = run_thread(protocol_sender, service_clone, network_port, protocol_id)
 			.select(close_rx.then(|_| Ok(())))

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -24,7 +24,7 @@ pub mod chain_spec;
 mod service;
 
 use tokio::prelude::Future;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 pub use cli::{VersionInfo, IntoExit, NoCustom};
 use substrate_service::{ServiceFactory, Roles as ServiceRoles};
 use std::ops::Deref;
@@ -87,7 +87,8 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 			info!("Chain specification: {}", config.chain_spec.name());
 			info!("Node name: {}", config.name);
 			info!("Roles: {:?}", config.roles);
-			let runtime = Runtime::new().map_err(|e| format!("{:?}", e))?;
+			let runtime = RuntimeBuilder::new().name_prefix("main-tokio-").build()
+				.map_err(|e| format!("{:?}", e))?;
 			let executor = runtime.executor();
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(


### PR DESCRIPTION
The threads will be named `main-tokio-0`, `main-tokio-1`, `libp2p-0`, `libp2p-1`, and so on, as opposed to `tokio-runtime-worker-N` at the moment.
Makes it easier to identify them when debugging, and makes it easier to identify where a panic comes from.
