### PR TITLE
Add even more diagnostic messages

### DIFF
--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -531,8 +531,14 @@ fn run_thread<B: BlockT + 'static>(
 						info!(target: "sync", "Banning {:?} because {:?}", who, message);
 						network_service_2.lock().ban_node(who)
 					},
-					Severity::Useless(_) => network_service_2.lock().drop_node(who),
-					Severity::Timeout => network_service_2.lock().drop_node(who),
+					Severity::Useless(message) => {
+						info!(target: "sync", "Dropping {:?} because {:?}", who, message);
+						network_service_2.lock().drop_node(who)
+					},
+					Severity::Timeout => {
+						info!(target: "sync", "Dropping {:?} because it is useless", who);
+						network_service_2.lock().drop_node(who)
+					},
 				}
 			},
 		}

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -536,7 +536,7 @@ fn run_thread<B: BlockT + 'static>(
 						network_service_2.lock().drop_node(who)
 					},
 					Severity::Timeout => {
-						info!(target: "sync", "Dropping {:?} because it is useless", who);
+						info!(target: "sync", "Dropping {:?} because it timed out", who);
 						network_service_2.lock().drop_node(who)
 					},
 				}


### PR DESCRIPTION
When dropping a node.
May help revealing bugs in the sync.