### PR TITLE
make sr-api-macros doc compile with current stable

### DIFF
--- a/core/sr-api-macros/src/decl_runtime_apis.rs
+++ b/core/sr-api-macros/src/decl_runtime_apis.rs
@@ -21,7 +21,6 @@ use crate::utils::{
 	generate_method_runtime_api_impl_name
 };
 
-use proc_macro;
 use proc_macro2::{TokenStream, Span};
 
 use quote::quote;

--- a/core/sr-api-macros/src/impl_runtime_apis.rs
+++ b/core/sr-api-macros/src/impl_runtime_apis.rs
@@ -21,7 +21,6 @@ use crate::utils::{
 	return_type_extract_type
 };
 
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
 
 use quote::quote;


### PR DESCRIPTION
Those rust2015 imports crash cargo doc in current stable.
This is fixed in current beta but it will be published in some weeks.