### PR TITLE
Fix Index reuse for zero ExistentialDeposit configured chains

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 34,
+	spec_version: 35,
 	impl_version: 35,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -275,7 +275,7 @@ impl<T: Trait> Module<T> {
 			Self::set_free_balance(who, balance);
 			UpdateBalanceOutcome::AccountKilled
 		} else {
-			if !<FreeBalance<T>>::exists(who) {
+			if !<FreeBalance<T>>::exists(who) && !<ReservedBalance<T>>::exists(who) {
 				Self::new_account(&who, balance);
 			}
 			Self::set_free_balance(who, balance);

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -620,6 +620,6 @@ where
 	T::Balance: MaybeSerializeDebug
 {
 	fn is_dead_account(who: &T::AccountId) -> bool {
-		Self::total_balance(who).is_zero()
+		!<FreeBalance<T>>::exists(who) && !<ReservedBalance<T>>::exists(who)
 	}
 }

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -275,7 +275,7 @@ impl<T: Trait> Module<T> {
 			Self::set_free_balance(who, balance);
 			UpdateBalanceOutcome::AccountKilled
 		} else {
-			if !<FreeBalance<T>>::exists(who) && !<ReservedBalance<T>>::exists(who) {
+			if Self::is_dead_account(&who) {
 				Self::new_account(&who, balance);
 			}
 			Self::set_free_balance(who, balance);


### PR DESCRIPTION
In chains that choose to allow zero ExistentialDeposit, the definition of a dead account is no longer the same as when existential deposit is greater than zero. In other words an account with zero balance is not considered dead. This has an impact on when an account index is (incorrectly) reused. 

In addition it really only makes sense for an account index to remain associated with the same account as long as the total balance is still positive. After an account is reaped it is reasonable to create a new account index.

This PR addresses these two points:

1. prevents incorrect account index reuse by changing implementation of the `IsDeadAccount` trait for the balances module.

2. Only calling new_account() when both the freebalance and reservedbalance components of an account don't exist