### PR TITLE
Replace the incorrect `commit` keyword with `rev`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,8 +2767,8 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.0.0"
-source = "git+https://github.com/w3f/schnorrkel#d3289df76b8ae6dfb68e733204c5c009df5343a9"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3597,7 +3597,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.0.0 (git+https://github.com/w3f/schnorrkel)",
+ "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-bip39 0.2.0 (git+https://github.com/paritytech/substrate-bip39)",
  "substrate-primitives 0.1.0",
  "tiny-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3634,11 +3634,11 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/substrate-bip39#a28806512c977992af8d6740d45352f5a1c832a0"
+source = "git+https://github.com/paritytech/substrate-bip39#080da45923885cfec2379cef3dee4e7f43e6c260"
 dependencies = [
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.0.0 (git+https://github.com/w3f/schnorrkel)",
+ "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4008,7 +4008,7 @@ dependencies = [
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.0.0 (git+https://github.com/w3f/schnorrkel)",
+ "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4688,7 +4688,7 @@ name = "twox-hash"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5285,7 +5285,7 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
-"checksum schnorrkel 0.0.0 (git+https://github.com/w3f/schnorrkel)" = "<none>"
+"checksum schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a700659388785588c75b197cecda0f23c7112a9281ef703e8ffc651061ce014c"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
 "checksum security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05"

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -22,7 +22,7 @@ untrusted = { version = "0.6", optional = true }
 hex-literal = { version = "0.1", optional = true }
 base58 = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2.18", optional = true }
-schnorrkel = { git = "https://github.com/w3f/schnorrkel", optional = true, commit = "d3289df76b8ae6dfb68e733204c5c009df5343a9" }
+schnorrkel = { version = "0.1", optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
 substrate-bip39 = { git = "https://github.com/paritytech/substrate-bip39", optional = true }

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
 substrate-bip39 = { git = "https://github.com/paritytech/substrate-bip39" }
-schnorrkel = { git = "https://github.com/w3f/schnorrkel", commit = "d3289df76b8ae6dfb68e733204c5c009df5343a9" }
+schnorrkel = "0.1"
 hex = "0.3"
 
 [features]


### PR DESCRIPTION
Cargo uses "revision" (`rev`) instead of "commit" as a keyword.