### PR TITLE
Do not try to synchronize from light client

### DIFF
--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -73,6 +73,18 @@ bitflags! {
 	}
 }
 
+impl Roles {
+	/// Does this role represents a client that holds full chain data locally?
+	pub fn is_full(&self) -> bool {
+		self.intersects(Roles::FULL | Roles::AUTHORITY)
+	}
+
+	/// Does this role represents a client that does not hold full chain data locally?
+	pub fn is_light(&self) -> bool {
+		!self.is_full()
+	}
+}
+
 impl parity_codec::Encode for Roles {
 	fn encode_to<T: parity_codec::Output>(&self, dest: &mut T) {
 		dest.push_byte(self.bits())

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -266,7 +266,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 	/// Handle new connected peer.
 	pub fn new_peer(&mut self, protocol: &mut Context<B>, who: PeerId, roles: Roles) {
 		// light nodes are not valid targets for consensus gossip messages
-		if !roles.intersects(Roles::FULL | Roles::AUTHORITY) {
+		if !roles.is_full() {
 			return;
 		}
 

--- a/core/network/src/on_demand.rs
+++ b/core/network/src/on_demand.rs
@@ -235,7 +235,7 @@ impl<B> OnDemandService<B> for OnDemand<B> where
 	B::Header: HeaderT,
 {
 	fn on_connect(&self, peer: PeerId, role: Roles, best_number: NumberFor<B>) {
-		if !role.intersects(Roles::FULL | Roles::AUTHORITY) {
+		if !role.is_full() {
 			return;
 		}
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -343,7 +343,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	}
 
 	/// Returns an object representing the status of the protocol.
-	pub fn status(&mut self) -> ProtocolStatus<B> {
+	pub fn status(&self) -> ProtocolStatus<B> {
 		ProtocolStatus {
 			sync: self.sync.status(),
 			num_peers: self.context_data.peers.values().count(),
@@ -613,6 +613,15 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			request.from,
 			request.to,
 			request.max);
+
+		// sending block requests to the node that is unable to serve it is considered a bad behavior
+		if !self.config.roles.is_full() {
+			trace!(target: "sync", "Peer {} is trying to sync from the light node", peer);
+			self.network_chan.send(NetworkMsg::DisconnectPeer(peer.clone()));
+			self.network_chan.send(NetworkMsg::ReportPeer(peer, i32::min_value()));
+			return;
+		}
+
 		let mut blocks = Vec::new();
 		let mut id = match request.from {
 			message::FromBlock::Hash(h) => BlockId::Hash(h),
@@ -774,7 +783,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				self.network_chan.send(NetworkMsg::DisconnectPeer(who));
 				return;
 			}
-			if self.config.roles & Roles::LIGHT == Roles::LIGHT {
+			if self.config.roles.is_light() {
 				let self_best_block = self
 					.context_data
 					.chain
@@ -963,7 +972,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		);
 
 		// blocks are not announced by light clients
-		if self.config.roles & Roles::LIGHT == Roles::LIGHT {
+		if self.config.roles.is_light() {
 			return;
 		}
 

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -157,7 +157,7 @@ impl<B: BlockT> ChainSync<B> {
 		info: &ClientInfo<B>,
 	) -> Self {
 		let mut required_block_attributes = message::BlockAttributes::HEADER | message::BlockAttributes::JUSTIFICATION;
-		if role.intersects(Roles::FULL | Roles::AUTHORITY) {
+		if role.is_full() {
 			required_block_attributes |= message::BlockAttributes::BODY;
 		}
 
@@ -209,6 +209,12 @@ impl<B: BlockT> ChainSync<B> {
 	/// Handle new connected peer. Call this method whenever we connect to a new peer.
 	pub(crate) fn new_peer(&mut self, protocol: &mut Context<B>, who: PeerId) {
 		if let Some(info) = protocol.peer_info(&who) {
+			// there's nothing sync can get from the node that has no blockchain data
+			// (the opposite is not true, but all requests are served at protocol level)
+			if !info.roles.is_full() {
+				return;
+			}
+
 			let status = block_status(&*protocol.client(), &self.queue_blocks, info.best_hash);
 			match (status, info.best_number) {
 				(Err(e), _) => {

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -16,6 +16,7 @@
 
 use client::{backend::Backend, blockchain::HeaderBackend};
 use crate::config::Roles;
+use crate::message;
 use consensus::BlockOrigin;
 use std::collections::HashSet;
 use super::*;
@@ -397,4 +398,57 @@ fn can_sync_small_non_best_forks() {
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
+}
+
+#[test]
+fn can_not_sync_from_light_peer() {
+	let _ = ::env_logger::try_init();
+
+	// given the network with 1 full nodes (#0) and 1 light node (#1)
+	let mut net = TestNet::new(1);
+	net.add_light_peer(&Default::default());
+
+	// generate some blocks on #0
+	net.peer(0).push_blocks(1, false);
+
+	// and let the light client sync from this node
+	// (mind the #1 is disconnected && not syncing)
+	net.sync();
+
+	// ensure #0 && #1 have the same best block
+	let full0_info = net.peer(0).client.info().unwrap().chain;
+	let light_info = net.peer(1).client.info().unwrap().chain;
+	assert_eq!(full0_info.best_number, 1);
+	assert_eq!(light_info.best_number, 1);
+	assert_eq!(light_info.best_hash, full0_info.best_hash);
+
+	// add new full client (#2) && sync without #0
+	net.add_full_peer(&Default::default());
+	net.peer(1).on_connect(net.peer(2));
+	net.peer(2).on_connect(net.peer(1));
+	net.peer(1).announce_block(light_info.best_hash);
+	net.sync_with(true, Some(vec![0].into_iter().collect()));
+
+	// ensure that the #2 has failed to sync block #1
+	assert_eq!(net.peer(2).client.info().unwrap().chain.best_number, 0);
+	// and that the #1 is still connected to #2
+	// (because #2 has not tried to fetch block data from the #1 light node)
+	assert_eq!(net.peer(1).protocol_status().num_peers, 2);
+
+	// and now try to fetch block data from light peer #1
+	// (this should result in disconnect)
+	net.peer(1).receive_message(
+		&net.peer(2).peer_id,
+		message::generic::Message::BlockRequest(message::generic::BlockRequest {
+			id: 0,
+			fields: message::BlockAttributes::HEADER,
+			from: message::FromBlock::Hash(light_info.best_hash),
+			to: None,
+			direction: message::Direction::Ascending,
+			max: Some(1),
+		}),
+	);
+	net.sync();
+	// check that light #1 has disconnected from #2
+	assert_eq!(net.peer(1).protocol_status().num_peers, 1);
 }

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -170,7 +170,7 @@ impl<Components: components::Components> Service<Components> {
 			Components::build_transaction_pool(config.transaction_pool.clone(), client.clone())?
 		);
 		let transaction_pool_adapter = Arc::new(TransactionPoolAdapter::<Components> {
-			imports_external_transactions: !(config.roles == Roles::LIGHT),
+			imports_external_transactions: !config.roles.is_light(),
 			pool: transaction_pool.clone(),
 			client: client.clone(),
 		 });


### PR DESCRIPTION
Changes introduced in this PR:
1) when new **light** peer connects, it is completely ignored by the `network/src/sync.rs`, because we can't benefit from syncing from light client (except if we're also light client ++ we're at the same CHT with the peer, but this is too large restriction => ignore this case);
2) if light client received `BlockRequest` message, the peer is considered bad && disconnected.