### PR TITLE
remove aura inherent-checking compatibility shim

### DIFF
--- a/core/client/src/block_builder/api.rs
+++ b/core/client/src/block_builder/api.rs
@@ -16,46 +16,10 @@
 
 //! The runtime api for building blocks.
 
-use runtime_primitives::{traits::Block as BlockT, ApplyResult, RuntimeString};
+use runtime_primitives::{traits::Block as BlockT, ApplyResult};
 use rstd::vec::Vec;
 use sr_api_macros::decl_runtime_apis;
 pub use inherents::{InherentData, CheckInherentsResult};
-use parity_codec::{Encode, Decode};
-
-/// The old representation of the inherent data.
-#[doc(hide)]
-#[derive(Encode, Decode)]
-pub struct OldInherentData {
-	/// Current timestamp.
-	pub timestamp: u64,
-	/// Blank report.
-	pub consensus: (),
-	/// Aura expected slot. Can take any value during block construction.
-	pub aura_expected_slot: u64,
-}
-
-impl OldInherentData {
-	/// Create a new `BasicInherentData` instance.
-	pub fn new(timestamp: u64, expected_slot: u64) -> Self {
-		Self {
-			timestamp,
-			consensus: (),
-			aura_expected_slot: expected_slot,
-		}
-	}
-}
-
-/// Error type used while checking inherents.
-#[doc(hide)]
-#[derive(Encode, PartialEq)]
-#[cfg_attr(feature = "std", derive(Decode))]
-pub enum OldCheckInherentError {
-	/// The inherents are generally valid but a delay until the given timestamp
-	/// is required.
-	ValidAtTimestamp(u64),
-	/// Some other error has occurred.
-	Other(RuntimeString),
-}
 
 decl_runtime_apis! {
 	/// The `BlockBuilder` api trait that provides required functions for building a block for a runtime.
@@ -69,11 +33,6 @@ decl_runtime_apis! {
 		fn inherent_extrinsics(inherent: InherentData) -> Vec<<Block as BlockT>::Extrinsic>;
 		/// Check that the inherents are valid. The inherent data will vary from chain to chain.
 		fn check_inherents(block: Block, data: InherentData) -> CheckInherentsResult;
-		/// Check that the inherents are valid. The inherent data will vary from chain to chain.
-		///
-		/// Old version that is used by the CC network.
-		#[changed_in(2)]
-		fn check_inherents(block: Block, data: OldInherentData) -> ::std::result::Result<(), OldCheckInherentError>;
 		/// Generate a random seed.
 		fn random_seed() -> <Block as BlockT>::Hash;
 	}


### PR DESCRIPTION
It was broken anyway for chains that had a different `InherentData`. It's not going to be part of our 1.0 API and most chains should have upgraded runtime by now to something handling new `InherentData`.