### PR TITLE
Fix handling of justifications

### DIFF
--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -358,17 +358,18 @@ impl<B: BlockT> BlockImporter<B> {
 		let success = self.justification_import.as_ref().map(|justification_import| {
 			justification_import.import_justification(hash, number, justification)
 				.map_err(|e| {
-					debug!("Justification import failed with {:?} for hash: {:?} number: {:?} coming from node: {:?}", e, hash, number, who);
+					debug!(target: "sync", "Justification import failed with {:?} for hash: {:?} number: {:?} coming from node: {:?}", e, hash, number, who);
 					e
 				}).is_ok()
 		}).unwrap_or(false);
+
 		if let Some(link) = self.link.as_ref() {
 			link.justification_imported(who, &hash, number, success);
 		}
 	}
 
 	fn handle_import_blocks(&mut self, origin: BlockOrigin, blocks: Vec<IncomingBlock<B>>) {
-		trace!(target:"sync", "Scheduling {} blocks for import", blocks.len());
+		trace!(target: "sync", "Scheduling {} blocks for import", blocks.len());
 		self.worker_sender
 			.send(BlockImportWorkerMsg::ImportBlocks(origin, blocks))
 			.expect("1. This is holding a sender to the worker, 2. the worker should not quit while a sender is still held; qed");
@@ -423,7 +424,7 @@ impl<B: BlockT, V: 'static + Verifier<B>> BlockImportWorker<B, V> {
 			_ => Default::default(),
 		};
 
-		trace!(target:"sync", "Starting import of {} blocks {}", count, blocks_range);
+		trace!(target: "sync", "Starting import of {} blocks {}", count, blocks_range);
 
 		let mut results = vec![];
 

--- a/core/finality-grandpa/src/authorities.rs
+++ b/core/finality-grandpa/src/authorities.rs
@@ -663,21 +663,51 @@ mod tests {
 			delay_kind: DelayKind::Finalized,
 		};
 
+		let change_b = PendingChange {
+			next_authorities: set_a.clone(),
+			delay: 10,
+			canon_height: 20,
+			canon_hash: "hash_b",
+			delay_kind: DelayKind::Finalized,
+		};
+
 		authorities.add_pending_change(change_a.clone(), &static_is_descendent_of(false)).unwrap();
+		authorities.add_pending_change(change_b.clone(), &static_is_descendent_of(true)).unwrap();
 
 		let is_descendent_of = is_descendent_of(|base, hash| match (*base, *hash) {
-			("hash_a", "hash_b") => true,
+			("hash_a", "hash_d") => true,
+			("hash_a", "hash_e") => true,
+			("hash_b", "hash_d") => true,
+			("hash_b", "hash_e") => true,
 			("hash_a", "hash_c") => false,
+			("hash_b", "hash_c") => false,
 			_ => unreachable!(),
 		});
 
 		// "hash_c" won't finalize the existing change since it isn't a descendent
-		assert!(!authorities.enacts_standard_change("hash_c", 15, &is_descendent_of).unwrap());
-		// "hash_b" at depth 14 won't work either
-		assert!(!authorities.enacts_standard_change("hash_b", 14, &is_descendent_of).unwrap());
+		assert_eq!(
+			authorities.enacts_standard_change("hash_c", 15, &is_descendent_of).unwrap(),
+			None,
+		);
+
+		// "hash_d" at depth 14 won't work either
+		assert_eq!(
+			authorities.enacts_standard_change("hash_d", 14, &is_descendent_of).unwrap(),
+			None,
+		);
 
 		// but it should work at depth 15 (change height + depth)
-		assert!(authorities.enacts_standard_change("hash_b", 15, &is_descendent_of).unwrap());
+		assert_eq!(
+			authorities.enacts_standard_change("hash_d", 15, &is_descendent_of).unwrap(),
+			Some(true),
+		);
+
+		// finalizing "hash_e" at depth 20 will trigger change at "hash_b", but
+		// it can't be applied yet since "hash_a" must be applied first
+		assert_eq!(
+			authorities.enacts_standard_change("hash_e", 30, &is_descendent_of).unwrap(),
+			Some(false),
+		);
 	}
 
 	#[test]
@@ -713,7 +743,10 @@ mod tests {
 
 		// there's an effective change triggered at block 15 but not a standard one.
 		// so this should do nothing.
-		assert!(!authorities.enacts_standard_change("hash_c", 15, &static_is_descendent_of(true)).unwrap());
+		assert_eq!(
+			authorities.enacts_standard_change("hash_c", 15, &static_is_descendent_of(true)).unwrap(),
+			None,
+		);
 
 		// throw a standard change into the mix to prove that it's discarded
 		// for being on the same fork.

--- a/core/finality-grandpa/src/authorities.rs
+++ b/core/finality-grandpa/src/authorities.rs
@@ -351,14 +351,18 @@ where
 	/// authority set change (without triggering it), ensuring that if there are
 	/// multiple changes in the same branch, finalizing this block won't
 	/// finalize past multiple transitions (i.e. transitions must be finalized
-	/// in-order). The given function `is_descendent_of` should return `true` if
-	/// the second hash (target) is a descendent of the first hash (base).
+	/// in-order). Returns `Some(true)` if the block being finalized enacts a
+	/// change that can be immediately applied, `Some(false)` if the block being
+	/// finalized enacts a change but it cannot be applied yet since there are
+	/// other dependent changes, and `None` if no change is enacted. The given
+	/// function `is_descendent_of` should return `true` if the second hash
+	/// (target) is a descendent of the first hash (base).
 	pub fn enacts_standard_change<F, E>(
 		&self,
 		finalized_hash: H,
 		finalized_number: N,
 		is_descendent_of: &F,
-	) -> Result<bool, fork_tree::Error<E>>
+	) -> Result<Option<bool>, fork_tree::Error<E>>
 	where F: Fn(&H, &H) -> Result<bool, E>,
 		  E: std::error::Error,
 	{

--- a/core/util/fork-tree/src/lib.rs
+++ b/core/util/fork-tree/src/lib.rs
@@ -253,8 +253,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 		// tree, if we find a valid node that passes the predicate then we must
 		// ensure that we're not finalizing past any of its child nodes.
 		for node in self.node_iter() {
-			if node.hash == *hash || is_descendent_of(&node.hash, hash)? {
-				if predicate(&node.data) {
+			if predicate(&node.data) {
+				if node.hash == *hash || is_descendent_of(&node.hash, hash)? {
 					for node in node.children.iter() {
 						if node.number <= number && is_descendent_of(&node.hash, &hash)? {
 							return Err(Error::UnfinalizedAncestor);
@@ -298,8 +298,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 		// we're not finalizing past any children node.
 		let mut position = None;
 		for (i, root) in self.roots.iter().enumerate() {
-			if root.hash == *hash || is_descendent_of(&root.hash, hash)? {
-				if predicate(&root.data) {
+			if predicate(&root.data) {
+				if root.hash == *hash || is_descendent_of(&root.hash, hash)? {
 					for node in root.children.iter() {
 						if node.number <= number && is_descendent_of(&node.hash, &hash)? {
 							return Err(Error::UnfinalizedAncestor);

--- a/core/util/fork-tree/src/lib.rs
+++ b/core/util/fork-tree/src/lib.rs
@@ -228,17 +228,19 @@ impl<H, N, V> ForkTree<H, N, V> where
 	/// Checks if any node in the tree is finalized by either finalizing the
 	/// node itself or a child node that's not in the tree, guaranteeing that
 	/// the node being finalized isn't a descendent of any of the node's
-	/// children. The given `predicate` is checked on the prospective finalized
-	/// root and must pass for finalization to occur. The given function
-	/// `is_descendent_of` should return `true` if the second hash (target) is a
-	/// descendent of the first hash (base).
+	/// children. Returns `Some(true)` if the node being finalized is a root,
+	/// `Some(false)` if the node being finalized is not a root, and `None` if
+	/// no node in the tree is finalized. The given `predicate` is checked on
+	/// the prospective finalized root and must pass for finalization to occur.
+	/// The given function `is_descendent_of` should return `true` if the second
+	/// hash (target) is a descendent of the first hash (base).
 	pub fn finalizes_any_with_descendent_if<F, P, E>(
 		&self,
 		hash: &H,
 		number: N,
 		is_descendent_of: &F,
 		predicate: P,
-	) -> Result<bool, Error<E>>
+	) -> Result<Option<bool>, Error<E>>
 		where E: std::error::Error,
 			  F: Fn(&H, &H) -> Result<bool, E>,
 			  P: Fn(&V) -> bool,
@@ -261,12 +263,12 @@ impl<H, N, V> ForkTree<H, N, V> where
 						}
 					}
 
-					return Ok(true);
+					return Ok(Some(self.roots.iter().any(|root| root.hash == node.hash)));
 				}
 			}
 		}
 
-		Ok(false)
+		Ok(None)
 	}
 
 	/// Finalize a root in the tree by either finalizing the node itself or a


### PR DESCRIPTION
This PR contains multiple fixes related to the justifications handling.

- Since justification import is now asynchronous we need to make sure we keep track of the justifications that we sent to the import queue, otherwise we might process a finalization notification before the import result notification from the queue (which will ruin our bookkeeping);
- In grandpa block import make sure we can import a justification before trying, i.e. there aren't any dependent pending changes, otherwise we'll validate the justification against an invalid voter set.
- Change the search in the fork tree to always check the given predicate first, which is supposed to be cheaper than a call to `is_descendent_of` (comparing block numbers).

This fixes the sync slowdown observed on Alexander at around blocks 200K (lots of authority set changes).