### PR TITLE
Fix #2073

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -76,7 +76,7 @@ impl<TMessage, TSubstream> Behaviour<TMessage, TSubstream> {
 				user_defined: known_addresses,
 				kademlia,
 				next_kad_random_query: Delay::new(Instant::now()),
-				duration_to_next_kad: Duration::from_secs(60),
+				duration_to_next_kad: Duration::from_secs(10),
 			},
 			identify,
 			events: Vec::new(),


### PR DESCRIPTION
Makes the connectivity tests pass faster by making the second batch of Kademlia request earlier.

Normally, when a node joins a network, the DHT of all the nodes that are part of the network is already well populated. But in the case of a local testnet (as we have here), the DHT starts empty. The Kademlia initialization process assumes that DHT queries will yield useful results, but since the DHT is empty, well, they don't.

After this initialization, we perform additional queries every 60 seconds to stay up-to-date. This PR decreases the time before the first additional query from 60 seconds to 10 seconds.
