### PR TITLE
Don't print dozens of the times the handler init warning

### DIFF
--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -488,9 +488,11 @@ where
 
 			ProtocolState::Init { substreams, mut init_deadline } => {
 				match init_deadline.poll() {
-					Ok(Async::Ready(())) =>
+					Ok(Async::Ready(())) => {
+						init_deadline.reset(Instant::now() + Duration::from_secs(60));
 						error!(target: "sub-libp2p", "Handler initialization process is too long \
-							with {:?}", self.remote_peer_id),
+							with {:?}", self.remote_peer_id)
+					},
 					Ok(Async::NotReady) => {}
 					Err(_) => error!(target: "sub-libp2p", "Tokio timer has errored")
 				}


### PR DESCRIPTION
That's an overlook from me.
If the timer triggers we print an error. The next time we poll (eg. as a response to a network event), we will print the error again because the timer we still be ready.