### PR TITLE
Fix hardcoded values in the PSM config

### DIFF
--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -73,8 +73,8 @@ where TMessage: CustomMessage + Send + 'static {
 
 	// Build the peerset.
 	let (peerset, peerset_receiver) = substrate_peerset::Peerset::from_config(substrate_peerset::PeersetConfig {
-		in_peers: 25,
-		out_peers: 25,
+		in_peers: config.in_peers,
+		out_peers: config.out_peers,
 		bootnodes,
 		reserved_only: config.non_reserved_mode == NonReservedPeerMode::Deny,
 		reserved_nodes,


### PR DESCRIPTION
Fixes a stupid mistake in #2042: we use hardcoded values instead of the ones provided in the configuration.