### PR TITLE
Forgot to handle Banned in inject_connected

### DIFF
--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -585,7 +585,7 @@ where
 					st @ _ => {
 						// This is a serious bug either in this state machine or in libp2p.
 						error!(target: "sub-libp2p", "Received inject_connected for \
-							already-connected node");
+							already-connected node; state is {:?}", st);
 						*entry.into_mut() = st;
 						return
 					}

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -571,7 +571,8 @@ where
 		match (self.peers.entry(peer_id), connected_point) {
 			(Entry::Occupied(mut entry), connected_point) => {
 				match mem::replace(entry.get_mut(), PeerState::Poisoned) {
-					PeerState::Requested | PeerState::PendingRequest { .. } => {
+					PeerState::Requested | PeerState::PendingRequest { .. } |
+					PeerState::Banned { .. } => {
 						debug!(target: "sub-libp2p", "Libp2p => Connected({:?}): Connection \
 							requested by PSM (through {:?})", entry.key(), connected_point);
 						debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", entry.key());


### PR DESCRIPTION
If libp2p connects to a node that is banned, we should accept it as well. At the moment we just print an error in the logs and go on, which causes further state mismatches later on.