### PR TITLE
Fix offchain-worker-execution default value

### DIFF
--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -261,7 +261,7 @@ pub struct ExecutionStrategies {
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
 			case_insensitive = "true",
-			default_value = r#""NativeWhenPossible""#
+			default_value = r#""NativeElseWasm""#
 		)
 	)]
 	pub offchain_worker_execution: ExecutionStrategy,


### PR DESCRIPTION
I got the following error message when I was trying to run a node with the latest master:
```
StefanieMBP:substrate stefaniedoll$ cargo run --release \-- --dev
Finished release [optimized] target(s) in 0.92s
Running `target/release/substrate --dev`
error: 'NativeWhenPossible' isn't a valid value for '--offchain-worker-execution <STRATEGY>'
	[possible values: Both, Native, NativeElseWasm, Wasm]

	Did you mean 'Native'?

USAGE:
    substrate --block-construction-execution <STRATEGY> --dev --importing-execution <STRATEGY> --in-peers <IN_PEERS> --node-key-type <TYPE> --offchain-worker <ENABLED> --offchain-worker-execution <STRATEGY> --other-execution <STRATEGY> --out-peers <OUT_PEERS> --pool-kbytes <COUNT> --pool-limit <COUNT> --syncing-execution <STRATEGY>
```
I think the reason is just a wrong default value for the  offchain-worker-execution which I canged to `NativeElseWasm`