### PR TITLE
core: network: reduce log level of peer drop messages

### DIFF
--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -533,11 +533,11 @@ fn run_thread<B: BlockT + 'static>(
 						network_service_2.lock().drop_node(&who)
 					},
 					Severity::Useless(message) => {
-						info!(target: "sync", "Dropping {:?} because {:?}", who, message);
+						debug!(target: "sync", "Dropping {:?} because {:?}", who, message);
 						network_service_2.lock().drop_node(&who)
 					},
 					Severity::Timeout => {
-						info!(target: "sync", "Dropping {:?} because it timed out", who);
+						debug!(target: "sync", "Dropping {:?} because it timed out", who);
 						network_service_2.lock().drop_node(&who)
 					},
 				}


### PR DESCRIPTION
These messages are too low-level to be logged at info.