### PR TITLE
grandpa: Voter persistence and upgrade to finality-grandpa v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,10 +752,10 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.1"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -908,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hash256-std-hasher"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1209,11 +1209,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "keccak-hasher"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3872,7 +3872,7 @@ name = "substrate-finality-grandpa"
 version = "1.0.0"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "finality-grandpa 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finality-grandpa 0.7.1",
  "fork-tree 1.0.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4057,7 +4057,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4322,15 +4322,15 @@ dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 1.0.0",
  "substrate-primitives 1.0.0",
- "trie-bench 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-bench 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4697,17 +4697,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "trie-bench"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4732,12 +4732,12 @@ dependencies = [
 
 [[package]]
 name = "trie-standardmap"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5184,7 +5184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
-"checksum finality-grandpa 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d415e902db2b87bd5a7df7a2b2de97a4566727a23b95ff39e1bfec25a66d4d1c"
 "checksum fixed-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a557e80084b05c32b455963ff565a9de6f2866da023d6671705c6aff6f65e01c"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -5202,7 +5201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba7fb417e5c470acdd61068c79767d0e65962e70836cf6c9dfd2409f06345ce0"
-"checksum hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1224388a21c88a80ae7087a2a245ca6d80acc97a9186b75789fb3eeefd0609af"
+"checksum hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f8b2027c19ec91eb304999abae7307d225cf93be42af53b0039f76e98ed5af86"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8e04cb7a5051270ef3fa79f8c7604d581ecfa73d520e74f554e45541c4b5881a"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
@@ -5234,7 +5233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5521613b31ea22d36d9f95ad642058dccec846a94ed8690957652d479f620707"
 "checksum jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20b8333a5a6e6ccbcf5c90f90919de557cba4929efa164e9bd0e8e497eb20e46"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-"checksum keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a02fb74dc1b613522069b5f2023c014756ce121c6c6fb39364c139b0efc39a2d"
+"checksum keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "af672553b2abac1c86c29fd62c79880638b6abc91d96db4aa42a5baab2bc1ca9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
 "checksum kvdb-memorydb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
@@ -5446,10 +5445,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-"checksum trie-bench 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eafa32a8662c06f5bf135984bc1a12821fd38770b5c2f2f9e8750327fcbe3955"
+"checksum trie-bench 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba20f7d9865497ea46511860b43e05a44f4ac9a76ee089d34cd80a839a690264"
 "checksum trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ba73747fd3a64ab531274c04cb588dfa9d30d972d62990831e63fbce2cfec59"
 "checksum trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa2e20c4f1418ac2e71ddc418e35e1b56e34022e2146209ffdbf1b2de8b1bd9"
-"checksum trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006314f54f2ea7944a878e66fd93ad7978095bc355f30a2f26ec40f664d86c86"
+"checksum trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e24277af05f38f3aaf03ac78e3a154be83f13db9c8ef0cb95bb1aa764a477b"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "555cd4909480122bbbf21e34faac4cb08a171f324775670447ed116726c474af"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hash256-std-hasher"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1209,11 +1209,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "keccak-hasher"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4057,7 +4057,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4322,15 +4322,15 @@ dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 1.0.0",
  "substrate-primitives 1.0.0",
- "trie-bench 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-bench 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4697,17 +4697,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "trie-bench"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4732,12 +4732,12 @@ dependencies = [
 
 [[package]]
 name = "trie-standardmap"
-version = "0.12.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5201,7 +5201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba7fb417e5c470acdd61068c79767d0e65962e70836cf6c9dfd2409f06345ce0"
-"checksum hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f8b2027c19ec91eb304999abae7307d225cf93be42af53b0039f76e98ed5af86"
+"checksum hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1224388a21c88a80ae7087a2a245ca6d80acc97a9186b75789fb3eeefd0609af"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8e04cb7a5051270ef3fa79f8c7604d581ecfa73d520e74f554e45541c4b5881a"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
@@ -5233,7 +5233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum jsonrpc-server-utils 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5521613b31ea22d36d9f95ad642058dccec846a94ed8690957652d479f620707"
 "checksum jsonrpc-ws-server 10.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20b8333a5a6e6ccbcf5c90f90919de557cba4929efa164e9bd0e8e497eb20e46"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-"checksum keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "af672553b2abac1c86c29fd62c79880638b6abc91d96db4aa42a5baab2bc1ca9"
+"checksum keccak-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a02fb74dc1b613522069b5f2023c014756ce121c6c6fb39364c139b0efc39a2d"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
 "checksum kvdb-memorydb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
@@ -5445,10 +5445,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-"checksum trie-bench 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ba20f7d9865497ea46511860b43e05a44f4ac9a76ee089d34cd80a839a690264"
+"checksum trie-bench 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eafa32a8662c06f5bf135984bc1a12821fd38770b5c2f2f9e8750327fcbe3955"
 "checksum trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1ba73747fd3a64ab531274c04cb588dfa9d30d972d62990831e63fbce2cfec59"
 "checksum trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfa2e20c4f1418ac2e71ddc418e35e1b56e34022e2146209ffdbf1b2de8b1bd9"
-"checksum trie-standardmap 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4e24277af05f38f3aaf03ac78e3a154be83f13db9c8ef0cb95bb1aa764a477b"
+"checksum trie-standardmap 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006314f54f2ea7944a878e66fd93ad7978095bc355f30a2f26ec40f664d86c86"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
 "checksum twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "555cd4909480122bbbf21e34faac4cb08a171f324775670447ed116726c474af"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
 [[package]]
 name = "finality-grandpa"
 version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3867,7 +3868,7 @@ name = "substrate-finality-grandpa"
 version = "1.0.0"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "finality-grandpa 0.7.1",
+ "finality-grandpa 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fork-tree 1.0.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5175,6 +5176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
+"checksum finality-grandpa 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c9da35679ad45649e32e6344a08a36e71ba5f5305ba02d18c34d262c49ce0072"
 "checksum fixed-hash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a557e80084b05c32b455963ff565a9de6f2866da023d6671705c6aff6f65e01c"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"

--- a/core/finality-grandpa/Cargo.toml
+++ b/core/finality-grandpa/Cargo.toml
@@ -22,7 +22,7 @@ network = { package = "substrate-network", path = "../network" }
 service = { package = "substrate-service", path = "../service", optional = true }
 srml-finality-tracker = { path = "../../srml/finality-tracker" }
 fg_primitives = { package = "substrate-finality-grandpa-primitives", path = "primitives" }
-grandpa = { package = "finality-grandpa", version = "0.6.0", features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", path = "../../../finality-grandpa", features = ["derive-codec"] }
 
 [dev-dependencies]
 network = { package = "substrate-network", path = "../network", features = ["test-helpers"] }

--- a/core/finality-grandpa/Cargo.toml
+++ b/core/finality-grandpa/Cargo.toml
@@ -22,7 +22,7 @@ network = { package = "substrate-network", path = "../network" }
 service = { package = "substrate-service", path = "../service", optional = true }
 srml-finality-tracker = { path = "../../srml/finality-tracker" }
 fg_primitives = { package = "substrate-finality-grandpa-primitives", path = "primitives" }
-grandpa = { package = "finality-grandpa", path = "../../../finality-grandpa", features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.7.1", features = ["derive-codec"] }
 
 [dev-dependencies]
 network = { package = "substrate-network", path = "../network", features = ["test-helpers"] }

--- a/core/finality-grandpa/src/authorities.rs
+++ b/core/finality-grandpa/src/authorities.rs
@@ -19,7 +19,7 @@
 use fork_tree::ForkTree;
 use parking_lot::RwLock;
 use substrate_primitives::ed25519;
-use grandpa::VoterSet;
+use grandpa::voter_set::VoterSet;
 use parity_codec::{Encode, Decode};
 use log::{debug, info};
 use substrate_telemetry::{telemetry, CONSENSUS_INFO};

--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -28,7 +28,7 @@ use log::{info, warn};
 
 use crate::authorities::{AuthoritySet, SharedAuthoritySet, PendingChange, DelayKind};
 use crate::consensus_changes::{SharedConsensusChanges, ConsensusChanges};
-use crate::environment::{CompletedRound, CompletedRounds, HasVoted, VoterSetState};
+use crate::environment::{CompletedRound, CompletedRounds, HasVoted, SharedVoterSetState, VoterSetState};
 use crate::NewAuthoritySet;
 
 use substrate_primitives::ed25519::Public as AuthorityId;
@@ -119,7 +119,7 @@ fn load_decode<B: AuxStore, T: Decode>(backend: &B, key: &[u8]) -> ClientResult<
 pub(crate) struct PersistentData<Block: BlockT> {
 	pub(crate) authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 	pub(crate) consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
-	pub(crate) set_state: VoterSetState<Block>,
+	pub(crate) set_state: SharedVoterSetState<Block>,
 }
 
 fn migrate_from_version0<Block: BlockT, B, G>(
@@ -268,7 +268,7 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 				return Ok(PersistentData {
 					authority_set: new_set.into(),
 					consensus_changes: Arc::new(consensus_changes.into()),
-					set_state,
+					set_state: set_state.into(),
 				});
 			}
 		},
@@ -277,7 +277,7 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 				return Ok(PersistentData {
 					authority_set: new_set.into(),
 					consensus_changes: Arc::new(consensus_changes.into()),
-					set_state,
+					set_state: set_state.into(),
 				});
 			}
 		},
@@ -311,7 +311,7 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 				return Ok(PersistentData {
 					authority_set: set.into(),
 					consensus_changes: Arc::new(consensus_changes.into()),
-					set_state,
+					set_state: set_state.into(),
 				});
 			}
 		},
@@ -348,7 +348,7 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 
 	Ok(PersistentData {
 		authority_set: genesis_set.into(),
-		set_state: genesis_state,
+		set_state: genesis_state.into(),
 		consensus_changes: Arc::new(consensus_changes.into()),
 	})
 }

--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -434,7 +434,7 @@ mod test {
 
 		let authorities = vec![(AuthorityId::default(), 100)];
 		let set_id = 3;
-		let round_number = 42;
+		let round_number: u64 = 42;
 		let round_state = RoundState::<H256, u64> {
 			prevote_ghost: Some((H256::random(), 32)),
 			finalized: None,
@@ -496,14 +496,14 @@ mod test {
 		);
 
 		assert_eq!(
-			set_state,
-			VoterSetState::Live {
-				last_completed_round: CompletedRound {
+			&*set_state.read(),
+			&VoterSetState::Live {
+				completed_rounds: CompletedRounds::new(CompletedRound {
 					number: round_number,
 					state: round_state.clone(),
 					base: round_state.prevote_ghost.unwrap(),
 					votes: vec![],
-				},
+				}),
 				current_round: HasVoted::No,
 			},
 		);

--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -28,7 +28,7 @@ use log::{info, warn};
 
 use crate::authorities::{AuthoritySet, SharedAuthoritySet, PendingChange, DelayKind};
 use crate::consensus_changes::{SharedConsensusChanges, ConsensusChanges};
-use crate::environment::{CompletedRound, HasVoted, VoterSetState};
+use crate::environment::{CompletedRound, CompletedRounds, HasVoted, VoterSetState};
 use crate::NewAuthoritySet;
 
 use substrate_primitives::ed25519::Public as AuthorityId;
@@ -154,12 +154,12 @@ fn migrate_from_version0<Block: BlockT, B, G>(
 			.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 		let set_state = VoterSetState::Live {
-			last_completed_round: CompletedRound {
+			completed_rounds: CompletedRounds::new(CompletedRound {
 				number: last_round_number,
 				state: last_round_state,
 				votes: Vec::new(),
 				base,
-			},
+			}),
 			current_round: HasVoted::No,
 		};
 
@@ -197,12 +197,12 @@ fn migrate_from_version1<Block: BlockT, B, G>(
 					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 				VoterSetState::Paused {
-					last_completed_round: CompletedRound {
+					completed_rounds: CompletedRounds::new(CompletedRound {
 						number: last_round_number,
 						state: set_state,
 						votes: Vec::new(),
 						base,
-					}
+					}),
 				}
 			},
 			Some(V1VoterSetState::Live(last_round_number, set_state)) => {
@@ -210,12 +210,12 @@ fn migrate_from_version1<Block: BlockT, B, G>(
 					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 				VoterSetState::Live {
-					last_completed_round: CompletedRound {
+					completed_rounds: CompletedRounds::new(CompletedRound {
 						number: last_round_number,
 						state: set_state,
 						votes: Vec::new(),
 						base,
-					},
+					}),
 					current_round: HasVoted::No,
 				}
 			},
@@ -225,12 +225,12 @@ fn migrate_from_version1<Block: BlockT, B, G>(
 					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 				VoterSetState::Live {
-					last_completed_round: CompletedRound {
+					completed_rounds: CompletedRounds::new(CompletedRound {
 						number: 0,
 						state: set_state,
 						votes: Vec::new(),
 						base,
-					},
+					}),
 					current_round: HasVoted::No,
 				}
 			},
@@ -297,12 +297,12 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 							.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 						VoterSetState::Live {
-							last_completed_round: CompletedRound {
+							completed_rounds: CompletedRounds::new(CompletedRound {
 								number: 0,
 								votes: Vec::new(),
 								base,
 								state,
-							},
+							}),
 							current_round: HasVoted::No,
 						}
 					}
@@ -330,12 +330,12 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 		.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
 
 	let genesis_state = VoterSetState::Live {
-		last_completed_round: CompletedRound {
+		completed_rounds: CompletedRounds::new(CompletedRound {
 			number: 0,
 			votes: Vec::new(),
 			state,
 			base,
-		},
+		}),
 		current_round: HasVoted::No,
 	};
 	backend.insert_aux(
@@ -373,12 +373,12 @@ pub(crate) fn update_authority_set<Block: BlockT, F, R>(
 			new_set.canon_number.clone(),
 		));
 		let set_state = VoterSetState::<Block>::Live {
-			last_completed_round: CompletedRound {
+			completed_rounds: CompletedRounds::new(CompletedRound {
 				number: 0,
 				state: round_state,
 				votes: Vec::new(),
 				base: (new_set.canon_hash, new_set.canon_number),
-			},
+			}),
 			current_round: HasVoted::No,
 		};
 		let encoded = set_state.encode();

--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -28,7 +28,7 @@ use log::{info, warn};
 
 use crate::authorities::{AuthoritySet, SharedAuthoritySet, PendingChange, DelayKind};
 use crate::consensus_changes::{SharedConsensusChanges, ConsensusChanges};
-use crate::environment::{HasVoted, VoterSetState};
+use crate::environment::{CompletedRound, HasVoted, VoterSetState};
 use crate::NewAuthoritySet;
 
 use substrate_primitives::ed25519::Public as AuthorityId;
@@ -142,7 +142,7 @@ fn migrate_from_version0<Block: BlockT, B, G>(
 		let new_set: AuthoritySet<Block::Hash, NumberFor<Block>> = old_set.into();
 		backend.insert_aux(&[(AUTHORITY_SET_KEY, new_set.encode().as_slice())], &[])?;
 
-		let last_completed_round = match load_decode::<_, V0VoterSetState<Block::Hash, NumberFor<Block>>>(
+		let (last_round_number, last_round_state) = match load_decode::<_, V0VoterSetState<Block::Hash, NumberFor<Block>>>(
 			backend,
 			SET_STATE_KEY,
 		)? {
@@ -150,8 +150,16 @@ fn migrate_from_version0<Block: BlockT, B, G>(
 			None => (0, genesis_round()),
 		};
 
+		let base = last_round_state.prevote_ghost
+			.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
 		let set_state = VoterSetState::Live {
-			last_completed_round,
+			last_completed_round: CompletedRound {
+				number: last_round_number,
+				state: last_round_state,
+				votes: Vec::new(),
+				base,
+			},
 			current_round: HasVoted::No,
 		};
 
@@ -185,19 +193,46 @@ fn migrate_from_version1<Block: BlockT, B, G>(
 			SET_STATE_KEY,
 		)? {
 			Some(V1VoterSetState::Paused(last_round_number, set_state)) => {
+				let base = set_state.prevote_ghost
+					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
 				VoterSetState::Paused {
-					last_completed_round: (last_round_number, set_state),
+					last_completed_round: CompletedRound {
+						number: last_round_number,
+						state: set_state,
+						votes: Vec::new(),
+						base,
+					}
 				}
 			},
 			Some(V1VoterSetState::Live(last_round_number, set_state)) => {
+				let base = set_state.prevote_ghost
+					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
 				VoterSetState::Live {
-					last_completed_round: (last_round_number, set_state),
+					last_completed_round: CompletedRound {
+						number: last_round_number,
+						state: set_state,
+						votes: Vec::new(),
+						base,
+					},
 					current_round: HasVoted::No,
 				}
 			},
-			None => VoterSetState::Live {
-				last_completed_round: (0, genesis_round()),
-				current_round: HasVoted::No,
+			None => {
+				let set_state = genesis_round();
+				let base = set_state.prevote_ghost
+					.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
+				VoterSetState::Live {
+					last_completed_round: CompletedRound {
+						number: 0,
+						state: set_state,
+						votes: Vec::new(),
+						base,
+					},
+					current_round: HasVoted::No,
+				}
 			},
 		};
 
@@ -256,10 +291,21 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 					SET_STATE_KEY,
 				)? {
 					Some(state) => state,
-					None => VoterSetState::Live {
-						last_completed_round: (0, make_genesis_round()),
-						current_round: HasVoted::No,
-					},
+					None => {
+						let state = make_genesis_round();
+						let base = state.prevote_ghost
+							.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
+						VoterSetState::Live {
+							last_completed_round: CompletedRound {
+								number: 0,
+								votes: Vec::new(),
+								base,
+								state,
+							},
+							current_round: HasVoted::No,
+						}
+					}
 				};
 
 				return Ok(PersistentData {
@@ -279,8 +325,17 @@ pub(crate) fn load_persistent<Block: BlockT, B, G>(
 		from genesis on what appears to be first startup.");
 
 	let genesis_set = AuthoritySet::genesis(genesis_authorities()?);
+	let state = make_genesis_round();
+	let base = state.prevote_ghost
+		.expect("state is for completed round; completed rounds must have a prevote ghost; qed.");
+
 	let genesis_state = VoterSetState::Live {
-		last_completed_round: (0, make_genesis_round()),
+		last_completed_round: CompletedRound {
+			number: 0,
+			votes: Vec::new(),
+			state,
+			base,
+		},
 		current_round: HasVoted::No,
 	};
 	backend.insert_aux(
@@ -318,7 +373,12 @@ pub(crate) fn update_authority_set<Block: BlockT, F, R>(
 			new_set.canon_number.clone(),
 		));
 		let set_state = VoterSetState::<Block>::Live {
-			last_completed_round: (0, round_state),
+			last_completed_round: CompletedRound {
+				number: 0,
+				state: round_state,
+				votes: Vec::new(),
+				base: (new_set.canon_hash, new_set.canon_number),
+			},
 			current_round: HasVoted::No,
 		};
 		let encoded = set_state.encode();
@@ -376,7 +436,7 @@ mod test {
 		let set_id = 3;
 		let round_number = 42;
 		let round_state = RoundState::<H256, u64> {
-			prevote_ghost: None,
+			prevote_ghost: Some((H256::random(), 32)),
 			finalized: None,
 			estimate: None,
 			completable: false,
@@ -438,7 +498,12 @@ mod test {
 		assert_eq!(
 			set_state,
 			VoterSetState::Live {
-				last_completed_round: (round_number, round_state),
+				last_completed_round: CompletedRound {
+					number: round_number,
+					state: round_state.clone(),
+					base: round_state.prevote_ghost.unwrap(),
+					votes: vec![],
+				},
 				current_round: HasVoted::No,
 			},
 		);

--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -50,16 +50,6 @@ pub enum V1VoterSetState<H, N> {
 	Live(u64, RoundState<H, N>),
 }
 
-impl<H: Clone, N: Clone> V1VoterSetState<H, N> {
-	/// Yields the current state.
-	pub(crate) fn round(&self) -> (u64, RoundState<H, N>) {
-		match *self {
-			V1VoterSetState::Paused(n, ref s) => (n, s.clone()),
-			V1VoterSetState::Live(n, ref s) => (n, s.clone()),
-		}
-	}
-}
-
 type V0VoterSetState<H, N> = (u64, RoundState<H, N>);
 
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -392,15 +392,15 @@ impl<Block: BlockT, N: Network<Block>> Sink for OutgoingMessages<Block, N>
 		match &mut msg {
 			grandpa::Message::PrimaryPropose(ref mut vote) =>
 				if let Some(propose) = self.has_voted.propose() {
-					*vote = propose;
+					*vote = propose.clone();
 				},
 			grandpa::Message::Prevote(ref mut vote) =>
 				if let Some(prevote) = self.has_voted.prevote() {
-					*vote = prevote;
+					*vote = prevote.clone();
 				},
 			grandpa::Message::Precommit(ref mut vote) =>
 				if let Some(precommit) = self.has_voted.precommit() {
-					*vote = precommit;
+					*vote = precommit.clone();
 				},
 		}
 

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -386,16 +386,25 @@ impl<Block: BlockT, N: Network<Block>> Sink for OutgoingMessages<Block, N>
 	type SinkItem = Message<Block>;
 	type SinkError = Error;
 
-	fn start_send(&mut self, msg: Message<Block>) -> StartSend<Message<Block>, Error> {
-		// only sign if we haven't voted in this round already.
-		let should_sign = match msg {
-			grandpa::Message::PrimaryPropose(_) => self.has_voted.can_propose(),
-			grandpa::Message::Prevote(_) => self.has_voted.can_prevote(),
-			grandpa::Message::Precommit(_) => self.has_voted.can_precommit(),
-		};
+	fn start_send(&mut self, mut msg: Message<Block>) -> StartSend<Message<Block>, Error> {
+		// if we've voted on this round previously under the same key, send that vote instead
+		match &mut msg {
+			grandpa::Message::PrimaryPropose(ref mut vote) =>
+				if let Some(propose) = self.has_voted.propose() {
+					*vote = propose;
+				},
+			grandpa::Message::Prevote(ref mut vote) =>
+				if let Some(prevote) = self.has_voted.prevote() {
+					*vote = prevote;
+				},
+			grandpa::Message::Precommit(ref mut vote) =>
+				if let Some(precommit) = self.has_voted.precommit() {
+					*vote = precommit;
+				},
+		}
 
 		// when locals exist, sign messages on import
-		if let (true, &Some((ref pair, ref local_id))) = (should_sign, &self.locals) {
+		if let Some((ref pair, ref local_id)) = self.locals {
 			let encoded = localized_payload(self.round, self.set_id, &msg);
 			let signature = pair.sign(&encoded[..]);
 

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -371,7 +371,8 @@ pub(crate) fn check_message_sig<Block: BlockT>(
 	}
 }
 
-/// A sink for outgoing messages to the network.
+/// A sink for outgoing messages to the network. Any messages that are sent will
+/// be replaced, as appropriate, according to the given `HasVoted`.
 struct OutgoingMessages<Block: BlockT, N: Network<Block>> {
 	round: u64,
 	set_id: u64,

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -373,6 +373,11 @@ pub(crate) fn check_message_sig<Block: BlockT>(
 
 /// A sink for outgoing messages to the network. Any messages that are sent will
 /// be replaced, as appropriate, according to the given `HasVoted`.
+/// NOTE: The votes are stored unsigned, which means that the signatures need to
+/// be "stable", i.e. we should end up with the exact same signed message if we
+/// use the same raw message and key to sign. This is currently true for
+/// `ed25519` and `BLS` signatures (which we might use in the future), care must
+/// be taken when switching to different key types.
 struct OutgoingMessages<Block: BlockT, N: Network<Block>> {
 	round: u64,
 	set_id: u64,

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -559,6 +559,7 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 		self.update_voter_set_state(|voter_set_state| {
 			let mut completed_rounds = voter_set_state.completed_rounds();
 
+			// NOTE: the Environment assumes that rounds are *always* completed in-order.
 			if !completed_rounds.push(CompletedRound {
 				number: round,
 				state: state.clone(),

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -207,17 +207,17 @@ impl<Block: BlockT> HasVoted<Block> {
 
 	/// Returns true if the voter can still propose, false otherwise.
 	pub fn can_propose(&self) -> bool {
-		self.propose().map(|_| false).unwrap_or(true)
+		self.propose().is_none()
 	}
 
 	/// Returns true if the voter can still prevote, false otherwise.
 	pub fn can_prevote(&self) -> bool {
-		self.prevote().map(|_| false).unwrap_or(true)
+		self.prevote().is_none()
 	}
 
 	/// Returns true if the voter can still precommit, false otherwise.
 	pub fn can_precommit(&self) -> bool {
-		self.precommit().map(|_| false).unwrap_or(true)
+		self.precommit().is_none()
 	}
 }
 

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -54,9 +54,13 @@ use ed25519::Public as AuthorityId;
 /// Data about a completed round.
 #[derive(Debug, Clone, Decode, Encode, PartialEq)]
 pub struct CompletedRound<Block: BlockT> {
+	/// The round number.
 	pub number: u64,
+	/// The round state (prevote ghost, estimate, finalized, etc.)
 	pub state: RoundState<Block::Hash, NumberFor<Block>>,
+	/// The target block base used for voting in the round.
 	pub base: (Block::Hash, NumberFor<Block>),
+	/// All the votes observed in the round.
 	pub votes: Vec<SignedMessage<Block>>,
 }
 
@@ -215,7 +219,6 @@ impl<Block: BlockT> HasVoted<Block> {
 	pub fn can_precommit(&self) -> bool {
 		self.precommit().map(|_| false).unwrap_or(true)
 	}
-
 }
 
 /// A voter set state meant to be shared safely across multiple owners.

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -27,7 +27,8 @@ use client::{
 	backend::Backend, BlockchainEvents, CallExecutor, Client, error::Error as ClientError
 };
 use grandpa::{
-	BlockNumberOps, Equivocation, Error as GrandpaError, round::State as RoundState, voter, VoterSet,
+	BlockNumberOps, Equivocation, Error as GrandpaError, round::State as RoundState,
+	voter, voter_set::VoterSet,
 };
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{
@@ -37,8 +38,8 @@ use substrate_primitives::{Blake2Hasher, ed25519, H256, Pair};
 use substrate_telemetry::{telemetry, CONSENSUS_INFO};
 
 use crate::{
-	Commit, Config, Error, Network, Precommit, Prevote,
-	CommandOrError, NewAuthoritySet, VoterCommand,
+	CommandOrError, Commit, Config, Error, Network, Precommit, Prevote,
+	PrimaryPropose, SignedMessage, NewAuthoritySet, VoterCommand,
 };
 
 use crate::authorities::SharedAuthoritySet;
@@ -261,7 +262,25 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 		}
 	}
 
-	fn completed(&self, round: u64, state: RoundState<Block::Hash, NumberFor<Block>>) -> Result<(), Self::Error> {
+	fn proposed(&self, _round: u64, _propose: PrimaryPropose<Block>) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn prevoted(&self, _round: u64, _prevote: Prevote<Block>) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn precommitted(&self, _round: u64, _precommit: Precommit<Block>) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn completed(
+		&self,
+		round: u64,
+		state: RoundState<Block::Hash, NumberFor<Block>>,
+		_base: (Block::Hash, NumberFor<Block>),
+		_votes: Vec<SignedMessage<Block>>,
+	) -> Result<(), Self::Error> {
 		debug!(
 			target: "afg", "Voter {} completed round {} in set {}. Estimate = {:?}, Finalized in round = {:?}",
 			self.config.name(),

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -50,16 +50,22 @@ use crate::until_imported::UntilVoteTargetImported;
 use ed25519::Public as AuthorityId;
 
 /// Data about a completed round.
-pub(crate) type CompletedRound<H, N> = (u64, RoundState<H, N>);
+#[derive(Debug, Clone, Decode, Encode, PartialEq)]
+pub struct CompletedRound<Block: BlockT> {
+	pub number: u64,
+	pub state: RoundState<Block::Hash, NumberFor<Block>>,
+	pub base: (Block::Hash, NumberFor<Block>),
+	pub votes: Vec<SignedMessage<Block>>,
+}
 
 #[derive(Debug, Clone, Decode, Encode, PartialEq)]
 pub enum VoterSetState<Block: BlockT> {
 	Live {
-		last_completed_round: CompletedRound<Block::Hash, NumberFor<Block>>,
+		last_completed_round: CompletedRound<Block>,
 		current_round: HasVoted<Block>,
 	},
 	Paused {
-		last_completed_round: CompletedRound<Block::Hash, NumberFor<Block>>,
+		last_completed_round: CompletedRound<Block>,
 	},
 }
 
@@ -135,7 +141,7 @@ impl<Block: BlockT> SharedVoterSetState<Block> {
 	}
 
 	/// Read the last completed round.
-	pub(crate) fn last_completed_round(&self) -> CompletedRound<Block::Hash, NumberFor<Block>> {
+	pub(crate) fn last_completed_round(&self) -> CompletedRound<Block> {
 		match &*self.inner.read() {
 			VoterSetState::Live { last_completed_round, .. } =>
 				last_completed_round.clone(),
@@ -430,8 +436,8 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 		&self,
 		round: u64,
 		state: RoundState<Block::Hash, NumberFor<Block>>,
-		_base: (Block::Hash, NumberFor<Block>),
-		_votes: Vec<SignedMessage<Block>>,
+		base: (Block::Hash, NumberFor<Block>),
+		votes: Vec<SignedMessage<Block>>,
 	) -> Result<(), Self::Error> {
 		debug!(
 			target: "afg", "Voter {} completed round {} in set {}. Estimate = {:?}, Finalized in round = {:?}",
@@ -444,7 +450,12 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 
 		self.voter_set_state.with(|voter_set_state| {
 			let set_state = VoterSetState::<Block>::Live {
-				last_completed_round: (round, state.clone()),
+				last_completed_round: CompletedRound {
+					number: round,
+					state: state.clone(),
+					base,
+					votes,
+				},
 				current_round: HasVoted::No,
 			};
 

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -309,7 +309,7 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 	fn round_data(
 		&self,
 		round: u64
-	) -> voter::RoundData<Self::Timer, Self::In, Self::Out> {
+	) -> voter::RoundData<Self::Id, Self::Timer, Self::In, Self::Out> {
 		let now = Instant::now();
 		let prevote_timer = Delay::new(now + self.config.gossip_duration * 2);
 		let precommit_timer = Delay::new(now + self.config.gossip_duration * 4);
@@ -337,6 +337,7 @@ impl<B, E, Block: BlockT<Hash=H256>, N, RA> voter::Environment<Block::Hash, Numb
 		let outgoing = Box::new(outgoing.sink_map_err(Into::into));
 
 		voter::RoundData {
+			voter_id: self.config.local_key.as_ref().map(|pair| pair.public().clone()),
 			prevote_timer: Box::new(prevote_timer.map_err(|e| Error::Timer(e).into())),
 			precommit_timer: Box::new(precommit_timer.map_err(|e| Error::Timer(e).into())),
 			incoming,

--- a/core/finality-grandpa/src/finality_proof.rs
+++ b/core/finality-grandpa/src/finality_proof.rs
@@ -29,7 +29,7 @@
 //! The caller should track the `set_id`. The most straightforward way is to fetch finality
 //! proofs ONLY for blocks on the tip of the chain and track the latest known `set_id`.
 
-use grandpa::VoterSet;
+use grandpa::voter_set::VoterSet;
 
 use client::{
 	blockchain::Backend as BlockchainBackend,

--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -362,7 +362,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA> GrandpaBlockImport<B, E, Block, RA
 				AppliedChanges::None => None,
 			};
 
-			crate::aux_schema::update_authority_set(
+			crate::aux_schema::update_authority_set::<Block, _, _>(
 				authorities,
 				authorities_change,
 				|insert| block.auxiliary.extend(

--- a/core/finality-grandpa/src/justification.rs
+++ b/core/finality-grandpa/src/justification.rs
@@ -21,7 +21,7 @@ use client::backend::Backend;
 use client::blockchain::HeaderBackend;
 use client::error::{Error as ClientError, ErrorKind as ClientErrorKind};
 use parity_codec::{Encode, Decode};
-use grandpa::VoterSet;
+use grandpa::voter_set::VoterSet;
 use grandpa::{Error as GrandpaError};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{NumberFor, Block as BlockT, Header as HeaderT};

--- a/core/finality-grandpa/src/justification.rs
+++ b/core/finality-grandpa/src/justification.rs
@@ -121,7 +121,7 @@ impl<Block: BlockT<Hash=H256>> GrandpaJustification<Block> {
 			voters,
 			&ancestry_chain,
 		) {
-			Ok(Some(_)) => {},
+			Ok(ref result) if result.ghost().is_some() => {},
 			_ => {
 				let msg = "invalid commit in grandpa justification".to_string();
 				return Err(ClientErrorKind::BadJustification(msg).into());

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -360,7 +360,7 @@ fn global_communication<Block: BlockT<Hash=H256>, I, O>(
 	>,
 {
 	let global_in = commits_in.map(|(round, commit)| {
-		voter::CommunicationIn::Commit(round, commit)
+		voter::CommunicationIn::Commit(round, commit, voter::Callback::Blank)
 	});
 
 	// NOTE: eventually this will also handle catch-up requests

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -530,7 +530,6 @@ pub fn run_grandpa<B, E, Block: BlockT<Hash=H256>, N, RA>(
 
 				Some(voter::Voter::new(
 					env.clone(),
-					config.local_key.as_ref().map(|key| key.public()),
 					voters,
 					global_comms,
 					last_completed_round.number,

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -601,8 +601,8 @@ pub fn run_grandpa<B, E, Block: BlockT<Hash=H256>, N, RA>(
 					info!(target: "afg", "Pausing old validator set: {}", reason);
 
 					// not racing because old voter is shut down.
-					let completed_rounds = env.voter_set_state.completed_rounds();
-					env.update_voter_set_state(|| {
+					env.update_voter_set_state(|voter_set_state| {
+						let completed_rounds = voter_set_state.completed_rounds();
 						let set_state = VoterSetState::Paused { completed_rounds };
 						aux_schema::write_voter_set_state(&**client.backend(), &set_state)?;
 						Ok(set_state)

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -507,7 +507,6 @@ pub fn run_grandpa<B, E, Block: BlockT<Hash=H256>, N, RA>(
 					_ => HasVoted::No,
 				};
 
-
 				// NOTE: only updated on disk when the voter first
 				// proposes/prevotes/precommits or completes a round.
 				Ok(Some(VoterSetState::Live {

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -1069,6 +1069,9 @@ fn voter_persists_its_votes() {
 			).expect("all in order with client and network");
 
 			let voter = future::poll_fn(move || {
+				// we need to keep the block_import alive since it owns the
+				// sender for the voter commands channel, if that gets dropped
+				// then the voter will stop
 				let _block_import = _block_import.clone();
 				voter.poll()
 			});

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -1015,3 +1015,193 @@ fn test_bad_justification() {
 		ImportResult::AlreadyInChain
 	);
 }
+
+#[test]
+fn voter_persists_its_votes() {
+	use std::iter::FromIterator;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+	use futures::future;
+	use futures::sync::mpsc;
+
+	env_logger::init();
+
+	// we have two authorities but we'll only be running the voter for alice
+	// we are going to be listening for the prevotes it casts
+	let peers = &[AuthorityKeyring::Alice, AuthorityKeyring::Bob];
+	let voters = make_ids(peers);
+
+	// alice has a chain with 20 blocks
+	let mut net = GrandpaTestNet::new(TestApi::new(voters.clone()), 2);
+	net.peer(0).push_blocks(20, false);
+	net.sync();
+
+	assert_eq!(net.peer(0).client().info().unwrap().chain.best_number, 20,
+			   "Peer #{} failed to sync", 0);
+
+	let mut runtime = current_thread::Runtime::new().unwrap();
+
+	let client = net.peer(0).client().clone();
+	let net = Arc::new(Mutex::new(net));
+
+	let (voter_tx, voter_rx) = mpsc::unbounded::<()>();
+
+	// startup a grandpa voter for alice but also listen for messages on a
+	// channel. whenever a message is received the voter is restarted. when the
+	// sender is dropped the voter is stopped.
+	{
+		let net = net.clone();
+
+		let voter = future::loop_fn(voter_rx, move |rx| {
+			let (_block_import, _, link) = net.lock().make_block_import(client.clone());
+			let link = link.lock().take().unwrap();
+
+			let mut voter = run_grandpa(
+				Config {
+					gossip_duration: TEST_GOSSIP_DURATION,
+					justification_period: 32,
+					local_key: Some(Arc::new(peers[0].clone().into())),
+					name: Some(format!("peer#{}", 0)),
+				},
+				link,
+				MessageRouting::new(net.clone(), 0),
+				InherentDataProviders::new(),
+				futures::empty(),
+			).expect("all in order with client and network");
+
+			let voter = future::poll_fn(move || {
+				let _block_import = _block_import.clone();
+				voter.poll()
+			});
+
+			voter.select2(rx.into_future()).then(|res| match res {
+				Ok(future::Either::A(x)) => {
+					panic!("voter stopped unexpectedly: {:?}", x);
+				},
+				Ok(future::Either::B(((Some(()), rx), _))) => {
+					Ok(future::Loop::Continue(rx))
+				},
+				Ok(future::Either::B(((None, _), _))) => {
+					Ok(future::Loop::Break(()))
+				},
+				Err(future::Either::A(err)) => {
+					panic!("unexpected error: {:?}", err);
+				},
+				Err(future::Either::B(..)) => {
+					// voter_rx dropped, stop the voter.
+					Ok(future::Loop::Break(()))
+				},
+			})
+		});
+
+		runtime.spawn(voter);
+	}
+
+	let (exit_tx, exit_rx) = futures::sync::oneshot::channel::<()>();
+
+	// create the communication layer for bob, but don't start any
+	// voter. instead we'll listen for the prevote that alice casts
+	// and cast our own manually
+	{
+		let config = Config {
+			gossip_duration: TEST_GOSSIP_DURATION,
+			justification_period: 32,
+			local_key: Some(Arc::new(peers[1].clone().into())),
+			name: Some(format!("peer#{}", 1)),
+		};
+		let routing = MessageRouting::new(net.clone(), 1);
+		let network = communication::NetworkBridge::new(routing, config.clone());
+
+		let (round_rx, round_tx) = network.round_communication(
+			communication::Round(1),
+			communication::SetId(0),
+			Arc::new(VoterSet::from_iter(voters)),
+			Some(config.local_key.unwrap()),
+			HasVoted::No,
+		);
+
+		let round_tx = Arc::new(Mutex::new(round_tx));
+		let exit_tx = Arc::new(Mutex::new(Some(exit_tx)));
+
+		let net = net.clone();
+		let state = AtomicUsize::new(0);
+
+		runtime.spawn(round_rx.for_each(move |signed| {
+			if state.compare_and_swap(0, 1, Ordering::SeqCst) == 0 {
+				// the first message we receive should be a prevote from alice.
+				let prevote = match signed.message {
+					grandpa::Message::Prevote(prevote) => prevote,
+					_ => panic!("voter should prevote."),
+				};
+
+				// its chain has 20 blocks and the voter targets 3/4 of the
+				// unfinalized chain, so the vote should be for block 15
+				assert!(prevote.target_number == 15);
+
+				// we push 20 more blocks to alice's chain
+				net.lock().peer(0).push_blocks(20, false);
+				net.lock().sync();
+
+				assert_eq!(net.lock().peer(0).client().info().unwrap().chain.best_number, 40,
+						   "Peer #{} failed to sync", 0);
+
+				let block_30_hash =
+					net.lock().peer(0).client().backend().blockchain().hash(30).unwrap().unwrap();
+
+				// we restart alice's voter
+				voter_tx.unbounded_send(()).unwrap();
+
+				// and we push our own prevote for block 30
+				let prevote = grandpa::Prevote {
+					target_number: 30,
+					target_hash: block_30_hash,
+				};
+
+				round_tx.lock().start_send(grandpa::Message::Prevote(prevote)).unwrap();
+
+			} else if state.compare_and_swap(1, 2, Ordering::SeqCst) == 1 {
+				// the next message we receive should be our own prevote
+				let prevote = match signed.message {
+					grandpa::Message::Prevote(prevote) => prevote,
+					_ => panic!("We should receive our own prevote."),
+				};
+
+				// targeting block 30
+				assert!(prevote.target_number == 30);
+
+				// after alice restarts it should send its previous prevote
+				// therefore we won't ever receive it again since it will be a
+				// known message on the gossip layer
+
+			} else if state.compare_and_swap(2, 3, Ordering::SeqCst) == 2 {
+				// we then receive a precommit from alice for block 15
+				// even though we casted a prevote for block 30
+				let precommit = match signed.message {
+					grandpa::Message::Precommit(precommit) => precommit,
+					_ => panic!("voter should precommit."),
+				};
+
+				assert!(precommit.target_number == 15);
+
+				// signal exit
+				exit_tx.clone().lock().take().unwrap().send(()).unwrap();
+			}
+
+			Ok(())
+		}).map_err(|_| ()));
+	}
+
+	let net = net.clone();
+	let drive_to_completion = ::tokio::timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
+		.for_each(move |_| {
+			net.lock().send_import_notifications();
+			net.lock().send_finality_notifications();
+			net.lock().route_fast();
+			Ok(())
+		})
+		.map(|_| ())
+		.map_err(|_| ());
+
+	let exit = exit_rx.into_future().map(|_| ()).map_err(|_| ());
+
+	runtime.block_on(drive_to_completion.select(exit).map(|_| ()).map_err(|_| ())).unwrap();
+}

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -1023,7 +1023,7 @@ fn voter_persists_its_votes() {
 	use futures::future;
 	use futures::sync::mpsc;
 
-	env_logger::init();
+	let _ = env_logger::try_init();
 
 	// we have two authorities but we'll only be running the voter for alice
 	// we are going to be listening for the prevotes it casts


### PR DESCRIPTION
Depends on #2110.

- Upgrade to finality-grandpa 0.7 (unreleased, depends on https://github.com/paritytech/finality-grandpa/pull/57, https://github.com/paritytech/finality-grandpa/pull/58, https://github.com/paritytech/finality-grandpa/pull/59).
- Support primary propose.
- Persist own votes and resend them when restarting (if appropriate).
- Persist all votes and base for the last completed round (useful for creating catch-up messages later on).

TODO
- [x] Docs
- [x] Cleanup
- [x] Tests
- [x] Release finality-grandpa 0.7.1
