### PR TITLE
fix backwards compatibility for aura seals

### DIFF
--- a/core/consensus/aura/slots/src/lib.rs
+++ b/core/consensus/aura/slots/src/lib.rs
@@ -202,7 +202,9 @@ pub enum CheckedHeader<H, S> {
 	Deferred(H, u64),
 	/// A header which is fully checked, including signature. This is the pre-header
 	/// accompanied by the seal components.
-	Checked(H, u64, S),
+	///
+	/// Includes the digest item that encoded the seal.
+	Checked(H, S),
 }
 
 /// A slot duration. Create with `get_or_compute`.

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -437,7 +437,9 @@ impl<B: Block, C, E, I, P, Error, SO> SlotWorker<B> for AuraWorker<C, E, I, P, S
 }
 
 /// check a header has been signed by the right key. If the slot is too far in the future, an error will be returned.
-/// if it's successful, returns the pre-header, the slot number, and the signat.
+/// if it's successful, returns the pre-header and the digest item containing the seal.
+///
+/// This digest item will always return `Some` when used with `as_aura_seal`.
 //
 // FIXME #1018 needs misbehavior types
 #[forbid(deprecated)]
@@ -447,7 +449,7 @@ fn check_header<B: Block, P: Pair>(
 	hash: B::Hash,
 	authorities: &[AuthorityId<P>],
 	allow_old_seals: bool,
-) -> Result<CheckedHeader<B::Header, P::Signature>, String>
+) -> Result<CheckedHeader<B::Header, DigestItemFor<B>>, String>
 	where DigestItemFor<B>: CompatibleDigestItem<P>,
 		P::Public: Clone + AsRef<P::Public>,
 		P::Signature: Decode,
@@ -475,7 +477,7 @@ fn check_header<B: Block, P: Pair>(
 		// chain state.
 		let expected_author = match slot_author::<P>(slot_num, &authorities) {
 			None => return Err("Slot Author not found".to_string()),
-			Some(author) => author
+			Some(author) => author,
 		};
 
 		let pre_hash = header.hash();
@@ -483,7 +485,7 @@ fn check_header<B: Block, P: Pair>(
 		let public = expected_author;
 
 		if P::verify(&sig, &to_sign[..], public) {
-			Ok(CheckedHeader::Checked(header, slot_num, sig))
+			Ok(CheckedHeader::Checked(header, digest_item))
 		} else {
 			Err(format!("Bad signature on {:?}", hash))
 		}
@@ -617,8 +619,9 @@ impl<B: Block, C, E, P> Verifier<B> for AuraVerifier<C, E, P> where
 			self.allow_old_seals,
 		)?;
 		match checked_header {
-			CheckedHeader::Checked(pre_header, slot_num, sig) => {
-				let item = <DigestItemFor<B>>::aura_seal(slot_num, sig);
+			CheckedHeader::Checked(pre_header, seal) => {
+				let (slot_num, _) = seal.as_aura_seal()
+					.expect("check_header always returns a seal digest item; qed");
 
 				// if the body is passed through, we need to use the runtime
 				// to check that the internally-set timestamp in the inherents
@@ -653,7 +656,7 @@ impl<B: Block, C, E, P> Verifier<B> for AuraVerifier<C, E, P> where
 				let import_block = ImportBlock {
 					origin,
 					header: pre_header,
-					post_digests: vec![item],
+					post_digests: vec![seal],
 					body,
 					finalized: false,
 					justification,


### PR DESCRIPTION
Previously, it would re-construct the digest from the parameters -- when importing blocks with deprecated but accepted seal format, this would change the seal format and lead to a hash mismatch.