### PR TITLE
Fix version check for renamed runtime api methods

### DIFF
--- a/core/sr-api-macros/src/decl_runtime_apis.rs
+++ b/core/sr-api-macros/src/decl_runtime_apis.rs
@@ -389,7 +389,7 @@ fn generate_call_api_at_calls(decl: &ItemTrait) -> Result<TokenStream> {
 				#(
 					// Check if we need to call the function by an old name.
 					if version.apis.iter().any(|(s, v)| {
-						s == &ID && #versions < *v
+						s == &ID && *v < #versions
 					}) {
 						return call_runtime_at.call_api_at::<R, fn() -> _>(
 							at,


### PR DESCRIPTION
Backport of https://github.com/paritytech/substrate/pull/2190