### PR TITLE
Remove As trait bound from Currency::Balance

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 72,
+	spec_version: 73,
 	impl_version: 73,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 
 pub trait Subtrait<I: Instance = DefaultInstance>: system::Trait {
 	/// The balance of an account.
-	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + MaybeSerializeDebug;
+	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + MaybeSerializeDebug;
 
 	/// A function that is invoked when the free-balance has fallen below the existential deposit and
 	/// has been reduced to zero.
@@ -181,7 +181,7 @@ pub trait Subtrait<I: Instance = DefaultInstance>: system::Trait {
 
 pub trait Trait<I: Instance = DefaultInstance>: system::Trait {
 	/// The balance of an account.
-	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + MaybeSerializeDebug;
+	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + MaybeSerializeDebug;
 
 	/// A function that is invoked when the free-balance has fallen below the existential deposit and
 	/// has been reduced to zero.

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -167,7 +167,7 @@ pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 
 pub trait Subtrait<I: Instance = DefaultInstance>: system::Trait {
 	/// The balance of an account.
-	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + As<u64> + MaybeSerializeDebug;
+	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + MaybeSerializeDebug;
 
 	/// A function that is invoked when the free-balance has fallen below the existential deposit and
 	/// has been reduced to zero.
@@ -181,7 +181,7 @@ pub trait Subtrait<I: Instance = DefaultInstance>: system::Trait {
 
 pub trait Trait<I: Instance = DefaultInstance>: system::Trait {
 	/// The balance of an account.
-	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + As<u64> + MaybeSerializeDebug;
+	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy + As<usize> + MaybeSerializeDebug;
 
 	/// A function that is invoked when the free-balance has fallen below the existential deposit and
 	/// has been reduced to zero.

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -894,8 +894,10 @@ impl<T: Trait> Module<T> {
 				Self::reward_validator(v, reward);
 			}
 			Self::deposit_event(RawEvent::Reward(reward));
-			let total_minted = reward * <BalanceOf<T> as As<usize>>::sa(validators.len());
-			let total_rewarded_stake = Self::slot_stake() * <BalanceOf<T> as As<usize>>::sa(validators.len());
+			let len = validators.len() as u64; // validators length can never overflow u64
+			let len = BalanceOf::<T>::sa(len);
+			let total_minted = reward * len;
+			let total_rewarded_stake = Self::slot_stake() * len;
 			T::OnRewardMinted::on_dilution(total_minted, total_rewarded_stake);
 		}
 

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -230,7 +230,7 @@ impl<
 /// Abstraction over a fungible assets system.
 pub trait Currency<AccountId> {
 	/// The balance of an account.
-	type Balance: SimpleArithmetic + As<usize> + As<u64> + Codec + Copy + MaybeSerializeDebug + Default;
+	type Balance: SimpleArithmetic + As<usize> + Codec + Copy + MaybeSerializeDebug + Default;
 
 	/// The opaque token type for an imbalance. This is returned by unbalanced operations
 	/// and must be dealt with. It may be dropped but cannot be cloned.

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -19,7 +19,7 @@
 use crate::rstd::result;
 use crate::codec::{Codec, Encode, Decode};
 use crate::runtime_primitives::traits::{
-	MaybeSerializeDebug, SimpleArithmetic, As
+	MaybeSerializeDebug, SimpleArithmetic
 };
 
 /// The account with the given id was killed.
@@ -195,7 +195,7 @@ pub enum SignedImbalance<B, P: Imbalance<B>>{
 impl<
 	P: Imbalance<B, Opposite=N>,
 	N: Imbalance<B, Opposite=P>,
-	B: SimpleArithmetic + As<usize> + As<u64> + Codec + Copy + MaybeSerializeDebug + Default,
+	B: SimpleArithmetic + Codec + Copy + MaybeSerializeDebug + Default,
 > SignedImbalance<B, P> {
 	pub fn zero() -> Self {
 		SignedImbalance::Positive(P::zero())
@@ -230,7 +230,7 @@ impl<
 /// Abstraction over a fungible assets system.
 pub trait Currency<AccountId> {
 	/// The balance of an account.
-	type Balance: SimpleArithmetic + As<usize> + Codec + Copy + MaybeSerializeDebug + Default;
+	type Balance: SimpleArithmetic + Codec + Copy + MaybeSerializeDebug + Default;
 
 	/// The opaque token type for an imbalance. This is returned by unbalanced operations
 	/// and must be dealt with. It may be dropped but cannot be cloned.


### PR DESCRIPTION
(I don't expect this can be merged. This is more of an issue with related code to show my point.)

I think we should release the `As` bound on `Balance` type because it may cause issues (#1377). Even substrate code base have no such issue exists, it is impossible to ensure such issue won't exist on other runtimes.

One module requires `Balance: As<usize>` shouldn't affect the shared abstract `Currency::Balance` type otherwise it means the abstraction is not correct.
In this case the Staking module can add additional trait bound and for people are not using Staking module, they don't need to support `Balance: As<usize>` at all.

Another reason I want to do this is because this prevents me to use some fancy type to support multi token currency with the existing `Currency` trait.
I want to use `Vec<(AssetId, Balance)>` as the Balance type but it is impossible to convert such type to a number.