### PR TITLE
Introduce `original_storage` and `original_storage_hash`

### DIFF
--- a/core/executor/src/native_executor.rs
+++ b/core/executor/src/native_executor.rs
@@ -54,13 +54,13 @@ fn fetch_cached_runtime_version<'a, E: Externalities<Blake2Hasher>>(
 	default_heap_pages: Option<u64>,
 ) -> Result<(&'a WasmModuleInstanceRef, &'a Option<RuntimeVersion>)> {
 
-	let code_hash = match ext.storage_hash(well_known_keys::CODE) {
+	let code_hash = match ext.original_storage_hash(well_known_keys::CODE) {
 		Some(code_hash) => code_hash,
 		None => return Err(ErrorKind::InvalidCode(vec![]).into()),
 	};
 	let maybe_runtime_preproc = cache.borrow_mut().entry(code_hash.into())
 		.or_insert_with(|| {
-			let code = match ext.storage(well_known_keys::CODE) {
+			let code = match ext.original_storage(well_known_keys::CODE) {
 				Some(code) => code,
 				None => return RuntimePreproc::InvalidCode,
 			};
@@ -86,7 +86,7 @@ fn fetch_cached_runtime_version<'a, E: Externalities<Blake2Hasher>>(
 		});
 	match maybe_runtime_preproc {
 		RuntimePreproc::InvalidCode => {
-			let code = ext.storage(well_known_keys::CODE).unwrap_or(vec![]);
+			let code = ext.original_storage(well_known_keys::CODE).unwrap_or(vec![]);
 			Err(ErrorKind::InvalidCode(code).into())
 		},
 		RuntimePreproc::ValidCode(m, v) => {

--- a/core/state-machine/src/basic.rs
+++ b/core/state-machine/src/basic.rs
@@ -111,6 +111,10 @@ impl<H: Hasher> Externalities<H> for BasicExternalities where H::Out: Ord + Heap
 		}
 	}
 
+	fn original_storage(&self, key: &[u8]) -> Option<Vec<u8>> {
+		Externalities::<H>::storage(self, key)
+	}
+
 	fn child_storage(&self, _storage_key: &[u8], _key: &[u8]) -> Option<Vec<u8>> {
 		None
 	}

--- a/core/state-machine/src/ext.rs
+++ b/core/state-machine/src/ext.rs
@@ -204,6 +204,16 @@ where
 			self.backend.storage_hash(key).expect(EXT_NOT_ALLOWED_TO_FAIL))
 	}
 
+	fn original_storage(&self, key: &[u8]) -> Option<Vec<u8>> {
+		let _guard = panic_handler::AbortGuard::new(true);
+		self.backend.storage(key).expect(EXT_NOT_ALLOWED_TO_FAIL)
+	}
+
+	fn original_storage_hash(&self, key: &[u8]) -> Option<H::Out> {
+		let _guard = panic_handler::AbortGuard::new(true);
+		self.backend.storage_hash(key).expect(EXT_NOT_ALLOWED_TO_FAIL)
+	}
+
 	fn child_storage(&self, storage_key: &[u8], key: &[u8]) -> Option<Vec<u8>> {
 		let _guard = panic_handler::AbortGuard::new(true);
 		self.overlay.child_storage(storage_key, key).map(|x| x.map(|x| x.to_vec())).unwrap_or_else(||

--- a/core/state-machine/src/lib.rs
+++ b/core/state-machine/src/lib.rs
@@ -95,6 +95,15 @@ pub trait Externalities<H: Hasher> {
 		self.storage(key).map(|v| H::hash(&v))
 	}
 
+	/// Read original runtime storage, ignoring any overlayed changes.
+	fn original_storage(&self, key: &[u8]) -> Option<Vec<u8>>;
+
+	/// Get original storage value hash, ignoring any overlayed changes.
+	/// This may be optimized for large values.
+	fn original_storage_hash(&self, key: &[u8]) -> Option<H::Out> {
+		self.original_storage(key).map(|v| H::hash(&v))
+	}
+
 	/// Read child runtime storage.
 	fn child_storage(&self, storage_key: &[u8], key: &[u8]) -> Option<Vec<u8>>;
 

--- a/core/state-machine/src/testing.rs
+++ b/core/state-machine/src/testing.rs
@@ -118,6 +118,10 @@ impl<H: Hasher> Externalities<H> for TestExternalities<H> where H::Out: Ord + He
 		}
 	}
 
+	fn original_storage(&self, key: &[u8]) -> Option<Vec<u8>> {
+		self.storage(key)
+	}
+
 	fn child_storage(&self, storage_key: &[u8], key: &[u8]) -> Option<Vec<u8>> {
 		self.changes.child_storage(storage_key, key)?.map(Vec::from)
 	}


### PR DESCRIPTION
Both functions will ignore any overlayed changes and access the backend
directly.