### PR TITLE
Peerset::discovered accepts many peer ids

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -255,7 +255,7 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<IdentifyEvent> for Behav
 				for addr in &info.listen_addrs {
 					self.discovery.kademlia.add_connected_address(&peer_id, addr.clone());
 				}
-				self.custom_protocols.add_discovered_node(&peer_id);
+				self.custom_protocols.add_discovered_nodes(Some(peer_id.clone()));
 				self.events.push(BehaviourOut::Identified { peer_id, info });
 			}
 			IdentifyEvent::Error { .. } => {}
@@ -272,7 +272,7 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<KademliaOut> for Behavio
 		match out {
 			KademliaOut::Discovered { .. } => {}
 			KademliaOut::KBucketAdded { peer_id, .. } => {
-				self.custom_protocols.add_discovered_node(&peer_id);
+				self.custom_protocols.add_discovered_nodes(Some(peer_id));
 			}
 			KademliaOut::FindNodeResult { key, closer_peers } => {
 				trace!(target: "sub-libp2p", "Libp2p => Query for {:?} yielded {:?} results",
@@ -303,9 +303,7 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<MdnsEvent> for Behaviour
 	fn inject_event(&mut self, event: MdnsEvent) {
 		match event {
 			MdnsEvent::Discovered(list) => {
-				for (peer_id, _) in list {
-					self.custom_protocols.add_discovered_node(&peer_id);
-				}
+				self.custom_protocols.add_discovered_nodes(list.into_iter().map(|(peer_id, _)| peer_id));
 			},
 			MdnsEvent::Expired(_) => {}
 		}

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -314,7 +314,10 @@ impl<TMessage, TSubstream> CustomProto<TMessage, TSubstream> {
 
 	/// Indicates to the peerset that we have discovered new addresses for a given node.
 	pub fn add_discovered_nodes<I: IntoIterator<Item = PeerId>>(&mut self, peer_ids: I) {
-		self.peerset.discovered(peer_ids);
+		self.peerset.discovered(peer_ids.into_iter().map(|peer_id| {
+			debug!(target: "sub-libp2p", "PSM <= Discovered({:?})", peer_id);
+			peer_id
+		}));
 	}
 
 	/// Returns the state of the peerset manager, for debugging purposes.

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -313,9 +313,8 @@ impl<TMessage, TSubstream> CustomProto<TMessage, TSubstream> {
 	}
 
 	/// Indicates to the peerset that we have discovered new addresses for a given node.
-	pub fn add_discovered_node(&mut self, peer_id: &PeerId) {
-		debug!(target: "sub-libp2p", "PSM <= Discovered({:?})", peer_id);
-		self.peerset.discovered(peer_id.clone())
+	pub fn add_discovered_nodes<I: IntoIterator<Item = PeerId>>(&mut self, peer_ids: I) {
+		self.peerset.discovered(peer_ids);
 	}
 
 	/// Returns the state of the peerset manager, for debugging purposes.

--- a/core/peerset/src/lib.rs
+++ b/core/peerset/src/lib.rs
@@ -365,7 +365,11 @@ impl Peerset {
 	/// Because of concurrency issues, it is acceptable to call `incoming` with a `PeerId` the
 	/// peerset is already connected to, in which case it must not answer.
 	pub fn incoming(&mut self, peer_id: PeerId, index: IncomingIndex) {
-		trace!("Incoming {}\nin_slots={:?}\nout_slots={:?}", peer_id, self.data.in_slots, self.data.out_slots);
+		trace!(
+			target: "peerset",
+			"Incoming {:?}\nin_slots={:?}\nout_slots={:?}",
+			peer_id, self.data.in_slots, self.data.out_slots
+		);
 		// if `reserved_only` is set, but this peer is not a part of our discovered list,
 		// a) it is not reserved, so we reject the connection
 		// b) we are already connected to it, so we reject the connection
@@ -417,7 +421,11 @@ impl Peerset {
 	/// Must only be called after the PSM has either generated a `Connect` message with this
 	/// `PeerId`, or accepted an incoming connection with this `PeerId`.
 	pub fn dropped(&mut self, peer_id: PeerId) {
-		trace!("Dropping {}\nin_slots={:?}\nout_slots={:?}", peer_id, self.data.in_slots, self.data.out_slots);
+		trace!(
+			target: "peerset",
+			"Dropping {:?}\nin_slots={:?}\nout_slots={:?}",
+			peer_id, self.data.in_slots, self.data.out_slots
+		);
 		// Automatically connect back if reserved.
 		if self.data.in_slots.is_connected_and_reserved(&peer_id) || self.data.out_slots.is_connected_and_reserved(&peer_id) {
 			self.message_queue.push_back(Message::Connect(peer_id));
@@ -440,8 +448,11 @@ impl Peerset {
 	/// >			of the PSM to remove `PeerId`s that fail to dial too often.
 	pub fn discovered<I: IntoIterator<Item = PeerId>>(&mut self, peer_ids: I) {
 		for peer_id in peer_ids {
-			if !self.data.in_slots.contains(&peer_id) && !self.data.out_slots.contains(&peer_id) {
+			if !self.data.in_slots.contains(&peer_id) && !self.data.out_slots.contains(&peer_id) && !self.data.discovered.contains(&peer_id) {
+				trace!(target: "peerset", "Discovered new peer: {:?}", peer_id);
 				self.data.discovered.add_peer(peer_id, SlotType::Common);
+			} else {
+				trace!(target: "peerset", "Discovered known peer: {:?}", peer_id);
 			}
 		}
 


### PR DESCRIPTION
- reduces number of calls to `alloc_slots` which always pops a peer from discovered list