### PR TITLE
assert trie odd nibble padding on decoding

### DIFF
--- a/core/trie/src/node_codec.rs
+++ b/core/trie/src/node_codec.rs
@@ -61,12 +61,18 @@ impl<H: Hasher> trie_db::NodeCodec<H> for NodeCodec<H> {
 				Ok(Node::Branch(children, value))
 			}
 			NodeHeader::Extension(nibble_count) => {
+				if nibble_count % 2 == 1 && input[0] & 0xf0 != 0x00 {
+					return Err(BadFormat);
+				}
 				let nibble_data = take(input, (nibble_count + 1) / 2).ok_or(BadFormat)?;
 				let nibble_slice = NibbleSlice::new_offset(nibble_data, nibble_count % 2);
 				let count = <Compact<u32>>::decode(input).ok_or(BadFormat)?.0 as usize;
 				Ok(Node::Extension(nibble_slice, take(input, count).ok_or(BadFormat)?))
 			}
 			NodeHeader::Leaf(nibble_count) => {
+				if nibble_count % 2 == 1 && input[0] & 0xf0 != 0x00 {
+					return Err(BadFormat);
+				}
 				let nibble_data = take(input, (nibble_count + 1) / 2).ok_or(BadFormat)?;
 				let nibble_slice = NibbleSlice::new_offset(nibble_data, nibble_count % 2);
 				let count = <Compact<u32>>::decode(input).ok_or(BadFormat)?.0 as usize;

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -2156,6 +2156,7 @@ version = "1.0.0"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 1.0.0",
  "sr-std 1.0.0",
  "srml-session 1.0.0",

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -2156,7 +2156,6 @@ version = "1.0.0"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 1.0.0",
  "sr-std 1.0.0",
  "srml-session 1.0.0",


### PR DESCRIPTION
Do not allow other padding than 0x0 in trie odd nibble (this is forced on encoding).
