### PR TITLE
Fix state inconsistency between handler and behaviour

### DIFF
--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -792,9 +792,9 @@ where
 				debug!(target: "sub-libp2p", "Handler({:?}) => Closed({:?})", source, result);
 
 				let mut entry = if let Entry::Occupied(entry) = self.peers.entry(source.clone()) {
-					error!(target: "sub-libp2p", "State mismatch in the custom protos handler");
 					entry
 				} else {
+					error!(target: "sub-libp2p", "State mismatch in the custom protos handler");
 					return
 				};
 

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -26,6 +26,35 @@ use std::{collections::hash_map::Entry, cmp, error, io, marker::PhantomData, mem
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Network behaviour that handles opening substreams for custom protocols with other nodes.
+///
+/// ## How it works
+///
+/// The role of the `CustomProto` is to synchronize the following components:
+///
+/// - The libp2p swarm that opens new connections and reports disconnects.
+/// - The connection handler (see `handler.rs`) that handles individual connections.
+/// - The peerset manager (PSM) that requests links to nodes to be established or broken.
+/// - The external API, that requires knowledge of the links that have been established.
+///
+/// Each connection handler can be in four different states: Enabled+Open, Enabled+Closed,
+/// Disabled+Open, or Disabled+Closed. The Enabled/Disabled component must be in sync with the
+/// peerset manager. For example, if the peerset manager requires a disconnection, we disable the
+/// existing handler. The Open/Closed component must be in sync with the external API.
+///
+/// However a connection handler only exists if we are actually connected to a node. What this
+/// means is that there are six possible states for each node: Disconnected, Dialing (trying to
+/// reach it), Enabled+Open, Enabled+Closed, Disabled+open, Disabled+Closed. Most notably, the
+/// Dialing state must correspond to a "link established" state in the peerset manager. In other
+/// words, the peerset manager doesn't differentiate whether we are dialing a node or connected
+/// to it.
+///
+/// Additionally, there also exists a "banning" system. If we fail to dial a node, we "ban" it for
+/// a few seconds. If the PSM requests a node that is in the "banned" state, then we delay the
+/// actual dialing attempt until after the ban expires, but the PSM will still consider the link
+/// to be established.
+/// Note that this "banning" system is not an actual ban. If a "banned" node tries to connect to
+/// us, we accept the connection. The "banning" system is only about delaying dialing attempts.
+///
 pub struct CustomProto<TMessage, TSubstream> {
 	/// List of protocols to open with peers. Never modified.
 	protocol: RegisteredProtocol<TMessage>,
@@ -761,23 +790,50 @@ where
 		match event {
 			CustomProtoHandlerOut::CustomProtocolClosed { result } => {
 				debug!(target: "sub-libp2p", "Handler({:?}) => Closed({:?})", source, result);
-				match self.peers.get_mut(&source) {
-					Some(PeerState::Enabled { ref mut open, .. }) if *open =>
-						*open = false,
-					Some(PeerState::Disabled { ref mut open, .. }) if *open =>
-						*open = false,
-					Some(PeerState::DisabledPendingEnable { ref mut open, .. }) if *open =>
-						*open = false,
-					_ => error!(target: "sub-libp2p", "State mismatch in the custom protos handler"),
-				}
+
+				let mut entry = if let Entry::Occupied(entry) = self.peers.entry(source.clone()) {
+					error!(target: "sub-libp2p", "State mismatch in the custom protos handler");
+					entry
+				} else {
+					return
+				};
 
 				debug!(target: "sub-libp2p", "External API <= Closed({:?})", source);
 				let event = CustomProtoOut::CustomProtocolClosed {
 					result,
-					peer_id: source,
+					peer_id: source.clone(),
 				};
-
 				self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+
+				match mem::replace(entry.get_mut(), PeerState::Poisoned) {
+					PeerState::Enabled { open, connected_point } => {
+						debug_assert!(open);
+
+						debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", source);
+						self.peerset.dropped(source.clone());
+
+						debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", source);
+						self.events.push(NetworkBehaviourAction::SendEvent {
+							peer_id: source.clone(),
+							event: CustomProtoHandlerIn::Disable,
+						});
+
+						*entry.into_mut() = PeerState::Disabled {
+							open: false,
+							connected_point,
+							banned_until: None
+						};
+					},
+					PeerState::Disabled { open, connected_point, banned_until } => {
+						debug_assert!(open);
+						*entry.into_mut() = PeerState::Disabled { open: false, connected_point, banned_until };
+					},
+					PeerState::DisabledPendingEnable { open, connected_point, timer } => {
+						debug_assert!(open);
+						*entry.into_mut() = PeerState::DisabledPendingEnable { open: false, connected_point, timer };
+					},
+					_ => error!(target: "sub-libp2p", "State mismatch in the custom protos handler"),
+				}
 			}
 
 			CustomProtoHandlerOut::CustomProtocolOpen { version } => {


### PR DESCRIPTION
A connection handler can be in four different states: open+enabled, open+disabled, closed+enabled, closed+disabled.

At the moment, if the handler is open+enabled and the remote closes the substream, the handler switches to closed+disabled but the behaviour erroneously thinks the handler's new state is closed+enabled.

This PR fixes it by making the handler switch to closed+enabled, and by making the behaviour send a "disabled" message to the handler as a response to that transition.