### PR TITLE
use a Event Cache to replace vec `Events` in `deposit_event`

### DIFF
--- a/srml/contract/src/tests.rs
+++ b/srml/contract/src/tests.rs
@@ -341,6 +341,7 @@ fn instantiate_and_call_and_deposit_event() {
 				vec![],
 			);
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
@@ -416,6 +417,7 @@ fn dispatch_call() {
 
 			// Let's keep this assert even though it's redundant. If you ever need to update the
 			// wasm source this test will fail and will show you the actual hash.
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
@@ -443,6 +445,7 @@ fn dispatch_call() {
 				vec![],
 			));
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),

--- a/srml/council/src/motions.rs
+++ b/srml/council/src/motions.rs
@@ -231,6 +231,7 @@ mod tests {
 			assert_eq!(CouncilMotions::proposal_of(&hash), Some(proposal));
 			assert_eq!(CouncilMotions::voting(&hash), Some((0, 3, vec![1], Vec::<u64>::new())));
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
@@ -284,6 +285,7 @@ mod tests {
 			assert_eq!(CouncilMotions::voting(&hash), Some((0, 2, Vec::<u64>::new(), vec![1])));
 			assert_noop!(CouncilMotions::vote(Origin::signed(1), hash.clone(), 0, false), "duplicate vote ignored");
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
@@ -306,6 +308,7 @@ mod tests {
 			assert_ok!(CouncilMotions::propose(Origin::signed(1), 3, Box::new(proposal.clone())));
 			assert_ok!(CouncilMotions::vote(Origin::signed(2), hash.clone(), 0, false));
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),
@@ -332,6 +335,7 @@ mod tests {
 			assert_ok!(CouncilMotions::propose(Origin::signed(1), 2, Box::new(proposal.clone())));
 			assert_ok!(CouncilMotions::vote(Origin::signed(2), hash.clone(), 0, true));
 
+			System::flush_events();
 			assert_eq!(System::events(), vec![
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(0),


### PR DESCRIPTION
issue 2223 https://github.com/paritytech/substrate/issues/2223
suggestion 1
use  a map `EventsCache` to replace vec `Events` in `deposit_event`, and flush cache into `Events` on `finalize()`