### PR TITLE
Add warning when using default protocol ID

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -158,7 +158,8 @@ impl<Components: components::Components> Service<Components> {
 				Some(pid) => pid,
 				None => {
 					warn!("Using default protocol ID {:?} because none is configured in the \
-						chain specs", DEFAULT_PROTOCOL_ID);
+						chain specs", DEFAULT_PROTOCOL_ID
+					);
 					DEFAULT_PROTOCOL_ID	
 				}
 			}.as_bytes();

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -154,7 +154,14 @@ impl<Components: components::Components> Service<Components> {
 		};
 
 		let protocol_id = {
-			let protocol_id_full = config.chain_spec.protocol_id().unwrap_or(DEFAULT_PROTOCOL_ID).as_bytes();
+			let protocol_id_full = match config.chain_spec.protocol_id() {
+				Some(pid) => pid,
+				None => {
+					warn!("Using default protocol ID {:?} because none is configured in the \
+						chain specs", DEFAULT_PROTOCOL_ID);
+					DEFAULT_PROTOCOL_ID	
+				}
+			}.as_bytes();
 			let mut protocol_id = network::ProtocolId::default();
 			if protocol_id_full.len() > protocol_id.len() {
 				warn!("Protocol ID truncated to {} chars", protocol_id.len());


### PR DESCRIPTION
We don't want Substrate, Polkadot, EdgeWare, etc. to use the same protocol ID.
If no protocol ID is configured in the chain specs, a chain automatically use the Substrate protocol ID.
This PR adds a warning if that happens.