### PR TITLE
Apply negative rating on explicit ban

### DIFF
--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -535,6 +535,7 @@ fn run_thread<B: BlockT + 'static>(
 					Severity::Bad(message) => {
 						info!(target: "sync", "Banning {:?} because {:?}", who, message);
 						network_service_2.lock().drop_node(&who);
+						// temporary: make sure the peer gets dropped from the peerset
 						peerset.report_peer(who, i32::min_value());
 					},
 					Severity::Useless(message) => {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -487,8 +487,9 @@ fn start_thread<B: BlockT + 'static>(
 	let (close_tx, close_rx) = oneshot::channel();
 	let service_clone = service.clone();
 	let mut runtime = RuntimeBuilder::new().name_prefix("libp2p-").build()?;
+	let peerset_clone = peerset.clone();
 	let thread = thread::Builder::new().name("network".to_string()).spawn(move || {
-		let fut = run_thread(protocol_sender, service_clone, network_port)
+		let fut = run_thread(protocol_sender, service_clone, network_port, peerset_clone)
 			.select(close_rx.then(|_| Ok(())))
 			.map(|(val, _)| val)
 			.map_err(|(err,_ )| err);
@@ -509,6 +510,7 @@ fn run_thread<B: BlockT + 'static>(
 	protocol_sender: Sender<FromNetworkMsg<B>>,
 	network_service: Arc<Mutex<NetworkService<Message<B>>>>,
 	network_port: NetworkPort<B>,
+	peerset: PeersetHandle,
 ) -> impl Future<Item = (), Error = io::Error> {
 
 	let network_service_2 = network_service.clone();
@@ -532,9 +534,8 @@ fn run_thread<B: BlockT + 'static>(
 				match severity {
 					Severity::Bad(message) => {
 						info!(target: "sync", "Banning {:?} because {:?}", who, message);
-						warn!(target: "sync", "Banning a node is a deprecated mechanism that \
-							should be removed");
-						network_service_2.lock().drop_node(&who)
+						network_service_2.lock().drop_node(&who);
+						peerset.report_peer(who, i32::min_value());
 					},
 					Severity::Useless(message) => {
 						debug!(target: "sync", "Dropping {:?} because {:?}", who, message);

--- a/core/peerset/src/lib.rs
+++ b/core/peerset/src/lib.rs
@@ -258,6 +258,7 @@ impl Peerset {
 				self.data.discovered.remove_peer(&peer_id);
 
 				// notify that connection has been made
+				trace!(target: "peerset", "Connecting to new reserved peer {}", peer_id);
 				self.message_queue.push_back(Message::Connect(peer_id));
 				return;
 			},
@@ -267,6 +268,7 @@ impl Peerset {
 				// let's add the peer we disconnected from to the discovered list again
 				self.data.discovered.add_peer(removed.clone(), SlotType::Common);
 				// swap connections
+				trace!(target: "peerset", "Connecting to new reserved peer {}, dropping {}", added, removed);
 				self.message_queue.push_back(Message::Drop(removed));
 				self.message_queue.push_back(Message::Connect(added));
 			}
@@ -336,10 +338,12 @@ impl Peerset {
 		while let Some((peer_id, slot_type)) = self.data.discovered.pop_peer(self.data.reserved_only) {
 			match self.data.out_slots.add_peer(peer_id, slot_type) {
 				SlotState::Added(peer_id) => {
+					trace!(target: "peerset", "Connecting to new peer {}", peer_id);
 					self.message_queue.push_back(Message::Connect(peer_id));
 				},
 				SlotState::Swaped { removed, added } => {
 					// insert peer back into discovered list
+					trace!(target: "peerset", "Connecting to new peer {}, dropping {}", added, removed);
 					self.data.discovered.add_peer(removed.clone(), SlotType::Common);
 					self.message_queue.push_back(Message::Drop(removed));
 					self.message_queue.push_back(Message::Connect(added));
@@ -428,6 +432,7 @@ impl Peerset {
 		);
 		// Automatically connect back if reserved.
 		if self.data.in_slots.is_connected_and_reserved(&peer_id) || self.data.out_slots.is_connected_and_reserved(&peer_id) {
+			trace!(target: "peerset", "Not dropped because reseved");
 			self.message_queue.push_back(Message::Connect(peer_id));
 			return;
 		}


### PR DESCRIPTION
This restores peer banning for e.g. being on a different chain, until this is properly implemented.