### PR TITLE
Enable CORS checks

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -475,6 +475,12 @@ where
 	config.rpc_ws = Some(
 		parse_address(&format!("{}:{}", ws_interface, 9944), cli.ws_port)?
 	);
+	// NOTE default is `Some(vec![])` to disallow all origins.
+	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| Some(vec![
+		"http://localhost:*".into(),
+		"https://localhost:*".into(),
+		"https://polkadot.js.org".into()
+	]));
 
 	// Override telemetry
 	if cli.no_telemetry {

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -329,6 +329,13 @@ pub struct RunCmd {
 	#[structopt(long = "ws-port", value_name = "PORT")]
 	pub ws_port: Option<u16>,
 
+	/// Specify browser Origins allowed to access the HTTP & WS RPC servers.
+	/// It's a comma-separated list of origins (protocol://domain or special `null` value).
+	/// Value of `all` will disable origin validation.
+	/// Default is to allow localhost and https://polkadot.js.org origin.
+	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = "parse_cors"))]
+	pub rpc_cors: Option<Option<Vec<String>>>,
+
 	/// Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.
 	#[structopt(long = "pruning", value_name = "PRUNING_MODE")]
 	pub pruning: Option<String>,
@@ -468,6 +475,23 @@ fn parse_telemetry_endpoints(s: &str) -> Result<(String, u8), Box<std::error::Er
 			Ok((url, verbosity))
 		}
 	}
+}
+
+/// Parse cors origins
+fn parse_cors(s: &str) -> Result<Option<Vec<String>>, Box<std::error::Error>> {
+	let mut is_all = false;
+	let mut origins = Vec::new();
+	for part in s.split(',') {
+		match part {
+			"all" | "*" => {
+				is_all = true;
+				break;
+			},
+			other => origins.push(other.to_owned()),
+		}
+	}
+
+	Ok(if is_all { None } else { Some(origins) })
 }
 
 impl_augment_clap!(RunCmd);

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -143,6 +143,7 @@ pub trait StartRPC<C: Components> {
 		system_info: SystemInfo,
 		rpc_http: Option<SocketAddr>,
 		rpc_ws: Option<SocketAddr>,
+		rpc_cors: Option<Vec<String>>,
 		task_executor: TaskExecutor,
 		transaction_pool: Arc<TransactionPool<C::TransactionPoolApi>>,
 	) -> error::Result<Self::ServersHandle>;
@@ -161,6 +162,7 @@ impl<C: Components> StartRPC<Self> for C where
 		rpc_system_info: SystemInfo,
 		rpc_http: Option<SocketAddr>,
 		rpc_ws: Option<SocketAddr>,
+		rpc_cors: Option<Vec<String>>,
 		task_executor: TaskExecutor,
 		transaction_pool: Arc<TransactionPool<C::TransactionPoolApi>>,
 	) -> error::Result<Self::ServersHandle> {
@@ -184,8 +186,8 @@ impl<C: Components> StartRPC<Self> for C where
 		};
 
 		Ok((
-			maybe_start_server(rpc_http, |address| rpc::start_http(address, handler()))?,
-			maybe_start_server(rpc_ws, |address| rpc::start_ws(address, handler()))?.map(Mutex::new),
+			maybe_start_server(rpc_http, |address| rpc::start_http(address, rpc_cors.as_ref(), handler()))?,
+			maybe_start_server(rpc_ws, |address| rpc::start_ws(address, rpc_cors.as_ref(), handler()))?.map(Mutex::new),
 		))
 	}
 }

--- a/core/service/src/config.rs
+++ b/core/service/src/config.rs
@@ -64,6 +64,8 @@ pub struct Configuration<C, G: Serialize + DeserializeOwned + BuildStorage> {
 	pub rpc_http: Option<SocketAddr>,
 	/// RPC over Websockets binding address. `None` if disabled.
 	pub rpc_ws: Option<SocketAddr>,
+	/// CORS settings for HTTP & WS servers. `None` if all origins are allowed.
+	pub rpc_cors: Option<Vec<String>>,
 	/// Telemetry service URL. `None` if disabled.
 	pub telemetry_endpoints: Option<TelemetryEndpoints>,
 	/// The default number of 64KB pages to allocate for Wasm execution
@@ -97,6 +99,7 @@ impl<C: Default, G: Serialize + DeserializeOwned + BuildStorage> Configuration<C
 			execution_strategies: Default::default(),
 			rpc_http: None,
 			rpc_ws: None,
+			rpc_cors: Some(vec![]),
 			telemetry_endpoints: None,
 			default_heap_pages: None,
 			offchain_worker: Default::default(),

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -160,7 +160,7 @@ impl<Components: components::Components> Service<Components> {
 					warn!("Using default protocol ID {:?} because none is configured in the \
 						chain specs", DEFAULT_PROTOCOL_ID
 					);
-					DEFAULT_PROTOCOL_ID	
+					DEFAULT_PROTOCOL_ID
 				}
 			}.as_bytes();
 			let mut protocol_id = network::ProtocolId::default();
@@ -301,7 +301,7 @@ impl<Components: components::Components> Service<Components> {
 		};
 		let rpc = Components::RuntimeServices::start_rpc(
 			client.clone(), network.clone(), has_bootnodes, system_info, config.rpc_http,
-			config.rpc_ws, task_executor.clone(), transaction_pool.clone(),
+			config.rpc_ws, config.rpc_cors.clone(), task_executor.clone(), transaction_pool.clone(),
 		)?;
 
 		// Telemetry

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -120,6 +120,7 @@ fn node_config<F: ServiceFactory> (
 		execution_strategies: Default::default(),
 		rpc_http: None,
 		rpc_ws: None,
+		rpc_cors: None,
 		telemetry_endpoints: None,
 		default_heap_pages: None,
 		offchain_worker: false,


### PR DESCRIPTION
By default allow `localhost` origins and `https://polkadot.js.org`.