### PR TITLE
docs: Update Substrate CLI Light option to be experimental

### DIFF
--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -305,7 +305,7 @@ pub struct RunCmd {
 	#[structopt(long = "no-grandpa")]
 	pub no_grandpa: bool,
 
-	/// Run in light client mode
+	/// Experimental: Run in light client mode
 	#[structopt(long = "light")]
 	pub light: bool,
 


### PR DESCRIPTION
Consistency with Parity Ethereum CLI Light option https://github.com/paritytech/parity-ethereum/blob/master/parity/cli/mod.rs#L263