### PR TITLE
Introduce `ext_println` to contract runtime

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -216,6 +216,7 @@ pub fn testnet_genesis(
 	initial_authorities: Vec<(AccountId, AccountId, AuthorityId)>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
+	enable_println: bool,
 ) -> GenesisConfig {
 	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
@@ -236,6 +237,22 @@ pub fn testnet_genesis(
 
 	const STASH: u128 = 1 << 20;
 	const ENDOWMENT: u128 = 1 << 20;
+
+	let mut contract_config = ContractConfig {
+		transaction_base_fee: 1,
+		transaction_byte_fee: 0,
+		transfer_fee: 0,
+		creation_fee: 0,
+		contract_fee: 21,
+		call_base_fee: 135,
+		create_base_fee: 175,
+		gas_price: 1,
+		max_depth: 1024,
+		block_gas_limit: 10_000_000,
+		current_schedule: Default::default(),
+	};
+	// this should only be enabled on development chains
+	contract_config.current_schedule.enable_println = enable_println;
 
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
@@ -308,19 +325,7 @@ pub fn testnet_genesis(
 			spend_period: 12 * 60 * 24,
 			burn: Permill::from_percent(50),
 		}),
-		contract: Some(ContractConfig {
-			transaction_base_fee: 1,
-			transaction_byte_fee: 0,
-			transfer_fee: 0,
-			creation_fee: 0,
-			contract_fee: 21,
-			call_base_fee: 135,
-			create_base_fee: 175,
-			gas_price: 1,
-			max_depth: 1024,
-			block_gas_limit: 10_000_000,
-			current_schedule: Default::default(),
-		}),
+		contract: Some(contract_config),
 		sudo: Some(SudoConfig {
 			key: root_key,
 		}),
@@ -337,6 +342,7 @@ fn development_config_genesis() -> GenesisConfig {
 		],
 		get_account_id_from_seed("Alice"),
 		None,
+		true,
 	)
 }
 
@@ -353,6 +359,7 @@ fn local_testnet_genesis() -> GenesisConfig {
 		],
 		get_account_id_from_seed("Alice"),
 		None,
+		false,
 	)
 }
 

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -527,6 +527,10 @@ pub struct Schedule<Gas> {
 	/// What is the maximal memory pages amount is allowed to have for
 	/// a contract.
 	pub max_memory_pages: u32,
+
+	/// Whether the `ext_println` function is allowed to be used contracts.
+	/// MUST only be enabled for `dev` chains, NOT for production chains
+	pub enable_println: bool,
 }
 
 impl<Gas: As<u64>> Default for Schedule<Gas> {
@@ -543,6 +547,7 @@ impl<Gas: As<u64>> Default for Schedule<Gas> {
 			sandbox_data_write_cost: Gas::sa(1),
 			max_stack_height: 64 * 1024,
 			max_memory_pages: 16,
+			enable_println: false,
 		}
 	}
 }

--- a/srml/contract/src/wasm/prepare.rs
+++ b/srml/contract/src/wasm/prepare.rs
@@ -230,6 +230,12 @@ impl<'a, Gas: 'a + As<u32> + Clone> ContractModule<'a, Gas> {
 				.get(*type_idx as usize)
 				.ok_or_else(|| "validation: import entry points to a non-existent type")?;
 
+			// We disallow importing `ext_println` unless debug features are enabled,
+			// which should only be allowed on a dev chain
+			if !self.schedule.enable_println && import.field().as_bytes() == b"ext_println" {
+				return Err("module imports `ext_println` but debug features disabled");
+			}
+
 			// We disallow importing `gas` function here since it is treated as implementation detail.
 			if import.field().as_bytes() == b"gas"
 				|| !C::can_satisfy(import.field().as_bytes(), func_ty)
@@ -338,6 +344,8 @@ mod tests {
 		gas(_ctx, _amount: u32) => { unreachable!(); },
 
 		nop(_ctx, _unused: u64) => { unreachable!(); },
+
+		ext_println(_ctx, _ptr: u32, _len: u32) => { unreachable!(); },
 	);
 
 	macro_rules! prepare_test {
@@ -515,6 +523,36 @@ mod tests {
 			"#,
 			Err("module imports a non-existent function")
 		);
+
+		prepare_test!(ext_println_debug_disabled,
+			r#"
+			(module
+				(import "env" "ext_println" (func $ext_println (param i32 i32)))
+
+				(func (export "call"))
+				(func (export "deploy"))
+			)
+			"#,
+			Err("module imports `ext_println` but debug features disabled")
+		);
+
+		#[test]
+		fn ext_println_debug_enabled() {
+			let wasm = wabt::Wat2Wasm::new().validate(false).convert(
+				r#"
+				(module
+					(import "env" "ext_println" (func $ext_println (param i32 i32)))
+
+					(func (export "call"))
+					(func (export "deploy"))
+				)
+				"#
+			).unwrap();
+			let mut schedule = Schedule::<u64>::default();
+			schedule.enable_println = true;
+			let r = prepare_contract::<Test, TestEnv>(wasm.as_ref(), &schedule);
+			assert_matches!(r, Ok(_));
+		}
 	}
 
 	mod entrypoints {

--- a/srml/contract/src/wasm/runtime.rs
+++ b/srml/contract/src/wasm/runtime.rs
@@ -608,4 +608,15 @@ define_env!(Env, <E: Ext>,
 
 		Ok(())
 	},
+
+	// Prints utf8 encoded string from the data buffer.
+	// Only available on `--dev` chains.
+	// This function may be removed at any time, superseded by a more general contract debugging feature.
+	ext_println(ctx, str_ptr: u32, str_len: u32) => {
+		let data = read_sandbox_memory(ctx, str_ptr, str_len)?;
+		if let Ok(utf8) = core::str::from_utf8(&data) {
+			runtime_io::print(utf8);
+		}
+		Ok(())
+	},
 );


### PR DESCRIPTION
Backport of #2239