### PR TITLE
Fix races in sync tests

### DIFF
--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -950,7 +950,7 @@ mod tests {
 		let drive_to_completion = ::tokio::timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
 			.for_each(move |_| {
 				net.lock().send_import_notifications();
-				net.lock().route_fast();
+				net.lock().sync_without_disconnects();
 				Ok(())
 			})
 			.map(|_| ())

--- a/core/consensus/common/Cargo.toml
+++ b/core/consensus/common/Cargo.toml
@@ -20,3 +20,7 @@ parity-codec = { version = "3.3", features = ["derive"] }
 
 [dev-dependencies]
 test_client = { package = "substrate-test-client", path = "../../test-client" }
+
+[features]
+default = []
+test-helpers = []

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -149,6 +149,18 @@ impl<B: BlockT> BasicQueue<B> {
 			sender: importer_sender,
 		}
 	}
+
+	/// Send synchronization request to the block import channel.
+	///
+	/// The caller should wait for Link::synchronized() call to ensure that it has synchronized
+	/// with ImportQueue.
+	#[cfg(any(test, feature = "test-helpers"))]
+	pub fn synchronize(&self) {
+		self
+			.sender
+			.send(BlockImportMsg::Synchronize)
+			.expect("1. self is holding a sender to the Importer, 2. Importer should handle messages while there are senders around; qed");
+	}
 }
 
 impl<B: BlockT> ImportQueue<B> for BasicQueue<B> {
@@ -191,6 +203,8 @@ pub enum BlockImportMsg<B: BlockT> {
 	ImportJustification(Origin, B::Hash, NumberFor<B>, Justification),
 	Start(Box<Link<B>>, Sender<Result<(), std::io::Error>>),
 	Stop,
+	#[cfg(any(test, feature = "test-helpers"))]
+	Synchronize,
 }
 
 pub enum BlockImportWorkerMsg<B: BlockT> {
@@ -201,6 +215,8 @@ pub enum BlockImportWorkerMsg<B: BlockT> {
 			B::Hash,
 		)>,
 	),
+	#[cfg(any(test, feature = "test-helpers"))]
+	Synchronize,
 }
 
 enum ImportMsgType<B: BlockT> {
@@ -279,13 +295,32 @@ impl<B: BlockT> BlockImporter<B> {
 				let _ = sender.send(Ok(()));
 			},
 			BlockImportMsg::Stop => return false,
+			#[cfg(any(test, feature = "test-helpers"))]
+			BlockImportMsg::Synchronize => {
+				self.worker_sender
+					.send(BlockImportWorkerMsg::Synchronize)
+					.expect("1. This is holding a sender to the worker, 2. the worker should not quit while a sender is still held; qed");
+			},
 		}
 		true
 	}
 
 	fn handle_worker_msg(&mut self, msg: BlockImportWorkerMsg<B>) -> bool {
+		let link = match self.link.as_ref() {
+			Some(link) => link,
+			None => {
+				trace!(target: "sync", "Received import result while import-queue has no link");
+				return true;
+			},
+		};
+
 		let results = match msg {
 			BlockImportWorkerMsg::Imported(results) => (results),
+			#[cfg(any(test, feature = "test-helpers"))]
+			BlockImportWorkerMsg::Synchronize => {
+				link.synchronized();
+				return true;
+			},
 			_ => unreachable!("Import Worker does not send ImportBlocks message; qed"),
 		};
 		let mut has_error = false;
@@ -300,14 +335,6 @@ impl<B: BlockT> BlockImporter<B> {
 			if result.is_err() {
 				has_error = true;
 			}
-
-			let link = match self.link.as_ref() {
-				Some(link) => link,
-				None => {
-					trace!(target: "sync", "Received import result for {} while import-queue has no link", hash);
-					return true;
-				},
-			};
 
 			match result {
 				Ok(BlockImportResult::ImportedKnown(number)) => link.block_imported(&hash, number),
@@ -403,8 +430,12 @@ impl<B: BlockT, V: 'static + Verifier<B>> BlockImportWorker<B, V> {
 					// Working until all senders have been dropped...
 					match msg {
 						BlockImportWorkerMsg::ImportBlocks(origin, blocks) => {
-							worker.import_a_batch_of_blocks(origin, blocks)
-						}
+							worker.import_a_batch_of_blocks(origin, blocks);
+						},
+						#[cfg(any(test, feature = "test-helpers"))]
+						BlockImportWorkerMsg::Synchronize => {
+							let _ = worker.result_sender.send(BlockImportWorkerMsg::Synchronize);
+						},
 						_ => unreachable!("Import Worker does not receive the Imported message; qed"),
 					}
 				}
@@ -480,6 +511,9 @@ pub trait Link<B: BlockT>: Send {
 	fn note_useless_and_restart_sync(&self, _who: Origin, _reason: &str) {}
 	/// Restart sync.
 	fn restart(&self) {}
+	/// Synchronization request has been processed.
+	#[cfg(any(test, feature = "test-helpers"))]
+	fn synchronized(&self) {}
 }
 
 /// Block import successful result.

--- a/core/finality-grandpa/Cargo.toml
+++ b/core/finality-grandpa/Cargo.toml
@@ -25,6 +25,7 @@ fg_primitives = { package = "substrate-finality-grandpa-primitives", path = "pri
 grandpa = { package = "finality-grandpa", version = "0.7.1", features = ["derive-codec"] }
 
 [dev-dependencies]
+consensus_common = { package = "substrate-consensus-common", path = "../consensus/common", features = ["test-helpers"] }
 network = { package = "substrate-network", path = "../network", features = ["test-helpers"] }
 keyring = { package = "substrate-keyring", path = "../keyring" }
 test_client = { package = "substrate-test-client", path = "../test-client"}

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -419,7 +419,7 @@ fn run_to_completion_with<F: FnOnce()>(
 		.for_each(move |_| {
 			net.lock().send_import_notifications();
 			net.lock().send_finality_notifications();
-			net.lock().route_fast();
+			net.lock().sync_without_disconnects();
 			Ok(())
 		})
 		.map(|_| ())
@@ -515,7 +515,7 @@ fn finalize_3_voters_1_observer() {
 		.map_err(|_| ());
 
 	let drive_to_completion = ::tokio::timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
-		.for_each(move |_| { net.lock().route_fast(); Ok(()) })
+		.for_each(move |_| { net.lock().sync_without_disconnects(); Ok(()) })
 		.map(|_| ())
 		.map_err(|_| ());
 
@@ -680,7 +680,7 @@ fn transition_3_voters_twice_1_observer() {
 		.for_each(move |_| {
 			net.lock().send_import_notifications();
 			net.lock().send_finality_notifications();
-			net.lock().route_fast();
+			net.lock().sync_without_disconnects();
 			Ok(())
 		})
 		.map(|_| ())
@@ -789,7 +789,7 @@ fn sync_justifications_on_change_blocks() {
 
 	// the last peer should get the justification by syncing from other peers
 	while net.lock().peer(3).client().justification(&BlockId::Number(21)).unwrap().is_none() {
-		net.lock().route_fast();
+		net.lock().sync_without_disconnects();
 	}
 }
 
@@ -1198,7 +1198,7 @@ fn voter_persists_its_votes() {
 		.for_each(move |_| {
 			net.lock().send_import_notifications();
 			net.lock().send_finality_notifications();
-			net.lock().route_fast();
+			net.lock().sync_without_disconnects();
 			Ok(())
 		})
 		.map(|_| ())

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -36,6 +36,7 @@ test_client = { package = "substrate-test-client", path = "../../core/test-clien
 env_logger = { version = "0.6" }
 keyring = { package = "substrate-keyring", path = "../../core/keyring" }
 test_client = { package = "substrate-test-client", path = "../../core/test-client" }
+consensus = { package = "substrate-consensus-common", path = "../../core/consensus/common", features = ["test-helpers"] }
 
 [features]
 default = []

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -466,6 +466,9 @@ pub enum NetworkMsg<B: BlockT + 'static> {
 	Outgoing(PeerId, Message<B>),
 	/// Report a peer.
 	ReportPeer(PeerId, Severity),
+	/// Synchronization response.
+	#[cfg(any(test, feature = "test-helpers"))]
+	Synchronized,
 }
 
 /// Starts the background thread that handles the networking.
@@ -546,6 +549,8 @@ fn run_thread<B: BlockT + 'static>(
 					},
 				}
 			},
+			#[cfg(any(test, feature = "test-helpers"))]
+			NetworkMsg::Synchronized => (),
 		}
 		Ok(())
 	})

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -48,8 +48,7 @@ fn sync_peers_works() {
 	net.sync();
 	for peer in 0..3 {
 		// Assert peers is up to date.
-		let peers = net.peer(peer).peers.read();
-		assert_eq!(peers.len(), 2);
+		assert_eq!(net.peer(peer).peers.read().len(), 2);
 		// And then disconnect.
 		for other in 0..3 {
 			if other != peer {
@@ -78,9 +77,6 @@ fn sync_cycle_from_offline_to_syncing_to_offline() {
 	// Generate blocks.
 	net.peer(2).push_blocks(100, false);
 	net.start();
-	net.route_fast();
-	thread::sleep(Duration::from_millis(100));
-	net.route_fast();
 	for peer in 0..3 {
 		// Online
 		assert!(!net.peer(peer).is_offline());
@@ -102,7 +98,6 @@ fn sync_cycle_from_offline_to_syncing_to_offline() {
 				net.peer(peer).on_disconnect(net.peer(other));
 			}
 		}
-		thread::sleep(Duration::from_millis(100));
 		assert!(net.peer(peer).is_offline());
 		assert!(!net.peer(peer).is_major_syncing());
 	}
@@ -116,9 +111,7 @@ fn syncing_node_not_major_syncing_when_disconnected() {
 	// Generate blocks.
 	net.peer(2).push_blocks(100, false);
 	net.start();
-	net.route_fast();
-	thread::sleep(Duration::from_millis(100));
-	net.route_fast();
+	net.sync_step();
 
 	// Peer 1 is major-syncing.
 	assert!(net.peer(1).is_major_syncing());
@@ -126,7 +119,6 @@ fn syncing_node_not_major_syncing_when_disconnected() {
 	// Disconnect peer 1 form everyone else.
 	net.peer(1).on_disconnect(net.peer(0));
 	net.peer(1).on_disconnect(net.peer(2));
-	thread::sleep(Duration::from_millis(100));
 
 	// Peer 1 is not major-syncing.
 	assert!(!net.peer(1).is_major_syncing());
@@ -363,7 +355,7 @@ fn blocks_are_not_announced_by_light_nodes() {
 	let mut disconnected = HashSet::new();
 	disconnected.insert(0);
 	disconnected.insert(2);
-	net.sync_with_disconnected(disconnected);
+	net.sync_with(true, Some(disconnected));
 
 	// peer 0 has the best chain
 	// peer 1 has the best chain


### PR DESCRIPTION
closes #2143 
closes #2121 

The original issue was that there was no guarantee that `Protocol` (and sometimes `BasicQueue`) thread has processed incoming messages before some decisions were made. E.g. exit condition of [this loop](https://github.com/paritytech/substrate/blob/b5b5c32895c046767827b8264f868e80b22965ad/core/network/src/test/mod.rs#L730) is: if there are no outgoing messages from all peers for 3 consequent checks => exit. But there's no guarantee that `Protocol`s threads had a chance to process messages from the previous loop iterations. The same was with some sync tests (especially where `thread::sleep` has been used).

I've tried to make least intrusive solution - instead of introducing for-tests synchronous implementations of `Protocol` and `BasicQueue`, there are couple of test-only messages for existing communication channels (i.e. `ProtocolMsg::Synchronize`, `ClientMsg::Synchronize`, ...). The idea is - once some message is sent to the channel, send `Synchronize` message right afterwards. The other end of the channel will read && process first message and then, upon receiving `Synchronization` request will respond with `Synchronized`. When `Synchronized` is received by original sender, it is guaranteed that the message has been processed and (possibly) new outgoing messages have been sent in response.

I've removed all `thread::sleep` calls from the sync tests, since they're not required anymore. There are still some things that could be cleaned up from sync tests infrastructure (like `TestNetFactory::sync_without_disconnects`, which is required because in some GRANDPA tests peers are disconnecting actually => we're unable to deliver some messages) - this could be done in separate PR later.