### PR TITLE
Add StorageList support in decl_storage

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 59,
-	impl_version: 60,
+	impl_version: 61,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -258,6 +258,7 @@ impl std::fmt::Debug for DefaultByteGetter {
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageFunctionType {
 	Plain(DecodeDifferentStr),
+	List(DecodeDifferentStr),
 	Map {
 		key: DecodeDifferentStr,
 		value: DecodeDifferentStr,

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -258,7 +258,6 @@ impl std::fmt::Debug for DefaultByteGetter {
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub enum StorageFunctionType {
 	Plain(DecodeDifferentStr),
-	List(DecodeDifferentStr),
 	Map {
 		key: DecodeDifferentStr,
 		value: DecodeDifferentStr,
@@ -270,6 +269,7 @@ pub enum StorageFunctionType {
 		value: DecodeDifferentStr,
 		key2_hasher: DecodeDifferentStr,
 	},
+	List(DecodeDifferentStr),
 }
 
 /// A storage function modifier.

--- a/srml/support/procedural/src/lib.rs
+++ b/srml/support/procedural/src/lib.rs
@@ -18,7 +18,7 @@
 //! Proc macro of Support code for the runtime.
 // end::description[]
 
-#![recursion_limit="256"]
+#![recursion_limit="512"]
 
 extern crate proc_macro;
 

--- a/srml/support/procedural/src/storage/impls.rs
+++ b/srml/support/procedural/src/storage/impls.rs
@@ -227,6 +227,18 @@ impl<'a, I: Iterator<Item=syn::Meta>> Impls<'a, I> {
 					storage.put(&<Self as #scrate::storage::generator::StorageList<#typ>>::key_for(index)[..], item);
 				}
 
+				fn pop<S: #scrate::GenericStorage>(storage: &S) -> Option<#typ> {
+					let count = <Self as #scrate::storage::generator::StorageList<#typ>>::len(storage);
+					let index = if count == 0 {
+						return None
+					} else {
+						count - 1
+					};
+					let ret = <Self as #scrate::storage::generator::StorageList<#typ>>::get(index, storage);
+					Self::set_len(index, storage);
+					ret
+				}
+
 				/// Load the value at given index. Returns `None` if the index is out-of-bounds.
 				fn get<S: #scrate::GenericStorage>(index: u32, storage: &S) -> Option<#typ> {
 					storage.get(&<Self as #scrate::storage::generator::StorageList<#typ>>::key_for(index)[..])

--- a/srml/support/procedural/src/storage/mod.rs
+++ b/srml/support/procedural/src/storage/mod.rs
@@ -129,10 +129,17 @@ struct DeclStorageBuild {
 
 #[derive(Parse, ToTokens, Debug)]
 enum DeclStorageType {
+	List(DeclStorageList),
 	Map(DeclStorageMap),
 	LinkedMap(DeclStorageLinkedMap),
 	DoubleMap(DeclStorageDoubleMap),
 	Simple(syn::Type),
+}
+
+#[derive(Parse, ToTokens, Debug)]
+struct DeclStorageList {
+	pub list_keyword: ext::CustomToken<ListKeyword>,
+	pub value: syn::Type,
 }
 
 #[derive(Parse, ToTokens, Debug)]
@@ -185,6 +192,7 @@ custom_keyword_impl!(DeclStorageGetter, "get", "storage getter");
 custom_keyword!(MapKeyword, "map", "map as keyword");
 custom_keyword!(LinkedMapKeyword, "linked_map", "linked_map as keyword");
 custom_keyword!(DoubleMapKeyword, "double_map", "double_map as keyword");
+custom_keyword!(ListKeyword, "list", "list as keyword");
 custom_keyword!(Blake2_256Keyword, "blake2_256", "Blake2_256 as keyword");
 custom_keyword!(Twox256Keyword, "twox_256", "Twox_256 as keyword");
 custom_keyword!(Twox128Keyword, "twox_128", "Twox_128 as keyword");

--- a/srml/support/src/storage/generator.rs
+++ b/srml/support/src/storage/generator.rs
@@ -166,6 +166,9 @@ pub trait StorageList<T: codec::Codec> {
 	/// Read out all the items.
 	fn items<S: Storage>(storage: &S) -> Vec<T>;
 
+	/// Push a new item to the list.
+	fn push<S: Storage>(item: &T, storage: &S);
+
 	/// Set the current set of items.
 	fn set_items<S: Storage>(items: &[T], storage: &S);
 
@@ -510,6 +513,14 @@ macro_rules! __storage_items_internal {
 				if index < <$name as $crate::storage::generator::StorageList<$ty>>::len(storage) {
 					storage.put(&<$name as $crate::storage::generator::StorageList<$ty>>::key_for(index)[..], item);
 				}
+			}
+
+			fn push<S: $crate::GenericStorage>(item: &$ty, storage: &S) {
+				let index = Self::len(storage);
+				let count = index + 1;
+				storage.put(&<$name as $crate::storage::generator::StorageList<$ty>>::len_key(), &count);
+
+				storage.put(&<$name as $crate::storage::generator::StorageList<$ty>>::key_for(index)[..], item);
 			}
 
 			/// Load the value at given index. Returns `None` if the index is out-of-bounds.

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -256,6 +256,9 @@ pub trait StorageList<T: Codec> {
 	/// Push a new item to the list.
 	fn push(item: &T);
 
+	/// Pop a item from the list.
+	fn pop() -> Option<T>;
+
 	/// Set the current set of items.
 	fn set_items(items: &[T]);
 
@@ -291,6 +294,10 @@ impl<T: Codec, U> StorageList<T> for U where U: generator::StorageList<T> {
 
 	fn push(item: &T) {
 		U::push(item, &RuntimeStorage)
+	}
+
+	fn pop() -> Option<T> {
+		U::pop(&RuntimeStorage)
 	}
 
 	fn set_items(items: &[T]) {

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -253,6 +253,9 @@ pub trait StorageList<T: Codec> {
 	/// Read out all the items.
 	fn items() -> Vec<T>;
 
+	/// Push a new item to the list.
+	fn push(item: &T);
+
 	/// Set the current set of items.
 	fn set_items(items: &[T]);
 
@@ -284,6 +287,10 @@ impl<T: Codec, U> StorageList<T> for U where U: generator::StorageList<T> {
 
 	fn items() -> Vec<T> {
 		U::items(&RuntimeStorage)
+	}
+
+	fn push(item: &T) {
+		U::push(item, &RuntimeStorage)
 	}
 
 	fn set_items(items: &[T]) {
@@ -560,7 +567,7 @@ pub trait StorageVec {
 /// child storage NOTE could replace unhashed by having only one kind of storage (root being null storage
 /// key (storage_key can become Option<&[u8]>).
 /// This module is a currently only a variant of unhashed with additional `storage_key`.
-/// Note that `storage_key` must be unique and strong (strong in the sense of being long enough to 
+/// Note that `storage_key` must be unique and strong (strong in the sense of being long enough to
 /// avoid collision from a resistant hash function (which unique implies)).
 pub mod child {
 	use super::{runtime_io, Codec, Decode, Vec, IncrementalChildInput};
@@ -632,7 +639,7 @@ pub mod child {
 		runtime_io::read_child_storage(storage_key, key, &mut [0;0][..], 0).is_some()
 	}
 
-	/// Remove all `storage_key` key/values 
+	/// Remove all `storage_key` key/values
 	pub fn kill_storage(storage_key: &[u8]) {
 		runtime_io::kill_child_storage(storage_key)
 	}

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -455,6 +455,8 @@ fn storage_with_instance_basic_operation() {
 		assert_eq!(List::len(), 2);
 		assert_eq!(List::get(0), Some(0));
 		assert_eq!(List::get(1), Some(1));
+		assert_eq!(List::pop(), Some(1));
+		assert_eq!(List::get(1), None);
 
 		assert_eq!(Value::exists(), true);
 		assert_eq!(Value::get(), 4);

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -28,7 +28,7 @@ use srml_support::Parameter;
 use inherents::{
 	ProvideInherent, InherentData, InherentIdentifier, RuntimeString, MakeFatalError
 };
-use srml_support::{StorageValue, StorageMap, StorageDoubleMap};
+use srml_support::{StorageValue, StorageMap, StorageDoubleMap, StorageList};
 use primitives::{H256, sr25519};
 
 pub trait Currency {
@@ -144,6 +144,7 @@ mod module1 {
 		trait Store for Module<T: Trait<I>, I: InstantiableThing> as Module1 {
 			pub Value config(value): u64;
 			pub Map: map u32 => u64;
+			pub List: u32;
 			pub LinkedMap: linked_map u32 => u64;
 		}
 	}
@@ -217,6 +218,7 @@ mod module2 {
 		trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Module2 {
 			pub Value config(value): T::Amount;
 			pub Map config(map): map u64 => u64;
+			pub List config(list): list u32;
 			pub LinkedMap config(linked_map): linked_map u64 => u64;
 			pub DoubleMap config(double_map): double_map u64, blake2_256(u64) => u64;
 		}
@@ -370,12 +372,14 @@ fn new_test_ext() -> runtime_io::TestExternalities<Blake2Hasher> {
 		module2: Some(module2::GenesisConfig {
 			value: 4,
 			map: vec![(0, 0)],
+			list: vec![0],
 			linked_map: vec![(0, 0)],
 			double_map: vec![(0, 0, 0)],
 		}),
 		module2_Instance1: Some(module2::GenesisConfig {
 			value: 4,
 			map: vec![(0, 0)],
+			list: vec![0],
 			linked_map: vec![(0, 0)],
 			double_map: vec![(0, 0, 0)],
 		}),
@@ -442,6 +446,15 @@ fn storage_with_instance_basic_operation() {
 		type Map = module2::Map<Runtime, module2::Instance1>;
 		type LinkedMap = module2::LinkedMap<Runtime, module2::Instance1>;
 		type DoubleMap = module2::DoubleMap<Runtime, module2::Instance1>;
+		type List = module2::List<Runtime, module2::Instance1>;
+
+		assert_eq!(List::len(), 1);
+		assert_eq!(List::get(0), Some(0));
+		assert_eq!(List::get(1), None);
+		List::push(&1);
+		assert_eq!(List::len(), 2);
+		assert_eq!(List::get(0), Some(0));
+		assert_eq!(List::get(1), Some(1));
 
 		assert_eq!(Value::exists(), true);
 		assert_eq!(Value::get(), 4);


### PR DESCRIPTION
Add back storage list support in `decl_storage` macro. Can fix issues like #2228.

A QoL function `StorageList::push` is also added.