### PR TITLE
Remove unused imports/ doc comments.

### DIFF
--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -1122,8 +1122,6 @@ impl<Block> client::backend::Backend<Block, Blake2Hasher> for Backend<Block> whe
 	}
 
 	fn revert(&self, n: NumberFor<Block>) -> Result<NumberFor<Block>, client::error::Error> {
-		use client::blockchain::HeaderBackend;
-
 		let mut best = self.blockchain.info()?.best_number;
 		let finalized = self.blockchain.info()?.finalized_number;
 		let revertible = best - finalized;

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -675,8 +675,6 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	) -> error::Result<ImportResult> where
 		E: CallExecutor<Block, Blake2Hasher> + Send + Sync + Clone,
 	{
-		use runtime_primitives::traits::Digest;
-
 		let ImportBlock {
 			origin,
 			header,

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -34,7 +34,7 @@ use grandpa::{
 };
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{
-	As, Block as BlockT, Header as HeaderT, NumberFor, One, Zero,
+	As, Block as BlockT, Header as HeaderT, NumberFor, One, Zero, BlockNumberToHash,
 };
 use substrate_primitives::{Blake2Hasher, ed25519, H256, Pair};
 use substrate_telemetry::{telemetry, CONSENSUS_INFO};
@@ -886,8 +886,6 @@ pub(crate) fn canonical_at_height<B, E, Block: BlockT<Hash=H256>, RA>(
 	B: Backend<Block, Blake2Hasher>,
 	E: CallExecutor<Block, Blake2Hasher> + Send + Sync,
 {
-	use runtime_primitives::traits::{One, Zero, BlockNumberToHash};
-
 	if height > base.1 {
 		return Ok(None);
 	}

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -416,7 +416,6 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 		if let Some((topic, keep)) = validation_result {
 			if let Some(ref mut peer) = self.peers.get_mut(&who) {
-				use std::collections::hash_map::Entry;
 				peer.known_messages.insert(message_hash);
 				if let Entry::Occupied(mut entry) = self.live_message_sinks.entry((engine_id, topic)) {
 					debug!(target: "gossip", "Pushing consensus message to sinks for {}.", topic);

--- a/core/network/src/message.rs
+++ b/core/network/src/message.rs
@@ -66,7 +66,7 @@ pub type BlockResponse<B> = generic::BlockResponse<
 /// A set of transactions.
 pub type Transactions<E> = Vec<E>;
 
-/// Bits of block data and associated artifacts to request.
+// Bits of block data and associated artifacts to request.
 bitflags! {
 	/// Node roles bitmask.
 	pub struct BlockAttributes: u8 {

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -19,8 +19,6 @@ use client::blockchain::HeaderBackend as BlockchainHeaderBackend;
 use crate::config::Roles;
 use consensus::BlockOrigin;
 use std::collections::HashSet;
-use std::thread;
-use std::time::Duration;
 use super::*;
 
 fn test_ancestor_search_when_common_is(n: usize) {

--- a/node-template/runtime/src/template.rs
+++ b/node-template/runtime/src/template.rs
@@ -19,16 +19,17 @@ pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
-/// This module's storage items.
+// This module's storage items.
 decl_storage! {
 	trait Store for Module<T: Trait> as TemplateModule {
-		// Just a dummy storage item. 
+		// Just a dummy storage item.
 		// Here we are declaring a StorageValue, `Something` as a Option<u32>
 		// `get(something)` is the default getter which returns either the stored `u32` or `None` if nothing stored
 		Something get(something): Option<u32>;
 	}
 }
 
+// dispatchable functions of this module
 decl_module! {
 	/// The module declaration.
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {

--- a/node-template/runtime/src/template.rs
+++ b/node-template/runtime/src/template.rs
@@ -29,7 +29,7 @@ decl_storage! {
 	}
 }
 
-// dispatchable functions of this module
+// The module's dispatchable functions.
 decl_module! {
 	/// The module declaration.
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {


### PR DESCRIPTION
Self-explanatory. Just to remove the known/trivial ones to make the rest of the warnings that are probably more important more emphasized.

A test will likely fail until https://github.com/paritytech/substrate/pull/2267 is merged. 

Only major warning left is explained here: https://github.com/paritytech/substrate/issues/1547.

A few doc-strings above macros changed to `//`. Makes sense since no rustdoc is generated from them. There might be more across the code-base but currently `cargo check` doesn't show more.