### PR TITLE
Use ed25519 by default for network keys

### DIFF
--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -189,7 +189,7 @@ pub struct NodeKeyParams {
 		raw(
 			possible_values = "&NodeKeyType::variants()",
 			case_insensitive = "true",
-			default_value = r#""Secp256k1""#
+			default_value = r#""Ed25519""#
 		)
 	)]
 	pub node_key_type: NodeKeyType,

--- a/core/network-libp2p/src/config.rs
+++ b/core/network-libp2p/src/config.rs
@@ -61,7 +61,7 @@ impl Default for NetworkConfiguration {
 			listen_addresses: Vec::new(),
 			public_addresses: Vec::new(),
 			boot_nodes: Vec::new(),
-			node_key: NodeKeyConfig::Secp256k1(Secret::New),
+			node_key: NodeKeyConfig::Ed25519(Secret::New),
 			in_peers: 25,
 			out_peers: 75,
 			reserved_nodes: Vec::new(),


### PR DESCRIPTION
We shouldn't use secp256k1, as it's deemed unsafe.

cc @romanb @burdges

**Note**: We must wait for devops to add the `--node-key-type=secp256k1` CLI option to the bootnodes of Polkadot/Substrate before deploying that, otherwise their keys will change and nobody will be able to connect anymore.
I'm unsure how to notify other chains that have a running testnet about this change.
