### PR TITLE
Disable CORS when running in --dev

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -475,7 +475,8 @@ where
 	config.rpc_ws = Some(
 		parse_address(&format!("{}:{}", ws_interface, 9944), cli.ws_port)?
 	);
-	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| if cli.dev {
+	let is_dev = cli.shared_params.dev;
+	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| if is_dev {
 		log::warn!("Running in --dev mode, RPC CORS has been disabled.");
 		None
 	} else {

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -482,7 +482,8 @@ where
 		Some(vec![
 			"http://localhost:*".into(),
 			"https://localhost:*".into(),
-			"https://polkadot.js.org".into()
+			"https://polkadot.js.org".into(),
+			"https://substrate-ui.parity.io".into(),
 		])
 	});
 

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -475,11 +475,16 @@ where
 	config.rpc_ws = Some(
 		parse_address(&format!("{}:{}", ws_interface, 9944), cli.ws_port)?
 	);
-	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| Some(vec![
-		"http://localhost:*".into(),
-		"https://localhost:*".into(),
-		"https://polkadot.js.org".into()
-	]));
+	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| if cli.dev {
+		log::warn!("Running in --dev mode, RPC CORS has been disabled.");
+		None
+	} else {
+		Some(vec![
+			"http://localhost:*".into(),
+			"https://localhost:*".into(),
+			"https://polkadot.js.org".into()
+		])
+	});
 
 	// Override telemetry
 	if cli.no_telemetry {

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -332,7 +332,8 @@ pub struct RunCmd {
 	/// Specify browser Origins allowed to access the HTTP & WS RPC servers.
 	/// It's a comma-separated list of origins (protocol://domain or special `null` value).
 	/// Value of `all` will disable origin validation.
-	/// Default is to allow localhost and https://polkadot.js.org origin.
+	/// Default is to allow localhost, https://polkadot.js.org and https://substrate-ui.parity.io origins.
+	/// When running in --dev mode the default is to allow all origins.
 	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = "parse_cors"))]
 	pub rpc_cors: Option<Option<Vec<String>>>,
 


### PR DESCRIPTION
And also whitelist `https://substrate-ui.parity.io`.

Closes #2287 