### PR TITLE
Configurable state cache size and enforce exact state cache size

### DIFF
--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -76,6 +76,12 @@ pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExe
 				TransferRateFormat(bandwidth_upload),
 			);
 
+			let backend = (*client).backend();
+			let used_state_cache_size = match backend.used_state_cache_size(){
+				Some(size) => size,
+				None => 0,
+			};
+
 			// get cpu usage and memory usage of this process
 			let (cpu_usage, memory) = if sys.refresh_process(self_pid) {
 				let proc = sys.get_process(self_pid).expect("Above refresh_process succeeds, this should be Some(), qed");
@@ -99,6 +105,7 @@ pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExe
 				"finalized_hash" => ?info.chain.finalized_hash,
 				"bandwidth_download" => bandwidth_download,
 				"bandwidth_upload" => bandwidth_upload,
+				"used_state_cache_size" => used_state_cache_size,
 			);
 		} else {
 			warn!("Error getting best block information");

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -404,6 +404,7 @@ where
 	config.database_path =
 		db_path(&base_path, config.chain_spec.id()).to_string_lossy().into();
 	config.database_cache_size = cli.database_cache_size;
+	config.state_cache_size = cli.state_cache_size;
 	config.pruning = match cli.pruning {
 		Some(ref s) if s == "archive" => PruningMode::ArchiveAll,
 		None => PruningMode::default(),

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -314,7 +314,7 @@ pub struct RunCmd {
 	pub database_cache_size: Option<u32>,
 
 	/// Specify the state cache size
-	#[structopt(long = "state-cache-size", value_name = "Bytes", default_value = "16777216")]
+	#[structopt(long = "state-cache-size", value_name = "Bytes", default_value = "67108864")]
 	pub state_cache_size: usize,
 
 	/// Listen to all RPC interfaces (default is local)

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -313,6 +313,10 @@ pub struct RunCmd {
 	#[structopt(long = "db-cache", value_name = "MiB")]
 	pub database_cache_size: Option<u32>,
 
+	/// Specify the state cache size
+	#[structopt(long = "state-cache-size", value_name = "Bytes", default_value = "16777216")]
+	pub state_cache_size: usize,
+
 	/// Listen to all RPC interfaces (default is local)
 	#[structopt(long = "rpc-external")]
 	pub rpc_external: bool,

--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -1163,6 +1163,11 @@ impl<Block> client::backend::Backend<Block, Blake2Hasher> for Backend<Block> whe
 		&self.blockchain
 	}
 
+	fn used_state_cache_size(&self) -> Option<usize> {
+		let used = (*&self.shared_cache).lock().used_storage_cache_size();
+		Some(used)
+	}
+
 	fn state_at(&self, block: BlockId<Block>) -> Result<Self::State, client::error::Error> {
 		use client::blockchain::HeaderBackend as BcHeaderBackend;
 

--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -65,7 +65,6 @@ use client::in_mem::Backend as InMemoryBackend;
 
 const CANONICALIZATION_DELAY: u64 = 4096;
 const MIN_BLOCKS_TO_KEEP_CHANGES_TRIES_FOR: u64 = 32768;
-const STATE_CACHE_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
 /// DB-backed patricia trie state, transaction type is an overlay of changes to commit.
 pub type DbState = state_machine::TrieBackend<Arc<state_machine::Storage<Blake2Hasher>>, Blake2Hasher>;
@@ -74,6 +73,8 @@ pub type DbState = state_machine::TrieBackend<Arc<state_machine::Storage<Blake2H
 pub struct DatabaseSettings {
 	/// Cache size in bytes. If `None` default is used.
 	pub cache_size: Option<usize>,
+	/// State cache size.
+	pub state_cache_size: usize,
 	/// Path to the database.
 	pub path: PathBuf,
 	/// Pruning mode.
@@ -543,7 +544,7 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 	pub fn new(config: DatabaseSettings, canonicalization_delay: u64) -> Result<Self, client::error::Error> {
 		let db = open_database(&config, columns::META, "full")?;
 
-		Backend::from_kvdb(db as Arc<_>, config.pruning, canonicalization_delay)
+		Backend::from_kvdb(db as Arc<_>, config.pruning, canonicalization_delay, config.state_cache_size)
 	}
 
 	#[cfg(any(test, feature = "test-helpers"))]
@@ -556,10 +557,11 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 			db as Arc<_>,
 			PruningMode::keep_blocks(keep_blocks),
 			canonicalization_delay,
+			16777216,
 		).expect("failed to create test-db")
 	}
 
-	fn from_kvdb(db: Arc<KeyValueDB>, pruning: PruningMode, canonicalization_delay: u64) -> Result<Self, client::error::Error> {
+	fn from_kvdb(db: Arc<KeyValueDB>, pruning: PruningMode, canonicalization_delay: u64, state_cache_size: usize) -> Result<Self, client::error::Error> {
 		let is_archive_pruning = pruning.is_archive();
 		let blockchain = BlockchainDb::new(db.clone())?;
 		let meta = blockchain.meta.clone();
@@ -582,7 +584,7 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 			changes_trie_config: Mutex::new(None),
 			blockchain,
 			canonicalization_delay,
-			shared_cache: new_shared_cache(STATE_CACHE_SIZE_BYTES),
+			shared_cache: new_shared_cache(state_cache_size),
 		})
 	}
 
@@ -1319,7 +1321,7 @@ mod tests {
 			db.storage.db.clone()
 		};
 
-		let backend = Backend::<Block>::from_kvdb(backing, PruningMode::keep_blocks(1), 0).unwrap();
+		let backend = Backend::<Block>::from_kvdb(backing, PruningMode::keep_blocks(1), 0, 16777216).unwrap();
 		assert_eq!(backend.blockchain().info().unwrap().best_number, 9);
 		for i in 0..10 {
 			assert!(backend.blockchain().hash(i).unwrap().is_some())

--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -132,7 +132,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 		}
 	}
 
-	fn storage_insert(&self, cache: &mut Cache<B, H>, k: StorageValue, v: Option<StorageValue>) {
+	fn storage_insert(cache: &mut Cache<B, H>, k: StorageValue, v: Option<StorageValue>) {
 		if let Some(v_) = &v {
 			while cache.storage_used_size + v_.len() > cache.shared_cache_size {
 				// pop until space constraint satisfied
@@ -148,7 +148,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 		cache.storage.insert(k, v);
 	}
 
-	fn storage_remove(&self,
+	fn storage_remove(
 		storage: &mut LruCache<StorageKey, Option<StorageValue>>,
 		k: &StorageKey,
 		storage_used_size: &mut usize,
@@ -189,7 +189,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 					m.is_canon = true;
 					for a in &m.storage {
 						trace!("Reverting enacted key {:?}", a);
-						self.storage_remove(&mut cache.storage, a, &mut cache.storage_used_size);
+						CachingState::<H, S, B>::storage_remove(&mut cache.storage, a, &mut cache.storage_used_size);
 					}
 					false
 				} else {
@@ -205,7 +205,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 					m.is_canon = false;
 					for a in &m.storage {
 						trace!("Retracted key {:?}", a);
-						self.storage_remove(&mut cache.storage, a, &mut cache.storage_used_size);
+						CachingState::<H, S, B>::storage_remove(&mut cache.storage, a, &mut cache.storage_used_size);
 					}
 					false
 				} else {
@@ -228,7 +228,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 			if is_best {
 				trace!("Committing {} local, {} hashes, {} modified entries", local_cache.storage.len(), local_cache.hashes.len(), changes.len());
 				for (k, v) in local_cache.storage.drain() {
-					self.storage_insert(cache, k, v);
+					CachingState::<H, S, B>::storage_insert(cache, k, v);
 				}
 				for (k, v) in local_cache.hashes.drain() {
 					cache.hashes.insert(k, v);
@@ -248,7 +248,7 @@ impl<H: Hasher, S: StateBackend<H>, B: Block> CachingState<H, S, B> {
 				modifications.insert(k.clone());
 				if is_best {
 					cache.hashes.remove(&k);
-					self.storage_insert(cache, k, v);
+					CachingState::<H, S, B>::storage_insert(cache, k, v);
 				}
 			}
 			// Save modified storage. These are ordered by the block number.

--- a/core/client/src/backend.rs
+++ b/core/client/src/backend.rs
@@ -141,6 +141,8 @@ pub trait Backend<Block, H>: AuxStore + Send + Sync where
 	fn finalize_block(&self, block: BlockId<Block>, justification: Option<Justification>) -> error::Result<()>;
 	/// Returns reference to blockchain backend.
 	fn blockchain(&self) -> &Self::Blockchain;
+	/// Returns the used state cache, if existent.
+	fn used_state_cache_size(&self) -> Option<usize>;
 	/// Returns reference to changes trie storage.
 	fn changes_trie_storage(&self) -> Option<&Self::ChangesTrieStorage>;
 	/// Returns true if state for given block is available.

--- a/core/client/src/in_mem.rs
+++ b/core/client/src/in_mem.rs
@@ -651,6 +651,10 @@ where
 		&self.blockchain
 	}
 
+	fn used_state_cache_size(&self) -> Option<usize> {
+		None
+	}
+
 	fn changes_trie_storage(&self) -> Option<&Self::ChangesTrieStorage> {
 		Some(&self.changes_trie_storage)
 	}

--- a/core/client/src/light/backend.rs
+++ b/core/client/src/light/backend.rs
@@ -183,6 +183,10 @@ impl<S, F, Block, H> ClientBackend<Block, H> for Backend<S, F, H> where
 		&self.blockchain
 	}
 
+	fn used_state_cache_size(&self) -> Option<usize> {
+		None
+	}
+
 	fn changes_trie_storage(&self) -> Option<&Self::ChangesTrieStorage> {
 		None
 	}

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -457,6 +457,7 @@ impl<Factory: ServiceFactory> Components for FullComponents<Factory> {
 	{
 		let db_settings = client_db::DatabaseSettings {
 			cache_size: config.database_cache_size.map(|u| u as usize),
+			state_cache_size: config.state_cache_size,
 			path: config.database_path.as_str().into(),
 			pruning: config.pruning.clone(),
 		};
@@ -532,6 +533,7 @@ impl<Factory: ServiceFactory> Components for LightComponents<Factory> {
 	{
 		let db_settings = client_db::DatabaseSettings {
 			cache_size: None,
+			state_cache_size: config.state_cache_size,
 			path: config.database_path.as_str().into(),
 			pruning: config.pruning.clone(),
 		};

--- a/core/service/src/config.rs
+++ b/core/service/src/config.rs
@@ -48,6 +48,8 @@ pub struct Configuration<C, G: Serialize + DeserializeOwned + BuildStorage> {
 	pub database_path: String,
 	/// Cache Size for internal database in MiB
 	pub database_cache_size: Option<u32>,
+	/// Size of internal state cache in Bytes
+	pub state_cache_size: usize,
 	/// Pruning settings.
 	pub pruning: PruningMode,
 	/// Additional key seeds.
@@ -93,6 +95,7 @@ impl<C: Default, G: Serialize + DeserializeOwned + BuildStorage> Configuration<C
 			keystore_path: Default::default(),
 			database_path: Default::default(),
 			database_cache_size: Default::default(),
+			state_cache_size: Default::default(),
 			keys: Default::default(),
 			custom: Default::default(),
 			pruning: PruningMode::default(),

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -112,6 +112,7 @@ fn node_config<F: ServiceFactory> (
 		keystore_path: root.join("key").to_str().unwrap().into(),
 		database_path: root.join("db").to_str().unwrap().into(),
 		database_cache_size: None,
+		state_cache_size: 16777216,
 		pruning: Default::default(),
 		keys: keys,
 		chain_spec: (*spec).clone(),


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/1360 and replaces the inaccurate guesstimate which was used when setting  up the state cache with exact tracking/enforcement.

The difference in the function signature of `storage_insert(…)` and `storage_remove(…)` is because when `storage_remove` is called `cache` is already borrowed mutably.

Side note: https://crates.io/crates/lru-cache contains
>WARNING: THIS PROJECT IS IN MAINTENANCE MODE, DUE TO INSUFFICIENT MAINTAINER RESOURCES
>It works fine, but will generally no longer be improved.