### PR TITLE
Adding Proposed and CandidacySubmitted events to CouncilVoting and CouncilSeats.

### DIFF
--- a/srml/council/src/seats.rs
+++ b/srml/council/src/seats.rs
@@ -203,6 +203,8 @@ decl_module! {
 				.map_err(|_| "candidate has not enough funds")?;
 
 			<RegisterInfoOf<T>>::insert(&who, (Self::vote_index(), slot as u32));
+
+			Self::deposit_event(RawEvent::CandidacySubmitted(who.clone(), slot as u32));
 			let mut candidates = candidates;
 			if slot == candidates.len() {
 				candidates.push(who);
@@ -368,6 +370,8 @@ decl_storage! {
 
 decl_event!(
 	pub enum Event<T> where <T as system::Trait>::AccountId {
+		/// new candidate announced in given slot
+		CandidacySubmitted(AccountId, u32),
 		/// reaped voter, reaper
 		VoterReaped(AccountId, AccountId),
 		/// slashed reaper

--- a/srml/council/src/voting.rs
+++ b/srml/council/src/voting.rs
@@ -53,6 +53,7 @@ decl_module! {
 			<ProposalOf<T>>::insert(proposal_hash, *proposal);
 			<ProposalVoters<T>>::insert(proposal_hash, vec![who.clone()]);
 			<CouncilVoteOf<T>>::insert((proposal_hash, who.clone()), true);
+			Self::deposit_event(RawEvent::Proposed(proposal_hash, expiry));
 		}
 
 		fn vote(origin, proposal: T::Hash, approve: bool) {
@@ -126,7 +127,9 @@ decl_storage! {
 }
 
 decl_event!(
-	pub enum Event<T> where <T as system::Trait>::Hash {
+	pub enum Event<T> where <T as system::Trait>::Hash, <T as system::Trait>::BlockNumber {
+		/// A council proposal has been created, ending at provided block.
+		Proposed(Hash, BlockNumber),
 		/// A voting tally has happened for a referendum cancellation vote.
 		/// Last three are yes, no, abstain counts.
 		TallyCancelation(Hash, u32, u32, u32),


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/2317

This PR adds "created" events to make it easier for applications to track when votes are proposed and when candidacies are submitted.