### PR TITLE
Remove limitation to 256 transactions, don't construct a vector.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 62,
-	impl_version: 64,
+	impl_version: 65,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -61,7 +61,7 @@ use rstd::marker::PhantomData;
 use rstd::result;
 use primitives::traits::{
 	self, Header, Zero, One, Checkable, Applyable, CheckEqual, OnFinalize,
-	OnInitialize, As, Digest, NumberFor, Block as BlockT, OffchainWorker
+	OnInitialize, Digest, NumberFor, Block as BlockT, OffchainWorker
 };
 use srml_support::{Dispatchable, traits::MakePayment};
 use parity_codec::{Codec, Encode};
@@ -311,24 +311,23 @@ impl<
 			}
 
 			// check index
-			let mut expected_index = <system::Module<System>>::account_nonce(sender);
+			let expected_index = <system::Module<System>>::account_nonce(sender);
 			if index < &expected_index {
 				return TransactionValidity::Invalid(ApplyError::Stale as i8)
 			}
-			if *index > expected_index + As::sa(256) {
-				return TransactionValidity::Unknown(ApplyError::Future as i8)
-			}
 
-			let mut deps = Vec::new();
-			while expected_index < *index {
-				deps.push((sender, expected_index).encode());
-				expected_index = expected_index + One::one();
-			}
+			let index = *index;
+			let provides = vec![(sender, index).encode()];
+			let requires = if expected_index < index {
+				vec![(sender, index - One::one()).encode()]
+			} else {
+				vec![]
+			};
 
 			TransactionValidity::Valid {
 				priority: encoded_len as TransactionPriority,
-				requires: deps,
-				provides: vec![(sender, *index).encode()],
+				requires,
+				provides,
 				longevity: TransactionLongevity::max_value(),
 			}
 		} else {


### PR DESCRIPTION
For account based systems it's fine if we only require one previous transaction, the rest (everything else between `expected_nonce .. index - 1` is required transitvely)

This allows us to remove the limitation of max 257 queued transactions, cause the vector is now always bounded.

Fixes #2308 