### PR TITLE
Remove as<u64> for BlockNumber and or else

### DIFF
--- a/core/client/src/cht.rs
+++ b/core/client/src/cht.rs
@@ -276,7 +276,7 @@ pub fn block_to_cht_number<N: SimpleArithmetic>(cht_size: u64, block_num: N) -> 
 }
 
 /// Convert header number into CHT key.
-pub fn encode_cht_key<N: As<u64>>(number: N) -> Vec<u8> {
+pub fn encode_cht_key<N: From<u64>>(number: N) -> Vec<u8> {
 	let number: u64 = number.as_();
 	vec![
 		(number >> 56) as u8,

--- a/core/client/src/cht.rs
+++ b/core/client/src/cht.rs
@@ -276,7 +276,7 @@ pub fn block_to_cht_number<N: SimpleArithmetic>(cht_size: u64, block_num: N) -> 
 }
 
 /// Convert header number into CHT key.
-pub fn encode_cht_key<N: From<u64>>(number: N) -> Vec<u8> {
+pub fn encode_cht_key<N: As<u64>>(number: N) -> Vec<u8> {
 	let number: u64 = number.as_();
 	vec![
 		(number >> 56) as u8,

--- a/core/client/src/in_mem.rs
+++ b/core/client/src/in_mem.rs
@@ -625,7 +625,7 @@ where
 			if let Some(changes_trie_root) = changes_trie_root {
 				if let Some(changes_trie_update) = operation.changes_trie_update {
 					let changes_trie_root: H::Out = changes_trie_root.into();
-					self.changes_trie_storage.0.insert(header.number().as_(), changes_trie_root, changes_trie_update);
+					self.changes_trie_storage.0.insert(header.number(), changes_trie_root, changes_trie_update);
 				}
 			}
 

--- a/core/consensus/common/src/evaluation.rs
+++ b/core/consensus/common/src/evaluation.rs
@@ -72,8 +72,9 @@ pub fn evaluate_initial<Block: BlockT>(
 		));
 	}
 
-	if parent_number.as_() + 1 != proposal.header().number().as_() {
-		bail!(ErrorKind::WrongNumber(parent_number.as_() + 1, proposal.header().number().as_()));
+	if parent_number + 1.into() != *proposal.header().number() {
+		// TODO TODO: make error generic
+		bail!(ErrorKind::WrongNumber(0, 0));// parent_number + 1.into(), proposal.header().number()));
 	}
 
 	Ok(())

--- a/core/sr-primitives/src/generic/era.rs
+++ b/core/sr-primitives/src/generic/era.rs
@@ -20,6 +20,7 @@
 use serde_derive::{Serialize, Deserialize};
 
 use crate::codec::{Decode, Encode, Input, Output};
+use crate::traits::SimpleArithmetic;
 
 pub type Period = u64;
 pub type Phase = u64;
@@ -79,18 +80,20 @@ impl Era {
 
 	/// Get the block number of the start of the era whose properties this object
 	/// describes that `current` belongs to.
-	pub fn birth(self, current: u64) -> u64 {
+	pub fn birth<T: SimpleArithmetic + From<u64>>(self, current: T) -> T {
 		match self {
-			Era::Immortal => 0,
-			Era::Mortal(period, phase) => (current.max(phase) - phase) / period * period + phase,
+			Era::Immortal => T::zero(),
+			Era::Mortal(period, phase) => {
+				(current.max(phase.into()) - phase.into()) / period.into() * period.into() + phase.into()
+			}
 		}
 	}
 
 	/// Get the block number of the first block at which the era has ended.
-	pub fn death(self, current: u64) -> u64 {
+	pub fn death<T: SimpleArithmetic + From<u64>>(self, current: T) -> T {
 		match self {
-			Era::Immortal => u64::max_value(),
-			Era::Mortal(period, _) => self.birth(current) + period,
+			Era::Immortal => T::max_value(),
+			Era::Mortal(period, _) => self.birth(current) + period.into(),
 		}
 	}
 }

--- a/core/sr-primitives/src/generic/header.rs
+++ b/core/sr-primitives/src/generic/header.rs
@@ -84,7 +84,7 @@ impl<Number, Hash, DigestItem> Encode for Header<Number, Hash, DigestItem> where
 }
 
 impl<Number, Hash, DigestItem> traits::Header for Header<Number, Hash, DigestItem> where
-	Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + MaybeDisplay + SimpleArithmetic + Codec + Copy + Into<u128>,
+	Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + MaybeDisplay + SimpleArithmetic + Codec + Copy + Into<u128> + From<u64>,
 	Hash: HashT,
 	DigestItem: DigestItemT<Hash = Hash::Output> + Codec,
 	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeSerializeDebugButNotDeserialize + MaybeDisplay + SimpleBitOps + Codec,

--- a/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_compact_extrinsic.rs
@@ -73,7 +73,7 @@ where
 	Call: Encode + Member,
 	Signature: Member + traits::Verify<Signer=AccountId>,
 	AccountId: Member + MaybeDisplay,
-	BlockNumber: SimpleArithmetic,
+	BlockNumber: SimpleArithmetic + From<u64>,
 	Hash: Encode,
 	Context: Lookup<Source=Address, Target=AccountId>
 		+ CurrentHeight<BlockNumber=BlockNumber>
@@ -84,7 +84,7 @@ where
 	fn check(self, context: &Context) -> Result<Self::Checked, &'static str> {
 		Ok(match self.signature {
 			Some((signed, signature, index, era)) => {
-				let h = context.block_number_to_hash(BlockNumber::sa(era.birth(context.current_height().as_())))
+				let h = context.block_number_to_hash(era.birth(context.current_height()))
 					.ok_or("transaction birth block ancient")?;
 				let signed = context.lookup(signed)?;
 				let raw_payload = (index, self.function, era, h);

--- a/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_mortal_extrinsic.rs
@@ -72,7 +72,7 @@ where
 	Call: Encode + Member,
 	Signature: Member + traits::Verify<Signer=AccountId>,
 	AccountId: Member + MaybeDisplay,
-	BlockNumber: SimpleArithmetic,
+	BlockNumber: SimpleArithmetic + From<u64>,
 	Hash: Encode,
 	Context: Lookup<Source=Address, Target=AccountId>
 		+ CurrentHeight<BlockNumber=BlockNumber>
@@ -83,7 +83,7 @@ where
 	fn check(self, context: &Context) -> Result<Self::Checked, &'static str> {
 		Ok(match self.signature {
 			Some((signed, signature, index, era)) => {
-				let h = context.block_number_to_hash(BlockNumber::sa(era.birth(context.current_height().as_())))
+				let h = context.block_number_to_hash(era.birth(context.current_height()))
 					.ok_or("transaction birth block ancient")?;
 				let signed = context.lookup(signed)?;
 				let raw_payload = (index, self.function, era, h);

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -575,7 +575,7 @@ impl<T: Send + Sync + Sized + MaybeDebug + Eq + PartialEq + Clone + 'static> Mem
 /// You can also create a `new` one from those fields.
 pub trait Header: Clone + Send + Sync + Codec + Eq + MaybeSerializeDebugButNotDeserialize + 'static {
 	/// Header number.
-	type Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec + Into<u64>;
+	type Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec + From<u64>;
 	/// Header hash type
 	type Hash: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + Default + SimpleBitOps + Codec + AsRef<[u8]> + AsMut<[u8]>;
 	/// Hashing algorithm

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -216,7 +216,7 @@ impl_numerics!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
 
 /// A meta trait for arithmetic.
 pub trait SimpleArithmetic:
-	Zero + One + IntegerSquareRoot + As<u64> +
+	Zero + One + IntegerSquareRoot +
 	Add<Self, Output = Self> + AddAssign<Self> +
 	Sub<Self, Output = Self> + SubAssign<Self> +
 	Mul<Self, Output = Self> + MulAssign<Self> +
@@ -234,7 +234,7 @@ pub trait SimpleArithmetic:
 	HasCompact
 {}
 impl<T:
-	Zero + One + IntegerSquareRoot + As<u64> +
+	Zero + One + IntegerSquareRoot +
 	Add<Self, Output = Self> + AddAssign<Self> +
 	Sub<Self, Output = Self> + SubAssign<Self> +
 	Mul<Self, Output = Self> + MulAssign<Self> +
@@ -575,7 +575,7 @@ impl<T: Send + Sync + Sized + MaybeDebug + Eq + PartialEq + Clone + 'static> Mem
 /// You can also create a `new` one from those fields.
 pub trait Header: Clone + Send + Sync + Codec + Eq + MaybeSerializeDebugButNotDeserialize + 'static {
 	/// Header number.
-	type Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec;
+	type Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec + Into<u64>;
 	/// Header hash type
 	type Hash: Member + MaybeSerializeDebug + ::rstd::hash::Hash + Copy + MaybeDisplay + Default + SimpleBitOps + Codec + AsRef<[u8]> + AsMut<[u8]>;
 	/// Hashing algorithm

--- a/core/state-machine/src/changes_trie/mod.rs
+++ b/core/state-machine/src/changes_trie/mod.rs
@@ -68,10 +68,10 @@ pub struct AnchorBlockId<Hash: ::std::fmt::Debug> {
 }
 
 /// Changes trie storage. Provides access to trie roots and trie nodes.
-pub trait RootsStorage<H: Hasher>: Send + Sync {
+pub trait RootsStorage<H: Hasher, BlockNumber>: Send + Sync {
 	/// Get changes trie root for the block with given number which is an ancestor (or the block
 	/// itself) of the anchor_block (i.e. anchor_block.number >= block).
-	fn root(&self, anchor: &AnchorBlockId<H::Out>, block: u64) -> Result<Option<H::Out>, String>;
+	fn root(&self, anchor: &AnchorBlockId<H::Out>, block: BlockNumber) -> Result<Option<H::Out>, String>;
 }
 
 /// Changes trie storage. Provides access to trie roots and trie nodes.

--- a/core/state-machine/src/testing.rs
+++ b/core/state-machine/src/testing.rs
@@ -28,14 +28,14 @@ use parity_codec::Encode;
 use super::{Externalities, OverlayedChanges};
 
 /// Simple HashMap-based Externalities impl.
-pub struct TestExternalities<H: Hasher> where H::Out: HeapSizeOf {
+pub struct TestExternalities<H: Hasher, BlockNumber> where H::Out: HeapSizeOf {
 	inner: HashMap<Vec<u8>, Vec<u8>>,
-	changes_trie_storage: ChangesTrieInMemoryStorage<H>,
+	changes_trie_storage: ChangesTrieInMemoryStorage<H, BlockNumber>,
 	changes: OverlayedChanges,
 	code: Option<Vec<u8>>,
 }
 
-impl<H: Hasher> TestExternalities<H> where H::Out: HeapSizeOf {
+impl<H: Hasher, BlockNumber> TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
 	/// Create a new instance of `TestExternalities`
 	pub fn new(inner: HashMap<Vec<u8>, Vec<u8>>) -> Self {
 		Self::new_with_code(&[], inner)
@@ -66,19 +66,19 @@ impl<H: Hasher> TestExternalities<H> where H::Out: HeapSizeOf {
 	}
 }
 
-impl<H: Hasher> ::std::fmt::Debug for TestExternalities<H> where H::Out: HeapSizeOf {
+impl<H: Hasher, BlockNumber> ::std::fmt::Debug for TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
 		write!(f, "{:?}", self.inner)
 	}
 }
 
-impl<H: Hasher> PartialEq for TestExternalities<H> where H::Out: HeapSizeOf {
-	fn eq(&self, other: &TestExternalities<H>) -> bool {
+impl<H: Hasher, BlockNumber> PartialEq for TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
+	fn eq(&self, other: &TestExternalities<H, BlockNumber>) -> bool {
 		self.inner.eq(&other.inner)
 	}
 }
 
-impl<H: Hasher> FromIterator<(Vec<u8>, Vec<u8>)> for TestExternalities<H> where H::Out: HeapSizeOf {
+impl<H: Hasher, BlockNumber> FromIterator<(Vec<u8>, Vec<u8>)> for TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
 	fn from_iter<I: IntoIterator<Item=(Vec<u8>, Vec<u8>)>>(iter: I) -> Self {
 		let mut t = Self::new(Default::default());
 		t.inner.extend(iter);
@@ -86,17 +86,17 @@ impl<H: Hasher> FromIterator<(Vec<u8>, Vec<u8>)> for TestExternalities<H> where 
 	}
 }
 
-impl<H: Hasher> Default for TestExternalities<H> where H::Out: HeapSizeOf {
+impl<H: Hasher, BlockNumber> Default for TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
 	fn default() -> Self { Self::new(Default::default()) }
 }
 
-impl<H: Hasher> From<TestExternalities<H>> for HashMap<Vec<u8>, Vec<u8>> where H::Out: HeapSizeOf {
-	fn from(tex: TestExternalities<H>) -> Self {
+impl<H: Hasher, BlockNumber> From<TestExternalities<H, BlockNumber>> for HashMap<Vec<u8>, Vec<u8>> where H::Out: HeapSizeOf {
+	fn from(tex: TestExternalities<H, BlockNumber>) -> Self {
 		tex.inner.into()
 	}
 }
 
-impl<H: Hasher> From< HashMap<Vec<u8>, Vec<u8>> > for TestExternalities<H> where H::Out: HeapSizeOf {
+impl<H: Hasher, BlockNumber> From< HashMap<Vec<u8>, Vec<u8>> > for TestExternalities<H, BlockNumber> where H::Out: HeapSizeOf {
 	fn from(hashmap: HashMap<Vec<u8>, Vec<u8>>) -> Self {
 		TestExternalities {
 			inner: hashmap,
@@ -110,7 +110,7 @@ impl<H: Hasher> From< HashMap<Vec<u8>, Vec<u8>> > for TestExternalities<H> where
 // TODO child test primitives are currently limited to `changes` (for non child the way
 // things are defined seems utterly odd to (put changes in changes but never make them
 // available for read through inner)
-impl<H: Hasher> Externalities<H> for TestExternalities<H> where H::Out: Ord + HeapSizeOf {
+impl<H: Hasher, BlockNumber> Externalities<H> for TestExternalities<H, BlockNumber> where H::Out: Ord + HeapSizeOf {
 	fn storage(&self, key: &[u8]) -> Option<Vec<u8>> {
 		match key {
 			CODE => self.code.clone(),

--- a/core/transaction-pool/graph/src/pool.rs
+++ b/core/transaction-pool/graph/src/pool.rs
@@ -138,7 +138,7 @@ impl<B: ChainApi> Pool<B> {
 							priority,
 							requires,
 							provides,
-							valid_till: block_number.as_().saturating_add(longevity),
+							valid_till: block_number.into().saturating_add(longevity),
 						})
 					},
 					TransactionValidity::Invalid(e) => {

--- a/core/transaction-pool/graph/src/rotator.rs
+++ b/core/transaction-pool/graph/src/rotator.rs
@@ -79,7 +79,7 @@ impl<Hash: hash::Hash + Eq + Clone> PoolRotator<Hash> {
 	/// Bans extrinsic if it's stale.
 	///
 	/// Returns `true` if extrinsic is stale and got banned.
-	pub fn ban_if_stale<Ex>(&self, now: &Instant, current_block: u64, xt: &Transaction<Hash, Ex>) -> bool {
+	pub fn ban_if_stale<Ex, BlockNumber: Ord>(&self, now: &Instant, current_block: BlockNumber, xt: &Transaction<Hash, Ex, BlockNumber>) -> bool {
 		if xt.valid_till > current_block {
 			return false;
 		}

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -135,7 +135,7 @@ pub trait Trait: 'static + Eq + Clone {
 	/// The block number type used by the runtime.
 	type BlockNumber:
 		Parameter + Member + MaybeSerializeDebug + MaybeDisplay + SimpleArithmetic + Default + Bounded + Copy
-		+ rstd::hash::Hash;
+		+ rstd::hash::Hash + From<u64>;
 
 	/// The output of the `Hashing` function.
 	type Hash:


### PR DESCRIPTION
This PR is nowhere near being mergable. It is just an first attempt to remove `as<u64>` from simple arithmetic and show progress on it.

For now it only add a generic BlockNumber to some structures in core.

Current issue:
* to build proof client make use of encode_cht_key which convert blocknumber to u64, I don't know that much about that part and how it should be changed yet.