### PR TITLE
ProtocolId can now be more than 3 bytes

### DIFF
--- a/core/network-libp2p/src/custom_proto/upgrade.rs
+++ b/core/network-libp2p/src/custom_proto/upgrade.rs
@@ -44,10 +44,11 @@ pub struct RegisteredProtocol<TMessage> {
 impl<TMessage> RegisteredProtocol<TMessage> {
 	/// Creates a new `RegisteredProtocol`. The `custom_data` parameter will be
 	/// passed inside the `RegisteredProtocolOutput`.
-	pub fn new(protocol: ProtocolId, versions: &[u8])
+	pub fn new(protocol: impl Into<ProtocolId>, versions: &[u8])
 		-> Self {
+		let protocol = protocol.into();
 		let mut base_name = Bytes::from_static(b"/substrate/");
-		base_name.extend_from_slice(&protocol);
+		base_name.extend_from_slice(protocol.as_bytes());
 		base_name.extend_from_slice(b"/");
 
 		RegisteredProtocol {
@@ -63,16 +64,15 @@ impl<TMessage> RegisteredProtocol<TMessage> {
 	}
 
 	/// Returns the ID of the protocol.
-	#[inline]
-	pub fn id(&self) -> ProtocolId {
-		self.id
+	pub fn id(&self) -> &ProtocolId {
+		&self.id
 	}
 }
 
 impl<TMessage> Clone for RegisteredProtocol<TMessage> {
 	fn clone(&self) -> Self {
 		RegisteredProtocol {
-			id: self.id,
+			id: self.id.clone(),
 			base_name: self.base_name.clone(),
 			supported_versions: self.supported_versions.clone(),
 			marker: PhantomData,
@@ -110,8 +110,8 @@ pub struct RegisteredProtocolSubstream<TMessage, TSubstream> {
 impl<TMessage, TSubstream> RegisteredProtocolSubstream<TMessage, TSubstream> {
 	/// Returns the protocol id.
 	#[inline]
-	pub fn protocol_id(&self) -> ProtocolId {
-		self.protocol_id
+	pub fn protocol_id(&self) -> &ProtocolId {
+		&self.protocol_id
 	}
 
 	/// Returns the version of the protocol that was negotiated.

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -38,8 +38,22 @@ use serde_derive::{Deserialize, Serialize};
 use slog_derive::SerdeValue;
 use std::{collections::{HashMap, HashSet}, error, fmt, time::Duration};
 
-/// Protocol / handler id
-pub type ProtocolId = [u8; 3];
+/// Name of a protocol, transmitted on the wire. Should be unique for each chain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProtocolId(smallvec::SmallVec<[u8; 6]>);
+
+impl<'a> From<&'a [u8]> for ProtocolId {
+	fn from(bytes: &'a [u8]) -> ProtocolId {
+		ProtocolId(bytes.into())
+	}
+}
+
+impl ProtocolId {
+	/// Exposes the `ProtocolId` as bytes.
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_ref()
+	}
+}
 
 /// Parses a string address and returns the component, if valid.
 pub fn parse_str_addr(addr_str: &str) -> Result<(PeerId, Multiaddr), ParseErr> {

--- a/core/network-libp2p/tests/test.rs
+++ b/core/network-libp2p/tests/test.rs
@@ -40,7 +40,7 @@ fn build_nodes<TMsg>(num: usize) -> Vec<substrate_network_libp2p::Service<TMsg>>
 			..substrate_network_libp2p::NetworkConfiguration::default()
 		};
 
-		let proto = substrate_network_libp2p::RegisteredProtocol::new(*b"tst", &[1]);
+		let proto = substrate_network_libp2p::RegisteredProtocol::new(&b"tst"[..], &[1]);
 		result.push(substrate_network_libp2p::start_service(config, proto).unwrap().0);
 	}
 

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -186,13 +186,7 @@ impl<Components: components::Components> Service<Components> {
 					DEFAULT_PROTOCOL_ID
 				}
 			}.as_bytes();
-			let mut protocol_id = network::ProtocolId::default();
-			if protocol_id_full.len() > protocol_id.len() {
-				warn!("Protocol ID truncated to {} chars", protocol_id.len());
-			}
-			let id_len = protocol_id_full.len().min(protocol_id.len());
-			&mut protocol_id[0..id_len].copy_from_slice(&protocol_id_full[0..id_len]);
-			protocol_id
+			network::ProtocolId::from(protocol_id_full)
 		};
 
 		let has_bootnodes = !network_params.network_config.boot_nodes.is_empty();


### PR DESCRIPTION
Turns `ProtocolId` into a `SmallVec` instead of a `[u8; 3]`.

I put the "breaksapi" label, but this only breaks the networking API which is unstable. Technically this doesn't consist in a breaking change, but I put it just in case.