### PR TITLE
git: allow diffing Cargo.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-Cargo.lock linguist-generated=true -diff
+Cargo.lock linguist-generated=true


### PR DESCRIPTION
I don't know why this was done but my editor respects this and I have to edit it out every time I want to diff the `Cargo.lock`.