### PR TITLE
CI update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -226,7 +226,7 @@ publish-s3-doc:
   stage:                           deploy
   when:                            manual
   retry:                           1
-  image:                           parity/kubectl-helm:$HELM_VERSION
+  image:                           parity/kubetools:latest
   <<:                              *build-only
   tags:
     # this is the runner that is used to deploy it


### PR DESCRIPTION
image name was changed, pipeline **will** fail
previous image was outdated and does not exist any more,
current image is not yet on docker hub