### PR TITLE
Add `pub` to functions in Contract module

### DIFF
--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -244,7 +244,7 @@ decl_module! {
 		/// Updates the schedule for metering contracts.
 		///
 		/// The schedule must have a greater version than the stored schedule.
-		fn update_schedule(schedule: Schedule<T::Gas>) -> Result {
+		pub fn update_schedule(schedule: Schedule<T::Gas>) -> Result {
 			if <Module<T>>::current_schedule().version >= schedule.version {
 				return Err("new schedule must have a greater version than current");
 			}
@@ -257,7 +257,7 @@ decl_module! {
 
 		/// Stores the given binary Wasm code into the chain's storage and returns its `codehash`.
 		/// You can instantiate contracts only with stored code.
-		fn put_code(
+		pub fn put_code(
 			origin,
 			#[compact] gas_limit: T::Gas,
 			code: Vec<u8>
@@ -284,7 +284,7 @@ decl_module! {
 		/// * If the account is a regular account, any value will be transferred.
 		/// * If no account exists and the call value is not less than `existential_deposit`,
 		/// a regular account will be created and any value will be transferred.
-		fn call(
+		pub fn call(
 			origin,
 			dest: <T::Lookup as StaticLookup>::Source,
 			#[compact] value: BalanceOf<T>,
@@ -340,7 +340,7 @@ decl_module! {
 		///   after the execution is saved as the `code` of the account. That code will be invoked
 		///   upon any call received by this account.
 		/// - The contract is initialized.
-		fn create(
+		pub fn create(
 			origin,
 			#[compact] endowment: BalanceOf<T>,
 			#[compact] gas_limit: T::Gas,
@@ -384,7 +384,7 @@ decl_module! {
 			result.map(|_| ())
 		}
 
-		fn on_finalize() {
+		pub fn on_finalize() {
 			<GasSpent<T>>::kill();
 		}
 	}

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -384,7 +384,7 @@ decl_module! {
 			result.map(|_| ())
 		}
 
-		pub fn on_finalize() {
+		fn on_finalize() {
 			<GasSpent<T>>::kill();
 		}
 	}


### PR DESCRIPTION
This is to support a wrapper module which will add an access control layer to the SRML Contract module.

See: https://github.com/shawntabrizi/sudo-contract

I am not 100% this will work, so if there are suggestions or guidance here, I am open ears.