### PR TITLE
Split Context::send_message into multiple methods

### DIFF
--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -123,10 +123,10 @@ impl<'g, 'p, B: BlockT> ValidatorContext<B> for NetworkContext<'g, 'p, B> {
 
 	/// Send addressed message to a peer.
 	fn send_message(&mut self, who: &PeerId, message: Vec<u8>) {
-		self.protocol.send_message(who.clone(), Message::Consensus(ConsensusMessage {
+		self.protocol.send_consensus(who.clone(), ConsensusMessage {
 			engine_id: self.engine_id,
 			data: message,
-		}));
+		});
 	}
 
 	/// Send all messages with given topic to a peer.
@@ -183,7 +183,7 @@ fn propagate<'a, B: BlockT, I>(
 			}
 			peer.known_messages.insert(message_hash.clone());
 			trace!(target: "gossip", "Propagating to {}: {:?}", id, message);
-			protocol.send_message(id.clone(), Message::Consensus(message.clone()));
+			protocol.send_consensus(id.clone(), message.clone());
 		}
 	}
 }
@@ -452,10 +452,10 @@ impl<B: BlockT> ConsensusGossip<B> {
 				}
 				peer.known_messages.insert(entry.message_hash.clone());
 				trace!(target: "gossip", "Sending topic message to {}: {:?}", who, entry.message);
-				protocol.send_message(who.clone(), Message::Consensus(ConsensusMessage {
+				protocol.send_consensus(who.clone(), ConsensusMessage {
 					engine_id: engine_id.clone(),
 					data: entry.message.data.clone(),
-				}));
+				});
 			}
 		}
 	}
@@ -492,7 +492,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 		trace!(target: "gossip", "Sending direct to {}: {:?}", who, message);
 
 		peer.known_messages.insert(message_hash);
-		protocol.send_message(who.clone(), Message::Consensus(message.clone()));
+		protocol.send_consensus(who.clone(), message.clone());
 	}
 }
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -22,7 +22,7 @@ use primitives::storage::StorageKey;
 use runtime_primitives::{generic::BlockId, ConsensusEngineId};
 use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, NumberFor, Zero};
 use consensus::import_queue::ImportQueue;
-use crate::message::{self, Message};
+use crate::message::{self, BlockRequest as BlockRequestMessage, Message};
 use crate::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
 use crate::on_demand::OnDemandService;
@@ -145,8 +145,14 @@ pub trait Context<B: BlockT> {
 	/// Get peer info.
 	fn peer_info(&self, peer: &PeerId) -> Option<PeerInfo<B>>;
 
-	/// Send a message to a peer.
-	fn send_message(&mut self, who: PeerId, data: crate::message::Message<B>);
+	/// Request a block from a peer.
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>);
+
+	/// Send a consensus message to a peer.
+	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage);
+
+	/// Send a chain-specific message to a peer.
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>);
 }
 
 /// Protocol context.
@@ -162,10 +168,6 @@ impl<'a, B: BlockT + 'a, H: 'a + ExHashT> ProtocolContext<'a, B, H> {
 }
 
 impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, H> {
-	fn send_message(&mut self, who: PeerId, message: Message<B>) {
-		send_message(&mut self.context_data.peers, &self.network_chan, who, message)
-	}
-
 	fn report_peer(&mut self, who: PeerId, reason: Severity) {
 		self.network_chan.send(NetworkMsg::ReportPeer(who, reason))
 	}
@@ -176,6 +178,21 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 
 	fn client(&self) -> &Client<B> {
 		&*self.context_data.chain
+	}
+
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::BlockRequest(request))
+	}
+
+	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::Consensus(consensus))
+	}
+
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::ChainSpecific(message))
 	}
 }
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -182,17 +182,20 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 
 	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>) {
 		send_message(&mut self.context_data.peers, &self.network_chan, who,
-			GenericMessage::BlockRequest(request))
+			GenericMessage::BlockRequest(request)
+		)
 	}
 
 	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage) {
 		send_message(&mut self.context_data.peers, &self.network_chan, who,
-			GenericMessage::Consensus(consensus))
+			GenericMessage::Consensus(consensus)
+		)
 	}
 
 	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {
 		send_message(&mut self.context_data.peers, &self.network_chan, who,
-			GenericMessage::ChainSpecific(message))
+			GenericMessage::ChainSpecific(message)
+		)
 	}
 }
 

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -29,7 +29,7 @@ use crate::blocks::BlockCollection;
 use runtime_primitives::Justification;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, NumberFor, Zero, CheckedSub};
 use runtime_primitives::generic::BlockId;
-use crate::message::{self, generic::Message as GenericMessage};
+use crate::message;
 use crate::config::Roles;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -200,7 +200,7 @@ impl<B: BlockT> PendingJustifications<B> {
 				max: Some(1),
 			};
 
-			protocol.send_message(peer, GenericMessage::BlockRequest(request));
+			protocol.send_block_request(peer, request);
 		}
 
 		self.pending_requests.append(&mut unhandled_requests);
@@ -984,7 +984,7 @@ impl<B: BlockT> ChainSync<B> {
 						max: Some(1),
 					};
 					peer.state = PeerSyncState::DownloadingStale(*hash);
-					protocol.send_message(who, GenericMessage::BlockRequest(request));
+					protocol.send_block_request(who, request);
 				},
 				_ => (),
 			}
@@ -1005,7 +1005,7 @@ impl<B: BlockT> ChainSync<B> {
 						max: Some(MAX_UNKNOWN_FORK_DOWNLOAD_LEN),
 					};
 					peer.state = PeerSyncState::DownloadingStale(*hash);
-					protocol.send_message(who, GenericMessage::BlockRequest(request));
+					protocol.send_block_request(who, request);
 				},
 				_ => (),
 			}
@@ -1034,7 +1034,7 @@ impl<B: BlockT> ChainSync<B> {
 							max: Some((range.end - range.start).as_() as u32),
 						};
 						peer.state = PeerSyncState::DownloadingNew(range.start);
-						protocol.send_message(who, GenericMessage::BlockRequest(request));
+						protocol.send_block_request(who, request);
 					} else {
 						trace!(target: "sync", "Nothing to request");
 					}
@@ -1054,7 +1054,7 @@ impl<B: BlockT> ChainSync<B> {
 			direction: message::Direction::Ascending,
 			max: Some(1),
 		};
-		protocol.send_message(who, GenericMessage::BlockRequest(request));
+		protocol.send_block_request(who, request);
 	}
 }
 


### PR DESCRIPTION
Starting some refactoring of the `network` crate.
Replaces `Context::send_message` with more specialized methods, so that we can eventually isolate code a bit more.

I kept `send_chain_specific` because it is used by Polkadot.