### PR TITLE
rm cargo install --git https://github.com/alexcrichton/wasm-gc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -184,7 +184,6 @@ curl https://sh.rustup.rs -sSf | sh
 rustup update nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 rustup update stable
-cargo install --git https://github.com/alexcrichton/wasm-gc
 ----
 
 You will also need to install the following packages:


### PR DESCRIPTION
No longer needed according to https://github.com/alexcrichton/wasm-gc.