### PR TITLE
Reduce penalty when InvalidViewChange

### DIFF
--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -65,7 +65,7 @@ mod cost {
 	pub(super) const MALFORMED_COMMIT: i32 = -1000;
 	pub(super) const FUTURE_MESSAGE: i32 = -500;
 
-	pub(super) const INVALID_VIEW_CHANGE: i32 = -500;
+	pub(super) const INVALID_VIEW_CHANGE: i32 = -100;
 	pub(super) const PER_UNDECODABLE_BYTE: i32 = -5;
 	pub(super) const PER_SIGNATURE_CHECKED: i32 = -25;
 	pub(super) const PER_BLOCK_LOADED: i32 = -10;


### PR DESCRIPTION
Non validator nodes are getting commits (and Neighbor Packages) out of height order and they are disconnecting from peers due to the penalty they apply for `InvalidViewChange`.

This PR only provides a temporal solution until I figure it out what is happening. 

Possible related issues: #2396, #2335

\cc @rphmeier @andresilva
