### PR TITLE
Make libp2p compile for wasm32-unkown-unknown

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,17 @@ test-linux-stable:                 &test
     - time cargo test --all --release --verbose --locked
     - sccache -s
 
+check-web-wasm:
+  stage:                           test
+  image:                           tomaka/cargo-web:latest
+  allow_failure: true
+  only:
+    - master
+  script:
+    # WASM support is in progress. As more and more crates support WASM, we
+    # should add entries here.
+    - time cargo web build -p substrate-network-libp2p
+
 .build-only:                      &build-only
   only:
     - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4179,7 +4179,6 @@ dependencies = [
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-peerset 1.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/network-libp2p/Cargo.toml
+++ b/core/network-libp2p/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0.70", features = ["derive"] }
 serde_json = "1.0.24"
 smallvec = "0.6"
 substrate-peerset = { path = "../peerset" }
-tokio = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2"
 unsigned-varint = { version = "0.2.1", features = ["codec"] }


### PR DESCRIPTION
I started working on compiling a Substrate light client for the browser.
This PR makes the `substrate-network-libp2p` crate compile successfully for WASM, and introduces a new CI step that checks whether it compiles.

Needs a review for the CI step.
