### PR TITLE
store contract keys with blake2_256

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 66,
+	spec_version: 67,
 	impl_version: 67,
 	apis: RUNTIME_API_VERSIONS,
 };


### PR DESCRIPTION
related to https://github.com/paritytech/substrate/issues/2365

also it could be better to have safety in child storage. https://github.com/paritytech/substrate/issues/2413

(I'm not sure I completely know why it is not the responsability of the contract to do it though)