### PR TITLE
Depreate functions that spawn a thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
  "substrate-basic-authorship 1.0.0",
  "substrate-cli 1.0.0",
  "substrate-client 1.0.0",
- "substrate-consensus-aura 1.0.1",
+ "substrate-consensus-aura 1.1.0",
  "substrate-finality-grandpa 1.0.0",
  "substrate-inherents 1.0.0",
  "substrate-keystore 1.0.0",
@@ -2105,7 +2105,7 @@ dependencies = [
  "substrate-basic-authorship 1.0.0",
  "substrate-cli 1.0.0",
  "substrate-client 1.0.0",
- "substrate-consensus-aura 1.0.1",
+ "substrate-consensus-aura 1.1.0",
  "substrate-executor 1.0.0",
  "substrate-inherents 1.0.0",
  "substrate-network 0.1.0",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-consensus-aura"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3892,7 +3892,7 @@ dependencies = [
  "substrate-consensus-aura-primitives 1.0.0",
  "substrate-consensus-authorities 1.0.0",
  "substrate-consensus-common 1.0.0",
- "substrate-consensus-slots 1.0.0",
+ "substrate-consensus-slots 1.1.0",
  "substrate-executor 1.0.0",
  "substrate-inherents 1.0.0",
  "substrate-keyring 1.0.0",
@@ -3947,7 +3947,7 @@ dependencies = [
  "substrate-consensus-authorities 1.0.0",
  "substrate-consensus-babe-primitives 1.0.0",
  "substrate-consensus-common 1.0.0",
- "substrate-consensus-slots 1.0.0",
+ "substrate-consensus-slots 1.1.0",
  "substrate-executor 1.0.0",
  "substrate-inherents 1.0.0",
  "substrate-keyring 1.0.0",
@@ -3966,7 +3966,7 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 1.0.0",
  "substrate-client 1.0.0",
- "substrate-consensus-slots 1.0.0",
+ "substrate-consensus-slots 1.1.0",
 ]
 
 [[package]]
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-consensus-slots"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/consensus/aura/Cargo.toml
+++ b/core/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-aura"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Aura consensus algorithm for substrate"
 edition = "2018"

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -194,6 +194,7 @@ impl SlotCompatible for AuraSlotCompatible {
 }
 
 /// Start the aura worker in a separate thread.
+#[deprecated(since = "1.1", note = "Please spawn a thread manually")]
 pub fn start_aura_thread<B, C, E, I, P, SO, Error, OnExit>(
 	slot_duration: SlotDuration,
 	local_key: Arc<P>,
@@ -231,6 +232,7 @@ pub fn start_aura_thread<B, C, E, I, P, SO, Error, OnExit>(
 		force_authoring,
 	};
 
+	#[allow(deprecated)]	// The function we are in is also deprecated.
 	slots::start_slot_worker_thread::<_, _, _, _, AuraSlotCompatible, u64, _>(
 		slot_duration.0,
 		client,

--- a/core/consensus/slots/Cargo.toml
+++ b/core/consensus/slots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-slots"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic slots-based utilities for consensus"
 edition = "2018"

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -71,6 +71,7 @@ pub fn inherent_to_common_error(err: inherents::RuntimeString) -> consensus_comm
 }
 
 /// Start a new slot worker in a separate thread.
+#[deprecated(since = "1.1", note = "Please spawn a thread manually")]
 pub fn start_slot_worker_thread<B, C, W, SO, SC, T, OnExit>(
 	slot_duration: SlotDuration<T>,
 	client: Arc<C>,


### PR DESCRIPTION
For #2416, let's deprecate the functions that call `thread::spawn` and instead ask the user to create a thread themselves if they want one.

The two deprecated functions aren't used anywhere.