### PR TITLE
Pass CLI `RunCmd` parameter to the user

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -201,7 +201,7 @@ where
 	CC: StructOpt + Clone + GetLogFilter,
 	RP: StructOpt + Clone + AugmentClap,
 	E: IntoExit,
-	RS: FnOnce(E, RP, FactoryFullConfiguration<F>) -> Result<(), String>,
+	RS: FnOnce(E, RunCmd, RP, FactoryFullConfiguration<F>) -> Result<(), String>,
 	I: IntoIterator<Item = T>,
 	T: Into<std::ffi::OsString> + Clone,
 {
@@ -516,11 +516,11 @@ where
 	F: ServiceFactory,
 	E: IntoExit,
 	S: FnOnce(&str) -> Result<Option<ChainSpec<FactoryGenesis<F>>>, String>,
-	RS: FnOnce(E, RP, FactoryFullConfiguration<F>) -> Result<(), String>,
+	RS: FnOnce(E, RunCmd, RP, FactoryFullConfiguration<F>) -> Result<(), String>,
  {
-	let config = create_run_node_config::<F, _>(cli.left, spec_factory, impl_name, version)?;
+	let config = create_run_node_config::<F, _>(cli.left.clone(), spec_factory, impl_name, version)?;
 
-	run_service(exit, cli.right, config).map_err(Into::into)
+	run_service(exit, cli.left, cli.right, config).map_err(Into::into)
 }
 
 //

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -17,7 +17,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 {
 	parse_and_execute::<service::Factory, NoCustom, NoCustom, _, _, _, _, _>(
 		load_spec, &version, "substrate-node", args, exit,
-	 	|exit, _custom_args, config| {
+	 	|exit, _cli_args, _custom_args, config| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by {}, 2017, 2018", version.author);

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -80,7 +80,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 {
 	cli::parse_and_execute::<service::Factory, NoCustom, NoCustom, _, _, _, _, _>(
 		load_spec, &version, "substrate-node", args, exit,
-		|exit, _custom_args, config| {
+		|exit, _cli_args, _custom_args, config| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by Parity Technologies, 2017-2019");


### PR DESCRIPTION
This is a breaking change and not sure if this is the best way to do it.

But I want to be able to customize the config including the core one before running the node, without the needs to fork substrate.

This also allow me to implement something like `--my-dev` which set bunch parameters include chain, cors, validator, key, etc. Similar to `--dev`, but with different set of configs.