### PR TITLE
Allow Blake2 and twoxx hashing in no_std

### DIFF
--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -9,7 +9,7 @@ rstd = { package = "sr-std", path = "../sr-std", default-features = false }
 parity-codec = { version = "3.4.0", default-features = false, features = ["derive"] }
 rustc-hex = { version = "2.0", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-twox-hash = { version = "1.2.0", optional = true }
+twox-hash = { version = "1.2.0", default-features = false }
 byteorder = { version = "1.3.1", default-features = false }
 primitive-types = { version = "0.2", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.1", optional = true }
@@ -19,7 +19,7 @@ hash256-std-hasher = { version = "0.12", default-features = false }
 ring = { version = "0.14", optional = true }
 untrusted = { version = "0.6", optional = true }
 base58 = { version = "0.1", optional = true }
-blake2-rfc = { version = "0.2.18", optional = true }
+blake2-rfc = { version = "0.2.18", default-features = false}
 schnorrkel = { version = "0.1", optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
@@ -52,8 +52,8 @@ std = [
 	"rstd/std",
 	"serde",
 	"rustc-hex/std",
-	"twox-hash",
-	"blake2-rfc",
+	"twox-hash/std",
+	"blake2-rfc/std",
 	"ring",
 	"untrusted",
 	"hex",

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -43,9 +43,7 @@ use serde::{Serialize, Deserialize};
 #[cfg(feature = "std")]
 pub use impl_serde::serialize as bytes;
 
-#[cfg(feature = "std")]
 pub mod hashing;
-#[cfg(feature = "std")]
 pub use hashing::{blake2_128, blake2_256, twox_64, twox_128, twox_256};
 #[cfg(feature = "std")]
 pub mod hexdisplay;


### PR DESCRIPTION
In order to use `substrate-primitives::blake2_256` in `no_std` environment, I suggest this PR

Currently, it fails because dependency twox_hash doesn't support no_std (actually, the dependency wouldn't be necessary to use blake2)
https://github.com/shepmaster/twox-hash/issues/19



