### PR TITLE
Change terminology used in srml-contract docs

### DIFF
--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -549,10 +549,10 @@ decl_storage! {
 		/// The amount of funds a contract should deposit in order to offset
 		/// the cost of one byte.
 		///
-		/// Let's suppose the deposit is 1,000 EDG/byte and the rent is 1 EDG/byte/day, then a contract
-		/// with 1,000,000 EDG that uses 1,000 bytes of storage would pay no rent.
-		/// But if the balance reduced to 500,000 EDG and the storage stayed the same at 1,000,
-		/// then it would pay 500 EDG/day.
+		/// Let's suppose the deposit is 1,000 BU (balance units)/byte and the rent is 1 BU/byte/day,
+		/// then a contract with 1,000,000 BU that uses 1,000 bytes of storage would pay no rent.
+		/// But if the balance reduced to 500,000 BU and the storage stayed the same at 1,000,
+		/// then it would pay 500 BU/day.
 		RentDepositOffset get(rent_deposit_offset) config(): BalanceOf<T>;
 		/// Reward that is received by the party whose touch has led
 		/// to removal of a contract.


### PR DESCRIPTION
Switch terminology to "balance units" since EDG was used only for example, and doesn't really represents the state of things, i.e. srml-contract is a module which can be used in different chains which can have their own balances called whatever they want.

This PR doesn't alter any logic, only rustdoc.