### PR TITLE
Add reputation system to network crate

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -29,7 +29,7 @@ use libp2p::mdns::{Mdns, MdnsEvent};
 use libp2p::multiaddr::Protocol;
 use libp2p::ping::{Ping, PingConfig, PingEvent, PingSuccess};
 use log::{debug, info, trace, warn};
-use std::{borrow::Cow, cmp, fmt, time::Duration};
+use std::{borrow::Cow, cmp, time::Duration};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::{Delay, clock::Clock};
 use void;
@@ -451,27 +451,3 @@ where
 		Async::NotReady
 	}
 }
-
-/// The severity of misbehaviour of a peer that is reported.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Severity {
-	/// Peer is timing out. Could be bad connectivity of overload of work on either of our sides.
-	Timeout,
-	/// Peer has been notably useless. E.g. unable to answer a request that we might reasonably consider
-	/// it could answer.
-	Useless(String),
-	/// Peer has behaved in an invalid manner. This doesn't necessarily need to be Byzantine, but peer
-	/// must have taken concrete action in order to behave in such a way which is wantanly invalid.
-	Bad(String),
-}
-
-impl fmt::Display for Severity {
-	fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-		match self {
-			Severity::Timeout => write!(fmt, "Timeout"),
-			Severity::Useless(r) => write!(fmt, "Useless ({})", r),
-			Severity::Bad(r) => write!(fmt, "Bad ({})", r),
-		}
-	}
-}
-

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -25,7 +25,6 @@ mod custom_proto;
 mod service_task;
 mod transport;
 
-pub use crate::behaviour::Severity;
 pub use crate::config::*;
 pub use crate::custom_proto::{CustomMessage, RegisteredProtocol};
 pub use crate::config::{NetworkConfiguration, NodeKeyConfig, Secret, NonReservedPeerMode};

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -24,7 +24,7 @@ use std::time;
 use log::{trace, debug};
 use futures::sync::mpsc;
 use lru_cache::LruCache;
-use network_libp2p::{Severity, PeerId};
+use network_libp2p::PeerId;
 use runtime_primitives::traits::{Block as BlockT, Hash, HashFor};
 use runtime_primitives::ConsensusEngineId;
 pub use crate::message::generic::{Message, ConsensusMessage};
@@ -35,6 +35,15 @@ use crate::config::Roles;
 const KNOWN_MESSAGES_CACHE_SIZE: usize = 4096;
 
 const REBROADCAST_INTERVAL: time::Duration = time::Duration::from_secs(30);
+/// Reputation change when a peer sends us a gossip message that we didn't know about.
+const GOSSIP_SUCCESS_REPUTATION_CHANGE: i32 = 1 << 4;
+/// Reputation change when a peer sends us a gossip message that we already knew about.
+const DUPLICATE_GOSSIP_REPUTATION_CHANGE: i32 = -(1 << 2);
+/// Reputation change when a peer sends us a gossip message for an unknown engine, whatever that
+/// means.
+const UNKNOWN_GOSSIP_REPUTATION_CHANGE: i32 = -(1 << 6);
+/// Reputation change when a peer sends a message from a topic it isn't registered on.
+const UNREGISTERED_TOPIC_REPUTATION_CHANGE: i32 = -(1 << 10);
 
 struct PeerConsensus<H> {
 	known_messages: HashSet<H>,
@@ -389,6 +398,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 		if self.known_messages.contains_key(&message_hash) {
 			trace!(target:"gossip", "Ignored already known message from {}", who);
+			protocol.report_peer(who.clone(), DUPLICATE_GOSSIP_REPUTATION_CHANGE);
 			return;
 		}
 
@@ -406,15 +416,14 @@ impl<B: BlockT> ConsensusGossip<B> {
 			Some(ValidationResult::Discard) => None,
 			None => {
 				trace!(target:"gossip", "Unknown message engine id {:?} from {}", engine_id, who);
-				protocol.report_peer(
-					who,
-					Severity::Useless(format!("Sent unknown consensus engine id")),
-				);
+				protocol.report_peer(who.clone(), UNKNOWN_GOSSIP_REPUTATION_CHANGE);
+				protocol.disconnect_peer(who);
 				return;
 			}
 		};
 
 		if let Some((topic, keep)) = validation_result {
+			protocol.report_peer(who.clone(), GOSSIP_SUCCESS_REPUTATION_CHANGE);
 			if let Some(ref mut peer) = self.peers.get_mut(&who) {
 				peer.known_messages.insert(message_hash);
 				if let Entry::Occupied(mut entry) = self.live_message_sinks.entry((engine_id, topic)) {
@@ -437,6 +446,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 				}
 			} else {
 				trace!(target:"gossip", "Ignored statement from unregistered peer {}", who);
+				protocol.report_peer(who.clone(), UNREGISTERED_TOPIC_REPUTATION_CHANGE);
 			}
 		} else {
 			trace!(target:"gossip", "Handled valid one hop message from peer {}", who);

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -19,7 +19,7 @@
 
 //! Substrate-specific P2P networking: synchronizing blocks, propagating BFT messages.
 //! Allows attachment of an optional subprotocol for chain-specific requests.
-//! 
+//!
 //! **Important**: This crate is unstable and the API and usage may change.
 //!
 
@@ -49,7 +49,7 @@ pub use protocol::{ProtocolStatus, PeerInfo, Context};
 pub use sync::{Status as SyncStatus, SyncState};
 pub use network_libp2p::{
 	identity, multiaddr,
-	ProtocolId, Severity, Multiaddr,
+	ProtocolId, Multiaddr,
 	NetworkState, NetworkStatePeer, NetworkStateNotConnectedPeer, NetworkStatePeerEndpoint,
 	NodeKeyConfig, Secret, Secp256k1Secret, Ed25519Secret,
 	build_multiaddr, PeerId, PublicKey

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -17,10 +17,10 @@
 use std::cmp::max;
 use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
-use log::{debug, trace, warn};
+use log::{debug, trace, info, warn};
 use crate::protocol::Context;
 use fork_tree::ForkTree;
-use network_libp2p::{Severity, PeerId};
+use network_libp2p::PeerId;
 use client::{BlockStatus, ClientInfo};
 use consensus::BlockOrigin;
 use consensus::import_queue::{ImportQueue, IncomingBlock};
@@ -47,6 +47,12 @@ const JUSTIFICATION_RETRY_WAIT: Duration = Duration::from_secs(10);
 const ANNOUNCE_HISTORY_SIZE: usize = 64;
 // Max number of blocks to download for unknown forks.
 const MAX_UNKNOWN_FORK_DOWNLOAD_LEN: u32 = 32;
+/// Reputation change when a peer sent us a status message that led to a database read error.
+const BLOCKCHAIN_STATUS_READ_ERROR_REPUTATION_CHANGE: i32 = -(1 << 16);
+/// Reputation change when a peer failed to answer our legitimate ancestry block search.
+const ANCESTRY_BLOCK_ERROR_REPUTATION_CHANGE: i32 = -(1 << 9);
+/// Reputation change when a peer sent us a status message with a different genesis than us.
+const GENESIS_MISMATCH_REPUTATION_CHANGE: i32 = i32::min_value() + 1;
 
 #[derive(Debug)]
 struct PeerSync<B: BlockT> {
@@ -470,16 +476,18 @@ impl<B: BlockT> ChainSync<B> {
 			match (status, info.best_number) {
 				(Err(e), _) => {
 					debug!(target:"sync", "Error reading blockchain: {:?}", e);
-					let reason = format!("Error legimimately reading blockchain status: {:?}", e);
-					protocol.report_peer(who, Severity::Useless(reason));
+					protocol.report_peer(who.clone(), BLOCKCHAIN_STATUS_READ_ERROR_REPUTATION_CHANGE);
+					protocol.disconnect_peer(who);
 				},
 				(Ok(BlockStatus::KnownBad), _) => {
-					let reason = format!("New peer with known bad best block {} ({}).", info.best_hash, info.best_number);
-					protocol.report_peer(who, Severity::Bad(reason));
+					info!("New peer with known bad best block {} ({}).", info.best_hash, info.best_number);
+					protocol.report_peer(who.clone(), i32::min_value());
+					protocol.disconnect_peer(who);
 				},
 				(Ok(BlockStatus::Unknown), b) if b == As::sa(0) => {
-					let reason = format!("New peer with unknown genesis hash {} ({}).", info.best_hash, info.best_number);
-					protocol.report_peer(who, Severity::Bad(reason));
+					info!("New peer with unknown genesis hash {} ({}).", info.best_hash, info.best_number);
+					protocol.report_peer(who.clone(), i32::min_value());
+					protocol.disconnect_peer(who);
 				},
 				(Ok(BlockStatus::Unknown), _) if self.queue_blocks.len() > MAJOR_SYNC_BLOCKS => {
 					// when actively syncing the common point moves too fast.
@@ -638,13 +646,15 @@ impl<B: BlockT> ChainSync<B> {
 							maybe_our_block_hash.map_or(false, |x| x == block.hash)
 						},
 						(None, _) => {
-							trace!(target:"sync", "Invalid response when searching for ancestor from {}", who);
-							protocol.report_peer(who, Severity::Bad("Invalid response when searching for ancestor".to_string()));
+							debug!(target: "sync", "Invalid response when searching for ancestor from {}", who);
+							protocol.report_peer(who.clone(), i32::min_value());
+							protocol.disconnect_peer(who);
 							return;
 						},
 						(_, Err(e)) => {
-							let reason = format!("Error answering legitimate blockchain query: {:?}", e);
-							protocol.report_peer(who, Severity::Useless(reason));
+							info!("Error answering legitimate blockchain query: {:?}", e);
+							protocol.report_peer(who.clone(), ANCESTRY_BLOCK_ERROR_REPUTATION_CHANGE);
+							protocol.disconnect_peer(who);
 							return;
 						},
 					};
@@ -653,7 +663,8 @@ impl<B: BlockT> ChainSync<B> {
 					}
 					if !block_hash_match && num == As::sa(0) {
 						trace!(target:"sync", "Ancestry search: genesis mismatch for peer {}", who);
-						protocol.report_peer(who, Severity::Bad("Ancestry search: genesis mismatch for peer".to_string()));
+						protocol.report_peer(who.clone(), GENESIS_MISMATCH_REPUTATION_CHANGE);
+						protocol.disconnect_peer(who);
 						return;
 					}
 					if let Some((next_state, next_block_num)) = Self::handle_ancestor_search_state(state, num, block_hash_match) {
@@ -710,13 +721,10 @@ impl<B: BlockT> ChainSync<B> {
 				match response.blocks.into_iter().next() {
 					Some(response) => {
 						if hash != response.hash {
-							let msg = format!(
-								"Invalid block justification provided: requested: {:?} got: {:?}",
-								hash,
-								response.hash,
-							);
-
-							protocol.report_peer(who, Severity::Bad(msg));
+							info!("Invalid block justification provided by {}: requested: {:?} got: {:?}",
+								who, hash, response.hash);
+							protocol.report_peer(who.clone(), i32::min_value());
+							protocol.disconnect_peer(who);
 							return;
 						}
 

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -157,12 +157,8 @@ impl<S: NetworkSpecialization<Block>> Link<Block> for TestLink<S> {
 		self.link.request_justification(hash, number);
 	}
 
-	fn useless_peer(&self, who: PeerId, reason: &str) {
-		self.link.useless_peer(who, reason);
-	}
-
-	fn note_useless_and_restart_sync(&self, who: PeerId, reason: &str) {
-		self.link.note_useless_and_restart_sync(who, reason);
+	fn report_peer(&self, who: PeerId, reputation_change: i32) {
+		self.link.report_peer(who, reputation_change);
 	}
 
 	fn restart(&self) {
@@ -704,6 +700,7 @@ pub trait TestNetFactory: Sized {
 			let need_continue = self.route_single(true, None, &|msg| match *msg {
 				NetworkMsg::Outgoing(_, crate::message::generic::Message::Status(_)) => true,
 				NetworkMsg::Outgoing(_, _) => false,
+				NetworkMsg::DisconnectPeer(_) |
 				NetworkMsg::ReportPeer(_, _) | NetworkMsg::Synchronized => true,
 			});
 			if !need_continue {
@@ -747,7 +744,7 @@ pub trait TestNetFactory: Sized {
 
 						peers[recipient_pos].receive_message(&peer.peer_id, packet);
 					},
-					NetworkMsg::ReportPeer(who, _) => {
+					NetworkMsg::DisconnectPeer(who) => {
 						if disconnect {
 							to_disconnect.insert(who);
 						}


### PR DESCRIPTION
Replaces reporting peers by severity with reputation changes and disconnects.
Also adds beneficial reputation changes for some events.
I replaced reporting "bad" peers with adding `i32::min_value()` to their reputation and sending a disconnect message.

The reputation values are quite arbitrary. I took some inspiration from the ones in `finality-grandpa`, but am unfortunately not sure about the frequency of events.

Breaks the API of the `network` crate, which is marked as unstable anyway.
