### PR TITLE
Clean up random seed to make a bit more flexible

### DIFF
--- a/core/executor/wasm/src/lib.rs
+++ b/core/executor/wasm/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![cfg_attr(feature = "strict", deny(warnings))]
 
-#![feature(alloc)]
 extern crate alloc;
 use alloc::vec::Vec;
 use alloc::slice;

--- a/core/finality-grandpa/primitives/src/lib.rs
+++ b/core/finality-grandpa/primitives/src/lib.rs
@@ -17,7 +17,6 @@
 //! Primitives for GRANDPA integration, suitable for WASM compilation.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -19,7 +19,6 @@
 #![warn(missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 /// Initialize a key-value collection from array.
 ///

--- a/core/sr-io/src/lib.rs
+++ b/core/sr-io/src/lib.rs
@@ -22,7 +22,6 @@
 #![cfg_attr(not(feature = "std"), feature(lang_items))]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #![cfg_attr(feature = "std", doc = "Substrate runtime standard library as compiled when linked with Rust's standard library.")]
 #![cfg_attr(not(feature = "std"), doc = "Substrate's runtime standard library as compiled without Rust's standard library.")]

--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -37,7 +37,6 @@
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 use rstd::prelude::*;
 

--- a/core/sr-std/src/lib.rs
+++ b/core/sr-std/src/lib.rs
@@ -19,7 +19,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #![cfg_attr(feature = "std", doc = "Substrate runtime standard library as compiled when linked with Rust's standard library.")]
 #![cfg_attr(not(feature = "std"), doc = "Substrate's runtime standard library as compiled without Rust's standard library.")]

--- a/core/trie/src/lib.rs
+++ b/core/trie/src/lib.rs
@@ -17,7 +17,6 @@
 //! Utility functions to interact with Substrate's Base-16 Modified Merkle Patricia tree ("trie").
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 mod error;
 mod node_header;

--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -1,7 +1,6 @@
 //! The Substrate Node Template runtime. This can be compiled with `#[no_std]`, ready for Wasm.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit="256"]
 

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -19,7 +19,6 @@
 #![warn(missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 use runtime_primitives::{
 	generic, traits::{Verify, BlakeTwo256}, OpaqueExtrinsic, AnySignature

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 69,
+	spec_version: 70,
 	impl_version: 70,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -443,7 +443,7 @@ mod tests {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
 					number: 1,
-					state_root: hex!("4c10fddf15e63c91ff2aa13ab3a9b7f6b19938d533829489e72ba40278a08fac").into(),
+					state_root: hex!("ac2840371d51ff2e036c8fc05af7313b7a030f735c38b2f03b94cbe87bfbb7c9").into(),
 					extrinsics_root: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into(),
 					digest: Digest { logs: vec![], },
 				},

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -17,7 +17,6 @@
 //! Support code for the runtime.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[macro_use]
 extern crate bitmask;

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -467,10 +467,36 @@ impl<T: Trait> Module<T> {
 		<ParentHash<T>>::put(n);
 	}
 
+	/// Get the basic random seed.
+	///
+	/// In general you won't want to use this, but rather `Self::random` which allows you to give a subject for the
+	/// random result and whose value will be independently low-influence random from any other such seeds.
 	pub fn random_seed() -> T::Hash {
 		Self::random(&[][..])
 	}
 
+	/// Get a low-influence "random" value.
+	///
+	/// Being a deterministic block chain, real randomness is difficult to come by. This gives you something that
+	/// approximates it. `subject` is a context identifier and allows you to get a different result to other callers
+	/// of this function; use it like `random(&b"my context"[..])`.
+	///
+	/// This is initially implemented through a low-influence "triplet mix" convolution of previous block hash values.
+	/// In the future it will be generated from a secure "VRF".
+	///
+	/// ### Security Notes
+	/// This randomness uses a low-influence function, drawing upon the block hashes from the previous 81 blocks. Its
+	/// result for any given subject will be known in advance by the block producer of this block (and, indeed, anyone
+	/// who knows the block's `parent_hash`). However, it is mostly impossible for the producer of this block *alone*
+	/// to influence the value of this hash. A sizable minority of dishonest and coordinating block producers would be
+	/// required in order to affect this value. If that is an insufficient security guarantee then two things can be
+	/// used to improve this randomness:
+	/// - Name, in advance, the block number whose random value will be used; ensure your module retains a buffer of
+	/// previous random values for its subject and then index into these in order to obviate the ability of your user
+	/// to look up the parent hash and choose when to transact based upon it.
+	/// - Require your user to first commit to an additional value by first posting its hash. Require them to reveal
+	/// the value to determine the final result, hashing it with the output of this random function. This reduces the
+	/// ability of a cabal of block producers from conspiring against individuals.
 	pub fn random(subject: &[u8]) -> T::Hash {
 		let (index, hash_series) = <RandomMaterial<T>>::get();
 		if hash_series.len() > 0 {

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -303,7 +303,7 @@ decl_storage! {
 		/// Extrinsics data for the current block (maps an extrinsic's index to its data).
 		ExtrinsicData get(extrinsic_data): map u32 => Vec<u8>;
 		/// Series of block headers from the last 81 blocks that acts as random seed material. This is arranged as a
-		/// ring buffer with the `u8` prefix being the index into the `Vec` of the oldest hash.
+		/// ring buffer with the `i8` prefix being the index into the `Vec` of the oldest hash.
 		RandomMaterial get(random_material): (i8, Vec<T::Hash>);
 		/// The current block number being processed. Set by `execute_block`.
 		Number get(block_number) build(|_| T::BlockNumber::sa(1u64)): T::BlockNumber;

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -497,6 +497,10 @@ impl<T: Trait> Module<T> {
 	/// - Require your user to first commit to an additional value by first posting its hash. Require them to reveal
 	/// the value to determine the final result, hashing it with the output of this random function. This reduces the
 	/// ability of a cabal of block producers from conspiring against individuals.
+	///
+	/// WARNING: Hashing the result of this function will remove any low-infleunce properties it has and mean that
+	/// all bits of the resulting value are entirely manipulatable by the author of the parent block, who can determine
+	/// the value of `parent_hash`.
 	pub fn random(subject: &[u8]) -> T::Hash {
 		let (index, hash_series) = <RandomMaterial<T>>::get();
 		if hash_series.len() > 0 {


### PR DESCRIPTION
- First 80 random values come from cycling the incomplete series (
  instead of filling with zeroes)
- Calculate random material each usage (use a single amalgamated
  ring buffer to store them for avoiding 81 lookups each time)
- Mutate inputs by hashing each with:
  - its index (into the 81)
  - an additional "subject" key provided by caller

This keeps the final output low-influence while still allowing
it to be used as the seed to independent contexts. (Hashing the
result to give the final seed is no better than using parent_hash).