### PR TITLE
tokio -> tokio-timer in consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,7 +3995,7 @@ dependencies = [
  "substrate-inherents 1.0.0",
  "substrate-primitives 1.0.0",
  "substrate-test-client 1.0.0",
- "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/consensus/common/Cargo.toml
+++ b/core/consensus/common/Cargo.toml
@@ -15,7 +15,7 @@ error-chain = "0.12"
 futures = "0.1"
 runtime_version = { package = "sr-version", path = "../../sr-version" }
 runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
-tokio = "0.1.7"
+tokio-timer = "0.2"
 parity-codec = { version = "3.3", features = ["derive"] }
 
 [dev-dependencies]

--- a/core/consensus/common/src/error.rs
+++ b/core/consensus/common/src/error.rs
@@ -35,7 +35,7 @@ error_chain! {
 		}
 
 		/// Unable to schedule wakeup.
-		FaultyTimer(e: ::tokio::timer::Error) {
+		FaultyTimer(e: ::tokio_timer::Error) {
 			description("Timer error"),
 			display("Timer error: {}", e),
 		}


### PR DESCRIPTION
Replaces `tokio` with `tokio-timer`, so that we don't indirectly depend on `mio`.
Relevant for #2416.
Shouldn't break any API.