### PR TITLE
Disable mDNS when passing --dev

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -322,6 +322,7 @@ fn fill_network_configuration(
 	chain_spec_id: &str,
 	config: &mut NetworkConfiguration,
 	client_id: String,
+	is_dev: bool,
 ) -> error::Result<()> {
 	config.boot_nodes.extend(cli.bootnodes.into_iter());
 	config.config_path = Some(
@@ -359,7 +360,7 @@ fn fill_network_configuration(
 	config.in_peers = cli.in_peers;
 	config.out_peers = cli.out_peers;
 
-	config.enable_mdns = !cli.no_mdns;
+	config.enable_mdns = !is_dev && !cli.no_mdns;
 
 	Ok(())
 }
@@ -441,6 +442,8 @@ where
 	config.roles = role;
 	config.disable_grandpa = cli.no_grandpa;
 
+	let is_dev = cli.shared_params.dev;
+
 	let client_id = config.client_id();
 	fill_network_configuration(
 		cli.network_config,
@@ -448,6 +451,7 @@ where
 		spec.id(),
 		&mut config.network,
 		client_id,
+		is_dev,
 	)?;
 
 	fill_transaction_pool_configuration::<F>(
@@ -476,7 +480,6 @@ where
 	config.rpc_ws = Some(
 		parse_address(&format!("{}:{}", ws_interface, 9944), cli.ws_port)?
 	);
-	let is_dev = cli.shared_params.dev;
 	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| if is_dev {
 		log::warn!("Running in --dev mode, RPC CORS has been disabled.");
 		None

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -119,7 +119,7 @@ pub struct NetworkConfigurationParams {
 	pub in_peers: u32,
 
 	/// By default, the network will use mDNS to discover other nodes on the local network. This
-	/// disables it.
+	/// disables it. Automatically implied when using --dev.
 	#[structopt(long = "no-mdns")]
 	pub no_mdns: bool,
 


### PR DESCRIPTION
One will no longer connect to other nodes when using `--dev`.