### PR TITLE
Show more information when too many addresses are reported

### DIFF
--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -263,7 +263,8 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<IdentifyEvent> for Behav
 				if info.listen_addrs.len() > 30 {
 					warn!(target: "sub-libp2p", "Node {:?} has reported more than 30 addresses; \
 						it is identified by {:?} and {:?}", peer_id, info.protocol_version,
-						info.agent_version);
+						info.agent_version
+					);
 					info.listen_addrs.truncate(30);
 				}
 				for addr in &info.listen_addrs {

--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -261,8 +261,9 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<IdentifyEvent> for Behav
 					warn!(target: "sub-libp2p", "Connected to a non-Substrate node: {:?}", info);
 				}
 				if info.listen_addrs.len() > 30 {
-					warn!(target: "sub-libp2p", "Node {:?} id reported more than 30 addresses",
-						peer_id);
+					warn!(target: "sub-libp2p", "Node {:?} has reported more than 30 addresses; \
+						it is identified by {:?} and {:?}", peer_id, info.protocol_version,
+						info.agent_version);
 					info.listen_addrs.truncate(30);
 				}
 				for addr in &info.listen_addrs {


### PR DESCRIPTION
On the Emberic Elm network, we sometimes have misbehaving nodes that report too many listened addresses (in practice it is probably caused by a very old bug in libp2p). We print more information about the node when that happens.