### PR TITLE
Merge the protocol thread with the network thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,6 +4165,7 @@ dependencies = [
  "substrate-primitives 1.0.0",
  "substrate-test-client 1.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -31,6 +31,7 @@ peerset = { package = "substrate-peerset", path = "../../core/peerset" }
 tokio = "0.1.11"
 keyring = { package = "substrate-keyring", path = "../../core/keyring", optional = true }
 test_client = { package = "substrate-test-client", path = "../../core/test-client", optional = true }
+void = "1.0"
 
 [dev-dependencies]
 env_logger = { version = "0.6" }

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -648,7 +648,7 @@ pub trait TestNetFactory: Sized {
 		let specialization = self::SpecializationFactory::create();
 		let peers: Arc<RwLock<HashMap<PeerId, ConnectedPeer<Block>>>> = Arc::new(Default::default());
 
-		let (protocol_sender, network_to_protocol_sender) = Protocol::new(
+		let (protocol, protocol_sender, network_to_protocol_sender) = Protocol::new(
 			status_sinks,
 			is_offline.clone(),
 			is_major_syncing.clone(),
@@ -661,6 +661,10 @@ pub trait TestNetFactory: Sized {
 			tx_pool,
 			specialization,
 		).unwrap();
+
+		std::thread::spawn(move || {
+			tokio::run(protocol.map_err(|err| void::unreachable(err)));
+		});
 
 		let peer = Arc::new(Peer::new(
 			is_offline,

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -642,14 +642,12 @@ pub trait TestNetFactory: Sized {
 		let (network_sender, network_port) = network_channel();
 
 		let import_queue = Box::new(BasicQueue::new(verifier, block_import, justification_import));
-		let status_sinks = Arc::new(Mutex::new(Vec::new()));
 		let is_offline = Arc::new(AtomicBool::new(true));
 		let is_major_syncing = Arc::new(AtomicBool::new(false));
 		let specialization = self::SpecializationFactory::create();
 		let peers: Arc<RwLock<HashMap<PeerId, ConnectedPeer<Block>>>> = Arc::new(Default::default());
 
 		let (protocol, protocol_sender, network_to_protocol_sender) = Protocol::new(
-			status_sinks,
 			is_offline.clone(),
 			is_major_syncing.clone(),
 			peers.clone(),


### PR DESCRIPTION
Part of making network more straight-forward, and also part of #2416 because background threads should die in favour of asynchronous Rust.
My general intent is to split the logic of handling the protocol from the fact that we have threads and channels. The first step would be that `network/src/service.rs` should contain all the threading and messages passing and `protocol.rs` only the pure logic of deciding what to send to nodes, then that threading logic would eventually be moved to `service/src/lib.rs`.

I'm going to submit several small PRs because I don't want to submit a giant one that will take months to review and require dozens of rebases.

This PR merges the thread of `protocol.rs` with the thread of `service.rs`. Since two objects are now in the same thread, I also removed `FromNetworkMsg`. The `NetworkChan` and `ProtocolMsg` enums are unfortunately much more engrained in the code, and will be the subject of other PRs.