### PR TITLE
backport fix doublemapkey

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 59,
-	impl_version: 59,
+	spec_version: 60,
+	impl_version: 60,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/support/procedural/src/lib.rs
+++ b/srml/support/procedural/src/lib.rs
@@ -54,7 +54,7 @@ use proc_macro::TokenStream;
 ///
 ///   `hasher($hash)` is optional and its default is `blake2_256`.
 ///
-///   /!\ Be careful with each key in the map that is inserted in the trie `$hash(module_name ++ storage_name ++ key)`.
+///   /!\ Be careful with each key in the map that is inserted in the trie `$hash(module_name ++ " " ++ storage_name ++ encoding(key))`.
 ///   If the keys are not trusted (e.g. can be set by a user), a cryptographic `hasher` such as
 ///   `blake2_256` must be used. Otherwise, other values in storage can be compromised.
 ///
@@ -71,7 +71,7 @@ use proc_macro::TokenStream;
 ///   The final key is calculated as follows:
 ///
 ///   ```nocompile
-///   $hash(module_name ++ storage_name ++ first_key) ++ $hash2(second_key)
+///   $hash(module_name ++ " " ++ storage_name ++ encoding(first_key)) ++ $hash2(encoding(second_key))
 ///   ```
 ///
 ///   If the first key is untrusted, a cryptographic `hasher` such as `blake2_256` must be used.

--- a/srml/support/procedural/src/lib.rs
+++ b/srml/support/procedural/src/lib.rs
@@ -40,23 +40,47 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
-/// Declaration is set with this header `(pub) trait Store for Module<T: Trait> as Example`
-/// with `Store` a (pub) trait generated associating each storage to the `Module` and
-/// `as Example` setting the prefix used for storages of this module. `Example` must be unique:
-/// another module with same name and same inner storage item name will conflict.
+/// Declaration is set with the header `(pub) trait Store for Module<T: Trait> as Example`,
+/// with `Store` a (pub) trait generated associating each storage item to the `Module` and
+/// `as Example` setting the prefix used for storage items of this module. `Example` must be unique:
+/// another module with the same name and the same inner storage item name will conflict.
 ///
 /// Basic storage consists of a name and a type; supported types are:
 ///
 /// * Value: `Foo: type`: Implements [StorageValue](../srml_support/storage/trait.StorageValue.html).
-/// * Map: `Foo: map type => type`: implements [StorageMap](../srml_support/storage/trait.StorageMap.html)
-/// * Linked map: `Foo: linked_map type => type`: Implements [StorageMap](../srml_support/storage/trait.StorageMap.html)
-/// and [EnumarableStorageMap](../srml_support/storage/trait.EnumerableStorageMap.html).
-/// * Double map: `Foo: double_map u32, $hash(u32) => u32;`: Implements `StorageDoubleMap` with `$hash` representing a
-/// choice of hashing algorithms available in [`Hashable` trait](../srml_support/trait.Hashable.html).
+/// * Map: `Foo: map hasher($hash) type => type`: Implements [StorageMap](../srml_support/storage/trait.StorageMap.html)
+///   with `$hash` representing a choice of hashing algorithms available in the
+///   [`Hashable` trait](../srml_support/trait.Hashable.html).
 ///
-///   /!\ Be careful when choosing the hash function, malicious actors could craft second keys to lower the trie.
+///   `hasher($hash)` is optional and its default is `blake2_256`.
 ///
-/// And it can be extended as such:
+///   /!\ Be careful with each key in the map that is inserted in the trie `$hash(module_name ++ storage_name ++ key)`.
+///   If the keys are not trusted (e.g. can be set by a user), a cryptographic `hasher` such as
+///   `blake2_256` must be used. Otherwise, other values in storage can be compromised.
+///
+/// * Linked map: `Foo: linked_map hasher($hash) type => type`: Same as `Map` but also implements
+///   [EnumarableStorageMap](../srml_support/storage/trait.EnumerableStorageMap.html).
+///
+/// * Double map: `Foo: double_map hasher($hash) u32, $hash2(u32) => u32`: Implements `StorageDoubleMap` with
+///   `$hash` and `$hash2` representing choices of hashing algorithms available in the
+///   [`Hashable` trait](../srml_support/trait.Hashable.html).
+///
+///   `hasher($hash)` is optional and its default is `blake2_256`.
+///
+///   /!\ Be careful with each key pair in the double map that is inserted in the trie.
+///   The final key is calculated as follows:
+///
+///   ```nocompile
+///   $hash(module_name ++ storage_name ++ first_key) ++ $hash2(second_key)
+///   ```
+///
+///   If the first key is untrusted, a cryptographic `hasher` such as `blake2_256` must be used.
+///   Otherwise, other values of all storage items can be compromised.
+///
+///   If the second key is untrusted, a cryptographic `hasher` such as `blake2_256` must be used.
+///   Otherwise, other items in storage with the same first key can be compromised.
+///
+/// Basic storage can be extended as such:
 ///
 /// `#vis #name get(#getter) config(#field_name) build(#closure): #type = #default;`
 ///
@@ -100,18 +124,18 @@ use proc_macro::TokenStream;
 ///
 /// This struct can be exposed as `Config` by the `decl_runtime!` macro.
 ///
-/// ### Module with instances
+/// ### Module with Instances
 ///
-/// The `decl_storage!` macro supports building modules with instances with the following syntax:
-/// (`DefaultInstance` type is optional)
+/// The `decl_storage!` macro supports building modules with instances with the following syntax
+/// (`DefaultInstance` type is optional):
 ///
 /// ```nocompile
 /// trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Example {}
 /// ```
 ///
-/// Then the genesis config is generated with two generic parameter `GenesisConfig<T, I>`
-/// and storage items are now accessible using two generic parameters, e.g.:
-/// `<Dummy<T, I>>::get()` or `Dummy::<T, I>::get()`
+/// Then the genesis config is generated with two generic parameters (i.e. `GenesisConfig<T, I>`)
+/// and storage items are accessible using two generic parameters, e.g.:
+/// `<Dummy<T, I>>::get()` or `Dummy::<T, I>::get()`.
 #[proc_macro]
 pub fn decl_storage(input: TokenStream) -> TokenStream {
 	storage::transformation::decl_storage_impl(input)

--- a/srml/support/procedural/src/storage/impls.rs
+++ b/srml/support/procedural/src/storage/impls.rs
@@ -621,9 +621,11 @@ impl<'a, I: Iterator<Item=syn::Meta>> Impls<'a, I> {
 				type Query = #value_type;
 
 				fn prefix_for(k1: &#k1ty) -> Vec<u8> {
+					use #scrate::storage::hashed::generator::StorageHasher;
+
 					let mut key = #as_double_map::prefix().to_vec();
 					#scrate::codec::Encode::encode_to(k1, &mut key);
-					#scrate::Hashable::#hasher(&key).to_vec()
+					#scrate::#hasher::hash(&key[..]).to_vec()
 				}
 
 				fn prefix() -> &'static [u8] {

--- a/srml/support/procedural/src/storage/mod.rs
+++ b/srml/support/procedural/src/storage/mod.rs
@@ -234,16 +234,6 @@ impl HasherKind {
 		}
 	}
 
-	fn into_hashable_fn(&self) -> TokenStream2 {
-		match self {
-			HasherKind::Blake2_256 => quote!( blake2_256 ),
-			HasherKind::Blake2_128 => quote!( blake2_128 ),
-			HasherKind::Twox256 => quote!( twox_256 ),
-			HasherKind::Twox128 => quote!( twox_128 ),
-			HasherKind::Twox64Concat => quote!( twox_64_concat),
-		}
-	}
-
 	fn into_metadata(&self) -> TokenStream2 {
 		match self {
 			HasherKind::Blake2_256 => quote!( StorageHasher::Blake2_256 ),

--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -596,7 +596,7 @@ fn decl_storage_items(
 				i.linked_map(hasher.into_storage_hasher_struct(), key_type)
 			},
 			DeclStorageTypeInfosKind::DoubleMap { key1_type, key2_type, key2_hasher, hasher } => {
-				i.double_map(hasher.into_hashable_fn(), key1_type, key2_type, key2_hasher)
+				i.double_map(hasher.into_storage_hasher_struct(), key1_type, key2_type, key2_hasher)
 			},
 		};
 		impls.extend(implementation)

--- a/srml/support/src/hashable.rs
+++ b/srml/support/src/hashable.rs
@@ -22,6 +22,7 @@ use crate::storage::hashed::generator::StorageHasher;
 use crate::Twox64Concat;
 use crate::rstd::prelude::Vec;
 
+/// Trait for available hash functions.
 // This trait must be kept coherent with srml-support-procedural HasherKind usage
 pub trait Hashable: Sized {
 	fn blake2_128(&self) -> [u8; 16];

--- a/srml/support/test/tests/final_keys.rs
+++ b/srml/support/test/tests/final_keys.rs
@@ -1,0 +1,81 @@
+use runtime_io::{with_externalities, Blake2Hasher};
+use srml_support::{StorageValue, StorageMap, StorageDoubleMap};
+use srml_support::storage::unhashed;
+use srml_support::runtime_primitives::BuildStorage;
+use parity_codec::Encode;
+
+pub trait Trait {
+	type Origin;
+	type BlockNumber;
+}
+
+srml_support::decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+}
+
+srml_support::decl_storage!{
+	trait Store for Module<T: Trait> as Module {
+		pub Value config(value): u32;
+
+		pub Map: map u32 => u32;
+		pub Map2: map hasher(twox_128) u32 => u32;
+
+		pub LinkedMap: linked_map u32 => u32;
+		pub LinkedMap2: linked_map hasher(twox_128) u32 => u32;
+
+		pub DoubleMap: double_map u32, blake2_256(u32) => u32;
+		pub DoubleMap2: double_map hasher(twox_128) u32, blake2_128(u32) => u32;
+	}
+}
+
+struct Test;
+impl Trait for Test {
+	type BlockNumber = u32;
+	type Origin = u32;
+}
+
+fn new_test_ext() -> runtime_io::TestExternalities<Blake2Hasher> {
+	GenesisConfig::<Test>::default().build_storage().unwrap().0.into()
+}
+
+#[test]
+fn final_keys() {
+	with_externalities(&mut new_test_ext(), || {
+		<Value<Test>>::put(1);
+		assert_eq!(unhashed::get::<u32>(&runtime_io::twox_128(b"Module Value")), Some(1u32));
+
+		<Map<Test>>::insert(1, 2);
+		let mut k = b"Module Map".to_vec();
+		k.extend(1u32.encode());
+		assert_eq!(unhashed::get::<u32>(&runtime_io::blake2_256(&k)), Some(2u32));
+
+		<Map2<Test>>::insert(1, 2);
+		let mut k = b"Module Map2".to_vec();
+		k.extend(1u32.encode());
+		assert_eq!(unhashed::get::<u32>(&runtime_io::twox_128(&k)), Some(2u32));
+
+		<LinkedMap<Test>>::insert(1, 2);
+		let mut k = b"Module LinkedMap".to_vec();
+		k.extend(1u32.encode());
+		assert_eq!(unhashed::get::<u32>(&runtime_io::blake2_256(&k)), Some(2u32));
+
+		<LinkedMap2<Test>>::insert(1, 2);
+		let mut k = b"Module LinkedMap2".to_vec();
+		k.extend(1u32.encode());
+		assert_eq!(unhashed::get::<u32>(&runtime_io::twox_128(&k)), Some(2u32));
+
+		<DoubleMap<Test>>::insert(1, 2, 3);
+		let mut k = b"Module DoubleMap".to_vec();
+		k.extend(1u32.encode());
+		let mut k = runtime_io::blake2_256(&k).to_vec();
+		k.extend(&runtime_io::blake2_256(&2u32.encode()));
+		assert_eq!(unhashed::get::<u32>(&k), Some(3u32));
+
+		<DoubleMap2<Test>>::insert(1, 2, 3);
+		let mut k = b"Module DoubleMap2".to_vec();
+		k.extend(1u32.encode());
+		let mut k = runtime_io::twox_128(&k).to_vec();
+		k.extend(&runtime_io::blake2_128(&2u32.encode()));
+		assert_eq!(unhashed::get::<u32>(&k), Some(3u32));
+	});
+}


### PR DESCRIPTION
I don't know if it is wanted in v1.0

backport https://github.com/paritytech/substrate/pull/2451
related to https://github.com/paritytech/substrate/issues/2443

and update the doc of decl_storage as on master

another possibility would be to document current behavior in the doc.