### PR TITLE
Revert from alpine to phusion and include wasm build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 doc
-target
+**target*
 .idea/
 Dockerfile
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,52 @@
-FROM alpine:edge AS builder
+FROM phusion/baseimage:0.10.2 as builder
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."
-
-RUN apk add build-base \
-    cmake \
-    linux-headers \
-    openssl-dev \
-    clang-dev \
-    cargo
 
 ARG PROFILE=release
 WORKDIR /substrate
 
 COPY . /substrate
 
-RUN cargo build --$PROFILE
+RUN apt-get update && \
+	apt-get upgrade -y && \
+	apt-get install -y cmake pkg-config libssl-dev git clang
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+	export PATH="$PATH:$HOME/.cargo/bin" && \
+	rustup toolchain install nightly && \
+	rustup target add wasm32-unknown-unknown --toolchain nightly && \
+	cargo install --git https://github.com/alexcrichton/wasm-gc && \
+	rustup default nightly && \
+ 	./scripts/build.sh && \
+ 	rustup default stable && \
+	cargo build --$PROFILE
 
 # ===== SECOND STAGE ======
 
-FROM alpine:edge
+FROM phusion/baseimage:0.10.2
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 ARG PROFILE=release
+
+RUN mv /usr/share/ca* /tmp && \
+	rm -rf /usr/share/*  && \
+	mv /tmp/ca-certificates /usr/share/ && \
+	mkdir -p /root/.local/share/Polkadot && \
+	ln -s /root/.local/share/Polkadot /data && \
+	useradd -m -u 1000 -U -s /bin/sh -d /substrate substrate
+
 COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
 
-RUN apk add --no-cache ca-certificates \
-    libstdc++ \
-    openssl
+# checks
+RUN ldd /usr/local/bin/substrate && \
+	/usr/local/bin/substrate --version
 
+# Shrinking
 RUN rm -rf /usr/lib/python* && \
-	mkdir -p /root/.local/share/Substrate && \
-	ln -s /root/.local/share/Substrate /data
+	rm -rf /usr/bin /usr/sbin /usr/share/man
 
+USER substrate
 EXPOSE 30333 9933 9944
 VOLUME ["/data"]
 
-ENTRYPOINT ["/usr/local/bin/substrate"]
+CMD ["/usr/local/bin/substrate"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Note: We don't use Alpine and its packaged Rust/Cargo because they're too often out of date,
+# preventing them from being used to build Substrate/Polkadot.
+
 FROM phusion/baseimage:0.10.2 as builder
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."


### PR DESCRIPTION
Alpine base images make great docker images because they are very small. Some of the binaries come unfortunately with delay. It happened already several times for the Substrate and Polkadot repos that the cargo version available on alpine was a tad too old and did not allow building substrate/polkadot.

The docker image for polkadot was reverted a while back already.

This PR reverts from `alpine` to using `phusion/base`. I did attempt to keep alpine as second stage which ends up being a little headache. The reason for that is that alpine uses `musl` instead of `glibc`. So the options would be to build using `musl` or install `glibc` in alpine. The second option is not trivial and ideal as the size will grow significantly.

I also tried a second stage using debian:stretch but the (not)included libssl libs make it a mess.
Thus my suggestion to stick with `phusion/baseimage` until both substrate and cargo stabilize.