### PR TITLE
Move hashing benches to Criterion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,7 @@ dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash256-std-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -33,6 +33,11 @@ substrate-serializer = { path = "../serializer" }
 pretty_assertions = "0.6"
 hex-literal = "0.2"
 rand = "0.6"
+criterion = "0.2"
+
+[[bench]]
+name = "benches"
+harness = false
 
 [features]
 default = ["std"]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -39,6 +39,9 @@ criterion = "0.2"
 name = "benches"
 harness = false
 
+[lib]
+bench = false
+
 [features]
 default = ["std"]
 std = [

--- a/core/primitives/benches/benches.rs
+++ b/core/primitives/benches/benches.rs
@@ -17,6 +17,7 @@
 extern crate criterion;
 
 use criterion::{Criterion, black_box, Bencher, Fun};
+use std::time::Duration;
 use substrate_primitives::hashing::{twox_128, blake2_128};
 
 const MAX_KEY_SIZE: u32 = 32;
@@ -64,6 +65,9 @@ fn bench_hash_128_dyn_size(c: &mut Criterion) {
 	c.bench_function_over_inputs("dyn size hashing - twox", |b, key| bench_twox_128(b, &key), keys);
 }
 
-criterion_group!(benches_fix, bench_hash_128_fix_size);
-criterion_group!(benches_dyn, bench_hash_128_dyn_size);
-criterion_main!(benches_fix, benches_dyn);
+criterion_group!{
+    name = benches;
+    config = Criterion::default().warm_up_time(Duration::from_millis(500)).without_plots();
+    targets = bench_hash_128_fix_size, bench_hash_128_dyn_size
+}
+criterion_main!(benches);

--- a/core/primitives/benches/benches.rs
+++ b/core/primitives/benches/benches.rs
@@ -12,48 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Move benchmark to criterion #2354
-#![feature(test)]
 
-extern crate test;
-use hex_literal::hex;
+#[macro_use]
+extern crate criterion;
+
+use criterion::{Criterion, black_box, Bencher, Fun};
 use substrate_primitives::hashing::{twox_128, blake2_128};
 
 const MAX_KEY_SIZE: u32 = 32;
 
-fn data_set() -> Vec<Vec<u8>> {
+fn get_key(key_size: u32) -> Vec<u8> {
 	use rand::SeedableRng;
 	use rand::Rng;
 
 	let rnd: [u8; 32] = rand::rngs::StdRng::seed_from_u64(12).gen();
 	let mut rnd = rnd.iter().cycle();
-	let mut res = Vec::new();
-	for size in 1..=MAX_KEY_SIZE {
-		for _ in 0..1_000 {
-			let value = (0..size)
-				.map(|_| rnd.next().unwrap().clone())
-				.collect();
-			res.push(value);
-		}
-	}
-	res
+
+	(0..key_size)
+		.map(|_| rnd.next().unwrap().clone())
+		.collect()
 }
 
-fn bench_hash_128(b: &mut test::Bencher, f: &Fn(&[u8]) -> [u8; 16]) {
-	let data_set = data_set();
+fn bench_blake2_128(b: &mut Bencher, key: &Vec<u8>) {
 	b.iter(|| {
-		for data in &data_set {
-			let _a = f(data);
-		}
+		let _a = blake2_128(black_box(key));
 	});
 }
 
-#[bench]
-fn bench_blake2_128(b: &mut test::Bencher) {
-	bench_hash_128(b, &blake2_128);
+fn bench_twox_128(b: &mut Bencher, key: &Vec<u8>) {
+	b.iter(|| {
+		let _a = twox_128(black_box(key));
+	});
 }
 
-#[bench]
-fn bench_twox_128(b: &mut test::Bencher) {
-	bench_hash_128(b, &twox_128);
+fn bench_hash_128_fix_size(c: &mut Criterion) {
+	let key = get_key(MAX_KEY_SIZE);
+	let blake_fn = Fun::new("blake2_128", bench_blake2_128);
+	let twox_fn = Fun::new("twox_128", bench_twox_128);
+	let fns = vec![blake_fn, twox_fn];
+
+	c.bench_functions("fixed size hashing", fns, key);
 }
+
+fn bench_hash_128_dyn_size(c: &mut Criterion) {
+	let mut keys = Vec::new();
+	for i in (2..MAX_KEY_SIZE).step_by(4) {
+		keys.push(get_key(i).clone())
+	}
+
+	c.bench_function_over_inputs("dyn size hashing - blake2", |b, key| bench_blake2_128(b, &key), keys.clone());
+	c.bench_function_over_inputs("dyn size hashing - twox", |b, key| bench_twox_128(b, &key), keys);
+}
+
+criterion_group!(benches_fix, bench_hash_128_fix_size);
+criterion_group!(benches_dyn, bench_hash_128_dyn_size);
+criterion_main!(benches_fix, benches_dyn);


### PR DESCRIPTION
fix #2354.

- Split benches into fixed size (hash one key with `MAX` size `N` times) and dynamic size (hash keys with size in range `(2,MAX,4)` `N` times).
- Interestingly shows that the twox hashes are dependent on the input size while blake seems to be not.  