### PR TITLE
v1.0: Silence errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "c_linked_list"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +908,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "get_if_addrs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "get_if_addrs-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1188,14 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "js-sys"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,30 +1360,30 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-dns 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-floodsub 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-identify 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-kad 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mdns 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mplex 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-noise 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-ping 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-plaintext 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-ratelimit 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-secio 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-tcp 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-uds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-websocket 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-yamux 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-dns 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-floodsub 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-identify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-kad 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-mdns 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-mplex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-noise 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-ping 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-plaintext 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-ratelimit 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-secio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-tcp 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-uds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-websocket 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-yamux 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1362,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "asn1_der 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,7 +1408,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "multistream-select 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1397,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1406,20 +1439,20 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-dns-unofficial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1427,7 +1460,7 @@ dependencies = [
  "cuckoofilter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1438,15 +1471,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1459,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1469,11 +1502,9 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-identify 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-ping 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1488,16 +1519,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,13 +1540,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1525,13 +1556,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1543,15 +1574,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1562,22 +1593,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-ratelimit"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aio-limited 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1585,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "libp2p-secio"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1594,30 +1625,35 @@ dependencies = [
  "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rw-stream-sink 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-listen 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1625,41 +1661,42 @@ dependencies = [
 
 [[package]]
 name = "libp2p-uds"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rw-stream-sink 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "yamux 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yamux 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2218,12 +2255,13 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multihash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2860,6 +2898,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "send_wrapper"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3049,11 @@ dependencies = [
  "static_slice 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sourcefile"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spin"
@@ -3839,7 +3887,7 @@ dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4017,7 +4065,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4074,7 +4122,7 @@ name = "substrate-peerset"
 version = "1.0.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4998,6 +5046,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,6 +5082,21 @@ version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasm-bindgen-webidl"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasmi"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5112,19 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5059,6 +5145,14 @@ dependencies = [
  "tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "weedle"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5165,7 +5259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yamux"
-version = "0.1.9"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5224,6 +5318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -5290,6 +5385,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
+"checksum get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
+"checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4feaabe24a0a658fd9cf4a9acf6ed284f045c77df0f49020ba3245cfb7b454"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
@@ -5319,6 +5416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum js-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3c994fd445b81741d77f6bcd227d6ed645b95b35a2ecfd2050767450ff1c0b6d"
 "checksum jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc15eef5f8b6bef5ac5f7440a957ff95d036e2f98706947741bfc93d1976db4c"
 "checksum jsonrpc-derive 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2dae61ca8a3b047fb11309b00661bc56837085bd07e46f907b9c562c0b03e68"
 "checksum jsonrpc-http-server 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11d2a00824306155b8ef57fe957f31b8cd8ad24262f15cf911d84dcf9a3f206d"
@@ -5336,24 +5434,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum libp2p 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5b9cd37b1ca54fa2fd0bbf0486adf2f55f8994f2be9410b65265050b24709b2"
-"checksum libp2p-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf9c56e6f04cb649fdeb806e963d2da223e3ed17748d9e924fdb836c09f76307"
-"checksum libp2p-core-derive 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "debea88a3d5de9fdaf7082bd6d238f2c4c6a0420f14bdf9e1c1083b3e7c69286"
-"checksum libp2p-dns 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350d0018af3668d954f61ce7311e7d64ab7c40f19a8eb895e4750efe24c3455f"
-"checksum libp2p-floodsub 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfbcf36cc58ad5d0252d8ebe9c1a87190693fe2cdbe40fb01d8046779f9a75ad"
-"checksum libp2p-identify 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82e98435973e958d7dea3f5074d7fca53d0dfce2e1ac6924119a21c2991fe443"
-"checksum libp2p-kad 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb0153418eaf0ea549008d1e22748a956c9c36af9374fbe7189d44607c14be"
-"checksum libp2p-mdns 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc915d0cde68a05d26a0dcb125eddce7dd2a425e97c5172ac300c1ee8716f55a"
-"checksum libp2p-mplex 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "355bb370dd12809792dc020638b280e7aaf8625318018abd311c51affd0a612d"
-"checksum libp2p-noise 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e86291401f4a83f9fa81c03f8a7ccf0b03ce6aaa40cba058a7ec1026a65a6fe4"
-"checksum libp2p-ping 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f3277f1f7eaadf5cdde6a76fb4afbf24e0eda6e2b04f288f526c6fa2e4293a6e"
-"checksum libp2p-plaintext 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4842a7ab54c12459b58b9e59cbeb03e3e1fd393fef48079472856f934352772"
-"checksum libp2p-ratelimit 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32ba52ee76aaa94af533526ce5a22fbfcc69a560174fccee82f4cdb557411d33"
-"checksum libp2p-secio 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00f416e1e3d0214bd7df2be2b6be8ef61771d44292b973c9e02bfbbd7f62fe46"
-"checksum libp2p-tcp 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af47af9997d69fc70aa13e6e7cd0d766614ebe74005e69e763221a64d9a0a5ef"
-"checksum libp2p-uds 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa72d81501aad6998d3b1b964f68f438ef99c3aaf54d921e144e0477fa87568"
-"checksum libp2p-websocket 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "647bd8862afe6e912eb34b7614f731c0ff89e8777b57d9f2f5f0fd593ecc8d9a"
-"checksum libp2p-yamux 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbb8d08cb536a964727e77b868a026c6d92993f08e387d49163565575a478d9"
+"checksum libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0231edab431064b30b7749484a39735eb36492cef4658c372c9059e58c3003aa"
+"checksum libp2p-core 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a3bad2ed26297112847678683dd221473a0d44297250b61f004e1b35e72493"
+"checksum libp2p-core-derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f765f103b680cbed910b02bfdbdcfce5b1142899c93e51acb960bf59b6f81b1"
+"checksum libp2p-dns 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b129d20cc8cbb6ce5da8361045649c024659173e246c5dfbf20ae06071c046a"
+"checksum libp2p-floodsub 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70d68816b8435d6788399416eb2f0a6974fb1d15c4be5c30141f87c8e81746df"
+"checksum libp2p-identify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "718ca645a065fd70855ca6042a7df686c24cd21add750c37a82c811fbd1e5c43"
+"checksum libp2p-kad 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bbe27c623a6a720efd5d704347838972062f89149a9c3cd149748da60bdcd3e0"
+"checksum libp2p-mdns 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9bc1a5d85f4812cae6367b49a432763fe28997bac7c530dc55b70ec18a78aa7"
+"checksum libp2p-mplex 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe5a858342a1cc89464474f7edc4bae1da649b9c823a3e04d9fb494493601746"
+"checksum libp2p-noise 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc6b5185c50a52a12e7bbe2ee7799059e24de4e52ab25edbfd26c8ab8515d317"
+"checksum libp2p-ping 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7905c1431ad115bee83405770629a27d6f17153ad02ec9670a7347998ef20e22"
+"checksum libp2p-plaintext 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc17626763ded57da8fed73187c2d9f6ebb89d30838673c430315bf560c7e4db"
+"checksum libp2p-ratelimit 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2409d08b809ab1a74269597f7da2829d117cc11b9ed3343af33fc20831619726"
+"checksum libp2p-secio 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "258cdc6742945c8f6402997bbbf36733588e2db18e5a0014da6d46e3ccfb92cf"
+"checksum libp2p-tcp 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b5691e2ba2720d42bd1e93d6b90239fa9235c1956ef6a5f1dd499a7ae2767be"
+"checksum libp2p-uds 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ab0b9ca050105fd94229c48911c0c84aef4d6b86a53d1b6df81d938354e47e"
+"checksum libp2p-websocket 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81692c3141a9aefd84f4faffdc93985af3858ef82ed7fe8185e6b27437b36183"
+"checksum libp2p-yamux 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6ff51a5b2056bacee1c9f2ed8455cdf3c5c619261ddb4efc783119130aaf52"
 "checksum librocksdb-sys 5.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfb546562f9b450237bb8df7a31961849ee9fb1186d9e356db1d7a6b7609ff2"
 "checksum libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "688e8d65e495567c2c35ea0001b26b9debf0b4ea11f8cccc954233b75fc3428a"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
@@ -5397,7 +5495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dcb43c05fb71c03b4ea7327bf15694da1e0f23f19d5b1e95bab6c6d74097e336"
 "checksum parity-codec-derive 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00a486fd383382ddcb2de928364b1f82571c1e48274fc43b7667a4738ee4056c"
 "checksum parity-crypto 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b9db194dfbcfe3b398d63d765437a5c7232d59906e203055f0e993f6458ff1"
-"checksum parity-multiaddr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61ae6944d4435d41f4d0f12108c5cbb9207cbb14bc8f2b4984c6e930dc9c8e41"
+"checksum parity-multiaddr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18a130a727008cfcd1068a28439fe939897ccad28664422aeca65b384d6de6d0"
 "checksum parity-multihash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05d6a68e07ab34a9e87bd8dd4936f6bb5be21e4f6dbcdbaf04d8e854eba0af01"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
 "checksum parity-ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2fec5048fba72a2e01baeb0d08089db79aead4b57e2443df172fb1840075a233"
@@ -5469,6 +5567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
 "checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
 "checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
@@ -5485,6 +5584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "60c04b4726fa04595ccf2c2dad7bcd15474242c4c5e109a8a376e8a2c9b1539a"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum snow 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a64f02fd208ef15bd2d1a65861df4707e416151e1272d02c8faafad1c138100"
+"checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
@@ -5570,12 +5670,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum wasm-bindgen 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "ffde3534e5fa6fd936e3260cd62cd644b8656320e369388f9303c955895e35d4"
 "checksum wasm-bindgen-backend 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "40c0543374a7ae881cdc5d32d19de28d1d1929e92263ffa7e31712cc2d53f9f1"
+"checksum wasm-bindgen-futures 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad171fc1f6e43f97d155d27f4ee5657bd8aa5cce7c497ef3a0a0c5b44618b2d"
 "checksum wasm-bindgen-macro 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "f914c94c2c5f4c9364510ca2429e59c92157ec89429243bcc245e983db990a71"
 "checksum wasm-bindgen-macro-support 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "9168c413491e4233db7b6884f09a43beb00c14d11d947ffd165242daa48a2385"
 "checksum wasm-bindgen-shared 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "326c32126e1a157b6ced7400061a84ac5b11182b2cda6edad7314eb3ae9ac9fe"
+"checksum wasm-bindgen-webidl 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "613dbf4d7d3bf10aeb212b35de14a8ef07222c26526d4f931061a83fc9e2a851"
 "checksum wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aebbaef470840d157a5c47c8c49f024da7b1b80e90ff729ca982b2b80447e78b"
 "checksum wasmi-validation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab380192444b3e8522ae79c0a1976e42a82920916ccdfbce3def89f456ea33f3"
+"checksum web-sys 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "24129e4be2281109b3e15a328d3d7f233ee232a5405f75ba1e9bb59a25ebc4d4"
 "checksum websocket 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7cc2d74d89f9df981ab41ae624e33cf302fdf456b93455c6a31911a99c9f0bb8"
+"checksum weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26a4c67f132386d965390b8a734d5d10adbcd30eb5cc74bd9229af8b83f10044"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
@@ -5589,5 +5693,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
-"checksum yamux 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "302defd1bed8a9a6d43b82f0e5a50510dfdfbbd02c270c93ff9d6f3f5e2dea89"
+"checksum yamux 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01bd67889938c48f0049fc60a77341039e6c3eaf16cb7693e6ead7c0ba701295"
 "checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -322,6 +322,7 @@ fn fill_network_configuration(
 	chain_spec_id: &str,
 	config: &mut NetworkConfiguration,
 	client_id: String,
+	is_dev: bool,
 ) -> error::Result<()> {
 	config.boot_nodes.extend(cli.bootnodes.into_iter());
 	config.config_path = Some(
@@ -359,7 +360,7 @@ fn fill_network_configuration(
 	config.in_peers = cli.in_peers;
 	config.out_peers = cli.out_peers;
 
-	config.enable_mdns = !cli.no_mdns;
+	config.enable_mdns = !is_dev && !cli.no_mdns;
 
 	Ok(())
 }
@@ -440,6 +441,8 @@ where
 	config.roles = role;
 	config.disable_grandpa = cli.no_grandpa;
 
+	let is_dev = cli.shared_params.dev;
+
 	let client_id = config.client_id();
 	fill_network_configuration(
 		cli.network_config,
@@ -447,6 +450,7 @@ where
 		spec.id(),
 		&mut config.network,
 		client_id,
+		is_dev,
 	)?;
 
 	fill_transaction_pool_configuration::<F>(

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -119,7 +119,7 @@ pub struct NetworkConfigurationParams {
 	pub in_peers: u32,
 
 	/// By default, the network will use mDNS to discover other nodes on the local network. This
-	/// disables it.
+	/// disables it. Automatically implied when using --dev.
 	#[structopt(long = "no-mdns")]
 	pub no_mdns: bool,
 

--- a/core/consensus/common/Cargo.toml
+++ b/core/consensus/common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 crossbeam-channel = "0.3.4"
-libp2p = { version = "0.6.0", default-features = false }
+libp2p = { version = "0.7.0", default-features = false }
 log = "0.4"
 primitives = { package = "substrate-primitives", path= "../../primitives" }
 inherents = { package = "substrate-inherents", path = "../../inherents" }

--- a/core/network-libp2p/Cargo.toml
+++ b/core/network-libp2p/Cargo.toml
@@ -13,7 +13,7 @@ bytes = "0.4"
 error-chain = { version = "0.12", default-features = false }
 fnv = "1.0"
 futures = "0.1"
-libp2p = { version = "0.6.0", default-features = false, features = ["secio-secp256k1", "libp2p-websocket"] }
+libp2p = { version = "0.7.0", default-features = false, features = ["secio-secp256k1", "libp2p-websocket"] }
 parking_lot = "0.7.1"
 lazy_static = "1.2"
 log = "0.4"

--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -27,7 +27,7 @@ use libp2p::mdns::{Mdns, MdnsEvent};
 use libp2p::multiaddr::Protocol;
 use libp2p::ping::{Ping, PingConfig, PingEvent, PingSuccess};
 use log::{debug, info, trace, warn};
-use std::{cmp, io, fmt, time::Duration};
+use std::{borrow::Cow, cmp, fmt, time::Duration};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::{Delay, clock::Clock};
 use void;
@@ -172,8 +172,8 @@ pub enum BehaviourOut<TMessage> {
 	CustomProtocolClosed {
 		/// Id of the peer we were connected to.
 		peer_id: PeerId,
-		/// Reason why the substream closed. If `Ok`, then it's a graceful exit (EOF).
-		result: io::Result<()>,
+		/// Reason why the substream closed, for diagnostic purposes.
+		reason: Cow<'static, str>,
 	},
 
 	/// Receives a message on a custom protocol substream.
@@ -215,8 +215,8 @@ impl<TMessage> From<CustomProtoOut<TMessage>> for BehaviourOut<TMessage> {
 			CustomProtoOut::CustomProtocolOpen { version, peer_id, endpoint } => {
 				BehaviourOut::CustomProtocolOpen { version, peer_id, endpoint }
 			}
-			CustomProtoOut::CustomProtocolClosed { peer_id, result } => {
-				BehaviourOut::CustomProtocolClosed { peer_id, result }
+			CustomProtoOut::CustomProtocolClosed { peer_id, reason } => {
+				BehaviourOut::CustomProtocolClosed { peer_id, reason }
 			}
 			CustomProtoOut::CustomMessage { peer_id, message } => {
 				BehaviourOut::CustomMessage { peer_id, message }

--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -252,8 +252,10 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<IdentifyEvent> for Behav
 					warn!(target: "sub-libp2p", "Connected to a non-Substrate node: {:?}", info);
 				}
 				if info.listen_addrs.len() > 30 {
-					warn!(target: "sub-libp2p", "Node {:?} id reported more than 30 addresses",
-						peer_id);
+					warn!(target: "sub-libp2p", "Node {:?} has reported more than 30 addresses; \
+						it is identified by {:?} and {:?}", peer_id, info.protocol_version,
+						info.agent_version
+					);
 					info.listen_addrs.truncate(30);
 				}
 				for addr in &info.listen_addrs {

--- a/core/network-libp2p/src/behaviour.rs
+++ b/core/network-libp2p/src/behaviour.rs
@@ -24,11 +24,12 @@ use libp2p::core::swarm::toggle::Toggle;
 use libp2p::identify::{Identify, IdentifyEvent, protocol::IdentifyInfo};
 use libp2p::kad::{Kademlia, KademliaOut};
 use libp2p::mdns::{Mdns, MdnsEvent};
-use libp2p::ping::{Ping, PingEvent};
-use log::{debug, trace, warn};
-use std::{cmp, io, fmt, time::Duration, time::Instant};
+use libp2p::multiaddr::Protocol;
+use libp2p::ping::{Ping, PingConfig, PingEvent, PingSuccess};
+use log::{debug, info, trace, warn};
+use std::{cmp, io, fmt, time::Duration};
 use tokio_io::{AsyncRead, AsyncWrite};
-use tokio_timer::Delay;
+use tokio_timer::{Delay, clock::Clock};
 use void;
 
 /// General behaviour of the network.
@@ -68,19 +69,22 @@ impl<TMessage, TSubstream> Behaviour<TMessage, TSubstream> {
 
 		let custom_protocols = CustomProto::new(protocol, peerset);
 
-		let mut kademlia = Kademlia::new(local_public_key.into_peer_id());
+		let mut kademlia = Kademlia::new(local_public_key.clone().into_peer_id());
 		for (peer_id, addr) in &known_addresses {
 			kademlia.add_connected_address(peer_id, addr.clone());
 		}
 
+		let clock = Clock::new();
 		Behaviour {
-			ping: Ping::new(),
+			ping: Ping::new(PingConfig::new()),
 			custom_protocols,
 			discovery: DiscoveryBehaviour {
 				user_defined: known_addresses,
 				kademlia,
-				next_kad_random_query: Delay::new(Instant::now()),
+				next_kad_random_query: Delay::new(clock.now()),
 				duration_to_next_kad: Duration::from_secs(1),
+				clock,
+				local_peer_id: local_public_key.into_peer_id(),
 			},
 			identify,
 			mdns: if enable_mdns {
@@ -291,10 +295,11 @@ impl<TMessage, TSubstream> NetworkBehaviourEventProcess<KademliaOut> for Behavio
 impl<TMessage, TSubstream> NetworkBehaviourEventProcess<PingEvent> for Behaviour<TMessage, TSubstream> {
 	fn inject_event(&mut self, event: PingEvent) {
 		match event {
-			PingEvent::PingSuccess { peer, time } => {
-				trace!(target: "sub-libp2p", "Ping time with {:?}: {:?}", peer, time);
-				self.events.push(BehaviourOut::PingSuccess { peer_id: peer, ping_time: time });
+			PingEvent { peer, result: Ok(PingSuccess::Ping { rtt }) } => {
+				trace!(target: "sub-libp2p", "Ping time with {:?}: {:?}", peer, rtt);
+				self.events.push(BehaviourOut::PingSuccess { peer_id: peer, ping_time: rtt });
 			}
+			_ => ()
 		}
 	}
 }
@@ -333,6 +338,10 @@ pub struct DiscoveryBehaviour<TSubstream> {
 	next_kad_random_query: Delay,
 	/// After `next_kad_random_query` triggers, the next one triggers after this duration.
 	duration_to_next_kad: Duration,
+	/// `Clock` instance that uses the current execution context's source of time.
+	clock: Clock,
+	/// Identity of our local node.
+	local_peer_id: PeerId,
 }
 
 impl<TSubstream> NetworkBehaviour for DiscoveryBehaviour<TSubstream>
@@ -384,6 +393,16 @@ where
 		NetworkBehaviour::inject_node_event(&mut self.kademlia, peer_id, event)
 	}
 
+	fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
+		let new_addr = addr.clone()
+			.with(Protocol::P2p(self.local_peer_id.clone().into()));
+		info!(target: "sub-libp2p", "Discovered external node address: {}", new_addr);
+	}
+
+	fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
+		info!(target: "sub-libp2p", "No longer listening on {}", addr);
+	}
+
 	fn poll(
 		&mut self,
 		params: &mut PollParameters,
@@ -410,7 +429,7 @@ where
 					self.kademlia.find_node(random_peer_id);
 
 					// Reset the `Delay` to the next random.
-					self.next_kad_random_query.reset(Instant::now() + self.duration_to_next_kad);
+					self.next_kad_random_query.reset(self.clock.now() + self.duration_to_next_kad);
 					self.duration_to_next_kad = cmp::min(self.duration_to_next_kad * 2,
 						Duration::from_secs(60));
 				},

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -603,31 +603,25 @@ where
 	}
 
 	fn inject_connected(&mut self, peer_id: PeerId, connected_point: ConnectedPoint) {
-		match (self.peers.entry(peer_id), connected_point) {
-			(Entry::Occupied(mut entry), connected_point) => {
-				match mem::replace(entry.get_mut(), PeerState::Poisoned) {
-					PeerState::Requested | PeerState::PendingRequest { .. } |
-					PeerState::Banned { .. } => {
-						debug!(target: "sub-libp2p", "Libp2p => Connected({:?}): Connection \
-							requested by PSM (through {:?})", entry.key(), connected_point);
-						debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", entry.key());
-						self.events.push(NetworkBehaviourAction::SendEvent {
-							peer_id: entry.key().clone(),
-							event: CustomProtoHandlerIn::Enable(connected_point.clone().into()),
-						});
-						*entry.into_mut() = PeerState::Enabled { open: false, connected_point };
-					}
-					st @ _ => {
-						// This is a serious bug either in this state machine or in libp2p.
-						error!(target: "sub-libp2p", "Received inject_connected for \
-							already-connected node; state is {:?}", st);
-						*entry.into_mut() = st;
-						return
-					}
-				}
+		match (self.peers.entry(peer_id.clone()).or_insert(PeerState::Poisoned), connected_point) {
+			(st @ &mut PeerState::Requested, connected_point) |
+			(st @ &mut PeerState::PendingRequest { .. }, connected_point) => {
+				debug!(target: "sub-libp2p", "Libp2p => Connected({:?}): Connection \
+					requested by PSM (through {:?})", peer_id, connected_point
+				);
+				debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", peer_id);
+				self.events.push(NetworkBehaviourAction::SendEvent {
+					peer_id: peer_id.clone(),
+					event: CustomProtoHandlerIn::Enable(connected_point.clone().into()),
+				});
+				*st = PeerState::Enabled { open: false, connected_point };
 			}
 
-			(Entry::Vacant(entry), connected_point @ ConnectedPoint::Listener { .. }) => {
+			// Note: it may seem weird that "Banned" nodes get treated as if there were absent.
+			// This is because the word "Banned" means "temporarily prevent outgoing connections to
+			// this node", and not "banned" in the sense that we would refuse the node altogether.
+			(st @ &mut PeerState::Poisoned, connected_point @ ConnectedPoint::Listener { .. }) |
+			(st @ &mut PeerState::Banned { .. }, connected_point @ ConnectedPoint::Listener { .. }) => {
 				let incoming_id = self.next_incoming_index.clone();
 				self.next_incoming_index.0 = match self.next_incoming_index.0.checked_add(1) {
 					Some(v) => v,
@@ -637,27 +631,40 @@ where
 					}
 				};
 				debug!(target: "sub-libp2p", "Libp2p => Connected({:?}): Incoming connection",
-					entry.key());
+					peer_id);
 				debug!(target: "sub-libp2p", "PSM <= Incoming({:?}, {:?}): Through {:?}",
-					incoming_id, entry.key(), connected_point);
-				self.peerset.incoming(entry.key().clone(), incoming_id);
+					incoming_id, peer_id, connected_point);
+				self.peerset.incoming(peer_id.clone(), incoming_id);
 				self.incoming.push(IncomingPeer {
-					peer_id: entry.key().clone(),
+					peer_id: peer_id.clone(),
 					alive: true,
 					incoming_id,
 				});
-				entry.insert(PeerState::Incoming { connected_point });
+				*st = PeerState::Incoming { connected_point };
 			}
 
-			(Entry::Vacant(entry), connected_point) => {
+			(st @ &mut PeerState::Poisoned, connected_point) |
+			(st @ &mut PeerState::Banned { .. }, connected_point) => {
+				let banned_until = if let PeerState::Banned { until } = st {
+					Some(*until)
+				} else {
+					None
+				};
 				debug!(target: "sub-libp2p", "Libp2p => Connected({:?}): Requested by something \
-					else than PSM, disabling", entry.key());
-				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", entry.key());
+					else than PSM, disabling", peer_id);
+				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", peer_id);
 				self.events.push(NetworkBehaviourAction::SendEvent {
-					peer_id: entry.key().clone(),
+					peer_id: peer_id.clone(),
 					event: CustomProtoHandlerIn::Disable,
 				});
-				entry.insert(PeerState::Disabled { open: false, connected_point, banned_until: None });
+				*st = PeerState::Disabled { open: false, connected_point, banned_until };
+			}
+
+			st => {
+				// This is a serious bug either in this state machine or in libp2p.
+				error!(target: "sub-libp2p", "Received inject_connected for \
+					already-connected node; state is {:?}", st
+				);
 			}
 		}
 	}

--- a/core/network-libp2p/src/custom_proto/behaviour.rs
+++ b/core/network-libp2p/src/custom_proto/behaviour.rs
@@ -22,7 +22,7 @@ use libp2p::core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourActi
 use libp2p::core::{Multiaddr, PeerId};
 use log::{debug, error, trace, warn};
 use smallvec::SmallVec;
-use std::{collections::hash_map::Entry, cmp, error, io, marker::PhantomData, mem, time::Duration, time::Instant};
+use std::{borrow::Cow, collections::hash_map::Entry, cmp, error, marker::PhantomData, mem, time::Duration, time::Instant};
 use tokio_io::{AsyncRead, AsyncWrite};
 
 /// Network behaviour that handles opening substreams for custom protocols with other nodes.
@@ -178,8 +178,8 @@ pub enum CustomProtoOut<TMessage> {
 	CustomProtocolClosed {
 		/// Id of the peer we were connected to.
 		peer_id: PeerId,
-		/// Reason why the substream closed. If `Ok`, then it's a graceful exit (EOF).
-		result: io::Result<()>,
+		/// Reason why the substream closed, for debugging purposes.
+		reason: Cow<'static, str>,
 	},
 
 	/// Receives a message on a custom protocol substream.
@@ -687,7 +687,7 @@ where
 					debug!(target: "sub-libp2p", "External API <= Closed({:?})", peer_id);
 					let event = CustomProtoOut::CustomProtocolClosed {
 						peer_id: peer_id.clone(),
-						result: Ok(()),
+						reason: "Disconnected by libp2p".into(),
 					};
 
 					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
@@ -704,7 +704,7 @@ where
 					debug!(target: "sub-libp2p", "External API <= Closed({:?})", peer_id);
 					let event = CustomProtoOut::CustomProtocolClosed {
 						peer_id: peer_id.clone(),
-						result: Ok(()),
+						reason: "Disconnected by libp2p".into(),
 					};
 
 					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
@@ -721,7 +721,7 @@ where
 					debug!(target: "sub-libp2p", "External API <= Closed({:?})", peer_id);
 					let event = CustomProtoOut::CustomProtocolClosed {
 						peer_id: peer_id.clone(),
-						result: Ok(()),
+						reason: "Disconnected by libp2p".into(),
 					};
 
 					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
@@ -793,8 +793,8 @@ where
 		event: CustomProtoHandlerOut<TMessage>,
 	) {
 		match event {
-			CustomProtoHandlerOut::CustomProtocolClosed { result } => {
-				debug!(target: "sub-libp2p", "Handler({:?}) => Closed({:?})", source, result);
+			CustomProtoHandlerOut::CustomProtocolClosed { reason } => {
+				debug!(target: "sub-libp2p", "Handler({:?}) => Closed: {}", source, reason);
 
 				let mut entry = if let Entry::Occupied(entry) = self.peers.entry(source.clone()) {
 					entry
@@ -805,7 +805,7 @@ where
 
 				debug!(target: "sub-libp2p", "External API <= Closed({:?})", source);
 				let event = CustomProtoOut::CustomProtocolClosed {
-					result,
+					reason,
 					peer_id: source.clone(),
 				};
 				self.events.push(NetworkBehaviourAction::GenerateEvent(event));

--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -26,7 +26,7 @@ use libp2p::core::{
 	upgrade::{InboundUpgrade, OutboundUpgrade}
 };
 use log::{debug, error};
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use std::{error, fmt, io, marker::PhantomData, mem, time::Duration, time::Instant};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::Delay;
@@ -73,13 +73,18 @@ use void::Void;
 /// `Disable` or an `Enable` message from the outer layer. At any time, the outer layer is free to
 /// toggle the handler between the disabled and enabled states.
 ///
-/// When the handler is enabled for the first time, if it is the dialer of the connection, it tries
-/// to open a substream. The substream negotiates either a protocol named `/substrate/xxx`, where
-/// `xxx` is chosen by the user.
+/// When the handler switches to "enabled", it opens a substream and negotiates the protocol named
+/// `/substrate/xxx`, where `xxx` is chosen by the user and depends on the chain.
 ///
-/// Then, we have one unique substream where bidirectional communications happen. If the remote
-/// closes the substream, we consider that we are now disconnected. Re-enabling is performed by
-/// re-opening the substream (even if we are not the dialer of the connection).
+/// For backwards compatibility reasons, when we switch to "enabled" for the first time (while we
+/// are still in "init" mode) and we are the connection listener, we don't open a substream.
+///
+/// In order the handle the situation where both the remote and us get enabled at the same time,
+/// we tolerate multiple substreams open at the same time. Messages are transmitted on an arbitrary
+/// substream. The endpoints don't try to agree on a single substream.
+///
+/// We consider that we are now "closed" if the remote closes all the existing substreams.
+/// Re-opening it can then be performed by closing all active substream and re-opening one.
 ///
 pub struct CustomProtoHandlerProto<TMessage, TSubstream> {
 	/// Configuration for the protocol upgrade to negotiate.
@@ -164,11 +169,11 @@ enum ProtocolState<TMessage, TSubstream> {
 		deadline: Delay,
 	},
 
-	/// Backwards-compatible mode. Contains the unique substream that is open.
+	/// Normal operating mode. Contains the substreams that are open.
 	/// If we are in this state, we have sent a `CustomProtocolOpen` message to the outside.
 	Normal {
-		/// The unique substream where bidirectional communications happen.
-		substream: RegisteredProtocolSubstream<TMessage, TSubstream>,
+		/// The substreams where bidirectional communications happen.
+		substreams: SmallVec<[RegisteredProtocolSubstream<TMessage, TSubstream>; 4]>,
 		/// Contains substreams which are being shut down.
 		shutdown: SmallVec<[RegisteredProtocolSubstream<TMessage, TSubstream>; 4]>,
 	},
@@ -279,8 +284,7 @@ where
 					};
 					self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
 					ProtocolState::Normal {
-						substream: incoming.into_iter().next()
-							.expect("We have a check above that incoming isn't empty; QED"),
+						substreams: incoming.into_iter().collect(),
 						shutdown: SmallVec::new()
 					}
 				}
@@ -314,9 +318,11 @@ where
 				ProtocolState::Disabled { shutdown: SmallVec::new(), reenable: false }
 			}
 
-			ProtocolState::Normal { mut substream, mut shutdown } => {
-				substream.shutdown();
-				shutdown.push(substream);
+			ProtocolState::Normal { substreams, mut shutdown } => {
+				for mut substream in substreams {
+					substream.shutdown();
+					shutdown.push(substream);
+				}
 				let event = CustomProtoHandlerOut::CustomProtocolClosed {
 					result: Ok(())
 				};
@@ -336,13 +342,12 @@ where
 	#[must_use]
 	fn poll_state(&mut self)
 		-> Option<ProtocolsHandlerEvent<RegisteredProtocol<TMessage>, (), CustomProtoHandlerOut<TMessage>>> {
-		let return_value;
-		self.state = match mem::replace(&mut self.state, ProtocolState::Poisoned) {
+		match mem::replace(&mut self.state, ProtocolState::Poisoned) {
 			ProtocolState::Poisoned => {
 				error!(target: "sub-libp2p", "Handler with {:?} is in poisoned state",
 					self.remote_peer_id);
-				return_value = None;
-				ProtocolState::Poisoned
+				self.state = ProtocolState::Poisoned;
+				None
 			}
 
 			ProtocolState::Init { substreams, mut init_deadline } => {
@@ -356,8 +361,8 @@ where
 					Err(_) => error!(target: "sub-libp2p", "Tokio timer has errored")
 				}
 
-				return_value = None;
-				ProtocolState::Init { substreams, init_deadline }
+				self.state = ProtocolState::Init { substreams, init_deadline };
+				None
 			}
 
 			ProtocolState::Opening { mut deadline } => {
@@ -368,63 +373,74 @@ where
 							is_severe: true,
 							error: "Timeout when opening protocol".to_string().into(),
 						};
-						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::Opening { deadline }
+						self.state = ProtocolState::Opening { deadline };
+						Some(ProtocolsHandlerEvent::Custom(event))
 					},
 					Ok(Async::NotReady) => {
-						return_value = None;
-						ProtocolState::Opening { deadline }
+						self.state = ProtocolState::Opening { deadline };
+						None
 					},
 					Err(_) => {
 						error!(target: "sub-libp2p", "Tokio timer has errored");
 						deadline.reset(Instant::now() + Duration::from_secs(60));
-						return_value = None;
-						ProtocolState::Opening { deadline }
+						self.state = ProtocolState::Opening { deadline };
+						None
 					},
 				}
 			}
 
-			ProtocolState::Normal { mut substream, shutdown } => {
-				match substream.poll() {
-					Ok(Async::Ready(Some(RegisteredProtocolEvent::Message(message)))) => {
-						let event = CustomProtoHandlerOut::CustomMessage {
-							message
-						};
-						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::Normal { substream, shutdown }
-					},
-					Ok(Async::Ready(Some(RegisteredProtocolEvent::Clogged { messages }))) => {
-						let event = CustomProtoHandlerOut::Clogged {
-							messages,
-						};
-						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::Normal { substream, shutdown }
-					}
-					Ok(Async::NotReady) => {
-						return_value = None;
-						ProtocolState::Normal { substream, shutdown }
-					}
-					Ok(Async::Ready(None)) => {
-						let event = CustomProtoHandlerOut::CustomProtocolClosed {
-							result: Ok(())
-						};
-						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::Disabled {
-							shutdown: shutdown.into_iter().collect(),
-							reenable: true
+			ProtocolState::Normal { mut substreams, shutdown } => {
+				for n in (0..substreams.len()).rev() {
+					let mut substream = substreams.swap_remove(n);
+					match substream.poll() {
+						Ok(Async::NotReady) => substreams.push(substream),
+						Ok(Async::Ready(Some(RegisteredProtocolEvent::Message(message)))) => {
+							let event = CustomProtoHandlerOut::CustomMessage {
+								message
+							};
+							substreams.push(substream);
+							self.state = ProtocolState::Normal { substreams, shutdown };
+							return Some(ProtocolsHandlerEvent::Custom(event));
+						},
+						Ok(Async::Ready(Some(RegisteredProtocolEvent::Clogged { messages }))) => {
+							let event = CustomProtoHandlerOut::Clogged {
+								messages,
+							};
+							substreams.push(substream);
+							self.state = ProtocolState::Normal { substreams, shutdown };
+							return Some(ProtocolsHandlerEvent::Custom(event));
 						}
-					}
-					Err(err) => {
-						let event = CustomProtoHandlerOut::CustomProtocolClosed {
-							result: Err(err),
-						};
-						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::Disabled {
-							shutdown: shutdown.into_iter().collect(),
-							reenable: true
+						Ok(Async::Ready(None)) => {
+							let event = CustomProtoHandlerOut::CustomProtocolClosed {
+								result: Ok(())
+							};
+							substreams.push(substream);
+							self.state = ProtocolState::Disabled {
+								shutdown: shutdown.into_iter().collect(),
+								reenable: true
+							};
+							return Some(ProtocolsHandlerEvent::Custom(event));
+						}
+						Err(err) => {
+							if substreams.is_empty() {
+								let event = CustomProtoHandlerOut::CustomProtocolClosed {
+									result: Err(err),
+								};
+								self.state = ProtocolState::Disabled {
+									shutdown: shutdown.into_iter().collect(),
+									reenable: true
+								};
+								return Some(ProtocolsHandlerEvent::Custom(event));
+							} else {
+								debug!(target: "sub-libp2p", "Error on extra substream: {:?}", err);
+							}
 						}
 					}
 				}
+
+				// This code is reached is none if and only if none of the substreams are in a ready state.
+				self.state = ProtocolState::Normal { substreams, shutdown };
+				None
 			}
 
 			ProtocolState::Disabled { mut shutdown, reenable } => {
@@ -432,21 +448,19 @@ where
 				// If `reenable` is `true`, that means we should open the substreams system again
 				// after all the substreams are closed.
 				if reenable && shutdown.is_empty() {
-					return_value = Some(ProtocolsHandlerEvent::OutboundSubstreamRequest {
+					self.state = ProtocolState::Opening {
+						deadline: Delay::new(Instant::now() + Duration::from_secs(60))
+					};
+					Some(ProtocolsHandlerEvent::OutboundSubstreamRequest {
 						protocol: SubstreamProtocol::new(self.protocol.clone()),
 						info: (),
-					});
-					ProtocolState::Opening {
-						deadline: Delay::new(Instant::now() + Duration::from_secs(60))
-					}
+					})
 				} else {
-					return_value = None;
-					ProtocolState::Disabled { shutdown, reenable }
+					self.state = ProtocolState::Disabled { shutdown, reenable };
+					None
 				}
 			}
-		};
-
-		return_value
+		}
 	}
 
 	/// Called by `inject_fully_negotiated_inbound` and `inject_fully_negotiated_outbound`.
@@ -476,17 +490,14 @@ where
 				};
 				self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
 				ProtocolState::Normal {
-					substream,
+					substreams: smallvec![substream],
 					shutdown: SmallVec::new()
 				}
 			}
 
-			ProtocolState::Normal { substream: existing, mut shutdown } => {
-				debug!(target: "sub-libp2p", "Received extra substream after having already one \
-					open in backwards-compatibility mode with {:?}", self.remote_peer_id);
-				substream.shutdown();
-				shutdown.push(substream);
-				ProtocolState::Normal { substream: existing, shutdown }
+			ProtocolState::Normal { substreams: mut existing, shutdown } => {
+				existing.push(substream);
+				ProtocolState::Normal { substreams: existing, shutdown }
 			}
 
 			ProtocolState::Disabled { mut shutdown, .. } => {
@@ -500,8 +511,8 @@ where
 	/// Sends a message to the remote.
 	fn send_message(&mut self, message: TMessage) {
 		match self.state {
-			ProtocolState::Normal { ref mut substream, .. } =>
-				substream.send_message(message),
+			ProtocolState::Normal { ref mut substreams, .. } =>
+				substreams[0].send_message(message),
 
 			_ => debug!(target: "sub-libp2p", "Tried to send message over closed protocol \
 				with {:?}", self.remote_peer_id)

--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -30,7 +30,6 @@ use smallvec::{smallvec, SmallVec};
 use std::{borrow::Cow, error, fmt, io, marker::PhantomData, mem, time::Duration, time::Instant};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::Delay;
-use void::Void;
 
 /// Implements the `IntoProtocolsHandler` trait of libp2p.
 ///
@@ -188,6 +187,10 @@ enum ProtocolState<TMessage, TSubstream> {
 		reenable: bool,
 	},
 
+	/// In this state, we don't care about anything anymore and need to kill the connection as soon
+	/// as possible.
+	KillAsap,
+
 	/// We sometimes temporarily switch to this state during processing. If we are in this state
 	/// at the beginning of a method, that means something bad happend in the source code.
 	Poisoned,
@@ -285,6 +288,7 @@ where
 				}
 			}
 
+			st @ ProtocolState::KillAsap => st,
 			st @ ProtocolState::Opening { .. } => st,
 			st @ ProtocolState::Normal { .. } => st,
 			ProtocolState::Disabled { shutdown, .. } => {
@@ -309,27 +313,18 @@ where
 				ProtocolState::Disabled { shutdown, reenable: false }
 			}
 
-			ProtocolState::Opening { .. } => {
-				ProtocolState::Disabled { shutdown: SmallVec::new(), reenable: false }
-			}
-
-			ProtocolState::Normal { substreams, mut shutdown } => {
-				for mut substream in substreams {
-					substream.shutdown();
-					shutdown.push(substream);
-				}
-				let event = CustomProtoHandlerOut::CustomProtocolClosed {
-					reason: "Disabled on purpose on our side".into()
-				};
-				self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-				ProtocolState::Disabled {
-					shutdown: shutdown.into_iter().collect(),
-					reenable: false
-				}
-			}
+			ProtocolState::Opening { .. } | ProtocolState::Normal { .. } =>
+				// At the moment, if we get disabled while things were working, we kill the entire
+				// connection in order to force a reset of the state.
+				// This is obviously an extremely shameful way to do things, but at the time of
+				// the writing of this comment, the networking works very poorly and a solution
+				// needs to be found.
+				ProtocolState::KillAsap,
 
 			ProtocolState::Disabled { shutdown, .. } =>
 				ProtocolState::Disabled { shutdown, reenable: false },
+
+			ProtocolState::KillAsap => ProtocolState::KillAsap,
 		};
 	}
 
@@ -457,6 +452,8 @@ where
 					None
 				}
 			}
+
+			ProtocolState::KillAsap => None,
 		}
 	}
 
@@ -502,6 +499,8 @@ where
 				shutdown.push(substream);
 				ProtocolState::Disabled { shutdown, reenable: false }
 			}
+
+			ProtocolState::KillAsap => ProtocolState::KillAsap,
 		};
 	}
 
@@ -522,7 +521,7 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 	type InEvent = CustomProtoHandlerIn<TMessage>;
 	type OutEvent = CustomProtoHandlerOut<TMessage>;
 	type Substream = TSubstream;
-	type Error = Void;
+	type Error = ConnectionKillError;
 	type InboundProtocol = RegisteredProtocol<TMessage>;
 	type OutboundProtocol = RegisteredProtocol<TMessage>;
 	type OutboundOpenInfo = ();
@@ -572,7 +571,8 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 		match self.state {
 			ProtocolState::Init { .. } | ProtocolState::Opening { .. } |
 			ProtocolState::Normal { .. } => KeepAlive::Yes,
-			ProtocolState::Disabled { .. } | ProtocolState::Poisoned => KeepAlive::No,
+			ProtocolState::Disabled { .. } | ProtocolState::Poisoned |
+      ProtocolState::KillAsap => KeepAlive::No,
 		}
 	}
 
@@ -586,6 +586,11 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 		if !self.events_queue.is_empty() {
 			let event = self.events_queue.remove(0);
 			return Ok(Async::Ready(event))
+		}
+
+		// Kill the connection if needed.
+		if let ProtocolState::KillAsap = self.state {
+			return Err(ConnectionKillError);
 		}
 
 		// Process all the substreams.
@@ -622,5 +627,18 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 			}
 		}
 		list.push(substream);
+	}
+}
+
+/// Error returned when switching from normal to disabled.
+#[derive(Debug)]
+pub struct ConnectionKillError;
+
+impl error::Error for ConnectionKillError {
+}
+
+impl fmt::Display for ConnectionKillError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "Connection kill when switching from normal to disabled")
 	}
 }

--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -344,7 +344,7 @@ where
 				match init_deadline.poll() {
 					Ok(Async::Ready(())) => {
 						init_deadline.reset(Instant::now() + Duration::from_secs(60));
-						error!(target: "sub-libp2p", "Handler initialization process is too long \
+						debug!(target: "sub-libp2p", "Handler initialization process is too long \
 							with {:?}", self.remote_peer_id)
 					},
 					Ok(Async::NotReady) => {}

--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::custom_proto::upgrade::{CustomMessage, CustomMessageId, RegisteredProtocol};
+use crate::custom_proto::upgrade::{CustomMessage, RegisteredProtocol};
 use crate::custom_proto::upgrade::{RegisteredProtocolEvent, RegisteredProtocolSubstream};
 use futures::prelude::*;
 use libp2p::core::{
@@ -25,8 +25,8 @@ use libp2p::core::{
 	protocols_handler::SubstreamProtocol,
 	upgrade::{InboundUpgrade, OutboundUpgrade}
 };
-use log::{debug, error, warn};
-use smallvec::{smallvec, SmallVec};
+use log::{debug, error};
+use smallvec::SmallVec;
 use std::{error, fmt, io, marker::PhantomData, mem, time::Duration, time::Instant};
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_timer::Delay;
@@ -69,26 +69,17 @@ use void::Void;
 ///
 /// ## How it works
 ///
-/// For backwards compatibility reasons, the behaviour of the handler is quite complicated. After
-/// enough nodes have upgraded, it should be simplified by using helpers provided by libp2p.
-///
 /// When the handler is created, it is initially in the `Init` state and waits for either a
 /// `Disable` or an `Enable` message from the outer layer. At any time, the outer layer is free to
 /// toggle the handler between the disabled and enabled states.
 ///
 /// When the handler is enabled for the first time, if it is the dialer of the connection, it tries
-/// to open a substream. The substream negotiates either a protocol named `/substrate/xxx` or a
-/// protocol named `/substrate/multi/xxx`. If it is the former, then we are in
-/// "backwards-compatibility mode". If it is the latter, we are in normal operation mode.
+/// to open a substream. The substream negotiates either a protocol named `/substrate/xxx`, where
+/// `xxx` is chosen by the user.
 ///
-/// In "backwards-compatibility mode", we have one unique substream where bidirectional
-/// communications happen. If the remote closes the substream, we consider that we are now
-/// disconnected. Re-enabling is performed by re-opening the substream.
-///
-/// In normal operation mode, each request gets sent over a different substream where the response
-/// is then sent back. If the remote refuses one of our substream open request, or if an error
-/// happens on one substream, we consider that we are disconnected. Re-enabling is performed by
-/// opening an outbound substream.
+/// Then, we have one unique substream where bidirectional communications happen. If the remote
+/// closes the substream, we consider that we are now disconnected. Re-enabling is performed by
+/// re-opening the substream (even if we are not the dialer of the connection).
 ///
 pub struct CustomProtoHandlerProto<TMessage, TSubstream> {
 	/// Configuration for the protocol upgrade to negotiate.
@@ -175,16 +166,12 @@ enum ProtocolState<TMessage, TSubstream> {
 
 	/// Backwards-compatible mode. Contains the unique substream that is open.
 	/// If we are in this state, we have sent a `CustomProtocolOpen` message to the outside.
-	BackCompat {
+	Normal {
 		/// The unique substream where bidirectional communications happen.
 		substream: RegisteredProtocolSubstream<TMessage, TSubstream>,
 		/// Contains substreams which are being shut down.
 		shutdown: SmallVec<[RegisteredProtocolSubstream<TMessage, TSubstream>; 4]>,
 	},
-
-	/// Normal functionning. Contains the substreams that are open.
-	/// If we are in this state, we have sent a `CustomProtocolOpen` message to the outside.
-	Normal(PerProtocolNormalState<TMessage, TSubstream>),
 
 	/// We are disabled. Contains substreams that are being closed.
 	/// If we are in this state, either we have sent a `CustomProtocolClosed` message to the
@@ -204,128 +191,6 @@ enum ProtocolState<TMessage, TSubstream> {
 	/// We sometimes temporarily switch to this state during processing. If we are in this state
 	/// at the beginning of a method, that means something bad happend in the source code.
 	Poisoned,
-}
-
-/// Normal functionning mode for a protocol.
-struct PerProtocolNormalState<TMessage, TSubstream> {
-	/// Optional substream that we opened.
-	outgoing_substream: Option<RegisteredProtocolSubstream<TMessage, TSubstream>>,
-
-	/// Substreams that have been opened by the remote. We are waiting for a packet from it.
-	incoming_substreams: SmallVec<[RegisteredProtocolSubstream<TMessage, TSubstream>; 4]>,
-
-	/// For each request that has been sent to the remote, contains the substream where we
-	/// expect a response.
-	pending_response: SmallVec<[(u64, RegisteredProtocolSubstream<TMessage, TSubstream>); 4]>,
-
-	/// For each request received by the remote, contains the substream where to send back our
-	/// response. Once a response has been sent, the substream closes.
-	pending_send_back: SmallVec<[(u64, RegisteredProtocolSubstream<TMessage, TSubstream>); 4]>,
-
-	/// List of messages waiting for a substream to open in order to be sent.
-	pending_messages: SmallVec<[TMessage; 6]>,
-
-	/// Contains substreams which are being shut down.
-	shutdown: SmallVec<[RegisteredProtocolSubstream<TMessage, TSubstream>; 4]>,
-}
-
-impl<TMessage, TSubstream> PerProtocolNormalState<TMessage, TSubstream>
-where TMessage: CustomMessage, TSubstream: AsyncRead + AsyncWrite {
-	/// Polls for things that are new. Same API constraints as `Future::poll()`.
-	/// Optionally returns the event to produce.
-	/// You must pass the `protocol_id` as we need have to inject it in the returned event.
-	/// API note: Ideally we wouldn't need to be passed a `ProtocolId`, and we would return a
-	/// 	different enum that doesn't contain any `protocol_id`, and the caller would inject
-	/// 	the ID itself, but that's a ton of code for not much gain.
-	fn poll(&mut self) -> Option<CustomProtoHandlerOut<TMessage>> {
-		for n in (0..self.pending_response.len()).rev() {
-			let (request_id, mut substream) = self.pending_response.swap_remove(n);
-			match substream.poll() {
-				Ok(Async::Ready(Some(RegisteredProtocolEvent::Message(message)))) => {
-					if message.request_id() == CustomMessageId::Response(request_id) {
-						let event = CustomProtoHandlerOut::CustomMessage {
-							message
-						};
-						self.shutdown.push(substream);
-						return Some(event);
-					} else {
-						self.shutdown.push(substream);
-						let event = CustomProtoHandlerOut::ProtocolError {
-							is_severe: true,
-							error: format!("Request ID doesn't match substream: expected {:?}, \
-								got {:?}", request_id, message.request_id()).into(),
-						};
-						return Some(event);
-					}
-				},
-				Ok(Async::Ready(Some(RegisteredProtocolEvent::Clogged { .. }))) =>
-					unreachable!("Cannot receive Clogged message with new protocol version; QED"),
-				Ok(Async::NotReady) =>
-					self.pending_response.push((request_id, substream)),
-				Ok(Async::Ready(None)) => {
-					self.shutdown.push(substream);
-					let event = CustomProtoHandlerOut::ProtocolError {
-						is_severe: false,
-						error: format!("Request ID {:?} didn't receive an answer", request_id).into(),
-					};
-					return Some(event);
-				}
-				Err(err) => {
-					self.shutdown.push(substream);
-					let event = CustomProtoHandlerOut::ProtocolError {
-						is_severe: false,
-						error: format!("Error while waiting for an answer for {:?}: {}",
-							request_id, err).into(),
-					};
-					return Some(event);
-				}
-			}
-		}
-
-		for n in (0..self.incoming_substreams.len()).rev() {
-			let mut substream = self.incoming_substreams.swap_remove(n);
-			match substream.poll() {
-				Ok(Async::Ready(Some(RegisteredProtocolEvent::Message(message)))) => {
-					return match message.request_id() {
-						CustomMessageId::Request(id) => {
-							self.pending_send_back.push((id, substream));
-							Some(CustomProtoHandlerOut::CustomMessage {
-								message
-							})
-						}
-						CustomMessageId::OneWay => {
-							self.shutdown.push(substream);
-							Some(CustomProtoHandlerOut::CustomMessage {
-								message
-							})
-						}
-						_ => {
-							self.shutdown.push(substream);
-							Some(CustomProtoHandlerOut::ProtocolError {
-								is_severe: true,
-								error: format!("Received response in new substream").into(),
-							})
-						}
-					}
-				},
-				Ok(Async::Ready(Some(RegisteredProtocolEvent::Clogged { .. }))) =>
-					unreachable!("Cannot receive Clogged message with new protocol version; QED"),
-				Ok(Async::NotReady) =>
-					self.incoming_substreams.push(substream),
-				Ok(Async::Ready(None)) => {}
-				Err(err) => {
-					self.shutdown.push(substream);
-					return Some(CustomProtoHandlerOut::ProtocolError {
-						is_severe: false,
-						error: format!("Error in incoming substream: {}", err).into(),
-					});
-				}
-			}
-		}
-
-		shutdown_list(&mut self.shutdown);
-		None
-	}
 }
 
 /// Event that can be received by a `CustomProtoHandler`.
@@ -408,26 +273,12 @@ where
 						deadline: Delay::new(Instant::now() + Duration::from_secs(60))
 					}
 
-				} else if incoming.iter().any(|s| s.is_multiplex()) {
-					let event = CustomProtoHandlerOut::CustomProtocolOpen {
-						version: incoming[0].protocol_version()
-					};
-					self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-					ProtocolState::Normal(PerProtocolNormalState {
-						outgoing_substream: None,
-						incoming_substreams: incoming.into_iter().collect(),
-						pending_response: SmallVec::new(),
-						pending_send_back: SmallVec::new(),
-						pending_messages: SmallVec::new(),
-						shutdown: SmallVec::new(),
-					})
-
 				} else {
 					let event = CustomProtoHandlerOut::CustomProtocolOpen {
 						version: incoming[0].protocol_version()
 					};
 					self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-					ProtocolState::BackCompat {
+					ProtocolState::Normal {
 						substream: incoming.into_iter().next()
 							.expect("We have a check above that incoming isn't empty; QED"),
 						shutdown: SmallVec::new()
@@ -436,7 +287,6 @@ where
 			}
 
 			st @ ProtocolState::Opening { .. } => st,
-			st @ ProtocolState::BackCompat { .. } => st,
 			st @ ProtocolState::Normal { .. } => st,
 			ProtocolState::Disabled { shutdown, .. } => {
 				ProtocolState::Disabled { shutdown, reenable: true }
@@ -464,7 +314,7 @@ where
 				ProtocolState::Disabled { shutdown: SmallVec::new(), reenable: false }
 			}
 
-			ProtocolState::BackCompat { mut substream, mut shutdown } => {
+			ProtocolState::Normal { mut substream, mut shutdown } => {
 				substream.shutdown();
 				shutdown.push(substream);
 				let event = CustomProtoHandlerOut::CustomProtocolClosed {
@@ -475,23 +325,6 @@ where
 					shutdown: shutdown.into_iter().collect(),
 					reenable: false
 				}
-			}
-
-			ProtocolState::Normal(state) => {
-				let mut out: SmallVec<[_; 6]> = SmallVec::new();
-				out.extend(state.outgoing_substream.into_iter());
-				out.extend(state.incoming_substreams.into_iter());
-				out.extend(state.pending_response.into_iter().map(|(_, s)| s));
-				out.extend(state.pending_send_back.into_iter().map(|(_, s)| s));
-				for s in &mut out {
-					s.shutdown();
-				}
-				out.extend(state.shutdown.into_iter());
-				let event = CustomProtoHandlerOut::CustomProtocolClosed {
-					result: Ok(())
-				};
-				self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-				ProtocolState::Disabled { shutdown: out, reenable: false }
 			}
 
 			ProtocolState::Disabled { shutdown, .. } =>
@@ -551,25 +384,25 @@ where
 				}
 			}
 
-			ProtocolState::BackCompat { mut substream, shutdown } => {
+			ProtocolState::Normal { mut substream, shutdown } => {
 				match substream.poll() {
 					Ok(Async::Ready(Some(RegisteredProtocolEvent::Message(message)))) => {
 						let event = CustomProtoHandlerOut::CustomMessage {
 							message
 						};
 						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::BackCompat { substream, shutdown }
+						ProtocolState::Normal { substream, shutdown }
 					},
 					Ok(Async::Ready(Some(RegisteredProtocolEvent::Clogged { messages }))) => {
 						let event = CustomProtoHandlerOut::Clogged {
 							messages,
 						};
 						return_value = Some(ProtocolsHandlerEvent::Custom(event));
-						ProtocolState::BackCompat { substream, shutdown }
+						ProtocolState::Normal { substream, shutdown }
 					}
 					Ok(Async::NotReady) => {
 						return_value = None;
-						ProtocolState::BackCompat { substream, shutdown }
+						ProtocolState::Normal { substream, shutdown }
 					}
 					Ok(Async::Ready(None)) => {
 						let event = CustomProtoHandlerOut::CustomProtocolClosed {
@@ -592,16 +425,6 @@ where
 						}
 					}
 				}
-			}
-
-			ProtocolState::Normal(mut norm_state) => {
-				if let Some(event) = norm_state.poll() {
-					return_value = Some(ProtocolsHandlerEvent::Custom(event));
-				} else {
-					return_value = None;
-				}
-
-				ProtocolState::Normal(norm_state)
 			}
 
 			ProtocolState::Disabled { mut shutdown, reenable } => {
@@ -652,65 +475,18 @@ where
 					version: substream.protocol_version()
 				};
 				self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-
-				match (substream.endpoint(), substream.is_multiplex()) {
-					(Endpoint::Dialer, true) => {
-						ProtocolState::Normal(PerProtocolNormalState {
-							outgoing_substream: Some(substream),
-							incoming_substreams: SmallVec::new(),
-							pending_response: SmallVec::new(),
-							pending_send_back: SmallVec::new(),
-							pending_messages: SmallVec::new(),
-							shutdown: SmallVec::new(),
-						})
-					},
-					(Endpoint::Listener, true) => {
-						ProtocolState::Normal(PerProtocolNormalState {
-							outgoing_substream: None,
-							incoming_substreams: smallvec![substream],
-							pending_response: SmallVec::new(),
-							pending_send_back: SmallVec::new(),
-							pending_messages: SmallVec::new(),
-							shutdown: SmallVec::new(),
-						})
-					},
-					(_, false) => {
-						ProtocolState::BackCompat {
-							substream,
-							shutdown: SmallVec::new()
-						}
-					},
+				ProtocolState::Normal {
+					substream,
+					shutdown: SmallVec::new()
 				}
 			}
 
-			ProtocolState::BackCompat { substream: existing, mut shutdown } => {
+			ProtocolState::Normal { substream: existing, mut shutdown } => {
 				debug!(target: "sub-libp2p", "Received extra substream after having already one \
 					open in backwards-compatibility mode with {:?}", self.remote_peer_id);
 				substream.shutdown();
 				shutdown.push(substream);
-				ProtocolState::BackCompat { substream: existing, shutdown }
-			}
-
-			ProtocolState::Normal(mut state) => {
-				if substream.endpoint() == Endpoint::Listener {
-					state.incoming_substreams.push(substream);
-				} else if !state.pending_messages.is_empty() {
-					let message = state.pending_messages.remove(0);
-					let request_id = message.request_id();
-					substream.send_message(message);
-					if let CustomMessageId::Request(request_id) = request_id {
-						state.pending_response.push((request_id, substream));
-					} else {
-						state.shutdown.push(substream);
-					}
-				} else {
-					debug!(target: "sub-libp2p", "Opened spurious outbound substream with {:?}",
-						self.remote_peer_id);
-					substream.shutdown();
-					state.shutdown.push(substream);
-				}
-
-				ProtocolState::Normal(state)
+				ProtocolState::Normal { substream: existing, shutdown }
 			}
 
 			ProtocolState::Disabled { mut shutdown, .. } => {
@@ -724,53 +500,8 @@ where
 	/// Sends a message to the remote.
 	fn send_message(&mut self, message: TMessage) {
 		match self.state {
-			ProtocolState::BackCompat { ref mut substream, .. } =>
+			ProtocolState::Normal { ref mut substream, .. } =>
 				substream.send_message(message),
-
-			ProtocolState::Normal(ref mut state) => {
-				if let CustomMessageId::Request(request_id) = message.request_id() {
-					if let Some(mut outgoing_substream) = state.outgoing_substream.take() {
-						outgoing_substream.send_message(message);
-						state.pending_response.push((request_id, outgoing_substream));
-					} else {
-						if state.pending_messages.len() >= 2048 {
-							let event = CustomProtoHandlerOut::Clogged {
-								messages: Vec::new(),
-							};
-							self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-						}
-						state.pending_messages.push(message);
-						self.events_queue.push(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-							protocol: SubstreamProtocol::new(self.protocol.clone()),
-							info: ()
-						});
-					}
-				} else if let CustomMessageId::Response(request_id) = message.request_id() {
-					if let Some(pos) = state.pending_send_back.iter().position(|(id, _)| *id == request_id) {
-						let (_, mut substream) = state.pending_send_back.remove(pos);
-						substream.send_message(message);
-						state.shutdown.push(substream);
-					} else {
-						warn!(target: "sub-libp2p", "Libp2p layer received response to a \
-							non-existing request ID {:?} with {:?}", request_id, self.remote_peer_id);
-					}
-				} else if let Some(mut outgoing_substream) = state.outgoing_substream.take() {
-					outgoing_substream.send_message(message);
-					state.shutdown.push(outgoing_substream);
-				} else {
-					if state.pending_messages.len() >= 2048 {
-						let event = CustomProtoHandlerOut::Clogged {
-							messages: Vec::new(),
-						};
-						self.events_queue.push(ProtocolsHandlerEvent::Custom(event));
-					}
-					state.pending_messages.push(message);
-					self.events_queue.push(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-						protocol: SubstreamProtocol::new(self.protocol.clone()),
-						info: ()
-					});
-				}
-			}
 
 			_ => debug!(target: "sub-libp2p", "Tried to send message over closed protocol \
 				with {:?}", self.remote_peer_id)
@@ -838,8 +569,7 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 
 		match self.state {
 			ProtocolState::Init { .. } | ProtocolState::Opening { .. } => {}
-			ProtocolState::BackCompat { .. } | ProtocolState::Normal { .. } =>
-				keep_forever = true,
+			ProtocolState::Normal { .. } => keep_forever = true,
 			ProtocolState::Disabled { .. } | ProtocolState::Poisoned => return KeepAlive::No,
 		}
 

--- a/core/network-libp2p/src/custom_proto/handler.rs
+++ b/core/network-libp2p/src/custom_proto/handler.rs
@@ -22,6 +22,7 @@ use libp2p::core::{
 	protocols_handler::IntoProtocolsHandler,
 	protocols_handler::KeepAlive,
 	protocols_handler::ProtocolsHandlerUpgrErr,
+	protocols_handler::SubstreamProtocol,
 	upgrade::{InboundUpgrade, OutboundUpgrade}
 };
 use log::{debug, error, warn};
@@ -399,7 +400,7 @@ where
 				if incoming.is_empty() {
 					if let Endpoint::Dialer = endpoint {
 						self.events_queue.push(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-							upgrade: self.protocol.clone(),
+							protocol: SubstreamProtocol::new(self.protocol.clone()),
 							info: (),
 						});
 					}
@@ -609,7 +610,7 @@ where
 				// after all the substreams are closed.
 				if reenable && shutdown.is_empty() {
 					return_value = Some(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-						upgrade: self.protocol.clone(),
+						protocol: SubstreamProtocol::new(self.protocol.clone()),
 						info: (),
 					});
 					ProtocolState::Opening {
@@ -740,7 +741,7 @@ where
 						}
 						state.pending_messages.push(message);
 						self.events_queue.push(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-							upgrade: self.protocol.clone(),
+							protocol: SubstreamProtocol::new(self.protocol.clone()),
 							info: ()
 						});
 					}
@@ -765,7 +766,7 @@ where
 					}
 					state.pending_messages.push(message);
 					self.events_queue.push(ProtocolsHandlerEvent::OutboundSubstreamRequest {
-						upgrade: self.protocol.clone(),
+						protocol: SubstreamProtocol::new(self.protocol.clone()),
 						info: ()
 					});
 				}
@@ -787,8 +788,8 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 	type OutboundProtocol = RegisteredProtocol<TMessage>;
 	type OutboundOpenInfo = ();
 
-	fn listen_protocol(&self) -> Self::InboundProtocol {
-		self.protocol.clone()
+	fn listen_protocol(&self) -> SubstreamProtocol<Self::InboundProtocol> {
+		SubstreamProtocol::new(self.protocol.clone())
 	}
 
 	fn inject_fully_negotiated_inbound(
@@ -839,13 +840,13 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 			ProtocolState::Init { .. } | ProtocolState::Opening { .. } => {}
 			ProtocolState::BackCompat { .. } | ProtocolState::Normal { .. } =>
 				keep_forever = true,
-			ProtocolState::Disabled { .. } | ProtocolState::Poisoned => return KeepAlive::Now,
+			ProtocolState::Disabled { .. } | ProtocolState::Poisoned => return KeepAlive::No,
 		}
 
 		if keep_forever {
-			KeepAlive::Forever
+			KeepAlive::Yes
 		} else {
-			KeepAlive::Now
+			KeepAlive::No
 		}
 	}
 

--- a/core/network-libp2p/src/custom_proto/mod.rs
+++ b/core/network-libp2p/src/custom_proto/mod.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 pub use self::behaviour::{CustomProto, CustomProtoOut};
-pub use self::upgrade::{CustomMessage, CustomMessageId, RegisteredProtocol};
+pub use self::upgrade::{CustomMessage, RegisteredProtocol};
 
 mod behaviour;
 mod handler;

--- a/core/network-libp2p/src/custom_proto/upgrade.rs
+++ b/core/network-libp2p/src/custom_proto/upgrade.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use libp2p::core::{Negotiated, Endpoint, UpgradeInfo, InboundUpgrade, OutboundUpgrade, upgrade::ProtocolName};
 use libp2p::tokio_codec::Framed;
 use log::warn;
-use std::{collections::VecDeque, io, iter, marker::PhantomData, vec::IntoIter as VecIntoIter};
+use std::{collections::VecDeque, io, marker::PhantomData, vec::IntoIter as VecIntoIter};
 use futures::{prelude::*, future, stream};
 use tokio_io::{AsyncRead, AsyncWrite};
 use unsigned_varint::codec::UviBytes;
@@ -100,9 +100,6 @@ pub struct RegisteredProtocolSubstream<TMessage, TSubstream> {
 	/// If true, we have sent a "remote is clogged" event recently and shouldn't send another one
 	/// unless the buffer empties then fills itself again.
 	clogged_fuse: bool,
-	/// If true, then this substream uses the "/multi/" version of the protocol. This is a hint
-	/// that the handler can behave differently.
-	is_multiplex: bool,
 	/// Marker to pin the generic.
 	marker: PhantomData<TMessage>,
 }
@@ -124,12 +121,6 @@ impl<TMessage, TSubstream> RegisteredProtocolSubstream<TMessage, TSubstream> {
 	/// substream from the remote (listener).
 	pub fn endpoint(&self) -> Endpoint {
 		self.endpoint
-	}
-
-	/// Returns true if we negotiated the "multiplexed" version. This means that the handler can
-	/// open multiple substreams instead of just one.
-	pub fn is_multiplex(&self) -> bool {
-		self.is_multiplex
 	}
 
 	/// Starts a graceful shutdown process on this substream.
@@ -162,31 +153,9 @@ pub trait CustomMessage {
 	/// Tries to parse `bytes` received from the network into a message.
 	fn from_bytes(bytes: &[u8]) -> Result<Self, ()>
 		where Self: Sized;
-
-	/// Returns a unique ID that is used to match request and responses.
-	///
-	/// The networking layer employs multiplexing in order to have multiple parallel data streams.
-	/// Transmitting messages over the network uses two kinds of substreams:
-	///
-	/// - Undirectional substreams, where we send a single message then close the substream.
-	/// - Bidirectional substreams, where we send a message then wait for a response. Once the
-	///   response has arrived, we close the substream.
-	///
-	/// If `request_id()` returns `OneWay`, then this message will be sent or received over a
-	/// unidirectional substream. If instead it returns `Request` or `Response`, then we use the
-	/// value to match a request with its response.
-	fn request_id(&self) -> CustomMessageId;
 }
 
-/// See the documentation of `CustomMessage::request_id`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum CustomMessageId {
-	OneWay,
-	Request(u64),
-	Response(u64),
-}
-
-// These trait implementations exist mostly for testing convenience. This should eventually be
+// This trait implementation exist mostly for testing convenience. This should eventually be
 // removed.
 
 impl CustomMessage for Vec<u8> {
@@ -196,45 +165,6 @@ impl CustomMessage for Vec<u8> {
 
 	fn from_bytes(bytes: &[u8]) -> Result<Self, ()> {
 		Ok(bytes.to_vec())
-	}
-
-	fn request_id(&self) -> CustomMessageId {
-		CustomMessageId::OneWay
-	}
-}
-
-impl CustomMessage for (Option<u64>, Vec<u8>) {
-	fn into_bytes(self) -> Vec<u8> {
-		use byteorder::WriteBytesExt;
-		use std::io::Write;
-		let mut out = Vec::new();
-		out.write_u64::<byteorder::BigEndian>(self.0.unwrap_or(u64::max_value()))
-			.expect("Writing to a Vec can never fail");
-		out.write_all(&self.1).expect("Writing to a Vec can never fail");
-		out
-	}
-
-	fn from_bytes(bytes: &[u8]) -> Result<Self, ()> {
-		use byteorder::ReadBytesExt;
-		use std::io::Read;
-		let mut rdr = std::io::Cursor::new(bytes);
-		let id = rdr.read_u64::<byteorder::BigEndian>().map_err(|_| ())?;
-		let mut out = Vec::new();
-		rdr.read_to_end(&mut out).map_err(|_| ())?;
-		let id = if id == u64::max_value() {
-			None
-		} else {
-			Some(id)
-		};
-		Ok((id, out))
-	}
-
-	fn request_id(&self) -> CustomMessageId {
-		if let Some(id) = self.0 {
-			CustomMessageId::Request(id)
-		} else {
-			CustomMessageId::OneWay
-		}
 	}
 }
 
@@ -328,33 +258,15 @@ impl<TMessage> UpgradeInfo for RegisteredProtocol<TMessage> {
 	#[inline]
 	fn protocol_info(&self) -> Self::InfoIter {
 		// Report each version as an individual protocol.
-		self.supported_versions.iter().flat_map(|&version| {
+		self.supported_versions.iter().map(|&version| {
 			let num = version.to_string();
 
-			// Note that `name1` is the multiplex version, as we priviledge it over the old one.
-			let mut name1 = self.base_name.clone();
-			name1.extend_from_slice(b"multi/");
-			name1.extend_from_slice(num.as_bytes());
-			let proto1 = RegisteredProtocolName {
-				name: name1,
+			let mut name = self.base_name.clone();
+			name.extend_from_slice(num.as_bytes());
+			RegisteredProtocolName {
+				name,
 				version,
-				is_multiplex: true,
-			};
-
-			let mut name2 = self.base_name.clone();
-			name2.extend_from_slice(num.as_bytes());
-			let proto2 = RegisteredProtocolName {
-				name: name2,
-				version,
-				is_multiplex: false,
-			};
-
-			// Important note: we prioritize the backwards compatible mode for now.
-			// After some intensive testing has been done, we should switch to the new mode by
-			// default.
-			// Then finally we can remove the old mode after everyone has switched.
-			// See https://github.com/paritytech/substrate/issues/1692
-			iter::once(proto2).chain(iter::once(proto1))
+			}
 		}).collect::<Vec<_>>().into_iter()
 	}
 }
@@ -366,8 +278,6 @@ pub struct RegisteredProtocolName {
 	name: Bytes,
 	/// Version number. Stored in string form in `name`, but duplicated here for easier retrieval.
 	version: u8,
-	/// If true, then this version is the one with the multiplexing.
-	is_multiplex: bool,
 }
 
 impl ProtocolName for RegisteredProtocolName {
@@ -403,7 +313,6 @@ where TSubstream: AsyncRead + AsyncWrite,
 			protocol_id: self.id,
 			protocol_version: info.version,
 			clogged_fuse: false,
-			is_multiplex: info.is_multiplex,
 			marker: PhantomData,
 		})
 	}
@@ -432,7 +341,6 @@ where TSubstream: AsyncRead + AsyncWrite,
 			protocol_id: self.id,
 			protocol_version: info.version,
 			clogged_fuse: false,
-			is_multiplex: info.is_multiplex,
 			marker: PhantomData,
 		})
 	}

--- a/core/network-libp2p/src/custom_proto/upgrade.rs
+++ b/core/network-libp2p/src/custom_proto/upgrade.rs
@@ -44,10 +44,11 @@ pub struct RegisteredProtocol<TMessage> {
 impl<TMessage> RegisteredProtocol<TMessage> {
 	/// Creates a new `RegisteredProtocol`. The `custom_data` parameter will be
 	/// passed inside the `RegisteredProtocolOutput`.
-	pub fn new(protocol: ProtocolId, versions: &[u8])
+	pub fn new(protocol: impl Into<ProtocolId>, versions: &[u8])
 		-> Self {
+		let protocol = protocol.into();
 		let mut base_name = Bytes::from_static(b"/substrate/");
-		base_name.extend_from_slice(&protocol);
+		base_name.extend_from_slice(protocol.as_bytes());
 		base_name.extend_from_slice(b"/");
 
 		RegisteredProtocol {
@@ -63,16 +64,15 @@ impl<TMessage> RegisteredProtocol<TMessage> {
 	}
 
 	/// Returns the ID of the protocol.
-	#[inline]
-	pub fn id(&self) -> ProtocolId {
-		self.id
+	pub fn id(&self) -> &ProtocolId {
+		&self.id
 	}
 }
 
 impl<TMessage> Clone for RegisteredProtocol<TMessage> {
 	fn clone(&self) -> Self {
 		RegisteredProtocol {
-			id: self.id,
+			id: self.id.clone(),
 			base_name: self.base_name.clone(),
 			supported_versions: self.supported_versions.clone(),
 			marker: PhantomData,
@@ -110,8 +110,8 @@ pub struct RegisteredProtocolSubstream<TMessage, TSubstream> {
 impl<TMessage, TSubstream> RegisteredProtocolSubstream<TMessage, TSubstream> {
 	/// Returns the protocol id.
 	#[inline]
-	pub fn protocol_id(&self) -> ProtocolId {
-		self.protocol_id
+	pub fn protocol_id(&self) -> &ProtocolId {
+		&self.protocol_id
 	}
 
 	/// Returns the version of the protocol that was negotiated.

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Networking layer of Substrate.
-//! 
+//!
 //! **Important**: This crate is unstable and the API and usage may change.
 //!
 
@@ -27,7 +27,7 @@ mod transport;
 
 pub use crate::behaviour::Severity;
 pub use crate::config::*;
-pub use crate::custom_proto::{CustomMessage, CustomMessageId, RegisteredProtocol};
+pub use crate::custom_proto::{CustomMessage, RegisteredProtocol};
 pub use crate::config::{NetworkConfiguration, NodeKeyConfig, Secret, NonReservedPeerMode};
 pub use crate::service_task::{start_service, Service, ServiceEvent};
 pub use libp2p::{Multiaddr, multiaddr, build_multiaddr};

--- a/core/network-libp2p/src/lib.rs
+++ b/core/network-libp2p/src/lib.rs
@@ -37,8 +37,22 @@ use libp2p::core::nodes::ConnectedPoint;
 use serde_derive::Serialize;
 use std::{collections::{HashMap, HashSet}, error, fmt, time::Duration};
 
-/// Protocol / handler id
-pub type ProtocolId = [u8; 3];
+/// Name of a protocol, transmitted on the wire. Should be unique for each chain.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProtocolId(smallvec::SmallVec<[u8; 6]>);
+
+impl<'a> From<&'a [u8]> for ProtocolId {
+	fn from(bytes: &'a [u8]) -> ProtocolId {
+		ProtocolId(bytes.into())
+	}
+}
+
+impl ProtocolId {
+	/// Exposes the `ProtocolId` as bytes.
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_ref()
+	}
+}
 
 /// Parses a string address and returns the component, if valid.
 pub fn parse_str_addr(addr_str: &str) -> Result<(PeerId, Multiaddr), ParseErr> {

--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -22,7 +22,7 @@ use crate::custom_proto::{CustomMessage, RegisteredProtocol};
 use crate::{NetworkConfiguration, NonReservedPeerMode, parse_str_addr};
 use fnv::FnvHashMap;
 use futures::{prelude::*, Stream};
-use libp2p::{multiaddr::Protocol, Multiaddr, core::swarm::NetworkBehaviour, PeerId};
+use libp2p::{Multiaddr, core::swarm::NetworkBehaviour, PeerId};
 use libp2p::core::{Swarm, nodes::Substream, transport::boxed::Boxed, muxing::StreamMuxerBox};
 use libp2p::core::nodes::ConnectedPoint;
 use log::{debug, info, warn};
@@ -84,6 +84,7 @@ where TMessage: CustomMessage + Send + 'static {
 	let local_identity = config.node_key.clone().into_keypair()?;
 	let local_public = local_identity.public();
 	let local_peer_id = local_public.clone().into_peer_id();
+	info!(target: "sub-libp2p", "Local node identity is: {}", local_peer_id.to_base58());
 
 	// Build the swarm.
 	let (mut swarm, bandwidth) = {
@@ -95,12 +96,8 @@ where TMessage: CustomMessage + Send + 'static {
 
 	// Listen on multiaddresses.
 	for addr in &config.listen_addresses {
-		match Swarm::listen_on(&mut swarm, addr.clone()) {
-			Ok(mut new_addr) => {
-				new_addr.append(Protocol::P2p(local_peer_id.clone().into()));
-				info!(target: "sub-libp2p", "Local node address is: {}", new_addr);
-			},
-			Err(err) => warn!(target: "sub-libp2p", "Can't listen on {} because: {:?}", addr, err)
+		if let Err(err) = Swarm::listen_on(&mut swarm, addr.clone()) {
+			warn!(target: "sub-libp2p", "Can't listen on {} because: {:?}", addr, err)
 		}
 	}
 

--- a/core/network-libp2p/tests/test.rs
+++ b/core/network-libp2p/tests/test.rs
@@ -40,7 +40,7 @@ fn build_nodes<TMsg>(num: usize) -> Vec<substrate_network_libp2p::Service<TMsg>>
 			..substrate_network_libp2p::NetworkConfiguration::default()
 		};
 
-		let proto = substrate_network_libp2p::RegisteredProtocol::new(*b"tst", &[1]);
+		let proto = substrate_network_libp2p::RegisteredProtocol::new(&b"tst"[..], &[1]);
 		result.push(substrate_network_libp2p::start_service(config, proto).unwrap().0);
 	}
 

--- a/core/network-libp2p/tests/test.rs
+++ b/core/network-libp2p/tests/test.rs
@@ -200,7 +200,7 @@ fn many_nodes_connectivity() {
 #[test]
 fn basic_two_nodes_requests_in_parallel() {
 	let (mut service1, mut service2) = {
-		let mut l = build_nodes::<(Option<u64>, Vec<u8>)>(2, 50550).into_iter();
+		let mut l = build_nodes::<Vec<u8>>(2, 50550).into_iter();
 		let a = l.next().unwrap();
 		let b = l.next().unwrap();
 		(a, b)
@@ -209,17 +209,8 @@ fn basic_two_nodes_requests_in_parallel() {
 	// Generate random messages with or without a request id.
 	let mut to_send = {
 		let mut to_send = Vec::new();
-		let mut next_id = 0;
 		for _ in 0..200 { // Note: don't make that number too high or the CPU usage will explode.
-			let id = if rand::random::<usize>() % 4 != 0 {
-				let i = next_id;
-				next_id += 1;
-				Some(i)
-			} else {
-				None
-			};
-
-			let msg = (id, (0..10).map(|_| rand::random::<u8>()).collect::<Vec<_>>());
+			let msg = (0..10).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
 			to_send.push(msg);
 		}
 		to_send

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -118,7 +118,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 				if let Status::Future = entry.status { continue }
 
 				known_messages.insert(entry.message_hash);
-				protocol.send_message(who.clone(), Message::Consensus(entry.message.clone()));
+				protocol.send_consensus(who.clone(), entry.message.clone());
 			}
 			self.peers.insert(who, PeerConsensus {
 				known_messages,
@@ -164,12 +164,12 @@ impl<B: BlockT> ConsensusGossip<B> {
 				if peer.known_messages.insert(message_hash.clone()) || force {
 					let message = get_message();
 					trace!(target:"gossip", "Propagating to authority {}: {:?}", id, message);
-					protocol.send_message(id.clone(), Message::Consensus(message));
+					protocol.send_consensus(id.clone(), message);
 				}
 			} else if non_authorities.contains(&id) {
 				let message = get_message();
 				trace!(target:"gossip", "Propagating to {}: {:?}", id, message);
-				protocol.send_message(id.clone(), Message::Consensus(message));
+				protocol.send_consensus(id.clone(), message);
 			}
 		}
 	}

--- a/core/network/src/message.rs
+++ b/core/network/src/message.rs
@@ -125,7 +125,7 @@ pub struct RemoteReadResponse {
 /// Generic types.
 pub mod generic {
 	use parity_codec::{Encode, Decode};
-	use network_libp2p::{CustomMessage, CustomMessageId};
+	use network_libp2p::CustomMessage;
 	use runtime_primitives::Justification;
 	use crate::config::Roles;
 	use super::{
@@ -212,26 +212,6 @@ pub mod generic {
 
 		fn from_bytes(bytes: &[u8]) -> Result<Self, ()> {
 			Decode::decode(&mut &bytes[..]).ok_or(())
-		}
-
-		fn request_id(&self) -> CustomMessageId {
-			match *self {
-				Message::Status(_) => CustomMessageId::OneWay,
-				Message::BlockRequest(ref req) => CustomMessageId::Request(req.id),
-				Message::BlockResponse(ref resp) => CustomMessageId::Response(resp.id),
-				Message::BlockAnnounce(_) => CustomMessageId::OneWay,
-				Message::Transactions(_) => CustomMessageId::OneWay,
-				Message::Consensus(_) => CustomMessageId::OneWay,
-				Message::RemoteCallRequest(ref req) => CustomMessageId::Request(req.id),
-				Message::RemoteCallResponse(ref resp) => CustomMessageId::Response(resp.id),
-				Message::RemoteReadRequest(ref req) => CustomMessageId::Request(req.id),
-				Message::RemoteReadResponse(ref resp) => CustomMessageId::Response(resp.id),
-				Message::RemoteHeaderRequest(ref req) => CustomMessageId::Request(req.id),
-				Message::RemoteHeaderResponse(ref resp) => CustomMessageId::Response(resp.id),
-				Message::RemoteChangesRequest(ref req) => CustomMessageId::Request(req.id),
-				Message::RemoteChangesResponse(ref resp) => CustomMessageId::Response(resp.id),
-				Message::ChainSpecific(_) => CustomMessageId::OneWay,
-			}
 		}
 	}
 

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -22,7 +22,7 @@ use primitives::storage::StorageKey;
 use runtime_primitives::{generic::BlockId, ConsensusEngineId};
 use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, NumberFor, Zero};
 use consensus::import_queue::ImportQueue;
-use crate::message::{self, Message};
+use crate::message::{self, BlockRequest as BlockRequestMessage, Message};
 use crate::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::consensus_gossip::ConsensusGossip;
 use crate::on_demand::OnDemandService;
@@ -145,8 +145,14 @@ pub trait Context<B: BlockT> {
 	/// Get peer info.
 	fn peer_info(&self, peer: &PeerId) -> Option<PeerInfo<B>>;
 
-	/// Send a message to a peer.
-	fn send_message(&mut self, who: PeerId, data: crate::message::Message<B>);
+	/// Request a block from a peer.
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>);
+
+	/// Send a consensus message to a peer.
+	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage);
+
+	/// Send a chain-specific message to a peer.
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>);
 }
 
 /// Protocol context.
@@ -162,10 +168,6 @@ impl<'a, B: BlockT + 'a, H: 'a + ExHashT> ProtocolContext<'a, B, H> {
 }
 
 impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, H> {
-	fn send_message(&mut self, who: PeerId, message: Message<B>) {
-		send_message(&mut self.context_data.peers, &self.network_chan, who, message)
-	}
-
 	fn report_peer(&mut self, who: PeerId, reason: Severity) {
 		self.network_chan.send(NetworkMsg::ReportPeer(who, reason))
 	}
@@ -176,6 +178,24 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 
 	fn client(&self) -> &Client<B> {
 		&*self.context_data.chain
+	}
+
+	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::BlockRequest(request)
+		)
+	}
+
+	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::Consensus(consensus)
+		)
+	}
+
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::ChainSpecific(message)
+		)
 	}
 }
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, thread};
-use log::{warn, debug, error, trace, info};
+use log::{warn, debug, error, trace};
 use futures::{Async, Future, Stream, stream, sync::oneshot, sync::mpsc};
 use parking_lot::{Mutex, RwLock};
 use network_libp2p::{ProtocolId, NetworkConfiguration, Severity};
@@ -519,7 +519,7 @@ fn run_thread<B: BlockT + 'static>(
 			NetworkMsg::ReportPeer(who, severity) => {
 				match severity {
 					Severity::Bad(message) => {
-						info!(target: "sync", "Banning {:?} because {:?}", who, message);
+						debug!(target: "sync", "Banning {:?} because {:?}", who, message);
 						network_service_2.lock().drop_node(&who);
 						// temporary: make sure the peer gets dropped from the peerset
 						peerset.report_peer(who, i32::min_value());

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -23,7 +23,7 @@ use futures::{Async, Future, Stream, stream, sync::oneshot, sync::mpsc};
 use parking_lot::{Mutex, RwLock};
 use network_libp2p::{ProtocolId, NetworkConfiguration, Severity};
 use network_libp2p::{start_service, parse_str_addr, Service as NetworkService, ServiceEvent as NetworkServiceEvent};
-use network_libp2p::{multiaddr, RegisteredProtocol, NetworkState};
+use network_libp2p::{RegisteredProtocol, NetworkState};
 use peerset::PeersetHandle;
 use consensus::import_queue::{ImportQueue, Link};
 use crate::consensus_gossip::ConsensusGossip;
@@ -344,8 +344,6 @@ pub trait ManageNetwork {
 	fn remove_reserved_peer(&self, peer: PeerId);
 	/// Add reserved peer
 	fn add_reserved_peer(&self, peer: String) -> Result<(), String>;
-	/// Returns a user-friendly identifier of our node.
-	fn node_id(&self) -> Option<String>;
 }
 
 impl<B: BlockT + 'static, S: NetworkSpecialization<B>> ManageNetwork for Service<B, S> {
@@ -366,19 +364,6 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>> ManageNetwork for Service
 		self.peerset.add_reserved_peer(peer_id.clone());
 		self.network.lock().add_known_address(peer_id, addr);
 		Ok(())
-	}
-
-	fn node_id(&self) -> Option<String> {
-		let network = self.network.lock();
-		let ret = network
-			.listeners()
-			.next()
-			.map(|addr| {
-				let mut addr = addr.clone();
-				addr.append(multiaddr::Protocol::P2p(network.peer_id().clone().into()));
-				addr.to_string()
-			});
-		ret
 	}
 }
 

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -29,7 +29,7 @@ use crate::blocks::BlockCollection;
 use runtime_primitives::Justification;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, As, NumberFor, Zero, CheckedSub};
 use runtime_primitives::generic::BlockId;
-use crate::message::{self, generic::Message as GenericMessage};
+use crate::message;
 use crate::config::Roles;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -200,7 +200,7 @@ impl<B: BlockT> PendingJustifications<B> {
 				max: Some(1),
 			};
 
-			protocol.send_message(peer, GenericMessage::BlockRequest(request));
+			protocol.send_block_request(peer, request);
 		}
 
 		self.pending_requests.append(&mut unhandled_requests);
@@ -984,7 +984,7 @@ impl<B: BlockT> ChainSync<B> {
 						max: Some(1),
 					};
 					peer.state = PeerSyncState::DownloadingStale(*hash);
-					protocol.send_message(who, GenericMessage::BlockRequest(request));
+					protocol.send_block_request(who, request);
 				},
 				_ => (),
 			}
@@ -1005,7 +1005,7 @@ impl<B: BlockT> ChainSync<B> {
 						max: Some(MAX_UNKNOWN_FORK_DOWNLOAD_LEN),
 					};
 					peer.state = PeerSyncState::DownloadingStale(*hash);
-					protocol.send_message(who, GenericMessage::BlockRequest(request));
+					protocol.send_block_request(who, request);
 				},
 				_ => (),
 			}
@@ -1034,7 +1034,7 @@ impl<B: BlockT> ChainSync<B> {
 							max: Some((range.end - range.start).as_() as u32),
 						};
 						peer.state = PeerSyncState::DownloadingNew(range.start);
-						protocol.send_message(who, GenericMessage::BlockRequest(request));
+						protocol.send_block_request(who, request);
 					} else {
 						trace!(target: "sync", "Nothing to request");
 					}
@@ -1054,7 +1054,7 @@ impl<B: BlockT> ChainSync<B> {
 			direction: message::Direction::Ascending,
 			max: Some(1),
 		};
-		protocol.send_message(who, GenericMessage::BlockRequest(request));
+		protocol.send_block_request(who, request);
 	}
 }
 

--- a/core/peerset/Cargo.toml
+++ b/core/peerset/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.1"
-libp2p = { version = "0.6.0", default-features = false }
+libp2p = { version = "0.7.0", default-features = false }
 linked-hash-map = "0.5"
 log = "0.4"
 lru-cache = "0.1.2"

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -154,14 +154,16 @@ impl<Components: components::Components> Service<Components> {
 		};
 
 		let protocol_id = {
-			let protocol_id_full = config.chain_spec.protocol_id().unwrap_or(DEFAULT_PROTOCOL_ID).as_bytes();
-			let mut protocol_id = network::ProtocolId::default();
-			if protocol_id_full.len() > protocol_id.len() {
-				warn!("Protocol ID truncated to {} chars", protocol_id.len());
-			}
-			let id_len = protocol_id_full.len().min(protocol_id.len());
-			&mut protocol_id[0..id_len].copy_from_slice(&protocol_id_full[0..id_len]);
-			protocol_id
+			let protocol_id_full = match config.chain_spec.protocol_id() {
+				Some(pid) => pid,
+				None => {
+					warn!("Using default protocol ID {:?} because none is configured in the \
+						chain specs", DEFAULT_PROTOCOL_ID
+					);
+					DEFAULT_PROTOCOL_ID
+				}
+			}.as_bytes();
+			network::ProtocolId::from(protocol_id_full)
 		};
 
 		let has_bootnodes = !network_params.network_config.boot_nodes.is_empty();

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -34,7 +34,7 @@ use service::{
 	Roles,
 	FactoryExtrinsic,
 };
-use network::{multiaddr, SyncProvider, ManageNetwork};
+use network::{multiaddr, Multiaddr, SyncProvider, ManageNetwork};
 use network::config::{NetworkConfiguration, NodeKeyConfig, Secret, NonReservedPeerMode};
 use sr_primitives::traits::As;
 use sr_primitives::generic::BlockId;
@@ -42,8 +42,8 @@ use consensus::{ImportBlock, BlockImport};
 
 struct TestNet<F: ServiceFactory> {
 	runtime: Runtime,
-	authority_nodes: Vec<(u32, Arc<F::FullService>)>,
-	full_nodes: Vec<(u32, Arc<F::FullService>)>,
+	authority_nodes: Vec<(u32, Arc<F::FullService>, Multiaddr)>,
+	full_nodes: Vec<(u32, Arc<F::FullService>, Multiaddr)>,
 	_light_nodes: Vec<(u32, Arc<F::LightService>)>,
 	chain_spec: FactoryChainSpec<F>,
 	base_port: u16,
@@ -54,7 +54,7 @@ impl<F: ServiceFactory> TestNet<F> {
 	pub fn run_until_all_full<P: Send + Sync + Fn(u32, &F::FullService) -> bool + 'static>(&mut self, predicate: P) {
 		let full_nodes = self.full_nodes.clone();
 		let interval = Interval::new_interval(Duration::from_millis(100)).map_err(|_| ()).for_each(move |_| {
-			if full_nodes.iter().all(|&(ref id, ref service)| predicate(*id, service)) {
+			if full_nodes.iter().all(|&(ref id, ref service, _)| predicate(*id, service)) {
 				Err(())
 			} else {
 				Ok(())
@@ -151,16 +151,24 @@ impl<F: ServiceFactory> TestNet<F> {
 		let base_port = self.base_port;
 		let spec = self.chain_spec.clone();
 		let executor = self.runtime.executor();
-		self.authority_nodes.extend(authorities.iter().enumerate().map(|(index, key)| ((index + nodes) as u32,
-			 Arc::new(F::new_full(node_config::<F>(index as u32, &spec, Roles::AUTHORITY, Some(key.clone()), base_port, &temp), executor.clone())
-					  .expect("Error creating test node service")))
-		));
+		self.authority_nodes.extend(authorities.iter().enumerate().map(|(index, key)| {
+			let node_config = node_config::<F>(index as u32, &spec, Roles::AUTHORITY, Some(key.clone()), base_port, &temp);
+			let addr = node_config.network.listen_addresses.iter().next().unwrap().clone();
+			let service = Arc::new(F::new_full(node_config, executor.clone())
+				.expect("Error creating test node service"));
+			let addr = addr.with(multiaddr::Protocol::P2p(service.network().local_peer_id().into()));
+			((index + nodes) as u32, service, addr)
+		}));
 		nodes += authorities.len();
 
-		self.full_nodes.extend((nodes..nodes + full as usize).map(|index| (index as u32,
-			Arc::new(F::new_full(node_config::<F>(index as u32, &spec, Roles::FULL, None, base_port, &temp), executor.clone())
-				.expect("Error creating test node service")))
-		));
+		self.full_nodes.extend((nodes..nodes + full as usize).map(|index| {
+			let node_config = node_config::<F>(index as u32, &spec, Roles::FULL, None, base_port, &temp);
+			let addr = node_config.network.listen_addresses.iter().next().unwrap().clone();
+			let service = Arc::new(F::new_full(node_config, executor.clone())
+				.expect("Error creating test node service"));
+			let addr = addr.with(multiaddr::Protocol::P2p(service.network().local_peer_id().into()));
+			(index as u32, service, addr)
+		}));
 		nodes += full as usize;
 
 		self._light_nodes.extend((nodes..nodes + light as usize).map(|index| (index as u32,
@@ -179,9 +187,9 @@ pub fn connectivity<F: ServiceFactory>(spec: FactoryChainSpec<F>) {
 		let runtime = {
 			let mut network = TestNet::<F>::new(&temp, spec.clone(), NUM_NODES, 0, vec![], 30400);
 			info!("Checking star topology");
-			let first_address = network.full_nodes[0].1.network().node_id().expect("No node address");
-			for (_, service) in network.full_nodes.iter().skip(1) {
-				service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
+			let first_address = network.full_nodes[0].2.clone();
+			for (_, service, _) in network.full_nodes.iter().skip(1) {
+				service.network().add_reserved_peer(first_address.to_string()).expect("Error adding reserved peer");
 			}
 			network.run_until_all_full(|_index, service|
 				service.network().peers().len() == NUM_NODES as usize - 1
@@ -198,10 +206,10 @@ pub fn connectivity<F: ServiceFactory>(spec: FactoryChainSpec<F>) {
 		{
 			let mut network = TestNet::<F>::new(&temp, spec, NUM_NODES, 0, vec![], 30400);
 			info!("Checking linked topology");
-			let mut address = network.full_nodes[0].1.network().node_id().expect("No node address");
-			for (_, service) in network.full_nodes.iter().skip(1) {
-				service.network().add_reserved_peer(address.clone()).expect("Error adding reserved peer");
-				address = service.network().node_id().expect("No node address");
+			let mut address = network.full_nodes[0].2.clone();
+			for (_, service, node_id) in network.full_nodes.iter().skip(1) {
+				service.network().add_reserved_peer(address.to_string()).expect("Error adding reserved peer");
+				address = node_id.clone();
 			}
 			network.run_until_all_full(|_index, service| {
 				service.network().peers().len() == NUM_NODES as usize - 1
@@ -231,11 +239,11 @@ where
 			let import_data = block_factory(&first_service);
 			first_service.client().import_block(import_data, HashMap::new()).expect("Error importing test block");
 		}
-		first_service.network().node_id().unwrap()
+		network.full_nodes[0].2.clone()
 	};
 	info!("Running sync");
-	for (_, service) in network.full_nodes.iter().skip(1) {
-		service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
+	for (_, service, _) in network.full_nodes.iter().skip(1) {
+		service.network().add_reserved_peer(first_address.to_string()).expect("Error adding reserved peer");
 	}
 	network.run_until_all_full(|_index, service|
 		service.client().info().unwrap().chain.best_number == As::sa(NUM_BLOCKS as u64)
@@ -258,20 +266,20 @@ pub fn consensus<F>(spec: FactoryChainSpec<F>, authorities: Vec<String>)
 	let temp = TempDir::new("substrate-conensus-test").expect("Error creating test dir");
 	let mut network = TestNet::<F>::new(&temp, spec.clone(), NUM_NODES / 2, 0, authorities, 30600);
 	info!("Checking consensus");
-	let first_address = network.authority_nodes[0].1.network().node_id().unwrap();
-	for (_, service) in network.full_nodes.iter() {
-		service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
+	let first_address = network.authority_nodes[0].2.clone();
+	for (_, service, _) in network.full_nodes.iter() {
+		service.network().add_reserved_peer(first_address.to_string()).expect("Error adding reserved peer");
 	}
-	for (_, service) in network.authority_nodes.iter().skip(1) {
-		service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
+	for (_, service, _) in network.authority_nodes.iter().skip(1) {
+		service.network().add_reserved_peer(first_address.to_string()).expect("Error adding reserved peer");
 	}
 	network.run_until_all_full(|_index, service| {
 		service.client().info().unwrap().chain.finalized_number >= As::sa(NUM_BLOCKS / 2)
 	});
 	info!("Adding more peers");
 	network.insert_nodes(&temp, NUM_NODES / 2, 0, vec![]);
-	for (_, service) in network.full_nodes.iter() {
-		service.network().add_reserved_peer(first_address.clone()).expect("Error adding reserved peer");
+	for (_, service, _) in network.full_nodes.iter() {
+		service.network().add_reserved_peer(first_address.to_string()).expect("Error adding reserved peer");
 	}
 	network.run_until_all_full(|_index, service|
 		service.client().info().unwrap().chain.finalized_number >= As::sa(NUM_BLOCKS)


### PR DESCRIPTION
This PR is against `v1.0` but it is not strictly a backport, it "forks" a bit v1.0 compared to master.
Based on top of #2486, and only the last commit is relevant.

More specifically, it silences two warnings in v1.0:

- "Banning node ...": banning has been removed in master by #2454, but the change is quite experimental and it might be a bad idea to backport it.
- "Handler initialization is too long": this is being fixed in master as part of the current effort to rework the threading story of network (#2475). But similarly this is too big of a change to backport.
