### PR TITLE
Isolate the code of ChainSync and turn it into a state machine

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -32,7 +32,6 @@ use parking_lot::RwLock;
 use rustc_hex::ToHex;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::{cmp, num::NonZeroUsize, time};
 use log::{trace, debug, warn, error};
 use crate::chain::Client;
@@ -291,8 +290,6 @@ pub enum ProtocolMsg<B: BlockT, S: NetworkSpecialization<B>> {
 impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	/// Create a new instance.
 	pub fn new(
-		is_offline: Arc<AtomicBool>,
-		is_major_syncing: Arc<AtomicBool>,
 		connected_peers: Arc<RwLock<HashMap<PeerId, ConnectedPeer<B>>>>,
 		network_chan: NetworkChan<B>,
 		config: ProtocolConfig,
@@ -304,7 +301,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	) -> error::Result<(Protocol<B, S, H>, mpsc::UnboundedSender<ProtocolMsg<B, S>>)> {
 		let (protocol_sender, port) = mpsc::unbounded();
 		let info = chain.info()?;
-		let sync = ChainSync::new(is_offline, is_major_syncing, config.roles, &info, import_queue);
+		let sync = ChainSync::new(config.roles, &info, import_queue);
 		let protocol = Protocol {
 			network_chan,
 			port,
@@ -340,6 +337,14 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				.filter(|p| p.block_request.is_some())
 				.count(),
 		}
+	}
+
+	pub fn is_major_syncing(&self) -> bool {
+		self.sync.status().is_major_syncing()
+	}
+
+	pub fn is_offline(&self) -> bool {
+		self.sync.status().is_offline()
 	}
 }
 

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -433,11 +433,6 @@ impl<D, S: NetworkSpecialization<Block>> Peer<D, S> {
 		*finalized_hash = Some(info.chain.finalized_hash);
 	}
 
-	/// Restart sync for a peer.
-	fn restart_sync(&self) {
-		self.net_proto_channel.send_from_client(ProtocolMsg::Abort);
-	}
-
 	/// Push a message into the gossip network and relay to peers.
 	/// `TestNet::sync_step` needs to be called to ensure it's propagated.
 	pub fn gossip_message(
@@ -831,11 +826,6 @@ pub trait TestNetFactory: Sized {
 	/// Send block finalization notifications for all peers.
 	fn send_finality_notifications(&mut self) {
 		self.peers().iter().for_each(|peer| peer.send_finality_notifications())
-	}
-
-	/// Restart sync for a peer.
-	fn restart_peer(&mut self, i: usize) {
-		self.peers()[i].restart_sync();
 	}
 
 	/// Perform synchronization until complete, if provided the

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -96,6 +96,7 @@ fn sync_cycle_from_offline_to_syncing_to_offline() {
 				net.peer(peer).on_disconnect(net.peer(other));
 			}
 		}
+		net.sync();
 		assert!(net.peer(peer).is_offline());
 		assert!(!net.peer(peer).is_major_syncing());
 	}
@@ -119,6 +120,7 @@ fn syncing_node_not_major_syncing_when_disconnected() {
 	net.peer(1).on_disconnect(net.peer(2));
 
 	// Peer 1 is not major-syncing.
+	net.sync();
 	assert!(!net.peer(1).is_major_syncing());
 }
 

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -33,7 +33,6 @@ fn test_ancestor_search_when_common_is(n: usize) {
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -143,7 +142,6 @@ fn sync_from_two_peers_with_ancestry_search_works() {
 	net.peer(0).push_blocks(10, true);
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -158,7 +156,6 @@ fn ancestry_search_works_when_backoff_is_one() {
 	net.peer(1).push_blocks(2, false);
 	net.peer(2).push_blocks(2, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -173,7 +170,6 @@ fn ancestry_search_works_when_ancestor_is_genesis() {
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));


### PR DESCRIPTION
Based on top of #2475 

Removes all `Arc`s (explicit or implicit (ie. the one inside of `Box<ImportQueue>`)) from the `sync.rs` module. This makes the code of `sync.rs` deterministic (except for request timeouts).

The only logic that's been removed, which is importing blocks and justifications to the import queue, has been moved to `service.rs`.
