### PR TITLE
Fix light connection issues

### DIFF
--- a/core/client/src/light/call_executor.rs
+++ b/core/client/src/light/call_executor.rs
@@ -148,7 +148,7 @@ where
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> ClientResult<RuntimeVersion> {
-		let call_result = self.call(id, "version", &[], ExecutionStrategy::NativeElseWasm, NeverOffchainExt::new())?;
+		let call_result = self.call(id, "Core_version", &[], ExecutionStrategy::NativeElseWasm, NeverOffchainExt::new())?;
 		RuntimeVersion::decode(&mut call_result.as_slice())
 			.ok_or_else(|| ClientError::VersionInvalid.into())
 	}

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -265,6 +265,11 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 	/// Handle new connected peer.
 	pub fn new_peer(&mut self, protocol: &mut Context<B>, who: PeerId, roles: Roles) {
+		// light nodes are not valid targets for consensus gossip messages
+		if !roles.intersects(Roles::FULL | Roles::AUTHORITY) {
+			return;
+		}
+
 		trace!(target:"gossip", "Registering {:?} {}", roles, who);
 		self.peers.insert(who.clone(), PeerConsensus {
 			known_messages: HashSet::new(),

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -72,10 +72,6 @@ const UNEXPECTED_STATUS_REPUTATION_CHANGE: i32 = -(1 << 20);
 const PEER_BEHIND_US_LIGHT_REPUTATION_CHANGE: i32 = -(1 << 8);
 /// Reputation change when a peer sends us an extrinsic that we didn't know about.
 const NEW_EXTRINSIC_REPUTATION_CHANGE: i32 = 1 << 7;
-/// Reputation change when a peer sends us a block. We don't know whether this block is valid or
-/// already known to us. Since this has a small cost, we decrease the reputation of the node, and
-/// will increase it back later if the import is successful.
-const BLOCK_ANNOUNCE_REPUTATION_CHANGE: i32 = -(1 << 2);
 /// We sent an RPC query to the given node, but it failed.
 const RPC_FAILED_REPUTATION_CHANGE: i32 = -(1 << 12);
 
@@ -991,7 +987,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			hash,
 			&header,
 		);
-		//self.network_chan.send(NetworkMsg::ReportPeer(who, BLOCK_ANNOUNCE_REPUTATION_CHANGE));
 	}
 
 	fn on_block_imported(&mut self, hash: B::Hash, header: &B::Header) {

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -991,7 +991,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			hash,
 			&header,
 		);
-		self.network_chan.send(NetworkMsg::ReportPeer(who, BLOCK_ANNOUNCE_REPUTATION_CHANGE));
+		//self.network_chan.send(NetworkMsg::ReportPeer(who, BLOCK_ANNOUNCE_REPUTATION_CHANGE));
 	}
 
 	fn on_block_imported(&mut self, hash: B::Hash, header: &B::Header) {


### PR DESCRIPTION
There are 3 issues currently (each one takes its own commit):
- the main issue that causes (almost) instant disconnect is that consensus gossip messages are sent to light nodes && light nodes do not have gossip listeners registered. I've fixed that by ignoring light nodes in `ConsensusGossip` - think that is the correct way;
- the second issue is a typo in `LightCallExecutor::version` - instead of "version" it should call "Core_version". Currently aura verifier calls this - that should be fixed by #1669 ;
- the third one is the most complex, linked to the peer reputation system. The initial node reputation is zero. Normally, when full nodes are connected to each other, they first interchanging with GRANDPA messages => their reputation is increased. But because of (first issue) above, we do not send gossip messages to light nodes. And when some block is announced, reputation of the peer is changed by -4 [here](https://github.com/paritytech/substrate/blame/17dcbe6cef54571065db4f4c026d873242cf4be9/core/network/src/protocol.rs#L994). This leads to the situation when node has negative reputation and we disconnect it [here](https://github.com/paritytech/substrate/blob/17dcbe6cef54571065db4f4c026d873242cf4be9/core/peerset/src/lib.rs#L269). @tomaka I need your help here - there are several ways to fix this, but I'm not sure what's better. Also - comment to `BLOCK_ANNOUNCE_REPUTATION_CHANGE` states that 'Since this has a small cost, we decrease the reputation of the node, and will increase it back later if the import is successful.' - I haven't found that. Could you, please, point me to that code? Probably it isn't executed on light, because I have seen on-announce-disconnects even after peer has provided us with several valid blocks.

Adding suggested reviewers to the PR (skipping Rob :) ).
Cc @andresilva and @niklasad1 (I'm not sure, but the second issue could be the issue you have found today as well).