### PR TITLE
Remove with_gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,6 +4165,7 @@ dependencies = [
  "substrate-primitives 1.0.0",
  "substrate-test-client 1.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -173,9 +173,7 @@ impl Network<Block> for MessageRouting {
 	fn register_validator(&self, v: Arc<dyn network_gossip::Validator<Block>>) {
 		let inner = self.inner.lock();
 		let peer = inner.peer(self.peer_id);
-		peer.with_gossip(move |gossip, context| {
-			gossip.register_validator(context, GRANDPA_ENGINE_ID, v);
-		});
+		peer.consensus_gossip_register_validator(GRANDPA_ENGINE_ID, v);
 	}
 
 	fn gossip_message(&self, topic: Hash, data: Vec<u8>, force: bool) {
@@ -192,16 +190,15 @@ impl Network<Block> for MessageRouting {
 		let inner = self.inner.lock();
 		let peer = inner.peer(self.peer_id);
 
-		peer.with_gossip(move |gossip, ctx| for who in &who {
-			gossip.send_message(
-				ctx,
-				who,
+		for who in &who {
+			peer.consensus_gossip_send(
+				who.clone(),
 				network_gossip::ConsensusMessage {
 					engine_id: GRANDPA_ENGINE_ID,
 					data: data.clone(),
 				}
 			)
-		})
+		}
 	}
 
 	fn report(&self, _who: network::PeerId, _cost_benefit: i32) {

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -31,6 +31,7 @@ peerset = { package = "substrate-peerset", path = "../../core/peerset" }
 tokio = "0.1.11"
 keyring = { package = "substrate-keyring", path = "../../core/keyring", optional = true }
 test_client = { package = "substrate-test-client", path = "../../core/test-client", optional = true }
+void = "1.0"
 
 [dev-dependencies]
 env_logger = { version = "0.6" }

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -17,9 +17,9 @@
 use futures::{prelude::*, sync::mpsc};
 use network_libp2p::PeerId;
 use primitives::storage::StorageKey;
-use runtime_primitives::{generic::BlockId, ConsensusEngineId};
+use consensus::{import_queue::IncomingBlock, import_queue::Origin, BlockOrigin};
+use runtime_primitives::{generic::BlockId, ConsensusEngineId, Justification};
 use runtime_primitives::traits::{As, Block as BlockT, Header as HeaderT, NumberFor, Zero};
-use consensus::import_queue::ImportQueue;
 use crate::message::{self, BlockRequest as BlockRequestMessage, Message};
 use crate::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
@@ -298,14 +298,13 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		network_chan: NetworkChan<B>,
 		config: ProtocolConfig,
 		chain: Arc<Client<B>>,
-		import_queue: Box<ImportQueue<B>>,
 		on_demand: Option<Arc<OnDemandService<B>>>,
 		transaction_pool: Arc<TransactionPool<H, B>>,
 		specialization: S,
 	) -> error::Result<(Protocol<B, S, H>, mpsc::UnboundedSender<ProtocolMsg<B, S>>)> {
 		let (protocol_sender, port) = mpsc::unbounded();
 		let info = chain.info()?;
-		let sync = ChainSync::new(config.roles, &info, import_queue);
+		let sync = ChainSync::new(config.roles, &info);
 		let protocol = Protocol {
 			network_chan,
 			port,
@@ -466,14 +465,15 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		}
 	}
 
-	pub fn on_custom_message(&mut self, who: PeerId, message: Message<B>) {
+	pub fn on_custom_message(&mut self, who: PeerId, message: Message<B>) -> CustomMessageOutcome<B> {
 		match message {
 			GenericMessage::Status(s) => self.on_status_message(who, s),
 			GenericMessage::BlockRequest(r) => self.on_block_request(who, r),
 			GenericMessage::BlockResponse(r) => {
 				if let Some(request) = self.handle_response(who.clone(), &r) {
-					self.on_block_response(who.clone(), request, r);
+					let outcome = self.on_block_response(who.clone(), request, r);
 					self.update_peer_info(&who);
+					return outcome
 				}
 			},
 			GenericMessage::BlockAnnounce(announce) => {
@@ -504,6 +504,8 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				&mut Some(other),
 			),
 		}
+
+		CustomMessageOutcome::None
 	}
 
 	fn send_message(&mut self, who: PeerId, message: Message<B>) {
@@ -652,7 +654,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		peer: PeerId,
 		request: message::BlockRequest<B>,
 		response: message::BlockResponse<B>,
-	) {
+	) -> CustomMessageOutcome<B> {
 		let blocks_range = match (
 				response.blocks.first().and_then(|b| b.header.as_ref().map(|h| h.number())),
 				response.blocks.last().and_then(|b| b.header.as_ref().map(|h| h.number())),
@@ -667,14 +669,26 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		// TODO [andre]: move this logic to the import queue so that
 		// justifications are imported asynchronously (#1482)
 		if request.fields == message::BlockAttributes::JUSTIFICATION {
-			self.sync.on_block_justification_data(
+			let outcome = self.sync.on_block_justification_data(
 				&mut ProtocolContext::new(&mut self.context_data, &self.network_chan),
 				peer,
 				request,
 				response,
 			);
+
+			if let Some((origin, hash, nb, just)) = outcome {
+				CustomMessageOutcome::JustificationImport(origin, hash, nb, just)
+			} else {
+				CustomMessageOutcome::None
+			}
+
 		} else {
-			self.sync.on_block_data(&mut ProtocolContext::new(&mut self.context_data, &self.network_chan), peer, request, response);
+			let outcome = self.sync.on_block_data(&mut ProtocolContext::new(&mut self.context_data, &self.network_chan), peer, request, response);
+			if let Some((origin, blocks)) = outcome {
+				CustomMessageOutcome::BlockImport(origin, blocks)
+			} else {
+				CustomMessageOutcome::None
+			}
 		}
 	}
 
@@ -1115,6 +1129,14 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			.as_ref()
 			.map(|s| s.on_remote_changes_response(who, response));
 	}
+}
+
+/// Outcome of an incoming custom message.
+#[derive(Debug)]
+pub enum CustomMessageOutcome<B: BlockT> {
+	BlockImport(BlockOrigin, Vec<IncomingBlock<B>>),
+	JustificationImport(Origin, B::Hash, NumberFor<B>, Justification),
+	None,
 }
 
 fn send_message<B: BlockT, H: ExHashT>(

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -279,10 +279,6 @@ pub enum ProtocolMsg<B: BlockT, S: NetworkSpecialization<B>> {
 	ExecuteWithGossip(Box<GossipTask<B> + Send + 'static>),
 	/// Incoming gossip consensus message.
 	GossipConsensusMessage(B::Hash, ConsensusEngineId, Vec<u8>, GossipMessageRecipient),
-	/// Tell protocol to abort sync (does not stop protocol).
-	/// Only used in tests.
-	#[cfg(any(test, feature = "test-helpers"))]
-	Abort,
 	/// Tell protocol to perform regular maintenance.
 	#[cfg(any(test, feature = "test-helpers"))]
 	Tick,
@@ -366,10 +362,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Future for Protocol<B, 
 
 		loop {
 			match self.port.poll() {
-				Ok(Async::Ready(None)) | Err(_) => {
-					self.stop();
-					return Ok(Async::Ready(()))
-				}
+				Ok(Async::Ready(None)) | Err(_) => return Ok(Async::Ready(())),
 				Ok(Async::Ready(Some(msg))) => if !self.handle_client_msg(msg) {
 					return Ok(Async::Ready(()))
 				}
@@ -422,8 +415,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			ProtocolMsg::PropagateExtrinsics => self.propagate_extrinsics(),
 			#[cfg(any(test, feature = "test-helpers"))]
 			ProtocolMsg::Tick => self.tick(),
-			#[cfg(any(test, feature = "test-helpers"))]
-			ProtocolMsg::Abort => self.abort(),
 			#[cfg(any(test, feature = "test-helpers"))]
 			ProtocolMsg::Synchronize => {
 				trace!(target: "sync", "handle_client_msg: received Synchronize msg");
@@ -912,22 +903,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			};
 			self.send_message(who, GenericMessage::Status(status))
 		}
-	}
-
-	fn abort(&mut self) {
-		self.sync.clear();
-		self.specialization.on_abort();
-		self.context_data.peers.clear();
-		self.handshaking_peers.clear();
-		self.consensus_gossip.abort();
-	}
-
-	fn stop(&mut self) {
-		// stop processing import requests first (without holding a sync lock)
-		self.sync.stop();
-
-		// and then clear all the sync data
-		self.abort();
 	}
 
 	fn on_block_announce(&mut self, who: PeerId, announce: message::BlockAnnounce<B::Header>) {

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -648,7 +648,7 @@ pub trait TestNetFactory: Sized {
 		let specialization = self::SpecializationFactory::create();
 		let peers: Arc<RwLock<HashMap<PeerId, ConnectedPeer<Block>>>> = Arc::new(Default::default());
 
-		let (protocol_sender, network_to_protocol_sender) = Protocol::new(
+		let (protocol, protocol_sender, network_to_protocol_sender) = Protocol::new(
 			status_sinks,
 			is_offline.clone(),
 			is_major_syncing.clone(),
@@ -661,6 +661,10 @@ pub trait TestNetFactory: Sized {
 			tx_pool,
 			specialization,
 		).unwrap();
+
+		std::thread::spawn(move || {
+			tokio::run(protocol.map_err(|err| void::unreachable(err)));
+		});
 
 		let peer = Arc::new(Peer::new(
 			is_offline,

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -642,14 +642,12 @@ pub trait TestNetFactory: Sized {
 		let (network_sender, network_port) = network_channel();
 
 		let import_queue = Box::new(BasicQueue::new(verifier, block_import, justification_import));
-		let status_sinks = Arc::new(Mutex::new(Vec::new()));
 		let is_offline = Arc::new(AtomicBool::new(true));
 		let is_major_syncing = Arc::new(AtomicBool::new(false));
 		let specialization = self::SpecializationFactory::create();
 		let peers: Arc<RwLock<HashMap<PeerId, ConnectedPeer<Block>>>> = Arc::new(Default::default());
 
 		let (protocol, protocol_sender, network_to_protocol_sender) = Protocol::new(
-			status_sinks,
 			is_offline.clone(),
 			is_major_syncing.clone(),
 			peers.clone(),

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -433,11 +433,6 @@ impl<D, S: NetworkSpecialization<Block>> Peer<D, S> {
 		*finalized_hash = Some(info.chain.finalized_hash);
 	}
 
-	/// Restart sync for a peer.
-	fn restart_sync(&self) {
-		self.net_proto_channel.send_from_client(ProtocolMsg::Abort);
-	}
-
 	/// Push a message into the gossip network and relay to peers.
 	/// `TestNet::sync_step` needs to be called to ensure it's propagated.
 	pub fn gossip_message(
@@ -831,11 +826,6 @@ pub trait TestNetFactory: Sized {
 	/// Send block finalization notifications for all peers.
 	fn send_finality_notifications(&mut self) {
 		self.peers().iter().for_each(|peer| peer.send_finality_notifications())
-	}
-
-	/// Restart sync for a peer.
-	fn restart_peer(&mut self, i: usize) {
-		self.peers()[i].restart_sync();
 	}
 
 	/// Perform synchronization until complete, if provided the

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -96,6 +96,7 @@ fn sync_cycle_from_offline_to_syncing_to_offline() {
 				net.peer(peer).on_disconnect(net.peer(other));
 			}
 		}
+		net.sync();
 		assert!(net.peer(peer).is_offline());
 		assert!(!net.peer(peer).is_major_syncing());
 	}
@@ -119,6 +120,7 @@ fn syncing_node_not_major_syncing_when_disconnected() {
 	net.peer(1).on_disconnect(net.peer(2));
 
 	// Peer 1 is not major-syncing.
+	net.sync();
 	assert!(!net.peer(1).is_major_syncing());
 }
 

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -33,7 +33,6 @@ fn test_ancestor_search_when_common_is(n: usize) {
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -143,7 +142,6 @@ fn sync_from_two_peers_with_ancestry_search_works() {
 	net.peer(0).push_blocks(10, true);
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -158,7 +156,6 @@ fn ancestry_search_works_when_backoff_is_one() {
 	net.peer(1).push_blocks(2, false);
 	net.peer(2).push_blocks(2, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));
@@ -173,7 +170,6 @@ fn ancestry_search_works_when_ancestor_is_genesis() {
 	net.peer(1).push_blocks(100, false);
 	net.peer(2).push_blocks(100, false);
 
-	net.restart_peer(0);
 	net.sync();
 	assert!(net.peer(0).client.backend().as_in_memory().blockchain()
 		.canon_equals_to(net.peer(1).client.backend().as_in_memory().blockchain()));


### PR DESCRIPTION
Based on top of #2497. Only the last commit is relevant.

Removes the `Service::with_gossip` method and turn its usage around the code into individual method calls.
