### PR TITLE
Bump master to v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,12 +382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chain-spec-builder"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-cli 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
+ "node-cli 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fork-tree"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2052,138 +2052,138 @@ dependencies = [
 
 [[package]]
 name = "node-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-executor 1.0.0",
- "node-primitives 1.0.0",
- "node-runtime 1.0.0",
+ "node-executor 2.0.0",
+ "node-primitives 2.0.0",
+ "node-runtime 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-basic-authorship 1.0.0",
- "substrate-cli 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura 1.1.0",
- "substrate-finality-grandpa 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keystore 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-service-test 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "substrate-basic-authorship 2.0.0",
+ "substrate-cli 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura 2.0.0",
+ "substrate-finality-grandpa 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keystore 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-service-test 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "node-executor"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "node-primitives 1.0.0",
- "node-runtime 1.0.0",
+ "node-primitives 2.0.0",
+ "node-runtime 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-contract 1.0.0",
- "srml-grandpa 1.0.0",
- "srml-indices 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "srml-treasury 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-contract 2.0.0",
+ "srml-grandpa 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "srml-treasury 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "node-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-serializer 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-serializer 2.0.0",
 ]
 
 [[package]]
 name = "node-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-primitives 1.0.0",
+ "node-primitives 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-aura 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-contract 1.0.0",
- "srml-council 1.0.0",
- "srml-democracy 1.0.0",
- "srml-executive 1.0.0",
- "srml-finality-tracker 1.0.0",
- "srml-grandpa 1.0.0",
- "srml-indices 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-sudo 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "srml-treasury 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-aura 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-contract 2.0.0",
+ "srml-council 2.0.0",
+ "srml-democracy 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-finality-tracker 2.0.0",
+ "srml-grandpa 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-sudo 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "srml-treasury 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "node-template"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-template-runtime 1.0.0",
+ "node-template-runtime 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "substrate-basic-authorship 1.0.0",
- "substrate-cli 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura 1.1.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-io 2.0.0",
+ "substrate-basic-authorship 2.0.0",
+ "substrate-cli 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2191,29 +2191,29 @@ dependencies = [
 
 [[package]]
 name = "node-template-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-aura 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-executive 1.0.0",
- "srml-indices 1.0.0",
- "srml-sudo 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-aura 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-sudo 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -3243,7 +3243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sr-api-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3251,35 +3251,35 @@ dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-test-client 2.0.0",
  "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "environmental 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3287,134 +3287,134 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-sandbox"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-version"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "srml-assets"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-aura"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-babe"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-consensus-babe-primitives 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-consensus-babe-primitives 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-balances"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-consensus"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-contract"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3422,203 +3422,203 @@ dependencies = [
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-sandbox 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-sandbox 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-primitives 2.0.0",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi-validation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-council"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-democracy 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-democracy 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-democracy"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-example"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "srml-balances 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-executive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-indices 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-finality-tracker"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-grandpa"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-finality-tracker 1.0.0",
- "srml-session 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-finality-grandpa-primitives 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-finality-tracker 2.0.0",
+ "srml-session 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-finality-grandpa-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-indices"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref_thread_local 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-metadata"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-session"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-staking"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-session 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-session 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-sudo"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-support-procedural 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-support"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3626,40 +3626,40 @@ dependencies = [
  "paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-metadata 1.0.0",
- "srml-support-procedural 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-metadata 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-support-procedural"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "srml-support-procedural-tools 1.0.0",
+ "sr-api-macros 2.0.0",
+ "srml-support-procedural-tools 2.0.0",
  "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 1.0.0",
+ "srml-support-procedural-tools-derive 2.0.0",
  "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3668,59 +3668,59 @@ dependencies = [
 
 [[package]]
 name = "srml-support-test"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "srml-support 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-system"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-timestamp"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-treasury"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -3839,49 +3839,49 @@ dependencies = [
 
 [[package]]
 name = "subkey"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-primitives 1.0.0",
- "node-runtime 1.0.0",
+ "node-primitives 2.0.0",
+ "node-runtime 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-cli 1.0.0",
+ "node-cli 2.0.0",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-basic-authorship"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-transaction-pool 2.0.0",
 ]
 
 [[package]]
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-cli"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3913,16 +3913,16 @@ dependencies = [
  "names 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-client 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-network 0.1.0",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-telemetry 1.0.0",
+ "substrate-client 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-telemetry 2.0.0",
  "sysinfo 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3943,24 +3943,24 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-api-macros 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-trie 2.0.0",
 ]
 
 [[package]]
 name = "substrate-client-db"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3971,21 +3971,21 @@ dependencies = [
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-db 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-db 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-trie 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-aura"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3993,53 +3993,53 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "srml-aura 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-consensus-slots 1.1.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "srml-aura 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-consensus-slots 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-authorities"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-babe"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4051,41 +4051,41 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "srml-babe 0.1.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-consensus-babe-primitives 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-consensus-slots 1.1.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "srml-babe 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-consensus-babe-primitives 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-consensus-slots 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-consensus-babe-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-slots 1.1.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-slots 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4093,17 +4093,17 @@ dependencies = [
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-client 2.0.0",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-consensus-rhd"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4112,40 +4112,40 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rhododendron 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-consensus-slots"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-executor"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4156,13 +4156,13 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-version 1.0.0",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-serializer 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-serializer 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4170,87 +4170,87 @@ dependencies = [
 
 [[package]]
 name = "substrate-finality-grandpa"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "finality-grandpa 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 1.0.0",
+ "fork-tree 2.0.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "srml-finality-tracker 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-finality-grandpa-primitives 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "srml-finality-tracker 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-finality-grandpa-primitives 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-finality-grandpa-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-inherents"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "substrate-keyring"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-keystore"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-network"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fork-tree 1.0.0",
+ "fork-tree 2.0.0",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4260,21 +4260,21 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-network-libp2p 1.0.0",
- "substrate-peerset 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-test-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-network-libp2p 2.0.0",
+ "substrate-peerset 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-client 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-network-libp2p"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4292,7 +4292,7 @@ dependencies = [
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-peerset 1.0.0",
+ "substrate-peerset 2.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4303,34 +4303,34 @@ dependencies = [
 
 [[package]]
 name = "substrate-offchain"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-offchain-primitives"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-peerset"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4371,9 +4371,9 @@ dependencies = [
  "schnorrkel 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
+ "sr-std 2.0.0",
  "substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)",
- "substrate-serializer 1.0.0",
+ "substrate-serializer 2.0.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4395,37 +4395,37 @@ dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-test-runtime 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-test-runtime 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-rpc-servers"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "jsonrpc-http-server 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-pubsub 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-rpc 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-rpc 2.0.0",
 ]
 
 [[package]]
 name = "substrate-serializer"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-service"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4445,73 +4445,73 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-client-db 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keystore 1.0.0",
- "substrate-network 0.1.0",
- "substrate-offchain 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-rpc-servers 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-transaction-pool 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-client-db 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keystore 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-offchain 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-rpc-servers 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-transaction-pool 2.0.0",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-service-test"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-network 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-service 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-network 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-service 2.0.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-state-db"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-state-machine"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-trie 1.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-telemetry"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4528,53 +4528,53 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-client-db 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-test-runtime 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-client-db 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-test-runtime 2.0.0",
 ]
 
 [[package]]
 name = "substrate-test-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-executive 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-consensus-babe-primitives 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-consensus-babe-primitives 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-transaction-graph"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4584,31 +4584,31 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-test-runtime 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-runtime 2.0.0",
 ]
 
 [[package]]
 name = "substrate-transaction-pool"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-test-client 1.0.0",
- "substrate-transaction-graph 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-test-client 2.0.0",
+ "substrate-transaction-graph 2.0.0",
 ]
 
 [[package]]
 name = "substrate-trie"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4616,8 +4616,8 @@ dependencies = [
  "keccak-hasher 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "trie-bench 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ path = "node/src/main.rs"
 
 [package]
 name = "substrate"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/core/basic-authorship/Cargo.toml
+++ b/core/basic-authorship/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-basic-authorship"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-cli"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate CLI interface."
 edition = "2018"

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/client/db/Cargo.toml
+++ b/core/client/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-client-db"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/consensus/aura/Cargo.toml
+++ b/core/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-aura"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Aura consensus algorithm for substrate"
 edition = "2018"

--- a/core/consensus/aura/primitives/Cargo.toml
+++ b/core/consensus/aura/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-aura-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"

--- a/core/consensus/authorities/Cargo.toml
+++ b/core/consensus/authorities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-authorities"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"

--- a/core/consensus/babe/Cargo.toml
+++ b/core/consensus/babe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-babe"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "BABE consensus algorithm for substrate"
 edition = "2018"

--- a/core/consensus/babe/primitives/Cargo.toml
+++ b/core/consensus/babe/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-babe-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for BABE consensus"
 edition = "2018"

--- a/core/consensus/common/Cargo.toml
+++ b/core/consensus/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-common"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Common utilities for substrate consensus"
 edition = "2018"

--- a/core/consensus/rhd/Cargo.toml
+++ b/core/consensus/rhd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-rhd"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Rhododendron Round-Based consensus-algorithm for substrate"
 edition = "2018"

--- a/core/consensus/slots/Cargo.toml
+++ b/core/consensus/slots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-consensus-slots"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic slots-based utilities for consensus"
 edition = "2018"

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-executor"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/executor/wasm/Cargo.lock
+++ b/core/executor/wasm/Cargo.lock
@@ -108,11 +108,11 @@ dependencies = [
 
 [[package]]
 name = "runtime-test"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "sr-io 1.0.0",
- "sr-sandbox 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-sandbox 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -148,28 +148,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-sandbox"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -181,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,7 +189,7 @@ dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]

--- a/core/executor/wasm/Cargo.toml
+++ b/core/executor/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-test"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/finality-grandpa/Cargo.toml
+++ b/core/finality-grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-finality-grandpa"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/finality-grandpa/primitives/Cargo.toml
+++ b/core/finality-grandpa/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-finality-grandpa-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/inherents/Cargo.toml
+++ b/core/inherents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-inherents"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/keyring/Cargo.toml
+++ b/core/keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-keyring"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/keystore/Cargo.toml
+++ b/core/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-keystore"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/network-libp2p/Cargo.toml
+++ b/core/network-libp2p/Cargo.toml
@@ -3,7 +3,7 @@ description = "libp2p implementation of the ethcore network library"
 homepage = "http://parity.io"
 license = "GPL-3.0"
 name = "substrate-network-libp2p"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate network protocol"
 name = "substrate-network"
-version = "0.1.0"
+version = "2.0.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/core/offchain/Cargo.toml
+++ b/core/offchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate offchain workers"
 name = "substrate-offchain"
-version = "0.1.0"
+version = "2.0.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/core/offchain/primitives/Cargo.toml
+++ b/core/offchain/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate offchain workers primitives"
 name = "substrate-offchain-primitives"
-version = "0.1.0"
+version = "2.0.0"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/core/panic-handler/Cargo.toml
+++ b/core/panic-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-panic-handler"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate panic handler."
 edition = "2018"

--- a/core/peerset/Cargo.toml
+++ b/core/peerset/Cargo.toml
@@ -3,7 +3,7 @@ description = "Connectivity manager based on reputation"
 homepage = "http://parity.io"
 license = "GPL-3.0"
 name = "substrate-peerset"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/rpc-servers/Cargo.toml
+++ b/core/rpc-servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-rpc-servers"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-rpc"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/serializer/Cargo.toml
+++ b/core/serializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-serializer"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-service"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/service/test/Cargo.toml
+++ b/core/service/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-service-test"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/sr-api-macros/Cargo.toml
+++ b/core/sr-api-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-api-macros"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/sr-io/Cargo.toml
+++ b/core/sr-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/core/sr-primitives/Cargo.toml
+++ b/core/sr-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/sr-sandbox/Cargo.toml
+++ b/core/sr-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-sandbox"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/core/sr-std/Cargo.toml
+++ b/core/sr-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/core/sr-version/Cargo.toml
+++ b/core/sr-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr-version"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/state-db/Cargo.toml
+++ b/core/state-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-state-db"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/state-machine/Cargo.toml
+++ b/core/state-machine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-state-machine"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate State Machine"
 edition = "2018"

--- a/core/telemetry/Cargo.toml
+++ b/core/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-telemetry"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Telemetry utils"
 edition = "2018"

--- a/core/test-client/Cargo.toml
+++ b/core/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-test-client"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-test-runtime"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/test-runtime/wasm/Cargo.lock
+++ b/core/test-runtime/wasm/Cargo.lock
@@ -2147,7 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sr-api-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2158,117 +2158,117 @@ dependencies = [
 
 [[package]]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "environmental 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-version"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "srml-executive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-metadata"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-support"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-metadata 1.0.0",
- "srml-support-procedural 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-metadata 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-support-procedural"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "srml-support-procedural-tools 1.0.0",
+ "sr-api-macros 2.0.0",
+ "srml-support-procedural-tools 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 1.0.0",
+ "srml-support-procedural-tools-derive 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2277,16 +2277,16 @@ dependencies = [
 
 [[package]]
 name = "srml-system"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2396,55 +2396,55 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-api-macros 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-trie 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-authorities"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-babe-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-slots 1.1.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-slots 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2452,33 +2452,33 @@ dependencies = [
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-consensus-slots"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
  "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-executor"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2487,49 +2487,49 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-version 1.0.0",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-serializer 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-serializer 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-inherents"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "substrate-keyring"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-offchain-primitives"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2537,11 +2537,12 @@ dependencies = [
 
 [[package]]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2550,22 +2551,20 @@ dependencies = [
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
+ "sr-std 2.0.0",
  "substrate-bip39 0.2.0 (git+https://github.com/paritytech/substrate-bip39)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-serializer"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2573,22 +2572,22 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-machine"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-trie 1.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-telemetry"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2605,47 +2604,47 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-executive 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-consensus-babe-primitives 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-consensus-babe-primitives 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-test-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "substrate-test-runtime 1.0.0",
+ "substrate-test-runtime 2.0.0",
 ]
 
 [[package]]
 name = "substrate-trie"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/core/test-runtime/wasm/Cargo.toml
+++ b/core/test-runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-test-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/transaction-pool/Cargo.toml
+++ b/core/transaction-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-transaction-pool"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/transaction-pool/graph/Cargo.toml
+++ b/core/transaction-pool/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-transaction-graph"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/core/trie/Cargo.toml
+++ b/core/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-trie"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Patricia trie stuff using a parity-codec node format"
 repository = "https://github.com/paritytech/parity-common"

--- a/core/util/fork-tree/Cargo.toml
+++ b/core/util/fork-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fork-tree"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/node-template/Cargo.toml
+++ b/node-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Anonymous"]
 build = "build.rs"
 edition = "2018"

--- a/node-template/runtime/Cargo.toml
+++ b/node-template/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template-runtime"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Anonymous"]
 edition = "2018"
 

--- a/node-template/runtime/wasm/Cargo.lock
+++ b/node-template/runtime/wasm/Cargo.lock
@@ -1354,36 +1354,36 @@ dependencies = [
 
 [[package]]
 name = "node-template-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-aura 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-executive 1.0.0",
- "srml-indices 1.0.0",
- "srml-sudo 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-aura 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-sudo 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "node-template-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "node-template-runtime 1.0.0",
+ "node-template-runtime 2.0.0",
 ]
 
 [[package]]
@@ -2181,7 +2181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sr-api-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2192,222 +2192,222 @@ dependencies = [
 
 [[package]]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "environmental 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-version"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "srml-aura"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-balances"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
 ]
 
 [[package]]
 name = "srml-consensus"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-executive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-indices"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-metadata"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-session"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
 ]
 
 [[package]]
 name = "srml-staking"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-session 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-session 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
 ]
 
 [[package]]
 name = "srml-sudo"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-support-procedural 1.0.0",
- "srml-system 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-support"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-metadata 1.0.0",
- "srml-support-procedural 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-metadata 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-support-procedural"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "srml-support-procedural-tools 1.0.0",
+ "sr-api-macros 2.0.0",
+ "srml-support-procedural-tools 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 1.0.0",
+ "srml-support-procedural-tools-derive 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2416,29 +2416,29 @@ dependencies = [
 
 [[package]]
 name = "srml-system"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-timestamp"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2548,45 +2548,45 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-api-macros 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-trie 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-authorities"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2594,16 +2594,16 @@ dependencies = [
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-executor"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2612,49 +2612,49 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-version 1.0.0",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-serializer 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-serializer 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-inherents"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "substrate-keyring"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-offchain-primitives"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2662,11 +2662,12 @@ dependencies = [
 
 [[package]]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2675,22 +2676,20 @@ dependencies = [
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
+ "sr-std 2.0.0",
  "substrate-bip39 0.2.0 (git+https://github.com/paritytech/substrate-bip39)",
  "tiny-bip39 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-serializer"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2698,22 +2697,22 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-machine"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-trie 1.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-telemetry"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2730,13 +2729,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-trie"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/node-template/runtime/wasm/Cargo.toml
+++ b/node-template/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Anonymous"]
 edition = "2018"
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-cli"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 build = "build.rs"

--- a/node/executor/Cargo.toml
+++ b/node/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-executor"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 edition = "2018"

--- a/node/primitives/Cargo.toml
+++ b/node/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-primitives"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-runtime"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,7 +58,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 76,
+	spec_version: 77,
 	impl_version: 77,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -1354,58 +1354,58 @@ dependencies = [
 
 [[package]]
 name = "node-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "node-runtime"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "node-primitives 1.0.0",
+ "node-primitives 2.0.0",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-aura 1.0.0",
- "srml-balances 1.0.0",
- "srml-consensus 1.0.0",
- "srml-contract 1.0.0",
- "srml-council 1.0.0",
- "srml-democracy 1.0.0",
- "srml-executive 1.0.0",
- "srml-finality-tracker 1.0.0",
- "srml-grandpa 1.0.0",
- "srml-indices 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-sudo 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "srml-treasury 1.0.0",
- "substrate-client 1.0.0",
- "substrate-consensus-aura-primitives 1.0.0",
- "substrate-consensus-authorities 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-offchain-primitives 0.1.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-aura 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-contract 2.0.0",
+ "srml-council 2.0.0",
+ "srml-democracy 2.0.0",
+ "srml-executive 2.0.0",
+ "srml-finality-tracker 2.0.0",
+ "srml-grandpa 2.0.0",
+ "srml-indices 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-sudo 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "srml-treasury 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
+ "substrate-consensus-authorities 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-offchain-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "node-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "node-runtime 1.0.0",
+ "node-runtime 2.0.0",
 ]
 
 [[package]]
@@ -2213,7 +2213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sr-api-macros"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2224,312 +2224,312 @@ dependencies = [
 
 [[package]]
 name = "sr-io"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "environmental 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "sr-sandbox"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-std"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-version"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "srml-aura"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-session 1.0.0",
- "srml-staking 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-session 2.0.0",
+ "srml-staking 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-balances"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
 ]
 
 [[package]]
 name = "srml-consensus"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-contract"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-sandbox 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-sandbox 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
+ "substrate-primitives 2.0.0",
  "wasmi-validation 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-council"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-democracy 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-democracy 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-democracy"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-executive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-finality-tracker"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-grandpa"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-finality-tracker 1.0.0",
- "srml-session 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-finality-grandpa-primitives 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-finality-tracker 2.0.0",
+ "srml-session 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-finality-grandpa-primitives 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-indices"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-metadata"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-session"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "srml-timestamp 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
 ]
 
 [[package]]
 name = "srml-staking"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-consensus 1.0.0",
- "srml-session 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-keyring 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-consensus 2.0.0",
+ "srml-session 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-keyring 2.0.0",
 ]
 
 [[package]]
 name = "srml-sudo"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-support-procedural 1.0.0",
- "srml-system 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
 name = "srml-support"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-metadata 1.0.0",
- "srml-support-procedural 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-metadata 2.0.0",
+ "srml-support-procedural 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-support-procedural"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "srml-support-procedural-tools 1.0.0",
+ "sr-api-macros 2.0.0",
+ "srml-support-procedural-tools 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 1.0.0",
+ "srml-support-procedural-tools-derive 2.0.0",
  "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2538,42 +2538,42 @@ dependencies = [
 
 [[package]]
 name = "srml-system"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "srml-timestamp"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
- "substrate-inherents 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
+ "substrate-inherents 2.0.0",
 ]
 
 [[package]]
 name = "srml-treasury"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "srml-balances 1.0.0",
- "srml-support 1.0.0",
- "srml-system 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "srml-balances 2.0.0",
+ "srml-support 2.0.0",
+ "srml-system 2.0.0",
 ]
 
 [[package]]
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-client"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "derive_more 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2683,45 +2683,45 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "substrate-consensus-common 1.0.0",
- "substrate-executor 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-keyring 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-telemetry 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-api-macros 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-consensus-common 2.0.0",
+ "substrate-executor 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-keyring 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-telemetry 2.0.0",
+ "substrate-trie 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-authorities"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "sr-version 1.0.0",
- "srml-support 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-io 2.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "sr-version 2.0.0",
+ "srml-support 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2729,16 +2729,16 @@ dependencies = [
  "libp2p 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-version 1.0.0",
- "substrate-inherents 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-executor"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2747,60 +2747,60 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 1.0.0",
- "sr-version 1.0.0",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-serializer 1.0.0",
- "substrate-state-machine 1.0.0",
- "substrate-trie 1.0.0",
+ "sr-io 2.0.0",
+ "sr-version 2.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-serializer 2.0.0",
+ "substrate-state-machine 2.0.0",
+ "substrate-trie 2.0.0",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-finality-grandpa-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
- "substrate-client 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-inherents"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
- "sr-std 1.0.0",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
 ]
 
 [[package]]
 name = "substrate-keyring"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 1.0.0",
+ "sr-primitives 2.0.0",
  "strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 1.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
 name = "substrate-offchain-primitives"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
- "sr-primitives 1.0.0",
- "substrate-client 1.0.0",
+ "sr-primitives 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2808,11 +2808,12 @@ dependencies = [
 
 [[package]]
 name = "substrate-primitives"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash256-std-hasher 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2821,22 +2822,20 @@ dependencies = [
  "primitive-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
+ "sr-std 2.0.0",
  "substrate-bip39 0.2.0 (git+https://github.com/paritytech/substrate-bip39)",
  "tiny-bip39 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-serializer"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2844,22 +2843,22 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-machine"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-panic-handler 1.0.0",
- "substrate-primitives 1.0.0",
- "substrate-trie 1.0.0",
+ "substrate-panic-handler 2.0.0",
+ "substrate-primitives 2.0.0",
+ "substrate-trie 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-telemetry"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2876,13 +2875,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-trie"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "hash-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 1.0.0",
- "substrate-primitives 1.0.0",
+ "sr-std 2.0.0",
+ "substrate-primitives 2.0.0",
  "trie-db 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/node/runtime/wasm/Cargo.toml
+++ b/node/runtime/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-runtime-wasm"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/scripts/node-template-release/Cargo.toml
+++ b/scripts/node-template-release/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template-release"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/assets/Cargo.toml
+++ b/srml/assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-assets"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/aura/Cargo.toml
+++ b/srml/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-aura"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/babe/Cargo.toml
+++ b/srml/babe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-babe"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/balances/Cargo.toml
+++ b/srml/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-balances"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/consensus/Cargo.toml
+++ b/srml/consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-consensus"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/contract/Cargo.toml
+++ b/srml/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-contract"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/council/Cargo.toml
+++ b/srml/council/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-council"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/democracy/Cargo.toml
+++ b/srml/democracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-democracy"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/example/Cargo.toml
+++ b/srml/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-example"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/executive/Cargo.toml
+++ b/srml/executive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-executive"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/finality-tracker/Cargo.toml
+++ b/srml/finality-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-finality-tracker"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/grandpa/Cargo.toml
+++ b/srml/grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-grandpa"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/indices/Cargo.toml
+++ b/srml/indices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-indices"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/metadata/Cargo.toml
+++ b/srml/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-metadata"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/session/Cargo.toml
+++ b/srml/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-session"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition =  "2018"
 

--- a/srml/staking/Cargo.toml
+++ b/srml/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-staking"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/sudo/Cargo.toml
+++ b/srml/sudo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-sudo"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/support/Cargo.toml
+++ b/srml/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-support"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/support/procedural/Cargo.toml
+++ b/srml/support/procedural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-support-procedural"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/support/procedural/tools/Cargo.toml
+++ b/srml/support/procedural/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-support-procedural-tools"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/support/procedural/tools/derive/Cargo.toml
+++ b/srml/support/procedural/tools/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-support-procedural-tools-derive"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/support/test/Cargo.toml
+++ b/srml/support/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-support-test"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["thiolliere <gui.thiolliere@gmail.com>"]
 edition = "2018"
 

--- a/srml/support/test/Cargo.toml
+++ b/srml/support/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "srml-support-test"
 version = "2.0.0"
-authors = ["thiolliere <gui.thiolliere@gmail.com>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dev-dependencies]

--- a/srml/system/Cargo.toml
+++ b/srml/system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-system"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -76,9 +76,12 @@ use serde::Serialize;
 use rstd::prelude::*;
 #[cfg(any(feature = "std", test))]
 use rstd::map;
-use primitives::traits::{self, CheckEqual, SimpleArithmetic, SimpleBitOps, Zero, One, Bounded, Lookup,
+use primitives::traits::{self, CheckEqual, SimpleArithmetic, SimpleBitOps, One, Bounded, Lookup,
 	Hash, Member, MaybeDisplay, EnsureOrigin, Digest as DigestT, As, CurrentHeight, BlockNumberToHash,
-	MaybeSerializeDebugButNotDeserialize, MaybeSerializeDebug, StaticLookup};
+	MaybeSerializeDebugButNotDeserialize, MaybeSerializeDebug, StaticLookup
+};
+#[cfg(any(feature = "std", test))]
+use primitives::traits::Zero;
 use substrate_primitives::storage::well_known_keys;
 use srml_support::{storage, StorageValue, StorageMap, Parameter, decl_module, decl_event, decl_storage};
 use safe_mix::TripletMix;

--- a/srml/timestamp/Cargo.toml
+++ b/srml/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-timestamp"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/srml/treasury/Cargo.toml
+++ b/srml/treasury/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srml-treasury"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subkey"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/test-utils/chain-spec-builder/Cargo.toml
+++ b/test-utils/chain-spec-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chain-spec-builder"
 version = "2.0.0"
-authors = ["haydn dufrene <haydn.dufrene@gmail.com>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]

--- a/test-utils/chain-spec-builder/Cargo.toml
+++ b/test-utils/chain-spec-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-spec-builder"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["haydn dufrene <haydn.dufrene@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
This is needed to tag master clients appropriately (otherwise they show up as v1.0 on telemetry).