### PR TITLE
core: use current_thread tokio runtime to poll network to proto channel

### DIFF
--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -673,7 +673,7 @@ pub trait TestNetFactory: Sized {
 		).unwrap();
 
 		std::thread::spawn(move || {
-			tokio::run(futures::future::poll_fn(move || {
+			tokio::runtime::current_thread::run(futures::future::poll_fn(move || {
 				while let Async::Ready(msg) = network_to_protocol_rx.poll().unwrap() {
 					match msg {
 						Some(FromNetworkMsg::PeerConnected(peer_id, debug_msg)) =>


### PR DESCRIPTION
Spawning a tokio runtime for each peer added on every test that's running concurrently can deplete system resources and have tests fail with: 

`thread '<unnamed>' panicked at 'failed to start new Runtime: Os { code: 24, kind: Other, message: "Too many open files" }', src/libcore/result.rs:997:5`