### PR TITLE
Related #1134 - Add intermediate node setup

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -45,17 +45,28 @@ construct_simple_protocol! {
 }
 
 /// Node specific configuration
+///
+/// Note that we can only use `[derive(Default)]` if all fields implement
+/// Default themselves, however previously we were using `Option<Arc<...`,
+/// which does not, so the derive macro would fail and we had to implement
+/// the `Default` trait manually below.
+///
+/// Reference: https://doc.rust-lang.org/std/default/trait.Default.html#derivable
 pub struct NodeConfig<F: substrate_service::ServiceFactory> {
-	/// grandpa connection to import block
-	// FIXME #1134 rather than putting this on the config, let's have an actual intermediate setup state
-	pub grandpa_import_setup: Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)>,
-	inherent_data_providers: InherentDataProviders,
+	// /// grandpa connection to import block
+	// // FIXME #1134 rather than putting this on the config, let's have an actual intermediate setup state
+	// pub grandpa_import_setup: Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)>,
+	inherent_data_providers: Option<InherentDataProviders>,
 }
 
+
+/// Implement the `Default` trait for the `NodeConfig` struct to provide default values
+///
+/// Reference: https://doc.rust-lang.org/std/default/trait.Default.html
 impl<F> Default for NodeConfig<F> where F: substrate_service::ServiceFactory {
 	fn default() -> NodeConfig<F> {
 		NodeConfig {
-			grandpa_import_setup: None,
+			// grandpa_import_setup: None,
 			inherent_data_providers: InherentDataProviders::new(),
 		}
 	}

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -51,25 +51,15 @@ construct_simple_protocol! {
 /// which does not, so the derive macro would fail and we had to implement
 /// the `Default` trait manually below.
 ///
-/// Reference: https://doc.rust-lang.org/std/default/trait.Default.html#derivable
+/// References:
+///   https://doc.rust-lang.org/std/default/trait.Default.html#derivable
+///   https://doc.rust-lang.org/std/default/trait.Default.html
+#[derive(Default)]
 pub struct NodeConfig<F: substrate_service::ServiceFactory> {
 	// /// grandpa connection to import block
 	// // FIXME #1134 rather than putting this on the config, let's have an actual intermediate setup state
 	// pub grandpa_import_setup: Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)>,
-	inherent_data_providers: Option<InherentDataProviders>,
-}
-
-
-/// Implement the `Default` trait for the `NodeConfig` struct to provide default values
-///
-/// Reference: https://doc.rust-lang.org/std/default/trait.Default.html
-impl<F> Default for NodeConfig<F> where F: substrate_service::ServiceFactory {
-	fn default() -> NodeConfig<F> {
-		NodeConfig {
-			// grandpa_import_setup: None,
-			inherent_data_providers: InherentDataProviders::new(),
-		}
-	}
+	inherent_data_providers: InherentDataProviders::new(),
 }
 
 construct_service_factory! {

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -56,9 +56,6 @@ construct_simple_protocol! {
 ///   https://doc.rust-lang.org/std/default/trait.Default.html
 #[derive(Default)]
 pub struct NodeConfig<F: substrate_service::ServiceFactory> {
-	// /// grandpa connection to import block
-	// // FIXME #1134 rather than putting this on the config, let's have an actual intermediate setup state
-	// pub grandpa_import_setup: Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)>,
 	inherent_data_providers: InherentDataProviders::new(),
 }
 

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -91,16 +91,16 @@ impl<F> Default for SetupState<F> {
 		}
 	}
 
-	// Set the configuration state, which includes discarding it after the systems are setup
-	fn set_setup(&mut self, mut setup) {
-		// TODO
-	}
+	// // Set the configuration state, which includes discarding it after the systems are setup
+	// fn set_setup(&mut self, mut setup) {
+	// 	// TODO
+	// }
 
-	/// Allow the configuration to be taken by `AuthoritySetup` using `take()`
-	fn get_setup(&mut self) -> Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)> {
-		// FIXME
-		self.grandpa_import_setup.take()
-	}
+	// /// Allow the configuration to be taken by `AuthoritySetup` using `take()`
+	// fn get_setup(&mut self) -> Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)> {
+	// 	// FIXME
+	// 	self.grandpa_import_setup.take()
+	// }
 }
 
 
@@ -110,6 +110,8 @@ impl<F> Default for SetupState<F> {
 /// Default themselves, however previously we were using `Option<Arc<...`,
 /// which does not, so the derive macro would fail and we had to implement
 /// the `Default` trait manually below.
+///
+/// Inherents may be attached by the runtime to blocks that are produced
 ///
 /// References:
 ///   https://doc.rust-lang.org/std/default/trait.Default.html#derivable

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -44,6 +44,21 @@ construct_simple_protocol! {
 	pub struct NodeProtocol where Block = Block { }
 }
 
+/// Intermediate Setup State
+pub struct SetupState<F: substrate_service::ServiceFactory> {
+	/// grandpa connection to import block
+	pub grandpa_import_setup: &mut Option<(Arc<grandpa::BlockImportForService<F>>, grandpa::LinkHalfForService<F>)>,
+}
+
+impl<F> Default for SetupState<F> {
+	fn default() -> SetupState<F> {
+		SetupState {
+			grandpa_import_setup: (),
+		}
+	}
+}
+
+
 /// Node specific configuration
 ///
 /// Note that we can only use `[derive(Default)]` if all fields implement
@@ -56,7 +71,7 @@ construct_simple_protocol! {
 ///   https://doc.rust-lang.org/std/default/trait.Default.html
 #[derive(Default)]
 pub struct NodeConfig<F: substrate_service::ServiceFactory> {
-	inherent_data_providers: InherentDataProviders::new(),
+	inherent_data_providers: InherentDataProviders::new,
 }
 
 construct_service_factory! {


### PR DESCRIPTION
- Notes: https://hackmd.io/TXalNnBLQKamBZN6g7rcyQ

- [ ] Description:
  - What it does? **Add intermediate node setup. See Notes above for details**
  - What important points reviewers should know?
  - Anything left for follow-up PRs?
- [ ] Labeled PR with appropriate labels
- [x] Mentioned related issue e.g. `Fixes #228` or `Related #1337`.
- [ ] Asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] PR adheres [the style guide](https://github.com/paritytech/polkadot/wiki/Style-Guide)
  - In particular, mind the maximal line length.
  - No commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] Updated any rustdocs which may have changed
- [x]  Remove `set_setup` and `get_setup` in implementation of `SetupState` (for storage/retrieval of latest state) since it should just happen in analog to
`FactoryFullConfiguration` Substrate service component configuration (which is just a fancy wrapper around Service::Configuration with some defaulting sugar on top) 
- [ ] Add generic to the `SetupState` struct to support different types
- [ ] Pass `setup_state` to all setup functions via `FullImportQueue` in node/cli/src/service.rs and core/service/src/lib.rs
- [ ] Allow `setup_state` to be discarded after setup of the systems
- [ ] Check if reference counting is required
- [ ] Update tests
- [ ] Fixing Rust compiler errors
