### PR TITLE
! fixing #2542 missing vec! macro for sandbox when building for SGX

### DIFF
--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -38,6 +38,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 use rstd::prelude::*;
 
 pub use primitives::sandbox::{TypedValue, ReturnValue, HostError};

--- a/core/sr-sandbox/without_std.rs
+++ b/core/sr-sandbox/without_std.rs
@@ -17,6 +17,7 @@
 use rstd::prelude::*;
 use rstd::{slice, marker, mem};
 use rstd::rc::Rc;
+use rstd::vec::Vec;
 use codec::{Decode, Encode};
 use primitives::sandbox as sandbox_primitives;
 use super::{Error, TypedValue, ReturnValue, HostFuncType};


### PR DESCRIPTION
fixes #2542 

