### PR TITLE
Language adjustment: Referendums -> Referenda

### DIFF
--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -94,8 +94,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node-template"),
 	impl_name: create_runtime_str!("node-template"),
 	authoring_version: 3,
-	spec_version: 3,
-	impl_version: 0,
+	spec_version: 4,
+	impl_version: 4,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 77,
-	impl_version: 77,
+	spec_version: 78,
+	impl_version: 78,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/council/src/voting.rs
+++ b/srml/council/src/voting.rs
@@ -270,7 +270,7 @@ mod tests {
 			System::set_block_number(1);
 			let proposal = set_balance_proposal(42);
 			assert_ok!(Democracy::internal_start_referendum(proposal.clone(), VoteThreshold::SuperMajorityApprove, 0), 0);
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
 
 			let cancellation = cancel_referendum_proposal(0);
 			let hash = cancellation.blake2_256().into();
@@ -282,7 +282,7 @@ mod tests {
 
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
-			assert_eq!(Democracy::active_referendums(), vec![]);
+			assert_eq!(Democracy::active_referenda(), vec![]);
 			assert_eq!(Balances::free_balance(&42), 0);
 		});
 	}
@@ -303,7 +303,7 @@ mod tests {
 
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
 		});
 	}
 
@@ -322,7 +322,7 @@ mod tests {
 
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(4, proposal, VoteThreshold::SuperMajorityApprove, 0))]);
 		});
 	}
 
@@ -335,7 +335,7 @@ mod tests {
 			assert_ok!(CouncilVoting::propose(Origin::signed(1), Box::new(proposal.clone())));
 			assert_ok!(CouncilVoting::veto(Origin::signed(2), hash));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums().len(), 0);
+			assert_eq!(Democracy::active_referenda().len(), 0);
 		});
 	}
 
@@ -386,7 +386,7 @@ mod tests {
 			System::set_block_number(4);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(7, set_balance_proposal(42), VoteThreshold::SimpleMajority, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(7, set_balance_proposal(42), VoteThreshold::SimpleMajority, 0))]);
 		});
 	}
 
@@ -403,7 +403,7 @@ mod tests {
 			assert_ok!(CouncilVoting::propose(Origin::signed(1), Box::new(proposal.clone())));
 			assert_ok!(CouncilVoting::veto(Origin::signed(3), hash));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums().len(), 0);
+			assert_eq!(Democracy::active_referenda().len(), 0);
 		});
 	}
 
@@ -433,7 +433,7 @@ mod tests {
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums().len(), 0);
+			assert_eq!(Democracy::active_referenda().len(), 0);
 		});
 	}
 
@@ -451,7 +451,7 @@ mod tests {
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(5, proposal, VoteThreshold::SuperMajorityAgainst, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(5, proposal, VoteThreshold::SuperMajorityAgainst, 0))]);
 		});
 	}
 
@@ -469,7 +469,7 @@ mod tests {
 			System::set_block_number(2);
 			assert_ok!(CouncilVoting::end_block(System::block_number()));
 			assert_eq!(CouncilVoting::proposals().len(), 0);
-			assert_eq!(Democracy::active_referendums(), vec![(0, ReferendumInfo::new(5, proposal, VoteThreshold::SimpleMajority, 0))]);
+			assert_eq!(Democracy::active_referenda(), vec![(0, ReferendumInfo::new(5, proposal, VoteThreshold::SimpleMajority, 0))]);
 		});
 	}
 

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -245,7 +245,7 @@ decl_storage! {
 		/// How often (in blocks) to check for new votes.
 		pub VotingPeriod get(voting_period) config(): T::BlockNumber = T::BlockNumber::sa(1000);
 
-		/// The next free referendum index, aka the number of referendums started so far.
+		/// The next free referendum index, aka the number of referenda started so far.
 		pub ReferendumCount get(referendum_count) build(|_| 0 as ReferendumIndex): ReferendumIndex;
 		/// The next referendum index that should be tallied.
 		pub NextTally get(next_tally) build(|_| 0 as ReferendumIndex): ReferendumIndex;
@@ -298,8 +298,8 @@ impl<T: Trait> Module<T> {
 		<ReferendumInfoOf<T>>::exists(ref_index)
 	}
 
-	/// Get all referendums currently active.
-	pub fn active_referendums() -> Vec<(ReferendumIndex, ReferendumInfo<T::BlockNumber, T::Proposal>)> {
+	/// Get all referenda currently active.
+	pub fn active_referenda() -> Vec<(ReferendumIndex, ReferendumInfo<T::BlockNumber, T::Proposal>)> {
 		let next = Self::next_tally();
 		let last = Self::referendum_count();
 		(next..last).into_iter()
@@ -307,8 +307,8 @@ impl<T: Trait> Module<T> {
 			.collect()
 	}
 
-	/// Get all referendums ready for tally at block `n`.
-	pub fn maturing_referendums_at(n: T::BlockNumber) -> Vec<(ReferendumIndex, ReferendumInfo<T::BlockNumber, T::Proposal>)> {
+	/// Get all referenda ready for tally at block `n`.
+	pub fn maturing_referenda_at(n: T::BlockNumber) -> Vec<(ReferendumIndex, ReferendumInfo<T::BlockNumber, T::Proposal>)> {
 		let next = Self::next_tally();
 		let last = Self::referendum_count();
 		(next..last).into_iter()
@@ -498,7 +498,7 @@ impl<T: Trait> Module<T> {
 		}
 
 		// tally up votes for any expiring referenda.
-		for (index, info) in Self::maturing_referendums_at(now).into_iter() {
+		for (index, info) in Self::maturing_referenda_at(now).into_iter() {
 			Self::bake_referendum(now.clone(), index, info)?;
 		}
 


### PR DESCRIPTION
This PR settles on referenda as the plural of referendum. Supporting [ngram comparison](https://books.google.com/ngrams/graph?content=referendums%2C+referenda&case_insensitive=on&year_start=1800&year_end=2010&corpus=15&smoothing=3&share=&direct_url=t4%3B%2Creferendums%3B%2Cc0%3B%2Cs0%3B%3Breferendums%3B%2Cc0%3B%3BReferendums%3B%2Cc0%3B.t4%3B%2Creferenda%3B%2Cc0%3B%2Cs0%3B%3Breferenda%3B%2Cc0%3B%3BReferenda%3B%2Cc0#t4%3B%2Creferendums%3B%2Cc0%3B%2Cs0%3B%3Breferendums%3B%2Cc0%3B%3BReferendums%3B%2Cc0%3B.t4%3B%2Creferenda%3B%2Cc0%3B%2Cs0%3B%3Breferenda%3B%2Cc0%3B%3BReferenda%3B%2Cc0)

It is a continuation of https://github.com/paritytech/substrate/pull/2457 which I accidentally fubar-ed.

I've updated the version numbers as requested there, but I'm not yet sure how / where to make a release note.

