### PR TITLE
Fix over/under flow risk in OnDilution

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 77,
-	impl_version: 77,
+	impl_version: 78,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
I was looking at Treasury and noticed that if `minted > portion` then this could overflow. Added a few checks.

Related https://github.com/paritytech/substrate/issues/1572 
