### PR TITLE
Add possibility to sign calls via cli

### DIFF
--- a/subkey/README.adoc
+++ b/subkey/README.adoc
@@ -53,3 +53,18 @@ You can use the included vanity generator to find a seed that provides an addres
 ```bash
 subkey vanity 1337
 ```
+
+=== Signing a transaction
+
+Sign a transaction from an encoded `Call`.
+
+```bash
+subkey sign-transaction \
+	--call <call-as-hex> \
+	--nonce 0 \
+	--suri <suri> \
+	--password <password> \
+	--prior-block-hash <prior-block-hash-as-hex>
+```
+
+Will output a signed and encoded `UncheckedMortalCompactExtrinsic` as hex.

--- a/subkey/README.adoc
+++ b/subkey/README.adoc
@@ -62,7 +62,7 @@ Sign a transaction from an encoded `Call`.
 subkey sign-transaction \
 	--call <call-as-hex> \
 	--nonce 0 \
-	--suri <suri> \
+	--suri <secret-uri> \
 	--password <password> \
 	--prior-block-hash <prior-block-hash-as-hex>
 ```

--- a/subkey/src/cli.yml
+++ b/subkey/src/cli.yml
@@ -92,3 +92,36 @@ subcommands:
             help: Number of keys to generate
             takes_value: true
             default_value: "1"
+  - sign-transaction:
+      about: Sign transaction from encoded Call. Returns a signed and encoded UncheckedMortalCompactExtrinsic as hex.
+      args:
+        - call:
+            short: c
+            long: call
+            help: The call, hex-encoded.
+            takes_value: true
+            required: true
+        - nonce:
+            short: n
+            long: nonce
+            help: The nonce.
+            takes_value: true
+            required: true
+        - suri:
+            long: suri
+            short: s
+            help: The secret key URI.
+            takes_value: true
+            required: true
+        - password:
+            short: p
+            long: password
+            takes_value: true
+            help: The password for the key.
+            required: true
+        - prior-block-hash:
+            short: h
+            long: prior-block-hash
+            help: The prior block hash, hex-encoded.
+            takes_value: true
+            required: true


### PR DESCRIPTION
Needed for chaos testnet tooling.

@rphmeier Can you please take a look if this fulfills your requirements? Please note that the returned value atm is an `UncheckedMortalCompactExtrinsic`, not an `UncheckedMortalExtrinsic`.

```
$ cd subkey/
$ cargo run -- sign-transaction \
    --call 0300ff408aa36b945720031fbb2e661fc9c9f1ed799be5369f991bbfce02103b5f0e44e514 \
    --nonce 0 \
    --suri //Alice/// \
    --password password \
    --prior-block-hash f8349fe94e9fd86e8a85745bbb70a4d2d5f4d8fc32a1f8fc08088faf1840e705
0x250281ffd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0ecdb36c371c4a5e2d7528e12f68fcc57912df0c80418cca794fd83c24f29825efbaaaa2ae4472726e065f4f1db75ba7c39114e25b58de4dde54d6b51aa3e20500000300ff408aa36b945720031fbb2e661fc9c9f1ed799be5369f991bbfce02103b5f0e44e514
```