### PR TITLE
Split SyncContext from protocol Context

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -25,7 +25,7 @@ use crate::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
 use crate::on_demand::OnDemandService;
 use crate::specialization::NetworkSpecialization;
-use crate::sync::{ChainSync, Status as SyncStatus, SyncState};
+use crate::sync::{ChainSync, Context as SyncContext, Status as SyncStatus, SyncState};
 use crate::service::{NetworkChan, NetworkMsg, TransactionPool, ExHashT};
 use crate::config::{ProtocolConfig, Roles};
 use parking_lot::RwLock;
@@ -147,21 +147,12 @@ pub struct PeerInfo<B: BlockT> {
 
 /// Context for a network-specific handler.
 pub trait Context<B: BlockT> {
-	/// Get a reference to the client.
-	fn client(&self) -> &crate::chain::Client<B>;
-
 	/// Adjusts the reputation of the peer. Use this to point out that a peer has been malign or
 	/// irresponsible or appeared lazy.
 	fn report_peer(&mut self, who: PeerId, reputation: i32);
 
 	/// Force disconnecting from a peer. Use this when a peer misbehaved.
 	fn disconnect_peer(&mut self, who: PeerId);
-
-	/// Get peer info.
-	fn peer_info(&self, peer: &PeerId) -> Option<PeerInfo<B>>;
-
-	/// Request a block from a peer.
-	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>);
 
 	/// Send a consensus message to a peer.
 	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage);
@@ -191,6 +182,28 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 		self.network_chan.send(NetworkMsg::DisconnectPeer(who))
 	}
 
+	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::Consensus(consensus)
+		)
+	}
+
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {
+		send_message(&mut self.context_data.peers, &self.network_chan, who,
+			GenericMessage::ChainSpecific(message)
+		)
+	}
+}
+
+impl<'a, B: BlockT + 'a, H: ExHashT + 'a> SyncContext<B> for ProtocolContext<'a, B, H> {
+	fn report_peer(&mut self, who: PeerId, reputation: i32) {
+		self.network_chan.send(NetworkMsg::ReportPeer(who, reputation))
+	}
+
+	fn disconnect_peer(&mut self, who: PeerId) {
+		self.network_chan.send(NetworkMsg::DisconnectPeer(who))
+	}
+
 	fn peer_info(&self, who: &PeerId) -> Option<PeerInfo<B>> {
 		self.context_data.peers.get(who).map(|p| p.info.clone())
 	}
@@ -202,18 +215,6 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 	fn send_block_request(&mut self, who: PeerId, request: BlockRequestMessage<B>) {
 		send_message(&mut self.context_data.peers, &self.network_chan, who,
 			GenericMessage::BlockRequest(request)
-		)
-	}
-
-	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage) {
-		send_message(&mut self.context_data.peers, &self.network_chan, who,
-			GenericMessage::Consensus(consensus)
-		)
-	}
-
-	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {
-		send_message(&mut self.context_data.peers, &self.network_chan, who,
-			GenericMessage::ChainSpecific(message)
 		)
 	}
 }

--- a/core/network/src/sync.rs
+++ b/core/network/src/sync.rs
@@ -34,7 +34,7 @@ use std::cmp::max;
 use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 use log::{debug, trace, info, warn};
-use crate::protocol::Context;
+use crate::protocol::PeerInfo as ProtocolPeerInfo;
 use fork_tree::ForkTree;
 use network_libp2p::PeerId;
 use client::{BlockStatus, ClientInfo};
@@ -66,6 +66,25 @@ const BLOCKCHAIN_STATUS_READ_ERROR_REPUTATION_CHANGE: i32 = -(1 << 16);
 const ANCESTRY_BLOCK_ERROR_REPUTATION_CHANGE: i32 = -(1 << 9);
 /// Reputation change when a peer sent us a status message with a different genesis than us.
 const GENESIS_MISMATCH_REPUTATION_CHANGE: i32 = i32::min_value() + 1;
+
+/// Context for a network-specific handler.
+pub trait Context<B: BlockT> {
+	/// Get a reference to the client.
+	fn client(&self) -> &crate::chain::Client<B>;
+
+	/// Adjusts the reputation of the peer. Use this to point out that a peer has been malign or
+	/// irresponsible or appeared lazy.
+	fn report_peer(&mut self, who: PeerId, reputation: i32);
+
+	/// Force disconnecting from a peer. Use this when a peer misbehaved.
+	fn disconnect_peer(&mut self, who: PeerId);
+
+	/// Get peer info.
+	fn peer_info(&self, peer: &PeerId) -> Option<ProtocolPeerInfo<B>>;
+
+	/// Request a block from a peer.
+	fn send_block_request(&mut self, who: PeerId, request: message::BlockRequest<B>);
+}
 
 #[derive(Debug)]
 struct PeerSync<B: BlockT> {


### PR DESCRIPTION
The `peer_info`, `client` and `send_block_request` methods of the `Context` are only ever used by the sync code.
This PR creates a different trait specific to the sync code, so that we don't expose these methods in the `Context` trait that everyone has access to.

The advantage of doing so is that the remaining methods (`disconnect_peer`, `report_peer`, `send_consensus` and `send_chain_specific`) can all be implemented by sending a message on a channel, therefore removing the need to somehow hold some sort of lock to the `Protocol` struct.

Does break the API of `network`, but doesn't break polkadot expect that we have to remove [these lines](https://github.com/paritytech/polkadot/blob/41f626526854757c219b55c91fa3a5531d761da7/network/src/tests/mod.rs#L48-L50) and [these lines](https://github.com/paritytech/polkadot/blob/41f626526854757c219b55c91fa3a5531d761da7/network/src/tests/mod.rs#L60-L66).
