### PR TITLE
Remove the NetworkChan from the OnDemandService

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -199,12 +199,10 @@ impl<Components: components::Components> Service<Components> {
 		};
 
 		let has_bootnodes = !network_params.network_config.boot_nodes.is_empty();
-		let (network, network_chan) = network::Service::new(
-			network_params,
-			protocol_id,
-			import_queue
-		)?;
-		on_demand.map(|on_demand| on_demand.set_network_sender(network_chan));
+		let network = network::Service::new(network_params, protocol_id, import_queue)?;
+		if let Some(on_demand) = on_demand.as_ref() {
+			on_demand.set_network_interface(Box::new(Arc::downgrade(&network)));
+		}
 
 		let inherents_pool = Arc::new(InherentsPool::default());
 		let offchain_workers =  if config.offchain_worker {


### PR DESCRIPTION
Replaces the `NetworkChan` with a `OnDemandNetwork` trait. Makes the code more flexible. The ultimate goal is to remove the `NetworkMsg` enum from the API surface of `network`.

cc #2536 