### PR TITLE
Increase tolerance for bandwidth usage in test

### DIFF
--- a/core/network-libp2p/tests/test.rs
+++ b/core/network-libp2p/tests/test.rs
@@ -150,7 +150,7 @@ fn many_nodes_connectivity() {
 			let mut num_connecs = 0;
 			stream::poll_fn(move || -> io::Result<_> {
 				loop {
-					const MAX_BANDWIDTH: u64 = NUM_NODES as u64 * 1024;		// 1kiB/s/node
+					const MAX_BANDWIDTH: u64 = NUM_NODES as u64 * 2048;		// 2kiB/s/node
 					assert!(node.average_download_per_sec() < MAX_BANDWIDTH);
 					assert!(node.average_upload_per_sec() < MAX_BANDWIDTH);
 


### PR DESCRIPTION
I spotted a CI failure caused by the `MAX_BANDWIDTH` being exceeded during this test.

For context, we spawn 25 nodes and wait for them to connect to each other. Then we check that the bandwidth usage doesn't exceed the `MAX_BANDWIDTH` constant.
Paradoxically, this limit could also be reached if our code becomes too efficient.

This constant is arbitrary anyway, so let's make it a bit more tolerant. 2kiB/sec per node is still very low.