### PR TITLE
fix(remove redundant import)

### DIFF
--- a/core/network/src/sync/extra_requests.rs
+++ b/core/network/src/sync/extra_requests.rs
@@ -304,8 +304,6 @@ impl<B: BlockT, Essence: ExtraRequestsEssence<B>> ExtraRequests<B, Essence> {
 			return Ok(());
 		}
 
-		use std::collections::HashSet;
-
 		self.tree.finalize(best_finalized_hash, best_finalized_number, &is_descendent_of)?;
 
 		let roots = self.tree.roots().collect::<HashSet<_>>();


### PR DESCRIPTION
Fixes

```bash
    Checking srml-grandpa v2.0.0 (/home/niklasad1/Github/substrate/srml/grandpa)
warning: the item `HashSet` is imported redundantly
   --> core/network/src/sync/extra_requests.rs:307:7
    |
17  | use std::collections::{HashMap, HashSet, VecDeque};
    |                                 ------- the item `HashSet` is already imported here
...
307 |         use std::collections::HashSet;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(unused_imports)] on by default
```