### PR TITLE
Default image to build wasm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,7 +92,6 @@ test-linux-stable:                 &test
 
 check-web-wasm:
   stage:                           test
-  image:                           tomaka/cargo-web:latest
   allow_failure:                   true
   only:
     - master


### PR DESCRIPTION
- Check-web-wasm job now uses the default builder image