### PR TITLE
node: set protocol id for flaming fir

### DIFF
--- a/node/cli/res/flaming-fir.json
+++ b/node/cli/res/flaming-fir.json
@@ -18,7 +18,7 @@
 	"telemetryEndpoints": [
 		["wss://telemetry.polkadot.io/submit/", 0]
 	],
-	"protocolId": null,
+	"protocolId": "fir",
 	"consensusEngine": null,
 	"genesis": {
 		"raw": {


### PR DESCRIPTION
To avoid clashes with other networks (Emberic Elm and others).

```
2019-05-15 11:52:33 Banning PeerId("QmTtcYKJho9vFmqtMA548QBSmLbmwAkBSiEKK3kWKfb6bJ") because "Peer is on different chain (our genesis: 0x78be?87c7 theirs: 0xe1aa?65e6)"
2019-05-15 11:52:33 Banning a node is a deprecated mechanism that should be removed
2019-05-15 11:52:33 Banning PeerId("QmWv9Ww7znzgLFyCzf21SR6tUKXrmHCZH9KhebeH4gyE9f") because "Peer is on different chain (our genesis: 0x78be?87c7 theirs: 0xe1aa?65e6)"
2019-05-15 11:52:33 Banning a node is a deprecated mechanism that should be removed
2019-05-15 11:52:34 Banning PeerId("QmTtcYKJho9vFmqtMA548QBSmLbmwAkBSiEKK3kWKfb6bJ") because "Peer is on different chain (our genesis: 0x78be?87c7 theirs: 0xe1aa?65e6)"
2019-05-15 11:52:34 Banning a node is a deprecated mechanism that should be removed
```

Requested by a user on riot channel.