### PR TITLE
ci: change docker image to debian:stretch-slim

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,26 +1,27 @@
-FROM ubuntu:xenial
+FROM debian:stretch-slim
 LABEL maintainer "devops-team@parity.io"
 LABEL description="Substrate: The platform for blockchain innovators"
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-		libssl1.0.0 \
-		ca-certificates \
-		curl && \
+      libssl1.1 \
+      ca-certificates \
+      curl && \
     apt-get autoremove -y && \
-    apt-get clean
-    
-RUN	find /var/lib/apt/lists/ -type f -not -name lock -delete
+    apt-get clean && \
+    find /var/lib/apt/lists/ -type f -not -name lock -delete
 
 COPY ./substrate /usr/local/bin
-
 
 
 RUN useradd -m -u 1000 -U -s /bin/sh -d /substrate substrate
 USER substrate
 
 ENV RUST_BACKTRACE 1
+
+# check if executable works in this container
+RUN /usr/local/bin/substrate --version
 
 EXPOSE 30333 9933 9944
 VOLUME ["/substrate"]


### PR DESCRIPTION
Ubuntu/Xenial based Docker base image doesn't work with the binaries produced by the build container (based on Debian/Stretch).

Fixes #2569