### PR TITLE
Remove remains from metadata v0

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 80,
-	impl_version: 81,
+	impl_version: 82,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -292,22 +292,6 @@ pub enum StorageFunctionModifier {
 	Default,
 }
 
-/// All metadata about the outer dispatch.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
-pub struct OuterDispatchMetadata {
-	pub name: DecodeDifferentStr,
-	pub calls: DecodeDifferentArray<OuterDispatchCall>,
-}
-
-/// A Call from the outer dispatch.
-#[derive(Clone, PartialEq, Eq, Encode)]
-#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
-pub struct OuterDispatchCall {
-	pub name: DecodeDifferentStr,
-	pub index: u16,
-}
-
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 /// Metadata prefixed by a u32 for reserved usage

--- a/srml/support/src/dispatch.rs
+++ b/srml/support/src/dispatch.rs
@@ -22,10 +22,7 @@ pub use crate::rstd::prelude::{Vec, Clone, Eq, PartialEq};
 pub use std::fmt;
 pub use crate::rstd::result;
 pub use crate::codec::{Codec, Decode, Encode, Input, Output, HasCompact, EncodeAsRef};
-pub use srml_metadata::{
-	FunctionMetadata, DecodeDifferent, DecodeDifferentArray,
-	FunctionArgumentMetadata, OuterDispatchMetadata, OuterDispatchCall
-};
+pub use srml_metadata::{FunctionMetadata, DecodeDifferent, DecodeDifferentArray, FunctionArgumentMetadata};
 
 /// A type that cannot be instantiated.
 pub enum Never {}


### PR DESCRIPTION
Was cleaning Metadata on the JS side, and saw a couple of stuff here that dates back to MetadataV0. Removing them.