### PR TITLE
Allow warnings

### DIFF
--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -533,7 +533,6 @@ impl<B: Block, C, E, I, Error, SO> SlotWorker<B> for BabeWorker<C, E, I, SO> whe
 /// This digest item will always return `Some` when used with `as_babe_seal`.
 //
 // FIXME #1018 needs misbehavior types
-#[forbid(warnings)]
 fn check_header<B: Block + Sized, C: AuxStore>(
 	client: &Arc<C>,
 	slot_now: u64,
@@ -585,7 +584,7 @@ fn check_header<B: Block + Sized, C: AuxStore>(
 					format!("VRF verification failed")
 				})?
 			};
-				
+
 			if check(&inout, threshold) {
 				match check_equivocation(&client, slot_now, slot_num, header.clone(), signer.clone()) {
 					Ok(Some(equivocation_proof)) => {
@@ -1015,7 +1014,7 @@ mod tests {
 			Default::default(),
 			0,
 		);
-		
+
 		let (inout, proof, _batchable_proof) = get_keypair(&pair).vrf_sign_n_check(transcript, |inout| check(inout, u64::MAX)).unwrap();
 		let pre_hash: H256 = header.hash();
 		let to_sign = (slot_num, pre_hash, proof.to_bytes()).encode();

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -51,8 +51,6 @@
 //! number (this is num(signal) + N). When finalizing a block, we either apply
 //! or prune any signaled changes based on whether the signaling block is
 //! included in the newly-finalized chain.
-#![forbid(warnings)]
-#![allow(deprecated)] // FIXME #2532: remove once the refactor is done https://github.com/paritytech/substrate/issues/2532
 
 use futures::prelude::*;
 use log::{debug, info, warn};


### PR DESCRIPTION
Denying warnings is a bad good-idea. New versions of Rust almost always introduce new warnings, be it deprecated functions or new lints. For example a new version of Rust may decide that it's no longer necessary to explicitly put lifetimes at certain locations, and emit a warning if you do.

It has personally happened to me often enough in the past that I now religiously remove all the `forbid(warnings)` that I stumble upon.

Forbidding warnings also paradoxically leads to silencing warnings, such as with the `allow(deprecated)` that I removed in this PR as well.
