### PR TITLE
Remove TaskExecutor from the API of the informant

### DIFF
--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -32,9 +32,16 @@ use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Header, As};
 
 /// Spawn informant on the event loop
+#[deprecated(note = "Please use informant::build instead, and then create the task manually")]
 pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExecutor) where
 	C: Components,
 {
+	handle.spawn(exit.until(build(service)).map(|_| ()));
+}
+
+/// Creates an informant in the form of a `Future` that must be polled regularly.
+pub fn build<C>(service: &Service<C>) -> impl Future<Item = (), Error = ()>
+where C: Components {
 	let network = service.network();
 	let client = service.client();
 	let txpool = service.transaction_pool();
@@ -156,8 +163,8 @@ pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExe
 		Ok(())
 	});
 
-	let informant_work = display_notifications.join3(display_block_import, display_txpool_import);
-	handle.spawn(exit.until(informant_work).map(|_| ()));
+	display_notifications.join3(display_block_import, display_txpool_import)
+		.map(|((), (), ())| ())
 }
 
 fn speed(best_number: u64, last_number: Option<u64>, last_update: time::Instant) -> String {

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -61,7 +61,7 @@ fn run_until_exit<T, C, E>(
 {
 	let (exit_send, exit) = exit_future::signal();
 
-	let informant = cli::informant::build(&service);
+	let informant = informant::build(&service);
 	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
 	let _ = runtime.block_on(e.into_exit());

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -61,8 +61,8 @@ fn run_until_exit<T, C, E>(
 {
 	let (exit_send, exit) = exit_future::signal();
 
-	let executor = runtime.executor();
-	informant::start(&service, exit.clone(), executor.clone());
+	let informant = cli::informant::build(&service);
+	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
 	let _ = runtime.block_on(e.into_exit());
 	exit_send.fire();

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -118,8 +118,8 @@ fn run_until_exit<T, C, E>(
 {
 	let (exit_send, exit) = exit_future::signal();
 
-	let executor = runtime.executor();
-	cli::informant::start(&service, exit.clone(), executor.clone());
+	let informant = cli::informant::build(&service);
+	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
 	let _ = runtime.block_on(e.into_exit());
 	exit_send.fire();


### PR DESCRIPTION
For #2416

Deprecates `informant::start()` and replaces it with `informant::build()`. The user would then be responsible for polling the informant.

Also decreases the API surface. We makes fewer assumptions about how the user wants to use our code, which is always a good thing IMO.
