### PR TITLE
Update build script to create a table for the runtime

### DIFF
--- a/node-template/runtime/wasm/build.sh
+++ b/node-template/runtime/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-$CARGO_CMD build --target=wasm32-unknown-unknown --release
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release
 for i in node_template_runtime_wasm
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm


### PR DESCRIPTION
This enables use of the sandbox needed for running smart contracts on Substrate

See: https://github.com/paritytech/substrate/issues/2570