### PR TITLE
docs: Update Support SRML rephrasing EnumerableStorageMap comment in Rustdocs

### DIFF
--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -332,8 +332,8 @@ impl<K: Codec, V: Codec, U> StorageMap<K, V> for U where U: hashed::generator::S
 
 /// A storage map that can be enumerated.
 ///
-/// Note that type is primarily useful for off-chain computations.
-/// Runtime implementors should avoid enumerating storage entries.
+/// Primarily useful for off-chain computations.
+/// Runtime implementors should avoid enumerating storage entries on-chain.
 pub trait EnumerableStorageMap<K: Codec, V: Codec>: StorageMap<K, V> {
 	/// Return current head element.
 	fn head() -> Option<K>;


### PR DESCRIPTION
I think these changes are correct, but I'm not entirely sure. Please review.