### PR TITLE
Deprecate IntoPoolError

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod chain_ops;
 pub mod error;
 
+use std::convert::TryInto;
 use std::io;
 use std::net::SocketAddr;
 use std::collections::HashMap;
@@ -48,7 +49,7 @@ pub use self::error::{ErrorKind, Error};
 pub use config::{Configuration, Roles, PruningMode};
 pub use chain_spec::{ChainSpec, Properties};
 pub use transaction_pool::txpool::{
-	self, Pool as TransactionPool, Options as TransactionPoolOptions, ChainApi, IntoPoolError
+	self, Pool as TransactionPool, Options as TransactionPoolOptions, ChainApi
 };
 use client::runtime_api::BlockT;
 pub use client::FinalityNotifications;
@@ -506,7 +507,7 @@ impl<C: Components> network::TransactionPool<ComponentExHash<C>, ComponentBlock<
 			let best_block_id = self.best_block_id()?;
 			match self.pool.submit_one(&best_block_id, uxt) {
 				Ok(hash) => Some(hash),
-				Err(e) => match e.into_pool_error() {
+				Err(e) => match e.try_into() {
 					Ok(txpool::error::Error(txpool::error::ErrorKind::AlreadyImported(hash), _)) => {
 						hash.downcast::<ComponentExHash<C>>().ok()
 							.map(|x| x.as_ref().clone())

--- a/core/transaction-pool/graph/src/error.rs
+++ b/core/transaction-pool/graph/src/error.rs
@@ -62,6 +62,7 @@ error_chain! {
 }
 
 /// Transaction pool error conversion.
+#[deprecated(note = "Use the TryFrom or TryInto traits instead")]
 pub trait IntoPoolError: ::std::error::Error + Send + Sized {
 	/// Try to extract original `Error`
 	///
@@ -71,6 +72,7 @@ pub trait IntoPoolError: ::std::error::Error + Send + Sized {
 	fn into_pool_error(self) -> ::std::result::Result<Error, Self> { Err(self) }
 }
 
+#[allow(deprecated)]
 impl IntoPoolError for Error {
 	fn into_pool_error(self) -> ::std::result::Result<Error, Self> { Ok(self) }
 }

--- a/core/transaction-pool/graph/src/lib.rs
+++ b/core/transaction-pool/graph/src/lib.rs
@@ -34,6 +34,7 @@ pub mod base_pool;
 pub mod error;
 pub mod watcher;
 
+#[allow(deprecated)]
 pub use self::error::IntoPoolError;
 pub use self::base_pool::{Transaction, Status};
 pub use self::pool::{Pool, Options, ChainApi, EventStream, ExtrinsicFor, BlockHash, ExHash, NumberFor, TransactionFor};

--- a/core/transaction-pool/src/error.rs
+++ b/core/transaction-pool/src/error.rs
@@ -25,6 +25,7 @@ use txpool;
 use error_chain::{
 	error_chain, error_chain_processing, impl_error_chain_processed, impl_extract_backtrace, impl_error_chain_kind
 };
+use std::convert::TryFrom;
 
 error_chain! {
 	foreign_links {
@@ -35,9 +36,21 @@ error_chain! {
 	}
 }
 
+#[allow(deprecated)]
 impl txpool::IntoPoolError for Error {
 	fn into_pool_error(self) -> ::std::result::Result<txpool::error::Error, Self> {
 		match self {
+			Error(ErrorKind::Pool(e), c) => Ok(txpool::error::Error(e, c)),
+			e => Err(e),
+		}
+	}
+}
+
+impl TryFrom<Error> for txpool::error::Error {
+	type Error = Error;
+
+	fn try_from(err: Error) -> ::std::result::Result<txpool::error::Error, Error> {
+		match err {
 			Error(ErrorKind::Pool(e), c) => Ok(txpool::error::Error(e, c)),
 			e => Err(e),
 		}


### PR DESCRIPTION
Replaces the `IntoPoolError` trait with `TryInto`, since it does the same.