### PR TITLE
get rid of refcell, use &mut storage

### DIFF
--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -295,7 +295,7 @@ fn decl_store_extra_genesis(
 						use #scrate::codec::{Encode, Decode};
 
 						let v = (#builder)(&self);
-						<#name<#traitinstance, #instance> as #scrate::storage::hashed::generator::StorageValue<#typ>>::put(&v, &storage);
+						<#name<#traitinstance, #instance> as #scrate::storage::hashed::generator::StorageValue<#typ>>::put(&v, storage);
 					}}
 				},
 				DeclStorageTypeInfosKind::Map { key_type, .. } => {
@@ -305,7 +305,7 @@ fn decl_store_extra_genesis(
 
 						let data = (#builder)(&self);
 						for (k, v) in data.into_iter() {
-							<#name<#traitinstance, #instance> as #scrate::storage::hashed::generator::StorageMap<#key_type, #typ>>::insert(&k, &v, &storage);
+							<#name<#traitinstance, #instance> as #scrate::storage::hashed::generator::StorageMap<#key_type, #typ>>::insert(&k, &v, storage);
 						}
 					}}
 				},
@@ -316,7 +316,7 @@ fn decl_store_extra_genesis(
 
 						let data = (#builder)(&self);
 						for (k1, k2, v) in data.into_iter() {
-							<#name<#traitinstance, #instance> as #scrate::storage::unhashed::generator::StorageDoubleMap<#key1_type, #key2_type, #typ>>::insert(&k1, &k2, &v, &storage);
+							<#name<#traitinstance, #instance> as #scrate::storage::unhashed::generator::StorageDoubleMap<#key1_type, #key2_type, #typ>>::insert(&k1, &k2, &v, storage);
 						}
 					}}
 				},
@@ -451,12 +451,11 @@ fn decl_store_extra_genesis(
 			#[cfg(feature = "std")]
 			impl#fparam_impl #scrate::runtime_primitives::BuildStorage for GenesisConfig#sparam {
 				fn assimilate_storage(self, r: &mut #scrate::runtime_primitives::StorageOverlay, c: &mut #scrate::runtime_primitives::ChildrenStorageOverlay) -> ::std::result::Result<(), String> {
-					use #scrate::rstd::cell::RefCell;
-					let storage = RefCell::new(r);
+					let storage = r;
 
 					#builders
 
-					let r = storage.into_inner();
+					let r = storage;
 
 					#scall(r, c, &self);
 

--- a/srml/support/src/storage/mod.rs
+++ b/srml/support/src/storage/mod.rs
@@ -70,17 +70,17 @@ impl<H: StorageHasher> HashedStorage<H> for RuntimeStorage {
 	}
 
 	/// Put a value in under a key.
-	fn put<T: Encode>(&self, key: &[u8], val: &T) {
+	fn put<T: Encode>(&mut self, key: &[u8], val: &T) {
 		hashed::put(&H::hash, key, val)
 	}
 
 	/// Remove the bytes of a key from storage.
-	fn kill(&self, key: &[u8]) {
+	fn kill(&mut self, key: &[u8]) {
 		hashed::kill(&H::hash, key)
 	}
 
 	/// Take a value from storage, deleting it after reading.
-	fn take<T: Decode>(&self, key: &[u8]) -> Option<T> {
+	fn take<T: Decode>(&mut self, key: &[u8]) -> Option<T> {
 		hashed::take(&H::hash, key)
 	}
 
@@ -88,7 +88,7 @@ impl<H: StorageHasher> HashedStorage<H> for RuntimeStorage {
 		hashed::get_raw(&H::hash, key)
 	}
 
-	fn put_raw(&self, key: &[u8], value: &[u8]) {
+	fn put_raw(&mut self, key: &[u8], value: &[u8]) {
 		hashed::put_raw(&H::hash, key, value)
 	}
 }
@@ -104,22 +104,22 @@ impl UnhashedStorage for RuntimeStorage {
 	}
 
 	/// Put a value in under a key.
-	fn put<T: Encode>(&self, key: &[u8], val: &T) {
+	fn put<T: Encode>(&mut self, key: &[u8], val: &T) {
 		unhashed::put(key, val)
 	}
 
 	/// Remove the bytes of a key from storage.
-	fn kill(&self, key: &[u8]) {
+	fn kill(&mut self, key: &[u8]) {
 		unhashed::kill(key)
 	}
 
 	/// Remove the bytes of a key from storage.
-	fn kill_prefix(&self, prefix: &[u8]) {
+	fn kill_prefix(&mut self, prefix: &[u8]) {
 		unhashed::kill_prefix(prefix)
 	}
 
 	/// Take a value from storage, deleting it after reading.
-	fn take<T: Decode>(&self, key: &[u8]) -> Option<T> {
+	fn take<T: Decode>(&mut self, key: &[u8]) -> Option<T> {
 		unhashed::take(key)
 	}
 
@@ -127,7 +127,7 @@ impl UnhashedStorage for RuntimeStorage {
 		unhashed::get_raw(key)
 	}
 
-	fn put_raw(&self, key: &[u8], value: &[u8]) {
+	fn put_raw(&mut self, key: &[u8], value: &[u8]) {
 		unhashed::put_raw(key, value)
 	}
 }
@@ -178,21 +178,21 @@ impl<T: Codec, U> StorageValue<T> for U where U: hashed::generator::StorageValue
 		U::get(&RuntimeStorage)
 	}
 	fn put<Arg: Borrow<T>>(val: Arg) {
-		U::put(val.borrow(), &RuntimeStorage)
+		U::put(val.borrow(), &mut RuntimeStorage)
 	}
 	fn mutate<R, F: FnOnce(&mut Self::Query) -> R>(f: F) -> R {
-		U::mutate(f, &RuntimeStorage)
+		U::mutate(f, &mut RuntimeStorage)
 	}
 	fn kill() {
-		U::kill(&RuntimeStorage)
+		U::kill(&mut RuntimeStorage)
 	}
 	fn take() -> Self::Query {
-		U::take(&RuntimeStorage)
+		U::take(&mut RuntimeStorage)
 	}
 	fn append<I: Encode>(items: &[I]) -> Result<(), &'static str>
 		where T: EncodeAppend<Item=I>
 	{
-		U::append(items, &RuntimeStorage)
+		U::append(items, &mut RuntimeStorage)
 	}
 }
 
@@ -244,11 +244,11 @@ impl<T: Codec, U> StorageList<T> for U where U: hashed::generator::StorageList<T
 	}
 
 	fn set_items(items: &[T]) {
-		U::set_items(items, &RuntimeStorage)
+		U::set_items(items, &mut RuntimeStorage)
 	}
 
 	fn set_item<Arg: Borrow<T>>(index: u32, val: Arg) {
-		U::set_item(index, val.borrow(), &RuntimeStorage)
+		U::set_item(index, val.borrow(), &mut RuntimeStorage)
 	}
 
 	fn get(index: u32) -> Option<T> {
@@ -260,7 +260,7 @@ impl<T: Codec, U> StorageList<T> for U where U: hashed::generator::StorageList<T
 	}
 
 	fn clear() {
-		U::clear(&RuntimeStorage)
+		U::clear(&mut RuntimeStorage)
 	}
 }
 
@@ -314,19 +314,19 @@ impl<K: Codec, V: Codec, U> StorageMap<K, V> for U where U: hashed::generator::S
 	}
 
 	fn insert<KeyArg: Borrow<K>, ValArg: Borrow<V>>(key: KeyArg, val: ValArg) {
-		U::insert(key.borrow(), val.borrow(), &RuntimeStorage)
+		U::insert(key.borrow(), val.borrow(), &mut RuntimeStorage)
 	}
 
 	fn remove<KeyArg: Borrow<K>>(key: KeyArg) {
-		U::remove(key.borrow(), &RuntimeStorage)
+		U::remove(key.borrow(), &mut RuntimeStorage)
 	}
 
 	fn mutate<KeyArg: Borrow<K>, R, F: FnOnce(&mut Self::Query) -> R>(key: KeyArg, f: F) -> R {
-		U::mutate(key.borrow(), f, &RuntimeStorage)
+		U::mutate(key.borrow(), f, &mut RuntimeStorage)
 	}
 
 	fn take<KeyArg: Borrow<K>>(key: KeyArg) -> Self::Query {
-		U::take(key.borrow(), &RuntimeStorage)
+		U::take(key.borrow(), &mut RuntimeStorage)
 	}
 }
 
@@ -444,19 +444,19 @@ where
 	}
 
 	fn take<KArg1: Borrow<K1>, KArg2: Borrow<K2>>(k1: KArg1, k2: KArg2) -> Self::Query {
-		U::take(k1.borrow(), k2.borrow(), &RuntimeStorage)
+		U::take(k1.borrow(), k2.borrow(), &mut RuntimeStorage)
 	}
 
 	fn insert<KArg1: Borrow<K1>, KArg2: Borrow<K2>, VArg: Borrow<V>>(k1: KArg1, k2: KArg2, val: VArg) {
-		U::insert(k1.borrow(), k2.borrow(), val.borrow(), &RuntimeStorage)
+		U::insert(k1.borrow(), k2.borrow(), val.borrow(), &mut RuntimeStorage)
 	}
 
 	fn remove<KArg1: Borrow<K1>, KArg2: Borrow<K2>>(k1: KArg1, k2: KArg2) {
-		U::remove(k1.borrow(), k2.borrow(), &RuntimeStorage)
+		U::remove(k1.borrow(), k2.borrow(), &mut RuntimeStorage)
 	}
 
 	fn remove_prefix<KArg1: Borrow<K1>>(k1: KArg1) {
-		U::remove_prefix(k1.borrow(), &RuntimeStorage)
+		U::remove_prefix(k1.borrow(), &mut RuntimeStorage)
 	}
 
 	fn mutate<KArg1, KArg2, R, F>(k1: KArg1, k2: KArg2, f: F) -> R
@@ -465,7 +465,7 @@ where
 		KArg2: Borrow<K2>,
 		F: FnOnce(&mut Self::Query) -> R
 	{
-		U::mutate(k1.borrow(), k2.borrow(), f, &RuntimeStorage)
+		U::mutate(k1.borrow(), k2.borrow(), f, &mut RuntimeStorage)
 	}
 
 	fn append<KArg1, KArg2, I>(
@@ -479,7 +479,7 @@ where
 		I: codec::Encode,
 		V: EncodeAppend<Item=I>,
 	{
-		U::append(k1.borrow(), k2.borrow(), items, &RuntimeStorage)
+		U::append(k1.borrow(), k2.borrow(), items, &mut RuntimeStorage)
 	}
 }
 

--- a/srml/support/src/storage/unhashed/generator.rs
+++ b/srml/support/src/storage/unhashed/generator.rs
@@ -34,66 +34,66 @@ pub trait UnhashedStorage {
 	fn get_or_default<T: codec::Decode + Default>(&self, key: &[u8]) -> T { self.get(key).unwrap_or_default() }
 
 	/// Put a value in under a key.
-	fn put<T: codec::Encode>(&self, key: &[u8], val: &T);
+	fn put<T: codec::Encode>(&mut self, key: &[u8], val: &T);
 
 	/// Remove the bytes of a key from storage.
-	fn kill(&self, key: &[u8]);
+	fn kill(&mut self, key: &[u8]);
 
 	/// Remove the bytes of a key from storage.
-	fn kill_prefix(&self, prefix: &[u8]);
+	fn kill_prefix(&mut self, prefix: &[u8]);
 
 	/// Take a value from storage, deleting it after reading.
-	fn take<T: codec::Decode>(&self, key: &[u8]) -> Option<T> {
+	fn take<T: codec::Decode>(&mut self, key: &[u8]) -> Option<T> {
 		let value = self.get(key);
 		self.kill(key);
 		value
 	}
 
 	/// Take a value from storage, deleting it after reading.
-	fn take_or_panic<T: codec::Decode>(&self, key: &[u8]) -> T { self.take(key).expect("Required values must be in storage") }
+	fn take_or_panic<T: codec::Decode>(&mut self, key: &[u8]) -> T { self.take(key).expect("Required values must be in storage") }
 
 	/// Take a value from storage, deleting it after reading.
-	fn take_or_default<T: codec::Decode + Default>(&self, key: &[u8]) -> T { self.take(key).unwrap_or_default() }
+	fn take_or_default<T: codec::Decode + Default>(&mut self, key: &[u8]) -> T { self.take(key).unwrap_or_default() }
 
 	/// Get a Vec of bytes from storage.
 	fn get_raw(&self, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Put a raw byte slice into storage.
-	fn put_raw(&self, key: &[u8], value: &[u8]);
+	fn put_raw(&mut self, key: &[u8], value: &[u8]);
 }
 
 // We use a construct like this during when genesis storage is being built.
 #[cfg(feature = "std")]
-impl UnhashedStorage for std::cell::RefCell<&mut sr_primitives::StorageOverlay> {
+impl UnhashedStorage for sr_primitives::StorageOverlay {
 	fn exists(&self, key: &[u8]) -> bool {
-		self.borrow().contains_key(key)
+		self.contains_key(key)
 	}
 
 	fn get<T: codec::Decode>(&self, key: &[u8]) -> Option<T> {
-		self.borrow().get(key)
+		self.get(key)
 			.map(|x| codec::Decode::decode(&mut x.as_slice()).expect("Unable to decode expected type."))
 	}
 
-	fn put<T: codec::Encode>(&self, key: &[u8], val: &T) {
-		self.borrow_mut().insert(key.to_vec(), codec::Encode::encode(val));
+	fn put<T: codec::Encode>(&mut self, key: &[u8], val: &T) {
+		self.insert(key.to_vec(), codec::Encode::encode(val));
 	}
 
-	fn kill(&self, key: &[u8]) {
-		self.borrow_mut().remove(key);
+	fn kill(&mut self, key: &[u8]) {
+		self.remove(key);
 	}
 
-	fn kill_prefix(&self, prefix: &[u8]) {
-		self.borrow_mut().retain(|key, _| {
+	fn kill_prefix(&mut self, prefix: &[u8]) {
+		self.retain(|key, _| {
 			!key.starts_with(prefix)
 		})
 	}
 
 	fn get_raw(&self, key: &[u8]) -> Option<Vec<u8>> {
-		self.borrow().get(key).cloned()
+		self.get(key).cloned()
 	}
 
-	fn put_raw(&self, key: &[u8], value: &[u8]) {
-		self.borrow_mut().insert(key.to_vec(), value.to_vec());
+	fn put_raw(&mut self, key: &[u8], value: &[u8]) {
+		self.insert(key.to_vec(), value.to_vec());
 	}
 }
 
@@ -131,32 +131,32 @@ pub trait StorageDoubleMap<K1: codec::Codec, K2: codec::Codec, V: codec::Codec> 
 	fn get<S: UnhashedStorage>(k1: &K1, k2: &K2, storage: &S) -> Self::Query;
 
 	/// Take the value under a key.
-	fn take<S: UnhashedStorage>(k1: &K1, k2: &K2, storage: &S) -> Self::Query;
+	fn take<S: UnhashedStorage>(k1: &K1, k2: &K2, storage: &mut S) -> Self::Query;
 
 	/// Store a value to be associated with the given key from the map.
-	fn insert<S: UnhashedStorage>(k1: &K1, k2: &K2, val: &V, storage: &S) {
+	fn insert<S: UnhashedStorage>(k1: &K1, k2: &K2, val: &V, storage: &mut S) {
 		storage.put(&Self::key_for(k1, k2), val);
 	}
 
 	/// Remove the value under a key.
-	fn remove<S: UnhashedStorage>(k1: &K1, k2: &K2, storage: &S) {
+	fn remove<S: UnhashedStorage>(k1: &K1, k2: &K2, storage: &mut S) {
 		storage.kill(&Self::key_for(k1, k2));
 	}
 
 	/// Removes all entries that shares the `k1` as the first key.
-	fn remove_prefix<S: UnhashedStorage>(k1: &K1, storage: &S) {
+	fn remove_prefix<S: UnhashedStorage>(k1: &K1, storage: &mut S) {
 		storage.kill_prefix(&Self::prefix_for(k1));
 	}
 
 	/// Mutate the value under a key.
-	fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: UnhashedStorage>(k1: &K1, k2: &K2, f: F, storage: &S) -> R;
+	fn mutate<R, F: FnOnce(&mut Self::Query) -> R, S: UnhashedStorage>(k1: &K1, k2: &K2, f: F, storage: &mut S) -> R;
 
 	/// Append the given items to the value under the key specified.
 	fn append<I, S: UnhashedStorage>(
 		k1: &K1,
 		k2: &K2,
 		items: &[I],
-		storage: &S,
+		storage: &mut S,
 	) -> Result<(), &'static str>
 	where
 		I: codec::Encode,


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/2474

currently in the code base we make use of RefCell to write to genesis storage. This is because we wrote the trait to write on a storage with immutability access to storage.
But the genesis storage can be handled as a mutable storage. instead of wrapped into an unnecessary RefCell.

The RuntimeStorage being an empty struct we can give mutable reference when wanted.

This PR make the add_extra_genesis build function being able to write to storage easily, for instance this PR wouldn't make use of a RefCell https://github.com/paritytech/polkadot/pull/245

breaking change: if other module are making use of refcell then just use the inner type or borrow mutably when necessary.