### PR TITLE
Contract storage size increase type capacity to u64

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 81,
-	impl_version: 82,
+	impl_version: 83,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contract/src/account_db.rs
+++ b/srml/contract/src/account_db.rs
@@ -120,7 +120,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 				} else if let Some(code_hash) = changed.code_hash {
 					AliveContractInfo::<T> {
 						code_hash,
-						storage_size: <Module<T>>::storage_size_offset(),
+						storage_size: <Module<T>>::storage_size_offset() as u64,
 						trie_id: <T as Trait>::TrieIdGenerator::trie_id(&address),
 						deduct_block: <system::Module<T>>::block_number(),
 						rent_allowance: <BalanceOf<T>>::max_value(),
@@ -145,10 +145,10 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 
 				for (k, v) in changed.storage.into_iter() {
 					if let Some(value) = child::get_raw(&new_info.trie_id[..], &blake2_256(&k)) {
-						new_info.storage_size -= value.len() as u32;
+						new_info.storage_size -= value.len() as u64;
 					}
 					if let Some(value) = v {
-						new_info.storage_size += value.len() as u32;
+						new_info.storage_size += value.len() as u64;
 						child::put_raw(&new_info.trie_id[..], &blake2_256(&k), &value[..]);
 					} else {
 						child::kill(&new_info.trie_id[..], &blake2_256(&k));

--- a/srml/contract/src/lib.rs
+++ b/srml/contract/src/lib.rs
@@ -195,7 +195,7 @@ pub struct RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
 	/// Unique ID for the subtree encoded as a bytes vector.
 	pub trie_id: TrieId,
 	/// The size of stored value in octet.
-	pub storage_size: u32,
+	pub storage_size: u64,
 	/// The code associated with a given account.
 	pub code_hash: CodeHash,
 	/// Pay rent at most up to this value.
@@ -591,8 +591,8 @@ decl_module! {
 			}
 
 			origin_contract.storage_size -= key_values_taken.iter()
-				.map(|(_, value)| value.len() as u32)
-				.sum::<u32>();
+				.map(|(_, value)| value.len() as u64)
+				.sum::<u64>();
 
 			<ContractInfoOf<T>>::remove(&origin);
 			<ContractInfoOf<T>>::insert(&dest, ContractInfo::Alive(RawAliveContractInfo {

--- a/srml/contract/src/tests.rs
+++ b/srml/contract/src/tests.rs
@@ -263,7 +263,7 @@ fn account_removal_removes_storage() {
 				Balances::deposit_creating(&1, 110);
 				ContractInfoOf::<Test>::insert(1, &ContractInfo::Alive(RawAliveContractInfo {
 					trie_id: trie_id1.clone(),
-					storage_size: Contract::storage_size_offset(),
+					storage_size: Contract::storage_size_offset() as u64,
 					deduct_block: System::block_number(),
 					code_hash: H256::repeat_byte(1),
 					rent_allowance: 40,
@@ -278,7 +278,7 @@ fn account_removal_removes_storage() {
 				Balances::deposit_creating(&2, 110);
 				ContractInfoOf::<Test>::insert(2, &ContractInfo::Alive(RawAliveContractInfo {
 					trie_id: trie_id2.clone(),
-					storage_size: Contract::storage_size_offset(),
+					storage_size: Contract::storage_size_offset() as u64,
 					deduct_block: System::block_number(),
 					code_hash: H256::repeat_byte(2),
 					rent_allowance: 40,
@@ -701,15 +701,15 @@ fn storage_size() {
 				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
 			));
 			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() + 4);
+			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() as u64 + 4);
 
 			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::set_storage_4_byte()));
 			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() + 4 + 4);
+			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() as u64 + 4 + 4);
 
 			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::remove_storage_4_byte()));
 			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() + 4);
+			assert_eq!(bob_contract.storage_size, Contract::storage_size_offset() as u64 + 4);
 		}
 	);
 }


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/2672

Now storage size is type u64, the implication is that the maximum effective storage size (storage after free_storage deduction) is bounded by balance type capacity. This seems OK, the only case I could think it could be wrong is if someone use a kind of float implementation of balance with rent_byte_price being less than 1.