### PR TITLE
Register previous rounds' votes with gossip service on startup

### DIFF
--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -99,6 +99,12 @@ pub trait Network<Block: BlockT>: Clone + Send + 'static {
 	/// Only should be used in case of consensus stall.
 	fn gossip_message(&self, topic: Block::Hash, data: Vec<u8>, force: bool);
 
+	/// Register a message with the gossip service, it isn't broadcast right
+	/// away to any peers, but may be sent to new peers joining or when asked to
+	/// broadcast the topic. Useful to register previous messages on node
+	/// startup.
+	fn register_gossip_message(&self, topic: Block::Hash, data: Vec<u8>);
+
 	/// Send a message to a bunch of specific peers, even if they've seen it already.
 	fn send_message(&self, who: Vec<network::PeerId>, data: Vec<u8>);
 
@@ -145,9 +151,19 @@ impl<B, S> Network<B> for Arc<NetworkService<B, S>> where
 			engine_id: GRANDPA_ENGINE_ID,
 			data,
 		};
+
 		self.with_gossip(
 			move |gossip, ctx| gossip.multicast(ctx, topic, msg, force)
 		)
+	}
+
+	fn register_gossip_message(&self, topic: B::Hash, data: Vec<u8>) {
+		let msg = ConsensusMessage {
+			engine_id: GRANDPA_ENGINE_ID,
+			data,
+		};
+
+		self.with_gossip(move |gossip, _| gossip.register_message(topic, msg))
 	}
 
 	fn send_message(&self, who: Vec<network::PeerId>, data: Vec<u8>) {
@@ -215,6 +231,8 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 	pub(crate) fn new(
 		service: N,
 		config: crate::Config,
+		set_id: u64,
+		set_state: &crate::environment::VoterSetState<B>,
 		on_exit: impl Future<Item=(),Error=()> + Clone + Send + 'static,
 	) -> (
 		Self,
@@ -224,6 +242,38 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 		let (validator, report_stream) = GossipValidator::new(config);
 		let validator = Arc::new(validator);
 		service.register_validator(validator.clone());
+
+		// register all previous votes with the gossip service so that they're
+		// available to peers potentially stuck on a previous round.
+		for round in set_state.completed_rounds().iter() {
+			let topic = round_topic::<B>(round.number, set_id);
+
+			// we need to note the round with the gossip validator otherwise
+			// messages will be ignored.
+			validator.note_round(Round(round.number), SetId(set_id), |_, _| {});
+
+			for signed in round.votes.iter() {
+				let message = gossip::GossipMessage::VoteOrPrecommit(
+					gossip::VoteOrPrecommitMessage::<B> {
+						message: signed.clone(),
+						round: Round(round.number),
+						set_id: SetId(set_id),
+					}
+				);
+
+				service.register_gossip_message(
+					topic,
+					message.encode(),
+				);
+			}
+
+			trace!(target: "afg", "Registered {} messages for topic {:?} (round: {}, set_id: {})",
+				   round.votes.len(),
+				   topic,
+				   round.number,
+				   set_id,
+			);
+		}
 
 		let (rebroadcast_job, neighbor_sender) = periodic::neighbor_packet_worker(service.clone());
 		let reporting_job = report_stream.consume(service.clone());

--- a/core/finality-grandpa/src/communication/tests.rs
+++ b/core/finality-grandpa/src/communication/tests.rs
@@ -72,6 +72,15 @@ impl super::Network<Block> for TestNetwork {
 		let _ = self.sender.unbounded_send(Event::SendMessage(who, data));
 	}
 
+	/// Register a message with the gossip service, it isn't broadcast right
+	/// away to any peers, but may be sent to new peers joining or when asked to
+	/// broadcast the topic. Useful to register previous messages on node
+	/// startup.
+	fn register_gossip_message(&self, _topic: Hash, _data: Vec<u8>) {
+		// NOTE: only required to restore previous state on startup
+		//       not required for tests currently
+	}
+
 	/// Report a peer's cost or benefit after some action.
 	fn report(&self, who: network::PeerId, cost_benefit: i32) {
 		let _ = self.sender.unbounded_send(Event::Report(who, cost_benefit));
@@ -136,6 +145,7 @@ fn make_test_network() -> impl Future<Item=Tester,Error=()> {
 	let (bridge, startup_work) = super::NetworkBridge::new(
 		net.clone(),
 		config(),
+		None,
 		Exit,
 	);
 

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -101,6 +101,10 @@ impl<Block: BlockT> CompletedRounds<Block> {
 		CompletedRounds { inner }
 	}
 
+	pub fn iter(&self) -> impl Iterator<Item=&CompletedRound<Block>> {
+		self.inner.iter()
+	}
+
 	/// Returns the last (latest) completed round.
 	pub fn last(&self) -> &CompletedRound<Block> {
 		self.inner.back()

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -502,8 +502,7 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 	let (network, network_startup) = NetworkBridge::new(
 		network,
 		config.clone(),
-		authority_set.set_id(),
-		&set_state.read(),
+		Some((authority_set.set_id(), &set_state.read())),
 		on_exit.clone(),
 	);
 

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -490,15 +490,22 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 
 	use futures::future::{self, Loop as FutureLoop};
 
-	let (network, network_startup) = NetworkBridge::new(network, config.clone(), on_exit.clone());
-
 	let LinkHalf {
 		client,
 		select_chain,
 		persistent_data,
 		voter_commands_rx,
 	} = link;
+
 	let PersistentData { authority_set, set_state, consensus_changes } = persistent_data;
+
+	let (network, network_startup) = NetworkBridge::new(
+		network,
+		config.clone(),
+		authority_set.set_id(),
+		&set_state.read(),
+		on_exit.clone(),
+	);
 
 	register_finality_tracker_inherent_data_provider(client.clone(), &inherent_data_providers)?;
 

--- a/core/finality-grandpa/src/observer.rs
+++ b/core/finality-grandpa/src/observer.rs
@@ -166,9 +166,16 @@ pub fn run_grandpa_observer<B, E, Block: BlockT<Hash=H256>, N, RA, SC>(
 	} = link;
 
 	let PersistentData { authority_set, consensus_changes, set_state } = persistent_data;
-	let initial_state = (authority_set, consensus_changes, set_state, voter_commands_rx.into_future());
 
-	let (network, network_startup) = NetworkBridge::new(network, config.clone(), on_exit.clone());
+	let (network, network_startup) = NetworkBridge::new(
+		network,
+		config.clone(),
+		authority_set.set_id(),
+		&set_state.read(),
+		on_exit.clone(),
+	);
+
+	let initial_state = (authority_set, consensus_changes, set_state, voter_commands_rx.into_future());
 
 	let observer_work = future::loop_fn(initial_state, move |state| {
 		let (authority_set, consensus_changes, set_state, voter_commands_rx) = state;

--- a/core/finality-grandpa/src/observer.rs
+++ b/core/finality-grandpa/src/observer.rs
@@ -170,8 +170,7 @@ pub fn run_grandpa_observer<B, E, Block: BlockT<Hash=H256>, N, RA, SC>(
 	let (network, network_startup) = NetworkBridge::new(
 		network,
 		config.clone(),
-		authority_set.set_id(),
-		&set_state.read(),
+		None,
 		on_exit.clone(),
 	);
 

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -253,6 +253,11 @@ impl Network<Block> for MessageRouting {
 		})
 	}
 
+	fn register_gossip_message(&self, _topic: Hash, _data: Vec<u8>) {
+		// NOTE: only required to restore previous state on startup
+		//       not required for tests currently
+	}
+
 	fn report(&self, _who: network::PeerId, _cost_benefit: i32) {
 
 	}
@@ -1242,7 +1247,12 @@ fn voter_persists_its_votes() {
 			name: Some(format!("peer#{}", 1)),
 		};
 		let routing = MessageRouting::new(net.clone(), 1);
-		let (network, routing_work) = communication::NetworkBridge::new(routing, config.clone(), Exit);
+		let (network, routing_work) = communication::NetworkBridge::new(
+			routing,
+			config.clone(),
+			None,
+			Exit,
+		);
 		runtime.block_on(routing_work).unwrap();
 
 		let (round_rx, round_tx) = network.round_communication(

--- a/core/network/src/consensus_gossip.rs
+++ b/core/network/src/consensus_gossip.rs
@@ -618,11 +618,9 @@ mod tests {
 		consensus.register_validator_internal([0, 0, 0, 0], Arc::new(AllowAll));
 
 		let message = ConsensusMessage { data: vec![4, 5, 6], engine_id: [0, 0, 0, 0] };
-
-		let message_hash = HashFor::<Block>::hash(&message.data);
 		let topic = HashFor::<Block>::hash(&[1,2,3]);
 
-		consensus.register_message(message_hash, topic, message.clone());
+		consensus.register_message(topic, message.clone());
 		let stream = consensus.messages_for([0, 0, 0, 0], topic);
 
 		assert_eq!(stream.wait().next(), Some(Ok(TopicNotification { message: message.data, sender: None })));
@@ -636,8 +634,8 @@ mod tests {
 		let msg_a = ConsensusMessage { data: vec![1, 2, 3], engine_id: [0, 0, 0, 0] };
 		let msg_b = ConsensusMessage { data: vec![4, 5, 6], engine_id: [0, 0, 0, 0] };
 
-		consensus.register_message(HashFor::<Block>::hash(&msg_a.data), topic,msg_a);
-		consensus.register_message(HashFor::<Block>::hash(&msg_b.data), topic,msg_b);
+		consensus.register_message(topic, msg_a);
+		consensus.register_message(topic, msg_b);
 
 		assert_eq!(consensus.messages.len(), 2);
 	}
@@ -648,11 +646,9 @@ mod tests {
 		consensus.register_validator_internal([0, 0, 0, 0], Arc::new(AllowAll));
 
 		let message = ConsensusMessage { data: vec![4, 5, 6], engine_id: [0, 0, 0, 0] };
-
-		let message_hash = HashFor::<Block>::hash(&message.data);
 		let topic = HashFor::<Block>::hash(&[1,2,3]);
 
-		consensus.register_message(message_hash, topic, message.clone());
+		consensus.register_message(topic, message.clone());
 
 		let stream1 = consensus.messages_for([0, 0, 0, 0], topic);
 		let stream2 = consensus.messages_for([0, 0, 0, 0], topic);
@@ -670,8 +666,8 @@ mod tests {
 		let msg_a = ConsensusMessage { data: vec![1, 2, 3], engine_id: [0, 0, 0, 0] };
 		let msg_b = ConsensusMessage { data: vec![4, 5, 6], engine_id: [0, 0, 0, 1] };
 
-		consensus.register_message(HashFor::<Block>::hash(&msg_a.data), topic, msg_a);
-		consensus.register_message(HashFor::<Block>::hash(&msg_b.data), topic, msg_b);
+		consensus.register_message(topic, msg_a);
+		consensus.register_message(topic, msg_b);
 
 		let mut stream = consensus.messages_for([0, 0, 0, 0], topic).wait();
 


### PR DESCRIPTION
The grandpa `VoterSetState` is persisted and it contains the votes seen in the latest completed rounds. When a node starts these votes are now registered with the gossip service so that they are available to be broadcast to other peers (e.g. if they send us a neighbor packet and they're on a previous round).