### PR TITLE
remove unused import

### DIFF
--- a/core/rpc/src/chain/number.rs
+++ b/core/rpc/src/chain/number.rs
@@ -17,7 +17,6 @@
 use serde::Deserialize;
 use std::{convert::TryFrom, fmt::Debug};
 use primitives::U256;
-use runtime_primitives::traits;
 
 /// RPC Block number type
 ///


### PR DESCRIPTION
remove unused import.

refactor code that fix building warnings.
