### PR TITLE
Add .envrc and shell.nix with build deps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -197,6 +197,10 @@ sudo apt install cmake pkg-config libssl-dev git clang libclang-dev
 [source, shell]
 brew install cmake pkg-config openssl git llvm
 
+ - Nix/NixOS:
+[source, shell]
+nix-shell
+
 To finish installation of Substrate, jump down to <<shared-steps,shared steps>>.
 
 ==== Windows

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+with (import <nixpkgs> {});
+
+mkShell {
+  buildInputs = [
+    rustup
+    cargo
+    cmake
+    pkg-config
+    openssl
+    git
+    rustfmt
+    wasm-gc
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.IOKit
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.CoreServices
+  ] ++ lib.optionals stdenv.isLinux [
+    llvm
+  ];
+}


### PR DESCRIPTION
This PR adds a `shell.nix` for use with the Nix package manager http://nixos.org/nix/

This should provide an OS-agnostic way to install all the build dependencies. 

*FIXME:* for some reason using `llvm` from Nix on Darwin causes a panic during the build of `librocksdb`. Happens while looking for clang folders.