### PR TITLE
Make RocksDB optional in client-db

### DIFF
--- a/core/client/db/Cargo.toml
+++ b/core/client/db/Cargo.toml
@@ -9,8 +9,8 @@ parking_lot = "0.7.1"
 log = "0.4"
 kvdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 # FIXME replace with release as soon as our rocksdb changes are released upstream https://github.com/paritytech/parity-common/issues/88
-kvdb-rocksdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
-kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d", optional = true }
+kvdb-rocksdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d", optional = true }
+kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 lru-cache = "0.1.1"
 hash-db = { version = "0.12" }
 primitives = { package = "substrate-primitives", path = "../../primitives" }
@@ -24,11 +24,10 @@ trie = { package = "substrate-trie", path = "../../trie" }
 consensus_common = { package = "substrate-consensus-common", path = "../../consensus/common" }
 
 [dev-dependencies]
-kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 substrate-keyring = { path = "../../keyring" }
 test-client = { package = "substrate-test-client", path = "../../test-client" }
 env_logger = { version = "0.6" }
 
 [features]
 default = []
-test-helpers = ["kvdb-memorydb"]
+test-helpers = []

--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -54,7 +54,7 @@ use runtime_primitives::BuildStorage;
 use state_machine::backend::Backend as StateBackend;
 use executor::RuntimeInfo;
 use state_machine::{CodeExecutor, DBValue};
-use crate::utils::{Meta, db_err, meta_keys, open_database, read_db, block_id_to_lookup_key, read_meta};
+use crate::utils::{Meta, db_err, meta_keys, read_db, block_id_to_lookup_key, read_meta};
 use client::leaves::{LeafSet, FinalizationDisplaced};
 use client::children;
 use state_db::StateDb;
@@ -542,8 +542,19 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 	///
 	/// The pruning window is how old a block must be before the state is pruned.
 	pub fn new(config: DatabaseSettings, canonicalization_delay: u64) -> Result<Self, client::error::Error> {
-		let db = open_database(&config, columns::META, "full")?;
+		Self::new_inner(config, canonicalization_delay)
+	}
 
+	#[cfg(feature = "kvdb-rocksdb")]
+	fn new_inner(config: DatabaseSettings, canonicalization_delay: u64) -> Result<Self, client::error::Error> {
+		let db = crate::utils::open_database(&config, columns::META, "full")?;
+		Backend::from_kvdb(db as Arc<_>, config.pruning, canonicalization_delay, config.state_cache_size)
+	}
+
+	#[cfg(not(feature = "kvdb-rocksdb"))]
+	fn new_inner(config: DatabaseSettings, canonicalization_delay: u64) -> Result<Self, client::error::Error> {
+		log::warn!("Running without the RocksDB feature. The database will NOT be saved.");
+		let db = Arc::new(kvdb_memorydb::create(crate::utils::NUM_COLUMNS));
 		Backend::from_kvdb(db as Arc<_>, config.pruning, canonicalization_delay, config.state_cache_size)
 	}
 

--- a/core/client/db/src/light.rs
+++ b/core/client/db/src/light.rs
@@ -37,8 +37,7 @@ use runtime_primitives::traits::{Block as BlockT, Header as HeaderT,
 };
 use consensus_common::well_known_cache_keys;
 use crate::cache::{DbCacheSync, DbCache, ComplexBlockId, EntryType as CacheEntryType};
-use crate::utils::{self, meta_keys, Meta, db_err, open_database,
-	read_db, block_id_to_lookup_key, read_meta};
+use crate::utils::{self, meta_keys, Meta, db_err, read_db, block_id_to_lookup_key, read_meta};
 use crate::DatabaseSettings;
 use log::{trace, warn, debug};
 
@@ -71,8 +70,19 @@ impl<Block> LightStorage<Block>
 {
 	/// Create new storage with given settings.
 	pub fn new(config: DatabaseSettings) -> ClientResult<Self> {
-		let db = open_database(&config, columns::META, "light")?;
+		Self::new_inner(config)
+	}
 
+	#[cfg(feature = "kvdb-rocksdb")]
+	fn new_inner(config: DatabaseSettings) -> ClientResult<Self> {
+		let db = crate::utils::open_database(&config, columns::META, "light")?;
+		Self::from_kvdb(db as Arc<_>)
+	}
+
+	#[cfg(not(feature = "kvdb-rocksdb"))]
+	fn new_inner(_config: DatabaseSettings) -> ClientResult<Self> {
+		log::warn!("Running without the RocksDB feature. The database will NOT be saved.");
+		let db = Arc::new(kvdb_memorydb::create(crate::utils::NUM_COLUMNS));
 		Self::from_kvdb(db as Arc<_>)
 	}
 

--- a/core/client/db/src/utils.rs
+++ b/core/client/db/src/utils.rs
@@ -22,6 +22,7 @@ use std::io;
 use std::convert::TryInto;
 
 use kvdb::{KeyValueDB, DBTransaction};
+#[cfg(feature = "kvdb-rocksdb")]
 use kvdb_rocksdb::{Database, DatabaseConfig};
 use log::debug;
 
@@ -195,6 +196,7 @@ pub fn db_err(err: io::Error) -> client::error::Error {
 }
 
 /// Open RocksDB database.
+#[cfg(feature = "kvdb-rocksdb")]
 pub fn open_database(config: &DatabaseSettings, col_meta: Option<u32>, db_type: &str) -> client::error::Result<Arc<KeyValueDB>> {
 	let mut db_config = DatabaseConfig::with_columns(Some(NUM_COLUMNS));
 	db_config.memory_budget = config.cache_size;

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -24,7 +24,7 @@ primitives = { package = "substrate-primitives", path = "../../core/primitives" 
 consensus_common = { package = "substrate-consensus-common", path = "../../core/consensus/common" }
 network = { package = "substrate-network", path = "../../core/network" }
 client = { package = "substrate-client", path = "../../core/client" }
-client_db = { package = "substrate-client-db", path = "../../core/client/db" }
+client_db = { package = "substrate-client-db", path = "../../core/client/db", features = ["kvdb-rocksdb"] }
 parity-codec = "3.3"
 substrate-executor = { path = "../../core/executor" }
 transaction_pool = { package = "substrate-transaction-pool", path = "../../core/transaction-pool" }


### PR DESCRIPTION
For #2416 

Makes RocksDB an optional feature in `substrate-client-db`, but that's always enabled in `substrate-service`.

When the library is compiled without the feature flag, we use `kvdb-memorydb` and a warning is printed.
When the library is compiled with the feature, we use `kvdb-rocksdb`.

This will make `substrate-client-db` successfully compile for WASM-browser once the telemetry has been revamped.
