### PR TITLE
Fix not connected peers being connected peers

### DIFF
--- a/core/network-libp2p/src/service_task.rs
+++ b/core/network-libp2p/src/service_task.rs
@@ -200,7 +200,7 @@ where TMessage: CustomMessage + Send + 'static {
 
 		let not_connected_peers = {
 			let swarm = &mut self.swarm;
-			let list = swarm.known_peers().filter(|p| !open.iter().all(|n| n != *p))
+			let list = swarm.known_peers().filter(|p| open.iter().all(|n| n != *p))
 				.cloned().collect::<Vec<_>>();
 			list.into_iter().map(move |peer_id| {
 				(peer_id.to_base58(), NetworkStateNotConnectedPeer {


### PR DESCRIPTION
The "not connected peers" are computed by taking all the peers minus the "connected peers".
But I screwed up the filter, so we were actually returning the connected peers.