### PR TITLE
Use $crate inside of native_executor_instance and parameter_types macros

### DIFF
--- a/core/executor/src/native_executor.rs
+++ b/core/executor/src/native_executor.rs
@@ -272,7 +272,7 @@ macro_rules! native_executor_instance {
 	( $pub:vis $name:ident, $dispatcher:path, $version:path, $code:expr) => {
 		/// A unit struct which implements `NativeExecutionDispatch` feeding in the hard-coded runtime.
 		$pub struct $name;
-		native_executor_instance!(IMPL $name, $dispatcher, $version, $code);
+		$crate::native_executor_instance!(IMPL $name, $dispatcher, $version, $code);
 	};
 	(IMPL $name:ident, $dispatcher:path, $version:path, $code:expr) => {
 		impl $crate::NativeExecutionDispatch for $name {

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -47,13 +47,13 @@ pub trait Get<T> {
 macro_rules! parameter_types {
 	(pub const $name:ident: $type:ty = $value:expr; $( $rest:tt )*) => (
 		pub struct $name;
-		parameter_types!{IMPL $name , $type , $value}
-		parameter_types!{ $( $rest )* }
+		$crate::parameter_types!{IMPL $name , $type , $value}
+		$crate::parameter_types!{ $( $rest )* }
 	);
 	(const $name:ident: $type:ty = $value:expr; $( $rest:tt )*) => (
 		struct $name;
-		parameter_types!{IMPL $name , $type , $value}
-		parameter_types!{ $( $rest )* }
+		$crate::parameter_types!{IMPL $name , $type , $value}
+		$crate::parameter_types!{ $( $rest )* }
 	);
 	() => ();
 	(IMPL $name:ident , $type:ty , $value:expr) => {


### PR DESCRIPTION
Currently this macro cannot be called as `substrate_executor::native_executor_instance`. It is required to import `native_executor_instance` in scope either with `use substrate_executor::native_executor_instance` or `macro_use` attribute.