### PR TITLE
Update docs on `Imbalance` in the Balances module

### DIFF
--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -51,7 +51,8 @@
 //! deleted, then the account is said to be dead.
 //! - **Imbalance:** A condition when some funds were credited or debited without equal and opposite accounting
 //! (i.e. a difference between total issuance and account balances). Functions that result in an imbalance will
-//! return an object of the `Imbalance` trait that must be handled.
+//! return an object of the `Imbalance` trait that can be managed within your runtime logic. When an imbalance is
+//! dropped, it automatically updates the total issuance accordingly.
 //! - **Lock:** A freeze on a specified amount of an account's free balance until a specified block number. Multiple
 //! locks always operate over the same funds, so they "overlay" rather than "stack".
 //! - **Vesting:** Similar to a lock, this is another, but independent, liquidity restriction that reduces linearly

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -51,8 +51,8 @@
 //! deleted, then the account is said to be dead.
 //! - **Imbalance:** A condition when some funds were credited or debited without equal and opposite accounting
 //! (i.e. a difference between total issuance and account balances). Functions that result in an imbalance will
-//! return an object of the `Imbalance` trait that can be managed within your runtime logic. When an imbalance is
-//! dropped, it automatically updates the total issuance accordingly.
+//! return an object of the `Imbalance` trait that can be managed within your runtime logic. (If an imbalance is
+//! simply dropped, it should automatically maintain any book-keeping such as total issuance.)
 //! - **Lock:** A freeze on a specified amount of an account's free balance until a specified block number. Multiple
 //! locks always operate over the same funds, so they "overlay" rather than "stack".
 //! - **Vesting:** Similar to a lock, this is another, but independent, liquidity restriction that reduces linearly


### PR DESCRIPTION
The original wording of docs on `Imbalance` imply that the user needs to do something with the imbalance. The user _can_ manage an `Imbalance` if they want, but the default action for the user is just to do nothing at all since the `Drop` trait will handle updating the total issuance accordingly.

