### PR TITLE
Tuple based session key module.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,6 +3459,7 @@ dependencies = [
  "srml-session 2.0.0",
  "srml-support 2.0.0",
  "srml-system 2.0.0",
+ "srml-timestamp 2.0.0",
  "substrate-finality-grandpa-primitives 2.0.0",
  "substrate-primitives 2.0.0",
 ]

--- a/core/sr-primitives/src/testing.rs
+++ b/core/sr-primitives/src/testing.rs
@@ -22,7 +22,6 @@ use crate::codec::{Codec, Encode, Decode};
 use crate::traits::{self, Checkable, Applyable, BlakeTwo256, Convert};
 use crate::generic::DigestItem as GenDigestItem;
 pub use substrate_primitives::H256;
-use substrate_primitives::U256;
 use substrate_primitives::sr25519::{Public as AuthorityId, Signature as AuthoritySignature};
 
 /// Authority Id
@@ -31,7 +30,7 @@ use substrate_primitives::sr25519::{Public as AuthorityId, Signature as Authorit
 pub struct UintAuthorityId(pub u64);
 impl Into<AuthorityId> for UintAuthorityId {
 	fn into(self) -> AuthorityId {
-		let bytes: [u8; 32] = U256::from(self.0).into();
+		let bytes: [u8; 32] = H256::from_low_u64_be(self.0).into();
 		AuthorityId(bytes)
 	}
 }

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -81,7 +81,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
 			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),    // FIXME change once we have #1252
-			authorities: initial_authorities.iter().map(|x| x.2.clone()).collect(),
+			authorities: initial_authorities.iter().map(|x| (x.1.clone(), x.2.clone())).collect(),
 		}),
 		system: None,
 		balances: Some(BalancesConfig {
@@ -104,7 +104,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 		session: Some(SessionConfig {
 			validators: initial_authorities.iter().map(|x| x.1.clone()).collect(),
 			session_length: 5 * MINUTES,
-			keys: initial_authorities.iter().map(|x| (x.1.clone(), x.2.clone())).collect::<Vec<_>>(),
+			keys: initial_authorities.iter().map(|x| (x.1.clone(), (x.1.clone(), x.2.clone()))).collect::<Vec<_>>(),
 		}),
 		staking: Some(StakingConfig {
 			current_era: 0,
@@ -270,7 +270,7 @@ pub fn testnet_genesis(
 	GenesisConfig {
 		consensus: Some(ConsensusConfig {
 			code: include_bytes!("../../runtime/wasm/target/wasm32-unknown-unknown/release/node_runtime.compact.wasm").to_vec(),
-			authorities: initial_authorities.iter().map(|x| x.2.clone()).collect(),
+			authorities: initial_authorities.iter().map(|x| (x.1.clone(), x.2.clone())).collect(),
 		}),
 		system: None,
 		indices: Some(IndicesConfig {
@@ -288,7 +288,7 @@ pub fn testnet_genesis(
 		session: Some(SessionConfig {
 			validators: initial_authorities.iter().map(|x| x.1.clone()).collect(),
 			session_length: 10,
-			keys: initial_authorities.iter().map(|x| (x.1.clone(), x.2.clone())).collect::<Vec<_>>(),
+			keys: initial_authorities.iter().map(|x| (x.1.clone(), (x.1.clone(), x.2.clone()))).collect::<Vec<_>>(),
 		}),
 		staking: Some(StakingConfig {
 			current_era: 0,

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -198,7 +198,8 @@ impl sudo::Trait for Runtime {
 }
 
 impl grandpa::Trait for Runtime {
-	type SessionKey = AuthorityId;
+	type LocalSessionKey = AuthorityId;
+	type ConvertLocalSessionKey = ();
 	type Log = Log;
 	type Event = Event;
 }

--- a/srml/grandpa/Cargo.toml
+++ b/srml/grandpa/Cargo.toml
@@ -19,6 +19,7 @@ finality-tracker = { package = "srml-finality-tracker", path = "../finality-trac
 
 [dev-dependencies]
 runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }
 
 [features]
 default = ["std"]

--- a/srml/grandpa/src/mock.rs
+++ b/srml/grandpa/src/mock.rs
@@ -39,9 +39,26 @@ impl From<RawLog<u64, u64>> for DigestItem {
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
 #[derive(Clone, PartialEq, Eq, Debug, Decode, Encode)]
 pub struct Test;
+impl timestamp::Trait for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+}
+impl consensus::Trait for Test {
+	type Log = DigestItem;
+	type SessionKey = substrate_primitives::sr25519::Public;
+	type InherentOfflineReport = ();
+}
+impl session::Trait for Test {
+	type ConvertAccountIdToSessionKey = ();
+	type OnSessionChange = ();
+	type OnDisable = ();
+	type CheckRotateSession = session::AuraCheckRotateSession<Self>;
+	type Event = TestEvent;
+}
 impl Trait for Test {
 	type Log = DigestItem;
-	type SessionKey = u64;
+	type LocalSessionKey = u64;
+	type ConvertLocalSessionKey = ();
 	type Event = TestEvent;
 }
 impl system::Trait for Test {
@@ -65,6 +82,7 @@ mod grandpa {
 impl_outer_event!{
 	pub enum TestEvent for Test {
 		grandpa<T>,
+		session<T>,
 	}
 }
 


### PR DESCRIPTION
The session module already supports tuple based session keys. You can add a custom session key type and provide `Into<sr25519::Public>` and `Into<ed25519::Public>` or `Into<ble::Public>` implementations. I updated the test to include such an example. Please let me know if I've missed the point :) @gavofyork @Kianenigma 