### PR TITLE
Enable `std` feature for all required crates

### DIFF
--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -71,4 +71,6 @@ std = [
 	"hex-literal",
 	"serde",
 	"substrate-keyring",
+  "consensus_authorities/std",
+  "offchain-primitives/std",
 ]

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -71,6 +71,6 @@ std = [
 	"hex-literal",
 	"serde",
 	"substrate-keyring",
-  "consensus_authorities/std",
-  "offchain-primitives/std",
+	"consensus_authorities/std",
+	"offchain-primitives/std",
 ]


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/2724