### PR TITLE
Add RPC to remove and ban transactions from the pool.

### DIFF
--- a/core/rpc/src/author/hash.rs
+++ b/core/rpc/src/author/hash.rs
@@ -1,0 +1,30 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use primitives::Bytes;
+use serde::Deserialize;
+
+/// RPC Extrinsic or hash
+///
+/// Allows to refer to extrinsics either by their raw representation or by it's hash.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExtrinsicOrHash<Hash> {
+	/// The hash of the extrinsic.
+	Hash(Hash),
+	/// Raw extrinsic bytes.
+	Extrinsic(Bytes),
+}

--- a/core/rpc/src/author/mod.rs
+++ b/core/rpc/src/author/mod.rs
@@ -18,9 +18,15 @@
 
 use std::sync::Arc;
 
-use log::warn;
 use client::{self, Client};
+use crate::rpc::futures::{Sink, Stream, Future};
+use crate::subscriptions::Subscriptions;
+use jsonrpc_derive::rpc;
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
+use log::warn;
 use parity_codec::{Encode, Decode};
+use primitives::{Bytes, Blake2Hasher, H256};
+use runtime_primitives::{generic, traits};
 use transaction_pool::{
 	txpool::{
 		ChainApi as PoolChainApi,
@@ -31,14 +37,9 @@ use transaction_pool::{
 		watcher::Status,
 	},
 };
-use jsonrpc_derive::rpc;
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
-use primitives::{Bytes, Blake2Hasher, H256};
-use crate::rpc::futures::{Sink, Stream, Future};
-use runtime_primitives::{generic, traits};
-use crate::subscriptions::Subscriptions;
 
 pub mod error;
+mod hash;
 
 #[cfg(test)]
 mod tests;
@@ -59,6 +60,10 @@ pub trait AuthorApi<Hash, BlockHash> {
 	#[rpc(name = "author_pendingExtrinsics")]
 	fn pending_extrinsics(&self) -> Result<Vec<Bytes>>;
 
+	/// Remove given extrinsic from the pool and temporarily ban it to prevent reimporting.
+	#[rpc(name = "author_removeExtrinsic")]
+	fn remove_extrinsic(&self, bytes_or_hash: Vec<hash::ExtrinsicOrHash<Hash>>) -> Result<Vec<Hash>>;
+
 	/// Submit an extrinsic to watch.
 	#[pubsub(subscription = "author_extrinsicUpdate", subscribe, name = "author_submitAndWatchExtrinsic")]
 	fn watch_extrinsic(&self, metadata: Self::Metadata, subscriber: Subscriber<Status<Hash, BlockHash>>, bytes: Bytes);
@@ -72,7 +77,7 @@ pub trait AuthorApi<Hash, BlockHash> {
 pub struct Author<B, E, P, RA> where P: PoolChainApi + Sync + Send + 'static {
 	/// Substrate client
 	client: Arc<Client<B, E, <P as PoolChainApi>::Block, RA>>,
-	/// Extrinsic pool
+	/// Transactions pool
 	pool: Arc<Pool<P>>,
 	/// Subscriptions manager
 	subscriptions: Subscriptions,
@@ -116,6 +121,25 @@ impl<B, E, P, RA> AuthorApi<ExHash<P>, BlockHash<P>> for Author<B, E, P, RA> whe
 
 	fn pending_extrinsics(&self) -> Result<Vec<Bytes>> {
 		Ok(self.pool.ready().map(|tx| tx.data.encode().into()).collect())
+	}
+
+	fn remove_extrinsic(&self, bytes_or_hash: Vec<hash::ExtrinsicOrHash<ExHash<P>>>) -> Result<Vec<ExHash<P>>> {
+		let hashes = bytes_or_hash.into_iter()
+			.map(|x| match x {
+				hash::ExtrinsicOrHash::Hash(h) => Ok(h),
+				hash::ExtrinsicOrHash::Extrinsic(bytes) => {
+					let xt = Decode::decode(&mut &bytes[..]).ok_or(error::Error::BadFormat)?;
+					Ok(self.pool.hash_of(&xt))
+				},
+			})
+			.collect::<Result<Vec<_>>>()?;
+
+		Ok(
+			self.pool.remove_invalid(&hashes)
+				.into_iter()
+				.map(|tx| tx.hash.clone())
+				.collect()
+		)
 	}
 
 	fn watch_extrinsic(&self, _metadata: Self::Metadata, subscriber: Subscriber<Status<ExHash<P>, BlockHash<P>>>, xt: Bytes) {

--- a/core/transaction-pool/graph/src/pool.rs
+++ b/core/transaction-pool/graph/src/pool.rs
@@ -417,8 +417,7 @@ impl<B: ChainApi> Pool<B> {
 	}
 
 	/// Returns transaction hash
-	#[cfg(test)]
-	fn hash_of(&self, xt: &ExtrinsicFor<B>) -> ExHash<B> {
+	pub fn hash_of(&self, xt: &ExtrinsicFor<B>) -> ExHash<B> {
 		self.api.hash_and_length(xt).0
 	}
 }


### PR DESCRIPTION
Resolves #2604 

I've decided to support both hash and raw representation of the extrinsic because `pending_extrinsics` removes the raw form.

It uses existing `remove_invalid` API, that will temporarily ban the transactions as well and remove all dependent transactions too.