### PR TITLE
Bump structopt and fix compilation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,7 @@ dependencies = [
  "srml-finality-tracker 2.0.0",
  "srml-indices 2.0.0",
  "srml-timestamp 2.0.0",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-basic-authorship 2.0.0",
  "substrate-cli 2.0.0",
  "substrate-client 2.0.0",
@@ -3730,16 +3730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3841,7 +3841,7 @@ dependencies = [
  "rpassword 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-client 2.0.0",
  "substrate-keyring 2.0.0",
  "substrate-network 2.0.0",
@@ -5822,8 +5822,8 @@ dependencies = [
 "checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
-"checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
+"checksum structopt 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fa19a5a708e22bb5be31c1b6108a2a902f909c4b9ba85cba44c06632386bc0ff"
+"checksum structopt-derive 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d59d0ae8ef8de16e49e3ca7afa16024a3e0dfd974a75ef93fdc5464e34523f"
 "checksum strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1810e25f576e7ffce1ff5243b37066da5ded0310b3274c20baaeccb1145b2806"
 "checksum strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "572a2f4e53dd4c3483fd79e5cc10ddd773a3acb1169bbfe8762365e107110579"
 "checksum substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)" = "<none>"

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -50,7 +50,7 @@ pub use structopt::clap::App;
 use params::{
 	RunCmd, PurgeChainCmd, RevertCmd, ImportBlocksCmd, ExportBlocksCmd, BuildSpecCmd,
 	NetworkConfigurationParams, MergeParameters, TransactionPoolParams,
-	NodeKeyParams, NodeKeyType
+	NodeKeyParams, NodeKeyType, Cors,
 };
 pub use params::{NoCustom, CoreParams, SharedParams};
 pub use traits::{GetLogFilter, AugmentClap};
@@ -485,9 +485,9 @@ where
 	config.rpc_ws_max_connections = cli.ws_max_connections;
 	config.rpc_cors = cli.rpc_cors.unwrap_or_else(|| if is_dev {
 		log::warn!("Running in --dev mode, RPC CORS has been disabled.");
-		None
+		Cors::All
 	} else {
-		Some(vec![
+		Cors::List(vec![
 			"http://localhost:*".into(),
 			"http://127.0.0.1:*".into(),
 			"https://localhost:*".into(),
@@ -495,7 +495,7 @@ where
 			"https://polkadot.js.org".into(),
 			"https://substrate-ui.parity.io".into(),
 		])
-	});
+	}).into();
 
 	// Override telemetry
 	if cli.no_telemetry {

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -343,7 +343,7 @@ pub struct RunCmd {
 	/// Default is to allow localhost, https://polkadot.js.org and https://substrate-ui.parity.io origins.
 	/// When running in --dev mode the default is to allow all origins.
 	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = "parse_cors"))]
-	pub rpc_cors: Option<Option<Vec<String>>>,
+	pub rpc_cors: Option<Cors>,
 
 	/// Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.
 	#[structopt(long = "pruning", value_name = "PRUNING_MODE")]
@@ -490,8 +490,29 @@ fn parse_telemetry_endpoints(s: &str) -> Result<(String, u8), Box<std::error::Er
 	}
 }
 
+/// CORS setting
+///
+/// The type is introduced to overcome `Option<Option<T>>`
+/// handling of `structopt`.
+#[derive(Clone, Debug)]
+pub enum Cors {
+	/// All hosts allowed
+	All,
+	/// Only hosts on the list are allowed.
+	List(Vec<String>),
+}
+
+impl From<Cors> for Option<Vec<String>> {
+	fn from(cors: Cors) -> Self {
+		match cors {
+			Cors::All => None,
+			Cors::List(list) => Some(list),
+		}
+	}
+}
+
 /// Parse cors origins
-fn parse_cors(s: &str) -> Result<Option<Vec<String>>, Box<std::error::Error>> {
+fn parse_cors(s: &str) -> Result<Cors, Box<std::error::Error>> {
 	let mut is_all = false;
 	let mut origins = Vec::new();
 	for part in s.split(',') {
@@ -504,7 +525,7 @@ fn parse_cors(s: &str) -> Result<Option<Vec<String>>, Box<std::error::Error>> {
 		}
 	}
 
-	Ok(if is_all { None } else { Some(origins) })
+	Ok(if is_all { Cors::All } else { Cors::List(origins) })
 }
 
 impl_augment_clap!(RunCmd);


### PR DESCRIPTION
https://github.com/TeXitoi/structopt/pull/190 Introduces handling of `Option<Option<T>>` parameters in `structopt` directly.
We've used the type together with `parse(try_from_str)` which now is broken with that type.

To overcome the issue I've introduced `Cors` enum that we parse the CLI option to first.