### PR TITLE
Split specialization context from network context

### DIFF
--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -46,7 +46,8 @@ pub use service::{
 	NetworkService, NetworkWorker, FetchFuture, TransactionPool, ManageNetwork,
 	NetworkMsg, SyncProvider, ExHashT, ReportHandle,
 };
-pub use protocol::{ProtocolStatus, PeerInfo, Context};
+pub use protocol::{ProtocolStatus, PeerInfo};
+pub use specialization::Context;
 pub use sync::{Status as SyncStatus, SyncState};
 pub use network_libp2p::{
 	identity, multiaddr,

--- a/core/network/src/specialization.rs
+++ b/core/network/src/specialization.rs
@@ -31,7 +31,12 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	fn on_disconnect(&mut self, ctx: &mut Context<B>, who: PeerId);
 
 	/// Called when a network-specific message arrives.
-	fn on_message(&mut self, ctx: &mut Context<B>, who: PeerId, message: &mut Option<crate::message::Message<B>>);
+	fn on_message(
+		&mut self,
+		ctx: &mut Context<B>,
+		who: PeerId,
+		message: &mut Option<crate::message::Message<B>>
+	);
 
 	/// Called on abort.
 	#[deprecated(note = "This method is never called; aborting corresponds to dropping the object")]

--- a/core/network/src/specialization.rs
+++ b/core/network/src/specialization.rs
@@ -18,7 +18,6 @@
 
 use crate::PeerId;
 use runtime_primitives::traits::Block as BlockT;
-use crate::protocol::Context;
 
 /// A specialization of the substrate network protocol. Handles events and sends messages.
 pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
@@ -44,6 +43,23 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	/// Called when a block is _imported_ at the head of the chain (not during major sync).
 	/// Not guaranteed to be called for every block, but will be most of the after major sync.
 	fn on_block_imported(&mut self, _ctx: &mut Context<B>, _hash: B::Hash, _header: &B::Header) { }
+}
+
+/// Context for a network-specific handler.
+pub trait Context<B: BlockT> {
+	/// Adjusts the reputation of the peer. Use this to point out that a peer has been malign or
+	/// irresponsible or appeared lazy.
+	fn report_peer(&mut self, who: PeerId, reputation: i32);
+
+	/// Force disconnecting from a peer. Use this when a peer misbehaved.
+	fn disconnect_peer(&mut self, who: PeerId);
+
+	/// Send a consensus message to a peer.
+	#[deprecated(note = "This method shouldn't have been part of the specialization API")]
+	fn send_consensus(&mut self, _who: PeerId, _consensus: crate::message::generic::ConsensusMessage) {}
+
+	/// Send a chain-specific message to a peer.
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>);
 }
 
 /// Construct a simple protocol that is composed of several sub protocols.

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -50,7 +50,7 @@ use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{AuthorityIdFor, Block as BlockT, Digest, DigestItem, Header, NumberFor};
 use runtime_primitives::{Justification, ConsensusEngineId};
 use crate::service::{NetworkLink, NetworkMsg, ProtocolMsg, TransactionPool};
-use crate::specialization::NetworkSpecialization;
+use crate::specialization::{NetworkSpecialization, Context as SpecializationContext};
 use test_client::{self, AccountKeyring};
 
 pub use test_client::runtime::{Block, Extrinsic, Hash, Transfer};
@@ -101,15 +101,15 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		vec![]
 	}
 
-	fn on_connect(&mut self, _ctx: &mut Context<Block>, _peer_id: PeerId, _status: crate::message::Status<Block>) {
+	fn on_connect(&mut self, _ctx: &mut SpecializationContext<Block>, _peer_id: PeerId, _status: crate::message::Status<Block>) {
 	}
 
-	fn on_disconnect(&mut self, _ctx: &mut Context<Block>, _peer_id: PeerId) {
+	fn on_disconnect(&mut self, _ctx: &mut SpecializationContext<Block>, _peer_id: PeerId) {
 	}
 
 	fn on_message(
 		&mut self,
-		_ctx: &mut Context<Block>,
+		_ctx: &mut SpecializationContext<Block>,
 		_peer_id: PeerId,
 		_message: &mut Option<crate::message::Message<Block>>,
 	) {

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -101,7 +101,12 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		vec![]
 	}
 
-	fn on_connect(&mut self, _ctx: &mut SpecializationContext<Block>, _peer_id: PeerId, _status: crate::message::Status<Block>) {
+	fn on_connect(
+		&mut self,
+		_ctx: &mut SpecializationContext<Block>,
+		_peer_id: PeerId,
+		_status: crate::message::Status<Block>
+	) {
 	}
 
 	fn on_disconnect(&mut self, _ctx: &mut SpecializationContext<Block>, _peer_id: PeerId) {


### PR DESCRIPTION
The gossiping code no longer has access to `send_chain_specific`, and the chain-specific code no longer has access to `send_consensus`.