### PR TITLE
Remove spurious `#[derive(Encode, Decode)]`

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 89,
-	impl_version: 89,
+	impl_version: 90,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -57,7 +57,6 @@ use primitives::traits::{SaturatedConversion, Saturating, Zero, One};
 use timestamp::OnTimestampSet;
 #[cfg(feature = "std")]
 use timestamp::TimestampInherentData;
-use parity_codec::{Encode, Decode};
 use inherents::{RuntimeString, InherentIdentifier, InherentData, ProvideInherent, MakeFatalError};
 #[cfg(feature = "std")]
 use inherents::{InherentDataProviders, ProvideInherentData};
@@ -163,7 +162,7 @@ decl_module! {
 }
 
 /// A report of skipped authorities in Aura.
-#[derive(Clone, Encode, Decode, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct AuraReport {
 	// The first skipped slot.

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -51,7 +51,6 @@
 pub use timestamp;
 
 use rstd::{result, prelude::*};
-use parity_codec::Decode;
 use srml_support::storage::StorageValue;
 use srml_support::{decl_storage, decl_module};
 use primitives::traits::{SaturatedConversion, Saturating, Zero, One};
@@ -133,6 +132,7 @@ impl ProvideInherentData for InherentDataProvider {
 	}
 
 	fn error_to_string(&self, error: &[u8]) -> Option<String> {
+		use parity_codec::Decode;
 		RuntimeString::decode(&mut &error[..]).map(Into::into)
 	}
 }

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -51,6 +51,7 @@
 pub use timestamp;
 
 use rstd::{result, prelude::*};
+use parity_codec::Decode;
 use srml_support::storage::StorageValue;
 use srml_support::{decl_storage, decl_module};
 use primitives::traits::{SaturatedConversion, Saturating, Zero, One};


### PR DESCRIPTION
They did not compile, since `Encode` and `Decode` are deliberately not
implemented for `usize`.

Fixes #2742.