### PR TITLE
Add support for tuples in `OnNewAccount` hook

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 90,
-	impl_version: 90,
+	impl_version: 91,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 89,
-	impl_version: 89,
+	impl_version: 90,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -46,7 +46,7 @@ macro_rules! impl_on_free_balance_zero {
 	);
 
 	( $($t:ident)* ) => {
-		impl<AccountId: Clone, $($t: OnFreeBalanceZero<AccountId>),*> OnFreeBalanceZero<AccountId> for ($($t,)*) {
+		impl<AccountId, $($t: OnFreeBalanceZero<AccountId>),*> OnFreeBalanceZero<AccountId> for ($($t,)*) {
 			fn on_free_balance_zero(who: &AccountId) {
 				$($t::on_free_balance_zero(who);)*
 			}

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -22,6 +22,8 @@ use crate::runtime_primitives::traits::{
 	MaybeSerializeDebug, SimpleArithmetic
 };
 
+use super::for_each_tuple;
+
 /// New trait for querying a single fixed value from a type.
 pub trait Get<T> {
 	/// Return a constant value.
@@ -67,19 +69,23 @@ pub trait OnFreeBalanceZero<AccountId> {
 	fn on_free_balance_zero(who: &AccountId);
 }
 
-impl<AccountId> OnFreeBalanceZero<AccountId> for () {
-	fn on_free_balance_zero(_who: &AccountId) {}
-}
-impl<
-	AccountId,
-	X: OnFreeBalanceZero<AccountId>,
-	Y: OnFreeBalanceZero<AccountId>,
-> OnFreeBalanceZero<AccountId> for (X, Y) {
-	fn on_free_balance_zero(who: &AccountId) {
-		X::on_free_balance_zero(who);
-		Y::on_free_balance_zero(who);
+macro_rules! impl_free_balance_zero {
+	() => (
+		impl<AccountId> OnFreeBalanceZero<AccountId> for () {
+			fn on_free_balance_zero(_: &AccountId) {}
+		}
+	);
+
+	( $($t:ident)* ) => {
+		impl<AccountId: Clone, $($t: OnFreeBalanceZero<AccountId>),*> OnFreeBalanceZero<AccountId> for ($($t,)*) {
+			fn on_free_balance_zero(who: &AccountId) {
+				$($t::on_free_balance_zero(who);)*
+			}
+		}
 	}
 }
+
+for_each_tuple!(impl_free_balance_zero);
 
 /// Trait for a hook to get called when some balance has been minted, causing dilution.
 pub trait OnDilution<Balance> {

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -69,7 +69,7 @@ pub trait OnFreeBalanceZero<AccountId> {
 	fn on_free_balance_zero(who: &AccountId);
 }
 
-macro_rules! impl_free_balance_zero {
+macro_rules! impl_on_free_balance_zero {
 	() => (
 		impl<AccountId> OnFreeBalanceZero<AccountId> for () {
 			fn on_free_balance_zero(_: &AccountId) {}
@@ -85,7 +85,7 @@ macro_rules! impl_free_balance_zero {
 	}
 }
 
-for_each_tuple!(impl_free_balance_zero);
+for_each_tuple!(impl_on_free_balance_zero);
 
 /// Trait for a hook to get called when some balance has been minted, causing dilution.
 pub trait OnDilution<Balance> {

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -85,7 +85,7 @@ use primitives::traits::Zero;
 use substrate_primitives::storage::well_known_keys;
 use srml_support::{
 	storage, decl_module, decl_event, decl_storage, StorageDoubleMap, StorageValue,
-	StorageMap, Parameter,
+	StorageMap, Parameter, for_each_tuple,
 };
 use safe_mix::TripletMix;
 use parity_codec::{Encode, Decode};
@@ -102,19 +102,23 @@ pub trait OnNewAccount<AccountId> {
 	fn on_new_account(who: &AccountId);
 }
 
-impl<AccountId> OnNewAccount<AccountId> for () {
-	fn on_new_account(_who: &AccountId) {}
-}
-impl<
-	AccountId,
-	X: OnNewAccount<AccountId>,
-	Y: OnNewAccount<AccountId>,
-> OnNewAccount<AccountId> for (X, Y) {
-	fn on_new_account(who: &AccountId) {
-		X::on_new_account(who);
-		Y::on_new_account(who);
+macro_rules! impl_on_new_account {
+	() => (
+		impl<AccountId> OnNewAccount<AccountId> for () {
+			fn on_new_account(_: &AccountId) {}
+		}
+	);
+
+	( $($t:ident)* ) => {
+		impl<AccountId: Clone, $($t: OnNewAccount<AccountId>),*> OnNewAccount<AccountId> for ($($t,)*) {
+			fn on_new_account(who: &AccountId) {
+				$($t::on_new_account(who);)*
+			}
+		}
 	}
 }
+
+for_each_tuple!(impl_on_new_account);
 
 /// Determiner to say whether a given account is unused.
 pub trait IsDeadAccount<AccountId> {

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -110,7 +110,7 @@ macro_rules! impl_on_new_account {
 	);
 
 	( $($t:ident)* ) => {
-		impl<AccountId: Clone, $($t: OnNewAccount<AccountId>),*> OnNewAccount<AccountId> for ($($t,)*) {
+		impl<AccountId, $($t: OnNewAccount<AccountId>),*> OnNewAccount<AccountId> for ($($t,)*) {
 			fn on_new_account(who: &AccountId) {
 				$($t::on_new_account(who);)*
 			}

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -105,6 +105,16 @@ pub trait OnNewAccount<AccountId> {
 impl<AccountId> OnNewAccount<AccountId> for () {
 	fn on_new_account(_who: &AccountId) {}
 }
+impl<
+	AccountId,
+	X: OnNewAccount<AccountId>,
+	Y: OnNewAccount<AccountId>,
+> OnNewAccount<AccountId> for (X, Y) {
+	fn on_new_account(who: &AccountId) {
+		X::on_new_account(who);
+		Y::on_new_account(who);
+	}
+}
 
 /// Determiner to say whether a given account is unused.
 pub trait IsDeadAccount<AccountId> {


### PR DESCRIPTION
This adds support for multiple modules to be specified with the `OnNewAccount` hook in the Balances module like so:

```
	type OnNewAccount = ((Module1, Module2), Module3);
```

or

```
	type OnNewAccount = (Module1, Module2, Module3);
```


Updates `OnFreeBalanceZero` to use the same `for_each_tuple` macro.

Fixes https://github.com/paritytech/substrate/issues/2763
