### PR TITLE
Support disabling validators.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -139,6 +139,7 @@ impl session::Trait for Runtime {
 	type ConvertAccountIdToSessionKey = ();
 	type OnSessionChange = (Staking, grandpa::SyncedAuthorities<Runtime>);
 	type OnDisable = Staking;
+	type CheckRotateSession = session::AuraCheckRotateSession<Self>;
 	type Event = Event;
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -138,6 +138,7 @@ impl timestamp::Trait for Runtime {
 impl session::Trait for Runtime {
 	type ConvertAccountIdToSessionKey = ();
 	type OnSessionChange = (Staking, grandpa::SyncedAuthorities<Runtime>);
+	type OnDisable = Staking;
 	type Event = Event;
 }
 

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -77,6 +77,7 @@ impl session::Trait for Test {
 	type ConvertAccountIdToSessionKey = ConvertUintAuthorityId;
 	type OnSessionChange = Staking;
 	type OnDisable = Staking;
+	type CheckRotateSession = session::AuraCheckRotateSession<Self>;
 	type Event = ();
 }
 impl timestamp::Trait for Test {

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -76,6 +76,7 @@ impl balances::Trait for Test {
 impl session::Trait for Test {
 	type ConvertAccountIdToSessionKey = ConvertUintAuthorityId;
 	type OnSessionChange = Staking;
+	type OnDisable = Staking;
 	type Event = ();
 }
 impl timestamp::Trait for Test {


### PR DESCRIPTION
Instead of forcing a new era when the staking module slashes a validator it disables the validator. The default implementation for this forces a new era, but the babe module should be able to do it's own book keeping.