### PR TITLE
Backport #2765: Add support for tuples in `OnNewAccount` hook

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 60,
-	impl_version: 61,
+	impl_version: 62,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
Backport: https://github.com/paritytech/substrate/pull/2765
Fixes: https://github.com/paritytech/substrate/issues/2763


This adds support for multiple modules to be specified with the `OnNewAccount` hook in the Balances module like so:

```
	type OnNewAccount = ((Module1, Module2), Module3);
```

or

```
	type OnNewAccount = (Module1, Module2, Module3);
```


Updates `OnFreeBalanceZero` to use the same `for_each_tuple` macro.

