### PR TITLE
Revert #2745

### DIFF
--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -46,8 +46,7 @@ pub use service::{
 	NetworkService, NetworkWorker, FetchFuture, TransactionPool, ManageNetwork,
 	NetworkMsg, SyncProvider, ExHashT, ReportHandle,
 };
-pub use protocol::{ProtocolStatus, PeerInfo};
-pub use specialization::Context;
+pub use protocol::{ProtocolStatus, PeerInfo, Context};
 pub use sync::{Status as SyncStatus, SyncState};
 pub use network_libp2p::{
 	identity, multiaddr,

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -32,7 +32,7 @@ use crate::message::{BlockAttributes, Direction, FromBlock, RequestId};
 use crate::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
 use crate::on_demand::{OnDemandCore, OnDemandNetwork, RequestData};
-use crate::specialization::{NetworkSpecialization, Context as SpecializationContext};
+use crate::specialization::NetworkSpecialization;
 use crate::sync::{ChainSync, Context as SyncContext, Status as SyncStatus, SyncState};
 use crate::service::{TransactionPool, ExHashT};
 use crate::config::Roles;
@@ -281,6 +281,9 @@ pub trait Context<B: BlockT> {
 
 	/// Send a consensus message to a peer.
 	fn send_consensus(&mut self, who: PeerId, consensus: ConsensusMessage);
+
+	/// Send a chain-specific message to a peer.
+	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>);
 }
 
 /// Protocol context.
@@ -311,16 +314,6 @@ impl<'a, B: BlockT + 'a, H: ExHashT + 'a> Context<B> for ProtocolContext<'a, B, 
 			who,
 			GenericMessage::Consensus(consensus)
 		)
-	}
-}
-
-impl<'a, B: BlockT + 'a, H: ExHashT + 'a> SpecializationContext<B> for ProtocolContext<'a, B, H> {
-	fn report_peer(&mut self, who: PeerId, reputation: i32) {
-		self.network_out.report_peer(who, reputation)
-	}
-
-	fn disconnect_peer(&mut self, who: PeerId) {
-		self.network_out.disconnect_peer(who)
 	}
 
 	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>) {

--- a/core/network/src/specialization.rs
+++ b/core/network/src/specialization.rs
@@ -18,6 +18,7 @@
 
 use crate::PeerId;
 use runtime_primitives::traits::Block as BlockT;
+use crate::protocol::Context;
 
 /// A specialization of the substrate network protocol. Handles events and sends messages.
 pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
@@ -48,23 +49,6 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	/// Called when a block is _imported_ at the head of the chain (not during major sync).
 	/// Not guaranteed to be called for every block, but will be most of the after major sync.
 	fn on_block_imported(&mut self, _ctx: &mut dyn Context<B>, _hash: B::Hash, _header: &B::Header) { }
-}
-
-/// Context for a network-specific handler.
-pub trait Context<B: BlockT> {
-	/// Adjusts the reputation of the peer. Use this to point out that a peer has been malign or
-	/// irresponsible or appeared lazy.
-	fn report_peer(&mut self, who: PeerId, reputation: i32);
-
-	/// Force disconnecting from a peer. Use this when a peer misbehaved.
-	fn disconnect_peer(&mut self, who: PeerId);
-
-	/// Send a consensus message to a peer.
-	#[deprecated(note = "This method shouldn't have been part of the specialization API")]
-	fn send_consensus(&mut self, _who: PeerId, _consensus: crate::message::generic::ConsensusMessage) {}
-
-	/// Send a chain-specific message to a peer.
-	fn send_chain_specific(&mut self, who: PeerId, message: Vec<u8>);
 }
 
 /// Construct a simple protocol that is composed of several sub protocols.

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -103,16 +103,16 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 
 	fn on_connect(
 		&mut self,
-		_ctx: &mut dyn SpecializationContext<Block>,
+		_ctx: &mut dyn Context<Block>,
 		_peer_id: PeerId,
 		_status: crate::message::Status<Block>
 	) {}
 
-	fn on_disconnect(&mut self, _ctx: &mut dyn SpecializationContext<Block>, _peer_id: PeerId) {}
+	fn on_disconnect(&mut self, _ctx: &mut dyn Context<Block>, _peer_id: PeerId) {}
 
 	fn on_message(
 		&mut self,
-		_ctx: &mut dyn SpecializationContext<Block>,
+		_ctx: &mut dyn Context<Block>,
 		_peer_id: PeerId,
 		_message: &mut Option<crate::message::Message<Block>>,
 	) {}

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -50,7 +50,7 @@ use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{AuthorityIdFor, Block as BlockT, Digest, DigestItem, Header, NumberFor};
 use runtime_primitives::{Justification, ConsensusEngineId};
 use crate::service::{NetworkLink, NetworkMsg, ProtocolMsg, TransactionPool};
-use crate::specialization::{NetworkSpecialization, Context as SpecializationContext};
+use crate::specialization::NetworkSpecialization;
 use test_client::{self, AccountKeyring};
 
 pub use test_client::runtime::{Block, Extrinsic, Hash, Transfer};

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -297,7 +297,7 @@ mod tests {
 			inherent_data.replace_data(finality_tracker::INHERENT_IDENTIFIER, &1u64);
 			inherent_data.replace_data(timestamp::INHERENT_IDENTIFIER, &(slot_num * 10));
 
-			let parent_id = BlockId::number(service.client().info().unwrap().chain.best_number);
+			let parent_id = BlockId::number(service.client().info().chain.best_number);
 			let parent_header = service.client().header(&parent_id).unwrap().unwrap();
 			let proposer_factory = Arc::new(substrate_basic_authorship::ProposerFactory {
 				client: service.client(),


### PR DESCRIPTION
#2745 prevents us from upgrading Polkadot.
I didn't realize that Polkadot was passing the context received through the network specialization to the gossiping code.