### PR TITLE
Move Council and Democracy logic to block initialization

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 92,
-	impl_version: 92,
+	impl_version: 93,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/council/src/seats.rs
+++ b/srml/council/src/seats.rs
@@ -305,7 +305,7 @@ decl_module! {
 			<TermDuration<T>>::put(count);
 		}
 
-		fn on_finalize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) {
 			if let Err(e) = Self::end_block(n) {
 				print("Guru meditation");
 				print(e);

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -485,7 +485,7 @@ decl_module! {
 			}
 		}
 
-		fn on_finalize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) {
 			if let Err(e) = Self::end_block(n) {
 				runtime_io::print(e);
 			}


### PR DESCRIPTION
Trivial attempt at https://github.com/paritytech/substrate/issues/2779

`cargo test -p srml-council` and `cargo test -p srml-democracy` both pass.