### PR TITLE
docs: Update Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -180,6 +180,7 @@ For Unix-based operating systems, you should run the following commands:
 [source, shell]
 ----
 curl https://sh.rustup.rs -sSf | sh
+source ~/.cargo/env
 
 rustup update nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly


### PR DESCRIPTION
I just tried setting it up on a new MacOS computer. This additional step is required to setup Cargo in the current shell session otherwise subsequent steps return `rustup: command not found`
