### PR TITLE
Add "Convert Mnemonic to Raw Seed" option to subkey

### DIFF
--- a/subkey/src/cli.yml
+++ b/subkey/src/cli.yml
@@ -19,6 +19,13 @@ args:
       required: false
       help: The password for the key
 subcommands:
+  - convert:
+      about: Given a mnemonic, show raw seed.
+      args:
+        - mnemonic:
+            index: 1
+            required: true
+            help: A mnemonic phrase.
   - generate:
       about: Generate a random account
   - inspect:

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -60,6 +60,17 @@ trait Crypto {
 			Self::ss58_from_pair(&pair)
 		);
 	}
+
+	/// Given a mnemonic phrase and optional password, print out the
+	/// equivalent raw seed in hexadecimal.
+	fn print_seed_from_phrase(phrase: &str, password: Option<&str>) {
+		let seed = Self::seed_from_phrase(phrase, password);
+		println!("Phrase `{}` is raw seed:\n  Seed: 0x{}\n",
+			phrase,
+			HexDisplay::from(&seed.as_ref())
+		);
+	}
+
 	fn print_from_phrase(phrase: &str, password: Option<&str>) {
 		let seed = Self::seed_from_phrase(phrase, password);
 		let pair = Self::pair_from_seed(&seed);
@@ -147,6 +158,11 @@ fn execute<C: Crypto<Seed=[u8; 32]>>(matches: clap::ArgMatches) where
 {
 	let password = matches.value_of("password");
 	match matches.subcommand() {
+		("convert", Some(matches)) => {
+			// Given a mnemonic, print out the raw seed
+			let mnemonic = matches.value_of("mnemonic").expect("Mnemonic required");
+			C::print_seed_from_phrase(mnemonic, password);
+		},
 		("generate", Some(_matches)) => {
 			// create a new randomly generated mnemonic phrase
 			let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);


### PR DESCRIPTION
In the watercooler, Jaco noted that the use of both mnemonics and raw seeds in the Polkadot UI was an artifact of history.  In general, users of Polkadot should generate the mnemonic.  However, in some use cases, such as setting up a validator, a user must enter the raw seed.  It therefore seemed useful for me to be able to convert a mnemonic phrase to a raw key, e.g., if a user had already generated an account via the UI by producing a mnemonic and now wished to use it when setting up a validator.

This potentially paves the way for more user-facing interfaces to focus only on the mnemonic, with only those who need the raw seed obtaining it via the `subkey` tool.

Note that `subkey` internally generates the raw seed from the mnemonic already, it just does not display it except immediately after generation.  This PR does not update any math or seed generation functions, merely provides a way to display the raw seed from the mnemonic by calling existing functions.

Another possibility would be to add the display of the raw seed to the "inspect" option, but I thought it would be better to avoid modifying output of options that people are already using.