### PR TITLE
More crate compiling for WASM-browser

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,10 +137,14 @@ check-web-wasm:
     - time cargo web build -p sr-io
     - time cargo web build -p sr-primitives
     - time cargo web build -p sr-std
+    - time cargo web build -p substrate-client
+    - time cargo web build -p substrate-consensus-aura
+    - time cargo web build -p substrate-consensus-babe
     - time cargo web build -p substrate-consensus-common
     - time cargo web build -p substrate-keyring
     - time cargo web build -p substrate-keystore
     - time cargo web build -p substrate-executor
+    - time cargo web build -p substrate-network
     - time cargo web build -p substrate-network-libp2p
     - time cargo web build -p substrate-panic-handler
     - time cargo web build -p substrate-peerset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "substrate-telemetry 2.0.0",
  "substrate-test-client 2.0.0",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4125,6 +4126,7 @@ dependencies = [
  "substrate-telemetry 2.0.0",
  "substrate-test-client 2.0.0",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4196,7 +4198,7 @@ dependencies = [
  "substrate-inherents 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-test-client 2.0.0",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/consensus/aura/Cargo.toml
+++ b/core/consensus/aura/Cargo.toml
@@ -22,7 +22,7 @@ consensus_common = { package = "substrate-consensus-common", path = "../common" 
 authorities = { package = "substrate-consensus-authorities", path = "../authorities" }
 runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
 futures = "0.1.17"
-tokio = "0.1.7"
+tokio-timer = "0.2.11"
 parking_lot = "0.8.0"
 log = "0.4"
 
@@ -32,4 +32,5 @@ substrate-executor = { path = "../../executor" }
 network = { package = "substrate-network", path = "../../network", features = ["test-helpers"]}
 service = { package = "substrate-service", path = "../../service" }
 test_client = { package = "substrate-test-client", path = "../../test-client" }
+tokio = "0.1.7"
 env_logger = "0.6"

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -56,7 +56,7 @@ use inherents::{InherentDataProviders, InherentData};
 use authorities::AuthoritiesApi;
 
 use futures::{Future, IntoFuture, future};
-use tokio::timer::Timeout;
+use tokio_timer::Timeout;
 use log::{error, warn, debug, info, trace};
 
 use srml_aura::{
@@ -914,7 +914,7 @@ mod tests {
 			.map(|_| ())
 			.map_err(|_| ());
 
-		let drive_to_completion = ::tokio::timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
+		let drive_to_completion = ::tokio_timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
 			.for_each(move |_| {
 				net.lock().send_import_notifications();
 				net.lock().sync_without_disconnects();

--- a/core/consensus/babe/Cargo.toml
+++ b/core/consensus/babe/Cargo.toml
@@ -23,7 +23,7 @@ authorities = { package = "substrate-consensus-authorities", path = "../authorit
 slots = { package = "substrate-consensus-slots", path = "../slots"  }
 runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
 futures = "0.1.26"
-tokio = "0.1.18"
+tokio-timer = "0.2.11"
 parking_lot = "0.8.0"
 log = "0.4.6"
 schnorrkel = "0.1.1"
@@ -36,4 +36,5 @@ substrate-executor = { path = "../../executor" }
 network = { package = "substrate-network", path = "../../network", features = ["test-helpers"]}
 service = { package = "substrate-service", path = "../../service" }
 test_client = { package = "substrate-test-client", path = "../../test-client" }
+tokio = "0.1.18"
 env_logger = "0.6.1"

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -79,7 +79,7 @@ use client::{
 };
 use slots::{CheckedHeader, check_equivocation};
 use futures::{Future, IntoFuture, future};
-use tokio::timer::Timeout;
+use tokio_timer::Timeout;
 use log::{error, warn, debug, info, trace};
 
 use slots::{SlotWorker, SlotData, SlotInfo, SlotCompatible, slot_now};
@@ -984,7 +984,7 @@ mod tests {
 			.map(drop)
 			.map_err(drop);
 
-		let drive_to_completion = ::tokio::timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
+		let drive_to_completion = ::tokio_timer::Interval::new_interval(TEST_ROUTING_INTERVAL)
 			.for_each(move |_| {
 				net.lock().send_import_notifications();
 				net.lock().sync_without_disconnects();

--- a/core/consensus/slots/Cargo.toml
+++ b/core/consensus/slots/Cargo.toml
@@ -13,7 +13,7 @@ runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
 consensus_common = { package = "substrate-consensus-common", path = "../common" }
 inherents = { package = "substrate-inherents", path = "../../inherents" }
 futures = "0.1.17"
-tokio = "0.1.7"
+tokio-timer = "0.2.11"
 parking_lot = "0.8.0"
 log = "0.4"
 

--- a/core/consensus/slots/src/slots.rs
+++ b/core/consensus/slots/src/slots.rs
@@ -26,7 +26,7 @@ use inherents::{InherentData, InherentDataProviders};
 use log::warn;
 use std::marker::PhantomData;
 use std::time::{Duration, Instant};
-use tokio::timer::Delay;
+use tokio_timer::Delay;
 
 /// Returns current duration since unix epoch.
 pub fn duration_now() -> Option<Duration> {

--- a/core/test-runtime/wasm/Cargo.lock
+++ b/core/test-runtime/wasm/Cargo.lock
@@ -2561,7 +2561,7 @@ dependencies = [
  "substrate-consensus-common 2.0.0",
  "substrate-inherents 2.0.0",
  "substrate-primitives 2.0.0",
- "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]


### PR DESCRIPTION
Makes more crates compile for wasm-browser (#2416)

Removes the deprecated function `start_slot_worker_thread`.