### PR TITLE
Passthru build.sh/script.sh command line arguments

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -20,12 +20,12 @@ case $TARGET in
 		sudo apt-get -y update
 		sudo apt-get install -y cmake pkg-config libssl-dev
 
-		cargo test --all --release --locked
+		cargo test --all --release --locked "$@"
 		;;
 
 	"wasm")
 		# Install prerequisites and build all wasm projects
 		./scripts/init.sh
-		./scripts/build.sh
+		./scripts/build.sh "$@"
 		;;
 esac

--- a/core/executor/wasm/build.sh
+++ b/core/executor/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release $@
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release "$@"
 for i in test
 do
 	wasm-gc target/wasm32-unknown-unknown/release/runtime_$i.wasm target/wasm32-unknown-unknown/release/runtime_$i.compact.wasm

--- a/core/test-runtime/wasm/build.sh
+++ b/core/test-runtime/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release $@
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release "$@"
 for i in substrate_test_runtime
 do
 	wasm-gc "target/wasm32-unknown-unknown/release/$i.wasm" "target/wasm32-unknown-unknown/release/$i.compact.wasm"

--- a/node-template/runtime/wasm/build.sh
+++ b/node-template/runtime/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release $@
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release "$@"
 for i in node_template_runtime_wasm
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm

--- a/node-template/scripts/build.sh
+++ b/node-template/scripts/build.sh
@@ -17,7 +17,7 @@ do
   echo "${bold}Building webassembly binary in $SRC...${normal}"
   cd "$PROJECT_ROOT/$SRC"
 
-  ./build.sh
+  ./build.sh "$@"
 
   cd - >> /dev/null
 done

--- a/node/runtime/wasm/build.sh
+++ b/node/runtime/wasm/build.sh
@@ -6,7 +6,7 @@ if cargo --version | grep -q "nightly"; then
 else
 	CARGO_CMD="cargo +nightly"
 fi
-CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release $@
+CARGO_INCREMENTAL=0 RUSTFLAGS="-C link-arg=--export-table" $CARGO_CMD build --target=wasm32-unknown-unknown --release "$@"
 for i in node_runtime
 do
 	wasm-gc target/wasm32-unknown-unknown/release/$i.wasm target/wasm32-unknown-unknown/release/$i.compact.wasm

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,7 +19,7 @@ do
   echo "*** Building wasm binaries in $SRC"
   cd "$PROJECT_ROOT/$SRC"
 
-  ./build.sh $@
+  ./build.sh "$@"
 
   cd - >> /dev/null
 done

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,7 +20,7 @@ do
   cd "$PROJECT_ROOT/$SRC"
 
   cargo update
-  ./build.sh
+  ./build.sh "$@"
 
   cd - >> /dev/null
 done


### PR DESCRIPTION
This PR adds additional passthrough for shell scripts and fixes issues with d6e91c1335 (ping @tomaka ) in order to support command line arguments with spaces in them. Without the extra quotes those would get passed as separate (unquoted) arguments.