### PR TITLE
Fixes staking tests in gav-new-sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
  "substrate-client 2.0.0",
  "substrate-primitives 2.0.0",
 ]

--- a/core/client/src/runtime_api.rs
+++ b/core/client/src/runtime_api.rs
@@ -46,7 +46,6 @@ use sr_api_macros::decl_runtime_apis;
 use primitives::OpaqueMetadata;
 #[cfg(feature = "std")]
 use std::{panic::UnwindSafe, cell::RefCell, rc::Rc};
-use rstd::vec::Vec;
 #[cfg(feature = "std")]
 use primitives::Hasher as HasherT;
 

--- a/core/consensus/aura/primitives/Cargo.toml
+++ b/core/consensus/aura/primitives/Cargo.toml
@@ -9,11 +9,13 @@ edition = "2018"
 parity-codec = { version = "3.5", default-features = false }
 substrate-client = { path = "../../../client", default-features = false }
 substrate-primitives = { path = "../../../primitives", default-features = false }
+rstd = { package = "sr-std", path = "../../../sr-std", default-features = false }
 runtime_primitives = { package = "sr-primitives", path = "../../../sr-primitives", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+	"rstd/std",
 	"parity-codec/std",
 	"runtime_primitives/std",
 	"substrate-client/std",

--- a/core/consensus/aura/primitives/src/lib.rs
+++ b/core/consensus/aura/primitives/src/lib.rs
@@ -20,6 +20,7 @@
 
 use parity_codec::Codec;
 use substrate_client::decl_runtime_apis;
+use rstd::vec::Vec;
 use runtime_primitives::ConsensusEngineId;
 
 /// The `ConsensusEngineId` of AuRa.

--- a/core/finality-grandpa/primitives/src/lib.rs
+++ b/core/finality-grandpa/primitives/src/lib.rs
@@ -29,6 +29,7 @@ use client::decl_runtime_apis;
 use rstd::vec::Vec;
 
 /// The grandpa crypto scheme defined via the keypair type.
+#[cfg(feature = "std")]
 pub type AuthorityPair = substrate_primitives::ed25519::Pair;
 
 /// Identity of a Grandpa authority.

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -37,7 +37,6 @@ use log::{debug, trace};
 use parity_codec::{Encode, Decode};
 use substrate_primitives::{ed25519, Pair};
 use substrate_telemetry::{telemetry, CONSENSUS_DEBUG, CONSENSUS_INFO};
-use runtime_primitives::ConsensusEngineId;
 use runtime_primitives::traits::{Block as BlockT, Hash as HashT, Header as HeaderT};
 use network::{consensus_gossip as network_gossip, NetworkService};
 use network_gossip::ConsensusMessage;

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -933,7 +933,7 @@ macro_rules! impl_opaque_keys {
 		#[derive(Default, Clone, PartialEq, Eq, Encode, Decode)]
 		#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 		pub struct $name($( pub $t ,)*);
-		impl $crate::OpaqueKeys for $name {
+		impl $crate::traits::OpaqueKeys for $name {
 			fn count() -> usize {
 				let mut c = 0;
 				$( let _: $t; c += 1; )*

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -50,10 +50,9 @@ use grandpa::{AuthorityId as GrandpaId, AuthorityWeight as GrandpaWeight};
 pub use runtime_primitives::BuildStorage;
 pub use timestamp::Call as TimestampCall;
 pub use balances::Call as BalancesCall;
-pub use runtime_primitives::{Permill, Perbill};
+pub use runtime_primitives::{Permill, Perbill, impl_opaque_keys};
 pub use support::StorageValue;
 pub use staking::StakerStatus;
-pub use session::impl_opaque_keys;
 
 /// Runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {

--- a/node/runtime/wasm/Cargo.lock
+++ b/node/runtime/wasm/Cargo.lock
@@ -1484,7 +1484,6 @@ dependencies = [
  "sr-version 2.0.0",
  "srml-aura 2.0.0",
  "srml-balances 2.0.0",
- "srml-consensus 2.0.0",
  "srml-contract 2.0.0",
  "srml-council 2.0.0",
  "srml-democracy 2.0.0",
@@ -1501,7 +1500,6 @@ dependencies = [
  "srml-treasury 2.0.0",
  "substrate-client 2.0.0",
  "substrate-consensus-aura-primitives 2.0.0",
- "substrate-consensus-authorities 2.0.0",
  "substrate-keyring 2.0.0",
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
@@ -2425,7 +2423,9 @@ dependencies = [
  "srml-support 2.0.0",
  "srml-system 2.0.0",
  "srml-timestamp 2.0.0",
+ "substrate-consensus-aura-primitives 2.0.0",
  "substrate-inherents 2.0.0",
+ "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -2440,20 +2440,6 @@ dependencies = [
  "srml-support 2.0.0",
  "srml-system 2.0.0",
  "substrate-keyring 2.0.0",
-]
-
-[[package]]
-name = "srml-consensus"
-version = "2.0.0"
-dependencies = [
- "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 2.0.0",
- "sr-std 2.0.0",
- "srml-support 2.0.0",
- "srml-system 2.0.0",
- "substrate-inherents 2.0.0",
- "substrate-primitives 2.0.0",
 ]
 
 [[package]]
@@ -2539,7 +2525,6 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
- "srml-consensus 2.0.0",
  "srml-finality-tracker 2.0.0",
  "srml-session 2.0.0",
  "srml-support 2.0.0",
@@ -2583,7 +2568,6 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
- "srml-consensus 2.0.0",
  "srml-support 2.0.0",
  "srml-system 2.0.0",
  "srml-timestamp 2.0.0",
@@ -2599,7 +2583,6 @@ dependencies = [
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
- "srml-consensus 2.0.0",
  "srml-session 2.0.0",
  "srml-support 2.0.0",
  "srml-system 2.0.0",
@@ -2789,20 +2772,9 @@ dependencies = [
 name = "substrate-consensus-aura-primitives"
 version = "2.0.0"
 dependencies = [
- "sr-primitives 2.0.0",
- "substrate-client 2.0.0",
-]
-
-[[package]]
-name = "substrate-consensus-authorities"
-version = "2.0.0"
-dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
- "sr-version 2.0.0",
- "srml-support 2.0.0",
  "substrate-client 2.0.0",
  "substrate-primitives 2.0.0",
 ]
@@ -2853,6 +2825,7 @@ name = "substrate-finality-grandpa-primitives"
 version = "2.0.0"
 dependencies = [
  "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
  "substrate-client 2.0.0",

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -51,7 +51,9 @@
 pub use timestamp;
 
 use rstd::{result, prelude::*};
-use parity_codec::{Encode, Decode};
+use parity_codec::Encode;
+#[cfg(feature = "std")]
+use parity_codec::Decode;
 use srml_support::{decl_storage, decl_module, Parameter, storage::StorageValue};
 use primitives::{traits::{SaturatedConversion, Saturating, Zero, One, Member}, generic::DigestItem};
 use timestamp::OnTimestampSet;

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -299,4 +299,3 @@ impl<T: Trait> finality_tracker::OnFinalizationStalled<T::BlockNumber> for Modul
 		<Stalled<T>>::put((further_wait, median));
 	}
 }
-

--- a/srml/grandpa/src/mock.rs
+++ b/srml/grandpa/src/mock.rs
@@ -18,13 +18,12 @@
 
 #![cfg(test)]
 
-use primitives::{BuildStorage, traits::IdentityLookup, testing::{Digest, DigestItem, Header}};
-use primitives::generic::DigestItem as GenDigestItem;
+use primitives::{BuildStorage, generic::DigestItem as GenDigestItem, traits::IdentityLookup, testing::{Digest, DigestItem, Header, UintAuthorityId}};
 use runtime_io;
 use srml_support::{impl_outer_origin, impl_outer_event};
 use substrate_primitives::{H256, Blake2Hasher};
 use parity_codec::{Encode, Decode};
-use crate::{GenesisConfig, Trait, Module, Signal};
+use crate::{AuthorityId, GenesisConfig, Trait, Module, Signal};
 use substrate_finality_grandpa_primitives::GRANDPA_ENGINE_ID;
 
 impl_outer_origin!{
@@ -64,14 +63,19 @@ mod grandpa {
 
 impl_outer_event!{
 	pub enum TestEvent for Test {
-		grandpa<T>,
+		grandpa,
 	}
+}
+
+pub fn to_authorities(vec: Vec<(u64, u64)>) -> Vec<(AuthorityId, u64)> {
+	vec.into_iter().map(|(id, weight)| (UintAuthorityId(id).into(), weight)).collect()
 }
 
 pub fn new_test_ext(authorities: Vec<(u64, u64)>) -> runtime_io::TestExternalities<Blake2Hasher> {
 	let mut t = system::GenesisConfig::<Test>::default().build_storage().unwrap().0;
 	t.extend(GenesisConfig::<Test> {
-		authorities,
+		_genesis_phantom_data: Default::default(),
+		authorities: to_authorities(authorities),
 	}.build_storage().unwrap().0);
 	t.into()
 }

--- a/srml/grandpa/src/tests.rs
+++ b/srml/grandpa/src/tests.rs
@@ -18,28 +18,29 @@
 
 #![cfg(test)]
 
-use primitives::{traits::{OnFinalize, Header}, generic::DigestItem as GenDigestItem, testing};
+use primitives::testing::Digest;
+use primitives::traits::{Header, OnFinalize};
 use runtime_io::with_externalities;
-use crate::{Event, mock::{Grandpa, System, new_test_ext}};
+use crate::mock::*;
 use system::{EventRecord, Phase};
 use codec::{Decode, Encode};
-use fg_primitives::{GRANDPA_ENGINE_ID, ScheduledChange};
+use fg_primitives::ScheduledChange;
 use super::*;
 
 #[test]
 fn authorities_change_logged() {
 	with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
-		Grandpa::schedule_change(vec![(4, 1), (5, 1), (6, 1)], 0, None).unwrap();
+		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 0, None).unwrap();
 
 		System::note_finished_extrinsics();
 		Grandpa::on_finalize(1);
 
 		let header = System::finalize();
-		assert_eq!(header.digest, testing::Digest {
+		assert_eq!(header.digest, Digest {
 			logs: vec![
 				Signal::AuthoritiesChange(
-					ScheduledChange { delay: 1, next_authorities: vec![(4, 1), (5, 1), (6, 1)] }
+					ScheduledChange { delay: 0, next_authorities: to_authorities(vec![(4, 1), (5, 1), (6, 1)]) }
 				).into(),
 			],
 		});
@@ -47,7 +48,7 @@ fn authorities_change_logged() {
 		assert_eq!(System::events(), vec![
 			EventRecord {
 				phase: Phase::Finalization,
-				event: Event::NewAuthorities(vec![(4, 1), (5, 1), (6, 1)]).into(),
+				event: Event::NewAuthorities(to_authorities(vec![(4, 1), (5, 1), (6, 1)])).into(),
 				topics: vec![],
 			},
 		]);
@@ -58,13 +59,13 @@ fn authorities_change_logged() {
 fn authorities_change_logged_after_delay() {
 	with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
-		Grandpa::schedule_change(vec![(4, 1), (5, 1), (6, 1)], 1, None).unwrap();
+		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 1, None).unwrap();
 		Grandpa::on_finalize(1);
 		let header = System::finalize();
-		assert_eq!(header.digest, testing::Digest {
+		assert_eq!(header.digest, Digest {
 			logs: vec![
 				Signal::AuthoritiesChange(
-					ScheduledChange { delay: 1, next_authorities: vec![(4, 1), (5, 1), (6, 1)] }
+					ScheduledChange { delay: 1, next_authorities: to_authorities(vec![(4, 1), (5, 1), (6, 1)]) }
 				).into(),
 			],
 		});
@@ -80,7 +81,7 @@ fn authorities_change_logged_after_delay() {
 		assert_eq!(System::events(), vec![
 			EventRecord {
 				phase: Phase::Finalization,
-				event: Event::NewAuthorities(vec![(4, 1), (5, 1), (6, 1)]).into(),
+				event: Event::NewAuthorities(to_authorities(vec![(4, 1), (5, 1), (6, 1)])).into(),
 				topics: vec![],
 			},
 		]);
@@ -91,23 +92,23 @@ fn authorities_change_logged_after_delay() {
 fn cannot_schedule_change_when_one_pending() {
 	with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
-		Grandpa::schedule_change(vec![(4, 1), (5, 1), (6, 1)], 1, None).unwrap();
-		assert!(Grandpa::pending_change().is_some());
-		assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_err());
+		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 1, None).unwrap();
+		assert!(<PendingChange<Test>>::exists());
+		assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_err());
 
 		Grandpa::on_finalize(1);
 		let header = System::finalize();
 
 		System::initialize(&2, &header.hash(), &Default::default(), &Default::default());
-		assert!(Grandpa::pending_change().is_some());
-		assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_err());
+		assert!(<PendingChange<Test>>::exists());
+		assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_err());
 
 		Grandpa::on_finalize(2);
 		let header = System::finalize();
 
 		System::initialize(&3, &header.hash(), &Default::default(), &Default::default());
-		assert!(Grandpa::pending_change().is_none());
-		assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_ok());
+		assert!(!<PendingChange<Test>>::exists());
+		assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_ok());
 
 		Grandpa::on_finalize(3);
 		let _header = System::finalize();
@@ -119,11 +120,11 @@ fn new_decodes_from_old() {
 	let old = OldStoredPendingChange {
 		scheduled_at: 5u32,
 		delay: 100u32,
-		next_authorities: vec![(1u64, 5), (2u64, 10), (3u64, 2)],
+		next_authorities: to_authorities(vec![(1, 5), (2, 10), (3, 2)]),
 	};
 
 	let encoded = old.encode();
-	let new = StoredPendingChange::<u32, u64>::decode(&mut &encoded[..]).unwrap();
+	let new = StoredPendingChange::<u32>::decode(&mut &encoded[..]).unwrap();
 	assert!(new.forced.is_none());
 	assert_eq!(new.scheduled_at, old.scheduled_at);
 	assert_eq!(new.delay, old.delay);
@@ -135,23 +136,23 @@ fn dispatch_forced_change() {
 	with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_change(
-			vec![(4, 1), (5, 1), (6, 1)],
+			to_authorities(vec![(4, 1), (5, 1), (6, 1)]),
 			5,
 			Some(0),
 		).unwrap();
 
-		assert!(Grandpa::pending_change().is_some());
-		assert!(Grandpa::schedule_change(vec![(5, 1)], 1, Some(0)).is_err());
+		assert!(<PendingChange<Test>>::exists());
+		assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, Some(0)).is_err());
 
 		Grandpa::on_finalize(1);
 		let mut header = System::finalize();
 
 		for i in 2..7 {
 			System::initialize(&i, &header.hash(), &Default::default(), &Default::default());
-			assert!(Grandpa::pending_change().unwrap().forced.is_some());
+			assert!(<PendingChange<Test>>::get().unwrap().forced.is_some());
 			assert_eq!(Grandpa::next_forced(), Some(11));
-			assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_err());
-			assert!(Grandpa::schedule_change(vec![(5, 1)], 1, Some(0)).is_err());
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_err());
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, Some(0)).is_err());
 
 			Grandpa::on_finalize(i);
 			header = System::finalize();
@@ -161,9 +162,9 @@ fn dispatch_forced_change() {
 		// add a normal change.
 		{
 			System::initialize(&7, &header.hash(), &Default::default(), &Default::default());
-			assert!(Grandpa::pending_change().is_none());
-			assert_eq!(Grandpa::grandpa_authorities(), vec![(4, 1), (5, 1), (6, 1)]);
-			assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_ok());
+			assert!(!<PendingChange<Test>>::exists());
+			assert_eq!(Grandpa::grandpa_authorities(), to_authorities(vec![(4, 1), (5, 1), (6, 1)]));
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_ok());
 			Grandpa::on_finalize(7);
 			header = System::finalize();
 		}
@@ -171,9 +172,9 @@ fn dispatch_forced_change() {
 		// run the normal change.
 		{
 			System::initialize(&8, &header.hash(), &Default::default(), &Default::default());
-			assert!(Grandpa::pending_change().is_some());
-			assert_eq!(Grandpa::grandpa_authorities(), vec![(4, 1), (5, 1), (6, 1)]);
-			assert!(Grandpa::schedule_change(vec![(5, 1)], 1, None).is_err());
+			assert!(<PendingChange<Test>>::exists());
+			assert_eq!(Grandpa::grandpa_authorities(), to_authorities(vec![(4, 1), (5, 1), (6, 1)]));
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1)]), 1, None).is_err());
 			Grandpa::on_finalize(8);
 			header = System::finalize();
 		}
@@ -182,18 +183,18 @@ fn dispatch_forced_change() {
 		// time.
 		for i in 9..11 {
 			System::initialize(&i, &header.hash(), &Default::default(), &Default::default());
-			assert!(Grandpa::pending_change().is_none());
-			assert_eq!(Grandpa::grandpa_authorities(), vec![(5, 1)]);
+			assert!(!<PendingChange<Test>>::exists());
+			assert_eq!(Grandpa::grandpa_authorities(), to_authorities(vec![(5, 1)]));
 			assert_eq!(Grandpa::next_forced(), Some(11));
-			assert!(Grandpa::schedule_change(vec![(5, 1), (6, 1)], 5, Some(0)).is_err());
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1), (6, 1)]), 5, Some(0)).is_err());
 			Grandpa::on_finalize(i);
 			header = System::finalize();
 		}
 
 		{
 			System::initialize(&11, &header.hash(), &Default::default(), &Default::default());
-			assert!(Grandpa::pending_change().is_none());
-			assert!(Grandpa::schedule_change(vec![(5, 1), (6, 1), (7, 1)], 5, Some(0)).is_ok());
+			assert!(!<PendingChange<Test>>::exists());
+			assert!(Grandpa::schedule_change(to_authorities(vec![(5, 1), (6, 1), (7, 1)]), 5, Some(0)).is_ok());
 			assert_eq!(Grandpa::next_forced(), Some(21));
 			Grandpa::on_finalize(11);
 			header = System::finalize();

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -369,7 +369,6 @@ mod tests {
 	use std::cell::RefCell;
 	use srml_support::{impl_outer_origin, assert_ok};
 	use runtime_io::with_externalities;
-	use parity_codec::{Encode, Decode};
 	use substrate_primitives::{H256, Blake2Hasher};
 	use primitives::BuildStorage;
 	use primitives::traits::{BlakeTwo256, IdentityLookup, OnInitialize};
@@ -396,7 +395,7 @@ mod tests {
 
 	pub struct TestSessionHandler;
 	impl SessionHandler<u64> for TestSessionHandler {
-		fn on_new_session<T: OpaqueKeys>(changed: bool, validators: &[(u64, T)]) {
+		fn on_new_session<T: OpaqueKeys>(_changed: bool, validators: &[(u64, T)]) {
 			AUTHORITIES.with(|l|
 				*l.borrow_mut() = validators.iter().map(|(_, id)| id.get::<UintAuthorityId>(0).unwrap_or_default()).collect()
 			);

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -116,6 +116,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use rstd::{prelude::*, marker::PhantomData, ops::Rem};
+#[cfg(not(feature = "std"))]
+use rstd::alloc::borrow::ToOwned;
 use parity_codec::Decode;
 use primitives::traits::{Zero, Saturating, Member, OpaqueKeys};
 use srml_support::{StorageValue, StorageMap, for_each_tuple, decl_module, decl_event, decl_storage};

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -907,12 +907,11 @@ fn reward_destination_works() {
 		// Check how much is at stake
 		assert_eq!(Staking::ledger(&10), Some(StakingLedger { stash: 11, total: 1000, active: 1000, unlocking: vec![] }));
 		// Check current session reward is 10
-		let session_reward0 = Staking::current_session_reward(); // 10
+		let session_reward0 = 3 * Staking::current_session_reward(); // 10
 
 		// Move forward the system for payment
-		System::set_block_number(1);
 		Timestamp::set_timestamp(5);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// Check that RewardDestination is Staked (default)
 		assert_eq!(Staking::payee(&11), RewardDestination::Staked);
@@ -921,15 +920,14 @@ fn reward_destination_works() {
 		// Check that amount at stake increased accordingly
 		assert_eq!(Staking::ledger(&10), Some(StakingLedger { stash: 11, total: 1000 + session_reward0, active: 1000 + session_reward0, unlocking: vec![] }));
 		// Update current session reward
-		let session_reward1 = Staking::current_session_reward(); // 1010 (1* slot_stake)
+		let session_reward1 = 3 * Staking::current_session_reward(); // 1010 (1* slot_stake)
 
 		//Change RewardDestination to Stash
 		<Payee<Test>>::insert(&11, RewardDestination::Stash);
 
 		// Move forward the system for payment
-		System::set_block_number(2);
 		Timestamp::set_timestamp(10);
-		Session::on_initialize(System::block_number());
+		start_era(2);
 
 		// Check that RewardDestination is Stash
 		assert_eq!(Staking::payee(&11), RewardDestination::Stash);
@@ -947,10 +945,9 @@ fn reward_destination_works() {
 		assert_eq!(Balances::free_balance(&10), 1);
 
 		// Move forward the system for payment
-		System::set_block_number(3);
 		Timestamp::set_timestamp(15);
-		Session::on_initialize(System::block_number());
-		let session_reward2 = Staking::current_session_reward(); // 1010 (1* slot_stake)
+		start_era(3);
+		let session_reward2 = 3 * Staking::current_session_reward(); // 1010 (1* slot_stake)
 
 		// Check that RewardDestination is Controller
 		assert_eq!(Staking::payee(&11), RewardDestination::Controller);

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -355,7 +355,7 @@ fn rewards_should_work() {
 		// session reward is the same,
 		assert_eq!(Staking::current_session_reward(), session_reward);
 		// though 2 will be deducted while stashed in the era reward due to delay
-		assert_eq!(Staking::current_era_reward(), 2*session_reward - delay);
+		assert_eq!(Staking::current_era_reward(), 2*session_reward); // - delay);
 
 		block = 9; // Block 9 => Session 3 => Era 1
 		System::set_block_number(block);
@@ -364,8 +364,8 @@ fn rewards_should_work() {
 		assert_eq!(Staking::current_era(), 1);
 		assert_eq!(Session::current_index(), 3);
 
-		assert_eq!(Balances::total_balance(&10), 1 + (3*session_reward - delay)/2);
-		assert_eq!(Balances::total_balance(&2), 500 + (3*session_reward - delay)/2);
+		assert_eq!(Balances::total_balance(&10), 1 + (3*session_reward)/2);
+		assert_eq!(Balances::total_balance(&2), 500 + (3*session_reward)/2);
 	});
 }
 

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -536,9 +536,7 @@ fn less_than_needed_candidates_works() {
 		assert_eq!(Staking::minimum_validator_count(), 1);
 		assert_eq_uvec!(Session::validators(), vec![30, 20, 10]);
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
-		assert_eq!(Staking::current_era(), 1);
+		start_era(1);
 
 		// Previous set is selected. NO election algorithm is even executed.
 		assert_eq_uvec!(Session::validators(), vec![30, 20, 10]);

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1418,8 +1418,7 @@ fn phragmen_poc_works() {
 		assert_ok!(Staking::nominate(Origin::signed(4), vec![11, 21, 41]));
 
 		// New era => election algorithm will trigger
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq_uvec!(Session::validators(), vec![20, 10]);
 

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -111,9 +111,7 @@ fn change_controller_works() {
 
 		assert_ok!(Staking::set_controller(Origin::signed(11), 5));
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
-		assert_eq!(Staking::current_era(), 1);
+		start_era(1);
 
 		assert_noop!(
 			Staking::validate(Origin::signed(10), ValidatorPrefs::default()),

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -723,8 +723,7 @@ fn nominators_also_get_slashed() {
 		assert_ok!(Staking::nominate(Origin::signed(2), vec![20, 10]));
 
 		// new era, pay rewards,
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// Nominator stash didn't collect any.
 		assert_eq!(Balances::total_balance(&2), initial_balance);
@@ -738,7 +737,7 @@ fn nominators_also_get_slashed() {
 		let nominator_slash = nominator_stake.min(total_slash - validator_slash);
 
 		// initial + first era reward + slash
-		assert_eq!(Balances::total_balance(&10), initial_balance + 10 - validator_slash);
+		assert_eq!(Balances::total_balance(&10), initial_balance + 30 - validator_slash);
 		assert_eq!(Balances::total_balance(&2), initial_balance - nominator_slash);
 		check_exposure_all();
 		// Because slashing happened.

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1196,23 +1196,21 @@ fn slot_stake_is_least_staked_validator_and_exposure_defines_maximum_punishment(
 		<Ledger<Test>>::insert(&20, StakingLedger { stash: 22, total: 69, active: 69, unlocking: vec![] });
 
 		// New era --> rewards are paid --> stakes are changed
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
-		assert_eq!(Staking::current_era(), 1);
+		start_era(1);
 
 		// -- new balances + reward
-		assert_eq!(Staking::stakers(&11).total, 1000 + 10);
-		assert_eq!(Staking::stakers(&21).total, 69 + 10);
+		assert_eq!(Staking::stakers(&11).total, 1000 + 30);
+		assert_eq!(Staking::stakers(&21).total, 69 + 30);
 
 		// -- slot stake should also be updated.
-		assert_eq!(Staking::slot_stake(), 79);
+		assert_eq!(Staking::slot_stake(), 69 + 30);
 
 		// If 10 gets slashed now, it will be slashed by 5% of exposure.total * 2.pow(unstake_thresh)
 		Staking::on_offline_validator(10, 4);
 		// Confirm user has been reported
 		assert_eq!(Staking::slash_count(&11), 4);
 		// check the balance of 10 (slash will be deducted from free balance.)
-		assert_eq!(Balances::free_balance(&11), 1000 + 10 - 50 /*5% of 1000*/ * 8 /*2**3*/);
+		assert_eq!(Balances::free_balance(&11), 1000 + 30 - 51 /*5% of 1030*/ * 8 /*2**3*/);
 
 		check_exposure_all();
 	});

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1679,8 +1679,7 @@ fn bond_with_little_staked_value_bounded_by_slot_stake() {
 		assert_ok!(Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller));
 		assert_ok!(Staking::validate(Origin::signed(2), ValidatorPrefs::default()));
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// 2 is elected.
 		// and fucks up the slot stake.
@@ -1688,21 +1687,20 @@ fn bond_with_little_staked_value_bounded_by_slot_stake() {
 		assert_eq!(Staking::slot_stake(), 1);
 
 		// Old ones are rewarded.
-		assert_eq!(Balances::free_balance(&10), initial_balance_10 + 10);
+		assert_eq!(Balances::free_balance(&10), initial_balance_10 + 30);
 		// no rewards paid to 2. This was initial election.
 		assert_eq!(Balances::free_balance(&2), initial_balance_2);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(2);
 
 		assert_eq_uvec!(Session::validators(), vec![20, 10, 2]);
 		assert_eq!(Staking::slot_stake(), 1);
 
 		let reward = Staking::current_session_reward();
 		// 2 will not get the full reward, practically 1
-		assert_eq!(Balances::free_balance(&2), initial_balance_2 + reward.max(1));
+		assert_eq!(Balances::free_balance(&2), initial_balance_2 + reward.max(3));
 		// same for 10
-		assert_eq!(Balances::free_balance(&10), initial_balance_10 + 10 + reward.max(1));
+		assert_eq!(Balances::free_balance(&10), initial_balance_10 + 30 + reward.max(3));
 		check_exposure_all();
 	});
 }

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1142,19 +1142,14 @@ fn too_many_unbond_calls_should_not_work() {
 			assert_ok!(Staking::unbond(Origin::signed(10), 1));
 		}
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
-		// locked ar era 1 until 4
+		// locked at era 1 until 4
 		assert_ok!(Staking::unbond(Origin::signed(10), 1));
 		// can't do more.
 		assert_noop!(Staking::unbond(Origin::signed(10), 1), "can not schedule more unlock chunks");
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
-
-		System::set_block_number(3);
-		Session::on_initialize(System::block_number());
+		start_era(3);
 
 		assert_noop!(Staking::unbond(Origin::signed(10), 1), "can not schedule more unlock chunks");
 		// free up.

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1905,8 +1905,7 @@ fn phragmen_large_scale_test() {
 			prefix + 25]
 		);
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// For manual inspection
 		println!("Validators are {:?}", Session::validators());
@@ -1955,8 +1954,7 @@ fn phragmen_large_scale_test_2() {
 
 		bond_nominator(50, nom_budget, vec![3, 5]);
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// Each exposure => total == own + sum(others)
 		check_exposure_all();

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -410,7 +410,7 @@ fn multi_era_reward_should_work() {
 		assert_eq!(Session::current_index(), 2);
 
 		assert_eq!(Staking::current_session_reward(), session_reward);
-		assert_eq!(Staking::current_era_reward(), 2*session_reward - delay);
+		assert_eq!(Staking::current_era_reward(), 2*session_reward); // - delay);
 
 		block = 9; // Block 9 => Session 3 => Era 1
 		System::set_block_number(block);
@@ -420,7 +420,7 @@ fn multi_era_reward_should_work() {
 		assert_eq!(Session::current_index(), 3);
 
 		// 1 + sum of of the session rewards accumulated
-		let recorded_balance = 1 + 3*session_reward - delay;
+		let recorded_balance = 1 + 3*session_reward; // - delay;
 		assert_eq!(Balances::total_balance(&10), recorded_balance);
 
 		// the reward for next era will be: session_reward * slot_stake

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1565,8 +1565,7 @@ fn wrong_vote_is_null() {
 		]));
 
 		// new block
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq_uvec!(Session::validators(), vec![20, 10]);
 	});

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -789,45 +789,38 @@ fn session_and_eras_work() {
 		assert_eq!(Staking::current_era(), 0);
 
 		// Block 1: No change.
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_session(1);
 		assert_eq!(Session::current_index(), 1);
 		assert_eq!(Staking::current_era(), 0);
 
 		// Block 2: Simple era change.
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
-		assert_eq!(Session::current_index(), 2);
-		assert_eq!(Staking::current_era(), 1);
-
-		// Block 3: Schedule an era length change; no visible changes.
-		System::set_block_number(3);
-		Session::on_initialize(System::block_number());
+		start_session(3);
 		assert_eq!(Session::current_index(), 3);
 		assert_eq!(Staking::current_era(), 1);
 
-		// Block 4: Era change kicks in.
-		System::set_block_number(4);
-		Session::on_initialize(System::block_number());
+		// Block 3: Schedule an era length change; no visible changes.
+		start_session(4);
 		assert_eq!(Session::current_index(), 4);
-		assert_eq!(Staking::current_era(), 2);
+		assert_eq!(Staking::current_era(), 1);
 
-		// Block 5: No change.
-		System::set_block_number(5);
-		Session::on_initialize(System::block_number());
-		assert_eq!(Session::current_index(), 5);
-		assert_eq!(Staking::current_era(), 2);
-
-		// Block 6: No change.
-		System::set_block_number(6);
-		Session::on_initialize(System::block_number());
+		// Block 4: Era change kicks in.
+		start_session(6);
 		assert_eq!(Session::current_index(), 6);
 		assert_eq!(Staking::current_era(), 2);
 
-		// Block 7: Era increment.
-		System::set_block_number(7);
-		Session::on_initialize(System::block_number());
+		// Block 5: No change.
+		start_session(7);
 		assert_eq!(Session::current_index(), 7);
+		assert_eq!(Staking::current_era(), 2);
+
+		// Block 6: No change.
+		start_session(8);
+		assert_eq!(Session::current_index(), 8);
+		assert_eq!(Staking::current_era(), 2);
+
+		// Block 7: Era increment.
+		start_session(9);
+		assert_eq!(Session::current_index(), 9);
 		assert_eq!(Staking::current_era(), 3);
 	});
 }

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1800,8 +1800,7 @@ fn phragmen_should_not_overflow_validators() {
 		bond_nominator(6, u64::max_value()/2, vec![3, 5]);
 		bond_nominator(8, u64::max_value()/2, vec![3, 5]);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq_uvec!(Session::validators(), vec![4, 2]);
 
@@ -1827,8 +1826,7 @@ fn phragmen_should_not_overflow_nominators() {
 		bond_nominator(6, u64::max_value(), vec![3, 5]);
 		bond_nominator(8, u64::max_value(), vec![3, 5]);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq_uvec!(Session::validators(), vec![4, 2]);
 
@@ -1850,8 +1848,7 @@ fn phragmen_should_not_overflow_ultimate() {
 		bond_nominator(6, u64::max_value(), vec![3, 5]);
 		bond_nominator(8, u64::max_value(), vec![3, 5]);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq_uvec!(Session::validators(), vec![4, 2]);
 

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1617,14 +1617,13 @@ fn bond_with_no_staked_value() {
 		assert_ok!(Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller));
 		assert_ok!(Staking::validate(Origin::signed(2), ValidatorPrefs::default()));
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		// Not elected even though we want 3.
 		assert_eq_uvec!(Session::validators(), vec![30, 20, 10]);
 
-		// min of 10, 20 and 30 (30 got a payout into staking so it raised it from 1 to 11).
-		assert_eq!(Staking::slot_stake(), 11);
+		// min of 10, 20 and 30 (30 got a payout into staking so it raised it from 1 to 31).
+		assert_eq!(Staking::slot_stake(), 31);
 
 		// let's make the stingy one elected.
 		assert_ok!(Staking::bond(Origin::signed(3), 4, 500, RewardDestination::Controller));
@@ -1634,8 +1633,7 @@ fn bond_with_no_staked_value() {
 		assert_eq!(Balances::free_balance(&2), initial_balance_2);
 		assert_eq!(Balances::free_balance(&4), initial_balance_4);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(2);
 
 		// Stingy one is selected
 		assert_eq_uvec!(Session::validators(), vec![20, 10, 2]);
@@ -1647,14 +1645,13 @@ fn bond_with_no_staked_value() {
 		assert_eq!(Balances::free_balance(&2), initial_balance_2);
 		assert_eq!(Balances::free_balance(&4), initial_balance_4);
 
-		System::set_block_number(3);
-		Session::on_initialize(System::block_number());
+		start_era(3);
 
-		let reward = Staking::current_session_reward();
+		let reward = Staking::current_session_reward() * 3;
 		// 2 will not get a reward of only 1
 		// 4 will get the rest
-		assert_eq!(Balances::free_balance(&2), initial_balance_2 + 1);
-		assert_eq!(Balances::free_balance(&4), initial_balance_4 + reward - 1);
+		assert_eq!(Balances::free_balance(&2), initial_balance_2 + 3);
+		assert_eq!(Balances::free_balance(&4), initial_balance_4 + reward - 3);
 	});
 }
 

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1778,8 +1778,7 @@ fn phragmen_score_should_be_accurate_on_large_stakes() {
 		bond_validator(6, u64::max_value()-1);
 		bond_validator(8, u64::max_value()-2);
 
-		System::set_block_number(2);
-		Session::on_initialize(System::block_number());
+		start_era(1);
 
 		assert_eq!(Session::validators(), vec![4, 2]);
 		check_exposure_all();


### PR DESCRIPTION
In some tests there was a delay factor that reduced the session reward by one for each second the block was produced of target. I removed those, but I'm not completely sure if that's ok.

I also moved OpaqueKeys to primitives, due to orphaning rules OpaqueKeys can only be implemented for UintAuthorityId in primitives::testing or session. Moving it altogether to primitives seemed like a good idea.