### PR TITLE
Fixed integration tests run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,6 +119,7 @@ test-linux-stable:
 
 test-linux-stable-int:             &test
   stage:                           test
+  <<:                              *docker-env
   variables:
     RUST_TOOLCHAIN: stable
     # Enable debug assertions since we are running optimized builds for testing


### PR DESCRIPTION
Here's an error: https://gitlab.parity.io/parity/substrate/-/jobs/160376.
I guess it just hasn't been updated in #2752 