### PR TITLE
Various minor fixes

### DIFF
--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -175,7 +175,7 @@ pub fn import_blocks<F, E, R>(
 
 		block_count = b;
 		if b % 1000 == 0 {
-			info!("#{}", b);
+			info!("#{} blocks were added to the queue", b);
 		}
 	}
 
@@ -184,6 +184,13 @@ pub fn import_blocks<F, E, R>(
 		wait_recv.recv()
 			.expect("Importing thread has panicked. Then the main process will die before this can be reached. qed.");
 		blocks_imported += 1;
+		if blocks_imported % 1000 == 0 {
+			info!(
+				"#{} blocks were imported (#{} left)",
+				blocks_imported,
+				count - blocks_imported
+			);
+		}
 	}
 
 	info!("Imported {} blocks. Best: #{}", block_count, client.info().chain.best_number);

--- a/core/sr-api-macros/benches/bench.rs
+++ b/core/sr-api-macros/benches/bench.rs
@@ -16,8 +16,8 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use test_client::{
-	DefaultTestClientBuilderExt, TestClientBuilder,
-    TestClientBuilderExt, runtime::TestAPI
+    DefaultTestClientBuilderExt, TestClientBuilder,
+    TestClientBuilderExt, runtime::TestAPI,
 };
 use runtime_primitives::{generic::BlockId, traits::ProvideRuntimeApi};
 use state_machine::ExecutionStrategy;

--- a/core/sr-api-macros/benches/bench.rs
+++ b/core/sr-api-macros/benches/bench.rs
@@ -15,7 +15,10 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use test_client::runtime::TestAPI;
+use test_client::{
+	DefaultTestClientBuilderExt, TestClientBuilder,
+    TestClientBuilderExt, runtime::TestAPI
+};
 use runtime_primitives::{generic::BlockId, traits::ProvideRuntimeApi};
 use state_machine::ExecutionStrategy;
 
@@ -53,13 +56,13 @@ fn sr_api_benchmark(c: &mut Criterion) {
 	});
 
 	c.bench_function("calling function by function pointer in wasm", |b| {
-		let client = test_client::new_with_execution_strategy(ExecutionStrategy::AlwaysWasm);
+		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 		let block_id = BlockId::Number(client.info().chain.best_number);
 		b.iter(|| client.runtime_api().benchmark_indirect_call(&block_id).unwrap())
 	});
 
 	c.bench_function("calling function in wasm", |b| {
-		let client = test_client::new_with_execution_strategy(ExecutionStrategy::AlwaysWasm);
+		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 		let block_id = BlockId::Number(client.info().chain.best_number);
 		b.iter(|| client.runtime_api().benchmark_direct_call(&block_id).unwrap())
 	});

--- a/core/telemetry/src/lib.rs
+++ b/core/telemetry/src/lib.rs
@@ -111,7 +111,7 @@ pub const SUBSTRATE_INFO: &str = "0";
 pub const CONSENSUS_TRACE: &str = "9";
 pub const CONSENSUS_DEBUG: &str = "5";
 pub const CONSENSUS_WARN: &str = "4";
-pub const CONSENSUS_INFO: &str = "0";
+pub const CONSENSUS_INFO: &str = "1";
 
 /// Telemetry object. Implements `Future` and must be polled regularly.
 /// Contains an `Arc` and can be cloned and pass around. Only one clone needs to be polled

--- a/test-utils/transaction-factory/src/complex_mode.rs
+++ b/test-utils/transaction-factory/src/complex_mode.rs
@@ -83,7 +83,7 @@ where
 	let seed = factory_state.start_number() + factory_state.block_no();
 	let to = RA::gen_random_account_id(&seed);
 
-	let mut amount;
+	let amount;
 	if factory_state.round() == RA::Number::zero() {
 		amount = RA::minimum_balance() * factory_state.rounds();
 	} else {


### PR DESCRIPTION
Changes consensus telemetry datapoints to not be send if the default telemetry logging level (`0`) is used, only if explicitly enabled (discussed with @gavofyork).

Fixes the bug from #2859, though the issue should not be closed until it's clear how (or if) we want to prevent this from reoccuring in the future.

Adds better import indication when importing from a file via cli (from #1860).