### PR TITLE
[WIP] fix overflow in staking

### DIFF
--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -317,8 +317,8 @@ impl<N: SimpleArithmetic + Clone> Rational<N> {
 		}
 
 		if num == den {
-			int += 1;
-			num = 0;
+			int += 1u8.into();
+			num = 0u8.into();
 		}
 
 		Rational { int, num, den }

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -306,7 +306,7 @@ impl<N: SimpleArithmetic + Clone> Rational<N> {
 	// operation of the remainder part in u64 arithmetic. (or u64, u128)
 	fn new(p: N, q: N) -> Self {
 		let mut num = p.clone() % q.clone();
-		let mut int = p - num.clone();
+		let mut int = p.clone() / q.clone();
 		let mut den = q;
 
 		// TODO: this can be improved using some dichotomic search.

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -2018,3 +2018,23 @@ fn phragmen_large_scale_test_2() {
 		assert_total_expo(5, nom_budget / 2 + c_budget);
 	})
 }
+
+#[test]
+fn rational() {
+	use std::convert::TryInto;
+
+	for &p in [0u32, 1, 2, 0x00ff_ffff, 0xffff_ffff, 0xa000_0000].into_iter() {
+		for &q in [1u32, 2, 0x00ff_ffff, 0xffff_ffff, 0xa000_0000].into_iter() {
+			let r = Rational::new(p, q);
+
+			for &t in [0u32, 1u32, 2, 0x00ff_ffff, 0xffff_ffff, 0xa000_0000].into_iter() {
+				let approx= r.clone().saturating_mul(t);
+				let res: u32 = (p as u64 * t as u64 / q as u64)
+					.try_into().unwrap_or(u32::max_value());
+
+				let err = (approx as i64 - res as i64).abs() as f64 / q as f64;
+				assert!(err < 0.0001);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduce a new struct Rational (that we might want to move to sr-primitves).

Rational allow to have a number represented as `int + num/den` with `num < den` and `den*num <= max_value`

This allows us to multiply whatever number with this rational it will only overflow if the actual result doesn't fits into N.

The property `den*num <= max_value` is done by lowering num/den precision, by deviding them by 2 as long as it is superior.

TODO:
* see todo in the code
* maybe some phragmen stuff as well.
* tests
* is the approximation OK ? how to evaluate that because I'm not confident at all with the current approximation actually

related to https://github.com/paritytech/substrate/issues/706 and https://github.com/paritytech/substrate/issues/1572

EDIT: another solution would be to ask simplearithmetic to have doublesize operation.

EDIT: another solution is to have an associated type which is ConvertDoubleSize, or DoOperationMultiplyDivide kind of things and let user do his operation