### PR TITLE
Handle RPC requests in the substrate-service

### DIFF
--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -22,7 +22,7 @@ use std::time;
 use futures::{Future, Stream};
 use service::{Service, Components};
 use tokio::runtime::TaskExecutor;
-use network::{SyncState, SyncProvider};
+use network::SyncState;
 use client::{backend::Backend, BlockchainEvents};
 use log::{info, warn};
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -43,7 +43,7 @@ pub mod test;
 pub use chain::{Client as ClientHandle, FinalityProofProvider};
 pub use service::{
 	NetworkService, NetworkWorker, FetchFuture, TransactionPool, ManageNetwork,
-	NetworkMsg, SyncProvider, ExHashT, ReportHandle,
+	NetworkMsg, ExHashT, ReportHandle,
 };
 pub use config::{NodeKeyConfig, Secret, Secp256k1Secret, Ed25519Secret};
 pub use protocol::{ProtocolStatus, PeerInfo, Context, consensus_gossip, message, specialization};

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 derive_more = "0.14.0"
+futures = "0.1"
 jsonrpc-core = "12.0.0"
 jsonrpc-core-client = "12.0.0"
 jsonrpc-pubsub = "12.0.0"

--- a/core/rpc/src/helpers.rs
+++ b/core/rpc/src/helpers.rs
@@ -14,6 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+use futures::{prelude::*, sync::oneshot};
+
+/// Wraps around `oneshot::Receiver` and adjusts the error type to produce an internal error if the
+/// sender gets dropped.
+pub struct Receiver<T>(pub oneshot::Receiver<T>);
+
+impl<T> Future for Receiver<T> {
+	type Item = T;
+	type Error = jsonrpc_core::Error;
+
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		self.0.poll().map_err(|_| jsonrpc_core::Error::internal_error())
+	}
+}
+
 /// Unwraps the trailing parameter or falls back with the closure result.
 pub fn unwrap_or_else<F, H, E>(or_else: F, optional: Option<H>) -> Result<H, E> where
 	F: FnOnce() -> Result<H, E>,

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -41,7 +41,6 @@ use primitives::Pair;
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::{Header, SaturatedConversion};
 use substrate_executor::NativeExecutor;
-use network::SyncProvider;
 use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 use tel::{telemetry, SUBSTRATE_INFO};
 

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -384,10 +384,10 @@ impl<Components: components::Components> Service<Components> {
 			impl_version: config.impl_version.into(),
 			properties: config.chain_spec.properties(),
 		};
+		let (system_rpc_tx, system_rpc_rx) = mpsc::unbounded();
 		let rpc = Components::RuntimeServices::start_rpc(
 			client.clone(),
-			network.clone(),
-			has_bootnodes,
+			system_rpc_tx,
 			system_info,
 			config.rpc_http,
 			config.rpc_ws,
@@ -396,6 +396,11 @@ impl<Components: components::Components> Service<Components> {
 			task_executor.clone(),
 			transaction_pool.clone(),
 		)?;
+		task_executor.spawn(build_system_rpc_handler::<Components>(
+			network.clone(),
+			system_rpc_rx,
+			has_bootnodes
+		));
 
 		let telemetry_connection_sinks: Arc<Mutex<Vec<mpsc::UnboundedSender<()>>>> = Default::default();
 
@@ -609,6 +614,39 @@ impl<C: Components> network::TransactionPool<ComponentExHash<C>, ComponentBlock<
 	fn on_broadcasted(&self, propagations: HashMap<ComponentExHash<C>, Vec<String>>) {
 		self.pool.on_broadcasted(propagations)
 	}
+}
+
+/// Builds a never-ending `Future` that answers the RPC requests coming on the receiver.
+fn build_system_rpc_handler<Components: components::Components>(
+	network: Arc<NetworkService<Components::Factory>>,
+	rx: mpsc::UnboundedReceiver<rpc::apis::system::Request<ComponentBlock<Components>>>,
+	should_have_peers: bool,
+) -> impl Future<Item = (), Error = ()> {
+	rx.for_each(move |request| {
+		match request {
+			rpc::apis::system::Request::Health(sender) => {
+				let _ = sender.send(rpc::apis::system::Health {
+					peers: network.peers_debug_info().len(),
+					is_syncing: network.is_major_syncing(),
+					should_have_peers,
+				});
+			},
+			rpc::apis::system::Request::Peers(sender) => {
+				let _ = sender.send(network.peers_debug_info().into_iter().map(|(peer_id, p)| rpc::apis::system::PeerInfo {
+					peer_id: peer_id.to_base58(),
+					roles: format!("{:?}", p.roles),
+					protocol_version: p.protocol_version,
+					best_hash: p.best_hash,
+					best_number: p.best_number,
+				}).collect());
+			}
+			rpc::apis::system::Request::NetworkState(sender) => {
+				let _ = sender.send(network.network_state());
+			}
+		};
+
+		Ok(())
+	})
 }
 
 /// Constructs a service factory with the given name that implements the `ServiceFactory` trait.

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -34,7 +34,7 @@ use service::{
 	Roles,
 	FactoryExtrinsic,
 };
-use network::{multiaddr, Multiaddr, SyncProvider, ManageNetwork};
+use network::{multiaddr, Multiaddr, ManageNetwork};
 use network::config::{NetworkConfiguration, NodeKeyConfig, Secret, NonReservedPeerMode};
 use sr_primitives::generic::BlockId;
 use consensus::{ImportBlock, BlockImport};


### PR DESCRIPTION
cc #2536 
I discussed this change with @folsen and @tomusdrw already before opening this.

Instead of passing to the RPC handler an `Arc<NetworkService>` where `NetworkService` contains a `Mutex`, we instead pass a channel sender that the RPC will use to send requests. The service is then responsible for polling RPC requests and answering them.

This will make it possible in the future to, for example, not answer RPC requests if the rest of the service is too busy, or to progressively build the answer to an RPC request without blocking the rest of the system.
By not passing the `NetworkService` to the RPC, we also decouple them a bit more, and avoid poisoning the `NetworkService` if the RPC handler panics.

I also removed the `SyncProvider` trait in the process.
