### PR TITLE
Add assumptions that must be held in assets module

### DIFF
--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -117,7 +117,8 @@
 //! Below are assumptions that must be held when using this module.  If any of
 //! them are violated, the behavior of this module is undefined.
 //!
-//! * The total count of assets should be less than `Trait::AssetId::max_value()`.
+//! * The total count of assets should be less than
+//!   `Trait::AssetId::max_value()`.
 //!
 //! ## Related Modules
 //!

--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -114,7 +114,8 @@
 //!
 //! ## Assumptions
 //!
-//! Below are assumptions that must be held when using this module, otherwise it can exhibits undefined behavior.
+//! Below are assumptions that must be held when using this module.  If any of
+//! them are violated, the behavior of this module is undefined.
 //!
 //! * The total count of assets should be less than `Trait::AssetId::max_value()`.
 //!

--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -112,6 +112,12 @@
 //! }
 //! ```
 //!
+//! ## Assumptions
+//!
+//! Below are assumptions that must be held when using this module, otherwise it can exhibits undefined behavior.
+//!
+//! * The total count of assets should be less than `Trait::AssetId::max_value()`.
+//!
 //! ## Related Modules
 //!
 //! * [`System`](../srml_system/index.html)


### PR DESCRIPTION
This is a test PR to get an opinion on whether this approach looks good.

For https://github.com/paritytech/substrate/issues/706, some of the overflow issues are just something-will-never-happen-in-next-100-years. For them, we may not need any checked proof or panic situations by code, and can use the plain `+`. However, it is still good to have it written down. So I added an "Assumptions" section in the module docs to document them.