### PR TITLE
client: Reorg to new best when finalizing divergent branch

### DIFF
--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -1118,6 +1118,7 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 					hash.clone(),
 					(number.clone(), hash.clone())
 				)?;
+				meta_updates.push((hash, *number, true, false));
 			} else {
 				return Err(client::error::Error::UnknownBlock(format!("Cannot set head {:?}", set_head)))
 			}

--- a/core/client/db/src/light.rs
+++ b/core/client/db/src/light.rs
@@ -497,6 +497,7 @@ impl<Block> LightBlockchainStorage<Block> for LightStorage<Block>
 			let mut transaction = DBTransaction::new();
 			self.set_head_with_transaction(&mut transaction, hash.clone(), (number.clone(), hash.clone()))?;
 			self.db.write(transaction).map_err(db_err)?;
+			self.update_meta(hash, header.number().clone(), true, false);
 			Ok(())
 		} else {
 			Err(ClientError::UnknownBlock(format!("Cannot set head {:?}", id)))

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1075,8 +1075,13 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		// if the block is not a direct ancestor of the current best chain,
 		// then some other block is the common ancestor.
 		if route_from_best.common_block().hash != block {
-			// FIXME: #1442 reorganize best block to be the best chain containing
-			// `block`.
+			// NOTE: we're setting the finalized block as best block, this might
+			// be slightly innacurate since we might have a "better" block
+			// further along this chain, but since best chain selection logic is
+			// pluggable we cannot make a better choice here. usages that need
+			// an accurate "best" block need to go through `SelectChain`
+			// instead.
+			operation.op.mark_head(BlockId::Hash(block))?;
 		}
 
 		let enacted = route_from_finalized.enacted();

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1604,9 +1604,12 @@ where
 	}
 
 	fn best_block_header(&self) -> error::Result<<Block as BlockT>::Header> {
-		let info : ChainInfo<Block> = self.backend.blockchain().info();
-		Ok(self.backend.blockchain().header(BlockId::Hash(info.best_hash))?
-			.expect("Best block header must always exist"))
+		let info = self.backend.blockchain().info();
+		let best_hash = self.best_containing(info.best_hash, None)?
+			.unwrap_or(info.best_hash);
+
+		Ok(self.backend.blockchain().header(BlockId::Hash(best_hash))?
+			.expect("given block hash was fetched from block in db; qed"))
 	}
 
 	/// Get the most recent block hash of the best (longest) chains

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1193,6 +1193,11 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	/// Mark all blocks up to given as finalized in operation. If a
 	/// justification is provided it is stored with the given finalized
 	/// block (any other finalized blocks are left unjustified).
+	///
+	/// If the block being finalized is on a different fork from the current
+	/// best block the finalized block is set as best, this might be slightly
+	/// innacurate (i.e. outdated), usages that require determining an accurate
+	/// best block should use `SelectChain` instead of the client.
 	pub fn apply_finality(
 		&self,
 		operation: &mut ClientImportOperation<Block, Blake2Hasher, B>,
@@ -1207,6 +1212,11 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 	/// Finalize a block. This will implicitly finalize all blocks up to it and
 	/// fire finality notifications.
+	///
+	/// If the block being finalized is on a different fork from the current
+	/// best block the finalized block is set as best, this might be slightly
+	/// innacurate (i.e. outdated), usages that require determining an accurate
+	/// best block should use `SelectChain` instead of the client.
 	///
 	/// Pass a flag to indicate whether finality notifications should be propagated.
 	/// This is usually tied to some synchronization state, where we don't send notifications


### PR DESCRIPTION
When we finalize a block on a divergent branch from the currently tracked best we need to figure out what the new best block is on the finalized branch and we need to re-org to it. This is done by having `finalize_block` optionally take a `SelectChain` which is the pluggable logic for best fork selection (currently only longest chain is implemented). If no `SelectChain` is provided and the finalized block is on a divergent branch then we set the finalized block as best (this is the case for the light client since it doesn't track leaves). When importing a block that is finalized the same thing can happen but in this case we don't need `SelectChain` since the given block that's being imported must be the new best.
I also renamed the `finality_target` in `SelectChain` since there's nothing relating to finality there (e.g. GRANDPA has further voting rules that restrict what we vote on), instead `SelectChain` is strictly concerned with defining the notion of a best block, regardless of what we do with it.

Fix #1442.