### PR TITLE
Maintain TotalIssurance integrity in case of sudo set_balance

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
 	spec_version: 94,
-	impl_version: 94,
+	impl_version: 95,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -142,11 +142,15 @@
 //! ## Genesis config
 //!
 //! The Balances module depends on the [`GenesisConfig`](./struct.GenesisConfig.html).
+//!
+//! ## Assumptions
+//!
+//! * Total issued balanced of all accounts should be less than `Trait::Balance::max_value()`.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use rstd::prelude::*;
-use rstd::{cmp, result};
+use rstd::{cmp, result, mem};
 use parity_codec::{Codec, Encode, Decode};
 use srml_support::{StorageValue, StorageMap, Parameter, decl_event, decl_storage, decl_module};
 use srml_support::traits::{
@@ -386,12 +390,26 @@ decl_module! {
 		/// # </weight>
 		fn set_balance(
 			who: <T::Lookup as StaticLookup>::Source,
-			#[compact] free: T::Balance,
-			#[compact] reserved: T::Balance
+			#[compact] new_free: T::Balance,
+			#[compact] new_reserved: T::Balance
 		) {
 			let who = T::Lookup::lookup(who)?;
-			Self::set_free_balance(&who, free);
-			Self::set_reserved_balance(&who, reserved);
+
+			let current_free = <FreeBalance<T, I>>::get(&who);
+			if new_free > current_free {
+				mem::drop(PositiveImbalance::<T, I>::new(new_free - current_free));
+			} else if new_free < current_free {
+				mem::drop(NegativeImbalance::<T, I>::new(current_free - new_free));
+			}
+			Self::set_free_balance(&who, new_free);
+
+			let current_reserved = <ReservedBalance<T, I>>::get(&who);
+			if new_reserved > current_reserved {
+				mem::drop(PositiveImbalance::<T, I>::new(new_reserved - current_reserved));
+			} else if new_reserved < current_reserved {
+				mem::drop(NegativeImbalance::<T, I>::new(current_reserved - new_reserved));
+			}
+			Self::set_reserved_balance(&who, new_reserved);
 		}
 	}
 }

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -377,10 +377,10 @@ decl_module! {
 
 		/// Set the balances of a given account.
 		///
-		/// This will alter `FreeBalance` and `ReservedBalance` in storage.
+		/// This will alter `FreeBalance` and `ReservedBalance` in storage. it will
+		/// also decrease the total issuance of the system (`TotalIssuance`).
 		/// If the new free or reserved balance is below the existential deposit,
-		/// it will also decrease the total issuance of the system (`TotalIssuance`)
-		/// and reset the account nonce (`system::AccountNonce`).
+		/// it will reset the account nonce (`system::AccountNonce`).
 		///
 		/// The dispatch origin for this call is `root`.
 		///


### PR DESCRIPTION
Currently, calling `set_balance` sudo method in balances module will not alter `TotalIssurance` when the account is above minimal balance. This PR fixes this.

rel #668 in the case that it can cause `TotalIssurance` to go negative.