### PR TITLE
Move libp2p tests to custom_proto

### DIFF
--- a/core/network/src/custom_proto/handler.rs
+++ b/core/network/src/custom_proto/handler.rs
@@ -585,7 +585,7 @@ where TSubstream: AsyncRead + AsyncWrite, TMessage: CustomMessage {
 			ProtocolState::Init { .. } | ProtocolState::Opening { .. } |
 			ProtocolState::Normal { .. } => KeepAlive::Yes,
 			ProtocolState::Disabled { .. } | ProtocolState::Poisoned |
-      ProtocolState::KillAsap => KeepAlive::No,
+	  		ProtocolState::KillAsap => KeepAlive::No,
 		}
 	}
 

--- a/core/network/src/custom_proto/mod.rs
+++ b/core/network/src/custom_proto/mod.rs
@@ -20,3 +20,4 @@ pub use self::upgrade::CustomMessage;
 mod behaviour;
 mod handler;
 mod upgrade;
+mod tests;

--- a/core/network/src/custom_proto/upgrade.rs
+++ b/core/network/src/custom_proto/upgrade.rs
@@ -141,19 +141,6 @@ pub trait CustomMessage {
 		where Self: Sized;
 }
 
-// This trait implementation exist mostly for testing convenience. This should eventually be
-// removed.
-
-impl CustomMessage for Vec<u8> {
-	fn into_bytes(self) -> Vec<u8> {
-		self
-	}
-
-	fn from_bytes(bytes: &[u8]) -> Result<Self, ()> {
-		Ok(bytes.to_vec())
-	}
-}
-
 /// Event produced by the `RegisteredProtocolSubstream`.
 #[derive(Debug, Clone)]
 pub enum RegisteredProtocolEvent<TMessage> {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -44,8 +44,6 @@ use crate::config::Params;
 use crate::error::Error;
 use crate::protocol::specialization::NetworkSpecialization;
 
-mod tests;
-
 /// Interval at which we send status updates on the status stream.
 const STATUS_INTERVAL: Duration = Duration::from_millis(5000);
 /// Interval at which we update the `peers` field on the main thread.


### PR DESCRIPTION
The next refactoring step I'd like to make is remove `start_service` and shuffle things a bit around.
Unfortunately the current libp2p tests use `start_service` (as it was the main entry point in `network-libp2p`).

This PR moves the libp2p tests in the `custom_protos` module where they are more appropriate.

