### PR TITLE
Remove uses of Error::description() use Display instead

### DIFF
--- a/core/client/db/src/utils.rs
+++ b/core/client/db/src/utils.rs
@@ -190,7 +190,7 @@ pub fn block_id_to_lookup_key<Block>(
 /// Maps database error to client error
 pub fn db_err(err: io::Error) -> client::error::Error {
 	use std::error::Error;
-	client::error::Error::Backend(err.description().into())
+	client::error::Error::Backend(format!("{}", err))
 }
 
 /// Open RocksDB database.

--- a/core/rpc/src/author/error.rs
+++ b/core/rpc/src/author/error.rs
@@ -85,7 +85,7 @@ impl From<Error> for rpc::Error {
 			},
 			Error::Verification(e) => rpc::Error {
 				code: rpc::ErrorCode::ServerError(VERIFICATION_ERROR),
-				message: e.description().into(),
+				message: format!("Verification Error: {}", e).into(),
 				data: Some(format!("{:?}", e).into()),
 			},
 			Error::Pool(PoolError::InvalidTransaction(code)) => rpc::Error {

--- a/core/rpc/src/author/error.rs
+++ b/core/rpc/src/author/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
 	/// Transaction pool error,
 	Pool(txpool::error::Error),
 	/// Verification error
-	#[display(fmt="Extrinsic verification error: {}", "_0.description()")]
+	#[display(fmt="Extrinsic verification error: {}", _0)]
 	Verification(Box<dyn std::error::Error + Send>),
 	/// Incorrect extrinsic format.
 	#[display(fmt="Invalid extrinsic format")]

--- a/core/util/fork-tree/src/lib.rs
+++ b/core/util/fork-tree/src/lib.rs
@@ -37,21 +37,17 @@ pub enum Error<E> {
 
 impl<E: std::error::Error> fmt::Display for Error<E> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		use std::error::Error;
-		write!(f, "{}", self.description())
+		let message = match *self {
+			Error::Duplicate => "Hash already exists in Tree".into(),
+			Error::UnfinalizedAncestor => "Finalized descendent of Tree node without finalizing its ancestor(s) first".into(),
+			Error::Revert => "Tried to import or finalize node that is an ancestor of a previously finalized node".into(),
+			Error::Client(ref err) => format!("Client error: {}", err),
+		};
+		write!(f, "{}", message)
 	}
 }
 
 impl<E: std::error::Error> std::error::Error for Error<E> {
-	fn description(&self) -> &str {
-		match *self {
-			Error::Duplicate => "Hash already exists in Tree",
-			Error::UnfinalizedAncestor => "Finalized descendent of Tree node without finalizing its ancestor(s) first",
-			Error::Revert => "Tried to import or finalize node that is an ancestor of a previously finalized node",
-			Error::Client(ref err) => err.description(),
-		}
-	}
-
 	fn cause(&self) -> Option<&dyn std::error::Error> {
 		None
 	}


### PR DESCRIPTION
Fixes  #2885 

Remove call to `description()` , use `format!` including actual error