### PR TITLE
Fix construct_runtime default expansion

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -247,7 +247,7 @@ construct_runtime!(
 		NodeBlock = node_primitives::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{default, Config<T>},
+		System: system,
 		Aura: aura::{Module, Config<T>, Inherent(Timestamp)},
 		Timestamp: timestamp::{Module, Call, Storage, Config<T>, Inherent},
 		Indices: indices,
@@ -261,7 +261,7 @@ construct_runtime!(
 		FinalityTracker: finality_tracker::{Module, Call, Inherent},
 		Grandpa: grandpa::{Module, Call, Storage, Config<T>, Event},
 		Treasury: treasury,
-		Contract: contract::{Module, Call, Storage, Config<T>, Event<T>},
+		Contract: contract,
 		Sudo: sudo,
 	}
 );

--- a/srml/support/src/runtime.rs
+++ b/srml/support/src/runtime.rs
@@ -109,7 +109,8 @@ macro_rules! construct_runtime {
 	) => {
 		$crate::construct_runtime!(
 			{ $( $preset )* };
-			{ $( $expanded )* $name: $module::{Module, Call, Storage, Event<T>, Config<T>}, };
+			{ $( $expanded )* };
+			$name: $module::{default},
 			$( $rest )*
 		);
 	};
@@ -117,27 +118,25 @@ macro_rules! construct_runtime {
 		{ $( $preset:tt )* };
 		{ $( $expanded:tt )* };
 		$name:ident: $module:ident::{
-			default,
-			$(
+			default
+			$(,
 				$modules:ident
 					$( <$modules_generic:ident $(, $modules_instance:ident)?> )*
 					$( ( $( $modules_args:ident ),* ) )*
-			),*
+			)*
 		},
 		$( $rest:tt )*
 	) => {
 		$crate::construct_runtime!(
 			{ $( $preset )* };
-			{
-				$( $expanded )*
-				$name: $module::{
-					Module, Call, Storage, Event<T>, Config<T>,
-					$(
-						$modules $( <$modules_generic $(, $modules_instance)?> )*
-						$( ( $( $modules_args ),* ) )*
-					),*
-				},
-			};
+			{ $( $expanded )* };
+			$name: $module::{
+				Module, Call, Storage, Event<T>, Config<T>
+				$(,
+					$modules $( <$modules_generic $(, $modules_instance)?> )*
+					$( ( $( $modules_args ),* ) )*
+				)*
+			},
 			$( $rest )*
 		);
 	};


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/2892

Old behavior only allowed default with additional elements, now no `{}` expands to `{default}` which himself expands to `{Module, ...,}`.

Only fully expanded `{}` is parsed