### PR TITLE
Try fix the failing networking tests

### DIFF
--- a/core/network/src/custom_proto/tests.rs
+++ b/core/network/src/custom_proto/tests.rs
@@ -58,11 +58,15 @@ fn build_nodes<T: CustomMessage + Send + 'static>()
 		let (peerset, _) = peerset::Peerset::from_config(peerset::PeersetConfig {
 			in_peers: 25,
 			out_peers: 25,
-			bootnodes: keypairs
-				.iter()
-				.enumerate()
-				.filter_map(|(n, p)| if n != index { Some(p.public().into_peer_id()) } else { None })
-				.collect(),
+			bootnodes: if index == 0 {
+				keypairs
+					.iter()
+					.skip(1)
+					.map(|keypair| keypair.public().into_peer_id())
+					.collect()
+			} else {
+				vec![]
+			},
 			reserved_only: false,
 			reserved_nodes: Vec::new(),
 		});


### PR DESCRIPTION
Right now two of the networking tests sometimes fail on CI.
I can't manage to reproduce the failure on my local machine, so this PR is very speculative.

What I think happens is that the two simulated nodes connect to each other simultaneously, which causes one of the connections to be closed. But since for test purposes we're using the `MemoryTransport`, which instantly delivers messages, the closed connection had already managed to negotiate the Substrate substream, which then causes the substream to be closed (only for it to be reopened immediately after on the other connection).

This is all normal and expected behaviour. However, the network tests are simplistic and don't handle the substream being closed. Handling that properly would complicate the code of the tests a lot.

What this PR does is that only node A knows about node B, and not the other way around. This means that only node A will connect, and eliminate the chances of a simultaneous connection.

However, again, since I can't reproduce the failure locally, I can only speculate that this is what happens.