### PR TITLE
Do not return empty entries from state_queryStorage

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -525,6 +525,8 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 	/// Get pairs of (block, extrinsic) where key has been changed at given blocks range.
 	/// Works only for runtimes that are supporting changes tries.
+	///
+	/// Changes are returned in descending order (i.e. last block comes first).
 	pub fn key_changes(
 		&self,
 		first: NumberFor<Block>,

--- a/core/rpc/src/state/mod.rs
+++ b/core/rpc/src/state/mod.rs
@@ -268,18 +268,17 @@ impl<B, E, Block: BlockT, RA> State<B, E, Block, RA> where
 			for key in keys {
 				let (has_changed, data) = {
 					let curr_data = self.client.storage(&id, key)?;
-					let prev_data = last_values.get(key).and_then(|x| x.as_ref());
-					(curr_data.as_ref() != prev_data, curr_data)
+					match last_values.get(key) {
+						Some(prev_data) => (curr_data != *prev_data, curr_data),
+						None => (true, curr_data),
+					}
 				};
 				if has_changed {
 					block_changes.changes.push((key.clone(), data.clone()));
 				}
 				last_values.insert(key.clone(), data);
 			}
-
-			// always insert entry for the first block, because we're claiming to provide values of
-			// all keys in this entry (if key has None value, it will be missing from the changes field)
-			if changes.is_empty() || !block_changes.changes.is_empty() {
+			if !block_changes.changes.is_empty() {
 				changes.push(block_changes);
 			}
 		}

--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -189,13 +189,7 @@ fn should_query_storage() {
 		let mut expected = vec![
 			StorageChangeSet {
 				block: genesis_hash,
-				changes: vec![
-					(StorageKey(vec![1]), None),
-					(StorageKey(vec![2]), None),
-					(StorageKey(vec![3]), None),
-					(StorageKey(vec![4]), None),
-					(StorageKey(vec![5]), None),
-				],
+				changes: vec![],
 			},
 			StorageChangeSet {
 				block: block1_hash,

--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -189,7 +189,13 @@ fn should_query_storage() {
 		let mut expected = vec![
 			StorageChangeSet {
 				block: genesis_hash,
-				changes: vec![],
+				changes: vec![
+					(StorageKey(vec![1]), None),
+					(StorageKey(vec![2]), None),
+					(StorageKey(vec![3]), None),
+					(StorageKey(vec![4]), None),
+					(StorageKey(vec![5]), None),
+				],
 			},
 			StorageChangeSet {
 				block: block1_hash,

--- a/core/test-runtime/client/src/block_builder_ext.rs
+++ b/core/test-runtime/client/src/block_builder_ext.rs
@@ -25,6 +25,8 @@ use generic_test_client::client::block_builder::api::BlockBuilder;
 pub trait BlockBuilderExt {
 	/// Add transfer extrinsic to the block.
 	fn push_transfer(&mut self, transfer: runtime::Transfer) -> Result<(), client::error::Error>;
+	/// Add storage change extrinsic to the block.
+	fn push_storage_change(&mut self, key: Vec<u8>, value: Option<Vec<u8>>) -> Result<(), client::error::Error>;
 }
 
 impl<'a, A> BlockBuilderExt for client::block_builder::BlockBuilder<'a, runtime::Block, A> where
@@ -33,5 +35,9 @@ impl<'a, A> BlockBuilderExt for client::block_builder::BlockBuilder<'a, runtime:
 {
 	fn push_transfer(&mut self, transfer: runtime::Transfer) -> Result<(), client::error::Error> {
 		self.push(transfer.into_signed_tx())
+	}
+
+	fn push_storage_change(&mut self, key: Vec<u8>, value: Option<Vec<u8>>) -> Result<(), client::error::Error> {
+		self.push(runtime::Extrinsic::StorageChange(key, value))
 	}
 }

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -106,6 +106,7 @@ pub enum Extrinsic {
 	AuthoritiesChange(Vec<AuthorityId>),
 	Transfer(Transfer, AccountSignature),
 	IncludeData(Vec<u8>),
+	StorageChange(Vec<u8>, Option<Vec<u8>>),
 }
 
 #[cfg(feature = "std")]
@@ -129,6 +130,7 @@ impl BlindCheckable for Extrinsic {
 				}
 			},
 			Extrinsic::IncludeData(_) => Err(runtime_primitives::BAD_SIGNATURE),
+			Extrinsic::StorageChange(key, value) => Ok(Extrinsic::StorageChange(key, value)),
 		}
 	}
 }

--- a/core/test-runtime/src/system.rs
+++ b/core/test-runtime/src/system.rs
@@ -238,6 +238,7 @@ fn execute_transaction_backend(utx: &Extrinsic) -> ApplyResult {
 		Extrinsic::Transfer(ref transfer, _) => execute_transfer_backend(transfer),
 		Extrinsic::AuthoritiesChange(ref new_auth) => execute_new_authorities_backend(new_auth),
 		Extrinsic::IncludeData(_) => Ok(ApplyOutcome::Success),
+		Extrinsic::StorageChange(key, value) => execute_storage_change(key, value.as_ref().map(|v| &**v)),
 	}
 }
 
@@ -270,6 +271,14 @@ fn execute_transfer_backend(tx: &Transfer) -> ApplyResult {
 fn execute_new_authorities_backend(new_authorities: &[AuthorityId]) -> ApplyResult {
 	let new_authorities: Vec<AuthorityId> = new_authorities.iter().cloned().collect();
 	<NewAuthorities>::put(new_authorities);
+	Ok(ApplyOutcome::Success)
+}
+
+fn execute_storage_change(key: &[u8], value: Option<&[u8]>) -> ApplyResult {
+	match value {
+		Some(value) => storage::unhashed::put_raw(key, value),
+		None => storage::unhashed::kill(key),
+	}
 	Ok(ApplyOutcome::Success)
 }
 


### PR DESCRIPTION
closes #2826 

The first problem occurs when CT are disabled. The result of `state_queryStorage` includes entries for every block in the range, even though changes are empty:
```json
{"jsonrpc":"2.0","result":[{"block":"0x610c","changes":[["0x05","0x05"],["0x0a","0x0a"]]}, {"block":"0x81..8d","changes":[]}],"id":1}
```
I've added a check for that && now entry is only included when `changes` field is not empty.

The second problem is linked to CT + fake changes (see #2865 ). When there's fake change, it is shown in `changes` => redundant entry appears.
```json
{"jsonrpc":"2.0","result":[{"block":"0x61..0c","changes":[["0x05","0x05"]]}, {"block":"0x81..8d","changes":[["0x05","0x05"]]}],"id":1}
```
I've fixed that by adding a check that `prev_value != new_value`.
```json
{"jsonrpc":"2.0","result":[{"block":"0x61..0c","changes":[["0x05","0x05"]]}, {"block":"0x81..8d","changes":[["0x05","0x06"]]}],"id":1}
```
So after this PR, every entry in resulting `Vec` is guaranteed to be inserted only when requested key(s) has actually been changed at linked block.