### PR TITLE
Ditch the input buffer

### DIFF
--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -711,22 +711,23 @@ mod tests {
 	;;    input_data_len: u32
 	;; ) -> u32
 	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_input_size" (func $ext_input_size (result i32)))
-	(import "env" "ext_input_copy" (func $ext_input_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "deploy")
 	)
 	(func (export "call")
 		(block $fail
-			;; fail if ext_input_size != 4
+			;; load and check the input data (which is stored in the scratch buffer).
+			;; fail if the input size is not != 4
 			(br_if $fail
 				(i32.ne
 					(i32.const 4)
-					(call $ext_input_size)
+					(call $ext_scratch_size)
 				)
 			)
 
-			(call $ext_input_copy
+			(call $ext_scratch_copy
 				(i32.const 0)
 				(i32.const 0)
 				(i32.const 4)

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 96,
-	impl_version: 96,
+	spec_version: 97,
+	impl_version: 97,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -348,18 +348,6 @@ This function serializes the current block's timestamp into the scratch buffer.
 
 **complexity**: Assuming that the timestamp is of constant size, this function has constant complexity.
 
-## ext_input_size
-
-**complexity**: This function is of constant complexity.
-
-## ext_input_copy
-
-This function copies slice of data from the input buffer to the sandbox memory. The calling code specifies the slice length. Execution of the function consists of the following steps:
-
-1. Storing a specified slice of the input data into the sandbox memory (see sandboxing memory set)
-
-**complexity**: The computing complexity of this function is proportional to the length of the slice. No additional memory is required.
-
 ## ext_scratch_size
 
 This function returns the size of the scratch buffer.

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -527,8 +527,8 @@ const CODE_SET_RENT: &str = r#"
 	(import "env" "ext_dispatch_call" (func $ext_dispatch_call (param i32 i32)))
 	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
 	(import "env" "ext_set_rent_allowance" (func $ext_set_rent_allowance (param i32 i32)))
-	(import "env" "ext_input_size" (func $ext_input_size (result i32)))
-	(import "env" "ext_input_copy" (func $ext_input_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; insert a value of 4 bytes into storage
@@ -575,7 +575,7 @@ const CODE_SET_RENT: &str = r#"
 	(func (export "call")
 		(local $input_size i32)
 		(set_local $input_size
-			(call $ext_input_size)
+			(call $ext_scratch_size)
 		)
 		(block $IF_ELSE
 			(block $IF_2
@@ -602,19 +602,19 @@ const CODE_SET_RENT: &str = r#"
 	;; Set call set_rent_allowance with input
 	(func (export "deploy")
 		(local $input_size i32)
+		(set_local $input_size
+			(call $ext_scratch_size)
+		)
+		(call $ext_scratch_copy
+			(i32.const 0)
+			(i32.const 0)
+			(get_local $input_size)
+		)
 		(call $ext_set_storage
 			(i32.const 0)
 			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
-		)
-		(set_local $input_size
-			(call $ext_input_size)
-		)
-		(call $ext_input_copy
-			(i32.const 0)
-			(i32.const 0)
-			(get_local $input_size)
 		)
 		(call $ext_set_rent_allowance
 			(i32.const 0)
@@ -631,7 +631,7 @@ const CODE_SET_RENT: &str = r#"
 "#;
 
 // Use test_hash_and_code test to get the actual hash if the code changed.
-const HASH_SET_RENT: [u8; 32] = hex!("21d6b1d59aa6038fcad632488e9026893a1bbb48581774c771b8f24320697f05");
+const HASH_SET_RENT: [u8; 32] = hex!("b2104e79e8757e2bc32ce3141850cb4af0229693165dc38401c94edf0797f390");
 
 /// Input data for each call in set_rent code
 mod call {
@@ -1116,8 +1116,8 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 		vec![acl_key, acl_key],
 	))));
 
-	let literal = "0105020000000000000021d6b1d59aa6038fcad632488e9026893a1bbb48581774c771b8f243206\
-		97f053200000000000000080100000000000000000000000000000000000000000000000000000000000000010\
+	let literal = "01050200000000000000b2104e79e8757e2bc32ce3141850cb4af0229693165dc38401c94edf079\
+		7f3903200000000000000080100000000000000000000000000000000000000000000000000000000000000010\
 		0000000000000000000000000000000000000000000000000000000000000";
 
 	assert_eq!(encoded, literal);

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -1136,7 +1136,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 		"The literal was changed and requires updating here and in `CODE_RESTORATION`",
 	);
 	assert_eq!(
-		hex::decode(literal).unwrap().len(),
+		hex::decode(ENCODED_CALL_LITERAL).unwrap().len(),
 		115,
 		"The size of the literal was changed and requires updating in `CODE_RESTORATION`",
 	);

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -1041,8 +1041,12 @@ const CODE_RESTORATION: &str = r#"
 
 	(func (export "call")
 		(call $ext_dispatch_call
-			(i32.const 200) ;; Pointer to the start of encoded call buffer
-			(i32.const 115) ;; Length of the buffer
+			;; Pointer to the start of the encoded call buffer
+			(i32.const 200)
+			;; The length of the encoded call buffer.
+			;;
+			;; NB: This is required to keep in sync with the values in `restoration`.
+			(i32.const 115)
 		)
 	)
 	(func (export "deploy")
@@ -1129,7 +1133,12 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 	assert_eq!(
 		encoded,
 		ENCODED_CALL_LITERAL,
-		"The literal was changed and requires updating here and in `CORE_RESOTRATION`",
+		"The literal was changed and requires updating here and in `CODE_RESTORATION`",
+	);
+	assert_eq!(
+		hex::decode(literal).unwrap().len(),
+		115,
+		"The size of the literal was changed and requires updating in `CODE_RESTORATION`",
 	);
 
 	let restoration_wasm = wabt::wat2wasm(CODE_RESTORATION).unwrap();

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -134,7 +134,7 @@ impl<'a, T: Trait> crate::exec::Vm<T> for WasmVm<'a, T> {
 
 		let mut runtime = Runtime::new(
 			ext,
-			input_data,
+			input_data.to_vec(),
 			empty_output_buf,
 			&self.schedule,
 			memory,

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -575,12 +575,18 @@ define_env!(Env, <E: Ext>,
 	},
 
 	// Returns the size of the scratch buffer.
+	//
+	// For more details on the scratch buffer see `ext_scratch_copy`.
 	ext_scratch_size(ctx) -> u32 => {
 		Ok(ctx.scratch_buf.len() as u32)
 	},
 
 	// Copy data from the scratch buffer starting from `offset` with length `len` into the contract memory.
 	// The region at which the data should be put is specified by `dest_ptr`.
+	//
+	// In order to get size of the scratch buffer use `ext_scratch_size`. At the start of contract
+	// execution, the scratch buffer is filled with the input data. Whenever a contract calls
+	// function that uses the scratch buffer the contents of the scratch buffer are overwritten.
 	ext_scratch_copy(ctx, dest_ptr: u32, offset: u32, len: u32) => {
 		let offset = offset as usize;
 		if offset > ctx.scratch_buf.len() {


### PR DESCRIPTION
Closes #2829

This PR removes the input buffer and at the start of execution fills the scratch buffer with the input data (as disccused in #2829).

Please note that now we are copying the `input_data` whereas it seems it shouldn't be necessary. This is planned to be addressed in a follow-up refactoring PR.