### PR TITLE
Add ProtocolBehaviour

### DIFF
--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -125,9 +125,10 @@ pub(crate) fn global_topic<B: BlockT>(set_id: u64) -> B::Hash {
 	<<B::Header as HeaderT>::Hashing as HashT>::hash(format!("{}-GLOBAL", set_id).as_bytes())
 }
 
-impl<B, S> Network<B> for Arc<NetworkService<B, S>> where
+impl<B, S, H> Network<B> for Arc<NetworkService<B, S, H>> where
 	B: BlockT,
 	S: network::specialization::NetworkSpecialization<B>,
+	H: network::ExHashT,
 {
 	type In = NetworkStream;
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -31,6 +31,7 @@ mod discovery;
 mod on_demand_layer;
 #[macro_use]
 mod protocol;
+mod protocol_behaviour;
 mod service;
 mod transport;
 

--- a/core/network/src/protocol_behaviour.rs
+++ b/core/network/src/protocol_behaviour.rs
@@ -1,0 +1,451 @@
+// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Implementation of libp2p's `NetworkBehaviour` trait that handles everything Substrate-specific.
+
+use crate::{ExHashT, DiscoveryNetBehaviour, ProtocolId};
+use crate::custom_proto::{CustomProto, CustomProtoOut};
+use crate::chain::{Client, FinalityProofProvider};
+use crate::protocol::{self, CustomMessageOutcome, Protocol, ProtocolConfig, ProtocolStatus};
+use crate::protocol::{PeerInfo, NetworkOut, message::Message, on_demand::RequestData};
+use crate::protocol::consensus_gossip::MessageRecipient as GossipMessageRecipient;
+use crate::protocol::specialization::NetworkSpecialization;
+use crate::service::TransactionPool;
+
+use client::light::fetcher::FetchChecker;
+use futures::prelude::*;
+use consensus::import_queue::SharedFinalityProofRequestBuilder;
+use log::debug;
+use libp2p::{PeerId, Multiaddr};
+use libp2p::core::swarm::{ConnectedPoint, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
+use libp2p::core::{nodes::Substream, muxing::StreamMuxerBox};
+use libp2p::core::protocols_handler::{ProtocolsHandler, IntoProtocolsHandler};
+use runtime_primitives::{traits::{Block as BlockT, NumberFor}, ConsensusEngineId};
+use std::sync::Arc;
+
+/// Implementation of `NetworkBehaviour` that handles everything related to Substrate and Polkadot.
+pub struct ProtocolBehaviour<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> {
+	/// Handles opening the unique substream and sending and receiving raw messages.
+	behaviour: CustomProto<Message<B>, Substream<StreamMuxerBox>>,
+	/// Handles the logic behind the raw messages that we receive.
+	protocol: Protocol<B, S, H>,
+	/// Used to report reputation changes.
+	peerset_handle: peerset::PeersetHandle,
+	transaction_pool: Arc<dyn TransactionPool<H, B>>,
+	/// When asked for a proof of finality, we use this struct to build one.
+	finality_proof_provider: Option<Arc<dyn FinalityProofProvider<B>>>,
+}
+
+impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S, H> {
+	/// Builds a new `ProtocolsBehaviour`.
+	pub fn new(
+		config: ProtocolConfig,
+		chain: Arc<dyn Client<B>>,
+		checker: Arc<dyn FetchChecker<B>>,
+		specialization: S,
+		transaction_pool: Arc<dyn TransactionPool<H, B>>,
+		finality_proof_provider: Option<Arc<dyn FinalityProofProvider<B>>>,
+		protocol_id: ProtocolId,
+		versions: &[u8],
+		peerset: peerset::Peerset,
+		peerset_handle: peerset::PeersetHandle,
+	) -> crate::error::Result<Self> {
+		let protocol = Protocol::new(config, chain, checker, specialization)?;
+		let behaviour = CustomProto::new(protocol_id, versions, peerset);
+
+		Ok(ProtocolBehaviour {
+			protocol,
+			behaviour,
+			peerset_handle,
+			transaction_pool,
+			finality_proof_provider,
+		})
+	}
+
+	/// Returns the list of all the peers we have an open channel to.
+	pub fn open_peers<'a>(&'a self) -> impl Iterator<Item = &'a PeerId> + 'a {
+		self.behaviour.open_peers()
+	}
+
+	/// Returns true if we have a channel open with this node.
+	pub fn is_open(&self, peer_id: &PeerId) -> bool {
+		self.behaviour.is_open(peer_id)
+	}
+
+	/// Disconnects the given peer if we are connected to it.
+	pub fn disconnect_peer(&mut self, peer_id: &PeerId) {
+		self.behaviour.disconnect_peer(peer_id)
+	}
+
+	/// Adjusts the reputation of a node.
+	pub fn report_peer(&mut self, who: PeerId, reputation: i32) {
+		self.peerset_handle.report_peer(who, reputation)
+	}
+
+	/// Returns true if we try to open protocols with the given peer.
+	pub fn is_enabled(&self, peer_id: &PeerId) -> bool {
+		self.behaviour.is_enabled(peer_id)
+	}
+
+	/// Sends a message to a peer.
+	///
+	/// Has no effect if the custom protocol is not open with the given peer.
+	///
+	/// Also note that even we have a valid open substream, it may in fact be already closed
+	/// without us knowing, in which case the packet will not be received.
+	pub fn send_packet(&mut self, target: &PeerId, message: Message<B>) {
+		self.behaviour.send_packet(target, message)
+	}
+
+	/// Returns the state of the peerset manager, for debugging purposes.
+	pub fn peerset_debug_info(&mut self) -> serde_json::Value {
+		self.behaviour.peerset_debug_info()
+	}
+
+	/// Returns an object representing the status of the protocol.
+	pub fn status(&self) -> ProtocolStatus<B> {
+		self.protocol.status()
+	}
+
+	pub fn is_major_syncing(&self) -> bool {
+		self.protocol.is_major_syncing()
+	}
+
+	pub fn is_offline(&self) -> bool {
+		self.protocol.is_offline()
+	}
+
+	/// Starts a new data demand request.
+	///
+	/// The parameter contains a `Sender` where the result, once received, must be sent.
+	pub(crate) fn add_on_demand_request(&mut self, rq: RequestData<B>) {
+		self.protocol.add_on_demand_request(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			rq
+		);
+	}
+
+	/// Returns information about all the peers we are connected to after the handshake message.
+	pub fn peers_info(&self) -> impl Iterator<Item = (&PeerId, &PeerInfo<B>)> {
+		self.protocol.peers_info()
+	}
+
+	/// Locks `self` and gives access to the protocol and a context that can be used in order to
+	/// use `consensus_gossip_lock` or `specialization_lock`.
+	///
+	/// **Important**: ONLY USE THIS FUNCTION TO CALL `consensus_gossip_lock` or `specialization_lock`.
+	/// This function is a very bad API.
+	pub fn protocol_context_lock<'a>(
+		&'a mut self,
+	) -> (&'a mut Protocol<B, S, H>, LocalNetworkOut<'a, B>) {
+		let net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
+		(&mut self.protocol, net_out)	
+	}
+
+	/// Gossip a consensus message to the network.
+	pub fn gossip_consensus_message(
+		&mut self,
+		topic: B::Hash,
+		engine_id: ConsensusEngineId,
+		message: Vec<u8>,
+		recipient: GossipMessageRecipient,
+	) {
+		self.protocol.gossip_consensus_message(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			topic,
+			engine_id,
+			message,
+			recipient
+		);
+	}
+
+	// TODO: needed?
+	pub fn propagate_extrinsics(
+		&mut self,
+	) {
+		self.protocol.propagate_extrinsics(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			&*self.transaction_pool
+		)
+	}
+
+	/// Make sure an important block is propagated to peers.
+	///
+	/// In chain-based consensus, we often need to make sure non-best forks are
+	/// at least temporarily synced.
+	pub fn announce_block(&mut self, hash: B::Hash) {
+		self.protocol.announce_block(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			hash
+		)
+	}
+
+	/// Call this when a block has been imported in the import queue and we should announce it on
+	/// the network.
+	pub fn on_block_imported(&mut self, hash: B::Hash, header: &B::Header) {
+		self.protocol.on_block_imported(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			hash,
+			header
+		)
+	}
+
+	/// Call this when a block has been finalized. The sync layer may have some additional
+	/// requesting to perform.
+	pub fn on_block_finalized(&mut self, hash: B::Hash, header: &B::Header) {
+		self.protocol.on_block_finalized(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			hash,
+			header
+		)
+	}
+
+	/// Request a justification for the given block.
+	///
+	/// Uses `protocol` to queue a new justification request and tries to dispatch all pending
+	/// requests.
+	pub fn request_justification(&mut self, hash: &B::Hash, number: NumberFor<B>) {
+		self.protocol.request_justification(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			hash,
+			number
+		)
+	}
+
+	/// Clears all pending justification requests.
+	pub fn clear_justification_requests(&mut self) {
+		self.protocol.clear_justification_requests()
+	}
+
+	/// A batch of blocks have been processed, with or without errors.
+	/// Call this when a batch of blocks have been processed by the import queue, with or without
+	/// errors.
+	pub fn blocks_processed(
+		&mut self,
+		processed_blocks: Vec<B::Hash>,
+		has_error: bool
+	) {
+		self.protocol.blocks_processed(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			processed_blocks,
+			has_error
+		)
+	}
+
+	/// Restart the sync process.
+	pub fn restart(&mut self) {
+		self.protocol.restart(&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle });
+	}
+
+	/// Notify about successful import of the given block.
+	pub fn block_imported(&mut self, hash: &B::Hash, number: NumberFor<B>) {
+		self.protocol.block_imported(hash, number)
+	}
+
+	pub fn set_finality_proof_request_builder(&mut self, request_builder: SharedFinalityProofRequestBuilder<B>) {
+		self.protocol.set_finality_proof_request_builder(request_builder)
+	}
+
+	/// Call this when a justification has been processed by the import queue, with or without
+	/// errors.
+	pub fn justification_import_result(&mut self, hash: B::Hash, number: NumberFor<B>, success: bool) {
+		self.protocol.justification_import_result(hash, number, success)
+	}
+
+	/// Request a finality proof for the given block.
+	///
+	/// Queues a new finality proof request and tries to dispatch all pending requests.
+	pub fn request_finality_proof(
+		&mut self,
+		hash: &B::Hash,
+		number: NumberFor<B>
+	) {
+		self.protocol.request_finality_proof(
+			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
+			&hash,
+			number
+		);
+	}
+
+	pub fn finality_proof_import_result(
+		&mut self,
+		request_block: (B::Hash, NumberFor<B>),
+		finalization_result: Result<(B::Hash, NumberFor<B>), ()>,
+	) {
+		self.protocol.finality_proof_import_result(request_block, finalization_result)
+	}
+
+}
+
+impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> NetworkBehaviour for
+ProtocolBehaviour<B, S, H> {
+	type ProtocolsHandler = <CustomProto<Message<B>, Substream<StreamMuxerBox>> as NetworkBehaviour>::ProtocolsHandler;
+	type OutEvent = CustomMessageOutcome<B>;
+
+	fn new_handler(&mut self) -> Self::ProtocolsHandler {
+		self.behaviour.new_handler()
+	}
+
+	fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+		self.behaviour.addresses_of_peer(peer_id)
+	}
+
+	fn inject_connected(&mut self, peer_id: PeerId, endpoint: ConnectedPoint) {
+		self.behaviour.inject_connected(peer_id, endpoint)
+	}
+
+	fn inject_disconnected(&mut self, peer_id: &PeerId, endpoint: ConnectedPoint) {
+		self.behaviour.inject_disconnected(peer_id, endpoint)
+	}
+
+	fn inject_node_event(
+		&mut self,
+		peer_id: PeerId,
+		event: <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::OutEvent
+	) {
+		self.behaviour.inject_node_event(peer_id, event)
+	}
+
+	fn poll(
+		&mut self,
+		params: &mut PollParameters
+	) -> Async<
+		NetworkBehaviourAction<
+			<<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent,
+			Self::OutEvent
+		>
+	> {
+		{
+			let mut net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
+			match self.protocol.poll(&mut net_out, &*self.transaction_pool) {
+				Ok(Async::Ready(v)) => void::unreachable(v),
+				Ok(Async::NotReady) => {}
+				Err(err) => void::unreachable(err),
+			}
+		}
+
+		let event = match self.behaviour.poll(params) {
+			Async::NotReady => return Async::NotReady,
+			Async::Ready(NetworkBehaviourAction::GenerateEvent(ev)) => ev,
+			Async::Ready(NetworkBehaviourAction::DialAddress { address }) =>
+				return Async::Ready(NetworkBehaviourAction::DialAddress { address }),
+			Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }) =>
+				return Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }),
+			Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }) =>
+				return Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }),
+			Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) =>
+				return Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }),
+		};
+
+		let mut network_out = LocalNetworkOut {
+			inner: &mut self.behaviour,
+			peerset_handle: &self.peerset_handle
+		};
+
+		let outcome = match event {
+			CustomProtoOut::CustomProtocolOpen { peer_id, version, .. } => {
+				debug_assert!(
+					version <= protocol::CURRENT_VERSION as u8
+					&& version >= protocol::MIN_VERSION as u8
+				);
+				self.protocol.on_peer_connected(&mut network_out, peer_id);
+				CustomMessageOutcome::None
+			}
+			CustomProtoOut::CustomProtocolClosed { peer_id, .. } => {
+				self.protocol.on_peer_disconnected(&mut network_out, peer_id);
+				CustomMessageOutcome::None
+			},
+			CustomProtoOut::CustomMessage { peer_id, message } =>
+				self.protocol.on_custom_message(
+					&mut network_out,
+					&*self.transaction_pool,
+					peer_id,
+					message,
+					self.finality_proof_provider.as_ref().map(|p| &**p)
+				),
+			CustomProtoOut::Clogged { peer_id, messages } => {
+				debug!(target: "sync", "{} clogging messages:", messages.len());
+				for msg in messages.into_iter().take(5) {
+					debug!(target: "sync", "{:?}", msg);
+					self.protocol.on_clogged_peer(&mut network_out, peer_id.clone(), Some(msg));
+				}
+				CustomMessageOutcome::None
+			}
+		};
+
+		if let CustomMessageOutcome::None = outcome {
+			Async::NotReady
+		} else {
+			Async::Ready(NetworkBehaviourAction::GenerateEvent(outcome))
+		}
+	}
+
+	fn inject_replaced(&mut self, peer_id: PeerId, closed_endpoint: ConnectedPoint, new_endpoint: ConnectedPoint) {
+		self.behaviour.inject_replaced(peer_id, closed_endpoint, new_endpoint)
+	}
+
+	fn inject_addr_reach_failure(
+		&mut self,
+		peer_id: Option<&PeerId>,
+		addr: &Multiaddr,
+		error: &dyn std::error::Error
+	) {
+		self.behaviour.inject_addr_reach_failure(peer_id, addr, error)
+	}
+
+	fn inject_dial_failure(&mut self, peer_id: &PeerId) {
+		self.behaviour.inject_dial_failure(peer_id)
+	}
+
+	fn inject_new_listen_addr(&mut self, addr: &Multiaddr) {
+		self.behaviour.inject_new_listen_addr(addr)
+	}
+
+	fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
+		self.behaviour.inject_expired_listen_addr(addr)
+	}
+
+	fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
+		self.behaviour.inject_new_external_addr(addr)
+	}
+}
+
+impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> DiscoveryNetBehaviour for
+ProtocolBehaviour<B, S, H> {
+	fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
+		self.behaviour.add_discovered_nodes(peer_ids)
+	}
+}
+
+/// Has to be public for stupid API reasons. This should be made private again ASAP.
+pub struct LocalNetworkOut<'a, B: BlockT> {
+	inner: &'a mut CustomProto<Message<B>, Substream<StreamMuxerBox>>,
+	peerset_handle: &'a peerset::PeersetHandle,
+}
+
+impl<'a, B: BlockT> NetworkOut<B> for LocalNetworkOut<'a, B> {
+	fn report_peer(&mut self, who: PeerId, reputation: i32) {
+		self.peerset_handle.report_peer(who, reputation)
+	}
+
+	fn disconnect_peer(&mut self, who: PeerId) {
+		self.inner.disconnect_peer(&who)
+	}
+
+	fn send_message(&mut self, who: PeerId, message: Message<B>) {
+		self.inner.send_packet(&who, message)
+	}
+}

--- a/core/network/src/protocol_behaviour.rs
+++ b/core/network/src/protocol_behaviour.rs
@@ -184,7 +184,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 		);
 	}
 
-	// TODO: needed?
+	/// Call when we must propagate ready extrinsics to peers.
 	pub fn propagate_extrinsics(&mut self) {
 		self.protocol.propagate_extrinsics(
 			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },

--- a/core/network/src/protocol_behaviour.rs
+++ b/core/network/src/protocol_behaviour.rs
@@ -247,7 +247,8 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 
 	/// Restart the sync process.
 	pub fn restart(&mut self) {
-		self.protocol.restart(&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle });
+		let mut net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
+		self.protocol.restart(&mut net_out);
 	}
 
 	/// Notify about successful import of the given block.
@@ -288,6 +289,9 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 		self.protocol.finality_proof_import_result(request_block, finalization_result)
 	}
 
+	pub fn tick(&mut self) {
+		self.protocol.tick(&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle });
+	}
 }
 
 impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> NetworkBehaviour for

--- a/core/network/src/protocol_behaviour.rs
+++ b/core/network/src/protocol_behaviour.rs
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// Copyright 2019 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
 // Substrate is free software: you can redistribute it and/or modify
@@ -246,12 +246,12 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 	pub fn blocks_processed(
 		&mut self,
 		processed_blocks: Vec<B::Hash>,
-		has_error: bool
+		has_error: bool,
 	) {
 		self.protocol.blocks_processed(
 			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
 			processed_blocks,
-			has_error
+			has_error,
 		)
 	}
 
@@ -282,12 +282,12 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 	pub fn request_finality_proof(
 		&mut self,
 		hash: &B::Hash,
-		number: NumberFor<B>
+		number: NumberFor<B>,
 	) {
 		self.protocol.request_finality_proof(
 			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
 			&hash,
-			number
+			number,
 		);
 	}
 
@@ -328,14 +328,14 @@ ProtocolBehaviour<B, S, H> {
 	fn inject_node_event(
 		&mut self,
 		peer_id: PeerId,
-		event: <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::OutEvent
+		event: <<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::OutEvent,
 	) {
 		self.behaviour.inject_node_event(peer_id, event)
 	}
 
 	fn poll(
 		&mut self,
-		params: &mut PollParameters
+		params: &mut PollParameters,
 	) -> Async<
 		NetworkBehaviourAction<
 			<<Self::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent,
@@ -364,7 +364,7 @@ ProtocolBehaviour<B, S, H> {
 
 		let mut network_out = LocalNetworkOut {
 			inner: &mut self.behaviour,
-			peerset_handle: &self.peerset_handle
+			peerset_handle: &self.peerset_handle,
 		};
 
 		let outcome = match event {
@@ -435,8 +435,8 @@ ProtocolBehaviour<B, S, H> {
 	}
 }
 
-impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> DiscoveryNetBehaviour for
-ProtocolBehaviour<B, S, H> {
+impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> DiscoveryNetBehaviour
+	for ProtocolBehaviour<B, S, H> {
 	fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
 		self.behaviour.add_discovered_nodes(peer_ids)
 	}

--- a/core/network/src/protocol_behaviour.rs
+++ b/core/network/src/protocol_behaviour.rs
@@ -50,7 +50,7 @@ pub struct ProtocolBehaviour<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT>
 }
 
 impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S, H> {
-	/// Builds a new `ProtocolsBehaviour`.
+	/// Builds a new `ProtocolBehaviour`.
 	pub fn new(
 		config: ProtocolConfig,
 		chain: Arc<dyn Client<B>>,
@@ -76,7 +76,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 	}
 
 	/// Returns the list of all the peers we have an open channel to.
-	pub fn open_peers<'a>(&'a self) -> impl Iterator<Item = &'a PeerId> + 'a {
+	pub fn open_peers(&self) -> impl Iterator<Item = &PeerId> {
 		self.behaviour.open_peers()
 	}
 
@@ -152,7 +152,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 		&'a mut self,
 	) -> (&'a mut Protocol<B, S, H>, LocalNetworkOut<'a, B>) {
 		let net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
-		(&mut self.protocol, net_out)	
+		(&mut self.protocol, net_out)
 	}
 
 	/// Gossip a consensus message to the network.
@@ -173,9 +173,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> ProtocolBehaviour<B, S,
 	}
 
 	// TODO: needed?
-	pub fn propagate_extrinsics(
-		&mut self,
-	) {
+	pub fn propagate_extrinsics(&mut self) {
 		self.protocol.propagate_extrinsics(
 			&mut LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle },
 			&*self.transaction_pool
@@ -332,13 +330,11 @@ ProtocolBehaviour<B, S, H> {
 			Self::OutEvent
 		>
 	> {
-		{
-			let mut net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
-			match self.protocol.poll(&mut net_out, &*self.transaction_pool) {
-				Ok(Async::Ready(v)) => void::unreachable(v),
-				Ok(Async::NotReady) => {}
-				Err(err) => void::unreachable(err),
-			}
+		let mut net_out = LocalNetworkOut { inner: &mut self.behaviour, peerset_handle: &self.peerset_handle };
+		match self.protocol.poll(&mut net_out, &*self.transaction_pool) {
+			Ok(Async::Ready(v)) => void::unreachable(v),
+			Ok(Async::NotReady) => {}
+			Err(err) => void::unreachable(err),
 		}
 
 		let event = match self.behaviour.poll(params) {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -191,8 +191,18 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkWorker
 
 		// Build the swarm.
 		let (mut swarm, bandwidth) = {
-			let user_agent = format!("{} ({})", params.network_config.client_version, params.network_config.node_name);
-			let behaviour = Behaviour::new(protocol, user_agent, local_public, known_addresses, params.network_config.enable_mdns);
+			let user_agent = format!(
+				"{} ({})",
+				params.network_config.client_version,
+				params.network_config.node_name
+			);
+			let behaviour = Behaviour::new(
+				protocol,
+				user_agent,
+				local_public,
+				known_addresses,
+				params.network_config.enable_mdns
+			);
 			let (transport, bandwidth) = transport::build_transport(
 				local_identity,
 				params.network_config.wasm_external_transport
@@ -374,7 +384,8 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkServic
 
 				Some((peer_id.to_base58(), NetworkStatePeer {
 					endpoint,
-					version_string: swarm.node(peer_id).and_then(|i| i.client_version().map(|s| s.to_owned())).clone(),
+					version_string: swarm.node(peer_id)
+						.and_then(|i| i.client_version().map(|s| s.to_owned())).clone(),
 					latest_ping_time: swarm.node(peer_id).and_then(|i| i.latest_ping()),
 					enabled: swarm.user_protocol().is_enabled(&peer_id),
 					open: swarm.user_protocol().is_open(&peer_id),
@@ -389,7 +400,8 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkServic
 				.cloned().collect::<Vec<_>>();
 			list.into_iter().map(move |peer_id| {
 				(peer_id.to_base58(), NetworkStateNotConnectedPeer {
-					version_string: swarm.node(&peer_id).and_then(|i| i.client_version().map(|s| s.to_owned())).clone(),
+					version_string: swarm.node(&peer_id)
+						.and_then(|i| i.client_version().map(|s| s.to_owned())).clone(),
 					latest_ping_time: swarm.node(&peer_id).and_then(|i| i.latest_ping()),
 					known_addresses: NetworkBehaviour::addresses_of_peer(&mut **swarm, &peer_id)
 						.into_iter().collect(),
@@ -419,7 +431,8 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkServic
 	}
 }
 
-impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> ::consensus::SyncOracle for NetworkService<B, S, H> {
+impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT>
+	::consensus::SyncOracle for NetworkService<B, S, H> {
 	fn is_major_syncing(&self) -> bool {
 		self.is_major_syncing()
 	}
@@ -569,7 +582,10 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Future for Ne
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		// Implementation of `protocol::NetworkOut` trait using the available local variables.
-		struct Context<'a, B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT>(&'a mut Swarm<B, S, H>, &'a PeersetHandle);
+		struct Context<'a, B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT>(
+			&'a mut Swarm<B, S, H>,
+			&'a PeersetHandle
+		);
 		impl<'a, B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkOut<B> for Context<'a, B, S, H> {
 			fn report_peer(&mut self, who: PeerId, reputation: i32) {
 				self.1.report_peer(who, reputation)
@@ -727,7 +743,8 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Future for Ne
 				ProtocolMsg::RequestFinalityProof(hash, number) =>
 					network_service.user_protocol_mut().request_finality_proof(&hash, number),
 				ProtocolMsg::FinalityProofImportResult(requested_block, finalziation_result) =>
-					network_service.user_protocol_mut().finality_proof_import_result(requested_block, finalziation_result),
+					network_service.user_protocol_mut()
+						.finality_proof_import_result(requested_block, finalziation_result),
 				ProtocolMsg::PropagateExtrinsics =>
 					network_service.user_protocol_mut().propagate_extrinsics(),
 				#[cfg(any(test, feature = "test-helpers"))]

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -38,9 +38,10 @@ use futures::sync::mpsc;
 
 // Type aliases.
 // These exist mainly to avoid typing `<F as Factory>::Foo` all over the code.
-/// Network service type for a factory.
-pub type NetworkService<F> =
-	network::NetworkService<<F as ServiceFactory>::Block, <F as ServiceFactory>::NetworkProtocol>;
+
+/// Network service type for `Components`.
+pub type NetworkService<C> =
+	network::NetworkService<ComponentBlock<C>, <<C as Components>::Factory as ServiceFactory>::NetworkProtocol, ComponentExHash<C>>;
 
 /// Code executor type for a factory.
 pub type CodeExecutor<F> = NativeExecutor<<F as ServiceFactory>::RuntimeDispatch>;

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -40,8 +40,11 @@ use futures::sync::mpsc;
 // These exist mainly to avoid typing `<F as Factory>::Foo` all over the code.
 
 /// Network service type for `Components`.
-pub type NetworkService<C> =
-	network::NetworkService<ComponentBlock<C>, <<C as Components>::Factory as ServiceFactory>::NetworkProtocol, ComponentExHash<C>>;
+pub type NetworkService<C> = network::NetworkService<
+	ComponentBlock<C>,
+	<<C as Components>::Factory as ServiceFactory>::NetworkProtocol,
+	ComponentExHash<C>
+>;
 
 /// Code executor type for a factory.
 pub type CodeExecutor<F> = NativeExecutor<<F as ServiceFactory>::RuntimeDispatch>;

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -74,7 +74,7 @@ const DEFAULT_PROTOCOL_ID: &str = "sup";
 pub struct Service<Components: components::Components> {
 	client: Arc<ComponentClient<Components>>,
 	select_chain: Option<<Components as components::Components>::SelectChain>,
-	network: Arc<components::NetworkService<Components::Factory>>,
+	network: Arc<components::NetworkService<Components>>,
 	transaction_pool: Arc<TransactionPool<Components::TransactionPoolApi>>,
 	keystore: Keystore,
 	exit: ::exit_future::Exit,
@@ -491,7 +491,7 @@ impl<Components> Service<Components> where Components: components::Components {
 	}
 
 	/// Get shared network instance.
-	pub fn network(&self) -> Arc<components::NetworkService<Components::Factory>> {
+	pub fn network(&self) -> Arc<components::NetworkService<Components>> {
 		self.network.clone()
 	}
 
@@ -619,7 +619,7 @@ impl<C: Components> network::TransactionPool<ComponentExHash<C>, ComponentBlock<
 
 /// Builds a never-ending `Future` that answers the RPC requests coming on the receiver.
 fn build_system_rpc_handler<Components: components::Components>(
-	network: Arc<NetworkService<Components::Factory>>,
+	network: Arc<NetworkService<Components>>,
 	rx: mpsc::UnboundedReceiver<rpc::apis::system::Request<ComponentBlock<Components>>>,
 	should_have_peers: bool,
 ) -> impl Future<Item = (), Error = ()> {


### PR DESCRIPTION
The next step in the refactoring is to implement the libp2p `NetworkBehaviour` trait on `Protocol`. This was done by adding a `ProtocolBehaviour` struct.

In other words:
Before: `CustomProto <-> Service <-> Protocol`.
After: `Service <-> (CustomProto <-> Protocol)`, and the thing in parentheses is `ProtocolBehaviour`.

This made it possible to move `start_service` in the constructor of `NetworkWorker`, which I did as well.

This unlocks the next step, which is to split `Protocol` in multiple `NetworkBehaviour`s.

Because #2500 was "rejected", I've had to use some hacks for granting access to the gossiping and specialization. It is unclear how I will clean that up, but I'll try to find a solution.
