### PR TITLE
Backport 2773: Generate docs for all workspace crates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ build-rust-doc-release:            &build
     - ./scripts/build.sh
   script:
     - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
-    - time cargo +nightly doc --release --verbose
+    - time cargo +nightly doc --release --all --verbose
     - cp -R ./target/doc ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=substrate_service/index.html>" > ./crate-docs/index.html
     - sccache -s


### PR DESCRIPTION
Backporting: https://github.com/paritytech/substrate/commit/6ea53d8614e7dd46f21d912bbcb2b8b1555df636#diff-96edf7a6f008de9e928d04e1ae5e12a5

Noticed that the v1.0 docs were still missing some crates, and here is the reason why.