### PR TITLE
srml-contract: ext_call/ext_create take gas buffer

### DIFF
--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -704,13 +704,14 @@ mod tests {
 	;; ext_call(
 	;;    callee_ptr: u32,
 	;;    callee_len: u32,
-	;;    gas: u64,
+	;;    gas_ptr: u32,
+	;;    gas_len: u32,
 	;;    value_ptr: u32,
 	;;    value_len: u32,
 	;;    input_data_ptr: u32,
 	;;    input_data_len: u32
 	;; ) -> u32
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
 	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
@@ -763,9 +764,10 @@ mod tests {
 				(call $ext_call
 					(i32.const 4)  ;; Pointer to "callee" address.
 					(i32.const 32)  ;; Length of "callee" address.
-					(i64.const 0)  ;; How much gas to devote for the execution. 0 = all.
-					(i32.const 36)  ;; Pointer to the buffer with value to transfer
-					(i32.const 16)   ;; Length of the buffer with value to transfer.
+					(i32.const 36)  ;; Pointer to amount of gas to devote for the execution.
+					(i32.const 8)   ;; Length of the buffer with the gas amount.
+					(i32.const 44)  ;; Pointer to the buffer with value to transfer
+					(i32.const 16)  ;; Length of the buffer with value to transfer.
 					(i32.const 0)   ;; Pointer to input data buffer address
 					(i32.const 0)   ;; Length of input data buffer
 				)
@@ -782,9 +784,12 @@ mod tests {
 		"\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 		"\00\00\00\00"
 	)
+	;; Amount of gas to devote for the execution. 0 = all.
+	;; Represented by u64 (8 bytes long) in little endian.
+	(data (i32.const 36) "\00\00\00\00\00\00\00\00")
 	;; Amount of value to transfer.
 	;; Represented by u128 (16 bytes long) in little endian.
-	(data (i32.const 36)
+	(data (i32.const 44)
 		"\06\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
 		"\00\00"
 	)

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 97,
-	impl_version: 98,
+	spec_version: 98,
+	impl_version: 99,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -328,23 +328,25 @@ mod tests {
 	;; ext_call(
 	;;    callee_ptr: u32,
 	;;    callee_len: u32,
-	;;    gas: u64,
+	;;    gas_ptr: u32,
+	;;    gas_len: u32,
 	;;    value_ptr: u32,
 	;;    value_len: u32,
 	;;    input_data_ptr: u32,
 	;;    input_data_len: u32
 	;;) -> u32
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
 			(call $ext_call
 				(i32.const 4)  ;; Pointer to "callee" address.
 				(i32.const 8)  ;; Length of "callee" address.
-				(i64.const 0)  ;; How much gas to devote for the execution. 0 = all.
-				(i32.const 12) ;; Pointer to the buffer with value to transfer
+				(i32.const 12) ;; Pointer to amount of gas to devote for the execution.
+				(i32.const 8)  ;; Length of the buffer with the gas amount.
+				(i32.const 20) ;; Pointer to the buffer with value to transfer
 				(i32.const 8)  ;; Length of the buffer with value to transfer.
-				(i32.const 20) ;; Pointer to input data buffer address
+				(i32.const 28) ;; Pointer to input data buffer address
 				(i32.const 4)  ;; Length of input data buffer
 			)
 		)
@@ -354,11 +356,14 @@ mod tests {
 	;; Destination AccountId to transfer the funds.
 	;; Represented by u64 (8 bytes long) in little endian.
 	(data (i32.const 4) "\09\00\00\00\00\00\00\00")
+	;; Amount of gas to devote for the execution. 0 = all.
+	;; Represented by u64 (8 bytes long) in little endian.
+	(data (i32.const 12) "\00\00\00\00\00\00\00\00")
 	;; Amount of value to transfer.
 	;; Represented by u64 (8 bytes long) in little endian.
-	(data (i32.const 12) "\06\00\00\00\00\00\00\00")
+	(data (i32.const 20) "\06\00\00\00\00\00\00\00")
 
-	(data (i32.const 20) "\01\02\03\04")
+	(data (i32.const 28) "\01\02\03\04")
 )
 "#;
 
@@ -380,7 +385,7 @@ mod tests {
 				to: 9,
 				value: 6,
 				data: vec![1, 2, 3, 4],
-				gas_left: 49970,
+				gas_left: 49961,
 			}]
 		);
 	}
@@ -390,36 +395,41 @@ mod tests {
 	;; ext_create(
 	;;     code_ptr: u32,
 	;;     code_len: u32,
-	;;     gas: u64,
+	;;     gas_ptr: u32,
+	;;     gas_len: u32,
 	;;     value_ptr: u32,
 	;;     value_len: u32,
 	;;     input_data_ptr: u32,
 	;;     input_data_len: u32,
 	;; ) -> u32
-	(import "env" "ext_create" (func $ext_create (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_create" (func $ext_create (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
 			(call $ext_create
-				(i32.const 16)   ;; Pointer to `code_hash`
+				(i32.const 24)   ;; Pointer to `code_hash`
 				(i32.const 32)   ;; Length of `code_hash`
-				(i64.const 0)    ;; How much gas to devote for the execution. 0 = all.
-				(i32.const 4)    ;; Pointer to the buffer with value to transfer
+				(i32.const 4)    ;; Pointer to amount of gas to devote for the execution.
+				(i32.const 8)    ;; Length of the buffer with the gas amount.
+				(i32.const 12)   ;; Pointer to the buffer with value to transfer
 				(i32.const 8)    ;; Length of the buffer with value to transfer
-				(i32.const 12)   ;; Pointer to input data buffer address
+				(i32.const 20)   ;; Pointer to input data buffer address
 				(i32.const 4)    ;; Length of input data buffer
 			)
 		)
 	)
 	(func (export "deploy"))
 
+	;; Amount of gas to devote for the execution. 0 = all.
+	;; Represented by u64 (8 bytes long) in little endian.
+	(data (i32.const 4) "\00\00\00\00\00\00\00\00")
 	;; Amount of value to transfer.
 	;; Represented by u64 (8 bytes long) in little endian.
-	(data (i32.const 4) "\03\00\00\00\00\00\00\00")
+	(data (i32.const 12) "\03\00\00\00\00\00\00\00")
 	;; Input data to pass to the contract being created.
-	(data (i32.const 12) "\01\02\03\04")
+	(data (i32.const 20) "\01\02\03\04")
 	;; Hash of code.
-	(data (i32.const 16)
+	(data (i32.const 24)
 		"\11\11\11\11\11\11\11\11\11\11\11\11\11\11\11\11"
 		"\11\11\11\11\11\11\11\11\11\11\11\11\11\11\11\11"
 	)
@@ -444,7 +454,7 @@ mod tests {
 				code_hash: [0x11; 32].into(),
 				endowment: 3,
 				data: vec![1, 2, 3, 4],
-				gas_left: 49946,
+				gas_left: 49937,
 			}]
 		);
 	}
@@ -454,23 +464,25 @@ mod tests {
 	;; ext_call(
 	;;    callee_ptr: u32,
 	;;    callee_len: u32,
-	;;    gas: u64,
+	;;    gas_ptr: u32,
+	;;    gas_len: u32,
 	;;    value_ptr: u32,
 	;;    value_len: u32,
 	;;    input_data_ptr: u32,
 	;;    input_data_len: u32
 	;;) -> u32
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
 			(call $ext_call
 				(i32.const 4)  ;; Pointer to "callee" address.
 				(i32.const 8)  ;; Length of "callee" address.
-				(i64.const 228)  ;; How much gas to devote for the execution.
-				(i32.const 12)  ;; Pointer to the buffer with value to transfer
+				(i32.const 12)  ;; Pointer to amount of gas to devote for the execution.
+				(i32.const 8)   ;; Length of the buffer with the gas amount.
+				(i32.const 20)  ;; Pointer to the buffer with value to transfer
 				(i32.const 8)   ;; Length of the buffer with value to transfer.
-				(i32.const 20)   ;; Pointer to input data buffer address
+				(i32.const 28)  ;; Pointer to input data buffer address
 				(i32.const 4)   ;; Length of input data buffer
 			)
 		)
@@ -480,11 +492,14 @@ mod tests {
 	;; Destination AccountId to transfer the funds.
 	;; Represented by u64 (8 bytes long) in little endian.
 	(data (i32.const 4) "\09\00\00\00\00\00\00\00")
+	;; Amount of gas to devote for the execution.
+	;; Represented by u64 (8 bytes long) in little endian.
+	(data (i32.const 12) "\e4\00\00\00\00\00\00\00")
 	;; Amount of value to transfer.
 	;; Represented by u64 (8 bytes long) in little endian.
-	(data (i32.const 12) "\06\00\00\00\00\00\00\00")
+	(data (i32.const 20) "\06\00\00\00\00\00\00\00")
 
-	(data (i32.const 20) "\01\02\03\04")
+	(data (i32.const 28) "\01\02\03\04")
 )
 "#;
 


### PR DESCRIPTION
This is meant to fix #2630.

Gas units are generic in the contract module configuration and the size may exceed that of u64. Instead of losing precision, treat gas the same as other function parameters and specify input with a serialized buffer.

This is a breaking change for existing contracts and for the ink! contract DSL. If we decide this is a good change, we will have to make a corresponding change to ink!

@pepyakin 