### PR TITLE
Remove tokio dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,6 @@ check-web-wasm:
     - time cargo web build -p substrate-consensus-aura
     - time cargo web build -p substrate-consensus-babe
     - time cargo web build -p substrate-consensus-common
-    - time cargo web build -p substrate-finality-grandpa
     - time cargo web build -p substrate-keyring
     - time cargo web build -p substrate-keystore
     - time cargo web build -p substrate-executor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,10 +157,12 @@ check-web-wasm:
     - time cargo web build -p substrate-consensus-aura
     - time cargo web build -p substrate-consensus-babe
     - time cargo web build -p substrate-consensus-common
+    - time cargo web build -p substrate-finality-grandpa
     - time cargo web build -p substrate-keyring
     - time cargo web build -p substrate-keystore
     - time cargo web build -p substrate-executor
     - time cargo web build -p substrate-network
+    - time cargo web build -p substrate-offchain
     - time cargo web build -p substrate-panic-handler
     - time cargo web build -p substrate-peerset
     - time cargo web build -p substrate-primitives

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,7 +4427,6 @@ dependencies = [
  "substrate-state-machine 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-transaction-pool 2.0.0",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,7 +4485,6 @@ dependencies = [
  "substrate-transaction-pool 2.0.0",
  "sysinfo 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "substrate-transaction-pool 2.0.0",
  "sysinfo 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
  "substrate-state-machine 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-transaction-pool 2.0.0",
+ "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,6 +4224,8 @@ dependencies = [
  "substrate-telemetry 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -645,7 +645,9 @@ where
 		None => Box::new(stdin()),
 	};
 
-	service::chain_ops::import_blocks::<F, _, _>(config, exit.into_exit(), file).map_err(Into::into)
+	let fut = service::chain_ops::import_blocks::<F, _, _>(config, exit.into_exit(), file)?;
+	tokio::run(fut);
+	Ok(())
 }
 
 fn revert_chain<F, S>(

--- a/core/finality-grandpa/Cargo.toml
+++ b/core/finality-grandpa/Cargo.toml
@@ -9,7 +9,8 @@ fork-tree = { path = "../../core/util/fork-tree" }
 futures = "0.1"
 log = "0.4"
 parking_lot = "0.8.0"
-tokio = "0.1.7"
+tokio-executor = "0.1.7"
+tokio-timer = "0.2.11"
 rand = "0.6"
 parity-codec = { version = "3.3", features = ["derive"] }
 runtime_primitives = { package = "sr-primitives", path = "../sr-primitives" }
@@ -31,6 +32,7 @@ network = { package = "substrate-network", path = "../network", features = ["tes
 keyring = { package = "substrate-keyring", path = "../keyring" }
 test-client = { package = "substrate-test-runtime-client", path = "../test-runtime/client"}
 env_logger = "0.6"
+tokio = "0.1.17"
 
 [features]
 default = ["service-integration"]

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -293,9 +293,9 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 			// to tokio globals, which aren't available outside.
 			let mut executor = tokio_executor::DefaultExecutor::current();
 			executor.spawn(Box::new(rebroadcast_job.select(on_exit.clone()).then(|_| Ok(()))))
-				.expect("failed to spawn task");
+				.expect("failed to spawn grandpa rebroadcast job task");
 			executor.spawn(Box::new(reporting_job.select(on_exit.clone()).then(|_| Ok(()))))
-				.expect("failed to spawn task");
+				.expect("failed to spawn grandpa reporting job task");
 			Ok(())
 		});
 

--- a/core/finality-grandpa/src/communication/mod.rs
+++ b/core/finality-grandpa/src/communication/mod.rs
@@ -34,6 +34,7 @@ use grandpa::Message::{Prevote, Precommit, PrimaryPropose};
 use futures::prelude::*;
 use futures::sync::{oneshot, mpsc};
 use log::{debug, trace};
+use tokio_executor::Executor;
 use parity_codec::{Encode, Decode};
 use substrate_primitives::{ed25519, Pair};
 use substrate_telemetry::{telemetry, CONSENSUS_DEBUG, CONSENSUS_INFO};
@@ -290,8 +291,11 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 		let startup_work = futures::future::lazy(move || {
 			// lazily spawn these jobs onto their own tasks. the lazy future has access
 			// to tokio globals, which aren't available outside.
-			tokio::spawn(rebroadcast_job.select(on_exit.clone()).then(|_| Ok(())));
-			tokio::spawn(reporting_job.select(on_exit.clone()).then(|_| Ok(())));
+			let mut executor = tokio_executor::DefaultExecutor::current();
+			executor.spawn(Box::new(rebroadcast_job.select(on_exit.clone()).then(|_| Ok(()))))
+				.expect("failed to spawn task");
+			executor.spawn(Box::new(reporting_job.select(on_exit.clone()).then(|_| Ok(()))))
+				.expect("failed to spawn task");
 			Ok(())
 		});
 

--- a/core/finality-grandpa/src/communication/periodic.rs
+++ b/core/finality-grandpa/src/communication/periodic.rs
@@ -21,7 +21,7 @@ use futures::prelude::*;
 use futures::sync::mpsc;
 use runtime_primitives::traits::{NumberFor, Block as BlockT};
 use network::PeerId;
-use tokio::timer::Delay;
+use tokio_timer::Delay;
 use log::warn;
 use parity_codec::Encode;
 

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use log::{debug, warn, info};
 use parity_codec::{Decode, Encode};
 use futures::prelude::*;
-use tokio::timer::Delay;
+use tokio_timer::Delay;
 use parking_lot::RwLock;
 
 use client::{

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -179,7 +179,7 @@ pub enum Error {
 	/// An invariant has been violated (e.g. not finalizing pending change blocks in-order)
 	Safety(String),
 	/// A timer failed to fire.
-	Timer(::tokio_timer::Error),
+	Timer(tokio_timer::Error),
 }
 
 impl From<GrandpaError> for Error {

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -443,7 +443,7 @@ fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT<Hash=H25
 }
 
 /// Parameters used to run Grandpa.
-pub struct GrandpaParams<'a, B, E, Block: BlockT<Hash=H256>, N, RA, SC, X> {
+pub struct GrandpaParams<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X> {
 	/// Configuration for the GRANDPA service.
 	pub config: Config,
 	/// A link to the block import worker.
@@ -455,7 +455,7 @@ pub struct GrandpaParams<'a, B, E, Block: BlockT<Hash=H256>, N, RA, SC, X> {
 	/// Handle to a future that will resolve on exit.
 	pub on_exit: X,
 	/// If supplied, can be used to hook on telemetry connection established events.
-	pub telemetry_on_connect: Option<TelemetryOnConnect<'a>>,
+	pub telemetry_on_connect: Option<TelemetryOnConnect>,
 }
 
 /// Run a GRANDPA voter as a task. Provide configuration and a link to a
@@ -503,7 +503,7 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 
 	register_finality_tracker_inherent_data_provider(client.clone(), &inherent_data_providers)?;
 
-	if let Some(telemetry_on_connect) = telemetry_on_connect {
+	let telemetry_task = if let Some(telemetry_on_connect) = telemetry_on_connect {
 		let authorities = authority_set.clone();
 		let events = telemetry_on_connect.telemetry_connection_sinks
 			.for_each(move |_| {
@@ -520,11 +520,11 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 				);
 				Ok(())
 			})
-			.then(|_| Ok(()));
-		let events = events.select(telemetry_on_connect.on_exit).then(|_| Ok(()));
-		telemetry_on_connect.executor.execute(Box::new(events))
-			.expect("failed to spawn task");
-	}
+			.then(|_| -> Result<(), ()> { Ok(()) });
+		futures::future::Either::A(events)
+	} else {
+		futures::future::Either::B(futures::future::empty())
+	};
 
 	let voters = authority_set.current_authorities();
 	let initial_environment = Arc::new(Environment {
@@ -724,7 +724,11 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 
 	let voter_work = network_startup.and_then(move |()| voter_work);
 
-	Ok(voter_work.select(on_exit).then(|_| Ok(())))
+	// Make sure that `telemetry_task` doesn't accidentally finish and kill grandpa.
+	let telemetry_task = telemetry_task
+		.then(|_| futures::future::empty::<(), ()>());
+
+	Ok(voter_work.select(on_exit).select2(telemetry_task).then(|_| Ok(())))
 }
 
 #[deprecated(since = "1.1", note = "Please switch to run_grandpa_voter.")]

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -179,7 +179,7 @@ pub enum Error {
 	/// An invariant has been violated (e.g. not finalizing pending change blocks in-order)
 	Safety(String),
 	/// A timer failed to fire.
-	Timer(::tokio::timer::Error),
+	Timer(::tokio_timer::Error),
 }
 
 impl From<GrandpaError> for Error {
@@ -522,7 +522,8 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 			})
 			.then(|_| Ok(()));
 		let events = events.select(telemetry_on_connect.on_exit).then(|_| Ok(()));
-		telemetry_on_connect.executor.spawn(events);
+		telemetry_on_connect.executor.execute(Box::new(events))
+			.expect("failed to spawn task");
 	}
 
 	let voters = authority_set.current_authorities();

--- a/core/finality-grandpa/src/until_imported.rs
+++ b/core/finality-grandpa/src/until_imported.rs
@@ -28,7 +28,7 @@ use futures::prelude::*;
 use futures::stream::Fuse;
 use parking_lot::Mutex;
 use runtime_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor};
-use tokio::timer::Interval;
+use tokio_timer::Interval;
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
@@ -411,7 +411,7 @@ pub(crate) type UntilCommitBlocksImported<Block, Status, I, U> = UntilImported<
 mod tests {
 	use super::*;
 	use tokio::runtime::current_thread::Runtime;
-	use tokio::timer::Delay;
+	use tokio_timer::Delay;
 	use test_client::runtime::{Block, Hash, Header};
 	use consensus_common::BlockOrigin;
 	use client::BlockImportNotification;

--- a/core/offchain/Cargo.toml
+++ b/core/offchain/Cargo.toml
@@ -16,12 +16,12 @@ parity-codec = { version = "3.3", features = ["derive"] }
 parking_lot = "0.8.0"
 primitives = { package = "substrate-primitives", path = "../../core/primitives" }
 runtime_primitives = { package = "sr-primitives", path = "../../core/sr-primitives" }
-tokio = "0.1.7"
 transaction_pool = { package = "substrate-transaction-pool", path = "../../core/transaction-pool" }
 
 [dev-dependencies]
 env_logger = "0.6"
 test-client = { package = "substrate-test-runtime-client", path = "../../core/test-runtime/client" }
+tokio = "0.1.7"
 
 [features]
 default = []

--- a/core/offchain/src/lib.rs
+++ b/core/offchain/src/lib.rs
@@ -104,9 +104,8 @@ impl<C, Block> OffchainWorkers<C, Block> where
 			let api = Box::new(api);
 			runtime.offchain_worker_with_context(&at, ExecutionContext::OffchainWorker(api), *number).unwrap();
 			futures::future::Either::A(runner.process())
-
 		} else {
-			futures::future::Either::B(futures::future::empty())
+			futures::future::Either::B(futures::future::ok(()))
 		}
 	}
 }

--- a/core/offchain/src/lib.rs
+++ b/core/offchain/src/lib.rs
@@ -125,8 +125,8 @@ mod tests {
 		let pool = Arc::new(Pool::new(Default::default(), ::transaction_pool::ChainApi::new(client.clone())));
 
 		// when
-		let offchain = OffchainWorkers::new(client, Arc::new(runtime.executor()));
-		offchain.on_block_imported(&0u64, &pool);
+		let offchain = OffchainWorkers::new(client);
+		runtime.executor().spawn(offchain.on_block_imported(&0u64, &pool));
 
 		// then
 		runtime.shutdown_on_idle().wait().unwrap();

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -24,7 +24,6 @@ state_machine = { package = "substrate-state-machine", path = "../state-machine"
 transaction_pool = { package = "substrate-transaction-pool", path = "../transaction-pool" }
 runtime_primitives = { package = "sr-primitives", path = "../sr-primitives" }
 runtime_version = { package = "sr-version", path = "../sr-version" }
-tokio = "0.1.7"
 
 [dev-dependencies]
 assert_matches = "1.1"

--- a/core/rpc/Cargo.toml
+++ b/core/rpc/Cargo.toml
@@ -31,3 +31,4 @@ futures = "0.1.17"
 sr-io = { path = "../sr-io" }
 test-client = { package = "substrate-test-runtime-client", path = "../test-runtime/client" }
 rustc-hex = "2.0"
+tokio = "0.1.17"

--- a/core/rpc/src/author/tests.rs
+++ b/core/rpc/src/author/tests.rs
@@ -44,7 +44,7 @@ fn submit_transaction_should_not_cause_error() {
 	let p = Author {
 		client: client.clone(),
 		pool: Arc::new(Pool::new(Default::default(), ChainApi::new(client))),
-		subscriptions: Subscriptions::new(runtime.executor()),
+		subscriptions: Subscriptions::new(Arc::new(runtime.executor())),
 	};
 	let xt = uxt(AccountKeyring::Alice, 1).encode();
 	let h: H256 = blake2_256(&xt).into();
@@ -65,7 +65,7 @@ fn submit_rich_transaction_should_not_cause_error() {
 	let p = Author {
 		client: client.clone(),
 		pool: Arc::new(Pool::new(Default::default(), ChainApi::new(client.clone()))),
-		subscriptions: Subscriptions::new(runtime.executor()),
+		subscriptions: Subscriptions::new(Arc::new(runtime.executor())),
 	};
 	let xt = uxt(AccountKeyring::Alice, 0).encode();
 	let h: H256 = blake2_256(&xt).into();
@@ -88,7 +88,7 @@ fn should_watch_extrinsic() {
 	let p = Author {
 		client,
 		pool: pool.clone(),
-		subscriptions: Subscriptions::new(runtime.executor()),
+		subscriptions: Subscriptions::new(Arc::new(runtime.executor())),
 	};
 	let (subscriber, id_rx, data) = ::jsonrpc_pubsub::typed::Subscriber::new_test("test");
 
@@ -128,7 +128,7 @@ fn should_return_pending_extrinsics() {
 	let p = Author {
 		client,
 		pool: pool.clone(),
-		subscriptions: Subscriptions::new(runtime.executor()),
+		subscriptions: Subscriptions::new(Arc::new(runtime.executor())),
 	};
 	let ex = uxt(AccountKeyring::Alice, 0);
 	AuthorApi::submit_extrinsic(&p, ex.encode().into()).unwrap();
@@ -146,7 +146,7 @@ fn should_remove_extrinsics() {
 	let p = Author {
 		client,
 		pool: pool.clone(),
-		subscriptions: Subscriptions::new(runtime.executor()),
+		subscriptions: Subscriptions::new(Arc::new(runtime.executor())),
 	};
 	let ex1 = uxt(AccountKeyring::Alice, 0);
 	p.submit_extrinsic(ex1.encode().into()).unwrap();

--- a/core/rpc/src/chain/tests.rs
+++ b/core/rpc/src/chain/tests.rs
@@ -29,7 +29,7 @@ fn should_return_header() {
 
 	let client = Chain {
 		client: Arc::new(test_client::new()),
-		subscriptions: Subscriptions::new(remote),
+		subscriptions: Subscriptions::new(Arc::new(remote)),
 	};
 
 	assert_matches!(
@@ -67,7 +67,7 @@ fn should_return_a_block() {
 
 	let api = Chain {
 		client: Arc::new(test_client::new()),
-		subscriptions: Subscriptions::new(remote),
+		subscriptions: Subscriptions::new(Arc::new(remote)),
 	};
 
 	let block = api.client.new_block(Default::default()).unwrap().bake().unwrap();
@@ -121,7 +121,7 @@ fn should_return_block_hash() {
 
 	let client = Chain {
 		client: Arc::new(test_client::new()),
-		subscriptions: Subscriptions::new(remote),
+		subscriptions: Subscriptions::new(Arc::new(remote)),
 	};
 
 	assert_matches!(
@@ -165,7 +165,7 @@ fn should_return_finalized_hash() {
 
 	let client = Chain {
 		client: Arc::new(test_client::new()),
-		subscriptions: Subscriptions::new(remote),
+		subscriptions: Subscriptions::new(Arc::new(remote)),
 	};
 
 	assert_matches!(
@@ -199,7 +199,7 @@ fn should_notify_about_latest_block() {
 	{
 		let api = Chain {
 			client: Arc::new(test_client::new()),
-			subscriptions: Subscriptions::new(remote),
+			subscriptions: Subscriptions::new(Arc::new(remote)),
 		};
 
 		api.subscribe_new_head(Default::default(), subscriber);
@@ -230,7 +230,7 @@ fn should_notify_about_finalized_block() {
 	{
 		let api = Chain {
 			client: Arc::new(test_client::new()),
-			subscriptions: Subscriptions::new(remote),
+			subscriptions: Subscriptions::new(Arc::new(remote)),
 		};
 
 		api.subscribe_finalized_heads(Default::default(), subscriber);

--- a/core/rpc/src/state/tests.rs
+++ b/core/rpc/src/state/tests.rs
@@ -32,7 +32,7 @@ fn should_return_storage() {
 	let core = tokio::runtime::Runtime::new().unwrap();
 	let client = Arc::new(test_client::new());
 	let genesis_hash = client.genesis_hash();
-	let client = State::new(client, Subscriptions::new(core.executor()));
+	let client = State::new(client, Subscriptions::new(Arc::new(core.executor())));
 	let key = StorageKey(b":code".to_vec());
 
 	assert_eq!(
@@ -57,7 +57,7 @@ fn should_return_child_storage() {
 		.add_child_storage("test", "key", vec![42_u8])
 		.build());
 	let genesis_hash = client.genesis_hash();
-	let client = State::new(client, Subscriptions::new(core.executor()));
+	let client = State::new(client, Subscriptions::new(Arc::new(core.executor())));
 	let child_key = StorageKey(well_known_keys::CHILD_STORAGE_KEY_PREFIX.iter().chain(b"test").cloned().collect());
 	let key = StorageKey(b"key".to_vec());
 
@@ -82,7 +82,7 @@ fn should_call_contract() {
 	let core = tokio::runtime::Runtime::new().unwrap();
 	let client = Arc::new(test_client::new());
 	let genesis_hash = client.genesis_hash();
-	let client = State::new(client, Subscriptions::new(core.executor()));
+	let client = State::new(client, Subscriptions::new(Arc::new(core.executor())));
 
 	assert_matches!(
 		client.call("balanceOf".into(), Bytes(vec![1,2,3]), Some(genesis_hash).into()),
@@ -97,7 +97,7 @@ fn should_notify_about_storage_changes() {
 	let (subscriber, id, transport) = Subscriber::new_test("test");
 
 	{
-		let api = State::new(Arc::new(test_client::new()), Subscriptions::new(remote));
+		let api = State::new(Arc::new(test_client::new()), Subscriptions::new(Arc::new(remote)));
 
 		api.subscribe_storage(Default::default(), subscriber, None.into());
 
@@ -128,7 +128,7 @@ fn should_send_initial_storage_changes_and_notifications() {
 	let (subscriber, id, transport) = Subscriber::new_test("test");
 
 	{
-		let api = State::new(Arc::new(test_client::new()), Subscriptions::new(remote));
+		let api = State::new(Arc::new(test_client::new()), Subscriptions::new(Arc::new(remote)));
 
 		let alice_balance_key = blake2_256(&runtime::system::balance_of_key(AccountKeyring::Alice.into()));
 
@@ -163,7 +163,7 @@ fn should_send_initial_storage_changes_and_notifications() {
 fn should_query_storage() {
 	fn run_tests(client: Arc<TestClient>) {
 		let core = tokio::runtime::Runtime::new().unwrap();
-		let api = State::new(client.clone(), Subscriptions::new(core.executor()));
+		let api = State::new(client.clone(), Subscriptions::new(Arc::new(core.executor())));
 
 		let add_block = |nonce| {
 			let mut builder = client.new_block(Default::default()).unwrap();
@@ -254,7 +254,7 @@ fn should_return_runtime_version() {
 	let core = tokio::runtime::Runtime::new().unwrap();
 
 	let client = Arc::new(test_client::new());
-	let api = State::new(client.clone(), Subscriptions::new(core.executor()));
+	let api = State::new(client.clone(), Subscriptions::new(Arc::new(core.executor())));
 
 	let result = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":1,\
 		\"specVersion\":1,\"implVersion\":1,\"apis\":[[\"0xdf6acb689907609b\",2],\
@@ -274,7 +274,7 @@ fn should_notify_on_runtime_version_initially() {
 
 	{
 		let client = Arc::new(test_client::new());
-		let api = State::new(client.clone(), Subscriptions::new(core.executor()));
+		let api = State::new(client.clone(), Subscriptions::new(Arc::new(core.executor())));
 
 		api.subscribe_runtime_version(Default::default(), subscriber);
 

--- a/core/rpc/src/subscriptions.rs
+++ b/core/rpc/src/subscriptions.rs
@@ -22,7 +22,6 @@ use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
 use parking_lot::Mutex;
 use crate::rpc::futures::sync::oneshot;
 use crate::rpc::futures::{Future, future};
-use tokio::runtime::TaskExecutor;
 
 type Id = u64;
 
@@ -50,16 +49,16 @@ impl IdProvider {
 ///
 /// Takes care of assigning unique subscription ids and
 /// driving the sinks into completion.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Subscriptions {
 	next_id: IdProvider,
 	active_subscriptions: Arc<Mutex<HashMap<Id, oneshot::Sender<()>>>>,
-	executor: TaskExecutor,
+	executor: Arc<dyn future::Executor<Box<dyn Future<Item = (), Error = ()> + Send>> + Send + Sync>,
 }
 
 impl Subscriptions {
 	/// Creates new `Subscriptions` object.
-	pub fn new(executor: TaskExecutor) -> Self {
+	pub fn new(executor: Arc<dyn future::Executor<Box<dyn Future<Item = (), Error = ()> + Send>> + Send + Sync>) -> Self {
 		Subscriptions {
 			next_id: Default::default(),
 			active_subscriptions: Default::default(),
@@ -86,7 +85,8 @@ impl Subscriptions {
 				.then(|_| Ok(()));
 
 			self.active_subscriptions.lock().insert(id, tx);
-			self.executor.spawn(future);
+			self.executor.execute(Box::new(future))
+				.expect("failed to spawn task");
 		}
 	}
 

--- a/core/rpc/src/subscriptions.rs
+++ b/core/rpc/src/subscriptions.rs
@@ -17,7 +17,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::{self, AtomicUsize}};
 
-use log::warn;
+use log::{error, warn};
 use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
 use parking_lot::Mutex;
 use crate::rpc::futures::sync::oneshot;
@@ -85,8 +85,9 @@ impl Subscriptions {
 				.then(|_| Ok(()));
 
 			self.active_subscriptions.lock().insert(id, tx);
-			self.executor.execute(Box::new(future))
-				.expect("failed to spawn task");
+			if self.executor.execute(Box::new(future)).is_err() {
+				error!("Failed to spawn RPC subscription task");
+			}
 		}
 	}
 

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -11,6 +11,7 @@ parking_lot = "0.8.0"
 lazy_static = "1.0"
 log = "0.4"
 slog = {version = "^2", features = ["nested-values"]}
+tokio-executor = "0.1.7"
 tokio-timer = "0.2"
 exit-future = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -11,7 +11,6 @@ parking_lot = "0.8.0"
 lazy_static = "1.0"
 log = "0.4"
 slog = {version = "^2", features = ["nested-values"]}
-tokio = "0.1.7"
 tokio-timer = "0.2"
 exit-future = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -257,7 +257,7 @@ pub trait OffchainWorker<C: Components> {
 		number: &FactoryBlockNumber<C::Factory>,
 		offchain: &offchain::OffchainWorkers<ComponentClient<C>, ComponentBlock<C>>,
 		pool: &Arc<TransactionPool<C::TransactionPoolApi>>,
-	) -> error::Result<()>;
+	) -> error::Result<Box<dyn Future<Item = (), Error = ()> + Send>>;
 }
 
 impl<C: Components> OffchainWorker<Self> for C where
@@ -268,8 +268,8 @@ impl<C: Components> OffchainWorker<Self> for C where
 		number: &FactoryBlockNumber<C::Factory>,
 		offchain: &offchain::OffchainWorkers<ComponentClient<C>, ComponentBlock<C>>,
 		pool: &Arc<TransactionPool<C::TransactionPoolApi>>,
-	) -> error::Result<()> {
-		Ok(offchain.on_block_imported(number, pool))
+	) -> error::Result<Box<dyn Future<Item = (), Error = ()> + Send>> {
+		Ok(Box::new(offchain.on_block_imported(number, pool)))
 	}
 }
 

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -18,7 +18,6 @@
 
 use std::{sync::Arc, net::SocketAddr, ops::Deref, ops::DerefMut};
 use serde::{Serialize, de::DeserializeOwned};
-use tokio::runtime::TaskExecutor;
 use crate::chain_spec::ChainSpec;
 use client_db;
 use client::{self, Client, runtime_api};
@@ -34,7 +33,7 @@ use crate::config::Configuration;
 use primitives::{Blake2Hasher, H256};
 use rpc::{self, apis::system::SystemInfo};
 use parking_lot::Mutex;
-use futures::sync::mpsc;
+use futures::{future::Executor, future::Future, sync::mpsc};
 
 // Type aliases.
 // These exist mainly to avoid typing `<F as Factory>::Foo` all over the code.
@@ -293,6 +292,9 @@ impl<C: Components, T> ServiceTrait<C> for T where
 	+ MaintainTransactionPool<C>
 	+ OffchainWorker<C>
 {}
+
+/// Alias for a an implementation of `futures::future::Executor`.
+pub type TaskExecutor = Arc<dyn Executor<Box<dyn Future<Item = (), Error = ()> + Send>> + Send + Sync>;
 
 /// A collection of types and methods to build a service on top of the substrate service.
 pub trait ServiceFactory: 'static + Sized {

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -728,7 +728,7 @@ fn build_system_rpc_handler<Components: components::Components>(
 /// ```
 /// # use substrate_service::{
 /// # 	construct_service_factory, Service, FullBackend, FullExecutor, LightBackend, LightExecutor,
-/// # 	FullComponents, LightComponents, FactoryFullConfiguration, FullClient, Executor
+/// # 	FullComponents, LightComponents, FactoryFullConfiguration, FullClient, TaskExecutor
 /// # };
 /// # use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 /// # use network::construct_simple_protocol;

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -556,6 +556,18 @@ impl<Components> Future for Service<Components> where Components: components::Co
 	type Error = ();
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		Future::poll(&mut &*self)
+	}
+}
+
+// Note that this implementation is totally unnecessary. It exists only because of tests. The tests
+// should eventually be reworked, as it would make it possible to remove the `Mutex`es. that we
+// lock here.
+impl<'a, Components> Future for &'a Service<Components> where Components: components::Components {
+	type Item = ();
+	type Error = ();
+
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		// The user is supposed to poll only one service, so it doesn't matter if we keep this
 		// mutex locked.
 		let mut to_poll = self.to_poll.lock();

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -106,13 +106,9 @@ pub fn new_client<Factory: components::ServiceFactory>(config: &FactoryFullConfi
 pub type TelemetryOnConnectNotifications = mpsc::UnboundedReceiver<()>;
 
 /// Used to hook on telemetry connection established events.
-pub struct TelemetryOnConnect<'a> {
-	/// Handle to a future that will resolve on exit.
-	pub on_exit: Box<dyn Future<Item=(), Error=()> + Send + 'static>,
+pub struct TelemetryOnConnect {
 	/// Event stream.
 	pub telemetry_connection_sinks: TelemetryOnConnectNotifications,
-	/// Executor to which the hook is spawned.
-	pub executor: &'a TaskExecutor,
 }
 
 impl<Components: components::Components> Service<Components> {

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -586,7 +586,7 @@ impl<'a, Components> Future for &'a Service<Components> where Components: compon
 		}
 
 		// Polling all the `to_poll` futures.
-		while let Some(pos) = to_poll.iter_mut().position(|t| t.poll().map(|t| !t.is_ready()).unwrap_or(true)) {
+		while let Some(pos) = to_poll.iter_mut().position(|t| t.poll().map(|t| t.is_ready()).unwrap_or(true)) {
 			to_poll.remove(pos);
 		}
 

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -262,7 +262,7 @@ pub fn connectivity<F: ServiceFactory>(spec: FactoryChainSpec<F>) {
 			network.runtime
 		};
 
-		runtime.shutdown_on_idle().wait().expect("Error shutting down runtime");
+		runtime.shutdown_now().wait().expect("Error shutting down runtime");
 
 		temp.close().expect("Error removing temp dir");
 	}

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::service;
 use futures::{future, Future, sync::oneshot};
-use std::{cell::RefCell, sync::Arc};
+use std::cell::RefCell;
 use tokio::runtime::Runtime;
 pub use substrate_cli::{VersionInfo, IntoExit, error};
 use substrate_cli::{informant, parse_and_execute, NoCustom};
@@ -25,16 +25,15 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 			info!("Node name: {}", config.name);
 			info!("Roles: {:?}", config.roles);
 			let runtime = Runtime::new().map_err(|e| format!("{:?}", e))?;
-			let executor = Arc::new(runtime.executor());
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,
-				 	service::Factory::new_light(config, executor).map_err(|e| format!("{:?}", e))?,
+				 	service::Factory::new_light(config).map_err(|e| format!("{:?}", e))?,
 					exit
 				),
 				_ => run_until_exit(
 					runtime,
-					service::Factory::new_full(config, executor).map_err(|e| format!("{:?}", e))?,
+					service::Factory::new_full(config).map_err(|e| format!("{:?}", e))?,
 					exit
 				),
 			}.map_err(|e| format!("{:?}", e))
@@ -55,7 +54,7 @@ fn run_until_exit<T, C, E>(
 	e: E,
 ) -> error::Result<()>
 	where
-		T: Deref<Target=substrate_service::Service<C>>,
+		T: Deref<Target=substrate_service::Service<C>> + Future<Item = (), Error = ()> + Send + 'static,
 		C: substrate_service::Components,
 		E: IntoExit,
 {
@@ -64,13 +63,13 @@ fn run_until_exit<T, C, E>(
 	let informant = informant::build(&service);
 	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
-	let _ = runtime.block_on(e.into_exit());
-	exit_send.fire();
-
 	// we eagerly drop the service so that the internal exit future is fired,
 	// but we need to keep holding a reference to the global telemetry guard
 	let _telemetry = service.telemetry();
-	drop(service);
+
+	let _ = runtime.block_on(service.select(e.into_exit()));
+	exit_send.fire();
+
 	Ok(())
 }
 

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::service;
 use futures::{future, Future, sync::oneshot};
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::Arc};
 use tokio::runtime::Runtime;
 pub use substrate_cli::{VersionInfo, IntoExit, error};
 use substrate_cli::{informant, parse_and_execute, NoCustom};
@@ -25,7 +25,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 			info!("Node name: {}", config.name);
 			info!("Roles: {:?}", config.roles);
 			let runtime = Runtime::new().map_err(|e| format!("{:?}", e))?;
-			let executor = runtime.executor();
+			let executor = Arc::new(runtime.executor());
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -65,7 +65,7 @@ construct_service_factory! {
 				FullComponents::<Factory>::new(config, executor)
 			},
 		AuthoritySetup = {
-			|service: Self::FullService, executor: TaskExecutor, key: Option<Arc<Pair>>| {
+			|service: Self::FullService, key: Option<Arc<Pair>>| {
 				if let Some(key) = key {
 					info!("Using authority key {}", key.public());
 					let proposer = Arc::new(ProposerFactory {
@@ -86,8 +86,7 @@ construct_service_factory! {
 						service.config.custom.inherent_data_providers.clone(),
 						service.config.force_authoring,
 					)?;
-					executor.execute(Box::new(aura.select(service.on_exit()).then(|_| Ok(()))))
-						.expect("failed to spawn task");
+					service.spawn_task(Box::new(aura.select(service.on_exit()).then(|_| Ok(()))));
 				}
 
 				Ok(service)

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -8,7 +8,7 @@ use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use node_template_runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
 use substrate_service::{
 	FactoryFullConfiguration, LightComponents, FullComponents, FullBackend,
-	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor, TaskExecutor,
+	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor,
 	error::{Error as ServiceError},
 };
 use basic_authorship::ProposerFactory;
@@ -61,8 +61,8 @@ construct_service_factory! {
 		Genesis = GenesisConfig,
 		Configuration = NodeConfig,
 		FullService = FullComponents<Self>
-			{ |config: FactoryFullConfiguration<Self>, executor: TaskExecutor|
-				FullComponents::<Factory>::new(config, executor)
+			{ |config: FactoryFullConfiguration<Self>|
+				FullComponents::<Factory>::new(config)
 			},
 		AuthoritySetup = {
 			|service: Self::FullService, key: Option<Arc<Pair>>| {
@@ -93,7 +93,7 @@ construct_service_factory! {
 			}
 		},
 		LightService = LightComponents<Self>
-			{ |config, executor| <LightComponents<Factory>>::new(config, executor) },
+			{ |config| <LightComponents<Factory>>::new(config) },
 		FullImportQueue = AuraImportQueue<
 			Self::Block,
 		>

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -8,8 +8,7 @@ use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use node_template_runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
 use substrate_service::{
 	FactoryFullConfiguration, LightComponents, FullComponents, FullBackend,
-	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor,
-	TaskExecutor,
+	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor, TaskExecutor,
 	error::{Error as ServiceError},
 };
 use basic_authorship::ProposerFactory;
@@ -87,7 +86,8 @@ construct_service_factory! {
 						service.config.custom.inherent_data_providers.clone(),
 						service.config.force_authoring,
 					)?;
-					executor.spawn(aura.select(service.on_exit()).then(|_| Ok(())));
+					executor.execute(Box::new(aura.select(service.on_exit()).then(|_| Ok(()))))
+						.expect("failed to spawn task");
 				}
 
 				Ok(service)

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -440,9 +440,9 @@ pub(crate) mod tests {
 		ChainSpec::from_genesis("Integration Test", "test", local_testnet_genesis_instant, vec![], None, None, None, None)
 	}
 
-	/*#[test]
+	#[test]
 	#[ignore]
 	fn test_connectivity() {
 		service_test::connectivity::<Factory>(integration_test_config_with_two_authorities());
-	}*/
+	}
 }

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -440,9 +440,9 @@ pub(crate) mod tests {
 		ChainSpec::from_genesis("Integration Test", "test", local_testnet_genesis_instant, vec![], None, None, None, None)
 	}
 
-	#[test]
+	/*#[test]
 	#[ignore]
 	fn test_connectivity() {
 		service_test::connectivity::<Factory>(integration_test_config_with_two_authorities());
-	}
+	}*/
 }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::prelude::Future;
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 pub use cli::{VersionInfo, IntoExit, NoCustom, SharedParams};
 use substrate_service::{ServiceFactory, Roles as ServiceRoles};
-use std::ops::Deref;
+use std::{ops::Deref, sync::Arc};
 use log::info;
 use structopt::{StructOpt, clap::App};
 use cli::{AugmentClap, GetLogFilter};
@@ -156,7 +156,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 			info!("Roles: {:?}", config.roles);
 			let runtime = RuntimeBuilder::new().name_prefix("main-tokio-").build()
 				.map_err(|e| format!("{:?}", e))?;
-			let executor = runtime.executor();
+			let executor = Arc::new(runtime.executor());
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -28,7 +28,7 @@ use tokio::prelude::Future;
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 pub use cli::{VersionInfo, IntoExit, NoCustom, SharedParams};
 use substrate_service::{ServiceFactory, Roles as ServiceRoles};
-use std::{ops::Deref, sync::Arc};
+use std::ops::Deref;
 use log::info;
 use structopt::{StructOpt, clap::App};
 use cli::{AugmentClap, GetLogFilter};
@@ -156,16 +156,15 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 			info!("Roles: {:?}", config.roles);
 			let runtime = RuntimeBuilder::new().name_prefix("main-tokio-").build()
 				.map_err(|e| format!("{:?}", e))?;
-			let executor = Arc::new(runtime.executor());
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,
-					service::Factory::new_light(config, executor).map_err(|e| format!("{:?}", e))?,
+					service::Factory::new_light(config).map_err(|e| format!("{:?}", e))?,
 					exit
 				),
 				_ => run_until_exit(
 					runtime,
-					service::Factory::new_full(config, executor).map_err(|e| format!("{:?}", e))?,
+					service::Factory::new_full(config).map_err(|e| format!("{:?}", e))?,
 					exit
 				),
 			}.map_err(|e| format!("{:?}", e))
@@ -207,7 +206,7 @@ fn run_until_exit<T, C, E>(
 	e: E,
 ) -> error::Result<()>
 	where
-	    T: Deref<Target=substrate_service::Service<C>>,
+		T: Deref<Target=substrate_service::Service<C>> + Future<Item = (), Error = ()> + Send + 'static,
 		C: substrate_service::Components,
 		E: IntoExit,
 {
@@ -216,13 +215,12 @@ fn run_until_exit<T, C, E>(
 	let informant = cli::informant::build(&service);
 	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
-	let _ = runtime.block_on(e.into_exit());
-	exit_send.fire();
-
 	// we eagerly drop the service so that the internal exit future is fired,
 	// but we need to keep holding a reference to the global telemetry guard
 	let _telemetry = service.telemetry();
-	drop(service);
+
+	let _ = runtime.block_on(service.select(e.into_exit()));
+	exit_send.fire();
 
 	// TODO [andre]: timeout this future #1318
 	let _ = runtime.shutdown_on_idle().wait();

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -31,7 +31,7 @@ use node_primitives::Block;
 use node_runtime::{GenesisConfig, RuntimeApi};
 use substrate_service::{
 	FactoryFullConfiguration, LightComponents, FullComponents, FullBackend,
-	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor, TaskExecutor,
+	FullClient, LightClient, LightBackend, FullExecutor, LightExecutor,
 	error::{Error as ServiceError},
 };
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
@@ -76,8 +76,8 @@ construct_service_factory! {
 		Genesis = GenesisConfig,
 		Configuration = NodeConfig<Self>,
 		FullService = FullComponents<Self>
-			{ |config: FactoryFullConfiguration<Self>, executor: TaskExecutor|
-				FullComponents::<Factory>::new(config, executor) },
+			{ |config: FactoryFullConfiguration<Self>|
+				FullComponents::<Factory>::new(config) },
 		AuthoritySetup = {
 			|mut service: Self::FullService, local_key: Option<Arc<ed25519::Pair>>| {
 				let (block_import, link_half) = service.config.custom.grandpa_import_setup.take()
@@ -152,7 +152,7 @@ construct_service_factory! {
 			}
 		},
 		LightService = LightComponents<Self>
-			{ |config, executor| <LightComponents<Factory>>::new(config, executor) },
+			{ |config| <LightComponents<Factory>>::new(config) },
 		FullImportQueue = AuraImportQueue<Self::Block>
 			{ |config: &mut FactoryFullConfiguration<Self> , client: Arc<FullClient<Self>>, select_chain: Self::SelectChain| {
 				let slot_duration = SlotDuration::get_or_compute(&*client)?;

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -135,9 +135,7 @@ construct_service_factory! {
 					},
 					Some(_) => {
 						let telemetry_on_connect = TelemetryOnConnect {
-							on_exit: Box::new(service.on_exit()),
 							telemetry_connection_sinks: service.telemetry_on_connect_stream(),
-							executor: &executor,
 						};
 						let grandpa_config = grandpa::GrandpaParams {
 							config: config,


### PR DESCRIPTION
Lots of small changes for #2416 :

- The RPC service now accepts an `Arc<dyn futures::future::Executor<Box<dyn Future>>>` instead of `tokio::runtime::TaskExecutor`, which makes it possible to not depend on tokio anymore.
- The import queue now manually polls the worker if we fail to spawn a future.
- The `Service` itself now works like the import queue: it must be polled, and polling attempts to spawn background tasks. If spawning a task fails, we poll it manually.
- Removes the `TaskExecutor` and `on_exit` from `TelemetryOnConnect`. Grandpa now spawns telemetry futures on the main executor.
- **Biggest breaking change**. Removes the `executor` parameter from various service constructors and components. You can use `service.spawn_task` instead of spawning a task using the executor.
- `import_blocks` now returns a `Future` that performs the operation, instead of blocking.

I unfortunately couldn't add `substrate-rpc` to the CI wasm testing, because [this line](https://github.com/paritytech/jsonrpc/blob/3bee17b525923a14c473be561f677d9f048a7dc7/derive/src/to_client.rs#L115) badly collides with the expectations of `cargo web`. For the initial WASM-browser prototype, I intended to remove the RPC endpoint anyway.

Small note: you can see that I added `.expect("failed to spawn task")` at several locations, and this panic is not proven. However, please note that before this PR we were using `task_executor.spawn()`, which [as you can see here](https://docs.rs/tokio/0.1.21/src/tokio/runtime/threadpool/task_executor.rs.html#56) calls `unwrap`.
In other words, while we now have additional calls to `expect()`, the actual changes of panicking are the same as before, except that before they were hidden.
