### PR TITLE
Expose the telemetry external transport in the config

### DIFF
--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -188,7 +188,7 @@ pub use config::{NodeKeyConfig, Secret, Secp256k1Secret, Ed25519Secret};
 pub use protocol::{PeerInfo, Context, consensus_gossip, message, specialization};
 pub use protocol::sync::SyncState;
 pub use libp2p::{Multiaddr, multiaddr, build_multiaddr};
-pub use libp2p::{identity, PeerId, core::PublicKey};
+pub use libp2p::{identity, PeerId, core::PublicKey, wasm_ext::ExtTransport};
 
 pub use message::{generic as generic_message, RequestId, Status as StatusMessage};
 pub use error::Error;

--- a/core/service/src/config.rs
+++ b/core/service/src/config.rs
@@ -21,6 +21,7 @@ use transaction_pool;
 use crate::chain_spec::ChainSpec;
 pub use client::ExecutionStrategies;
 pub use client_db::PruningMode;
+pub use network::ExtTransport;
 pub use network::config::{NetworkConfiguration, Roles};
 use runtime_primitives::BuildStorage;
 use serde::{Serialize, de::DeserializeOwned};
@@ -74,6 +75,9 @@ pub struct Configuration<C, G: Serialize + DeserializeOwned + BuildStorage> {
 	pub rpc_cors: Option<Vec<String>>,
 	/// Telemetry service URL. `None` if disabled.
 	pub telemetry_endpoints: Option<TelemetryEndpoints>,
+	/// External WASM transport for the telemetry. If `Some`, when connection to a telemetry
+	/// endpoint, this transport will be tried in priority before all others.
+	pub telemetry_external_transport: Option<ExtTransport>,
 	/// The default number of 64KB pages to allocate for Wasm execution
 	pub default_heap_pages: Option<u64>,
 	/// Should offchain workers be executed.
@@ -112,6 +116,7 @@ impl<C: Default, G: Serialize + DeserializeOwned + BuildStorage> Configuration<C
 			rpc_ws_max_connections: None,
 			rpc_cors: Some(vec![]),
 			telemetry_endpoints: None,
+			telemetry_external_transport: None,
 			default_heap_pages: None,
 			offchain_worker: Default::default(),
 			force_authoring: false,

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -421,7 +421,7 @@ impl<Components: components::Components> Service<Components> {
 			let telemetry_connection_sinks_ = telemetry_connection_sinks.clone();
 			let telemetry = tel::init_telemetry(tel::TelemetryConfig {
 				endpoints,
-				wasm_external_transport: None,
+				wasm_external_transport: config.telemetry_external_transport.take(),
 			});
 			let future = telemetry.clone()
 				.for_each(move |event| {

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -151,6 +151,7 @@ fn node_config<F: ServiceFactory> (
 		rpc_ws_max_connections: None,
 		rpc_cors: None,
 		telemetry_endpoints: None,
+		telemetry_external_transport: None,
 		default_heap_pages: None,
 		offchain_worker: false,
 		force_authoring: false,


### PR DESCRIPTION
For #2416 

I've recently added the possibility to have an external transport for the telemetry, but it wasn't accessible through the configuration. This is now done.