### PR TITLE
srml-contract: Fix Gas type to u64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
+ "srml-contracts 2.0.0",
  "srml-finality-tracker 2.0.0",
  "srml-indices 2.0.0",
  "srml-timestamp 2.0.0",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -38,6 +38,7 @@ indices = { package = "srml-indices", path = "../../srml/indices" }
 timestamp = { package = "srml-timestamp", path = "../../srml/timestamp", default-features = false }
 rand = "0.6"
 finality_tracker = { package = "srml-finality-tracker", path = "../../srml/finality-tracker", default-features = false }
+contracts = { package = "srml-contracts", path = "../../srml/contracts" }
 
 [dev-dependencies]
 consensus-common = { package = "substrate-consensus-common", path = "../../core/consensus/common" }

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -174,12 +174,14 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			transfer_fee: 1 * CENTS,
 			creation_fee: 1 * CENTS,
 			contract_fee: 1 * CENTS,
-			call_base_fee: 1000,
-			create_base_fee: 1000,
 			gas_price: 1 * MILLICENTS,
 			max_depth: 1024,
 			block_gas_limit: 10_000_000,
-			current_schedule: Default::default(),
+			current_schedule: contracts::Schedule {
+				call_base_cost: 1000,
+				instantiate_base_cost: 1000,
+				..Default::default()
+			},
 		}),
 		sudo: Some(SudoConfig {
 			key: endowed_accounts[0].clone(),
@@ -268,27 +270,6 @@ pub fn testnet_genesis(
 	const ENDOWMENT: u128 = 1 << 20;
 
 	let council_desired_seats = (endowed_accounts.len() / 2 - initial_authorities.len()) as u32;
-	let mut contracts_config = ContractsConfig {
-		signed_claim_handicap: 2,
-		rent_byte_price: 4,
-		rent_deposit_offset: 1000,
-		storage_size_offset: 8,
-		surcharge_reward: 150,
-		tombstone_deposit: 16,
-		transaction_base_fee: 1,
-		transaction_byte_fee: 0,
-		transfer_fee: 0,
-		creation_fee: 0,
-		contract_fee: 21,
-		call_base_fee: 135,
-		create_base_fee: 175,
-		gas_price: 1,
-		max_depth: 1024,
-		block_gas_limit: 10_000_000,
-		current_schedule: Default::default(),
-	};
-	// this should only be enabled on development chains
-	contracts_config.current_schedule.enable_println = enable_println;
 
 	GenesisConfig {
 		system: Some(SystemConfig {
@@ -349,7 +330,26 @@ pub fn testnet_genesis(
 			spend_period: 12 * 60 * 24,
 			burn: Permill::from_percent(50),
 		}),
-		contracts: Some(contracts_config),
+		contracts: Some(ContractsConfig {
+			signed_claim_handicap: 2,
+			rent_byte_price: 4,
+			rent_deposit_offset: 1000,
+			storage_size_offset: 8,
+			surcharge_reward: 150,
+			tombstone_deposit: 16,
+			transaction_base_fee: 1,
+			transaction_byte_fee: 0,
+			transfer_fee: 0,
+			creation_fee: 0,
+			contract_fee: 21,
+			gas_price: 1,
+			max_depth: 1024,
+			block_gas_limit: 10_000_000,
+			current_schedule: contracts::Schedule {
+				enable_println, // this should only be enabled on development chains
+				..Default::default()
+			},
+		}),
 		sudo: Some(SudoConfig {
 			key: root_key,
 		}),

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 98,
-	impl_version: 101,
+	spec_version: 99,
+	impl_version: 102,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -221,7 +221,6 @@ impl contracts::Trait for Runtime {
 	type Currency = Balances;
 	type Call = Call;
 	type Event = Event;
-	type Gas = u64;
 	type DetermineContractAddress = contracts::SimpleAddressDeterminator<Runtime>;
 	type ComputeDispatchFee = contracts::DefaultDispatchFeeComputor<Runtime>;
 	type TrieIdGenerator = contracts::TrieIdFromParentCounter<Runtime>;

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -17,7 +17,7 @@
 use super::{CodeHash, Config, ContractAddressFor, Event, RawEvent, Trait,
 	TrieId, BalanceOf, ContractInfoOf};
 use crate::account_db::{AccountDb, DirectAccountDb, OverlayAccountDb};
-use crate::gas::{GasMeter, Token, approx_gas_for_balance};
+use crate::gas::{Gas, GasMeter, Token, approx_gas_for_balance};
 
 use rstd::prelude::*;
 use runtime_primitives::traits::{Bounded, CheckedAdd, CheckedSub, Zero};
@@ -239,7 +239,7 @@ pub enum ExecFeeToken {
 impl<T: Trait> Token<T> for ExecFeeToken {
 	type Metadata = Config<T>;
 	#[inline]
-	fn calculate_amount(&self, metadata: &Config<T>) -> T::Gas {
+	fn calculate_amount(&self, metadata: &Config<T>) -> Gas {
 		match *self {
 			ExecFeeToken::Call => metadata.schedule.call_base_cost,
 			ExecFeeToken::Instantiate => metadata.schedule.instantiate_base_cost,
@@ -465,13 +465,13 @@ impl<T: Trait> Token<T> for TransferFeeToken<BalanceOf<T>> {
 	type Metadata = Config<T>;
 
 	#[inline]
-	fn calculate_amount(&self, metadata: &Config<T>) -> T::Gas {
+	fn calculate_amount(&self, metadata: &Config<T>) -> Gas {
 		let balance_fee = match self.kind {
 			TransferFeeKind::ContractInstantiate => metadata.contract_account_instantiate_fee,
 			TransferFeeKind::AccountCreate => metadata.account_create_fee,
 			TransferFeeKind::Transfer => metadata.transfer_fee,
 		};
-		approx_gas_for_balance::<T>(self.gas_price, balance_fee)
+		approx_gas_for_balance(self.gas_price, balance_fee)
 	}
 }
 
@@ -491,7 +491,7 @@ enum TransferCause {
 /// is specified using the `cause` parameter.
 ///
 /// NOTE: that the fee is denominated in `BalanceOf<T>` units, but
-/// charged in `T::Gas` from the provided `gas_meter`. This means
+/// charged in `Gas` from the provided `gas_meter`. This means
 /// that the actual amount charged might differ.
 ///
 /// NOTE: that we allow for draining all funds of the contract so it

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -241,8 +241,8 @@ impl<T: Trait> Token<T> for ExecFeeToken {
 	#[inline]
 	fn calculate_amount(&self, metadata: &Config<T>) -> T::Gas {
 		match *self {
-			ExecFeeToken::Call => metadata.call_base_fee,
-			ExecFeeToken::Instantiate => metadata.instantiate_base_fee,
+			ExecFeeToken::Call => metadata.schedule.call_base_cost,
+			ExecFeeToken::Instantiate => metadata.schedule.instantiate_base_cost,
 		}
 	}
 }

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -90,15 +90,16 @@ mod tests;
 
 use crate::exec::ExecutionContext;
 use crate::account_db::{AccountDb, DirectAccountDb};
+use crate::gas::Gas;
 
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
 use substrate_primitives::crypto::UncheckedFrom;
-use rstd::{prelude::*, marker::PhantomData, convert::TryFrom};
+use rstd::{prelude::*, marker::PhantomData};
 use parity_codec::{Codec, Encode, Decode};
 use runtime_io::blake2_256;
 use runtime_primitives::traits::{
-	Hash, SimpleArithmetic, Bounded, StaticLookup, Zero, MaybeSerializeDebug, Member
+	Hash, StaticLookup, Zero, MaybeSerializeDebug, Member
 };
 use srml_support::dispatch::{Result, Dispatchable};
 use srml_support::{
@@ -287,9 +288,6 @@ pub trait Trait: timestamp::Trait {
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 
-	type Gas: Parameter + Default + Codec + SimpleArithmetic + Bounded + Copy +
-		Into<BalanceOf<Self>> + TryFrom<BalanceOf<Self>>;
-
 	/// A function type to get the contract address given the creator.
 	type DetermineContractAddress: ContractAddressFor<CodeHash<Self>, Self::AccountId>;
 
@@ -349,7 +347,7 @@ decl_module! {
 		/// Updates the schedule for metering contracts.
 		///
 		/// The schedule must have a greater version than the stored schedule.
-		pub fn update_schedule(schedule: Schedule<T::Gas>) -> Result {
+		pub fn update_schedule(schedule: Schedule) -> Result {
 			if <Module<T>>::current_schedule().version >= schedule.version {
 				return Err("new schedule must have a greater version than current");
 			}
@@ -364,7 +362,7 @@ decl_module! {
 		/// You can instantiate contracts only with stored code.
 		pub fn put_code(
 			origin,
-			#[compact] gas_limit: T::Gas,
+			#[compact] gas_limit: Gas,
 			code: Vec<u8>
 		) -> Result {
 			let origin = ensure_signed(origin)?;
@@ -393,7 +391,7 @@ decl_module! {
 			origin,
 			dest: <T::Lookup as StaticLookup>::Source,
 			#[compact] value: BalanceOf<T>,
-			#[compact] gas_limit: T::Gas,
+			#[compact] gas_limit: Gas,
 			data: Vec<u8>
 		) -> Result {
 			let origin = ensure_signed(origin)?;
@@ -453,7 +451,7 @@ decl_module! {
 		pub fn create(
 			origin,
 			#[compact] endowment: BalanceOf<T>,
-			#[compact] gas_limit: T::Gas,
+			#[compact] gas_limit: Gas,
 			code_hash: CodeHash<T>,
 			data: Vec<u8>
 		) -> Result {
@@ -684,11 +682,11 @@ decl_storage! {
 		/// The maximum nesting level of a call/create stack.
 		MaxDepth get(max_depth) config(): u32 = 100;
 		/// The maximum amount of gas that could be expended per block.
-		BlockGasLimit get(block_gas_limit) config(): T::Gas = 10_000_000.into();
+		BlockGasLimit get(block_gas_limit) config(): Gas = 10_000_000;
 		/// Gas spent so far in this block.
-		GasSpent get(gas_spent): T::Gas;
+		GasSpent get(gas_spent): Gas;
 		/// Current cost schedule for contracts.
-		CurrentSchedule get(current_schedule) config(): Schedule<T::Gas> = Schedule::default();
+		CurrentSchedule get(current_schedule) config(): Schedule = Schedule::default();
 		/// A mapping from an original code hash to the original code, untouched by instrumentation.
 		pub PristineCode: map CodeHash<T> => Option<Vec<u8>>;
 		/// A mapping between an original code hash and instrumented wasm code, ready for execution.
@@ -714,7 +712,7 @@ impl<T: Trait> OnFreeBalanceZero<T::AccountId> for Module<T> {
 /// We assume that these values can't be changed in the
 /// course of transaction execution.
 pub struct Config<T: Trait> {
-	pub schedule: Schedule<T::Gas>,
+	pub schedule: Schedule,
 	pub existential_deposit: BalanceOf<T>,
 	pub max_depth: u32,
 	pub contract_account_instantiate_fee: BalanceOf<T>,
@@ -738,7 +736,7 @@ impl<T: Trait> Config<T> {
 /// Definition of the cost schedule and other parameterizations for wasm vm.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Clone, Encode, Decode, PartialEq, Eq)]
-pub struct Schedule<Gas> {
+pub struct Schedule {
 	/// Version of the schedule.
 	pub version: u32,
 
@@ -795,21 +793,21 @@ pub struct Schedule<Gas> {
 	pub max_subject_len: u32,
 }
 
-impl<Gas: From<u32>> Default for Schedule<Gas> {
-	fn default() -> Schedule<Gas> {
+impl Default for Schedule {
+	fn default() -> Schedule {
 		Schedule {
 			version: 0,
-			put_code_per_byte_cost: 1.into(),
-			grow_mem_cost: 1.into(),
-			regular_op_cost: 1.into(),
-			return_data_per_byte_cost: 1.into(),
-			event_data_per_byte_cost: 1.into(),
-			event_per_topic_cost: 1.into(),
-			event_base_cost: 1.into(),
-			call_base_cost: 135.into(),
-			instantiate_base_cost: 175.into(),
-			sandbox_data_read_cost: 1.into(),
-			sandbox_data_write_cost: 1.into(),
+			put_code_per_byte_cost: 1,
+			grow_mem_cost: 1,
+			regular_op_cost: 1,
+			return_data_per_byte_cost: 1,
+			event_data_per_byte_cost: 1,
+			event_per_topic_cost: 1,
+			event_base_cost: 1,
+			call_base_cost: 135,
+			instantiate_base_cost: 175,
+			sandbox_data_read_cost: 1,
+			sandbox_data_write_cost: 1,
 			max_event_topics: 4,
 			max_stack_height: 64 * 1024,
 			max_memory_pages: 16,

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -679,10 +679,6 @@ decl_storage! {
 		TransactionByteFee get(transaction_byte_fee) config(): BalanceOf<T>;
 		/// The fee required to create a contract instance.
 		ContractFee get(contract_fee) config(): BalanceOf<T> = 21.into();
-		/// The base fee charged for calling into a contract.
-		CallBaseFee get(call_base_fee) config(): T::Gas = 135.into();
-		/// The base fee charged for creating a contract.
-		CreateBaseFee get(create_base_fee) config(): T::Gas = 175.into();
 		/// The price of one unit of gas.
 		GasPrice get(gas_price) config(): BalanceOf<T> = 1.into();
 		/// The maximum nesting level of a call/create stack.
@@ -724,8 +720,6 @@ pub struct Config<T: Trait> {
 	pub contract_account_instantiate_fee: BalanceOf<T>,
 	pub account_create_fee: BalanceOf<T>,
 	pub transfer_fee: BalanceOf<T>,
-	pub call_base_fee: T::Gas,
-	pub instantiate_base_fee: T::Gas,
 }
 
 impl<T: Trait> Config<T> {
@@ -737,8 +731,6 @@ impl<T: Trait> Config<T> {
 			contract_account_instantiate_fee: <Module<T>>::contract_fee(),
 			account_create_fee: <Module<T>>::creation_fee(),
 			transfer_fee: <Module<T>>::transfer_fee(),
-			call_base_fee: <Module<T>>::call_base_fee(),
-			instantiate_base_fee: <Module<T>>::create_base_fee(),
 		}
 	}
 }
@@ -770,6 +762,12 @@ pub struct Schedule<Gas> {
 
 	/// Gas cost to deposit an event; the base.
 	pub event_base_cost: Gas,
+
+	/// Base gas cost to call into a contract.
+	pub call_base_cost: Gas,
+
+ 	/// Base gas cost to instantiate a contract.
+	pub instantiate_base_cost: Gas,
 
 	/// Gas cost per one byte read from the sandbox memory.
 	pub sandbox_data_read_cost: Gas,
@@ -808,6 +806,8 @@ impl<Gas: From<u32>> Default for Schedule<Gas> {
 			event_data_per_byte_cost: 1.into(),
 			event_per_topic_cost: 1.into(),
 			event_base_cost: 1.into(),
+			call_base_cost: 135.into(),
+			instantiate_base_cost: 175.into(),
 			sandbox_data_read_cost: 1.into(),
 			sandbox_data_write_cost: 1.into(),
 			max_event_topics: 4,

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -93,7 +93,6 @@ impl timestamp::Trait for Test {
 impl Trait for Test {
 	type Currency = Balances;
 	type Call = Call;
-	type Gas = u64;
 	type DetermineContractAddress = DummyContractAddressFor;
 	type Event = MetaEvent;
 	type ComputeDispatchFee = DummyComputeDispatchFee;
@@ -215,8 +214,6 @@ impl ExtBuilder {
 				transfer_fee: self.transfer_fee,
 				creation_fee: self.creation_fee,
 				contract_fee: 21,
-				call_base_fee: 135,
-				create_base_fee: 175,
 				gas_price: self.gas_price,
 				max_depth: 100,
 				block_gas_limit: self.block_gas_limit,

--- a/srml/contracts/src/wasm/env_def/macros.rs
+++ b/srml/contracts/src/wasm/env_def/macros.rs
@@ -200,7 +200,7 @@ mod tests {
 	use crate::wasm::tests::MockExt;
 	use crate::wasm::Runtime;
 	use crate::exec::Ext;
-	use crate::Trait;
+	use crate::gas::Gas;
 
 	#[test]
 	fn macro_unmarshall_then_body_then_marshall_value_or_trap() {
@@ -256,7 +256,7 @@ mod tests {
 	#[test]
 	fn macro_define_func() {
 		define_func!( <E: Ext> ext_gas (_ctx, amount: u32) => {
-			let amount = <E::T as Trait>::Gas::from(amount);
+			let amount = Gas::from(amount);
 			if !amount.is_zero() {
 				Ok(())
 			} else {
@@ -308,7 +308,7 @@ mod tests {
 
 		define_env!(Env, <E: Ext>,
 			ext_gas( _ctx, amount: u32 ) => {
-				let amount = <E::T as Trait>::Gas::from(amount);
+				let amount = Gas::from(amount);
 				if !amount.is_zero() {
 					Ok(())
 				} else {

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -63,17 +63,17 @@ pub struct WasmExecutable {
 }
 
 /// Loader which fetches `WasmExecutable` from the code cache.
-pub struct WasmLoader<'a, T: Trait> {
-	schedule: &'a Schedule<T::Gas>,
+pub struct WasmLoader<'a> {
+	schedule: &'a Schedule,
 }
 
-impl<'a, T: Trait> WasmLoader<'a, T> {
-	pub fn new(schedule: &'a Schedule<T::Gas>) -> Self {
+impl<'a> WasmLoader<'a> {
+	pub fn new(schedule: &'a Schedule) -> Self {
 		WasmLoader { schedule }
 	}
 }
 
-impl<'a, T: Trait> crate::exec::Loader<T> for WasmLoader<'a, T> {
+impl<'a, T: Trait> crate::exec::Loader<T> for WasmLoader<'a> {
 	type Executable = WasmExecutable;
 
 	fn load_init(&self, code_hash: &CodeHash<T>) -> Result<WasmExecutable, &'static str> {
@@ -93,17 +93,17 @@ impl<'a, T: Trait> crate::exec::Loader<T> for WasmLoader<'a, T> {
 }
 
 /// Implementation of `Vm` that takes `WasmExecutable` and executes it.
-pub struct WasmVm<'a, T: Trait> {
-	schedule: &'a Schedule<T::Gas>,
+pub struct WasmVm<'a> {
+	schedule: &'a Schedule,
 }
 
-impl<'a, T: Trait> WasmVm<'a, T> {
-	pub fn new(schedule: &'a Schedule<T::Gas>) -> Self {
+impl<'a> WasmVm<'a> {
+	pub fn new(schedule: &'a Schedule) -> Self {
 		WasmVm { schedule }
 	}
 }
 
-impl<'a, T: Trait> crate::exec::Vm<T> for WasmVm<'a, T> {
+impl<'a, T: Trait> crate::exec::Vm<T> for WasmVm<'a> {
 	type Executable = WasmExecutable;
 
 	fn execute<E: Ext<T = T>>(
@@ -303,9 +303,9 @@ mod tests {
 		use crate::exec::Vm;
 
 		let wasm = wabt::wat2wasm(wat).unwrap();
-		let schedule = crate::Schedule::<u64>::default();
+		let schedule = crate::Schedule::default();
 		let prefab_module =
-			prepare_contract::<Test, super::runtime::Env>(&wasm, &schedule).unwrap();
+			prepare_contract::<super::runtime::Env>(&wasm, &schedule).unwrap();
 
 		let exec = WasmExecutable {
 			// Use a "call" convention.


### PR DESCRIPTION
Second attempt at fixing #2630.

Gas units are generic in the contract module configuration and the size may exceed that of u64. In order to facilitate potentially moving more gas metering operations into the contract runtime, we make Gas an unconfigurable type fixed as u64, which should be more than enough precision for any use case with little performance hit vs a smaller type on common architectures.

@pepyakin