### PR TITLE
Allow spending all available gas.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -58,8 +58,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("node"),
 	impl_name: create_runtime_str!("substrate-node"),
 	authoring_version: 10,
-	spec_version: 97,
-	impl_version: 99,
+	spec_version: 98,
+	impl_version: 100,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -230,14 +230,17 @@ impl ExtBuilder {
 	}
 }
 
+// Perform a simple transfer to a non-existent account supplying way more gas than needed.
+// Then we check that the all unused gas is refunded.
 #[test]
 fn refunds_unused_gas() {
-	with_externalities(&mut ExtBuilder::default().build(), || {
-		Balances::deposit_creating(&0, 100_000_000);
+	with_externalities(&mut ExtBuilder::default().gas_price(2).build(), || {
+		Balances::deposit_creating(&ALICE, 100_000_000);
 
-		assert_ok!(Contract::call(Origin::signed(0), 1, 0, 100_000, Vec::new()));
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, Vec::new()));
 
-		assert_eq!(Balances::free_balance(&0), 100_000_000 - (2 * 135));
+		// 2 * 135 - gas price multiplied by the call base fee.
+		assert_eq!(Balances::free_balance(&ALICE), 100_000_000 - (2 * 135));
 	});
 }
 


### PR DESCRIPTION
At the moment, there is this piece of code

https://github.com/paritytech/substrate/blob/1c2eaa3bc6a5659fb70cfcc88037573921612064/srml/contracts/src/gas.rs#L128-L132

If you take a look at it, it feels weird. And it just doesn't allow spending the last unit of gas. However, the way it's written implied that it is for purpose there. @jimpo [raised a question](https://github.com/paritytech/substrate/pull/2924#discussion_r296813273) whether we actually need this. I was unable to find any evidence that it is actually used.

So what we did here is added some tests. Initially we thought that we would need to add some balancing mechanism to ensure that new tests work, but it turns out that it is not necessary.

cc @jimpo 