### PR TITLE
srml-contract: Fail calls to removed contracts instead of succeeding.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -67,8 +67,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 103,
-	impl_version: 103,
+	spec_version: 104,
+	impl_version: 104,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -15,13 +15,14 @@
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
 use super::{CodeHash, Config, ContractAddressFor, Event, RawEvent, Trait,
-	TrieId, BalanceOf, ContractInfoOf};
+	TrieId, BalanceOf};
 use crate::account_db::{AccountDb, DirectAccountDb, OverlayAccountDb};
 use crate::gas::{Gas, GasMeter, Token, approx_gas_for_balance};
+use crate::rent;
 
 use rstd::prelude::*;
 use runtime_primitives::traits::{Bounded, CheckedAdd, CheckedSub, Zero};
-use srml_support::{StorageMap, traits::{WithdrawReason, Currency}};
+use srml_support::traits::{WithdrawReason, Currency};
 use timestamp;
 
 pub type AccountIdOf<T> = <T as system::Trait>::AccountId;
@@ -267,11 +268,11 @@ where
 {
 	/// Create the top level execution context.
 	///
-	/// The specified `origin` address will be used as `sender` for
+	/// The specified `origin` address will be used as `sender` for. The `origin` must be a regular
+	/// account (not a contract).
 	pub fn top_level(origin: T::AccountId, cfg: &'a Config<T>, vm: &'a V, loader: &'a L) -> Self {
 		ExecutionContext {
-			self_trie_id: <ContractInfoOf<T>>::get(&origin)
-				.and_then(|i| i.as_alive().map(|i| i.trie_id.clone())),
+			self_trie_id: None,
 			self_account: origin,
 			overlay: OverlayAccountDb::<T>::new(&DirectAccountDb),
 			depth: 0,
@@ -283,10 +284,11 @@ where
 		}
 	}
 
-	fn nested(&self, overlay: OverlayAccountDb<'a, T>, dest: T::AccountId) -> Self {
+	fn nested(&self, overlay: OverlayAccountDb<'a, T>, dest: T::AccountId, trie_id: Option<TrieId>)
+		-> Self
+	{
 		ExecutionContext {
-			self_trie_id: <ContractInfoOf<T>>::get(&dest)
-				.and_then(|i| i.as_alive().map(|i| i.trie_id.clone())),
+			self_trie_id: trie_id,
 			self_account: dest,
 			overlay,
 			depth: self.depth + 1,
@@ -321,14 +323,15 @@ where
 		// Assumption: pay_rent doesn't collide with overlay because
 		// pay_rent will be done on first call and dest contract and balance
 		// cannot be changed before the first call
-		crate::rent::pay_rent::<T>(&dest);
+		let contract_info = rent::pay_rent::<T>(&dest);
 
 		let mut output_data = Vec::new();
 
 		let (change_set, events, calls) = {
 			let mut nested = self.nested(
 				OverlayAccountDb::new(&self.overlay),
-				dest.clone()
+				dest.clone(),
+				contract_info.and_then(|i| i.as_alive().map(|i| i.trie_id.clone()))
 			);
 
 			if value > BalanceOf::<T>::zero() {
@@ -400,7 +403,8 @@ where
 
 			overlay.create_contract(&dest, code_hash.clone())?;
 
-			let mut nested = self.nested(overlay, dest.clone());
+			// TrieId has not been generated yet and storage is empty since contract is new.
+			let mut nested = self.nested(overlay, dest.clone(), None);
 
 			// Send funds unconditionally here. If the `endowment` is below existential_deposit
 			// then error will be returned here.

--- a/srml/contracts/src/rent.rs
+++ b/srml/contracts/src/rent.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{BalanceOf, ContractInfo, ContractInfoOf, TombstoneContractInfo, Trait};
+use crate::{BalanceOf, ContractInfo, ContractInfoOf, TombstoneContractInfo, Trait, AliveContractInfo};
 use runtime_primitives::traits::{Bounded, CheckedDiv, CheckedMul, Saturating, Zero,
 	SaturatedConversion};
 use srml_support::traits::{Currency, ExistenceRequirement, Get, WithdrawReason};
@@ -50,9 +50,10 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 	account: &T::AccountId,
 	handicap: T::BlockNumber,
 	pay_rent: bool,
-) -> RentOutcome {
-	let contract = match <ContractInfoOf<T>>::get(account) {
-		None | Some(ContractInfo::Tombstone(_)) => return RentOutcome::Exempted,
+) -> (RentOutcome, Option<ContractInfo<T>>) {
+	let contract_info = <ContractInfoOf<T>>::get(account);
+	let contract = match contract_info {
+		None | Some(ContractInfo::Tombstone(_)) => return (RentOutcome::Exempted, contract_info),
 		Some(ContractInfo::Alive(contract)) => contract,
 	};
 
@@ -65,7 +66,7 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 		let n = effective_block_number.saturating_sub(contract.deduct_block);
 		if n.is_zero() {
 			// Rent has already been paid
-			return RentOutcome::Exempted;
+			return (RentOutcome::Exempted, Some(ContractInfo::Alive(contract)));
 		}
 		n
 	};
@@ -89,7 +90,7 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 	if fee_per_block.is_zero() {
 		// The rent deposit offset reduced the fee to 0. This means that the contract
 		// gets the rent for free.
-		return RentOutcome::Exempted;
+		return (RentOutcome::Exempted, Some(ContractInfo::Alive(contract)));
 	}
 
 	// The minimal amount of funds required for a contract not to be evicted.
@@ -99,7 +100,7 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 		// The contract cannot afford to leave a tombstone, so remove the contract info altogether.
 		<ContractInfoOf<T>>::remove(account);
 		runtime_io::kill_child_storage(&contract.trie_id);
-		return RentOutcome::Evicted;
+		return (RentOutcome::Evicted, None);
 	}
 
 	let dues = fee_per_block
@@ -149,33 +150,34 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 			&child_storage_root[..],
 			contract.code_hash,
 		);
-		<ContractInfoOf<T>>::insert(account, ContractInfo::Tombstone(tombstone));
+		let tombstone_info = ContractInfo::Tombstone(tombstone);
+		<ContractInfoOf<T>>::insert(account, &tombstone_info);
 
 		runtime_io::kill_child_storage(&contract.trie_id);
 
-		return RentOutcome::Evicted;
+		return (RentOutcome::Evicted, Some(tombstone_info));
 	}
 
 	if pay_rent {
-		<ContractInfoOf<T>>::mutate(account, |contract| {
-			let contract = contract
-				.as_mut()
-				.and_then(|c| c.as_alive_mut())
-				.expect("Dead or nonexistent account has been exempt above; qed");
+		let contract_info = ContractInfo::Alive(AliveContractInfo::<T> {
+			rent_allowance: contract.rent_allowance - dues, // rent_allowance is not exceeded
+			deduct_block: current_block_number,
+			..contract
+		});
 
-			contract.rent_allowance -= dues; // rent_allowance is not exceeded
-			contract.deduct_block = current_block_number;
-		})
+		<ContractInfoOf<T>>::insert(account, &contract_info);
+
+		return (RentOutcome::Ok, Some(contract_info));
 	}
 
-	RentOutcome::Ok
+	(RentOutcome::Ok, Some(ContractInfo::Alive(contract)))
 }
 
 /// Make account paying the rent for the current block number
 ///
 /// NOTE: This function acts eagerly.
-pub fn pay_rent<T: Trait>(account: &T::AccountId) {
-	let _ = try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true);
+pub fn pay_rent<T: Trait>(account: &T::AccountId) -> Option<ContractInfo<T>> {
+	try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true).1
 }
 
 /// Evict the account if it should be evicted at the given block number.
@@ -186,5 +188,5 @@ pub fn pay_rent<T: Trait>(account: &T::AccountId) {
 ///
 /// NOTE: This function acts eagerly.
 pub fn try_evict<T: Trait>(account: &T::AccountId, handicap: T::BlockNumber) -> RentOutcome {
-	try_evict_or_and_pay_rent::<T>(account, handicap, false)
+	try_evict_or_and_pay_rent::<T>(account, handicap, false).0
 }


### PR DESCRIPTION
Previously, the calls would transfer funds and succeed without executing any code on the target account, which is unintuitive behavior.

There is also a bit of refactoring to reduce unnecessary storage lookups when constructing `ExecutionContext`s. 

@pepyakin 