### PR TITLE
fix typo in balances module

### DIFF
--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -872,7 +872,7 @@ where
 		}
 	}
 
-	fn make_free_balance_be(who: &T::AccountId, balance: T::Balance) -> (
+	fn make_free_balance_be(who: &T::AccountId, balance: Self::Balance) -> (
 		SignedImbalance<Self::Balance, Self::PositiveImbalance>,
 		UpdateBalanceOutcome
 	) {


### PR DESCRIPTION
modify `T::Balance` to `Self::Balance`  in `srml-balances` mod to fit `srml_support::Currency` trait, which would eliminate error hints.
