### PR TITLE
Adds `if_std!` macro

### DIFF
--- a/core/sr-std/src/lib.rs
+++ b/core/sr-std/src/lib.rs
@@ -30,6 +30,32 @@ macro_rules! map {
 	)
 }
 
+/// Feature gate some code that should only be run when `std` feature is enabled.
+///
+/// # Example
+///
+/// ```
+/// use sr_std::if_std;
+///
+/// if_std! {
+///     // This code is only being compiled and executed when the `std` feature is enabled.
+///     println!("Hello native world");
+/// }
+/// ```
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! if_std {
+	( $( $code:tt )* ) => {
+		$( $code )*
+	}
+}
+
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! if_std {
+	( $( $code:tt )* ) => {}
+}
+
 #[cfg(feature = "std")]
 include!("../with_std.rs");
 


### PR DESCRIPTION
This macro compiles and executes the given code only when `std` feature
is enabled. This can be useful for debugging without needing to worry
that your code does not compile on `no_std`.
