### PR TITLE
Fix peer discovery delays.

### DIFF
--- a/core/network/src/discovery.rs
+++ b/core/network/src/discovery.rs
@@ -181,84 +181,83 @@ where
 			Self::OutEvent,
 		>,
 	> {
-		// Poll Kademlia.
-		match self.kademlia.poll(params) {
-			Async::NotReady => (),
-			Async::Ready(NetworkBehaviourAction::GenerateEvent(ev)) => {
-				match ev {
-					KademliaOut::Discovered { .. } => {}
-					KademliaOut::KBucketAdded { peer_id, .. } => {
-						let ev = DiscoveryOut::Discovered(peer_id);
-						return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
-					}
-					KademliaOut::FindNodeResult { key, closer_peers } => {
-						trace!(target: "sub-libp2p", "Libp2p => Query for {:?} yielded {:?} results",
-							key, closer_peers.len());
-						if closer_peers.is_empty() {
-							warn!(target: "sub-libp2p", "Libp2p => Random Kademlia query has yielded empty \
-								results");
-						}
-					}
-					KademliaOut::GetValueResult(res) => {
-						let ev = match res {
-							GetValueResult::Found { results } => {
-								let results = results
-										.into_iter()
-										.map(|r| (r.key, r.value))
-										.collect();
+		// Poll the stream that fires when we need to start a random Kademlia query.
+		match self.next_kad_random_query.poll() {
+			Ok(Async::NotReady) => {},
+			Ok(Async::Ready(_)) => {
+				let random_peer_id = PeerId::random();
+				debug!(target: "sub-libp2p", "Libp2p <= Starting random Kademlia request for \
+					{:?}", random_peer_id);
+				self.kademlia.find_node(random_peer_id);
 
-								DiscoveryOut::ValueFound(results)
-							}
-							GetValueResult::NotFound { key, .. } => {
-								DiscoveryOut::ValueNotFound(key)
-							}
-						};
-						return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
-					}
-					KademliaOut::PutValueResult(res) => {
-						let ev = match res {
-							PutValueResult::Ok{ key, .. } =>  {
-								DiscoveryOut::ValuePut(key)
-							}
-							PutValueResult::Err { key, .. } => {
-								DiscoveryOut::ValuePutFailed(key)
-							}
-						};
-						return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
-					}
-					// We never start any other type of query.
-					KademliaOut::GetProvidersResult { .. } => {}
-				}
+				// Reset the `Delay` to the next random.
+				self.next_kad_random_query.reset(self.clock.now() + self.duration_to_next_kad);
+				self.duration_to_next_kad = cmp::min(self.duration_to_next_kad * 2,
+					Duration::from_secs(60));
 			},
-			Async::Ready(NetworkBehaviourAction::DialAddress { address }) =>
-				return Async::Ready(NetworkBehaviourAction::DialAddress { address }),
-			Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }) =>
-				return Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }),
-			Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }) =>
-				return Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }),
-			Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) =>
-				return Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }),
+			Err(err) => {
+				warn!(target: "sub-libp2p", "Kademlia query timer errored: {:?}", err);
+			}
 		}
 
-		// Poll the stream that fires when we need to start a random Kademlia query.
+		// Poll Kademlia.
 		loop {
-			match self.next_kad_random_query.poll() {
-				Ok(Async::NotReady) => break,
-				Ok(Async::Ready(_)) => {
-					let random_peer_id = PeerId::random();
-					debug!(target: "sub-libp2p", "Libp2p <= Starting random Kademlia request for \
-						{:?}", random_peer_id);
-					self.kademlia.find_node(random_peer_id);
+			match self.kademlia.poll(params) {
+				Async::NotReady => break,
+				Async::Ready(NetworkBehaviourAction::GenerateEvent(ev)) => {
+					match ev {
+						KademliaOut::Discovered { .. } => {}
+						KademliaOut::KBucketAdded { peer_id, .. } => {
+							let ev = DiscoveryOut::Discovered(peer_id);
+							return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+						}
+						KademliaOut::FindNodeResult { key, closer_peers } => {
+							trace!(target: "sub-libp2p", "Libp2p => Query for {:?} yielded {:?} results",
+								key, closer_peers.len());
+							if closer_peers.is_empty() {
+								warn!(target: "sub-libp2p", "Libp2p => Random Kademlia query has yielded empty \
+									results");
+							}
+						}
+						KademliaOut::GetValueResult(res) => {
+							let ev = match res {
+								GetValueResult::Found { results } => {
+									let results = results
+											.into_iter()
+											.map(|r| (r.key, r.value))
+											.collect();
 
-					// Reset the `Delay` to the next random.
-					self.next_kad_random_query.reset(self.clock.now() + self.duration_to_next_kad);
-					self.duration_to_next_kad = cmp::min(self.duration_to_next_kad * 2,
-						Duration::from_secs(60));
+									DiscoveryOut::ValueFound(results)
+								}
+								GetValueResult::NotFound { key, .. } => {
+									DiscoveryOut::ValueNotFound(key)
+								}
+							};
+							return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+						}
+						KademliaOut::PutValueResult(res) => {
+							let ev = match res {
+								PutValueResult::Ok{ key, .. } =>  {
+									DiscoveryOut::ValuePut(key)
+								}
+								PutValueResult::Err { key, .. } => {
+									DiscoveryOut::ValuePutFailed(key)
+								}
+							};
+							return Async::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+						}
+						// We never start any other type of query.
+						KademliaOut::GetProvidersResult { .. } => {}
+					}
 				},
-				Err(err) => {
-					warn!(target: "sub-libp2p", "Kademlia query timer errored: {:?}", err);
-					break
-				}
+				Async::Ready(NetworkBehaviourAction::DialAddress { address }) =>
+					return Async::Ready(NetworkBehaviourAction::DialAddress { address }),
+				Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }) =>
+					return Async::Ready(NetworkBehaviourAction::DialPeer { peer_id }),
+				Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }) =>
+					return Async::Ready(NetworkBehaviourAction::SendEvent { peer_id, event }),
+				Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }) =>
+					return Async::Ready(NetworkBehaviourAction::ReportObservedAddr { address }),
 			}
 		}
 


### PR DESCRIPTION
This fix is extracted from https://github.com/paritytech/substrate/pull/2981.

Due to the order of operations and a missing loop, the current implementation of `DiscoveryBehaviour::poll` regularly returns `NotReady` from `poll` despite the inner Kademlia behaviour having events ready, thus letting the `poll`ing be largely driven by the task wakeups from the Delay for the next random Kademlia query, inducing major delays in consuming the ready Kademlia events and thus slowing progress.

With the changes made here, the discovery test now passes more quickly.
