### PR TITLE
typo fix in without_std.rs

### DIFF
--- a/core/sr-std/without_std.rs
+++ b/core/sr-std/without_std.rs
@@ -68,7 +68,7 @@ pub use core::slice;
 // Allow intepreting vectors of bytes as strings, but not constructing them.
 pub use core::str;
 // We are trying to avoid certain things here, such as `core::string`
-// (if you need `String` you most probably doing something wrong, since
+// (if you need `String` you are probably doing something wrong, since
 // runtime doesn't require anything human readable).
 
 pub mod collections {


### PR DESCRIPTION
fix typo

Thank you for your Pull Request!

Before you submitting, please check that:

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [x] You labeled the PR with appropriate labels if you have permissions to do so.
- [x] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [x] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [x] Your PR adheres [the style guide](https://github.com/paritytech/polkadot/wiki/Style-Guide)
  - In particular, mind the maximal line length.
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [x] You bumped the runtime version if there are breaking changes in the **runtime**.
- [x] You updated any rustdocs which may have changed

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
