### PR TITLE
on_start now returns the precise elements to request

### DIFF
--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -194,8 +194,9 @@ pub trait BlockImport<B: BlockT> {
 pub trait JustificationImport<B: BlockT> {
 	type Error: ::std::error::Error + Send + 'static;
 
-	/// Called by the import queue when it is started.
-	fn on_start(&self, _link: &mut dyn crate::import_queue::Link<B>) { }
+	/// Called by the import queue when it is started. Returns a list of justifications to request
+	/// from the network.
+	fn on_start(&self) -> Vec<(B::Hash, NumberFor<B>)> { Vec::new() }
 
 	/// Import a Block justification and finalize the given block.
 	fn import_justification(
@@ -210,8 +211,9 @@ pub trait JustificationImport<B: BlockT> {
 pub trait FinalityProofImport<B: BlockT> {
 	type Error: std::error::Error + Send + 'static;
 
-	/// Called by the import queue when it is started.
-	fn on_start(&self, _link: &mut dyn crate::import_queue::Link<B>) { }
+	/// Called by the import queue when it is started. Returns a list of finality proofs to request
+	/// from the network.
+	fn on_start(&self) -> Vec<(B::Hash, NumberFor<B>)> { Vec::new() }
 
 	/// Import a Block justification and finalize the given block. Returns finalized block or error.
 	fn import_finality_proof(

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -267,10 +267,15 @@ impl<B: BlockT, V: 'static + Verifier<B>> BlockImportWorker<B, V> {
 		};
 
 		if let Some(justification_import) = worker.justification_import.as_ref() {
-			justification_import.on_start(&mut worker.result_sender);
+			for (hash, number) in justification_import.on_start() {
+				worker.result_sender.request_justification(&hash, number);
+			}
 		}
+
 		if let Some(finality_proof_import) = worker.finality_proof_import.as_ref() {
-			finality_proof_import.on_start(&mut worker.result_sender);
+			for (hash, number) in finality_proof_import.on_start() {
+				worker.result_sender.request_finality_proof(&hash, number);
+			}
 		}
 
 		let future = futures::future::poll_fn(move || {

--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -76,7 +76,8 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> JustificationImport<Block>
 {
 	type Error = ConsensusError;
 
-	fn on_start(&self, link: &mut dyn consensus_common::import_queue::Link<Block>) {
+	fn on_start(&self) -> Vec<(Block::Hash, NumberFor<Block>)> {
+		let mut out = Vec::new();
 		let chain_info = self.inner.info().chain;
 
 		// request justifications for all pending changes for which change blocks have already been imported
@@ -94,12 +95,14 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> JustificationImport<Block>
 				if let Ok(Some(hash)) = effective_block_hash {
 					if let Ok(Some(header)) = self.inner.header(&BlockId::Hash(hash)) {
 						if *header.number() == pending_change.effective_number() {
-							link.request_justification(&header.hash(), *header.number());
+							out.push((header.hash(), *header.number()));
 						}
 					}
 				}
 			}
 		}
+
+		out
 	}
 
 	fn import_justification(

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -144,15 +144,18 @@ impl<B, E, Block: BlockT<Hash=H256>, RA> FinalityProofImport<Block>
 {
 	type Error = ConsensusError;
 
-	fn on_start(&self, link: &mut dyn consensus_common::import_queue::Link<Block>) {
+	fn on_start(&self) -> Vec<(Block::Hash, NumberFor<Block>)> {
+		let mut out = Vec::new();
 		let chain_info = self.client.info().chain;
 
 		let data = self.data.read();
 		for (pending_number, pending_hash) in data.consensus_changes.pending_changes() {
 			if *pending_number > chain_info.finalized_number && *pending_number <= chain_info.best_number {
-				link.request_finality_proof(pending_hash, *pending_number);
+				out.push((pending_hash.clone(), *pending_number));
 			}
 		}
+
+		out
 	}
 
 	fn import_finality_proof(

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -575,8 +575,8 @@ pub mod tests {
 	{
 		type Error = ConsensusError;
 
-		fn on_start(&self, link: &mut dyn consensus_common::import_queue::Link<Block>) {
-			self.0.on_start(link)
+		fn on_start(&self) -> Vec<(Block::Hash, NumberFor<Block>)> {
+			self.0.on_start()
 		}
 
 		fn import_finality_proof(


### PR DESCRIPTION
Some basic refactoring.
Instead of giving `on_start` full access to the import queue link, we make it have a more precise behaviour.

The objective of that is to allow some more refactoring of the import queue.