### PR TITLE
Implement Executor for Service and SpawnHandle

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -623,7 +623,8 @@ impl<Components> Future for Service<Components> where Components: components::Co
 }
 
 impl<Components> Executor<Box<dyn Future<Item = (), Error = ()> + Send>>
-for Service<Components> where Components: components::Components {
+	for Service<Components> where Components: components::Components
+{
 	fn execute(
 		&self,
 		future: Box<dyn Future<Item = (), Error = ()> + Send>

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -124,11 +124,10 @@ impl Executor<Box<dyn Future<Item = (), Error = ()> + Send>> for SpawnTaskHandle
 		&self,
 		future: Box<dyn Future<Item = (), Error = ()> + Send>
 	) -> Result<(), futures::future::ExecuteError<Box<dyn Future<Item = (), Error = ()> + Send>>> {
-		if self.sender.is_closed() {
+		if let Err(err) = self.sender.unbounded_send(future) {
 			let kind = futures::future::ExecuteErrorKind::Shutdown;
-			Err(futures::future::ExecuteError::new(kind, future))
+			Err(futures::future::ExecuteError::new(kind, err.into_inner()))
 		} else {
-			let _ = self.sender.unbounded_send(future);
 			Ok(())
 		}
 	}
@@ -629,11 +628,10 @@ impl<Components> Executor<Box<dyn Future<Item = (), Error = ()> + Send>>
 		&self,
 		future: Box<dyn Future<Item = (), Error = ()> + Send>
 	) -> Result<(), futures::future::ExecuteError<Box<dyn Future<Item = (), Error = ()> + Send>>> {
-		if self.to_spawn_tx.is_closed() {
+		if let Err(err) = self.to_spawn_tx.unbounded_send(future) {
 			let kind = futures::future::ExecuteErrorKind::Shutdown;
-			Err(futures::future::ExecuteError::new(kind, future))
+			Err(futures::future::ExecuteError::new(kind, err.into_inner()))
 		} else {
-			let _ = self.to_spawn_tx.unbounded_send(future);
 			Ok(())
 		}
 	}

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -119,10 +119,18 @@ pub struct SpawnTaskHandle {
 	sender: mpsc::UnboundedSender<Box<dyn Future<Item = (), Error = ()> + Send>>,
 }
 
-impl SpawnTaskHandle {
-	/// Spawn a task to run the given future.
-	pub fn spawn_task(&self, task: impl Future<Item = (), Error = ()> + Send + 'static) {
-		let _ = self.sender.unbounded_send(Box::new(task));
+impl Executor<Box<dyn Future<Item = (), Error = ()> + Send>> for SpawnTaskHandle {
+	fn execute(
+		&self,
+		future: Box<dyn Future<Item = (), Error = ()> + Send>
+	) -> Result<(), futures::future::ExecuteError<Box<dyn Future<Item = (), Error = ()> + Send>>> {
+		if self.sender.is_closed() {
+			let kind = futures::future::ExecuteErrorKind::Shutdown;
+			Err(futures::future::ExecuteError::new(kind, future))
+		} else {
+			let _ = self.sender.unbounded_send(future);
+			Ok(())
+		}
 	}
 }
 
@@ -611,6 +619,22 @@ impl<Components> Future for Service<Components> where Components: components::Co
 
 		// The service future never ends.
 		Ok(Async::NotReady)
+	}
+}
+
+impl<Components> Executor<Box<dyn Future<Item = (), Error = ()> + Send>>
+for Service<Components> where Components: components::Components {
+	fn execute(
+		&self,
+		future: Box<dyn Future<Item = (), Error = ()> + Send>
+	) -> Result<(), futures::future::ExecuteError<Box<dyn Future<Item = (), Error = ()> + Send>>> {
+		if self.to_spawn_tx.is_closed() {
+			let kind = futures::future::ExecuteErrorKind::Shutdown;
+			Err(futures::future::ExecuteError::new(kind, future))
+		} else {
+			let _ = self.to_spawn_tx.unbounded_send(future);
+			Ok(())
+		}
 	}
 }
 


### PR DESCRIPTION
Let's implement `Executor` instead of having an inherent method on `SpawnHandle`.

Necessary to upgrade Polkadot, so it would be great to merge this quickly-ish.
