### PR TITLE
Update trie dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,12 +1068,12 @@ dependencies = [
 
 [[package]]
 name = "hash-db"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hash256-std-hasher"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1451,11 +1451,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "keccak-hasher"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2025,12 +2025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memory-db"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ dependencies = [
  "substrate-state-machine 2.0.0",
  "substrate-test-client 2.0.0",
  "substrate-trie 2.0.0",
- "trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2353,7 +2353,7 @@ dependencies = [
  "substrate-service 2.0.0",
  "substrate-transaction-pool 2.0.0",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2572,11 +2572,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3511,7 +3510,7 @@ name = "sr-io"
 version = "2.0.0"
 dependencies = [
  "environmental 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4135,7 +4134,7 @@ dependencies = [
  "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
  "kvdb-memorydb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -4162,7 +4161,7 @@ name = "substrate-client-db"
 version = "2.0.0"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
  "kvdb-memorydb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
  "kvdb-rocksdb 0.1.4 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)",
@@ -4536,8 +4535,8 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash256-std-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash256-std-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4692,7 +4691,7 @@ dependencies = [
 name = "substrate-state-machine"
 version = "2.0.0"
 dependencies = [
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4701,8 +4700,8 @@ dependencies = [
  "substrate-panic-handler 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-trie 2.0.0",
- "trie-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4730,7 +4729,7 @@ name = "substrate-test-client"
 version = "2.0.0"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "substrate-client 2.0.0",
@@ -4767,7 +4766,7 @@ dependencies = [
  "substrate-test-runtime-client 2.0.0",
  "substrate-trie 2.0.0",
  "substrate-wasm-builder-runner 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4819,17 +4818,17 @@ name = "substrate-trie"
 version = "2.0.0"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
  "substrate-primitives 2.0.0",
- "trie-bench 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-bench 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5261,26 +5260,26 @@ dependencies = [
 
 [[package]]
 name = "trie-bench"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-standardmap 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-standardmap 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "trie-db"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5288,19 +5287,19 @@ dependencies = [
 
 [[package]]
 name = "trie-root"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "trie-standardmap"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "keccak-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5936,8 +5935,8 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum h2 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "a539b63339fbbb00e081e84b6e11bd1d9634a82d91da2984a18ac74a8823f392"
-"checksum hash-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3c95a428c86ed4633d83e07ef9e0a147a906da01e931f07e74a85bedce5a43"
-"checksum hash256-std-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "663ce20dae36902c16d12c6aaae400ca40d922407a8cf2b4caf8cae9b39b4f03"
+"checksum hash-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a2710506bcc28e53b6d48d9686b233a31ad831597da7de91e6112a2fc8f260"
+"checksum hash256-std-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4a5dcbaf4fe8977852851d137546bcad8679c9582f170032ca35b30701138e"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hashmap_core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8e04cb7a5051270ef3fa79f8c7604d581ecfa73d520e74f554e45541c4b5881a"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
@@ -5977,7 +5976,7 @@ dependencies = [
 "checksum jsonrpc-server-utils 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "036a53ffa47533dcccf1e1bb16abb0f45ef9a2dc9a63654d2d2cd199b80ad33e"
 "checksum jsonrpc-ws-server 12.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "977ea40f077c027553e4112d750114b9e5cc7bcf5642512838abc2a9b322bd23"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-"checksum keccak-hasher 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6c936c737d79690593c34275faf583151a0e8c0abf34eaecad10399eed0beb7d"
+"checksum keccak-hasher 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3767172fe16797c41f975f12f38247964ace8e5e1a2539b82d5e19f9106b1cb9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kvdb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
 "checksum kvdb-memorydb 0.1.0 (git+https://github.com/paritytech/parity-common?rev=b0317f649ab2c665b7987b8475878fc4d2e1f81d)" = "<none>"
@@ -6021,7 +6020,7 @@ dependencies = [
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum memory-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1eeeeab44c01c7da4409e68ec5b5db74c92305386efab3615e495b1dacaec196"
+"checksum memory-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "896b24d1a9850e7a25b070d552f311cbb8735214456efa222dcc4c431073c215"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum merlin 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c39467de91b004f5b9c06fac5bbc8e7d28309a205ee66905166b70804a71fea"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -6059,7 +6058,7 @@ dependencies = [
 "checksum parity-multiaddr 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
 "checksum parity-multihash 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eb83358a0c05e52c44d658981fec2d146d3516d1adffd9e553684f8c8e9e8fa5"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
-"checksum parity-util-mem 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89e80f22052161e0cb55cb5a8a75890420c525031f95c9d262dbb0434aa85dc1"
+"checksum parity-util-mem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2005637ccf93dbb60c85081ccaaf3f945f573da48dcc79f27f9646caa3ec1dc"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
 "checksum parking_lot 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4d05f1349491390b1730afba60bb20d55761bef489a954546b58b4b34e1e2ac"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
@@ -6210,10 +6209,10 @@ dependencies = [
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-"checksum trie-bench 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c77697a371f69381757831ea9ac2656700bff62b730de6ecec094c0cfc2f62e6"
-"checksum trie-db 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ae063390324bfcf36c7e8e4fb1f85f6f0fb5dd04e1cd282581eb7b8b34b32de7"
-"checksum trie-root 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "485c5dd851148b6fdac9009f7c256d0a4b5f99f08bd2e63c258f1e483aed4f1d"
-"checksum trie-standardmap 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "40787fb1a63a97ed56d12bc303937ea274e09d1afa2e20e4f074eff2074b24d3"
+"checksum trie-bench 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "401abff5ad06075d2c65d1eedeaaa70616d0df268f3186a82cf1aa2d798977d7"
+"checksum trie-db 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1803d8ff63ec3743bee883aacf3df74c524ffab188d9abebe18ded4da0dcd5d4"
+"checksum trie-root 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "226f4b2e7bc6a71172ffe7f137385cf63833de7c684059dde7520ddbf1fb04f4"
+"checksum trie-standardmap 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b65b79aee5dcdcc7247fdd811f7e26b47e65ecc17f776ecf5db8e8fd46db3b54"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum trybuild 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b7592bfd3449da952920cb55618d55f34779293127f76d946c4a54f258ca87b8"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -17,7 +17,7 @@ state-machine = { package = "substrate-state-machine", path = "../state-machine"
 keyring = { package = "substrate-keyring", path = "../keyring", optional = true }
 trie = { package = "substrate-trie", path = "../trie", optional = true }
 substrate-telemetry = { path = "../telemetry", optional = true }
-hash-db = { version = "0.12.4", default-features = false }
+hash-db = { version = "0.14.0", default-features = false }
 kvdb = { git = "https://github.com/paritytech/parity-common", optional = true, rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 parity-codec = { version = "4.1.1", default-features = false, features = ["derive"] }
 primitives = { package = "substrate-primitives", path = "../primitives", default-features = false }

--- a/core/client/db/Cargo.toml
+++ b/core/client/db/Cargo.toml
@@ -12,7 +12,7 @@ kvdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c
 kvdb-rocksdb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d", optional = true }
 kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 linked-hash-map = "0.5"
-hash-db = { version = "0.12" }
+hash-db = { version = "0.14.0" }
 primitives = { package = "substrate-primitives", path = "../../primitives" }
 runtime_primitives = { package = "sr-primitives", path = "../../sr-primitives" }
 client = { package = "substrate-client", path = "../../client" }

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -14,8 +14,8 @@ byteorder = { version = "1.3.1", default-features = false }
 primitive-types = { version = "0.4.0", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.1", optional = true }
 wasmi = { version = "0.4.3", optional = true }
-hash-db = { version = "0.12", default-features = false }
-hash256-std-hasher = { version = "0.12", default-features = false }
+hash-db = { version = "0.14.0", default-features = false }
+hash256-std-hasher = { version = "0.14.0", default-features = false }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 base58 = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2.18", optional = true }

--- a/core/sr-io/Cargo.toml
+++ b/core/sr-io/Cargo.toml
@@ -12,7 +12,7 @@ rustc_version = "0.2"
 rstd = { package = "sr-std", path = "../sr-std", default-features = false }
 primitives = { package = "substrate-primitives", path = "../primitives", default-features = false }
 codec = { package = "parity-codec", version = "4.1.1", default-features = false }
-hash-db = { version = "0.12", default-features = false }
+hash-db = { version = "0.14.0", default-features = false }
 libsecp256k1 = { version = "0.2.1", optional = true }
 tiny-keccak = { version = "1.4.2", optional = true }
 environmental = { version = "1.0.1", optional = true }

--- a/core/state-machine/Cargo.toml
+++ b/core/state-machine/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 parking_lot = "0.8.0"
-hash-db = "0.12"
-trie-db = "0.12"
-trie-root = "0.12"
+hash-db = "0.14.0"
+trie-db = "0.14.0"
+trie-root = "0.14.0"
 trie = { package = "substrate-trie", path = "../trie" }
 primitives = { package = "substrate-primitives", path = "../primitives" }
 panic-handler = { package = "substrate-panic-handler", path = "../panic-handler" }

--- a/core/test-client/Cargo.toml
+++ b/core/test-client/Cargo.toml
@@ -10,7 +10,7 @@ client-db = { package = "substrate-client-db", path = "../client/db", features =
 consensus = { package = "substrate-consensus-common", path = "../consensus/common" }
 executor = { package = "substrate-executor", path = "../executor" }
 futures = { version = "0.1.27" }
-hash-db = "0.12"
+hash-db = "0.14.0"
 keyring = { package = "substrate-keyring", path = "../keyring" }
 parity-codec = "4.1.1"
 primitives = { package = "substrate-primitives", path = "../primitives" }

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -21,7 +21,7 @@ runtime_primitives = { package = "sr-primitives", path = "../sr-primitives", def
 runtime_version = { package = "sr-version", path = "../sr-version", default-features = false }
 runtime_support = { package = "srml-support", path = "../../srml/support", default-features = false }
 substrate-trie = { path = "../trie", default-features = false }
-trie-db = { version = "0.12", default-features = false }
+trie-db = { version = "0.14.0", default-features = false }
 offchain-primitives = { package = "substrate-offchain-primitives", path = "../offchain/primitives", default-features = false}
 executive = { package = "srml-executive", path = "../../srml/executive", default-features = false }
 cfg-if = "0.1.6"

--- a/core/trie/Cargo.toml
+++ b/core/trie/Cargo.toml
@@ -14,16 +14,16 @@ harness = false
 [dependencies]
 codec = { package = "parity-codec", version = "4.1.1", default-features = false }
 rstd = { package = "sr-std", path = "../sr-std", default-features = false }
-hash-db = { version = "0.12.4", default-features = false }
-trie-db = { version = "0.12.2", default-features = false }
-trie-root = { version = "0.12.2", default-features = false }
-memory-db = { version = "0.12.2", default-features = false }
+hash-db = { version = "0.14.0", default-features = false }
+trie-db = { version = "0.14.0", default-features = false }
+trie-root = { version = "0.14.0", default-features = false }
+memory-db = { version = "0.14.0", default-features = false }
 substrate-primitives = { path = "../primitives", default-features = false }
 
 [dev-dependencies]
-trie-bench = { version = "0.13" }
-trie-standardmap = { version = "0.12" }
-keccak-hasher = { version = "0.12" }
+trie-bench = { version = "0.14.0" }
+trie-standardmap = { version = "0.14.0" }
+keccak-hasher = { version = "0.14.0" }
 criterion = "0.2"
 hex-literal = "0.2.0"
 

--- a/node-template/Cargo.toml
+++ b/node-template/Cargo.toml
@@ -18,7 +18,7 @@ tokio = "0.1"
 exit-future = "0.1"
 parking_lot = "0.8.0"
 parity-codec = "4.1.1"
-trie-root = "0.12.2"
+trie-root = "0.14.0"
 sr-io = { path = "../core/sr-io" }
 substrate-cli = { path = "../core/cli" }
 primitives = { package = "substrate-primitives", path = "../core/primitives" }

--- a/node/executor/Cargo.toml
+++ b/node/executor/Cargo.toml
@@ -6,7 +6,7 @@ description = "Substrate node implementation in Rust."
 edition = "2018"
 
 [dependencies]
-trie-root = "0.12"
+trie-root = "0.14.0"
 parity-codec = "4.1.1"
 runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 state_machine = { package = "substrate-state-machine", path = "../../core/state-machine" }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -72,7 +72,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 104,
-	impl_version: 104,
+	impl_version: 105,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
This PR update trie dependencies. Trie crate update include update of parity-util-mem to version 0.2.0 which do not include anymore a problematic dependency to clear_on_drop (clear_on_drop remains used by dalek crate and schnorkel but it is probably correctly managed for no_std).

I added patch version to all trie dependency so it becomes easier to sed update next time.