### PR TITLE
scripts: fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 	cargo install --git https://github.com/alexcrichton/wasm-gc && \
 	rustup default nightly && \
-	./scripts/build.sh && \
 	rustup default stable && \
 	cargo build --$PROFILE
 


### PR DESCRIPTION
`./scripts/build.sh` was removed in #2868.