### PR TITLE
Use bip39 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4050,7 +4049,7 @@ dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schnorrkel 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
- "substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)",
+ "substrate-bip39 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-primitives 2.0.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4084,8 +4083,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.2.1"
-source = "git+https://github.com/paritytech/substrate-bip39#44307fda4ea17fe97aeb93af317fbc8f6ed34193"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4551,7 +4550,7 @@ dependencies = [
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
- "substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)",
+ "substrate-bip39 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-serializer 2.0.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "twox-hash 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6170,7 +6169,7 @@ dependencies = [
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum strum 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1810e25f576e7ffce1ff5243b37066da5ded0310b3274c20baaeccb1145b2806"
 "checksum strum_macros 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "572a2f4e53dd4c3483fd79e5cc10ddd773a3acb1169bbfe8762365e107110579"
-"checksum substrate-bip39 0.2.1 (git+https://github.com/paritytech/substrate-bip39)" = "<none>"
+"checksum substrate-bip39 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d69ace596e9ca97837cc41f8edcfc4e0a997f227d5fc153d1010b60a0fe9acda"
 "checksum substrate-wasm-builder-runner 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "131fa5f29b2a2e459f226411e4718ecda62e360123b7cfd76ae6a7da5bcaeb0d"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -22,7 +22,7 @@ blake2-rfc = { version = "0.2.18", optional = true }
 schnorrkel = { version = "0.1.1", optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
-substrate-bip39 = { git = "https://github.com/paritytech/substrate-bip39", optional = true }
+substrate-bip39 = { version = "0.2.2", optional = true }
 tiny-bip39 = { version = "0.6.1", optional = true }
 hex = { version = "0.3", optional = true }
 regex = { version = "1.1", optional = true }

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -13,7 +13,7 @@ rand = "0.6"
 clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
-substrate-bip39 = { git = "https://github.com/paritytech/substrate-bip39" }
+substrate-bip39 = "0.2.2"
 schnorrkel = "0.1.1"
 hex = "0.3"
 hex-literal = "0.2"


### PR DESCRIPTION
cc #2416 

It happens to support no_std environments as well.