### PR TITLE
End build when `wasm-builder` does not find a prerequisite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/executor/runtime-test/build.rs
+++ b/core/executor/runtime-test/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../utils/wasm-builder",
-			version: "1.0.2",
+			version: "1.0.3",
 		},
 	);
 }

--- a/core/test-runtime/build.rs
+++ b/core/test-runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../utils/wasm-builder",
-			version: "1.0.2",
+			version: "1.0.3",
 		},
 	);
 }

--- a/core/utils/wasm-builder/Cargo.toml
+++ b/core/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -78,7 +78,7 @@
 //! - wasm-gc
 //!
 
-use std::{env, fs, path::PathBuf, process::{Command, Stdio}};
+use std::{env, fs, path::PathBuf, process::{Command, Stdio, self}};
 
 mod prerequisites;
 mod wasm_project;
@@ -107,24 +107,16 @@ pub fn build_project(file_name: &str, cargo_manifest: &str) {
 	let cargo_manifest = PathBuf::from(cargo_manifest);
 
 	if !cargo_manifest.exists() {
-		create_out_file(
-			file_name,
-			format!("compile_error!(\"'{}' does not exists!\")", cargo_manifest.display())
-		);
-		return
+		panic!("'{}' does not exists!", cargo_manifest.display());
 	}
 
 	if !cargo_manifest.ends_with("Cargo.toml") {
-		create_out_file(
-			file_name,
-			format!("compile_error!(\"'{}' no valid path to a `Cargo.toml`!\")", cargo_manifest.display())
-		);
-		return
+		panic!("'{}' no valid path to a `Cargo.toml`!", cargo_manifest.display());
 	}
 
 	if let Some(err_msg) = prerequisites::check() {
-		create_out_file(file_name, format!("compile_error!(\"{}\");", err_msg));
-		return
+		eprintln!("{}", err_msg);
+		process::exit(1);
 	}
 
 	let (wasm_binary, bloaty) = wasm_project::create_and_compile(&cargo_manifest);

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -107,7 +107,7 @@ pub fn build_project(file_name: &str, cargo_manifest: &str) {
 	let cargo_manifest = PathBuf::from(cargo_manifest);
 
 	if !cargo_manifest.exists() {
-		panic!("'{}' does not exists!", cargo_manifest.display());
+		panic!("'{}' does not exist!", cargo_manifest.display());
 	}
 
 	if !cargo_manifest.ends_with("Cargo.toml") {

--- a/core/utils/wasm-builder/src/prerequisites.rs
+++ b/core/utils/wasm-builder/src/prerequisites.rs
@@ -33,7 +33,7 @@ pub fn check() -> Option<&'static str> {
 		.status()
 		.map(|s| !s.success()).unwrap_or(true)
 	{
-		return Some("wasm-gc not installed, please install it!")
+		return Some("`wasm-gc` not installed, please install it!")
 	}
 
 	if !check_wasm_toolchain_installed() {

--- a/node-template/runtime/build.rs
+++ b/node-template/runtime/build.rs
@@ -17,5 +17,5 @@
 use wasm_builder_runner::{build_current_project, WasmBuilderSource};
 
 fn main() {
-	build_current_project("wasm_binary.rs", WasmBuilderSource::Crates("1.0.2"));
+	build_current_project("wasm_binary.rs", WasmBuilderSource::Crates("1.0.3"));
 }

--- a/node/runtime/build.rs
+++ b/node/runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../core/utils/wasm-builder",
-			version: "1.0.2",
+			version: "1.0.3",
 		},
 	);
 }


### PR DESCRIPTION
Using `compile_error!` was a stupid idea by me, as rust would not re-execute the build.rs.