### PR TITLE
core/finality: Ref `run_grandpa_voter` instead of deprecated func in doc

### DIFF
--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -28,9 +28,9 @@
 //! must pass through this wrapper, otherwise consensus is likely to break in
 //! unexpected ways.
 //!
-//! Next, use the `LinkHalf` and a local configuration to `run_grandpa`. This requires a
-//! `Network` implementation. The returned future should be driven to completion and
-//! will finalize blocks in the background.
+//! Next, use the `LinkHalf` and a local configuration to `run_grandpa_voter`.
+//! This requires a `Network` implementation. The returned future should be
+//! driven to completion and will finalize blocks in the background.
 //!
 //! # Changing authority sets
 //!


### PR DESCRIPTION
Reference `run_grandpa_voter` instead of deprecated function `run_grandpa` in `substrate_finality_grandpa` crate docs.