### PR TITLE
README: Replace outdated `period` with `minimumPeriod`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -138,7 +138,7 @@ Now, edit `~/chainspec.json` in your editor. There are a lot of individual field
 [source, json]
 ----
      "timestamp": {
-        "period": 10
+        "minimumPeriod": 10
       },
 ----
 


### PR DESCRIPTION
Block period was renamed to minimum period in https://github.com/paritytech/substrate/pull/2132. This commit updates the
README accordingly.

Relates to https://github.com/paritytech/substrate/pull/2132.