### PR TITLE
Specialization::on_message now takes Vec<u8>

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -592,6 +592,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				self.on_finality_proof_request(who, request),
 			GenericMessage::FinalityProofResponse(response) =>
 				return self.on_finality_proof_response(who, response),
+			GenericMessage::RemoteReadChildRequest(_) => {}
 			GenericMessage::Consensus(msg) => {
 				if self.context_data.peers.get(&who).map_or(false, |peer| peer.info.protocol_version > 2) {
 					self.consensus_gossip.on_incoming(
@@ -601,10 +602,10 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 					);
 				}
 			}
-			other => self.specialization.on_message(
+			GenericMessage::ChainSpecific(msg) => self.specialization.on_message(
 				&mut ProtocolContext::new(&mut self.context_data, &mut self.behaviour, &self.peerset_handle),
 				who,
-				&mut Some(other),
+				msg,
 			),
 		}
 

--- a/core/network/src/protocol/specialization.rs
+++ b/core/network/src/protocol/specialization.rs
@@ -36,7 +36,7 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 		&mut self,
 		ctx: &mut dyn Context<B>,
 		who: PeerId,
-		message: &mut Option<crate::message::Message<B>>
+		message: Vec<u8>
 	);
 
 	/// Called when a network-specific event arrives.
@@ -131,7 +131,7 @@ macro_rules! construct_simple_protocol {
 				&mut self,
 				_ctx: &mut $crate::Context<$block>,
 				_who: $crate::PeerId,
-				_message: &mut Option<$crate::message::Message<$block>>
+				_message: Vec<u8>,
 			) {
 				$( self.$sub_protocol_name.on_message(_ctx, _who, _message); )*
 			}

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -114,7 +114,7 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		&mut self,
 		_ctx: &mut dyn Context<Block>,
 		_peer_id: PeerId,
-		_message: &mut Option<crate::message::Message<Block>>,
+		_message: Vec<u8>,
 	) {}
 
 	fn on_event(


### PR DESCRIPTION
`Message` is an enum that contains all the possible network messages.
Right now the `NetworkSpecialization` receives only the `ChainSpecific` variants (and `RemoteReadChildRequest` variants, but that's a mistake) but wrapped inside of this `Message` enum.

This PR breaks the API but doesn't wrap the message inside of `Message` anymore.

Here's the Polkadot patch to apply:

```patch
diff --git a/network/src/lib.rs b/network/src/lib.rs
index 379f9dbc..e16409f1 100644
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -573,24 +573,18 @@ impl Specialization<Block> for PolkadotProtocol {
 		&mut self,
 		ctx: &mut dyn Context<Block>,
 		who: PeerId,
-		message: &mut Option<message::Message<Block>>
+		message: Vec<u8>,
 	) {
-		match message.take() {
-			Some(generic_message::Message::ChainSpecific(raw)) => {
-				match Message::decode(&mut raw.as_slice()) {
-					Some(msg) => {
-						ctx.report_peer(who.clone(), benefit::VALID_FORMAT);
-						self.on_polkadot_message(ctx, who, msg)
-					},
-					None => {
-						trace!(target: "p_net", "Bad message from {}", who);
-						ctx.report_peer(who, cost::INVALID_FORMAT);
-						*message = Some(generic_message::Message::ChainSpecific(raw));
-					}
-				}
+		match Message::decode(&mut raw.as_slice()) {
+			Some(msg) => {
+				ctx.report_peer(who.clone(), benefit::VALID_FORMAT);
+				self.on_polkadot_message(ctx, who, msg)
+			},
+			None => {
+				trace!(target: "p_net", "Bad message from {}", who);
+				ctx.report_peer(who, cost::INVALID_FORMAT);
+				*message = Some(generic_message::Message::ChainSpecific(raw));
 			}
-			Some(other) => *message = Some(other),
-			_ => {}
 		}
 	}
```
