### PR TITLE
core/network: Log when ignoring genesis block announcement

### DIFF
--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -797,7 +797,7 @@ impl<B: BlockT> ChainSync<B> {
 		let number = *header.number();
 		debug!(target: "sync", "Received block announcement with number {:?}", number);
 		if number.is_zero() {
-			warn!(target: "sync", "Ignored invalid block announcement from {}: {}", who, hash);
+			warn!(target: "sync", "Ignored genesis block (#0) announcement from {}: {}", who, hash);
 			return false;
 		}
 		let parent_status = block_status(&*protocol.client(), &self.queue_blocks, header.parent_hash().clone()).ok()


### PR DESCRIPTION
Instead of logging the fact that a generic invalid block announcement is
ignored, log that the given block is the genesis block.

This warning log line confused me while debugging a different issue.

Let me know if this makes sense.