### PR TITLE
network: don't announce genesis block

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -1036,6 +1036,12 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				return;
 			}
 		};
+
+		// don't announce genesis block since it will be ignored
+		if header.number().is_zero() {
+			return;
+		}
+
 		let hash = header.hash();
 
 		let message = GenericMessage::BlockAnnounce(message::BlockAnnounce { header: header.clone() });


### PR DESCRIPTION
Genesis block announcements are ignored (https://github.com/paritytech/substrate/blob/master/core/network/src/protocol/sync.rs#L799) therefore we shouldn't be sending them. I think this happens when starting an empty chain since on the first round of GRANDPA voters will be voting for genesis (and announce the block they voted on).