### PR TITLE
Remove set_finality_proof_request_builder

### DIFF
--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -37,7 +37,6 @@ use consensus_common::{self, BlockImport, Environment, Proposer,
 };
 use consensus_common::import_queue::{
 	Verifier, BasicQueue, BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport,
-	BoxFinalityProofRequestBuilder,
 };
 use client::{
 	block_builder::api::BlockBuilder as BlockBuilderApi,
@@ -677,7 +676,6 @@ pub fn import_queue<B, C, P>(
 	block_import: BoxBlockImport<B>,
 	justification_import: Option<BoxJustificationImport<B>>,
 	finality_proof_import: Option<BoxFinalityProofImport<B>>,
-	finality_proof_request_builder: Option<BoxFinalityProofRequestBuilder<B>>,
 	client: Arc<C>,
 	inherent_data_providers: InherentDataProviders,
 ) -> Result<AuraImportQueue<B>, consensus_common::Error> where
@@ -704,7 +702,6 @@ pub fn import_queue<B, C, P>(
 		block_import,
 		justification_import,
 		finality_proof_import,
-		finality_proof_request_builder,
 	))
 }
 

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -33,7 +33,6 @@ pub use babe_primitives::*;
 pub use consensus_common::SyncOracle;
 use consensus_common::import_queue::{
 	BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport,
-	BoxFinalityProofRequestBuilder,
 };
 use consensus_common::well_known_cache_keys::Id as CacheKeyId;
 use runtime_primitives::{generic, generic::{BlockId, OpaqueDigestItemId}, Justification};
@@ -832,7 +831,6 @@ pub fn import_queue<B, C, E>(
 	block_import: BoxBlockImport<B>,
 	justification_import: Option<BoxJustificationImport<B>>,
 	finality_proof_import: Option<BoxFinalityProofImport<B>>,
-	finality_proof_request_builder: Option<BoxFinalityProofRequestBuilder<B>>,
 	client: Arc<C>,
 	inherent_data_providers: InherentDataProviders,
 ) -> Result<(BabeImportQueue<B>, BabeLink), consensus_common::Error> where
@@ -857,7 +855,6 @@ pub fn import_queue<B, C, E>(
 		block_import,
 		justification_import,
 		finality_proof_import,
-		finality_proof_request_builder,
 	), timestamp_core))
 }
 

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -247,9 +247,3 @@ pub trait FinalityProofImport<B: BlockT> {
 		verifier: &dyn Verifier<B>,
 	) -> Result<(B::Hash, NumberFor<B>), Self::Error>;
 }
-
-/// Finality proof request builder.
-pub trait FinalityProofRequestBuilder<B: BlockT>: Send {
-	/// Build data blob, associated with the request.
-	fn build_request_data(&mut self, hash: &B::Hash) -> Vec<u8>;
-}

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -30,7 +30,7 @@ use runtime_primitives::{Justification, traits::{Block as BlockT, Header as _, N
 use crate::{error::Error as ConsensusError, well_known_cache_keys::Id as CacheKeyId};
 use crate::block_import::{
 	BlockImport, BlockOrigin, ImportBlock, ImportedAux, JustificationImport, ImportResult,
-	FinalityProofImport, FinalityProofRequestBuilder,
+	FinalityProofImport,
 };
 
 pub use basic_queue::BasicQueue;
@@ -46,9 +46,6 @@ pub type BoxJustificationImport<B> = Box<dyn JustificationImport<B, Error=Consen
 
 /// Shared finality proof import struct used by the queue.
 pub type BoxFinalityProofImport<B> = Box<dyn FinalityProofImport<B, Error=ConsensusError> + Send + Sync>;
-
-/// Shared finality proof request builder struct used by the queue.
-pub type BoxFinalityProofRequestBuilder<B> = Box<dyn FinalityProofRequestBuilder<B> + Send + Sync>;
 
 /// Maps to the Origin used by the network.
 pub type Origin = libp2p::PeerId;
@@ -139,8 +136,6 @@ pub trait Link<B: BlockT>: Send {
 	) {}
 	/// Request a finality proof for the given block.
 	fn request_finality_proof(&mut self, _hash: &B::Hash, _number: NumberFor<B>) {}
-	/// Remember finality proof request builder on start.
-	fn set_finality_proof_request_builder(&mut self, _request_builder: BoxFinalityProofRequestBuilder<B>) {}
 	/// Adjusts the reputation of the given peer.
 	fn report_peer(&mut self, _who: Origin, _reputation_change: i32) {}
 	/// Restart sync.

--- a/core/consensus/common/src/lib.rs
+++ b/core/consensus/common/src/lib.rs
@@ -48,7 +48,7 @@ const MAX_BLOCK_SIZE: usize = 4 * 1024 * 1024 + 512;
 pub use self::error::Error;
 pub use block_import::{
 	BlockImport, BlockOrigin, ForkChoiceStrategy, ImportedAux, ImportBlock, ImportResult,
-	JustificationImport, FinalityProofImport, FinalityProofRequestBuilder,
+	JustificationImport, FinalityProofImport,
 };
 pub use select_chain::SelectChain;
 

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -27,10 +27,11 @@ use client::{
 };
 use parity_codec::{Encode, Decode};
 use consensus_common::{
-	import_queue::{Verifier, BoxFinalityProofRequestBuilder}, well_known_cache_keys,
+	import_queue::Verifier, well_known_cache_keys,
 	BlockOrigin, BlockImport, FinalityProofImport, ImportBlock, ImportResult, ImportedAux,
-	Error as ConsensusError, FinalityProofRequestBuilder,
+	Error as ConsensusError,
 };
+use network::config::{BoxFinalityProofRequestBuilder, FinalityProofRequestBuilder};
 use runtime_primitives::Justification;
 use runtime_primitives::traits::{
 	NumberFor, Block as BlockT, Header as HeaderT, ProvideRuntimeApi, DigestFor,

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -19,7 +19,7 @@
 use super::*;
 use network::test::{Block, DummySpecialization, Hash, TestNetFactory, Peer, PeersClient};
 use network::test::{PassThroughVerifier};
-use network::config::{ProtocolConfig, Roles};
+use network::config::{ProtocolConfig, Roles, BoxFinalityProofRequestBuilder};
 use parking_lot::Mutex;
 use tokio::runtime::current_thread;
 use keyring::ed25519::{Keyring as AuthorityKeyring};
@@ -30,9 +30,7 @@ use client::{
 };
 use test_client::{self, runtime::BlockNumber};
 use consensus_common::{BlockOrigin, ForkChoiceStrategy, ImportedAux, ImportBlock, ImportResult};
-use consensus_common::import_queue::{BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport,
-	BoxFinalityProofRequestBuilder,
-};
+use consensus_common::import_queue::{BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport};
 use std::collections::{HashMap, HashSet};
 use std::result;
 use parity_codec::Decode;

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -54,6 +54,11 @@ pub struct Params<B: BlockT, S, H: ExHashT> {
 	/// from us.
 	pub finality_proof_provider: Option<Arc<dyn FinalityProofProvider<B>>>,
 
+	/// How to build requests for proofs of finality.
+	///
+	/// This object, if `Some`, is used when we need a proof of finality from another node.
+	pub finality_proof_request_builder: Option<BoxFinalityProofRequestBuilder<B>>,
+
 	/// The `OnDemand` object acts as a "receiver" for block data requests from the client.
 	/// If `Some`, the network worker will process these requests and answer them.
 	/// Normally used only for light clients.
@@ -115,6 +120,25 @@ impl parity_codec::Decode for Roles {
 		Self::from_bits(input.read_byte()?)
 	}
 }
+
+/// Finality proof request builder.
+pub trait FinalityProofRequestBuilder<B: BlockT>: Send {
+	/// Build data blob, associated with the request.
+	fn build_request_data(&mut self, hash: &B::Hash) -> Vec<u8>;
+}
+
+/// Implementation of `FinalityProofRequestBuilder` that builds a dummy empty request.
+#[derive(Debug, Default)]
+pub struct DummyFinalityProofRequestBuilder;
+
+impl<B: BlockT> FinalityProofRequestBuilder<B> for DummyFinalityProofRequestBuilder {
+	fn build_request_data(&mut self, _: &B::Hash) -> Vec<u8> {
+		Vec::new()
+	}
+}
+
+/// Shared finality proof request builder struct used by the queue.
+pub type BoxFinalityProofRequestBuilder<B> = Box<dyn FinalityProofRequestBuilder<B> + Send + Sync>;
 
 /// Name of a protocol, transmitted on the wire. Should be unique for each chain.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -28,7 +28,6 @@ use runtime_primitives::traits::{
 	Block as BlockT, Header as HeaderT, NumberFor, One, Zero,
 	CheckedSub, SaturatedConversion
 };
-use consensus::import_queue::BoxFinalityProofRequestBuilder;
 use message::{
 	BlockRequest as BlockRequestMessage,
 	FinalityProofRequest as FinalityProofRequestMessage, Message,
@@ -41,7 +40,7 @@ use on_demand::{OnDemandCore, OnDemandNetwork, RequestData};
 use specialization::NetworkSpecialization;
 use sync::{ChainSync, Context as SyncContext, SyncState};
 use crate::service::{TransactionPool, ExHashT};
-use crate::config::Roles;
+use crate::config::{BoxFinalityProofRequestBuilder, Roles};
 use rustc_hex::ToHex;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -390,11 +389,12 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		specialization: S,
 		transaction_pool: Arc<dyn TransactionPool<H, B>>,
 		finality_proof_provider: Option<Arc<dyn FinalityProofProvider<B>>>,
+		finality_proof_request_builder: Option<BoxFinalityProofRequestBuilder<B>>,
 		protocol_id: ProtocolId,
 		peerset_config: peerset::PeersetConfig,
 	) -> error::Result<(Protocol<B, S, H>, peerset::PeersetHandle)> {
 		let info = chain.info();
-		let sync = ChainSync::new(config.roles, &info);
+		let sync = ChainSync::new(config.roles, &info, finality_proof_request_builder);
 		let (peerset, peerset_handle) = peerset::Peerset::from_config(peerset_config);
 		let versions = &((MIN_VERSION as u8)..=(CURRENT_VERSION as u8)).collect::<Vec<u8>>();
 		let behaviour = CustomProto::new(protocol_id, versions, peerset);
@@ -1243,10 +1243,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	/// Notify about successful import of the given block.
 	pub fn block_imported(&mut self, hash: &B::Hash, number: NumberFor<B>) {
 		self.sync.block_imported(hash, number)
-	}
-
-	pub fn set_finality_proof_request_builder(&mut self, request_builder: BoxFinalityProofRequestBuilder<B>) {
-		self.sync.set_finality_proof_request_builder(request_builder)
 	}
 
 	/// Call this when a justification has been processed by the import queue, with or without

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -28,7 +28,7 @@
 use std::{collections::HashMap, fs, marker::PhantomData, io, path::Path};
 use std::sync::{Arc, atomic::{AtomicBool, AtomicUsize, Ordering}};
 
-use consensus::import_queue::{ImportQueue, Link, BoxFinalityProofRequestBuilder};
+use consensus::import_queue::{ImportQueue, Link};
 use futures::{prelude::*, sync::mpsc};
 use log::{warn, error, info};
 use libp2p::core::{swarm::NetworkBehaviour, transport::boxed::Boxed, muxing::StreamMuxerBox};
@@ -169,6 +169,7 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkWorker
 			params.specialization,
 			params.transaction_pool,
 			params.finality_proof_provider,
+			params.finality_proof_request_builder,
 			params.protocol_id,
 			peerset_config,
 		)?;
@@ -682,8 +683,5 @@ impl<'a, B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Link<B> for Network
 	}
 	fn restart(&mut self) {
 		self.protocol.user_protocol_mut().restart()
-	}
-	fn set_finality_proof_request_builder(&mut self, builder: BoxFinalityProofRequestBuilder<B>) {
-		self.protocol.user_protocol_mut().set_finality_proof_request_builder(builder)
 	}
 }

--- a/core/network/src/test/block_import.rs
+++ b/core/network/src/test/block_import.rs
@@ -75,7 +75,7 @@ fn async_import_queue_drops() {
 	// Perform this test multiple times since it exhibits non-deterministic behavior.
 	for _ in 0..100 {
 		let verifier = Arc::new(PassThroughVerifier(true));
-		let queue = BasicQueue::new(verifier, Box::new(test_client::new()), None, None, None);
+		let queue = BasicQueue::new(verifier, Box::new(test_client::new()), None, None);
 		drop(queue);
 	}
 }

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -35,14 +35,13 @@ use crate::config::Roles;
 use consensus::import_queue::BasicQueue;
 use consensus::import_queue::{
 	BoxBlockImport, BoxJustificationImport, Verifier, BoxFinalityProofImport,
-	BoxFinalityProofRequestBuilder,
 };
 use consensus::block_import::{BlockImport, ImportResult};
 use consensus::{Error as ConsensusError, well_known_cache_keys::{self, Id as CacheKeyId}};
 use consensus::{BlockOrigin, ForkChoiceStrategy, ImportBlock, JustificationImport};
 use futures::prelude::*;
 use crate::{NetworkWorker, NetworkService, config::ProtocolId};
-use crate::config::{NetworkConfiguration, TransportConfig};
+use crate::config::{NetworkConfiguration, TransportConfig, BoxFinalityProofRequestBuilder};
 use libp2p::PeerId;
 use parking_lot::Mutex;
 use primitives::{H256, Blake2Hasher};
@@ -457,7 +456,6 @@ pub trait TestNetFactory: Sized {
 			Box::new(block_import.clone()),
 			justification_import,
 			finality_proof_import,
-			finality_proof_request_builder,
 		));
 
 		let listen_addr = build_multiaddr![Memory(rand::random::<u64>())];
@@ -471,6 +469,7 @@ pub trait TestNetFactory: Sized {
 			},
 			chain: client.clone(),
 			finality_proof_provider: self.make_finality_proof_provider(PeersClient::Full(client.clone())),
+			finality_proof_request_builder,
 			on_demand: None,
 			transaction_pool: Arc::new(EmptyTransactionPool),
 			protocol_id: ProtocolId::from(&b"test-protocol-name"[..]),
@@ -514,7 +513,6 @@ pub trait TestNetFactory: Sized {
 			Box::new(block_import.clone()),
 			justification_import,
 			finality_proof_import,
-			finality_proof_request_builder,
 		));
 
 		let listen_addr = build_multiaddr![Memory(rand::random::<u64>())];
@@ -528,6 +526,7 @@ pub trait TestNetFactory: Sized {
 			},
 			chain: client.clone(),
 			finality_proof_provider: self.make_finality_proof_provider(PeersClient::Light(client.clone())),
+			finality_proof_request_builder,
 			on_demand: None,
 			transaction_pool: Arc::new(EmptyTransactionPool),
 			protocol_id: ProtocolId::from(&b"test-protocol-name"[..]),

--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -130,7 +130,11 @@ pub fn import_blocks<F, E, R>(
 	let client = new_client::<F>(&config)?;
 	// FIXME #1134 this shouldn't need a mutable config.
 	let select_chain = components::FullComponents::<F>::build_select_chain(&mut config, client.clone())?;
-	let mut queue = components::FullComponents::<F>::build_import_queue(&mut config, client.clone(), select_chain)?;
+	let (mut queue, _) = components::FullComponents::<F>::build_import_queue(
+		&mut config,
+		client.clone(),
+		select_chain
+	)?;
 
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
 	::std::thread::spawn(move || {

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -23,7 +23,7 @@ use client_db;
 use client::{self, Client, runtime_api};
 use crate::{error, Service, AuthorityKeyProvider};
 use consensus_common::{import_queue::ImportQueue, SelectChain};
-use network::{self, OnDemand, FinalityProofProvider};
+use network::{self, OnDemand, FinalityProofProvider, config::BoxFinalityProofRequestBuilder};
 use substrate_executor::{NativeExecutor, NativeExecutionDispatch};
 use transaction_pool::txpool::{self, Options as TransactionPoolOptions, Pool as TransactionPool};
 use runtime_primitives::{
@@ -356,7 +356,7 @@ pub trait ServiceFactory: 'static + Sized {
 	fn build_light_import_queue(
 		config: &mut FactoryFullConfiguration<Self>,
 		_client: Arc<LightClient<Self>>
-	) -> Result<Self::LightImportQueue, error::Error> {
+	) -> Result<(Self::LightImportQueue, BoxFinalityProofRequestBuilder<Self::Block>), error::Error> {
 		if let Some(name) = config.chain_spec.consensus_engine() {
 			match name {
 				_ => Err(format!("Chain Specification defines unknown consensus engine '{}'", name).into())
@@ -407,12 +407,13 @@ pub trait Components: Sized + 'static {
 	fn build_transaction_pool(config: TransactionPoolOptions, client: Arc<ComponentClient<Self>>)
 		-> Result<TransactionPool<Self::TransactionPoolApi>, error::Error>;
 
-	/// instance of import queue for clients
+	/// Build the queue that imports blocks from the network, and optionally a way for the network
+	/// to build requests for proofs of finality.
 	fn build_import_queue(
 		config: &mut FactoryFullConfiguration<Self::Factory>,
 		client: Arc<ComponentClient<Self>>,
 		select_chain: Option<Self::SelectChain>,
-	) -> Result<Self::ImportQueue, error::Error>;
+	) -> Result<(Self::ImportQueue, Option<BoxFinalityProofRequestBuilder<FactoryBlock<Self::Factory>>>), error::Error>;
 
 	/// Finality proof provider for serving network requests.
 	fn build_finality_proof_provider(
@@ -513,10 +514,11 @@ impl<Factory: ServiceFactory> Components for FullComponents<Factory> {
 		config: &mut FactoryFullConfiguration<Self::Factory>,
 		client: Arc<ComponentClient<Self>>,
 		select_chain: Option<Self::SelectChain>,
-	) -> Result<Self::ImportQueue, error::Error> {
+	) -> Result<(Self::ImportQueue, Option<BoxFinalityProofRequestBuilder<FactoryBlock<Self::Factory>>>), error::Error> {
 		let select_chain = select_chain
 			.ok_or(error::Error::SelectChainRequired)?;
 		Factory::build_full_import_queue(config, client, select_chain)
+			.map(|queue| (queue, None))
 	}
 
 	fn build_select_chain(
@@ -615,8 +617,9 @@ impl<Factory: ServiceFactory> Components for LightComponents<Factory> {
 		config: &mut FactoryFullConfiguration<Self::Factory>,
 		client: Arc<ComponentClient<Self>>,
 		_select_chain: Option<Self::SelectChain>,
-	) -> Result<Self::ImportQueue, error::Error> {
+	) -> Result<(Self::ImportQueue, Option<BoxFinalityProofRequestBuilder<FactoryBlock<Self::Factory>>>), error::Error> {
 		Factory::build_light_import_queue(config, client)
+			.map(|(queue, builder)| (queue, Some(builder)))
 	}
 
 	fn build_finality_proof_provider(

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -915,7 +915,7 @@ impl offchain::AuthorityKeyProvider for AuthorityKeyProvider {
 /// # 	FullComponents, LightComponents, FactoryFullConfiguration, FullClient
 /// # };
 /// # use transaction_pool::{self, txpool::{Pool as TransactionPool}};
-/// # use network::construct_simple_protocol;
+/// # use network::{config::DummyFinalityProofRequestBuilder, construct_simple_protocol};
 /// # use client::{self, LongestChain};
 /// # use consensus_common::import_queue::{BasicQueue, Verifier};
 /// # use consensus_common::{BlockOrigin, ImportBlock, well_known_cache_keys::Id as CacheKeyId};
@@ -969,9 +969,12 @@ impl offchain::AuthorityKeyProvider for AuthorityKeyProvider {
 /// 		LightService = LightComponents<Self>
 /// 			{ |config| <LightComponents<Factory>>::new(config) },
 /// 		FullImportQueue = BasicQueue<Block>
-/// 			{ |_, client, _| Ok(BasicQueue::new(Arc::new(MyVerifier), Box::new(client), None, None, None)) },
+/// 			{ |_, client, _| Ok(BasicQueue::new(Arc::new(MyVerifier), Box::new(client), None, None)) },
 /// 		LightImportQueue = BasicQueue<Block>
-/// 			{ |_, client| Ok(BasicQueue::new(Arc::new(MyVerifier), Box::new(client), None, None, None)) },
+/// 			{ |_, client| {
+/// 				let fprb = Box::new(DummyFinalityProofRequestBuilder::default()) as Box<_>;
+/// 				Ok((BasicQueue::new(Arc::new(MyVerifier), Box::new(client), None, None), fprb))
+/// 			}},
 /// 		SelectChain = LongestChain<FullBackend<Self>, Self::Block>
 /// 			{ |config: &FactoryFullConfiguration<Self>, client: Arc<FullClient<Self>>| {
 /// 				#[allow(deprecated)]

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -65,7 +65,7 @@ use components::{StartRPC, MaintainTransactionPool, OffchainWorker};
 #[doc(hidden)]
 pub use std::{ops::Deref, result::Result, sync::Arc};
 #[doc(hidden)]
-pub use network::{FinalityProofProvider, OnDemand};
+pub use network::{FinalityProofProvider, OnDemand, config::BoxFinalityProofRequestBuilder};
 #[doc(hidden)]
 pub use futures::future::Executor;
 
@@ -205,11 +205,12 @@ impl<Components: components::Components> Service<Components> {
 
 		let (client, on_demand) = Components::build_client(&config, executor)?;
 		let select_chain = Components::build_select_chain(&mut config, client.clone())?;
-		let import_queue = Box::new(Components::build_import_queue(
+		let (import_queue, finality_proof_request_builder) = Components::build_import_queue(
 			&mut config,
 			client.clone(),
 			select_chain.clone(),
-		)?);
+		)?;
+		let import_queue = Box::new(import_queue);
 		let finality_proof_provider = Components::build_finality_proof_provider(client.clone())?;
 		let chain_info = client.info().chain;
 
@@ -248,6 +249,7 @@ impl<Components: components::Components> Service<Components> {
 			network_config: config.network.clone(),
 			chain: client.clone(),
 			finality_proof_provider,
+			finality_proof_request_builder,
 			on_demand,
 			transaction_pool: transaction_pool_adapter.clone() as _,
 			import_queue,
@@ -1065,7 +1067,7 @@ macro_rules! construct_service_factory {
 			fn build_light_import_queue(
 				config: &mut FactoryFullConfiguration<Self>,
 				client: Arc<$crate::LightClient<Self>>,
-			) -> Result<Self::LightImportQueue, $crate::Error> {
+			) -> Result<(Self::LightImportQueue, $crate::BoxFinalityProofRequestBuilder<$block>), $crate::Error> {
 				( $( $light_import_queue_init )* ) (config, client)
 			}
 

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -171,7 +171,6 @@ construct_service_factory! {
 					Box::new(block_import),
 					Some(Box::new(justification_import)),
 					None,
-					None,
 					client,
 					config.custom.inherent_data_providers.clone(),
 				).map_err(Into::into)
@@ -194,10 +193,9 @@ construct_service_factory! {
 					Box::new(block_import),
 					None,
 					Some(Box::new(finality_proof_import)),
-					Some(finality_proof_request_builder),
 					client,
 					config.custom.inherent_data_providers.clone(),
-				).map_err(Into::into)
+				).map(|q| (q, finality_proof_request_builder)).map_err(Into::into)
 			}},
 		SelectChain = LongestChain<FullBackend<Self>, Self::Block>
 			{ |config: &FactoryFullConfiguration<Self>, client: Arc<FullClient<Self>>| {


### PR DESCRIPTION
Fix #2857 

We build a "finality proof request builder" when creating the service.

Before this PR, this FPRB is passed to the import queue. This import queue then calls `set_finality_proof_request_builder()` in order to pass that FPRB to the network. The network then stores that into the `sync` protocol.

After this PR, we directly pass the FPRB to the network as parameter when constructing it.

I also moved the `FinalityProofRequestBuilder` and `BoxFinalityProofRequestBuilder` items to the network configuration, where it is now more appropriate.

Polkadot patch:

```patch
diff --git a/service/src/lib.rs b/service/src/lib.rs
index 2501e633..fe205a42 100644
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -329,7 +329,6 @@ service::construct_service_factory! {
 					block_import,
 					Some(justification_import),
 					None,
-					None,
 					client,
 					config.custom.inherent_data_providers.clone(),
 				).map_err(Into::into)
@@ -355,10 +354,9 @@ service::construct_service_factory! {
 					block_import,
 					None,
 					Some(finality_proof_import),
-					Some(finality_proof_request_builder),
 					client,
 					config.custom.inherent_data_providers.clone(),
-				).map_err(Into::into)
+				).map(|q| (q, finality_proof_request_builder)).map_err(Into::into)
 			}},
 		SelectChain = LongestChain<FullBackend<Self>, Self::Block>
 			{ |config: &FactoryFullConfiguration<Self>, client: Arc<FullClient<Self>>| {
```