### PR TITLE
Cleanup CLI and introduce `execution-all`

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -424,12 +424,13 @@ where
 		};
 
 	let exec = cli.execution_strategies;
+	let exec_all_or = |strat: params::ExecutionStrategy| exec.execution_all.unwrap_or(strat).into();
 	config.execution_strategies = ExecutionStrategies {
-		syncing: exec.syncing_execution.into(),
-		importing: exec.importing_execution.into(),
-		block_construction: exec.block_construction_execution.into(),
-		offchain_worker: exec.offchain_worker_execution.into(),
-		other: exec.other_execution.into(),
+		syncing: exec_all_or(exec.execution_syncing),
+		importing: exec_all_or(exec.execution_import_block),
+		block_construction: exec_all_or(exec.execution_block_construction),
+		offchain_worker: exec_all_or(exec.execution_offchain_worker),
+		other: exec_all_or(exec.execution_other),
 	};
 
 	config.offchain_worker = match (cli.offchain_worker, role) {

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -424,7 +424,7 @@ where
 		};
 
 	let exec = cli.execution_strategies;
-	let exec_all_or = |strat: params::ExecutionStrategy| exec.execution_all.unwrap_or(strat).into();
+	let exec_all_or = |strat: params::ExecutionStrategy| exec.execution.unwrap_or(strat).into();
 	config.execution_strategies = ExecutionStrategies {
 		syncing: exec_all_or(exec.execution_syncing),
 		importing: exec_all_or(exec.execution_import_block),

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -33,13 +33,12 @@ macro_rules! impl_get_log_filter {
 
 arg_enum! {
 	/// How to execute blocks
-	#[derive(Debug, Clone)]
+	#[derive(Debug, Clone, Copy)]
 	pub enum ExecutionStrategy {
 		Native,
 		Wasm,
 		Both,
 		NativeElseWasm,
-		NativeWhenPossible,
 	}
 }
 
@@ -50,7 +49,6 @@ impl Into<client::ExecutionStrategy> for ExecutionStrategy {
 			ExecutionStrategy::Wasm => client::ExecutionStrategy::AlwaysWasm,
 			ExecutionStrategy::Both => client::ExecutionStrategy::Both,
 			ExecutionStrategy::NativeElseWasm => client::ExecutionStrategy::NativeElseWasm,
-			ExecutionStrategy::NativeWhenPossible => client::ExecutionStrategy::NativeWhenPossible,
 		}
 	}
 }
@@ -227,7 +225,7 @@ pub struct TransactionPoolParams {
 pub struct ExecutionStrategies {
 	/// The means of execution used when calling into the runtime while syncing blocks.
 	#[structopt(
-		long = "syncing-execution",
+		long = "execution-syncing",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
@@ -235,11 +233,11 @@ pub struct ExecutionStrategies {
 			default_value = r#""NativeElseWasm""#
 		)
 	)]
-	pub syncing_execution: ExecutionStrategy,
+	pub execution_syncing: ExecutionStrategy,
 
 	/// The means of execution used when calling into the runtime while importing blocks.
 	#[structopt(
-		long = "importing-execution",
+		long = "execution-import-block",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
@@ -247,11 +245,11 @@ pub struct ExecutionStrategies {
 			default_value = r#""NativeElseWasm""#
 		)
 	)]
-	pub importing_execution: ExecutionStrategy,
+	pub execution_import_block: ExecutionStrategy,
 
 	/// The means of execution used when calling into the runtime while constructing blocks.
 	#[structopt(
-		long = "block-construction-execution",
+		long = "execution-block-construction",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
@@ -259,31 +257,49 @@ pub struct ExecutionStrategies {
 			default_value = r#""Wasm""#
 		)
 	)]
-	pub block_construction_execution: ExecutionStrategy,
+	pub execution_block_construction: ExecutionStrategy,
 
 	/// The means of execution used when calling into the runtime while using an off-chain worker.
 	#[structopt(
-		long = "offchain-worker-execution",
+		long = "execution-offchain-worker",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
 			case_insensitive = "true",
-			default_value = r#""NativeWhenPossible""#
+			default_value = r#""Native""#
 		)
 	)]
-	pub offchain_worker_execution: ExecutionStrategy,
+	pub execution_offchain_worker: ExecutionStrategy,
 
 	/// The means of execution used when calling into the runtime while not syncing, importing or constructing blocks.
 	#[structopt(
-		long = "other-execution",
+		long = "execution-other",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
 			case_insensitive = "true",
-			default_value = r#""Wasm""#
+			default_value = r#""Native""#
 		)
 	)]
-	pub other_execution: ExecutionStrategy,
+	pub execution_other: ExecutionStrategy,
+
+	/// The execution strategy that should be used by all execution contexts.
+	#[structopt(
+		long = "execution-all",
+		value_name = "STRATEGY",
+		raw(
+			possible_values = "&ExecutionStrategy::variants()",
+			case_insensitive = "true",
+			conflicts_with_all = "&[
+				\"execution_other\",
+				\"execution_offchain_worker\",
+				\"execution_block_construction\",
+				\"execution_import_block\",
+				\"execution_syncing\",
+			]"
+		)
+	)]
+	pub execution_all: Option<ExecutionStrategy>,
 }
 
 /// The `run` command used to run a node.
@@ -426,7 +442,7 @@ lazy_static::lazy_static! {
 			let conflicts_with = keyring::AuthorityKeyring::iter()
 				.filter(|b| a != *b)
 				.map(|b| b.to_string().to_lowercase())
-				.chain(["name", "key"].iter().map(|s| s.to_string()))
+				.chain(["name", "key"].iter().map(ToString::to_string))
 				.collect::<Vec<_>>();
 			let name = a.to_string().to_lowercase();
 

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -285,7 +285,7 @@ pub struct ExecutionStrategies {
 
 	/// The execution strategy that should be used by all execution contexts.
 	#[structopt(
-		long = "execution-all",
+		long = "execution",
 		value_name = "STRATEGY",
 		raw(
 			possible_values = "&ExecutionStrategy::variants()",
@@ -299,7 +299,7 @@ pub struct ExecutionStrategies {
 			]"
 		)
 	)]
-	pub execution_all: Option<ExecutionStrategy>,
+	pub execution: Option<ExecutionStrategy>,
 }
 
 /// The `run` command used to run a node.


### PR DESCRIPTION
`--execution-all` sets the execution strategies for all available
execution contexts.

Fixes: https://github.com/paritytech/substrate/issues/2636
