### PR TITLE
Switch the telemetry to new futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-util-preview"
 version = "0.3.0-alpha.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4808,6 +4817,8 @@ version = "2.0.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4816,9 +4827,7 @@ dependencies = [
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6018,6 +6027,7 @@ dependencies = [
 "checksum futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "082e402605fcb8b1ae1e5ba7d7fdfd3e31ef510e2a8367dd92927bb41ae41b3a"
 "checksum futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "bf25f91c8a9a1f64c451e91b43ba269ed359b9f52d35ed4b3ce3f9c842435867"
 "checksum futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4309a25a1069a1f3c10647b227b9afe6722b67a030d3f00a9cbdc171fc038de4"
+"checksum futures-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb4a32e84935678650944c6ebd0d912db46405d37bf94f1a058435c5080abcb1"
 "checksum futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "af8198c48b222f02326940ce2b3aa9e6e91a32886eeaad7ca3b8e4c70daa3f4e"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,12 +955,87 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures-channel-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-core-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-executor-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-io-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-timer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-util-preview"
+version = "0.3.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2701,6 +2776,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -4633,6 +4713,7 @@ dependencies = [
  "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-executor 2.0.0",
@@ -4716,6 +4797,8 @@ version = "2.0.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4724,9 +4807,7 @@ dependencies = [
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5919,7 +6000,15 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
+"checksum futures-channel-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "21c71ed547606de08e9ae744bb3c6d80f5627527ef31ecf2a7210d0e67bc8fae"
+"checksum futures-core-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4b141ccf9b7601ef987f36f1c0d9522f76df3bba1cf2e63bfacccc044c4558f5"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-executor-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "87ba260fe51080ba37f063ad5b0732c4ff1f737ea18dcb67833d282cdc2c6f14"
+"checksum futures-io-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "082e402605fcb8b1ae1e5ba7d7fdfd3e31ef510e2a8367dd92927bb41ae41b3a"
+"checksum futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "bf25f91c8a9a1f64c451e91b43ba269ed359b9f52d35ed4b3ce3f9c842435867"
+"checksum futures-sink-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4309a25a1069a1f3c10647b227b9afe6722b67a030d3f00a9cbdc171fc038de4"
+"checksum futures-timer 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb4a32e84935678650944c6ebd0d912db46405d37bf94f1a058435c5080abcb1"
+"checksum futures-util-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)" = "af8198c48b222f02326940ce2b3aa9e6e91a32886eeaad7ca3b8e4c70daa3f4e"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
@@ -6068,6 +6157,7 @@ dependencies = [
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 derive_more = "0.14.0"
 futures = "0.1.17"
+futures03 = { package = "futures-preview", version = "0.3.0-alpha.17", features = ["compat"] }
 parking_lot = "0.8.0"
 lazy_static = "1.0"
 log = "0.4"

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -35,6 +35,7 @@ use parking_lot::Mutex;
 use client::{BlockchainEvents, backend::Backend, runtime_api::BlockT};
 use exit_future::Signal;
 use futures::prelude::*;
+use futures03::stream::{StreamExt as _, TryStreamExt as _};
 use keystore::Store as Keystore;
 use network::NetworkState;
 use log::{info, warn, debug, error};
@@ -444,6 +445,8 @@ impl<Components: components::Components> Service<Components> {
 				wasm_external_transport: config.telemetry_external_transport.take(),
 			});
 			let future = telemetry.clone()
+				.map(|ev| Ok::<_, ()>(ev))
+				.compat()
 				.for_each(move |event| {
 					// Safe-guard in case we add more events in the future.
 					let tel::TelemetryEvent::Connected = event;

--- a/core/telemetry/Cargo.toml
+++ b/core/telemetry/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 [dependencies]
 bytes = "0.4"
 parking_lot = "0.8.0"
-futures = "0.1"
+futures01 = { package = "futures", version = "0.1" }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
+futures-timer = "0.2.1"
 libp2p = { version = "0.10.0", default-features = false, features = ["libp2p-websocket"] }
 log = "0.4"
 rand = "0.6"
@@ -17,8 +19,4 @@ slog = { version = "^2", features = ["nested-values"] }
 slog-json = { version = "^2", features = ["nested-values"] }
 slog-scope = "^4"
 tokio-io = "0.1"
-tokio-timer = "0.2"
 void = "1.0"
-
-[dev-dependencies]
-tokio = "0.1"

--- a/core/telemetry/src/worker.rs
+++ b/core/telemetry/src/worker.rs
@@ -27,12 +27,11 @@
 //!
 
 use bytes::BytesMut;
-use futures::prelude::*;
+use futures::compat::Compat01As03Sink;
 use libp2p::{core::transport::OptionalTransport, core::ConnectedPoint, Multiaddr, Transport, wasm_ext};
 use log::{trace, warn, error};
 use slog::Drain;
-use std::{io, time};
-use tokio_io::AsyncWrite;
+use std::{io, pin::Pin, task::Context, task::Poll, time};
 
 mod node;
 
@@ -58,19 +57,29 @@ pub struct TelemetryWorker {
 /// The pile of libp2p transports.
 #[cfg(not(target_os = "unknown"))]
 type WsTrans = libp2p::core::transport::timeout::TransportTimeout<
-	libp2p::core::transport::OrTransport<
-		libp2p::core::transport::map::Map<
-			OptionalTransport<wasm_ext::ExtTransport>,
-			fn(wasm_ext::Connection, ConnectedPoint) -> StreamSink<wasm_ext::Connection>
+	libp2p::core::transport::map::Map<
+		libp2p::core::transport::OrTransport<
+			libp2p::core::transport::map::Map<
+				OptionalTransport<wasm_ext::ExtTransport>,
+				fn(wasm_ext::Connection, ConnectedPoint) -> StreamSink<wasm_ext::Connection>
+			>,
+			libp2p::websocket::framed::WsConfig<libp2p::dns::DnsConfig<libp2p::tcp::TcpConfig>>
 		>,
-		libp2p::websocket::framed::WsConfig<libp2p::dns::DnsConfig<libp2p::tcp::TcpConfig>>
+		fn(libp2p::core::either::EitherOutput<StreamSink<wasm_ext::Connection>,
+			libp2p::websocket::framed::BytesConnection<libp2p::tcp::TcpTransStream>>, ConnectedPoint)
+			-> Compat01As03Sink<libp2p::core::either::EitherOutput<StreamSink<wasm_ext::Connection>,
+			libp2p::websocket::framed::BytesConnection<libp2p::tcp::TcpTransStream>>, BytesMut>
 	>
 >;
 #[cfg(target_os = "unknown")]
 type WsTrans = libp2p::core::transport::timeout::TransportTimeout<
 	libp2p::core::transport::map::Map<
-		OptionalTransport<wasm_ext::ExtTransport>,
-		fn(wasm_ext::Connection, ConnectedPoint) -> StreamSink<wasm_ext::Connection>
+		libp2p::core::transport::map::Map<
+			OptionalTransport<wasm_ext::ExtTransport>,
+			fn(wasm_ext::Connection, ConnectedPoint) -> StreamSink<wasm_ext::Connection>
+		>,
+		fn(StreamSink<wasm_ext::Connection>, ConnectedPoint)
+			-> Compat01As03Sink<StreamSink<wasm_ext::Connection>, BytesMut>
 	>
 >;
 
@@ -98,7 +107,9 @@ impl TelemetryWorker {
 			libp2p::websocket::framed::WsConfig::new(inner)
 		});
 
-		let transport = transport.with_timeout(CONNECT_TIMEOUT);
+		let transport = transport
+			.map((|inner, _| Compat01As03Sink::new(inner)) as fn(_, _) -> _)
+			.with_timeout(CONNECT_TIMEOUT);
 
 		TelemetryWorker {
 			nodes: endpoints.into_iter().map(|(addr, verbosity)| {
@@ -109,19 +120,19 @@ impl TelemetryWorker {
 	}
 
 	/// Polls the worker for events that happened.
-	pub fn poll(&mut self) -> Async<TelemetryWorkerEvent> {
+	pub fn poll(&mut self, cx: &mut Context) -> Poll<TelemetryWorkerEvent> {
 		for (node, _) in &mut self.nodes {
 			loop {
-				match node.poll() {
-					Async::Ready(node::NodeEvent::Connected) =>
-						return Async::Ready(TelemetryWorkerEvent::Connected),
-					Async::Ready(node::NodeEvent::Disconnected(_)) => continue,
-					Async::NotReady => break,
+				match node::Node::poll(Pin::new(node), cx) {
+					Poll::Ready(node::NodeEvent::Connected) =>
+						return Poll::Ready(TelemetryWorkerEvent::Connected),
+					Poll::Ready(node::NodeEvent::Disconnected(_)) => continue,
+					Poll::Pending => break,
 				}
 			}
 		}
 
-		Async::NotReady
+		Poll::Pending
 	}
 
 	/// Equivalent to `slog::Drain::log`, but takes `self` by `&mut` instead, which is more convenient.
@@ -132,7 +143,7 @@ impl TelemetryWorker {
 		let msg_verbosity = match record.tag().parse::<u8>() {
 			Ok(v) => v,
 			Err(err) => {
-				warn!(target: "telemetry", "Failed to parse telemetry tag {:?}: {:?}", 
+				warn!(target: "telemetry", "Failed to parse telemetry tag {:?}: {:?}",
 					record.tag(), err);
 				return Err(())
 			}
@@ -176,27 +187,27 @@ impl TelemetryWorker {
 /// For some context, we put this object around the `wasm_ext::ExtTransport` in order to make sure
 /// that each telemetry message maps to one single call to `write` in the WASM FFI.
 struct StreamSink<T>(T);
-impl<T: AsyncWrite> Sink for StreamSink<T> {
+impl<T: tokio_io::AsyncWrite> futures01::Sink for StreamSink<T> {
 	type SinkItem = BytesMut;
 	type SinkError = io::Error;
 
-	fn start_send(&mut self, item: Self::SinkItem) -> Result<AsyncSink<Self::SinkItem>, io::Error> {
+	fn start_send(&mut self, item: Self::SinkItem) -> Result<futures01::AsyncSink<Self::SinkItem>, io::Error> {
 		match self.0.write(&item[..]) {
-			Ok(n) if n == item.len() => Ok(AsyncSink::Ready),
+			Ok(n) if n == item.len() => Ok(futures01::AsyncSink::Ready),
 			Ok(_) => {
 				error!(target: "telemetry",
 					"Detected some internal buffering happening in the telemetry");
 				Err(io::Error::new(io::ErrorKind::Other, "Internal buffering detected"))
 			},
-			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(AsyncSink::NotReady(item)),
+			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(futures01::AsyncSink::NotReady(item)),
 			Err(err) => Err(err),
 		}
 	}
 
-	fn poll_complete(&mut self) -> Poll<(), io::Error> {
+	fn poll_complete(&mut self) -> futures01::Poll<(), io::Error> {
 		match self.0.flush() {
-			Ok(()) => Ok(Async::Ready(())),
-			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(Async::NotReady),
+			Ok(()) => Ok(futures01::Async::Ready(())),
+			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(futures01::Async::NotReady),
 			Err(err) => Err(err),
 		}
 	}

--- a/core/telemetry/src/worker.rs
+++ b/core/telemetry/src/worker.rs
@@ -191,7 +191,8 @@ impl<T: tokio_io::AsyncWrite> futures01::Sink for StreamSink<T> {
 	type SinkItem = BytesMut;
 	type SinkError = io::Error;
 
-	fn start_send(&mut self, item: Self::SinkItem) -> Result<futures01::AsyncSink<Self::SinkItem>, io::Error> {
+	fn start_send(&mut self, item: Self::SinkItem)
+		-> Result<futures01::AsyncSink<Self::SinkItem>, io::Error> {
 		match self.0.write(&item[..]) {
 			Ok(n) if n == item.len() => Ok(futures01::AsyncSink::Ready),
 			Ok(_) => {
@@ -199,7 +200,8 @@ impl<T: tokio_io::AsyncWrite> futures01::Sink for StreamSink<T> {
 					"Detected some internal buffering happening in the telemetry");
 				Err(io::Error::new(io::ErrorKind::Other, "Internal buffering detected"))
 			},
-			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Ok(futures01::AsyncSink::NotReady(item)),
+			Err(ref err) if err.kind() == io::ErrorKind::WouldBlock =>
+				Ok(futures01::AsyncSink::NotReady(item)),
 			Err(err) => Err(err),
 		}
 	}

--- a/core/telemetry/src/worker/node.rs
+++ b/core/telemetry/src/worker/node.rs
@@ -195,10 +195,11 @@ where TTrans::Output: Sink<BytesMut, Error = TSinkErr> + Unpin {
 				if let Err(err) = Sink::start_send(Pin::new(&mut self.sink), item) {
 					return Poll::Ready(Err(err))
 				}
-				trace!(target: "telemetry", "Successfully sent {:?} bytes message to {}",
-					item_len, my_addr);
+				trace!(
+					target: "telemetry", "Successfully sent {:?} bytes message to {}",
+					item_len, my_addr
+				);
 				self.need_flush = true;
-
 			} else if self.need_flush {
 				match Sink::poll_flush(Pin::new(&mut self.sink), cx) {
 					Poll::Pending => {}

--- a/core/telemetry/src/worker/node.rs
+++ b/core/telemetry/src/worker/node.rs
@@ -17,13 +17,13 @@
 //! Contains the `Node` struct, which handles communications with a single telemetry endpoint.
 
 use bytes::BytesMut;
-use futures::prelude::*;
+use futures::{prelude::*, compat::{Future01CompatExt as _, Compat01As03}};
+use futures_timer::Delay;
 use libp2p::Multiaddr;
 use libp2p::core::transport::Transport;
 use log::{trace, debug, warn, error};
 use rand::Rng as _;
-use std::{collections::VecDeque, fmt, mem, time::Duration, time::Instant};
-use tokio_timer::Delay;
+use std::{collections::VecDeque, fmt, mem, pin::Pin, task::Context, task::Poll, time::Duration};
 
 /// Maximum number of pending telemetry messages.
 const MAX_PENDING: usize = 10;
@@ -42,7 +42,7 @@ enum NodeSocket<TTrans: Transport> {
 	/// We're connected to the node. This is the normal state.
 	Connected(NodeSocketConnected<TTrans>),
 	/// We are currently dialing the node.
-	Dialing(TTrans::Dial),
+	Dialing(Compat01As03<TTrans::Dial>),
 	/// A new connection should be started as soon as possible.
 	ReconnectNow,
 	/// Waiting before attempting to dial again.
@@ -86,8 +86,7 @@ impl<TTrans: Transport> Node<TTrans> {
 }
 
 impl<TTrans: Transport, TSinkErr> Node<TTrans>
-where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSinkErr>,
-	TSinkErr: fmt::Debug {
+where TTrans: Clone + Unpin, TTrans::Dial: Unpin, TTrans::Output: Sink<BytesMut, Error = TSinkErr> + Unpin, TSinkErr: fmt::Debug {
 	/// Sends a WebSocket frame to the node. Returns an error if we are not connected to the node.
 	///
 	/// After calling this method, you should call `poll` in order for it to be properly processed.
@@ -108,29 +107,29 @@ where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSink
 	}
 
 	/// Polls the node for updates. Must be performed regularly.
-	pub fn poll(&mut self) -> Async<NodeEvent<TSinkErr>> {
+	pub fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<NodeEvent<TSinkErr>> {
 		let mut socket = mem::replace(&mut self.socket, NodeSocket::Poisoned);
 		self.socket = loop {
 			match socket {
-				NodeSocket::Connected(mut conn) => match conn.poll(&self.addr) {
-					Ok(Async::Ready(v)) => void::unreachable(v),
-					Ok(Async::NotReady) => break NodeSocket::Connected(conn),
-					Err(err) => {
+				NodeSocket::Connected(mut conn) => match NodeSocketConnected::poll(Pin::new(&mut conn), cx, &self.addr) {
+					Poll::Ready(Ok(v)) => match v {}
+					Poll::Pending => break NodeSocket::Connected(conn),
+					Poll::Ready(Err(err)) => {
 						debug!(target: "telemetry", "Disconnected from {}: {:?}", self.addr, err);
 						let timeout = gen_rand_reconnect_delay();
 						self.socket = NodeSocket::WaitingReconnect(timeout);
-						return Async::Ready(NodeEvent::Disconnected(err))
+						return Poll::Ready(NodeEvent::Disconnected(err))
 					}
 				}
-				NodeSocket::Dialing(mut s) => match s.poll() {
-					Ok(Async::Ready(sink)) => {
+				NodeSocket::Dialing(mut s) => match Future::poll(Pin::new(&mut s), cx) {
+					Poll::Ready(Ok(sink)) => {
 						debug!(target: "telemetry", "Connected to {}", self.addr);
 						let conn = NodeSocketConnected { sink, pending: VecDeque::new(), need_flush: false };
 						self.socket = NodeSocket::Connected(conn);
-						return Async::Ready(NodeEvent::Connected)
+						return Poll::Ready(NodeEvent::Connected)
 					},
-					Ok(Async::NotReady) => break NodeSocket::Dialing(s),
-					Err(err) => {
+					Poll::Pending => break NodeSocket::Dialing(s),
+					Poll::Ready(Err(err)) => {
 						debug!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
 						let timeout = gen_rand_reconnect_delay();
 						socket = NodeSocket::WaitingReconnect(timeout);
@@ -139,7 +138,7 @@ where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSink
 				NodeSocket::ReconnectNow => match self.transport.clone().dial(self.addr.clone()) {
 					Ok(d) => {
 						debug!(target: "telemetry", "Started dialing {}", self.addr);
-						socket = NodeSocket::Dialing(d);
+						socket = NodeSocket::Dialing(d.compat());
 					}
 					Err(err) => {
 						debug!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
@@ -147,7 +146,7 @@ where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSink
 						socket = NodeSocket::WaitingReconnect(timeout);
 					}
 				}
-				NodeSocket::WaitingReconnect(mut s) => if let Ok(Async::Ready(_)) = s.poll() {
+				NodeSocket::WaitingReconnect(mut s) => if let Poll::Ready(_) = Future::poll(Pin::new(&mut s), cx) {
 					socket = NodeSocket::ReconnectNow;
 				} else {
 					break NodeSocket::WaitingReconnect(s)
@@ -159,7 +158,7 @@ where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSink
 			}
 		};
 
-		Async::NotReady
+		Poll::Pending
 	}
 }
 
@@ -169,36 +168,47 @@ where TTrans: Clone, TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSink
 /// re-connection time.
 fn gen_rand_reconnect_delay() -> Delay {
 	let random_delay = rand::thread_rng().gen_range(5, 10);
-	Delay::new(Instant::now() + Duration::from_secs(random_delay))
+	Delay::new(Duration::from_secs(random_delay))
 }
 
 impl<TTrans: Transport, TSinkErr> NodeSocketConnected<TTrans>
-where TTrans::Output: Sink<SinkItem = BytesMut, SinkError = TSinkErr> {
+where TTrans::Output: Sink<BytesMut, Error = TSinkErr> + Unpin {
 	/// Processes the queue of messages for the connected socket.
 	///
 	/// The address is passed for logging purposes only.
-	fn poll(&mut self, my_addr: &Multiaddr) -> Poll<void::Void, TSinkErr> {
+	fn poll(
+		mut self: Pin<&mut Self>,
+		cx: &mut Context,
+		my_addr: &Multiaddr
+	) -> Poll<Result<futures::never::Never, TSinkErr>> {
 		loop {
 			if let Some(item) = self.pending.pop_front() {
-				let item_len = item.len();
-				if let AsyncSink::NotReady(item) = self.sink.start_send(item)? {
+				if let Poll::Pending = Sink::poll_ready(Pin::new(&mut self.sink), cx) {
 					self.pending.push_front(item);
-					break
-				} else {
-					trace!(target: "telemetry", "Successfully sent {:?} bytes message to {}",
-						item_len, my_addr);
-					self.need_flush = true;
+					return Poll::Pending
 				}
 
-			} else if self.need_flush && self.sink.poll_complete()?.is_ready() {
-				self.need_flush = false;
+				let item_len = item.len();
+				if let Err(err) = Sink::start_send(Pin::new(&mut self.sink), item) {
+					return Poll::Ready(Err(err))
+				}
+				trace!(target: "telemetry", "Successfully sent {:?} bytes message to {}",
+					item_len, my_addr);
+				self.need_flush = true;
+
+			} else if self.need_flush {
+				match Sink::poll_flush(Pin::new(&mut self.sink), cx) {
+					Poll::Pending => {}
+					Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+					Poll::Ready(Ok(())) => self.need_flush = false,
+				}
 
 			} else {
 				break
 			}
 		}
 
-		Ok(Async::NotReady)
+		Poll::Pending
 	}
 }
 


### PR DESCRIPTION
cc #3099 

The majority of the switch to new futures is straight-forward, but for the telemetry it is pretty much not straight-forward.
Since libp2p is using futures v0.1, and the telemetry has a wrapper that guarantees that one telemetry write equals one WebSocket frame, we need to have a compatibility shim.

After this PR, the API of `substrate-telemetry` uses new futures.
