### PR TITLE
Operational Transaction.

### DIFF
--- a/core/sr-primitives/src/generic/checked_extrinsic.rs
+++ b/core/sr-primitives/src/generic/checked_extrinsic.rs
@@ -19,6 +19,7 @@
 
 use crate::traits::{self, Member, SimpleArithmetic, MaybeDisplay};
 use crate::weights::{Weighable, Weight};
+use crate::transaction_validity::TransactionPriority;
 
 /// Definition of something that the external world might want to say; its
 /// existence implies that it has been checked and is good, particularly with
@@ -62,5 +63,11 @@ where
 {
 	fn weight(&self, len: usize) -> Weight {
 		self.function.weight(len)
+	}
+	fn priority(&self, len: usize) -> TransactionPriority {
+		self.function.priority(len)
+	}
+	fn is_block_full(&self, block_weight: Weight, len: usize) -> bool {
+		self.function.is_block_full(block_weight, len)
 	}
 }

--- a/core/sr-primitives/src/testing.rs
+++ b/core/sr-primitives/src/testing.rs
@@ -21,7 +21,8 @@ use std::{fmt::Debug, ops::Deref, fmt};
 use crate::codec::{Codec, Encode, Decode};
 use crate::traits::{self, Checkable, Applyable, BlakeTwo256, OpaqueKeys, TypedKey};
 use crate::{generic, KeyTypeId};
-use crate::weights::{Weighable, Weight};
+use crate::weights::{Weighable, Weight, MAX_TRANSACTIONS_WEIGHT};
+use crate::transaction_validity::TransactionPriority;
 pub use substrate_primitives::H256;
 use substrate_primitives::U256;
 use substrate_primitives::ed25519::{Public as AuthorityId};
@@ -237,7 +238,13 @@ impl<Call> Applyable for TestXt<Call> where
 }
 impl<Call> Weighable for TestXt<Call> {
 	fn weight(&self, len: usize) -> Weight {
-		// for testing: weight == size.
 		len as Weight
+	}
+	fn priority(&self, len: usize) -> TransactionPriority {
+		len as TransactionPriority
+	}
+	fn is_block_full(&self, current_weight: Weight, len: usize)
+	 -> bool {
+		current_weight + self.weight(len) > MAX_TRANSACTIONS_WEIGHT
 	}
 }

--- a/core/sr-primitives/src/weights.rs
+++ b/core/sr-primitives/src/weights.rs
@@ -59,8 +59,7 @@ pub enum TransactionWeight {
 	/// Basic weight (base, byte).
 	/// The values contained are the base weight and byte weight respectively.
 	///
-	/// The priority of this transaction will be proportional to its computed weight, w.r.t. to the
-	/// total available weight.
+	/// The priority of this transaction will be proportional to its computed weight.
 	Basic(Weight, Weight),
 	/// Operational transaction. These are typically root transactions for operational updates,
 	/// runtime code changes or consensus reports through inherents. These transactions are still

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -69,7 +69,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 109,
+	spec_version: 110,
 	impl_version: 110,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -69,8 +69,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 110,
-	impl_version: 110,
+	spec_version: 109,
+	impl_version: 111,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -264,7 +264,7 @@ where
 
 		// Check the weight of the block if that extrinsic is applied.
 		let block_weight = <system::Module<System>>::all_extrinsics_weight();
-		if xt.is_block_full(block_weight, encoded_len) {
+		if <CheckedOf<Block::Extrinsic, Context> as Weighable>::is_block_full(&xt, block_weight, encoded_len) {
 			return Err(internal::ApplyError::FullBlock);
 		}
 


### PR DESCRIPTION
closes #3092 

TODOs:

- Now that the `Weighable` is actually doing more than merely communicating weight info up to the rest of the stack, it should probably be renamed to sth more general.  Likewise the `#[weight]` thingy.

By definition, it can be applied to anything which lives in `decl_module`, it is _static information_ (stateless except for input parameters it receives) and it _describes the dispatch function_.`#[meta =$x]` and `pub trait DispatchMetaInfo`? 