### PR TITLE
Logs will be saved to the job artifacts only in case of failure.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,13 +154,20 @@ test-linux-stable-int:
   <<:                              *test-linux
   except:
     refs:
-      - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+      - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
     variables:
       - $DEPLOY_TAG
   script:
-    - time RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-        cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
+    - echo "___Logs will be saved to the job artifacts only in case of failure.___"
+    - RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+        time cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
+        &> ${CI_COMMIT_REF_NAME}_int_failure.log
     - sccache -s
+  artifacts:
+    name:                          $CI_COMMIT_REF_SLUG
+    when:                          on_failure
+    paths:
+      - ${CI_COMMIT_REF_NAME}_int_failure.log
   allow_failure:                   true
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,11 +163,13 @@ test-linux-stable-int:
     - RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
         time cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-    - awk '/FAILED/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
     - sccache -s
+  after_script:
+    - awk '/FAILED/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
   artifacts:
     name:                          $CI_COMMIT_SHORT_SHA
     when:                          on_failure
+    expire_in:                     24 hrs
     paths:
       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
   allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,16 +158,18 @@ test-linux-stable-int:
     variables:
       - $DEPLOY_TAG
   script:
-    - echo "___Logs will be saved to the job artifacts only in case of failure.___"
+    - echo "___Logs will be partly shown at the end in case of failure.___"
+    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
     - RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
         time cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
-        &> ${CI_COMMIT_REF_NAME}_int_failure.log
+        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+    - awk '/FAILED/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
     - sccache -s
   artifacts:
-    name:                          $CI_COMMIT_REF_SLUG
+    name:                          $CI_COMMIT_SHORT_SHA
     when:                          on_failure
     paths:
-      - ${CI_COMMIT_REF_NAME}_int_failure.log
+      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
   allow_failure:                   true
 
 


### PR DESCRIPTION
Logs for `test-linux-stable-int` CI job are too massive (161 Mb now). 
Now they are saved to the job artifacts only in case of failure. 
The failure is also listed to the CI's UI after the job is finished.

An example of the failed job: https://gitlab.parity.io/parity/substrate/-/jobs/183680