### PR TITLE
node: fix hardcoded block time in integration tests

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -216,7 +216,7 @@ mod tests {
 	use aura::CompatibleDigestItem;
 	use consensus_common::{Environment, Proposer, ImportBlock, BlockOrigin, ForkChoiceStrategy};
 	use node_primitives::DigestItem;
-	use node_runtime::{BalancesCall, Call, CENTS, UncheckedExtrinsic};
+	use node_runtime::{BalancesCall, Call, CENTS, SECS_PER_BLOCK, UncheckedExtrinsic};
 	use parity_codec::{Compact, Encode, Decode};
 	use primitives::{
 		crypto::Pair as CryptoPair, ed25519::Pair, blake2_256,
@@ -302,7 +302,7 @@ mod tests {
 				.create_inherent_data()
 				.expect("Creates inherent data.");
 			inherent_data.replace_data(finality_tracker::INHERENT_IDENTIFIER, &1u64);
-			inherent_data.replace_data(timestamp::INHERENT_IDENTIFIER, &(slot_num * 10));
+			inherent_data.replace_data(timestamp::INHERENT_IDENTIFIER, &(slot_num * SECS_PER_BLOCK));
 
 			let parent_id = BlockId::number(service.client().info().chain.best_number);
 			let parent_header = service.client().header(&parent_id).unwrap().unwrap();
@@ -312,7 +312,7 @@ mod tests {
 			});
 
 			let mut digest = Digest::<H256>::default();
-			digest.push(<DigestItem as CompatibleDigestItem<Pair>>::aura_pre_digest(slot_num * 10 / 2));
+			digest.push(<DigestItem as CompatibleDigestItem<Pair>>::aura_pre_digest(slot_num));
 			let proposer = proposer_factory.init(&parent_header).unwrap();
 			let new_block = proposer.propose(
 				inherent_data,


### PR DESCRIPTION
The chain spec used for the integration tests used to have a 4 second block time which was changed in #3093. In the integration tests we generate blocks manually which means that the timestamp we set on the block must be consistent with the slot duration of the block proposal mechanism. The tests were failing because the seal (i.e. slot number) and timestamp were not consistent with each other.