### PR TITLE
srml-contracts: Avoid unnecessary lookups during call context initialization

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 111,
-	impl_version: 111,
+	impl_version: 112,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -174,14 +174,18 @@ Assuming marshaled size of a balance value is of the constant size we can neglec
 
 ## Initialization
 
-Before a call or create can be performed the execution context must be initialized. This involves
-two calls:
+Before a call or create can be performed the execution context must be initialized.
+
+For the first call or instantiation in the handling of an extrinsic, this involves two calls:
 
 1. `<timestamp::Module<T>>::now()`
 2. `<system::Module<T>>::block_number()`
 
-the complexity of initialization depends on the complexity of these functions. In the current
+The complexity of initialization depends on the complexity of these functions. In the current
 implementation they just involve a DB read.
+
+For subsequent calls and instantiations during contract execution, the initialization requires no
+expensive operations.
 
 ## Call
 

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -262,6 +262,8 @@ pub struct ExecutionContext<'a, T: Trait + 'a, V, L> {
 	pub config: &'a Config<T>,
 	pub vm: &'a V,
 	pub loader: &'a L,
+	pub timestamp: T::Moment,
+	pub block_number: T::BlockNumber,
 }
 
 impl<'a, T, E, V, L> ExecutionContext<'a, T, V, L>
@@ -285,6 +287,8 @@ where
 			config: &cfg,
 			vm: &vm,
 			loader: &loader,
+			timestamp: <timestamp::Module<T>>::now(),
+			block_number: <system::Module<T>>::block_number(),
 		}
 	}
 
@@ -301,6 +305,8 @@ where
 			config: self.config,
 			vm: self.vm,
 			loader: self.loader,
+			timestamp: self.timestamp.clone(),
+			block_number: self.block_number.clone(),
 		}
 	}
 
@@ -366,8 +372,8 @@ where
 							ctx: &mut nested,
 							caller: self.self_account.clone(),
 							value_transferred: value,
-							timestamp: <timestamp::Module<T>>::now(),
-							block_number: <system::Module<T>>::block_number(),
+							timestamp: self.timestamp.clone(),
+							block_number: self.block_number.clone(),
 						},
 						input_data,
 						empty_output_buf,
@@ -437,8 +443,8 @@ where
 						ctx: &mut nested,
 						caller: self.self_account.clone(),
 						value_transferred: endowment,
-						timestamp: <timestamp::Module<T>>::now(),
-						block_number: <system::Module<T>>::block_number(),
+						timestamp: self.timestamp.clone(),
+						block_number: self.block_number.clone(),
 					},
 					input_data,
 					EmptyOutputBuf::new(),


### PR DESCRIPTION
Tiny optimization in contract execution noticed during review of #3114 

See https://github.com/paritytech/substrate/pull/3114#discussion_r303402045
