### PR TITLE
Contract storage limit

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -69,8 +69,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 111,
-	impl_version: 111,
+	spec_version: 112,
+	impl_version: 112,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -370,6 +370,7 @@ impl contracts::Trait for Runtime {
 	type CallBaseFee = contracts::DefaultCallBaseFee;
 	type CreateBaseFee = contracts::DefaultCreateBaseFee;
 	type MaxDepth = contracts::DefaultMaxDepth;
+	type MaxValueSize = contracts::DefaultMaxValueSize;
 	type BlockGasLimit = contracts::DefaultBlockGasLimit;
 }
 

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -310,6 +310,8 @@ parameter_types! {
 	pub const DefaultCreateBaseFee: u32 = 1000;
 	/// A resonable default value for [`Trait::MaxDepth`].
 	pub const DefaultMaxDepth: u32 = 1024;
+	/// A resonable default value for [`Trait::MaxValueSize`].
+	pub const DefaultMaxValueSize: u32 = 16_384;
 	/// A resonable default value for [`Trait::BlockGasLimit`].
 	pub const DefaultBlockGasLimit: u32 = 10_000_000;
 }

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -393,6 +393,9 @@ pub trait Trait: timestamp::Trait {
 	/// The maximum nesting level of a call/create stack.
 	type MaxDepth: Get<u32>;
 
+	/// The maximum size of a storage value in bytes.
+	type MaxValueSize: Get<u32>;
+
 	/// The maximum amount of gas that could be expended per block.
 	type BlockGasLimit: Get<Gas>;
 }
@@ -491,6 +494,9 @@ decl_module! {
 		/// The maximum nesting level of a call/create stack. A reasonable default
 		/// value is 100.
 		const MaxDepth: u32 = T::MaxDepth::get();
+
+		/// The maximum size of a storage value in bytes. A reasonable default is 16 KiB.
+		const MaxValueSize: u32 = T::MaxValueSize::get();
 
 		/// The maximum amount of gas that could be expended per block. A reasonable
 		/// default value is 10_000_000.
@@ -833,6 +839,7 @@ pub struct Config<T: Trait> {
 	pub schedule: Schedule,
 	pub existential_deposit: BalanceOf<T>,
 	pub max_depth: u32,
+	pub max_value_size: u32,
 	pub contract_account_instantiate_fee: BalanceOf<T>,
 	pub account_create_fee: BalanceOf<T>,
 	pub transfer_fee: BalanceOf<T>,
@@ -844,6 +851,7 @@ impl<T: Trait> Config<T> {
 			schedule: <Module<T>>::current_schedule(),
 			existential_deposit: T::Currency::minimum_balance(),
 			max_depth: T::MaxDepth::get(),
+			max_value_size: T::MaxValueSize::get(),
 			contract_account_instantiate_fee: T::ContractFee::get(),
 			account_create_fee: T::CreationFee::get(),
 			transfer_fee: T::TransferFee::get(),

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -148,6 +148,7 @@ parameter_types! {
 	pub const CallBaseFee: u64 = 135;
 	pub const CreateBaseFee: u64 = 175;
 	pub const MaxDepth: u32 = 100;
+	pub const MaxValueSize: u32 = 16_384;
 }
 impl Trait for Test {
 	type Currency = Balances;
@@ -171,6 +172,7 @@ impl Trait for Test {
 	type CallBaseFee = CallBaseFee;
 	type CreateBaseFee = CreateBaseFee;
 	type MaxDepth = MaxDepth;
+	type MaxValueSize = MaxValueSize;
 	type BlockGasLimit = BlockGasLimit;
 }
 

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -215,8 +215,11 @@ mod tests {
 		fn get_storage(&self, key: &StorageKey) -> Option<Vec<u8>> {
 			self.storage.get(key).cloned()
 		}
-		fn set_storage(&mut self, key: StorageKey, value: Option<Vec<u8>>) {
+		fn set_storage(&mut self, key: StorageKey, value: Option<Vec<u8>>)
+			-> Result<(), &'static str>
+		{
 			*self.storage.entry(key).or_insert(Vec::new()) = value.unwrap_or(Vec::new());
+			Ok(())
 		}
 		fn instantiate(
 			&mut self,
@@ -293,6 +296,8 @@ mod tests {
 		}
 
 		fn block_number(&self) -> u64 { 121 }
+
+		fn max_value_size(&self) -> u32 { 16_384 }
 	}
 
 	fn execute<E: Ext>(


### PR DESCRIPTION
Limits contract storage values to 16 KiB. Based on analysis [here](https://github.com/paritytech/substrate/issues/2966#issuecomment-510087309), this is a threshold where reads/writes to/from LevelDB are minimally impacted by the size of the value stored. Above this threshold, the IO required to read/write the value begins to have a noticeable impact.

Fixes #2192.
