### PR TITLE
Consistency with the Block trait name

### DIFF
--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -47,7 +47,7 @@ use client::{
 };
 
 use runtime_primitives::{generic::{self, BlockId, OpaqueDigestItemId}, Justification};
-use runtime_primitives::traits::{Block, Header, DigestItemFor, ProvideRuntimeApi, Zero, Member};
+use runtime_primitives::traits::{Block as BlockT, Header, DigestItemFor, ProvideRuntimeApi, Zero, Member};
 
 use primitives::Pair;
 use inherents::{InherentDataProviders, InherentData};
@@ -84,7 +84,7 @@ impl SlotDuration {
 	pub fn get_or_compute<A, B, C>(client: &C) -> CResult<Self>
 	where
 		A: Codec,
-		B: Block,
+		B: BlockT,
 		C: AuxStore + ProvideRuntimeApi,
 		C::Api: AuraApi<B, A>,
 	{
@@ -140,7 +140,7 @@ pub fn start_aura<B, C, SC, E, I, P, SO, Error, H>(
 	inherent_data_providers: InherentDataProviders,
 	force_authoring: bool,
 ) -> Result<impl Future<Item=(), Error=()>, consensus_common::Error> where
-	B: Block<Header=H>,
+	B: BlockT<Header=H>,
 	C: ProvideRuntimeApi + ProvideCache<B> + AuxStore + Send + Sync,
 	C::Api: AuraApi<B, AuthorityId<P>>,
 	SC: SelectChain<B>,
@@ -187,7 +187,7 @@ struct AuraWorker<C, E, I, P, SO> {
 }
 
 impl<H, B, C, E, I, P, Error, SO> SlotWorker<B> for AuraWorker<C, E, I, P, SO> where
-	B: Block<Header=H>,
+	B: BlockT<Header=H>,
 	C: ProvideRuntimeApi + ProvideCache<B> + Sync,
 	C::Api: AuraApi<B, AuthorityId<P>>,
 	E: Environment<B, Error=Error>,
@@ -358,7 +358,7 @@ macro_rules! aura_err {
 	};
 }
 
-fn find_pre_digest<B: Block, P: Pair>(header: &B::Header) -> Result<u64, String>
+fn find_pre_digest<B: BlockT, P: Pair>(header: &B::Header) -> Result<u64, String>
 	where DigestItemFor<B>: CompatibleDigestItem<P>,
 		P::Signature: Decode,
 		P::Public: Encode + Decode + PartialEq + Clone,
@@ -382,7 +382,7 @@ fn find_pre_digest<B: Block, P: Pair>(header: &B::Header) -> Result<u64, String>
 /// This digest item will always return `Some` when used with `as_aura_seal`.
 //
 // FIXME #1018 needs misbehavior types
-fn check_header<C, B: Block, P: Pair>(
+fn check_header<C, B: BlockT, P: Pair>(
 	client: &C,
 	slot_now: u64,
 	mut header: B::Header,
@@ -451,7 +451,7 @@ pub struct AuraVerifier<C, P> {
 impl<C, P> AuraVerifier<C, P>
 	where P: Send + Sync + 'static
 {
-	fn check_inherents<B: Block>(
+	fn check_inherents<B: BlockT>(
 		&self,
 		block: B,
 		block_id: BlockId<B>,
@@ -501,7 +501,7 @@ impl<C, P> AuraVerifier<C, P>
 }
 
 #[forbid(deprecated)]
-impl<B: Block, C, P> Verifier<B> for AuraVerifier<C, P> where
+impl<B: BlockT, C, P> Verifier<B> for AuraVerifier<C, P> where
 	C: ProvideRuntimeApi + Send + Sync + client::backend::AuxStore + ProvideCache<B>,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>>,
 	DigestItemFor<B>: CompatibleDigestItem<P>,
@@ -604,7 +604,7 @@ impl<B: Block, C, P> Verifier<B> for AuraVerifier<C, P> where
 
 fn initialize_authorities_cache<A, B, C>(client: &C) -> Result<(), ConsensusError> where
 	A: Codec,
-	B: Block,
+	B: BlockT,
 	C: ProvideRuntimeApi + ProvideCache<B>,
 	C::Api: AuraApi<B, A>,
 {
@@ -638,7 +638,7 @@ fn initialize_authorities_cache<A, B, C>(client: &C) -> Result<(), ConsensusErro
 #[allow(deprecated)]
 fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, ConsensusError> where
 	A: Codec,
-	B: Block,
+	B: BlockT,
 	C: ProvideRuntimeApi + ProvideCache<B>,
 	C::Api: AuraApi<B, A>,
 {
@@ -679,7 +679,7 @@ pub fn import_queue<B, C, P>(
 	client: Arc<C>,
 	inherent_data_providers: InherentDataProviders,
 ) -> Result<AuraImportQueue<B>, consensus_common::Error> where
-	B: Block,
+	B: BlockT,
 	C: 'static + ProvideRuntimeApi + ProvideCache<B> + Send + Sync + AuxStore,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>>,
 	DigestItemFor<B>: CompatibleDigestItem<P>,

--- a/core/consensus/common/src/lib.rs
+++ b/core/consensus/common/src/lib.rs
@@ -31,7 +31,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use runtime_primitives::traits::{Block, DigestFor};
+use runtime_primitives::traits::{Block as BlockT, DigestFor};
 use futures::prelude::*;
 pub use inherents::InherentData;
 
@@ -53,7 +53,7 @@ pub use block_import::{
 pub use select_chain::SelectChain;
 
 /// Environment producer for a Consensus instance. Creates proposer instance and communication streams.
-pub trait Environment<B: Block> {
+pub trait Environment<B: BlockT> {
 	/// The proposer type this creates.
 	type Proposer: Proposer<B>;
 	/// Error which can occur upon creation.
@@ -71,7 +71,7 @@ pub trait Environment<B: Block> {
 /// block.
 ///
 /// Proposers are generic over bits of "consensus data" which are engine-specific.
-pub trait Proposer<B: Block> {
+pub trait Proposer<B: BlockT> {
 	/// Error type which can occur when proposing or evaluating.
 	type Error: From<Error> + ::std::fmt::Debug + 'static;
 	/// Future that resolves to a committed proposal.

--- a/core/consensus/rhd/src/lib.rs
+++ b/core/consensus/rhd/src/lib.rs
@@ -795,9 +795,11 @@ pub fn check_justification<B: BlockT>(
 /// Provide all valid authorities.
 ///
 /// On failure, returns the justification back.
-pub fn check_prepare_justification<B: BlockT>(authorities: &[AuthorityId], parent: B::Hash, just: UncheckedJustification<B::Hash>)
-	-> Result<PrepareJustification<B::Hash>, UncheckedJustification<B::Hash>>
-{
+pub fn check_prepare_justification<B: BlockT>(
+	authorities: &[AuthorityId],
+	parent: B::Hash,
+	just: UncheckedJustification<B::Hash>
+) -> Result<PrepareJustification<B::Hash>, UncheckedJustification<B::Hash>> {
 	let vote: Action<B, B::Hash> = Action::Prepare(just.0.round_number as u32, just.0.digest.clone());
 	let message = localized_encode(parent, vote);
 
@@ -842,7 +844,11 @@ pub fn check_vote<B: BlockT>(
 	check_action::<B>(action, parent_hash, &vote.signature)
 }
 
-fn check_action<B: BlockT>(action: Action<B, B::Hash>, parent_hash: &B::Hash, sig: &LocalizedSignature) -> Result<(), Error> {
+fn check_action<B: BlockT>(
+	action: Action<B, B::Hash>,
+	parent_hash: &B::Hash,
+	sig: &LocalizedSignature
+) -> Result<(), Error> {
 	let message = localized_encode(*parent_hash, action);
 	if ed25519::Pair::verify(&sig.signature, &message, &sig.signer) {
 		Ok(())
@@ -981,7 +987,8 @@ impl<N, C, A> consensus::Environment<<C as AuthoringApi>::Block> for ProposerFac
 
 		let id = BlockId::hash(parent_hash);
 		let random_seed = self.client.random_seed(&id)?;
-		let random_seed = <<<C as AuthoringApi>::Block as BlockT>::Header as HeaderT>::Hashing::hash(random_seed.as_ref());
+		let random_seed = <<<C as AuthoringApi>::Block as BlockT>::Header as HeaderT>
+			::Hashing::hash(random_seed.as_ref());
 
 		let validators = self.client.validators(&id)?;
 		self.offline.write().note_new_block(&validators[..]);
@@ -1225,7 +1232,10 @@ impl<C, A> LocalProposer<<C as AuthoringApi>::Block> for Proposer<C, A> where
 		proposer
 	}
 
-	fn import_misbehavior(&self, _misbehavior: Vec<(AuthorityId, Misbehavior<<<C as AuthoringApi>::Block as BlockT>::Hash>)>) {
+	fn import_misbehavior(
+		&self,
+		_misbehavior: Vec<(AuthorityId, Misbehavior<<<C as AuthoringApi>::Block as BlockT>::Hash>)>
+	) {
 		use rhododendron::Misbehavior as GenericMisbehavior;
 		use runtime_primitives::bft::{MisbehaviorKind, MisbehaviorReport};
 		use node_runtime::{Call, UncheckedExtrinsic, ConsensusCall};

--- a/core/consensus/rhd/src/lib.rs
+++ b/core/consensus/rhd/src/lib.rs
@@ -150,7 +150,7 @@ pub type Misbehavior<H> = rhododendron::Misbehavior<H, LocalizedSignature>;
 pub type SharedOfflineTracker = Arc<RwLock<OfflineTracker>>;
 
 /// A proposer for a rhododendron instance. This must implement the base proposer logic.
-pub trait LocalProposer<B: Block>: BaseProposer<B, Error=Error> {
+pub trait LocalProposer<B: BlockT>: BaseProposer<B, Error=Error> {
 	/// Import witnessed rhododendron misbehavior.
 	fn import_misbehavior(&self, misbehavior: Vec<(AuthorityId, Misbehavior<B::Hash>)>);
 
@@ -224,7 +224,7 @@ struct RoundCache<H> {
 }
 
 /// Instance of BFT agreement.
-struct BftInstance<B: Block, P> {
+struct BftInstance<B: BlockT, P> {
 	key: Arc<ed25519::Pair>,
 	authorities: Vec<AuthorityId>,
 	parent_hash: B::Hash,
@@ -233,7 +233,7 @@ struct BftInstance<B: Block, P> {
 	proposer: P,
 }
 
-impl<B: Block, P: LocalProposer<B>> BftInstance<B, P>
+impl<B: BlockT, P: LocalProposer<B>> BftInstance<B, P>
 	where
 		B: Clone + Eq,
 		B::Hash: ::std::hash::Hash
@@ -262,7 +262,7 @@ impl<B: Block, P: LocalProposer<B>> BftInstance<B, P>
 	}
 }
 
-impl<B: Block, P: LocalProposer<B>> rhododendron::Context for BftInstance<B, P>
+impl<B: BlockT, P: LocalProposer<B>> rhododendron::Context for BftInstance<B, P>
 	where
 		B: Clone + Eq,
 		B::Hash: ::std::hash::Hash,
@@ -465,7 +465,7 @@ impl Drop for AgreementHandle {
 /// is notified of.
 ///
 /// This assumes that it is being run in the context of a tokio runtime.
-pub struct BftService<B: Block, P, I> {
+pub struct BftService<B: BlockT, P, I> {
 	client: Arc<I>,
 	live_agreement: Mutex<Option<(B::Header, AgreementHandle)>>,
 	round_cache: Arc<Mutex<RoundCache<B::Hash>>>,
@@ -638,14 +638,14 @@ impl<B, P, I> BftService<B, P, I>
 /// This stream is localized to a specific parent block-hash, as all messages
 /// will be signed in a way that accounts for it. When using this with
 /// `BftService::build_upon`, the user should take care to use the same hash as for that.
-pub struct CheckedStream<B: Block, S> {
+pub struct CheckedStream<B: BlockT, S> {
 	inner: S,
 	local_id: AuthorityId,
 	authorities: Vec<AuthorityId>,
 	parent_hash: B::Hash,
 }
 
-impl<B: Block, S> CheckedStream<B, S> {
+impl<B: BlockT, S> CheckedStream<B, S> {
 	/// Construct a new checked stream.
 	pub fn new(
 		inner: S,
@@ -662,7 +662,7 @@ impl<B: Block, S> CheckedStream<B, S> {
 	}
 }
 
-impl<B: Block, S: Stream<Item=Vec<u8>>> Stream for CheckedStream<B, S>
+impl<B: BlockT, S: Stream<Item=Vec<u8>>> Stream for CheckedStream<B, S>
 	where S::Error: From<InputStreamConcluded>,
 {
 	type Item = Communication<B>;
@@ -780,7 +780,7 @@ fn check_justification_signed_message<H>(
 /// Provide all valid authorities.
 ///
 /// On failure, returns the justification back.
-pub fn check_justification<B: Block>(
+pub fn check_justification<B: BlockT>(
 	authorities: &[AuthorityId],
 	parent: B::Hash,
 	just: UncheckedJustification<B::Hash>
@@ -795,7 +795,7 @@ pub fn check_justification<B: Block>(
 /// Provide all valid authorities.
 ///
 /// On failure, returns the justification back.
-pub fn check_prepare_justification<B: Block>(authorities: &[AuthorityId], parent: B::Hash, just: UncheckedJustification<B::Hash>)
+pub fn check_prepare_justification<B: BlockT>(authorities: &[AuthorityId], parent: B::Hash, just: UncheckedJustification<B::Hash>)
 	-> Result<PrepareJustification<B::Hash>, UncheckedJustification<B::Hash>>
 {
 	let vote: Action<B, B::Hash> = Action::Prepare(just.0.round_number as u32, just.0.digest.clone());
@@ -824,7 +824,7 @@ pub fn check_proposal<B: Block + Clone>(
 
 /// Check vote message signatures and authority.
 /// Provide all valid authorities.
-pub fn check_vote<B: Block>(
+pub fn check_vote<B: BlockT>(
 	authorities: &[AuthorityId],
 	parent_hash: &B::Hash,
 	vote: &rhododendron::LocalizedVote<B::Hash, AuthorityId, LocalizedSignature>)
@@ -842,7 +842,7 @@ pub fn check_vote<B: Block>(
 	check_action::<B>(action, parent_hash, &vote.signature)
 }
 
-fn check_action<B: Block>(action: Action<B, B::Hash>, parent_hash: &B::Hash, sig: &LocalizedSignature) -> Result<(), Error> {
+fn check_action<B: BlockT>(action: Action<B, B::Hash>, parent_hash: &B::Hash, sig: &LocalizedSignature) -> Result<(), Error> {
 	let message = localized_encode(*parent_hash, action);
 	if ed25519::Pair::verify(&sig.signature, &message, &sig.signer) {
 		Ok(())

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -38,12 +38,12 @@ use futures::{
 use inherents::{InherentData, InherentDataProviders};
 use log::{debug, error, info, warn};
 use runtime_primitives::generic::BlockId;
-use runtime_primitives::traits::{ApiRef, Block, ProvideRuntimeApi};
+use runtime_primitives::traits::{ApiRef, Block as BlockT, ProvideRuntimeApi};
 use std::fmt::Debug;
 use std::ops::Deref;
 
 /// A worker that should be invoked at every new slot.
-pub trait SlotWorker<B: Block> {
+pub trait SlotWorker<B: BlockT> {
 	/// The type of the future that will be returned when a new slot is
 	/// triggered.
 	type OnSlot: IntoFuture<Item = (), Error = consensus_common::Error>;
@@ -78,7 +78,7 @@ pub fn start_slot_worker<B, C, W, T, SO, SC>(
 	timestamp_extractor: SC,
 ) -> impl Future<Item = (), Error = ()>
 where
-	B: Block,
+	B: BlockT,
 	C: SelectChain<B> + Clone,
 	W: SlotWorker<B>,
 	SO: SyncOracle + Send + Clone,
@@ -193,7 +193,7 @@ impl<T: Clone> SlotDuration<T> {
 	///
 	/// `slot_key` is marked as `'static`, as it should really be a
 	/// compile-time constant.
-	pub fn get_or_compute<B: Block, C, CB>(client: &C, cb: CB) -> ::client::error::Result<Self> where
+	pub fn get_or_compute<B: BlockT, C, CB>(client: &C, cb: CB) -> ::client::error::Result<Self> where
 		C: client::backend::AuxStore,
 		C: ProvideRuntimeApi,
 		CB: FnOnce(ApiRef<C::Api>, &BlockId<B>) -> ::client::error::Result<T>,


### PR DESCRIPTION
Addresses my review on #3105 and renames `Block` to `BlockT` everywhere.

Doesn't break any API, since this is just about renaming an import.