### PR TITLE
docs: add srml readme, clarify comment in staking

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 115,
-	impl_version: 116,
+	impl_version: 115,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 115,
-	impl_version: 115,
+	impl_version: 116,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/README.adoc
+++ b/srml/README.adoc
@@ -1,4 +1,26 @@
 
-= Runtime
+= SRML
 
-Set of libs for the substrate runtime.
+The Substrate Runtime Module Library (SRML) is a collection of runtime modules.
+
+== What are runtime modules?
+
+A Substrate runtime can be composed of several smaller components for separation of concerns. These components are called runtime _modules_. Each runtime module packages together a set of functions (dispatchable extrinsic calls, public or private, mutable or immutable), storage items, and events.
+
+There are four primary components that support runtime modules:
+
+=== system module
+
+https://github.com/paritytech/substrate/tree/master/srml/system[`system`] provides low-level APIs and utilities for other modules. https://github.com/paritytech/substrate/tree/master/srml/system[`system`] also defines all core types and extrinsic events for the Substrate runtime. *All modules depend on the system module.*
+
+=== executive module
+
+https://github.com/paritytech/substrate/tree/master/srml/executive[`executive`] dispatches incoming extrinsic calls to the respective modules in the runtime.
+
+=== support macros
+
+https://github.com/paritytech/substrate/tree/master/srml/support[`support` macros] are a collection of Rust macros to facilitate the implementation of common module components. https://github.com/paritytech/substrate/tree/master/srml/support[`support` macros] expand at runtime to generate types (e.g. `Module`, `Call`, `Store`, `Event`) which are thereafter used by the runtime to communicate with the modules. Common support macros include https://crates.parity.io/srml_support/macro.decl_module.html[`decl_module`], https://crates.parity.io/srml_support_procedural/macro.decl_storage.html[`decl_storage`], https://crates.parity.io/srml_support/macro.decl_event.html[`decl_event`], and https://crates.parity.io/srml_support/macro.ensure.html[`ensure`].
+
+=== runtime
+
+The runtime expands the support macros to get type and trait implementations for each module before calling https://github.com/paritytech/substrate/tree/master/srml/executive[`executive`] to dispatch calls to the individual modules. To see an example of how this might look, see https://github.com/paritytech/substrate/blob/master/node/runtime/src/lib.rs[`../node/runtime`].

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -447,7 +447,7 @@ pub const DEFAULT_BONDING_DURATION: u32 = 1;
 
 /// Means for interacting with a specialized version of the `session` trait.
 ///
-/// This is needed because `Staking` sets the `ValidatorId` of the `session::Trait`
+/// This is needed because `Staking` sets the `ValidatorIdOf` of the `session::Trait`
 pub trait SessionInterface<AccountId>: system::Trait {
 	/// Disable a given validator by stash ID.
 	fn disable_validator(validator: &AccountId) -> Result<(), ()>;


### PR DESCRIPTION
We might as well move the relevant part of [the high-level Substrate Runtime docs](https://substrate.dev/docs/en/runtime/substrate-runtime-module-library) to the [SRML readme](https://github.com/paritytech/substrate/blob/master/srml/README.adoc). cc @shawntabrizi 

Also, I noticed that the `srml/staking/lib.rs` requires a `SessionInterface` because it claims that `Staking` sets the `ValidatorId` of the `session::Trait`. `Staking` seems to set the `ValidatorIdOf` for `session::Trait` in [`node/runtime`](https://github.com/paritytech/substrate/blob/cf98501f92a98ab7133829a746128be98aea0117/node/runtime/src/lib.rs#L218);`ValidatorId = AccountId` in `node/runtime`. I changed a comment in `staking` to reflect this, but, if there is something I'm missing here, this change can easily be reverted.