### PR TITLE
Rename ImportBlock to BlockImportParams

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -29,7 +29,7 @@ use runtime_primitives::{
 	generic::{BlockId, SignedBlock},
 };
 use consensus::{
-	Error as ConsensusError, ImportBlock,
+	Error as ConsensusError, BlockImportParams,
 	ImportResult, BlockOrigin, ForkChoiceStrategy,
 	well_known_cache_keys::Id as CacheKeyId,
 	SelectChain, self,
@@ -817,12 +817,12 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	pub fn apply_block(
 		&self,
 		operation: &mut ClientImportOperation<Block, Blake2Hasher, B>,
-		import_block: ImportBlock<Block>,
+		import_block: BlockImportParams<Block>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> error::Result<ImportResult> where
 		E: CallExecutor<Block, Blake2Hasher> + Send + Sync + Clone,
 	{
-		let ImportBlock {
+		let BlockImportParams {
 			origin,
 			header,
 			justification,
@@ -1460,10 +1460,10 @@ impl<'a, B, E, Block, RA> consensus::BlockImport<Block> for &'a Client<B, E, Blo
 	type Error = ConsensusError;
 
 	/// Import a checked and validated block. If a justification is provided in
-	/// `ImportBlock` then `finalized` *must* be true.
+	/// `BlockImportParams` then `finalized` *must* be true.
 	fn import_block(
 		&mut self,
-		import_block: ImportBlock<Block>,
+		import_block: BlockImportParams<Block>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
 		self.lock_import_and_run(|operation| {
@@ -1506,7 +1506,7 @@ impl<B, E, Block, RA> consensus::BlockImport<Block> for Client<B, E, Block, RA> 
 
 	fn import_block(
 		&mut self,
-		import_block: ImportBlock<Block>,
+		import_block: BlockImportParams<Block>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
 		(&*self).import_block(import_block, new_cache)

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -32,7 +32,7 @@ use std::{sync::Arc, time::Duration, thread, marker::PhantomData, hash::Hash, fm
 
 use parity_codec::{Encode, Decode, Codec};
 use consensus_common::{self, BlockImport, Environment, Proposer,
-	ForkChoiceStrategy, ImportBlock, BlockOrigin, Error as ConsensusError,
+	ForkChoiceStrategy, BlockImportParams, BlockOrigin, Error as ConsensusError,
 	SelectChain, well_known_cache_keys::{self, Id as CacheKeyId}
 };
 use consensus_common::import_queue::{
@@ -317,7 +317,7 @@ impl<H, B, C, E, I, P, Error, SO> SlotWorker<B> for AuraWorker<C, E, I, P, SO> w
 			let signature = pair.sign(header_hash.as_ref());
 			let signature_digest_item = <DigestItemFor<B> as CompatibleDigestItem<P>>::aura_seal(signature);
 
-			let import_block: ImportBlock<B> = ImportBlock {
+			let import_block: BlockImportParams<B> = BlockImportParams {
 				origin: BlockOrigin::Own,
 				header,
 				justification: None,
@@ -515,7 +515,7 @@ impl<B: BlockT, C, P> Verifier<B> for AuraVerifier<C, P> where
 		header: B::Header,
 		justification: Option<Justification>,
 		mut body: Option<Vec<B::Extrinsic>>,
-	) -> Result<(ImportBlock<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 		let mut inherent_data = self.inherent_data_providers.create_inherent_data().map_err(String::from)?;
 		let (timestamp_now, slot_now, _) = AuraSlotCompatible.extract_timestamp_and_slot(&inherent_data)
 			.map_err(|e| format!("Could not extract timestamp and slot: {:?}", e))?;
@@ -578,7 +578,7 @@ impl<B: BlockT, C, P> Verifier<B> for AuraVerifier<C, P> where
 						_ => None,
 					});
 
-				let import_block = ImportBlock {
+				let import_block = BlockImportParams {
 					origin,
 					header: pre_header,
 					post_digests: vec![seal],

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -62,7 +62,7 @@ use schnorrkel::{
 };
 use consensus_common::{
 	self, BlockImport, Environment, Proposer,
-	ForkChoiceStrategy, ImportBlock, BlockOrigin, Error as ConsensusError,
+	ForkChoiceStrategy, BlockImportParams, BlockOrigin, Error as ConsensusError,
 };
 use srml_babe::{
 	BabeInherentData,
@@ -373,7 +373,7 @@ impl<Hash, H, B, C, E, I, Error, SO> SlotWorker<B> for BabeWorker<C, E, I, SO> w
 			let signature = pair.sign(header_hash.as_ref());
 			let signature_digest_item = DigestItemFor::<B>::babe_seal(signature);
 
-			let import_block: ImportBlock<B> = ImportBlock {
+			let import_block: BlockImportParams<B> = BlockImportParams {
 				origin: BlockOrigin::Own,
 				header,
 				justification: None,
@@ -598,7 +598,7 @@ impl<B: BlockT, C> Verifier<B> for BabeVerifier<C> where
 		header: B::Header,
 		justification: Option<Justification>,
 		mut body: Option<Vec<B::Extrinsic>>,
-	) -> Result<(ImportBlock<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 		trace!(
 			target: "babe",
 			"Verifying origin: {:?} header: {:?} justification: {:?} body: {:?}",
@@ -666,7 +666,7 @@ impl<B: BlockT, C> Verifier<B> for BabeVerifier<C> where
 					.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(&BABE_ENGINE_ID)))
 					.map(|blob| vec![(well_known_cache_keys::AUTHORITIES, blob.to_vec())]);
 
-				let import_block = ImportBlock {
+				let import_block = BlockImportParams {
 					origin,
 					header: pre_header,
 					post_digests: vec![seal],

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -97,7 +97,7 @@ pub enum ForkChoiceStrategy {
 }
 
 /// Data required to import a Block
-pub struct ImportBlock<Block: BlockT> {
+pub struct BlockImportParams<Block: BlockT> {
 	/// Origin of the Block
 	pub origin: BlockOrigin,
 	/// The header, without consensus post-digests applied. This should be in the same
@@ -130,7 +130,7 @@ pub struct ImportBlock<Block: BlockT> {
 	pub fork_choice: ForkChoiceStrategy,
 }
 
-impl<Block: BlockT> ImportBlock<Block> {
+impl<Block: BlockT> BlockImportParams<Block> {
 	/// Deconstruct the justified header into parts.
 	pub fn into_inner(self)
 		-> (
@@ -186,7 +186,7 @@ pub trait BlockImport<B: BlockT> {
 	/// Cached data can be accessed through the blockchain cache.
 	fn import_block(
 		&mut self,
-		block: ImportBlock<B>,
+		block: BlockImportParams<B>,
 		cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error>;
 }
@@ -206,7 +206,7 @@ where for<'r> &'r T: BlockImport<B, Error = E>
 
 	fn import_block(
 		&mut self,
-		block: ImportBlock<B>,
+		block: BlockImportParams<B>,
 		cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
 		(&**self).import_block(block, cache)

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -29,7 +29,7 @@ use std::{sync::Arc, collections::HashMap};
 use runtime_primitives::{Justification, traits::{Block as BlockT, Header as _, NumberFor}};
 use crate::{error::Error as ConsensusError, well_known_cache_keys::Id as CacheKeyId};
 use crate::block_import::{
-	BlockImport, BlockOrigin, ImportBlock, ImportedAux, JustificationImport, ImportResult,
+	BlockImport, BlockOrigin, BlockImportParams, ImportedAux, JustificationImport, ImportResult,
 	FinalityProofImport,
 };
 
@@ -67,7 +67,7 @@ pub struct IncomingBlock<B: BlockT> {
 
 /// Verify a justification of a block
 pub trait Verifier<B: BlockT>: Send + Sync {
-	/// Verify the given data and return the ImportBlock and an optional
+	/// Verify the given data and return the BlockImportParams and an optional
 	/// new set of validators to import. If not, err with an Error-Message
 	/// presented to the User in the logs.
 	fn verify(
@@ -76,7 +76,7 @@ pub trait Verifier<B: BlockT>: Send + Sync {
 		header: B::Header,
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>,
-	) -> Result<(ImportBlock<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String>;
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String>;
 }
 
 /// Blocks import queue API.

--- a/core/consensus/common/src/lib.rs
+++ b/core/consensus/common/src/lib.rs
@@ -47,7 +47,7 @@ const MAX_BLOCK_SIZE: usize = 4 * 1024 * 1024 + 512;
 
 pub use self::error::Error;
 pub use block_import::{
-	BlockImport, BlockOrigin, ForkChoiceStrategy, ImportedAux, ImportBlock, ImportResult,
+	BlockImport, BlockOrigin, ForkChoiceStrategy, ImportedAux, BlockImportParams, ImportResult,
 	JustificationImport, FinalityProofImport,
 };
 pub use select_chain::SelectChain;

--- a/core/consensus/rhd/src/lib.rs
+++ b/core/consensus/rhd/src/lib.rs
@@ -46,7 +46,7 @@ use consensus::error::{ErrorKind as CommonErrorKind};
 use consensus::{Authorities, BlockImport, Environment, Proposer as BaseProposer};
 use client::{Client as SubstrateClient, CallExecutor};
 use client::runtime_api::{Core, BlockBuilder as BlockBuilderAPI, OldTxQueue, BlockBuilderError};
-use runtime_primitives::generic::{BlockId, Era, ImportResult, ImportBlock, BlockOrigin};
+use runtime_primitives::generic::{BlockId, Era, ImportResult, BlockImportParams, BlockOrigin};
 use runtime_primitives::traits::{Block, Header};
 use runtime_primitives::traits::{
 	Block as BlockT, Hash as HashT, Header as HeaderT,
@@ -391,7 +391,7 @@ impl<B, P, I, InStream, OutSink> Future for BftFuture<B, P, I, InStream, OutSink
 				justified_block.header().number(), hash);
 			let just: Justification = UncheckedJustification(committed.justification.uncheck()).into();
 			let (header, body) = justified_block.deconstruct();
-			let import_block = ImportBlock {
+			let import_block = BlockImportParams {
 				origin: BlockOrigin::ConsensusBroadcast,
 				header: header,
 				justification: Some(just),
@@ -1344,7 +1344,7 @@ mod tests {
 		type Error = Error;
 
 		fn import_block(&self,
-			block: ImportBlock<TestBlock>,
+			block: BlockImportParams<TestBlock>,
 			_new_authorities: Option<Vec<AuthorityId>>
 		) -> Result<ImportResult, Self::Error> {
 			assert!(self.imported_heights.lock().insert(block.header.number));

--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -27,7 +27,7 @@ use client::backend::Backend;
 use client::runtime_api::ApiExt;
 use consensus_common::{
 	BlockImport, Error as ConsensusError,
-	ImportBlock, ImportResult, JustificationImport, well_known_cache_keys,
+	BlockImportParams, ImportResult, JustificationImport, well_known_cache_keys,
 	SelectChain,
 };
 use fg_primitives::GrandpaApi;
@@ -244,7 +244,7 @@ where
 		}
 	}
 
-	fn make_authorities_changes<'a>(&'a self, block: &mut ImportBlock<Block>, hash: Block::Hash)
+	fn make_authorities_changes<'a>(&'a self, block: &mut BlockImportParams<Block>, hash: Block::Hash)
 		-> Result<PendingSetChanges<'a, Block>, ConsensusError>
 	{
 		// when we update the authorities, we need to hold the lock
@@ -405,7 +405,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> BlockImport<Block>
 {
 	type Error = ConsensusError;
 
-	fn import_block(&mut self, mut block: ImportBlock<Block>, new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>)
+	fn import_block(&mut self, mut block: BlockImportParams<Block>, new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>)
 		-> Result<ImportResult, Self::Error>
 	{
 		let hash = block.post_header().hash();

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -28,7 +28,7 @@ use client::{
 use parity_codec::{Encode, Decode};
 use consensus_common::{
 	import_queue::Verifier, well_known_cache_keys,
-	BlockOrigin, BlockImport, FinalityProofImport, ImportBlock, ImportResult, ImportedAux,
+	BlockOrigin, BlockImport, FinalityProofImport, BlockImportParams, ImportResult, ImportedAux,
 	Error as ConsensusError,
 };
 use network::config::{BoxFinalityProofRequestBuilder, FinalityProofRequestBuilder};
@@ -128,7 +128,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA> BlockImport<Block>
 
 	fn import_block(
 		&mut self,
-		block: ImportBlock<Block>,
+		block: BlockImportParams<Block>,
 		new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
 		do_import_block::<_, _, _, _, GrandpaJustification<Block>>(
@@ -230,7 +230,7 @@ impl<B: BlockT<Hash=H256>> FinalityProofRequestBuilder<B> for GrandpaFinalityPro
 fn do_import_block<B, E, Block: BlockT<Hash=H256>, RA, J>(
 	mut client: &Client<B, E, Block, RA>,
 	data: &mut LightImportData<Block>,
-	mut block: ImportBlock<Block>,
+	mut block: BlockImportParams<Block>,
 	new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 ) -> Result<ImportResult, ConsensusError>
 	where
@@ -573,7 +573,7 @@ pub mod tests {
 
 		fn import_block(
 			&mut self,
-			mut block: ImportBlock<Block>,
+			mut block: BlockImportParams<Block>,
 			new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 		) -> Result<ImportResult, Self::Error> {
 			block.justification.take();
@@ -640,7 +640,7 @@ pub mod tests {
 			authority_set: LightAuthoritySet::genesis(vec![(AuthorityId::from_raw([1; 32]), 1)]),
 			consensus_changes: ConsensusChanges::empty(),
 		};
-		let block = ImportBlock {
+		let block = BlockImportParams {
 			origin: BlockOrigin::Own,
 			header: Header {
 				number: 1,

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -30,7 +30,7 @@ use client::{
 	LongestChain,
 };
 use test_client::{self, runtime::BlockNumber};
-use consensus_common::{BlockOrigin, ForkChoiceStrategy, ImportedAux, ImportBlock, ImportResult};
+use consensus_common::{BlockOrigin, ForkChoiceStrategy, ImportedAux, BlockImportParams, ImportResult};
 use consensus_common::import_queue::{BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport};
 use std::collections::{HashMap, HashSet};
 use std::result;
@@ -969,7 +969,7 @@ fn allows_reimporting_change_blocks() {
 
 	let block = || {
 		let block = block.clone();
-		ImportBlock {
+		BlockImportParams {
 			origin: BlockOrigin::File,
 			header: block.header,
 			justification: None,
@@ -1018,7 +1018,7 @@ fn test_bad_justification() {
 
 	let block = || {
 		let block = block.clone();
-		ImportBlock {
+		BlockImportParams {
 			origin: BlockOrigin::File,
 			header: block.header,
 			justification: Some(Vec::new()),

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -38,7 +38,7 @@ use consensus::import_queue::{
 };
 use consensus::block_import::{BlockImport, ImportResult};
 use consensus::{Error as ConsensusError, well_known_cache_keys::{self, Id as CacheKeyId}};
-use consensus::{BlockOrigin, ForkChoiceStrategy, ImportBlock, JustificationImport};
+use consensus::{BlockOrigin, ForkChoiceStrategy, BlockImportParams, JustificationImport};
 use futures::prelude::*;
 use futures03::{StreamExt as _, TryStreamExt as _};
 use crate::{NetworkWorker, NetworkService, config::ProtocolId};
@@ -73,14 +73,14 @@ impl<B: BlockT> Verifier<B> for PassThroughVerifier {
 		header: B::Header,
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>
-	) -> Result<(ImportBlock<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 		let maybe_keys = header.digest()
 			.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(b"aura"))
 				.or_else(|| l.try_as_raw(OpaqueDigestItemId::Consensus(b"babe")))
 			)
 			.map(|blob| vec![(well_known_cache_keys::AUTHORITIES, blob.to_vec())]);
 
-		Ok((ImportBlock {
+		Ok((BlockImportParams {
 			origin,
 			header,
 			body,
@@ -388,7 +388,7 @@ impl<T: ?Sized + BlockImport<Block>> BlockImport<Block> for BlockImportAdapter<T
 
 	fn import_block(
 		&mut self,
-		block: ImportBlock<Block>,
+		block: BlockImportParams<Block>,
 		cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
 		self.0.lock().import_block(block, cache)

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -926,7 +926,7 @@ impl offchain::AuthorityKeyProvider for AuthorityKeyProvider {
 /// # use network::{config::DummyFinalityProofRequestBuilder, construct_simple_protocol};
 /// # use client::{self, LongestChain};
 /// # use consensus_common::import_queue::{BasicQueue, Verifier};
-/// # use consensus_common::{BlockOrigin, ImportBlock, well_known_cache_keys::Id as CacheKeyId};
+/// # use consensus_common::{BlockOrigin, BlockImportParams, well_known_cache_keys::Id as CacheKeyId};
 /// # use node_runtime::{GenesisConfig, RuntimeApi};
 /// # use std::sync::Arc;
 /// # use node_primitives::Block;
@@ -944,7 +944,7 @@ impl offchain::AuthorityKeyProvider for AuthorityKeyProvider {
 /// # 		header: B::Header,
 /// # 		justification: Option<Justification>,
 /// # 		body: Option<Vec<B::Extrinsic>>,
-/// # 	) -> Result<(ImportBlock<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+/// # 	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 /// # 		unimplemented!();
 /// # 	}
 /// # }

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -37,7 +37,7 @@ use service::{
 use network::{multiaddr, Multiaddr};
 use network::config::{NetworkConfiguration, TransportConfig, NodeKeyConfig, Secret, NonReservedPeerMode};
 use sr_primitives::generic::BlockId;
-use consensus::{ImportBlock, BlockImport};
+use consensus::{BlockImportParams, BlockImport};
 
 /// Maximum duration of single wait call.
 const MAX_WAIT_TIME: Duration = Duration::from_secs(60 * 3);
@@ -354,7 +354,7 @@ pub fn sync<F, B, E>(spec: FactoryChainSpec<F>, mut block_factory: B, mut extrin
 	F: ServiceFactory,
 	F::FullService: Future<Item=(), Error=()>,
 	F::LightService: Future<Item=(), Error=()>,
-	B: FnMut(&SyncService<F::FullService>) -> ImportBlock<F::Block>,
+	B: FnMut(&SyncService<F::FullService>) -> BlockImportParams<F::Block>,
 	E: FnMut(&SyncService<F::FullService>) -> FactoryExtrinsic<F>,
 {
 	const NUM_FULL_NODES: usize = 10;

--- a/core/test-client/src/client_ext.rs
+++ b/core/test-client/src/client_ext.rs
@@ -18,7 +18,7 @@
 
 use client::{self, Client};
 use consensus::{
-	ImportBlock, BlockImport, BlockOrigin, Error as ConsensusError,
+	BlockImportParams, BlockImport, BlockOrigin, Error as ConsensusError,
 	ForkChoiceStrategy,
 };
 use hash_db::Hasher;
@@ -64,7 +64,7 @@ impl<B, E, RA, Block> ClientExt<Block> for Client<B, E, Block, RA>
 		-> Result<(), ConsensusError>
 	{
 		let (header, extrinsics) = block.deconstruct();
-		let import = ImportBlock {
+		let import = BlockImportParams {
 			origin,
 			header,
 			justification: None,
@@ -85,7 +85,7 @@ impl<B, E, RA, Block> ClientExt<Block> for Client<B, E, Block, RA>
 		justification: Justification,
 	) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = ImportBlock {
+		let import = BlockImportParams {
 			origin,
 			header,
 			justification: Some(justification),

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -214,7 +214,7 @@ construct_service_factory! {
 mod tests {
 	use std::sync::Arc;
 	use aura::CompatibleDigestItem;
-	use consensus_common::{Environment, Proposer, ImportBlock, BlockOrigin, ForkChoiceStrategy};
+	use consensus_common::{Environment, Proposer, BlockImportParams, BlockOrigin, ForkChoiceStrategy};
 	use node_primitives::DigestItem;
 	use node_runtime::{BalancesCall, Call, CENTS, SECS_PER_BLOCK, UncheckedExtrinsic};
 	use parity_codec::{Compact, Encode, Decode};
@@ -233,7 +233,7 @@ mod tests {
 	#[cfg(feature = "rhd")]
 	fn test_sync() {
 		use {service_test, Factory};
-		use client::{ImportBlock, BlockOrigin};
+		use client::{BlockImportParams, BlockOrigin};
 
 		let alice: Arc<ed25519::Pair> = Arc::new(Keyring::Alice.into());
 		let bob: Arc<ed25519::Pair> = Arc::new(Keyring::Bob.into());
@@ -253,7 +253,7 @@ mod tests {
 			};
 			let (proposer, _, _) = proposer_factory.init(&parent_header, &validators, alice.clone()).unwrap();
 			let block = proposer.propose().expect("Error making test block");
-			ImportBlock {
+			BlockImportParams {
 				origin: BlockOrigin::File,
 				justification: Vec::new(),
 				internal_justification: Vec::new(),
@@ -331,7 +331,7 @@ mod tests {
 			);
 			slot_num += 1;
 
-			ImportBlock {
+			BlockImportParams {
 				origin: BlockOrigin::File,
 				header: new_header,
 				justification: None,

--- a/test-utils/transaction-factory/src/lib.rs
+++ b/test-utils/transaction-factory/src/lib.rs
@@ -30,7 +30,7 @@ use log::info;
 use client::block_builder::api::BlockBuilder;
 use client::runtime_api::ConstructRuntimeApi;
 use consensus_common::{
-	BlockOrigin, ImportBlock, InherentData, ForkChoiceStrategy,
+	BlockOrigin, BlockImportParams, InherentData, ForkChoiceStrategy,
 	SelectChain
 };
 use consensus_common::block_import::BlockImport;
@@ -166,7 +166,7 @@ fn import_block<F>(
 	block: <F as ServiceFactory>::Block
 ) -> () where F: ServiceFactory
 {
-	let import = ImportBlock {
+	let import = BlockImportParams {
 		origin: BlockOrigin::File,
 		header: block.header().clone(),
 		post_digests: Vec::new(),


### PR DESCRIPTION
We've got three items whose names are quite similar: `BlockImport`, `ImportBlock`, and `IncomingBlock`. This can be confusing.
For clarity, let's rename `ImportBlock` to `BlockImportParams`. This makes it obvious that it's just something you pass to `BlockImport`.

The usage of this struct is spread everywhere, therefore it's better if I do it in a single PR than if this change is hidden in the middle of a larger PR.