### PR TITLE
Report to the PSM when a severe protocol error happens

### DIFF
--- a/core/network/src/custom_proto/behaviour.rs
+++ b/core/network/src/custom_proto/behaviour.rs
@@ -930,6 +930,7 @@ where
 			CustomProtoHandlerOut::ProtocolError { error, .. } => {
 				debug!(target: "sub-libp2p", "Handler({:?}) => Severe protocol error: {:?}",
 					source, error);
+				self.peerset.report_peer(source.clone(), i32::min_value());
 				self.disconnect_peer_inner(&source, Some(Duration::from_secs(5)));
 			}
 		}

--- a/core/network/src/custom_proto/behaviour.rs
+++ b/core/network/src/custom_proto/behaviour.rs
@@ -930,6 +930,10 @@ where
 			CustomProtoHandlerOut::ProtocolError { error, .. } => {
 				debug!(target: "sub-libp2p", "Handler({:?}) => Severe protocol error: {:?}",
 					source, error);
+				// A severe protocol error happens when we detect a "bad" node, such as a node on
+				// a different chain, or a node that doesn't speak the same protocol(s). We
+				// decrease the node's reputation, hence lowering the chances we try this node
+				// again in the short term.
 				self.peerset.report_peer(source.clone(), i32::min_value());
 				self.disconnect_peer_inner(&source, Some(Duration::from_secs(5)));
 			}


### PR DESCRIPTION
Right now we have a lot of network activity, and most of it is caused by trying to connect to "bad" nodes (nodes from a different chain, or IPFS nodes for example).

A "severe protocol error" happens when we detect a "bad" node. This PR makes it so that severe protocol errors now decrease the node's reputation by 2^31, hence lowering the chances we try this node again in the short term.
