### PR TITLE
Expose instancing in metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ name = "srml-support-test"
 version = "2.0.0"
 dependencies = [
  "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "srml-support 2.0.0",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -75,8 +75,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 118,
-	impl_version: 118,
+	spec_version: 119,
+	impl_version: 119,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -292,9 +292,6 @@ pub enum StorageEntryModifier {
 pub struct StorageMetadata {
 	/// The common prefix used by all storage entries.
 	pub prefix: DecodeDifferent<&'static str, StringBuf>,
-	/// The instance identifier. This identifier is appended to each storage entry prefix to make it
-	/// unique per instance.
-	pub instance: Option<DecodeDifferent<&'static str, StringBuf>>,
 	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
 }
 

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -286,6 +286,18 @@ pub enum StorageEntryModifier {
 	Default,
 }
 
+/// All metadata of the storage.
+#[derive(Clone, PartialEq, Eq, Encode)]
+#[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
+pub struct StorageMetadata {
+	/// The common prefix used by all storage entries.
+	pub prefix: DecodeDifferent<&'static str, StringBuf>,
+	/// The instance identifier. This identifier is appended to each storage entry prefix to make it
+	/// unique per instance.
+	pub instance: Option<DecodeDifferent<&'static str, StringBuf>>,
+	pub entries: DecodeDifferent<&'static [StorageEntryMetadata], Vec<StorageEntryMetadata>>,
+}
+
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 /// Metadata prefixed by a u32 for reserved usage
@@ -309,8 +321,10 @@ pub enum RuntimeMetadata {
 	V4(RuntimeMetadataDeprecated),
 	/// Version 5 for runtime metadata. No longer used.
 	V5(RuntimeMetadataDeprecated),
-	/// Version 6 for runtime metadata.
-	V6(RuntimeMetadataV6),
+	/// Version 6 for runtime metadata. No longer used.
+	V6(RuntimeMetadataDeprecated),
+	/// Version 7 for runtime metadata.
+	V7(RuntimeMetadataV7),
 }
 
 /// Enum that should fail.
@@ -332,17 +346,19 @@ impl Decode for RuntimeMetadataDeprecated {
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
-pub struct RuntimeMetadataV6 {
+pub struct RuntimeMetadataV7 {
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 }
+
+/// The latest version of the metadata.
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV7;
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode)]
 #[cfg_attr(feature = "std", derive(Decode, Debug, Serialize))]
 pub struct ModuleMetadata {
 	pub name: DecodeDifferentStr,
-	pub prefix: DecodeDifferent<FnEncode<&'static str>, StringBuf>,
-	pub storage: ODFnA<StorageEntryMetadata>,
+	pub storage: Option<DecodeDifferent<FnEncode<StorageMetadata>, StorageMetadata>>,
 	pub calls: ODFnA<FunctionMetadata>,
 	pub event: ODFnA<EventMetadata>,
 	pub constants: DFnA<ModuleConstantMetadata>,
@@ -357,8 +373,8 @@ impl Into<primitives::OpaqueMetadata> for RuntimeMetadataPrefixed {
 	}
 }
 
-impl Into<RuntimeMetadataPrefixed> for RuntimeMetadata {
+impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
 	fn into(self) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, self)
+		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V7(self))
 	}
 }

--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -596,7 +596,7 @@ fn create_and_impl_instance(
 		});
 	}
 
-	let prefix = format!("{}{}", cratename.to_string(), instance_prefix);
+	let prefix = format!("{}{}", instance_prefix, cratename.to_string());
 
 	quote! {
 		// Those trait are derived because of wrong bounds for generics

--- a/srml/support/procedural/tools/src/lib.rs
+++ b/srml/support/procedural/tools/src/lib.rs
@@ -37,8 +37,8 @@ fn generate_hidden_includes_mod_name(unique_id: &str) -> Ident {
 
 /// Generates the access to the `srml-support` crate.
 pub fn generate_crate_access(unique_id: &str, def_crate: &str) -> TokenStream {
-	if ::std::env::var("CARGO_PKG_NAME").unwrap() == def_crate {
-		quote::quote!( crate )
+	if std::env::var("CARGO_PKG_NAME").unwrap() == def_crate {
+		quote::quote!( srml_support )
 	} else {
 		let mod_name = generate_hidden_includes_mod_name(unique_id);
 		quote::quote!( self::#mod_name::hidden_include )

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -18,6 +18,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+/// Export ourself as `srml_support` to make tests happy.
+extern crate self as srml_support;
+
 #[macro_use]
 extern crate bitmask;
 
@@ -251,9 +254,8 @@ mod tests {
 	use codec::Codec;
 	use runtime_io::{with_externalities, Blake2Hasher};
 	pub use srml_metadata::{
-		DecodeDifferent, StorageEntryMetadata,
-		StorageEntryType, StorageEntryModifier,
-		DefaultByte, DefaultByteGetter, StorageHasher
+		DecodeDifferent, StorageEntryMetadata, StorageMetadata, StorageEntryType,
+		StorageEntryModifier, DefaultByte, DefaultByteGetter, StorageHasher
 	};
 	pub use rstd::marker::PhantomData;
 
@@ -431,112 +433,118 @@ mod tests {
 		});
 	}
 
-	const EXPECTED_METADATA: &[StorageEntryMetadata] = &[
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("Data"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map{
-				hasher: StorageHasher::Twox64Concat,
-				key: DecodeDifferent::Encode("u32"), value: DecodeDifferent::Encode("u64"), is_linked: true
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructData(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GenericData"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map{
-				hasher: StorageHasher::Twox128,
-				key: DecodeDifferent::Encode("T::BlockNumber"),
-				value: DecodeDifferent::Encode("T::BlockNumber"),
-				is_linked: true
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGenericData(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GenericData2"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map{
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("T::BlockNumber"),
-				value: DecodeDifferent::Encode("T::BlockNumber"),
-				is_linked: true
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGenericData2(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("DataDM"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::DoubleMap{
-				hasher: StorageHasher::Twox64Concat,
-				key1: DecodeDifferent::Encode("u32"),
-				key2: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("u64"),
-				key2_hasher: StorageHasher::Blake2_256,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructDataDM(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GenericDataDM"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::DoubleMap{
-				hasher: StorageHasher::Blake2_256,
-				key1: DecodeDifferent::Encode("T::BlockNumber"),
-				key2: DecodeDifferent::Encode("T::BlockNumber"),
-				value: DecodeDifferent::Encode("T::BlockNumber"),
-				key2_hasher: StorageHasher::Twox128,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGenericDataDM(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GenericData2DM"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::DoubleMap{
-				hasher: StorageHasher::Blake2_256,
-				key1: DecodeDifferent::Encode("T::BlockNumber"),
-				key2: DecodeDifferent::Encode("T::BlockNumber"),
-				value: DecodeDifferent::Encode("T::BlockNumber"),
-				key2_hasher: StorageHasher::Twox256,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGenericData2DM(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("AppendableDM"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::DoubleMap{
-				hasher: StorageHasher::Blake2_256,
-				key1: DecodeDifferent::Encode("u32"),
-				key2: DecodeDifferent::Encode("T::BlockNumber"),
-				value: DecodeDifferent::Encode("Vec<u32>"),
-				key2_hasher: StorageHasher::Blake2_256,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGenericData2DM(PhantomData::<Test>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-	];
+	const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
+		prefix: DecodeDifferent::Encode("Example"),
+		instance: None,
+		entries: DecodeDifferent::Encode(
+			&[
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("Data"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map{
+						hasher: StorageHasher::Twox64Concat,
+						key: DecodeDifferent::Encode("u32"), value: DecodeDifferent::Encode("u64"), is_linked: true
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructData(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GenericData"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map{
+						hasher: StorageHasher::Twox128,
+						key: DecodeDifferent::Encode("T::BlockNumber"),
+						value: DecodeDifferent::Encode("T::BlockNumber"),
+						is_linked: true
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGenericData(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GenericData2"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map{
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("T::BlockNumber"),
+						value: DecodeDifferent::Encode("T::BlockNumber"),
+						is_linked: true
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGenericData2(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("DataDM"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::DoubleMap{
+						hasher: StorageHasher::Twox64Concat,
+						key1: DecodeDifferent::Encode("u32"),
+						key2: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("u64"),
+						key2_hasher: StorageHasher::Blake2_256,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructDataDM(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GenericDataDM"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::DoubleMap{
+						hasher: StorageHasher::Blake2_256,
+						key1: DecodeDifferent::Encode("T::BlockNumber"),
+						key2: DecodeDifferent::Encode("T::BlockNumber"),
+						value: DecodeDifferent::Encode("T::BlockNumber"),
+						key2_hasher: StorageHasher::Twox128,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGenericDataDM(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GenericData2DM"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::DoubleMap{
+						hasher: StorageHasher::Blake2_256,
+						key1: DecodeDifferent::Encode("T::BlockNumber"),
+						key2: DecodeDifferent::Encode("T::BlockNumber"),
+						value: DecodeDifferent::Encode("T::BlockNumber"),
+						key2_hasher: StorageHasher::Twox256,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGenericData2DM(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("AppendableDM"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::DoubleMap{
+						hasher: StorageHasher::Blake2_256,
+						key1: DecodeDifferent::Encode("u32"),
+						key2: DecodeDifferent::Encode("T::BlockNumber"),
+						value: DecodeDifferent::Encode("Vec<u32>"),
+						key2_hasher: StorageHasher::Blake2_256,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGenericData2DM(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+			]
+		),
+	};
 
 	#[test]
 	fn store_metadata() {
-		let metadata = Module::<Test>::store_metadata_functions();
+		let metadata = Module::<Test>::storage_metadata();
 		assert_eq!(EXPECTED_METADATA, metadata);
 	}
 }

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -435,7 +435,6 @@ mod tests {
 
 	const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
 		prefix: DecodeDifferent::Encode("Example"),
-		instance: None,
 		entries: DecodeDifferent::Encode(
 			&[
 				StorageEntryMetadata {

--- a/srml/support/src/metadata.rs
+++ b/srml/support/src/metadata.rs
@@ -184,44 +184,6 @@ macro_rules! __runtime_modules_to_metadata_calls_event {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! __runtime_modules_to_metadata_calls_storagename {
-	(
-		$mod: ident,
-		$module: ident $( <$instance:ident> )?,
-		$runtime: ident,
-		with Storage
-		$(with $kws:ident)*
-	) => {
-		$crate::metadata::DecodeDifferent::Encode(
-			$crate::metadata::FnEncode(
-				$mod::$module::<$runtime $(, $mod::$instance )?>::storage_metadata_name
-			)
-		)
-	};
-	(
-		$mod: ident,
-		$module: ident $( <$instance:ident> )?,
-		$runtime: ident,
-		with $_:ident
-		$(with $kws:ident)*
-	) => {
-		$crate::__runtime_modules_to_metadata_calls_storagename! {
-			$mod, $module $( <$instance> )?, $runtime, $(with $kws)*
-		};
-	};
-	(
-		$mod: ident,
-		$module: ident $( <$instance:ident> )?,
-		$runtime: ident,
-	) => {
-		$crate::metadata::DecodeDifferent::Encode(
-			$crate::metadata::FnEncode(|| "")
-		)
-	};
-}
-
-#[macro_export]
-#[doc(hidden)]
 macro_rules! __runtime_modules_to_metadata_calls_storage {
 	(
 		$mod: ident,

--- a/srml/support/src/metadata.rs
+++ b/srml/support/src/metadata.rs
@@ -475,7 +475,6 @@ mod tests {
 				storage: Some(DecodeDifferent::Encode(
 					FnEncode(|| StorageMetadata {
 						prefix: DecodeDifferent::Encode("TestStorage"),
-						instance: None,
 						entries: DecodeDifferent::Encode(
 							&[
 								StorageEntryMetadata {

--- a/srml/support/src/metadata.rs
+++ b/srml/support/src/metadata.rs
@@ -15,16 +15,42 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 pub use srml_metadata::{
-	DecodeDifferent, FnEncode, RuntimeMetadata, ModuleMetadata, RuntimeMetadataV6,
-	DefaultByteGetter, RuntimeMetadataPrefixed, StorageEntryMetadata,
+	DecodeDifferent, FnEncode, RuntimeMetadata, ModuleMetadata, RuntimeMetadataLastVersion,
+	DefaultByteGetter, RuntimeMetadataPrefixed, StorageEntryMetadata, StorageMetadata,
 	StorageEntryType, StorageEntryModifier, DefaultByte, StorageHasher
 };
 
 /// Implements the metadata support for the given runtime and all its modules.
 ///
 /// Example:
-/// ```compile_fail
-/// impl_runtime_metadata!(for RUNTIME_NAME with modules MODULE0, MODULE2, MODULE3 with Storage);
+/// ```
+///# mod module0 {
+///#    pub trait Trait {
+///#        type Origin;
+///#        type BlockNumber;
+///#    }
+///#    srml_support::decl_module! {
+///#        pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+///#    }
+///#
+///#    srml_support::decl_storage! {
+///#        trait Store for Module<T: Trait> as TestStorage {}
+///#    }
+///# }
+///# use module0 as module1;
+///# use module0 as module2;
+///# impl module0::Trait for Runtime {
+///#     type Origin = u32;
+///#     type BlockNumber = u32;
+///# }
+///
+/// struct Runtime;
+/// srml_support::impl_runtime_metadata! {
+///     for Runtime with modules
+///         module0::Module as Module0 with,
+///         module1::Module as Module1 with,
+///         module2::Module as Module2 with Storage,
+/// };
 /// ```
 ///
 /// In this example, just `MODULE3` implements the `Storage` trait.
@@ -36,11 +62,9 @@ macro_rules! impl_runtime_metadata {
 	) => {
 		impl $runtime {
 			pub fn metadata() -> $crate::metadata::RuntimeMetadataPrefixed {
-				$crate::metadata::RuntimeMetadata::V6 (
-					$crate::metadata::RuntimeMetadataV6 {
+				$crate::metadata::RuntimeMetadataLastVersion {
 						modules: $crate::__runtime_modules_to_metadata!($runtime;; $( $rest )*),
-					}
-				).into()
+				}.into()
 			}
 		}
 	}
@@ -52,17 +76,22 @@ macro_rules! __runtime_modules_to_metadata {
 	(
 		$runtime: ident;
 		$( $metadata:expr ),*;
-		$mod:ident::$module:ident $( < $instance:ident > )? $(with)+ $($kw:ident)*,
+		$mod:ident::$module:ident $( < $instance:ident > )? as $name:ident $(with)+ $($kw:ident)*,
 		$( $rest:tt )*
 	) => {
 		$crate::__runtime_modules_to_metadata!(
 			$runtime;
 			$( $metadata, )* $crate::metadata::ModuleMetadata {
-				name: $crate::metadata::DecodeDifferent::Encode(stringify!($mod)),
-				prefix: $crate::__runtime_modules_to_metadata_calls_storagename!($mod, $module $( <$instance> )?, $runtime, $(with $kw)*),
-				storage: $crate::__runtime_modules_to_metadata_calls_storage!($mod, $module $( <$instance> )?, $runtime, $(with $kw)*),
-				calls: $crate::__runtime_modules_to_metadata_calls_call!($mod, $module $( <$instance> )?, $runtime, $(with $kw)*),
-				event: $crate::__runtime_modules_to_metadata_calls_event!($mod, $module $( <$instance> )?, $runtime, $(with $kw)*),
+				name: $crate::metadata::DecodeDifferent::Encode(stringify!($name)),
+				storage: $crate::__runtime_modules_to_metadata_calls_storage!(
+					$mod, $module $( <$instance> )?, $runtime, $(with $kw)*
+				),
+				calls: $crate::__runtime_modules_to_metadata_calls_call!(
+					$mod, $module $( <$instance> )?, $runtime, $(with $kw)*
+				),
+				event: $crate::__runtime_modules_to_metadata_calls_event!(
+					$mod, $module $( <$instance> )?, $runtime, $(with $kw)*
+				),
 				constants: $crate::metadata::DecodeDifferent::Encode(
 					$crate::metadata::FnEncode(
 						$mod::$module::<$runtime $(, $mod::$instance )?>::module_constants_metadata
@@ -103,7 +132,9 @@ macro_rules! __runtime_modules_to_metadata_calls_call {
 		with $_:ident
 		$(with $kws:ident)*
 	) => {
-		$crate::__runtime_modules_to_metadata_calls_call!( $mod, $module $( <$instance> )?, $runtime, $(with $kws)* );
+		$crate::__runtime_modules_to_metadata_calls_call! {
+			$mod, $module $( <$instance> )?, $runtime, $(with $kws)*
+		};
 	};
 	(
 		$mod: ident,
@@ -163,7 +194,7 @@ macro_rules! __runtime_modules_to_metadata_calls_storagename {
 	) => {
 		$crate::metadata::DecodeDifferent::Encode(
 			$crate::metadata::FnEncode(
-				$mod::$module::<$runtime $(, $mod::$instance )?>::store_metadata_name
+				$mod::$module::<$runtime $(, $mod::$instance )?>::storage_metadata_name
 			)
 		)
 	};
@@ -174,7 +205,9 @@ macro_rules! __runtime_modules_to_metadata_calls_storagename {
 		with $_:ident
 		$(with $kws:ident)*
 	) => {
-		$crate::__runtime_modules_to_metadata_calls_storagename!( $mod, $module $( <$instance> )?, $runtime, $(with $kws)* );
+		$crate::__runtime_modules_to_metadata_calls_storagename! {
+			$mod, $module $( <$instance> )?, $runtime, $(with $kws)*
+		};
 	};
 	(
 		$mod: ident,
@@ -199,7 +232,7 @@ macro_rules! __runtime_modules_to_metadata_calls_storage {
 	) => {
 		Some($crate::metadata::DecodeDifferent::Encode(
 			$crate::metadata::FnEncode(
-				$mod::$module::<$runtime $(, $mod::$instance )?>::store_metadata_functions
+				$mod::$module::<$runtime $(, $mod::$instance )?>::storage_metadata
 			)
 		))
 	};
@@ -210,7 +243,9 @@ macro_rules! __runtime_modules_to_metadata_calls_storage {
 		with $_:ident
 		$(with $kws:ident)*
 	) => {
-		$crate::__runtime_modules_to_metadata_calls_storage!( $mod, $module $( <$instance> )?, $runtime, $(with $kws)* );
+		$crate::__runtime_modules_to_metadata_calls_storage! {
+			$mod, $module $( <$instance> )?, $runtime, $(with $kws)*
+		};
 	};
 	(
 		$mod: ident,
@@ -381,9 +416,9 @@ mod tests {
 
 	impl_runtime_metadata!(
 		for TestRuntime with modules
-			system::Module with Event,
-			event_module::Module with Event Call,
-			event_module2::Module with Event Storage Call,
+			system::Module as System with Event,
+			event_module::Module as Module with Event Call,
+			event_module2::Module as Module2 with Event Storage Call,
 	);
 
 	struct ConstantBlockNumberByteGetter;
@@ -407,110 +442,111 @@ mod tests {
 		}
 	}
 
-	const EXPECTED_METADATA: RuntimeMetadata = RuntimeMetadata::V6(
-		RuntimeMetadataV6 {
-			modules: DecodeDifferent::Encode(&[
-				ModuleMetadata {
-					name: DecodeDifferent::Encode("system"),
-					prefix: DecodeDifferent::Encode(FnEncode(|| "")),
-					storage: None,
-					calls: None,
-					event: Some(DecodeDifferent::Encode(
-						FnEncode(||&[
-							EventMetadata {
-								name: DecodeDifferent::Encode("SystemEvent"),
-								arguments: DecodeDifferent::Encode(&[]),
-								documentation: DecodeDifferent::Encode(&[])
-							}
-						])
-					)),
-					constants: DecodeDifferent::Encode(
-						FnEncode(|| &[
-							ModuleConstantMetadata {
-								name: DecodeDifferent::Encode("BlockNumber"),
-								ty: DecodeDifferent::Encode("T::BlockNumber"),
-								value: DecodeDifferent::Encode(
-									DefaultByteGetter(&ConstantBlockNumberByteGetter)
-								),
-								documentation: DecodeDifferent::Encode(&[" Hi, I am a comment."]),
-							},
-							ModuleConstantMetadata {
-								name: DecodeDifferent::Encode("GetType"),
-								ty: DecodeDifferent::Encode("T::AccountId"),
-								value: DecodeDifferent::Encode(
-									DefaultByteGetter(&ConstantGetTypeByteGetter)
-								),
-								documentation: DecodeDifferent::Encode(&[]),
-							},
-							ModuleConstantMetadata {
-								name: DecodeDifferent::Encode("ASSOCIATED_CONST"),
-								ty: DecodeDifferent::Encode("u64"),
-								value: DecodeDifferent::Encode(
-									DefaultByteGetter(&ConstantAssociatedConstByteGetter)
-								),
-								documentation: DecodeDifferent::Encode(&[]),
-							}
-						])
-					),
-				},
-				ModuleMetadata {
-					name: DecodeDifferent::Encode("event_module"),
-					prefix: DecodeDifferent::Encode(FnEncode(|| "")),
-					storage: None,
-					calls: Some(
-						DecodeDifferent::Encode(FnEncode(|| &[
-							FunctionMetadata {
-								name: DecodeDifferent::Encode("aux_0"),
-								arguments: DecodeDifferent::Encode(&[]),
-								documentation: DecodeDifferent::Encode(&[]),
-							}
-						]))),
-					event: Some(DecodeDifferent::Encode(
-						FnEncode(||&[
-							EventMetadata {
-								name: DecodeDifferent::Encode("TestEvent"),
-								arguments: DecodeDifferent::Encode(&["Balance"]),
-								documentation: DecodeDifferent::Encode(&[" Hi, I am a comment."])
-							}
-						])
-					)),
-					constants: DecodeDifferent::Encode(FnEncode(|| &[])),
-				},
-				ModuleMetadata {
-					name: DecodeDifferent::Encode("event_module2"),
-					prefix: DecodeDifferent::Encode(FnEncode(||"TestStorage")),
-					storage: Some(DecodeDifferent::Encode(
-						FnEncode(||&[
-							StorageEntryMetadata {
-								name: DecodeDifferent::Encode("StorageMethod"),
-								modifier: StorageEntryModifier::Optional,
-								ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-								default: DecodeDifferent::Encode(
-									DefaultByteGetter(
-										&event_module2::__GetByteStructStorageMethod(
-											std::marker::PhantomData::<TestRuntime>
+	const EXPECTED_METADATA: RuntimeMetadataLastVersion = RuntimeMetadataLastVersion {
+		modules: DecodeDifferent::Encode(&[
+			ModuleMetadata {
+				name: DecodeDifferent::Encode("System"),
+				storage: None,
+				calls: None,
+				event: Some(DecodeDifferent::Encode(
+					FnEncode(||&[
+						EventMetadata {
+							name: DecodeDifferent::Encode("SystemEvent"),
+							arguments: DecodeDifferent::Encode(&[]),
+							documentation: DecodeDifferent::Encode(&[])
+						}
+					])
+				)),
+				constants: DecodeDifferent::Encode(
+					FnEncode(|| &[
+						ModuleConstantMetadata {
+							name: DecodeDifferent::Encode("BlockNumber"),
+							ty: DecodeDifferent::Encode("T::BlockNumber"),
+							value: DecodeDifferent::Encode(
+								DefaultByteGetter(&ConstantBlockNumberByteGetter)
+							),
+							documentation: DecodeDifferent::Encode(&[" Hi, I am a comment."]),
+						},
+						ModuleConstantMetadata {
+							name: DecodeDifferent::Encode("GetType"),
+							ty: DecodeDifferent::Encode("T::AccountId"),
+							value: DecodeDifferent::Encode(
+								DefaultByteGetter(&ConstantGetTypeByteGetter)
+							),
+							documentation: DecodeDifferent::Encode(&[]),
+						},
+						ModuleConstantMetadata {
+							name: DecodeDifferent::Encode("ASSOCIATED_CONST"),
+							ty: DecodeDifferent::Encode("u64"),
+							value: DecodeDifferent::Encode(
+								DefaultByteGetter(&ConstantAssociatedConstByteGetter)
+							),
+							documentation: DecodeDifferent::Encode(&[]),
+						}
+					])
+				),
+			},
+			ModuleMetadata {
+				name: DecodeDifferent::Encode("Module"),
+				storage: None,
+				calls: Some(
+					DecodeDifferent::Encode(FnEncode(|| &[
+						FunctionMetadata {
+							name: DecodeDifferent::Encode("aux_0"),
+							arguments: DecodeDifferent::Encode(&[]),
+							documentation: DecodeDifferent::Encode(&[]),
+						}
+					]))),
+				event: Some(DecodeDifferent::Encode(
+					FnEncode(||&[
+						EventMetadata {
+							name: DecodeDifferent::Encode("TestEvent"),
+							arguments: DecodeDifferent::Encode(&["Balance"]),
+							documentation: DecodeDifferent::Encode(&[" Hi, I am a comment."])
+						}
+					])
+				)),
+				constants: DecodeDifferent::Encode(FnEncode(|| &[])),
+			},
+			ModuleMetadata {
+				name: DecodeDifferent::Encode("Module2"),
+				storage: Some(DecodeDifferent::Encode(
+					FnEncode(|| StorageMetadata {
+						prefix: DecodeDifferent::Encode("TestStorage"),
+						instance: None,
+						entries: DecodeDifferent::Encode(
+							&[
+								StorageEntryMetadata {
+									name: DecodeDifferent::Encode("StorageMethod"),
+									modifier: StorageEntryModifier::Optional,
+									ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+									default: DecodeDifferent::Encode(
+										DefaultByteGetter(
+											&event_module2::__GetByteStructStorageMethod(
+												std::marker::PhantomData::<TestRuntime>
+											)
 										)
-									)
-								),
-								documentation: DecodeDifferent::Encode(&[]),
-							}
-						])
-					)),
-					calls: Some(DecodeDifferent::Encode(FnEncode(|| &[]))),
-					event: Some(DecodeDifferent::Encode(
-						FnEncode(||&[
-							EventMetadata {
-								name: DecodeDifferent::Encode("TestEvent"),
-								arguments: DecodeDifferent::Encode(&["Balance"]),
-								documentation: DecodeDifferent::Encode(&[])
-							}
-						])
-					)),
-					constants: DecodeDifferent::Encode(FnEncode(|| &[])),
-				},
-			])
-		}
-	);
+									),
+									documentation: DecodeDifferent::Encode(&[]),
+								}
+							]
+						)
+					}),
+				)),
+				calls: Some(DecodeDifferent::Encode(FnEncode(|| &[]))),
+				event: Some(DecodeDifferent::Encode(
+					FnEncode(||&[
+						EventMetadata {
+							name: DecodeDifferent::Encode("TestEvent"),
+							arguments: DecodeDifferent::Encode(&["Balance"]),
+							documentation: DecodeDifferent::Encode(&[])
+						}
+					])
+				)),
+				constants: DecodeDifferent::Encode(FnEncode(|| &[])),
+			},
+		])
+	};
 
 	#[test]
 	fn runtime_metadata() {

--- a/srml/support/src/runtime.rs
+++ b/srml/support/src/runtime.rs
@@ -576,7 +576,9 @@ macro_rules! __decl_runtime_metadata {
 			$runtime;
 			{
 				$( $parsed )*
-				$module $( < $module_instance > )?  { $( $( $leading_module )* )? $( $modules )* }
+				$module $( < $module_instance > )? as $name {
+					$( $( $leading_module )* )? $( $modules )*
+				}
 			};
 			$( $rest )*
 		);
@@ -618,11 +620,18 @@ macro_rules! __decl_runtime_metadata {
 	// end of decl
 	(
 		$runtime:ident;
-		{ $( $parsed_modules:ident $( < $module_instance:ident > )? { $( $withs:ident )* } )* };
+		{
+			$(
+				$parsed_modules:ident $( < $module_instance:ident > )? as $parsed_name:ident {
+					$( $withs:ident )*
+				}
+			)*
+		};
 	) => {
 		$crate::impl_runtime_metadata!(
 			for $runtime with modules
-				$( $parsed_modules::Module $( < $module_instance > )? with $( $withs )* , )*
+				$( $parsed_modules::Module $( < $module_instance > )? as $parsed_name
+					with $( $withs )* , )*
 		);
 	}
 }

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -390,325 +390,331 @@ mod tests {
 		type BlockNumber = u32;
 	}
 
-	const EXPECTED_METADATA: &[StorageEntryMetadata] = &[
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("U32"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[ " Hello, this is doc!" ]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBU32"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("U32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBU32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETU32"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("T::Origin")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETU32"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETU32WITHCONFIG"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETU32WITHCONFIG(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETU32WITHCONFIG"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIG(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETU32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETU32MYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETU32WITHCONFIGMYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETU32WITHCONFIGMYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETU32WITHCONFIGMYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIGMYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETU32WITHCONFIGMYDEFOPT"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIGMYDEFOPT(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
+	const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
+		prefix: DecodeDifferent::Encode("TestStorage"),
+		instance: None,
+		entries: DecodeDifferent::Encode(
+			&[
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("U32"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[ " Hello, this is doc!" ]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBU32"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("U32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBU32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETU32"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("T::Origin")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETU32"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETU32WITHCONFIG"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETU32WITHCONFIG(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETU32WITHCONFIG"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIG(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETU32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETU32MYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETU32WITHCONFIGMYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETU32WITHCONFIGMYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETU32WITHCONFIGMYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIGMYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETU32WITHCONFIGMYDEFOPT"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETU32WITHCONFIGMYDEFOPT(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
 
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("MAPU32"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBMAPU32"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("MAPU32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBMAPU32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETMAPU32"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETMAPU32"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETMAPU32MYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETMAPU32MYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: false,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("LINKEDMAPU32"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: true,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructLINKEDMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBLINKEDMAPU32MYDEF"),
-			modifier: StorageEntryModifier::Optional,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: true,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBLINKEDMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("GETLINKEDMAPU32"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: true,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructGETLINKEDMAPU32(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("PUBGETLINKEDMAPU32MYDEF"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Map {
-				hasher: StorageHasher::Blake2_256,
-				key: DecodeDifferent::Encode("u32"),
-				value: DecodeDifferent::Encode("String"),
-				is_linked: true,
-			},
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructPUBGETLINKEDMAPU32MYDEF(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("COMPLEXTYPE1"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("::std::vec::Vec<<T as Trait>::Origin>")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructCOMPLEXTYPE1(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("COMPLEXTYPE2"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("(Vec<Vec<(u16, Box<()>)>>, u32)")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructCOMPLEXTYPE2(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-		StorageEntryMetadata {
-			name: DecodeDifferent::Encode("COMPLEXTYPE3"),
-			modifier: StorageEntryModifier::Default,
-			ty: StorageEntryType::Plain(DecodeDifferent::Encode("([u32; 25])")),
-			default: DecodeDifferent::Encode(
-				DefaultByteGetter(&__GetByteStructCOMPLEXTYPE3(PhantomData::<TraitImpl>))
-			),
-			documentation: DecodeDifferent::Encode(&[]),
-		},
-	];
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("MAPU32"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBMAPU32"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("MAPU32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBMAPU32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETMAPU32"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETMAPU32"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETMAPU32MYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETMAPU32MYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: false,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("LINKEDMAPU32"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: true,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructLINKEDMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBLINKEDMAPU32MYDEF"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: true,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBLINKEDMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GETLINKEDMAPU32"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: true,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGETLINKEDMAPU32(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("PUBGETLINKEDMAPU32MYDEF"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Map {
+						hasher: StorageHasher::Blake2_256,
+						key: DecodeDifferent::Encode("u32"),
+						value: DecodeDifferent::Encode("String"),
+						is_linked: true,
+					},
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructPUBGETLINKEDMAPU32MYDEF(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("COMPLEXTYPE1"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("::std::vec::Vec<<T as Trait>::Origin>")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructCOMPLEXTYPE1(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("COMPLEXTYPE2"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("(Vec<Vec<(u16, Box<()>)>>, u32)")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructCOMPLEXTYPE2(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("COMPLEXTYPE3"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("([u32; 25])")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructCOMPLEXTYPE3(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+			]
+		),
+	};
 
 	#[test]
 	fn store_metadata() {
-		let metadata = Module::<TraitImpl>::store_metadata_functions();
+		let metadata = Module::<TraitImpl>::storage_metadata();
 		assert_eq!(EXPECTED_METADATA, metadata);
 	}
 

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -392,7 +392,6 @@ mod tests {
 
 	const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
 		prefix: DecodeDifferent::Encode("TestStorage"),
-		instance: None,
 		entries: DecodeDifferent::Encode(
 			&[
 				StorageEntryMetadata {

--- a/srml/support/test/Cargo.toml
+++ b/srml/support/test/Cargo.toml
@@ -12,6 +12,7 @@ srml-support = { version = "2", path = "../", default-features = false }
 inherents = { package = "substrate-inherents", path = "../../../core/inherents", default-features = false }
 primitives = { package = "substrate-primitives", path = "../../../core/primitives", default-features = false }
 trybuild = "1"
+pretty_assertions = "0.6.1"
 
 [features]
 default = ["std"]

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -19,6 +19,10 @@ use runtime_io::{with_externalities, Blake2Hasher};
 use srml_support::{
 	Parameter, traits::Get, parameter_types,
 	runtime_primitives::{generic, BuildStorage, traits::{BlakeTwo256, Block as _, Verify}},
+	metadata::{
+		DecodeDifferent, StorageMetadata, StorageEntryModifier, StorageEntryType, DefaultByteGetter,
+		StorageEntryMetadata, StorageHasher
+	},
 };
 use inherents::{
 	ProvideInherent, InherentData, InherentIdentifier, RuntimeString, MakeFatalError
@@ -407,4 +411,87 @@ fn storage_with_instance_basic_operation() {
 		DoubleMap::remove(key1, key2);
 		assert_eq!(DoubleMap::get(key1, key2), 0);
 	});
+}
+
+const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
+	prefix: DecodeDifferent::Encode("Module2"),
+	instance: Some(DecodeDifferent::Encode("Instance2")),
+	entries: DecodeDifferent::Encode(
+		&[
+			StorageEntryMetadata {
+				name: DecodeDifferent::Encode("Value"),
+				modifier: StorageEntryModifier::Default,
+				ty: StorageEntryType::Plain(DecodeDifferent::Encode("T::Amount")),
+				default: DecodeDifferent::Encode(
+					DefaultByteGetter(
+						&module2::__GetByteStructValue(
+							std::marker::PhantomData::<(Runtime, module2::Instance2)>
+						)
+					)
+				),
+				documentation: DecodeDifferent::Encode(&[]),
+			},
+			StorageEntryMetadata {
+				name: DecodeDifferent::Encode("Map"),
+				modifier: StorageEntryModifier::Default,
+				ty: StorageEntryType::Map {
+					hasher: StorageHasher::Blake2_256,
+					key: DecodeDifferent::Encode("u64"),
+					value: DecodeDifferent::Encode("u64"),
+					is_linked: false,
+				},
+				default: DecodeDifferent::Encode(
+					DefaultByteGetter(
+						&module2::__GetByteStructMap(
+							std::marker::PhantomData::<(Runtime, module2::Instance2)>
+						)
+					)
+				),
+				documentation: DecodeDifferent::Encode(&[]),
+			},
+			StorageEntryMetadata {
+				name: DecodeDifferent::Encode("LinkedMap"),
+				modifier: StorageEntryModifier::Default,
+				ty: StorageEntryType::Map {
+					hasher: StorageHasher::Blake2_256,
+					key: DecodeDifferent::Encode("u64"),
+					value: DecodeDifferent::Encode("u64"),
+					is_linked: true,
+				},
+				default: DecodeDifferent::Encode(
+					DefaultByteGetter(
+						&module2::__GetByteStructLinkedMap(
+							std::marker::PhantomData::<(Runtime, module2::Instance2)>
+						)
+					)
+				),
+				documentation: DecodeDifferent::Encode(&[]),
+			},
+			StorageEntryMetadata {
+				name: DecodeDifferent::Encode("DoubleMap"),
+				modifier: StorageEntryModifier::Default,
+				ty: StorageEntryType::DoubleMap {
+					hasher: StorageHasher::Blake2_256,
+					key2_hasher: StorageHasher::Blake2_256,
+					key1: DecodeDifferent::Encode("u64"),
+					key2: DecodeDifferent::Encode("u64"),
+					value: DecodeDifferent::Encode("u64"),
+				},
+				default: DecodeDifferent::Encode(
+					DefaultByteGetter(
+						&module2::__GetByteStructDoubleMap(
+							std::marker::PhantomData::<(Runtime, module2::Instance2)>
+						)
+					)
+				),
+				documentation: DecodeDifferent::Encode(&[]),
+			}
+		]
+	)
+};
+
+#[test]
+fn test_instance_storage_metadata() {
+	let metadata = Module2_2::storage_metadata();
+	pretty_assertions::assert_eq!(EXPECTED_METADATA, metadata);
 }

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -414,8 +414,7 @@ fn storage_with_instance_basic_operation() {
 }
 
 const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
-	prefix: DecodeDifferent::Encode("Module2"),
-	instance: Some(DecodeDifferent::Encode("Instance2")),
+	prefix: DecodeDifferent::Encode("Module2Instance2"),
 	entries: DecodeDifferent::Encode(
 		&[
 			StorageEntryMetadata {

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -414,7 +414,7 @@ fn storage_with_instance_basic_operation() {
 }
 
 const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
-	prefix: DecodeDifferent::Encode("Module2Instance2"),
+	prefix: DecodeDifferent::Encode("Instance2Module2"),
 	entries: DecodeDifferent::Encode(
 		&[
 			StorageEntryMetadata {
@@ -493,4 +493,15 @@ const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
 fn test_instance_storage_metadata() {
 	let metadata = Module2_2::storage_metadata();
 	pretty_assertions::assert_eq!(EXPECTED_METADATA, metadata);
+}
+
+#[test]
+fn instance_prefix_is_prefix_of_entries() {
+	use module2::Instance;
+
+	let prefix = module2::Instance2::PREFIX;
+	assert!(module2::Instance2::PREFIX_FOR_Value.starts_with(prefix));
+	assert!(module2::Instance2::PREFIX_FOR_Map.starts_with(prefix));
+	assert!(module2::Instance2::PREFIX_FOR_LinkedMap.starts_with(prefix));
+	assert!(module2::Instance2::PREFIX_FOR_DoubleMap.starts_with(prefix));
 }


### PR DESCRIPTION
- Introduces metadata v7
- If a module is using instancing, the storage exposes the instance in
metadata
- Metadata module name is now the upper case one given to
`construct_runtime!`
