### PR TITLE
Make function `get` of parameter types public

### DIFF
--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -98,7 +98,7 @@ macro_rules! parameter_types {
 	() => ();
 	(IMPL $name:ident , $type:ty , $value:expr) => {
 		impl $name {
-			fn get() -> $type {
+			pub fn get() -> $type {
 				$value
 			}
 		}


### PR DESCRIPTION
I missed this while making parameter types more flexible.