### PR TITLE
Informant cleanup

### DIFF
--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -16,19 +16,16 @@
 
 //! Console informant. Prints sync progress and block events. Runs on the calling thread.
 
-use ansi_term::Colour;
-use std::fmt;
-use std::time;
 use futures::{Future, Stream};
 use futures03::{StreamExt as _, TryStreamExt as _};
 use service::{Service, Components};
 use tokio::runtime::TaskExecutor;
-use network::SyncState;
 use client::{backend::Backend, BlockchainEvents};
 use log::{info, warn};
-
 use runtime_primitives::generic::BlockId;
-use runtime_primitives::traits::{Header, SaturatedConversion};
+use runtime_primitives::traits::Header;
+
+mod display;
 
 /// Spawn informant on the event loop
 #[deprecated(note = "Please use informant::build instead, and then create the task manually")]
@@ -42,37 +39,12 @@ pub fn start<C>(service: &Service<C>, exit: ::exit_future::Exit, handle: TaskExe
 pub fn build<C>(service: &Service<C>) -> impl Future<Item = (), Error = ()>
 where C: Components {
 	let client = service.client();
-	let mut last_number = None;
-	let mut last_update = time::Instant::now();
+
+	let mut display = display::InformantDisplay::new();
 
 	let display_notifications = service.network_status().for_each(move |(net_status, _)| {
-
 		let info = client.info();
-		let best_number = info.chain.best_number.saturated_into::<u64>();
-		let best_hash = info.chain.best_hash;
-		let speed = move || speed(best_number, last_number, last_update);
-		last_update = time::Instant::now();
-		let (status, target) = match (net_status.sync_state, net_status.best_seen_block) {
-			(SyncState::Idle, _) => ("Idle".into(), "".into()),
-			(SyncState::Downloading, None) => (format!("Syncing{}", speed()), "".into()),
-			(SyncState::Downloading, Some(n)) => (format!("Syncing{}", speed()), format!(", target=#{}", n)),
-		};
-		last_number = Some(best_number);
-		let finalized_number: u64 = info.chain.finalized_number.saturated_into::<u64>();
-		info!(
-			target: "substrate",
-			"{}{} ({} peers), best: #{} ({}), finalized #{} ({}), ⬇ {} ⬆ {}",
-			Colour::White.bold().paint(&status),
-			target,
-			Colour::White.bold().paint(format!("{}", net_status.num_connected_peers)),
-			Colour::White.paint(format!("{}", best_number)),
-			best_hash,
-			Colour::White.paint(format!("{}", finalized_number)),
-			info.chain.finalized_hash,
-			TransferRateFormat(net_status.average_download_per_sec),
-			TransferRateFormat(net_status.average_upload_per_sec),
-		);
-
+		display.display(&info, net_status);
 		Ok(())
 	});
 
@@ -114,43 +86,4 @@ where C: Components {
 
 	display_notifications.join(display_block_import)
 		.map(|((), ())| ())
-}
-
-fn speed(best_number: u64, last_number: Option<u64>, last_update: time::Instant) -> String {
-	let since_last_millis = last_update.elapsed().as_secs() * 1000;
-	let since_last_subsec_millis = last_update.elapsed().subsec_millis() as u64;
-	let speed = last_number
-		.and_then(|num|
-			(best_number.saturating_sub(num) * 10_000).checked_div(since_last_millis + since_last_subsec_millis))
-		.map_or(0.0, |s| s as f64);
-
-	if speed < 1.0 {
-		"".into()
-	} else {
-		format!(" {:4.1} bps", speed / 10.0)
-	}
-}
-
-/// Contains a number of bytes per second. Implements `fmt::Display` and shows this number of bytes
-/// per second in a nice way.
-struct TransferRateFormat(u64);
-impl fmt::Display for TransferRateFormat {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		// Special case 0.
-		if self.0 == 0 {
-			return write!(f, "0")
-		}
-
-		// Under 0.1 kiB, display plain bytes.
-		if self.0 < 100 {
-			return write!(f, "{} B/s", self.0)
-		}
-
-		// Under 1.0 MiB/sec, display the value in kiB/sec.
-		if self.0 < 1024 * 1024 {
-			return write!(f, "{:.1}kiB/s", self.0 as f64 / 1024.0)
-		}
-
-		write!(f, "{:.1}MiB/s", self.0 as f64 / (1024.0 * 1024.0))
-	}
 }

--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -16,14 +16,14 @@
 
 //! Console informant. Prints sync progress and block events. Runs on the calling thread.
 
+use client::{backend::Backend, BlockchainEvents};
 use futures::{Future, Stream};
 use futures03::{StreamExt as _, TryStreamExt as _};
-use service::{Service, Components};
-use tokio::runtime::TaskExecutor;
-use client::{backend::Backend, BlockchainEvents};
 use log::{info, warn};
 use runtime_primitives::generic::BlockId;
 use runtime_primitives::traits::Header;
+use service::{Service, Components};
+use tokio::runtime::TaskExecutor;
 
 mod display;
 

--- a/core/cli/src/informant/display.rs
+++ b/core/cli/src/informant/display.rs
@@ -15,12 +15,12 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use ansi_term::Colour;
-use std::{fmt, marker::PhantomData, time};
-use service::NetworkStatus;
-use network::SyncState;
 use client::ClientInfo;
 use log::info;
+use network::SyncState;
 use runtime_primitives::traits::{Block as BlockT, SaturatedConversion};
+use service::NetworkStatus;
+use std::{fmt, marker::PhantomData, time};
 
 /// State of the informant display system.
 pub struct InformantDisplay<B: BlockT> {

--- a/core/cli/src/informant/display.rs
+++ b/core/cli/src/informant/display.rs
@@ -23,6 +23,18 @@ use service::NetworkStatus;
 use std::{convert::TryInto, fmt, time};
 
 /// State of the informant display system.
+///
+/// This is the system that handles the line that gets regularly printed and that looks something
+/// like:
+///
+/// > Syncing  5.4 bps, target=#531028 (4 peers), best: #90683 (0x4ca8…51b8),
+/// >  finalized #360 (0x6f24…a38b), ⬇ 5.5kiB/s ⬆ 0.9kiB/s
+///
+/// # Usage
+///
+/// Call `InformantDisplay::new` to initialize the state, then regularly call `display` with the
+/// information to display.
+///
 pub struct InformantDisplay<B: BlockT> {
 	/// Head of chain block number from the last time `display` has been called.
 	/// `None` if `display` has never been called.

--- a/core/cli/src/informant/display.rs
+++ b/core/cli/src/informant/display.rs
@@ -1,0 +1,113 @@
+// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use ansi_term::Colour;
+use std::{fmt, marker::PhantomData, time};
+use service::NetworkStatus;
+use network::SyncState;
+use client::ClientInfo;
+use log::info;
+use runtime_primitives::traits::{Block as BlockT, SaturatedConversion};
+
+/// State of the informant display system.
+pub struct InformantDisplay<B: BlockT> {
+	/// Head of chain block number from the last time `display` has been called.
+	/// `None` if `display` has never been called.
+	// TODO: use `NumberFor<B>` instead of `u64`
+	// https://github.com/paritytech/substrate/issues/2652
+	last_number: Option<u64>,
+	/// The last time `display` or `new` has been called.
+	last_update: time::Instant,
+	marker: PhantomData<B>,
+}
+
+impl<B: BlockT> InformantDisplay<B> {
+	/// Builds a new informant display system.
+	pub fn new() -> InformantDisplay<B> {
+		InformantDisplay {
+			last_number: None,
+			last_update: time::Instant::now(),
+			marker: PhantomData,
+		}
+	}
+
+	/// Displays the informant by calling `info!`.
+	pub fn display(&mut self, info: &ClientInfo<B>, net_status: NetworkStatus<B>) {
+		let best_number = info.chain.best_number.saturated_into::<u64>();
+		let best_hash = info.chain.best_hash;
+		let speed = speed(best_number, self.last_number, self.last_update);
+		self.last_update = time::Instant::now();
+		let (status, target) = match (net_status.sync_state, net_status.best_seen_block) {
+			(SyncState::Idle, _) => ("Idle".into(), "".into()),
+			(SyncState::Downloading, None) => (format!("Syncing{}", speed), "".into()),
+			(SyncState::Downloading, Some(n)) => (format!("Syncing{}", speed), format!(", target=#{}", n)),
+		};
+		self.last_number = Some(best_number);
+		let finalized_number: u64 = info.chain.finalized_number.saturated_into::<u64>();
+		info!(
+			target: "substrate",
+			"{}{} ({} peers), best: #{} ({}), finalized #{} ({}), ⬇ {} ⬆ {}",
+			Colour::White.bold().paint(&status),
+			target,
+			Colour::White.bold().paint(format!("{}", net_status.num_connected_peers)),
+			Colour::White.paint(format!("{}", best_number)),
+			best_hash,
+			Colour::White.paint(format!("{}", finalized_number)),
+			info.chain.finalized_hash,
+			TransferRateFormat(net_status.average_download_per_sec),
+			TransferRateFormat(net_status.average_upload_per_sec),
+		);
+	}
+}
+
+fn speed(best_number: u64, last_number: Option<u64>, last_update: time::Instant) -> String {
+	let since_last_millis = last_update.elapsed().as_secs() * 1000;
+	let since_last_subsec_millis = last_update.elapsed().subsec_millis() as u64;
+	let speed = last_number
+		.and_then(|num|
+			(best_number.saturating_sub(num) * 10_000).checked_div(since_last_millis + since_last_subsec_millis))
+		.map_or(0.0, |s| s as f64);
+
+	if speed < 1.0 {
+		"".into()
+	} else {
+		format!(" {:4.1} bps", speed / 10.0)
+	}
+}
+
+/// Contains a number of bytes per second. Implements `fmt::Display` and shows this number of bytes
+/// per second in a nice way.
+struct TransferRateFormat(u64);
+impl fmt::Display for TransferRateFormat {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		// Special case 0.
+		if self.0 == 0 {
+			return write!(f, "0")
+		}
+
+		// Under 0.1 kiB, display plain bytes.
+		if self.0 < 100 {
+			return write!(f, "{} B/s", self.0)
+		}
+
+		// Under 1.0 MiB/sec, display the value in kiB/sec.
+		if self.0 < 1024 * 1024 {
+			return write!(f, "{:.1}kiB/s", self.0 as f64 / 1024.0)
+		}
+
+		write!(f, "{:.1}MiB/s", self.0 as f64 / (1024.0 * 1024.0))
+	}
+}


### PR DESCRIPTION
Fix #2652 

Splits the informant in two files, one that does the `Future` stuff and one that only does the displaying.
Also fixes #2652 by trying `try_into::<u128>` and falling back to pure-integer mathematics if it fails.

For what it's worth, I locally tested the pure-integer code path, and it doesn't seem to cause any abnormal CPU usage, even in debug.
