### PR TITLE
wasm-builder: allow default cargo nightly

### DIFF
--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -152,17 +152,11 @@ fn create_out_file(file_name: &str, content: String) {
 
 /// Get a cargo command that compiles with nightly
 fn get_nightly_cargo() -> Command {
-	let version = Command::new("cargo")
-		.arg("--version")
-		.output()
-		.map_err(|_| ())
-		.and_then(|o| String::from_utf8(o.stdout).map_err(|_| ()))
-		.unwrap_or_default();
+	let mut default_cargo = Command::new("cargo");
 
-	if version.contains("-nightly") {
-		Command::new("cargo")
-	}
-	else if Command::new("rustup")
+	if is_nightly(&mut default_cargo) {
+		default_cargo
+	} else if Command::new("rustup")
 		.args(&["run", "nightly", "cargo"])
 		.stdout(Stdio::null())
 		.stderr(Stdio::null())
@@ -173,6 +167,17 @@ fn get_nightly_cargo() -> Command {
 		cmd.args(&["run", "nightly", "cargo"]);
 		cmd
 	} else {
-		Command::new("cargo")
+		default_cargo
 	}
+}
+
+/// Check if the supplied cargo command is a nightly version
+fn is_nightly(command: &mut Command) -> bool {
+	command
+		.arg("--version")
+		.output()
+		.map_err(|_| ())
+		.and_then(|o| String::from_utf8(o.stdout).map_err(|_| ()))
+		.unwrap_or_default()
+		.contains("-nightly")
 }

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -177,14 +177,12 @@ impl CargoCommand {
 		CargoCommand { program: program.into(), args: Vec::new() }
 	}
 
-	fn arg<S: Into<OsString>>(&mut self, arg: S) -> &mut Self {
+	fn arg(&mut self, arg: &str) -> &mut Self {
 		self.args.push(arg.into());
 		self
 	}
 
-	fn args<I, S>(&mut self, args: I) -> &mut Self
-		where I: IntoIterator<Item=S>, S: Into<OsString>
-	{
+	fn args(&mut self, args: &[&str]) -> &mut Self {
 		for arg in args {
 			self.arg(arg);
 		}

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -152,7 +152,17 @@ fn create_out_file(file_name: &str, content: String) {
 
 /// Get a cargo command that compiles with nightly
 fn get_nightly_cargo() -> Command {
-	if Command::new("rustup")
+	let version = Command::new("cargo")
+		.arg("--version")
+		.output()
+		.map_err(|_| ())
+		.and_then(|o| String::from_utf8(o.stdout).map_err(|_| ()))
+		.unwrap_or_default();
+
+	if version.contains("-nightly") {
+		Command::new("cargo")
+	}
+	else if Command::new("rustup")
 		.args(&["run", "nightly", "cargo"])
 		.stdout(Stdio::null())
 		.stderr(Stdio::null())

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -79,7 +79,7 @@
 //! - wasm-gc
 //!
 
-use std::{env, ffi::{OsString}, fs, path::PathBuf, process::{Command, Stdio, self}};
+use std::{env, fs, path::PathBuf, process::{Command, Stdio, self}};
 
 mod prerequisites;
 mod wasm_project;
@@ -168,8 +168,8 @@ fn get_nightly_cargo() -> CargoCommand {
 /// Builder for cargo commands
 #[derive(Debug)]
 struct CargoCommand {
-	program: OsString,
-	args: Vec<OsString>,
+	program: String,
+	args: Vec<String>,
 }
 
 impl CargoCommand {

--- a/core/utils/wasm-builder/src/prerequisites.rs
+++ b/core/utils/wasm-builder/src/prerequisites.rs
@@ -44,21 +44,8 @@ pub fn check() -> Option<&'static str> {
 }
 
 fn check_nightly_installed() -> bool {
-	let version = Command::new("cargo")
-		.arg("--version")
-		.output()
-		.map_err(|_| ())
-		.and_then(|o| String::from_utf8(o.stdout).map_err(|_| ()))
-		.unwrap_or_default();
-
-	let version2 = Command::new("rustup")
-		.args(&["run", "nightly", "cargo", "--version"])
-		.output()
-		.map_err(|_| ())
-		.and_then(|o| String::from_utf8(o.stdout).map_err(|_| ()))
-		.unwrap_or_default();
-
-	version.contains("-nightly") || version2.contains("-nightly")
+	let mut command = crate::get_nightly_cargo();
+	crate::is_nightly(&mut command)
 }
 
 fn check_wasm_toolchain_installed() -> bool {

--- a/core/utils/wasm-builder/src/prerequisites.rs
+++ b/core/utils/wasm-builder/src/prerequisites.rs
@@ -45,7 +45,7 @@ pub fn check() -> Option<&'static str> {
 
 fn check_nightly_installed() -> bool {
 	let mut command = crate::get_nightly_cargo();
-	crate::is_nightly(&mut command)
+	!crate::is_nightly(&mut command)
 }
 
 fn check_wasm_toolchain_installed() -> bool {

--- a/core/utils/wasm-builder/src/prerequisites.rs
+++ b/core/utils/wasm-builder/src/prerequisites.rs
@@ -44,8 +44,8 @@ pub fn check() -> Option<&'static str> {
 }
 
 fn check_nightly_installed() -> bool {
-	let mut command = crate::get_nightly_cargo();
-	!crate::is_nightly(&mut command)
+	let command = crate::get_nightly_cargo();
+	command.is_nightly()
 }
 
 fn check_wasm_toolchain_installed() -> bool {
@@ -74,6 +74,7 @@ fn check_wasm_toolchain_installed() -> bool {
 
 	let manifest_path = manifest_path.display().to_string();
 	crate::get_nightly_cargo()
+		.command()
 		.args(&["build", "--target=wasm32-unknown-unknown", "--manifest-path", &manifest_path])
 		.stdout(Stdio::null())
 		.stderr(Stdio::null())

--- a/core/utils/wasm-builder/src/wasm_project.rs
+++ b/core/utils/wasm-builder/src/wasm_project.rs
@@ -259,7 +259,7 @@ fn is_release_build() -> bool {
 /// Build the project to create the WASM binary.
 fn build_project(project: &Path) {
 	let manifest_path = project.join("Cargo.toml");
-	let mut build_cmd = crate::get_nightly_cargo();
+	let mut build_cmd = crate::get_nightly_cargo().command();
 
 	let rustflags = format!(
 		"-C link-arg=--export-table {}",


### PR DESCRIPTION
I [added](https://github.com/paritytech/ink/pull/124) a dev-dependency on substrate from `ink!`, and the build failed with https://github.com/paritytech/substrate/blob/33609c707a3bf7b1a520d639b7b1199dc77c0cff/core/utils/wasm-builder/src/prerequisites.rs#L40

It's because ink has the `rust-toolchain` file https://github.com/paritytech/ink/blob/master/rust-toolchain, which means that the vanilla `cargo` defaults to that version. It's a fixed version of nightly, and the wasm toolchain is installed for that version and not the latest nightly.

This PR fixes `get_nightly_cargo` to return the default `cargo` command if it is a nightly version. 