### PR TITLE
srml: staking: track session index of current era start

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,8 +79,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 120,
-	impl_version: 120,
+	spec_version: 121,
+	impl_version: 121,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -590,6 +590,9 @@ decl_storage! {
 		/// The start of the current era.
 		pub CurrentEraStart get(current_era_start): MomentOf<T>;
 
+		/// The session index at which the current era started.
+		pub CurrentEraStartSessionIndex get(current_era_start_session_index): SessionIndex;
+
 		/// Rewards for the current era. Using indices of current elected set.
 		pub CurrentEraRewards: EraRewards;
 
@@ -1169,6 +1172,9 @@ impl<T: Trait> Module<T> {
 
 		// Increment current era.
 		let current_era = CurrentEra::mutate(|s| { *s += 1; *s });
+		CurrentEraStartSessionIndex::mutate(|v| {
+			*v = start_session_index;
+		});
 		let bonding_duration = T::BondingDuration::get();
 
 		if current_era > bonding_duration {


### PR DESCRIPTION
Adds a field in the staking module that tracks the session index at which the current era started. This is necessary for the ui to be able to display the progress of the current era, since eras can be skipped we can't do this based on session index alone.

cc @jacogr 