### PR TITLE
core/consensus,node/runtime: Declare and implement authorities endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "srml-treasury 2.0.0",
  "substrate-client 2.0.0",
  "substrate-consensus-babe-primitives 2.0.0",
+ "substrate-consensus-common-primitives 2.0.0",
  "substrate-keyring 2.0.0",
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
@@ -4415,6 +4416,16 @@ dependencies = [
  "substrate-inherents 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-test-runtime-client 2.0.0",
+]
+
+[[package]]
+name = "substrate-consensus-common-primitives"
+version = "2.0.0"
+dependencies = [
+ "parity-codec 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 2.0.0",
+ "sr-std 2.0.0",
+ "substrate-client 2.0.0",
 ]
 
 [[package]]

--- a/core/consensus/common/primitives/Cargo.toml
+++ b/core/consensus/common/primitives/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "substrate-consensus-common-primitives"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+description = "Primitives for session"
+edition = "2018"
+
+[dependencies]
+parity-codec = { version = "4.1.1", default-features = false }
+client = { package = "substrate-client", path = "../../../client", default-features = false }
+runtime_primitives = { package = "sr-primitives", path = "../../../sr-primitives", default-features = false }
+rstd = { package = "sr-std", path = "../../../sr-std", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "rstd/std",
+    "client/std",
+    "parity-codec/std",
+    "runtime_primitives/std"
+]

--- a/core/consensus/common/primitives/Cargo.toml
+++ b/core/consensus/common/primitives/Cargo.toml
@@ -2,13 +2,13 @@
 name = "substrate-consensus-common-primitives"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-description = "Primitives for session"
+description = "Common consensus primitives"
 edition = "2018"
 
 [dependencies]
 parity-codec = { version = "4.1.1", default-features = false }
 client = { package = "substrate-client", path = "../../../client", default-features = false }
-runtime_primitives = { package = "sr-primitives", path = "../../../sr-primitives", default-features = false }
+sr-primitives = { package = "sr-primitives", path = "../../../sr-primitives", default-features = false }
 rstd = { package = "sr-std", path = "../../../sr-std", default-features = false }
 
 [features]
@@ -17,5 +17,5 @@ std = [
     "rstd/std",
     "client/std",
     "parity-codec/std",
-    "runtime_primitives/std"
+    "sr-primitives/std"
 ]

--- a/core/consensus/common/primitives/src/lib.rs
+++ b/core/consensus/common/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use parity_codec::{Codec};
+use parity_codec::Codec;
 use client::decl_runtime_apis;
 use rstd::vec::Vec;
 

--- a/core/consensus/common/primitives/src/lib.rs
+++ b/core/consensus/common/primitives/src/lib.rs
@@ -1,0 +1,31 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Common consensus primitives.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use parity_codec::{Codec};
+use client::decl_runtime_apis;
+use rstd::vec::Vec;
+
+decl_runtime_apis! {
+	/// Common consensus runtime api.
+	pub trait ConsensusApi<AuthorityId: Codec> {
+		/// Returns the set of authorities of the currently active consensus mechanism.
+		fn authorities() -> Vec<AuthorityId>;
+	}
+}

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -19,6 +19,7 @@ support = { package = "srml-support", path = "../../srml/support", default-featu
 authorship = { package = "srml-authorship", path = "../../srml/authorship", default-features = false }
 babe = { package = "srml-babe", path = "../../srml/babe", default-features = false }
 babe-primitives = { package = "substrate-consensus-babe-primitives", path = "../../core/consensus/babe/primitives", default-features = false }
+consensus-primitives = { package = "substrate-consensus-common-primitives", path = "../../core/consensus/common/primitives", default-features = false }
 balances = { package = "srml-balances", path = "../../srml/balances", default-features = false }
 contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false }
 collective = { package = "srml-collective", path = "../../srml/collective", default-features = false }
@@ -57,6 +58,7 @@ std = [
 	"authorship/std",
 	"babe/std",
 	"babe-primitives/std",
+	"consensus-primitives/std",
 	"balances/std",
 	"contracts/std",
 	"collective/std",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -534,4 +534,10 @@ impl_runtime_apis! {
 			}
 		}
 	}
+
+	impl consensus_primitives::ConsensusApi<Block, babe_primitives::AuthorityId> for Runtime {
+		fn authorities() -> Vec<babe_primitives::AuthorityId> {
+			Babe::authorities().into_iter().map(|(a, _)| a).collect()
+		}
+	}
 }


### PR DESCRIPTION
The goal of the commit is to be able to retrieve the current set of authorities
without needing to know the concrete consensus mechanism in place.

In order to achieve the above this commit introduces the
`core/consensus/common/primitives` crate, declaring the `ConsensusApi` runtime
API. In addition it implements the above mentioned trait definition in
`node/runtime` by returning the current authorities of the BABE consensus
mechanism.

>  You bumped the runtime version if there are breaking changes in the runtime.

Does adding an API require a runtime version bump? 

This is part of the effort of validators discovering and connecting other
validators on the network layer (See https://github.com/paritytech/substrate/issues/1693). I will be proposing small
pull requests instead of a single big one for better reviewability. Let me know
if you prefer a single one.

Next to directly connecting to consensus authorities, we should probably also
directly connect to finality authorities.
