### PR TITLE
Use milliseconds for timestamp resolution

### DIFF
--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -764,7 +764,7 @@ mod tests {
 		}
 	}
 
-	const SLOT_DURATION: u64 = 1;
+	const SLOT_DURATION: u64 = 1000;
 
 	pub struct AuraTestNet {
 		peers: Vec<Peer<(), DummySpecialization>>,

--- a/core/consensus/slots/src/slots.rs
+++ b/core/consensus/slots/src/slots.rs
@@ -57,15 +57,14 @@ impl SignedDuration {
 			duration_now() + self.offset
 		} else {
 			duration_now() - self.offset
-		}.as_secs()) / slot_duration
+		}.as_millis() as u64) / slot_duration
 	}
 }
 
 /// Returns the duration until the next slot, based on current duration since
 pub fn time_until_next(now: Duration, slot_duration: u64) -> Duration {
-	let remaining_full_secs = slot_duration - (now.as_secs() % slot_duration) - 1;
-	let remaining_nanos = 1_000_000_000 - now.subsec_nanos();
-	Duration::new(remaining_full_secs, remaining_nanos)
+	let remaining_full_millis = slot_duration - (now.as_millis() as u64 % slot_duration) - 1;
+	Duration::from_millis(remaining_full_millis)
 }
 
 /// Information about a slot.
@@ -89,7 +88,7 @@ impl SlotInfo {
 		if now < self.ends_at {
 			self.ends_at.duration_since(now)
 		} else {
-			Duration::from_secs(0)
+			Duration::from_millis(0)
 		}
 	}
 }
@@ -156,7 +155,7 @@ impl<SC: SlotCompatible + Unpin> Stream for Slots<SC> {
 			};
 			// reschedule delay for next slot.
 			let ends_in = offset +
-				time_until_next(Duration::from_secs(timestamp), slot_duration);
+				time_until_next(Duration::from_millis(timestamp), slot_duration);
 			let ends_at = Instant::now() + ends_in;
 			self.inner_delay = Some(Delay::new(ends_in));
 

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -540,7 +540,7 @@ cfg_if! {
 			}
 
 			impl aura_primitives::AuraApi<Block, AuraId> for Runtime {
-				fn slot_duration() -> u64 { 1 }
+				fn slot_duration() -> u64 { 1000 }
 				fn authorities() -> Vec<AuraId> { system::authorities() }
 			}
 
@@ -548,7 +548,7 @@ cfg_if! {
 				fn startup_data() -> babe_primitives::BabeConfiguration {
 					babe_primitives::BabeConfiguration {
 						median_required_blocks: 0,
-						slot_duration: 3,
+						slot_duration: 3000,
 						c: (3, 10),
 					}
 				}
@@ -739,7 +739,7 @@ cfg_if! {
 				fn startup_data() -> babe_primitives::BabeConfiguration {
 					babe_primitives::BabeConfiguration {
 						median_required_blocks: 0,
-						slot_duration: 1,
+						slot_duration: 1000,
 						c: (3, 10),
 					}
 				}

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -354,7 +354,7 @@ impl srml_system::Trait for Runtime {
 }
 
 impl srml_timestamp::Trait for Runtime {
-	/// A timestamp: seconds since the unix epoch.
+	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
@@ -731,7 +731,7 @@ cfg_if! {
 			}
 
 			impl aura_primitives::AuraApi<Block, AuraId> for Runtime {
-				fn slot_duration() -> u64 { 1 }
+				fn slot_duration() -> u64 { 1000 }
 				fn authorities() -> Vec<AuraId> { system::authorities() }
 			}
 

--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -150,10 +150,10 @@ impl indices::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 5;
+	pub const MinimumPeriod: u64 = 5000;
 }
 impl timestamp::Trait for Runtime {
-	/// A timestamp: seconds since the unix epoch.
+	/// A timestamp: milliseconds since the unix epoch.
 	type Moment = u64;
 	type OnTimestampSet = Aura;
 	type MinimumPeriod = MinimumPeriod;

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -264,7 +264,7 @@ mod tests {
 	use consensus_common::{Environment, Proposer, BlockImportParams, BlockOrigin, ForkChoiceStrategy};
 	use node_primitives::DigestItem;
 	use node_runtime::{BalancesCall, Call, UncheckedExtrinsic};
-	use node_runtime::constants::{currency::CENTS, time::SECS_PER_BLOCK};
+	use node_runtime::constants::{currency::CENTS, time::SLOT_DURATION};
 	use parity_codec::{Encode, Decode};
 	use primitives::{
 		crypto::Pair as CryptoPair, blake2_256,
@@ -365,7 +365,7 @@ mod tests {
 			// even though there's only one authority some slots might be empty,
 			// so we must keep trying the next slots until we can claim one.
 			let babe_pre_digest = loop {
-				inherent_data.replace_data(timestamp::INHERENT_IDENTIFIER, &(slot_num * SECS_PER_BLOCK));
+				inherent_data.replace_data(timestamp::INHERENT_IDENTIFIER, &(slot_num * SLOT_DURATION));
 				if let Some(babe_pre_digest) = babe::test_helpers::claim_slot(
 					&*service.client(),
 					&parent_id,

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -463,7 +463,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 					signed: None,
-					function: Call::Timestamp(timestamp::Call::set(42)),
+					function: Call::Timestamp(timestamp::Call::set(42 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((alice(), signed_extra(0, 0))),
@@ -485,7 +485,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 					signed: None,
-					function: Call::Timestamp(timestamp::Call::set(42)),
+					function: Call::Timestamp(timestamp::Call::set(42 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((alice(), signed_extra(0, 0))),
@@ -500,7 +500,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 					signed: None,
-					function: Call::Timestamp(timestamp::Call::set(52)),
+					function: Call::Timestamp(timestamp::Call::set(52 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((bob(), signed_extra(0, 0))),
@@ -528,7 +528,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 					signed: None,
-					function: Call::Timestamp(timestamp::Call::set(time)),
+					function: Call::Timestamp(timestamp::Call::set(time * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((alice(), signed_extra(nonce, 0))),
@@ -784,7 +784,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 					signed: None,
-					function: Call::Timestamp(timestamp::Call::set(42)),
+					function: Call::Timestamp(timestamp::Call::set(42 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((charlie(), signed_extra(0, 0))),
@@ -983,7 +983,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 				signed: None,
-				function: Call::Timestamp(timestamp::Call::set(42)),
+				function: Call::Timestamp(timestamp::Call::set(42 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((charlie(), signed_extra(0, 0))),
@@ -1000,7 +1000,7 @@ mod tests {
 			vec![
 				CheckedExtrinsic {
 				signed: None,
-				function: Call::Timestamp(timestamp::Call::set(52)),
+				function: Call::Timestamp(timestamp::Call::set(52 * 1000)),
 				},
 				CheckedExtrinsic {
 					signed: Some((charlie(), signed_extra(1, 0))),
@@ -1147,7 +1147,7 @@ mod tests {
 
 			xts.insert(0, CheckedExtrinsic {
 				signed: None,
-				function: Call::Timestamp(timestamp::Call::set(time)),
+				function: Call::Timestamp(timestamp::Call::set(time * 1000)),
 			});
 
 			// NOTE: this is super slow. Can probably be improved.
@@ -1213,7 +1213,7 @@ mod tests {
 				vec![
 					CheckedExtrinsic {
 						signed: None,
-						function: Call::Timestamp(timestamp::Call::set(time)),
+						function: Call::Timestamp(timestamp::Call::set(time * 1000)),
 					},
 					CheckedExtrinsic {
 						signed: Some((charlie(), signed_extra(nonce, 0))),

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -50,7 +50,7 @@ pub type Index = u64;
 /// A hash of some data used by the chain.
 pub type Hash = primitives::H256;
 
-/// A timestamp: seconds since the unix epoch.
+/// A timestamp: milliseconds since the unix epoch.
 pub type Timestamp = u64;
 
 /// Digest item type.

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -51,6 +51,8 @@ pub type Index = u64;
 pub type Hash = primitives::H256;
 
 /// A timestamp: milliseconds since the unix epoch.
+/// `u64` is enough to represent a duration of half a billion years, when the
+/// time scale is milliseconds.
 pub type Timestamp = u64;
 
 /// Digest item type.

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -18,21 +18,21 @@
 
 /// Money matters.
 pub mod currency {
-    use node_primitives::Balance;
+	use node_primitives::Balance;
 
-    pub const MILLICENTS: Balance = 1_000_000_000;
-    pub const CENTS: Balance = 1_000 * MILLICENTS;    // assume this is worth about a cent.
-    pub const DOLLARS: Balance = 100 * CENTS;
+	pub const MILLICENTS: Balance = 1_000_000_000;
+	pub const CENTS: Balance = 1_000 * MILLICENTS;    // assume this is worth about a cent.
+	pub const DOLLARS: Balance = 100 * CENTS;
 }
 
 /// Time.
 pub mod time {
-    use node_primitives::Moment;
+	use node_primitives::Moment;
 
-    pub const SECS_PER_BLOCK: Moment = 6;
-    pub const MINUTES: Moment = 60 / SECS_PER_BLOCK;
-    pub const HOURS: Moment = MINUTES * 60;
-    pub const DAYS: Moment = HOURS * 24;
+	pub const SECS_PER_BLOCK: Moment = 6;
+	pub const MINUTES: Moment = 60 / SECS_PER_BLOCK;
+	pub const HOURS: Moment = MINUTES * 60;
+	pub const DAYS: Moment = HOURS * 24;
 }
 
 // CRITICAL NOTE: The system module maintains two constants: a _maximum_ block weight and a
@@ -45,8 +45,8 @@ pub mod time {
 // the ratio that `system` module uses to find normal transaction quota.
 /// Fee-related.
 pub mod fee {
-    pub use runtime_primitives::Perbill;
+	pub use runtime_primitives::Perbill;
 
-    /// The block saturation level. Fees will be updates based on this value.
-    pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
+	/// The block saturation level. Fees will be updates based on this value.
+	pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
 }

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -29,7 +29,11 @@ pub mod currency {
 pub mod time {
 	use node_primitives::Moment;
 
-	pub const SECS_PER_BLOCK: Moment = 6;
+	pub const MILLISECS_PER_BLOCK: Moment = 6000;
+	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+	pub const SLOT_DURATION: Moment = 6000;
+
+	// These time units are defined in number of blocks.
 	pub const MINUTES: Moment = 60 / SECS_PER_BLOCK;
 	pub const HOURS: Moment = MINUTES * 60;
 	pub const DAYS: Moment = HOURS * 24;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -166,7 +166,7 @@ impl balances::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = SECS_PER_BLOCK / 2;
+	pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
 }
 impl timestamp::Trait for Runtime {
 	type Moment = Moment;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,8 +79,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 121,
-	impl_version: 121,
+	spec_version: 122,
+	impl_version: 122,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -166,7 +166,7 @@ impl balances::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
+	pub const MinimumPeriod: Moment = SLOT_DURATION / 2;
 }
 impl timestamp::Trait for Runtime {
 	type Moment = Moment;

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -170,7 +170,7 @@ impl ProvideInherentData for InherentDataProvider {
 			.map_err(|_| {
 				"Current time is before unix epoch".into()
 			}).and_then(|d| {
-				let duration: InherentType = d.as_secs();
+				let duration: InherentType = d.as_millis() as u64;
 				inherent_data.put_data(INHERENT_IDENTIFIER, &duration)
 			})
 	}


### PR DESCRIPTION
The srml timestamp module itself is unit dependent, as long as we are consistent with the data that we feed it. I only needed to update the `InherentDataProvider` to extract milliseconds from clock time, and the slot worker to use millisecond resolution for slot duration. This change is needed because BABE needs to be able to define slot durations at the millisecond level to account for the security parameters.