### PR TITLE
node: Update BABE protocol parameters

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -371,7 +371,7 @@ mod tests {
 					&parent_id,
 					slot_num,
 					&alice,
-					(3, 10),
+					(278, 1000),
 				) {
 					break babe_pre_digest;
 				}

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -31,7 +31,15 @@ pub mod time {
 
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
-	pub const SLOT_DURATION: Moment = 6000;
+
+	pub const SLOT_DURATION: Moment = 1650;
+
+	pub const EPOCH_DURATION_IN_BLOCKS: Moment = 10 * MINUTES;
+	pub const EPOCH_DURATION_IN_SLOTS: Moment = {
+		const SLOT_FILL_RATE: f64 = MILLISECS_PER_BLOCK as f64 / SLOT_DURATION as f64;
+
+		(EPOCH_DURATION_IN_BLOCKS as f64 * SLOT_FILL_RATE) as Moment
+	};
 
 	// These time units are defined in number of blocks.
 	pub const MINUTES: Moment = 60 / SECS_PER_BLOCK;

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -29,6 +29,17 @@ pub mod currency {
 pub mod time {
 	use node_primitives::Moment;
 
+	/// Since BABE is probabilistic this is the average expected block time that
+	/// we are targetting. Blocks will be produced at a minimum duration defined
+	/// by `SLOT_DURATION`, but some slots will not be allocated to any
+	/// authority and hence no block will be produced. We expect to have this
+	/// block time on average following the defined slot duration and the value
+	/// of `c` configured for BABE.
+	/// This value is only used indirectly to define the unit constants below
+	/// that are expressed in blocks. The rest of the code should use
+	/// `SLOT_DURATION` instead (like the timestamp module for calculating the
+	/// minimum period).
+	/// [https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results]
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -39,7 +39,7 @@ pub mod time {
 	/// that are expressed in blocks. The rest of the code should use
 	/// `SLOT_DURATION` instead (like the timestamp module for calculating the
 	/// minimum period).
-	/// [https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results]
+	/// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
 	pub const MILLISECS_PER_BLOCK: Moment = 6000;
 	pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -519,7 +519,7 @@ impl_runtime_apis! {
 		fn startup_data() -> babe_primitives::BabeConfiguration {
 			// The choice of `c` parameter is done in accordance to
 			// the slot duration and expected target block time, for
-			// safely resisting network delays of maximum two minutes.
+			// safely resisting network delays of maximum two seconds.
 			// [https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results]
 			babe_primitives::BabeConfiguration {
 				median_required_blocks: 1000,

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -520,7 +520,7 @@ impl_runtime_apis! {
 			// The choice of `c` parameter is done in accordance to
 			// the slot duration and expected target block time, for
 			// safely resisting network delays of maximum two seconds.
-			// [https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results]
+			// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
 			babe_primitives::BabeConfiguration {
 				median_required_blocks: 1000,
 				slot_duration: Babe::slot_duration(),

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -127,7 +127,7 @@ impl system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const EpochDuration: u64 = 10 * MINUTES;
+	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
 }
 
 impl babe::Trait for Runtime {
@@ -517,10 +517,14 @@ impl_runtime_apis! {
 
 	impl babe_primitives::BabeApi<Block> for Runtime {
 		fn startup_data() -> babe_primitives::BabeConfiguration {
+			// The choice of `c` parameter is done in accordance to
+			// the slot duration and expected target block time, for
+			// safely resisting network delays of maximum two minutes.
+			// [https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results]
 			babe_primitives::BabeConfiguration {
 				median_required_blocks: 1000,
 				slot_duration: Babe::slot_duration(),
-				c: (3, 10),
+				c: (278, 1000),
 			}
 		}
 


### PR DESCRIPTION
~Depends on #3210. Only the last commit in this PR is relevant, you should review only that change until #3210 is merged.~

This PR updates the slot duration, epoch duration (to define it in slots), and `c` parameter for the BABE protocol. These parameters were chosen in accordance to the results in https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results. Specifically, we are targetting a 6 second block time with resistance of maximum network delay up to 2 seconds. 

The epoch duration should be way longer in order to collect enough randomness, but for development purposes it is useful to have it relatively low. For Kusama we will use a much longer period.

cc @burdges