### PR TITLE
Minor cleanup in native_executor.rs

### DIFF
--- a/core/client/src/genesis.rs
+++ b/core/client/src/genesis.rs
@@ -41,7 +41,7 @@ pub fn construct_genesis_block<
 mod tests {
 	use super::*;
 	use parity_codec::{Encode, Decode, Joiner};
-	use executor::{NativeExecutionDispatch, native_executor_instance};
+	use executor::native_executor_instance;
 	use state_machine::{self, OverlayedChanges, ExecutionStrategy, InMemoryChangesTrieStorage};
 	use state_machine::backend::InMemory;
 	use test_client::{
@@ -61,7 +61,7 @@ mod tests {
 	);
 
 	fn executor() -> executor::NativeExecutor<Executor> {
-		NativeExecutionDispatch::new(None)
+		executor::NativeExecutor::new(None)
 	}
 
 	fn construct_block(
@@ -226,7 +226,7 @@ mod tests {
 			Some(&InMemoryChangesTrieStorage::<_, u64>::new()),
 			state_machine::NeverOffchainExt::new(),
 			&mut overlay,
-			&Executor::new(None),
+			&executor(),
 			"Core_execute_block",
 			&b1data,
 		).execute(

--- a/core/client/src/light/call_executor.rs
+++ b/core/client/src/light/call_executor.rs
@@ -481,7 +481,7 @@ pub fn check_execution_proof<Header, E, H>(
 mod tests {
 	use consensus::BlockOrigin;
 	use test_client::{self, runtime::Header, ClientExt, TestClient};
-	use executor::NativeExecutionDispatch;
+	use executor::NativeExecutor;
 	use crate::backend::{Backend, NewBlockState};
 	use crate::in_mem::Backend as InMemBackend;
 	use crate::light::fetcher::tests::OkCallFetcher;
@@ -502,7 +502,7 @@ mod tests {
 			).unwrap();
 
 			// check remote execution proof locally
-			let local_executor = test_client::LocalExecutor::new(None);
+			let local_executor = NativeExecutor::<test_client::LocalExecutor>::new(None);
 			let local_result = check_execution_proof(&local_executor, &RemoteCallRequest {
 				block: test_client::runtime::Hash::default(),
 				header: test_client::runtime::Header {

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -488,7 +488,7 @@ pub mod tests {
 	use parking_lot::Mutex;
 	use parity_codec::Decode;
 	use crate::client::tests::prepare_client_with_key_changes;
-	use executor::{self, NativeExecutionDispatch};
+	use executor::{self, NativeExecutor};
 	use crate::error::Error as ClientError;
 	use test_client::{
 		self, ClientExt, blockchain::HeaderBackend, AccountKeyring,
@@ -578,7 +578,7 @@ pub mod tests {
 			None,
 			crate::backend::NewBlockState::Final,
 		).unwrap();
-		let local_executor = test_client::LocalExecutor::new(None);
+		let local_executor = NativeExecutor::<test_client::LocalExecutor>::new(None);
 		let local_checker = LightDataChecker::new(Arc::new(DummyBlockchain::new(DummyStorage::new())), local_executor);
 		(local_checker, remote_block_header, remote_read_proof, heap_pages)
 	}
@@ -604,7 +604,7 @@ pub mod tests {
 		if insert_cht {
 			local_storage.insert_cht_root(1, local_cht_root);
 		}
-		let local_executor = test_client::LocalExecutor::new(None);
+		let local_executor = NativeExecutor::<test_client::LocalExecutor>::new(None);
 		let local_checker = LightDataChecker::new(Arc::new(DummyBlockchain::new(DummyStorage::new())), local_executor);
 		(local_checker, local_cht_root, remote_block_header, remote_header_proof)
 	}
@@ -665,7 +665,7 @@ pub mod tests {
 		let (remote_client, local_roots, test_cases) = prepare_client_with_key_changes();
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(DummyStorage::new())),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
 		let max = remote_client.info().chain.best_number;
@@ -733,7 +733,7 @@ pub mod tests {
 		local_storage.changes_tries_cht_roots.insert(0, local_cht_root);
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(local_storage)),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 
 		// check proof on local client
@@ -761,7 +761,7 @@ pub mod tests {
 		let (remote_client, local_roots, test_cases) = prepare_client_with_key_changes();
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(DummyStorage::new())),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
 		let max = remote_client.info().chain.best_number;
@@ -842,7 +842,7 @@ pub mod tests {
 		// fails when changes trie CHT is missing from the local db
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(DummyStorage::new())),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		assert!(local_checker.check_changes_tries_proof(4, &remote_proof.roots,
 			remote_proof.roots_proof.clone()).is_err());
@@ -852,7 +852,7 @@ pub mod tests {
 		local_storage.changes_tries_cht_roots.insert(0, local_cht_root);
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(local_storage)),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		assert!(local_checker.check_changes_tries_proof(4, &remote_proof.roots, vec![]).is_err());
 	}
@@ -866,7 +866,7 @@ pub mod tests {
 
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(DummyStorage::new())),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 
 		let body_request = RemoteBodyRequest {
@@ -889,7 +889,7 @@ pub mod tests {
 
 		let local_checker = TestChecker::new(
 			Arc::new(DummyBlockchain::new(DummyStorage::new())),
-			test_client::LocalExecutor::new(None)
+			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 
 		let body_request = RemoteBodyRequest {

--- a/core/executor/src/native_executor.rs
+++ b/core/executor/src/native_executor.rs
@@ -52,16 +52,11 @@ pub trait NativeExecutionDispatch: Send + Sync {
 	/// Get the wasm code that the native dispatch will be equivalent to.
 	fn native_equivalent() -> &'static [u8];
 
-	/// Dispatch a method and input data to be executed natively. Returns `Some` result or `None`
-	/// if the `method` is unknown. Panics if there's an unrecoverable error.
-	// fn dispatch<H: hash_db::Hasher>(ext: &mut Externalities<H>, method: &str, data: &[u8]) -> Result<Vec<u8>>;
+	/// Dispatch a method and input data to be executed natively.
 	fn dispatch(ext: &mut dyn Externalities<Blake2Hasher>, method: &str, data: &[u8]) -> Result<Vec<u8>>;
 
 	/// Provide native runtime version.
 	fn native_version() -> NativeVersion;
-
-	/// Construct corresponding `NativeExecutor`
-	fn new(default_heap_pages: Option<u64>) -> NativeExecutor<Self> where Self: Sized;
 }
 
 /// A generic `CodeExecutor` implementation that uses a delegate to determine wasm code equivalence
@@ -222,17 +217,18 @@ macro_rules! native_executor_instance {
 				// get a proper build script, this must be strictly adhered to or things will go wrong.
 				$code
 			}
-			fn dispatch(ext: &mut $crate::Externalities<$crate::Blake2Hasher>, method: &str, data: &[u8]) -> $crate::error::Result<Vec<u8>> {
+
+			fn dispatch(
+				ext: &mut $crate::Externalities<$crate::Blake2Hasher>,
+				method: &str,
+				data: &[u8]
+			) -> $crate::error::Result<Vec<u8>> {
 				$crate::with_native_environment(ext, move || $dispatcher(method, data))?
 					.ok_or_else(|| $crate::error::Error::MethodNotFound(method.to_owned()))
 			}
 
 			fn native_version() -> $crate::NativeVersion {
 				$version()
-			}
-
-			fn new(default_heap_pages: Option<u64>) -> $crate::NativeExecutor<$name> {
-				$crate::NativeExecutor::new(default_heap_pages)
 			}
 		}
 	}

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -39,7 +39,7 @@ mod tests {
 	use super::Executor;
 	use {balances, contracts, indices, staking, system, timestamp};
 	use runtime_io;
-	use substrate_executor::{WasmExecutor, NativeExecutionDispatch};
+	use substrate_executor::WasmExecutor;
 	use parity_codec::{Encode, Decode, Joiner};
 	use keyring::{AccountKeyring, Ed25519Keyring, Sr25519Keyring};
 	use runtime_support::{Hashable, StorageValue, StorageMap, assert_eq_error_rate, traits::Currency};
@@ -422,7 +422,7 @@ mod tests {
 		};
 
 		// execute the block to get the real header.
-		Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+		executor().call::<_, NeverNativeValue, fn() -> _>(
 			env,
 			"Core_initialize_block",
 			&header.encode(),
@@ -431,7 +431,7 @@ mod tests {
 		).0.unwrap();
 
 		for i in extrinsics.iter() {
-			Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+			executor().call::<_, NeverNativeValue, fn() -> _>(
 				env,
 				"BlockBuilder_apply_extrinsic",
 				&i.encode(),
@@ -440,7 +440,7 @@ mod tests {
 			).0.unwrap();
 		}
 
-		let header = match Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+		let header = match executor().call::<_, NeverNativeValue, fn() -> _>(
 			env,
 			"BlockBuilder_finalize_block",
 			&[0u8;0],
@@ -846,7 +846,7 @@ mod tests {
 	fn native_big_block_import_succeeds() {
 		let mut t = new_test_ext(COMPACT_CODE, false);
 
-		Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+		executor().call::<_, NeverNativeValue, fn() -> _>(
 			&mut t,
 			"Core_execute_block",
 			&block_with_size(42, 0, 120_000).0,
@@ -860,7 +860,7 @@ mod tests {
 		let mut t = new_test_ext(COMPACT_CODE, false);
 
 		assert!(
-			Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+			executor().call::<_, NeverNativeValue, fn() -> _>(
 				&mut t,
 				"Core_execute_block",
 				&block_with_size(42, 0, 120_000).0,
@@ -926,7 +926,7 @@ mod tests {
 		let block = Block::decode(&mut &block_data[..]).unwrap();
 
 		let mut t = new_test_ext(COMPACT_CODE, true);
-		Executor::new(None).call::<_, NeverNativeValue, fn() -> _>(
+		executor().call::<_, NeverNativeValue, fn() -> _>(
 			&mut t,
 			"Core_execute_block",
 			&block.encode(),


### PR DESCRIPTION
Remove a no-longer-true comment, and the `NativeExecutionDispatch::new` method.