### PR TITLE
Allow creating a ChainSpec from a Vec<u8>

### DIFF
--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -161,11 +161,6 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 	}
 
 	/// Parse json content into a `ChainSpec`
-	pub fn from_embedded(json: &'static [u8]) -> Result<Self, String> {
-		Self::from_json_bytes(json)
-	}
-
-	/// Parse json content into a `ChainSpec`
 	pub fn from_json_bytes(json: impl Into<Cow<'static, [u8]>>) -> Result<Self, String> {
 		let json = json.into();
 		let spec = json::from_slice(json.as_ref()).map_err(|e| format!("Error parsing spec file: {}", e))?;

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -30,7 +30,7 @@ use tel::TelemetryEndpoints;
 
 enum GenesisSource<G> {
 	File(PathBuf),
-	Embedded(Cow<'static, [u8]>),
+	Binary(Cow<'static, [u8]>),
 	Factory(fn() -> G),
 }
 
@@ -38,7 +38,7 @@ impl<G: RuntimeGenesis> Clone for GenesisSource<G> {
 	fn clone(&self) -> Self {
 		match *self {
 			GenesisSource::File(ref path) => GenesisSource::File(path.clone()),
-			GenesisSource::Embedded(ref d) => GenesisSource::Embedded(d.clone()),
+			GenesisSource::Binary(ref d) => GenesisSource::Binary(d.clone()),
 			GenesisSource::Factory(f) => GenesisSource::Factory(f),
 		}
 	}
@@ -58,7 +58,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 					json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
 			},
-			GenesisSource::Embedded(buf) => {
+			GenesisSource::Binary(buf) => {
 				let genesis: GenesisContainer<G> =
 					json::from_reader(buf.as_ref()).map_err(|e| format!("Error parsing embedded file: {}", e))?;
 				Ok(genesis.genesis)
@@ -171,7 +171,7 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 		let spec = json::from_slice(json.as_ref()).map_err(|e| format!("Error parsing spec file: {}", e))?;
 		Ok(ChainSpec {
 			spec,
-			genesis: GenesisSource::Embedded(json),
+			genesis: GenesisSource::Binary(json),
 		})
 	}
 

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -54,11 +54,13 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 		match self {
 			GenesisSource::File(path) => {
 				let file = File::open(path).map_err(|e| format!("Error opening spec file: {}", e))?;
-				let genesis: GenesisContainer<G> = json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
+				let genesis: GenesisContainer<G> =
+					json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
 			},
 			GenesisSource::Embedded(buf) => {
-				let genesis: GenesisContainer<G> = json::from_reader(buf.as_ref()).map_err(|e| format!("Error parsing embedded file: {}", e))?;
+				let genesis: GenesisContainer<G> =
+					json::from_reader(buf.as_ref()).map_err(|e| format!("Error parsing embedded file: {}", e))?;
 				Ok(genesis.genesis)
 			},
 			GenesisSource::Factory(f) => Ok(Genesis::Runtime(f())),

--- a/core/service/src/chain_spec.rs
+++ b/core/service/src/chain_spec.rs
@@ -16,6 +16,7 @@
 
 //! Substrate chain configurations.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
@@ -29,7 +30,7 @@ use tel::TelemetryEndpoints;
 
 enum GenesisSource<G> {
 	File(PathBuf),
-	Embedded(&'static [u8]),
+	Embedded(Cow<'static, [u8]>),
 	Factory(fn() -> G),
 }
 
@@ -37,7 +38,7 @@ impl<G: RuntimeGenesis> Clone for GenesisSource<G> {
 	fn clone(&self) -> Self {
 		match *self {
 			GenesisSource::File(ref path) => GenesisSource::File(path.clone()),
-			GenesisSource::Embedded(d) => GenesisSource::Embedded(d),
+			GenesisSource::Embedded(ref d) => GenesisSource::Embedded(d.clone()),
 			GenesisSource::Factory(f) => GenesisSource::Factory(f),
 		}
 	}
@@ -50,14 +51,14 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 			genesis: Genesis<G>,
 		}
 
-		match *self {
-			GenesisSource::File(ref path) => {
+		match self {
+			GenesisSource::File(path) => {
 				let file = File::open(path).map_err(|e| format!("Error opening spec file: {}", e))?;
 				let genesis: GenesisContainer<G> = json::from_reader(file).map_err(|e| format!("Error parsing spec file: {}", e))?;
 				Ok(genesis.genesis)
 			},
 			GenesisSource::Embedded(buf) => {
-				let genesis: GenesisContainer<G> = json::from_reader(buf).map_err(|e| format!("Error parsing embedded file: {}", e))?;
+				let genesis: GenesisContainer<G> = json::from_reader(buf.as_ref()).map_err(|e| format!("Error parsing embedded file: {}", e))?;
 				Ok(genesis.genesis)
 			},
 			GenesisSource::Factory(f) => Ok(Genesis::Runtime(f())),
@@ -159,7 +160,13 @@ impl<G: RuntimeGenesis> ChainSpec<G> {
 
 	/// Parse json content into a `ChainSpec`
 	pub fn from_embedded(json: &'static [u8]) -> Result<Self, String> {
-		let spec = json::from_slice(json).map_err(|e| format!("Error parsing spec file: {}", e))?;
+		Self::from_json_bytes(json)
+	}
+
+	/// Parse json content into a `ChainSpec`
+	pub fn from_json_bytes(json: impl Into<Cow<'static, [u8]>>) -> Result<Self, String> {
+		let json = json.into();
+		let spec = json::from_slice(json.as_ref()).map_err(|e| format!("Error parsing spec file: {}", e))?;
 		Ok(ChainSpec {
 			spec,
 			genesis: GenesisSource::Embedded(json),

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -39,7 +39,7 @@ pub type ChainSpec = substrate_service::ChainSpec<GenesisConfig>;
 
 /// Flaming Fir testnet generator
 pub fn flaming_fir_config() -> Result<ChainSpec, String> {
-	ChainSpec::from_embedded(include_bytes!("../res/flaming-fir.json"))
+	ChainSpec::from_json_bytes(&include_bytes!("../res/flaming-fir.json")[..])
 }
 
 fn session_keys(ed_key: ed25519::Public, sr_key: sr25519::Public) -> SessionKeys {


### PR DESCRIPTION
For #2416 I'd like to be able to pass the chain-spec JSON from the JavaScript API.

Right now, you can create a `ChainSpec` from only three ways: from a `&'static [u8]`, from a file (through a `PathBuf`), or manually.

This PR adds the possibility to pass a `Vec<u8>`.