### PR TITLE
Fix substrate factory CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,7 @@ dependencies = [
  "srml-contracts 2.0.0",
  "srml-finality-tracker 2.0.0",
  "srml-indices 2.0.0",
+ "srml-support 2.0.0",
  "srml-system 2.0.0",
  "srml-timestamp 2.0.0",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -51,7 +51,7 @@ use params::{
 	NetworkConfigurationParams, MergeParameters, TransactionPoolParams,
 	NodeKeyParams, NodeKeyType, Cors,
 };
-pub use params::{NoCustom, CoreParams, SharedParams};
+pub use params::{NoCustom, CoreParams, SharedParams, ExecutionStrategy as ExecutionStrategyParam};
 pub use traits::{GetLogFilter, AugmentClap};
 use app_dirs::{AppInfo, AppDataType};
 use log::info;
@@ -639,7 +639,12 @@ where
 	E: IntoExit,
 	S: FnOnce(&str) -> Result<Option<ChainSpec<FactoryGenesis<F>>>, String>,
 {
-	let config = create_config_with_db_path::<F, _>(spec_factory, &cli.shared_params, version)?;
+	let mut config = create_config_with_db_path::<F, _>(spec_factory, &cli.shared_params, version)?;
+	config.execution_strategies = ExecutionStrategies {
+		importing: cli.execution.into(),
+		other: cli.execution.into(),
+		..Default::default()
+	};
 
 	let file: Box<dyn Read> = match cli.input {
 		Some(filename) => Box::new(File::open(filename)?),

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -33,6 +33,7 @@ macro_rules! impl_get_log_filter {
 
 arg_enum! {
 	/// How to execute blocks
+	#[allow(missing_docs)]
 	#[derive(Debug, Clone, Copy)]
 	pub enum ExecutionStrategy {
 		Native,
@@ -610,6 +611,18 @@ pub struct ImportBlocksCmd {
 	#[allow(missing_docs)]
 	#[structopt(flatten)]
 	pub shared_params: SharedParams,
+
+	/// The means of execution used when calling into the runtime while importing blocks.
+	#[structopt(
+		long = "execution",
+		value_name = "STRATEGY",
+		raw(
+			possible_values = "&ExecutionStrategy::variants()",
+			case_insensitive = "true",
+			default_value = r#""NativeElseWasm""#
+		)
+	)]
+	pub execution: ExecutionStrategy,
 }
 
 impl_get_log_filter!(ImportBlocksCmd);

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -42,6 +42,7 @@ finality_tracker = { package = "srml-finality-tracker", path = "../../srml/final
 contracts = { package = "srml-contracts", path = "../../srml/contracts" }
 system = { package = "srml-system", path = "../../srml/system" }
 balances = { package = "srml-balances", path = "../../srml/balances" }
+support = { package = "srml-support", path = "../../srml/support", default-features = false }
 
 [dev-dependencies]
 babe = { package = "substrate-consensus-babe", path = "../../core/consensus/babe", features = ["test-helpers"] }

--- a/node/cli/src/factory_impl.rs
+++ b/node/cli/src/factory_impl.rs
@@ -23,11 +23,13 @@ use rand::rngs::StdRng;
 
 use parity_codec::Decode;
 use keyring::sr25519::Keyring;
-use node_runtime::{Call, CheckedExtrinsic, UncheckedExtrinsic, SignedExtra, BalancesCall};
+use node_primitives::Hash;
+use node_runtime::{Call, CheckedExtrinsic, UncheckedExtrinsic, SignedExtra, BalancesCall, ExistentialDeposit};
 use primitives::{sr25519, crypto::Pair};
 use parity_codec::Encode;
 use sr_primitives::{generic::Era, traits::{Block as BlockT, Header as HeaderT, SignedExtension}};
 use substrate_service::ServiceFactory;
+use support::traits::Get;
 use transaction_factory::RuntimeAdapter;
 use transaction_factory::modes::Mode;
 use crate::service;
@@ -133,7 +135,7 @@ impl RuntimeAdapter for FactoryState<Number> {
 		sender: &Self::AccountId,
 		key: &Self::Secret,
 		destination: &Self::AccountId,
-		amount: &Self::Number,
+		amount: &Self::Balance,
 		prior_block_hash: &<Self::Block as BlockT>::Hash,
 	) -> <Self::Block as BlockT>::Extrinsic {
 		let index = self.extract_index(&sender, prior_block_hash);
@@ -161,9 +163,9 @@ impl RuntimeAdapter for FactoryState<Number> {
 		inherent
 	}
 
-	fn minimum_balance() -> Self::Number {
+	fn minimum_balance() -> Self::Balance {
 		// TODO get correct amount via api. See #2587.
-		1337
+		ExistentialDeposit::get()
 	}
 
 	fn master_account_id() -> Self::AccountId {

--- a/test-utils/transaction-factory/src/complex_mode.rs
+++ b/test-utils/transaction-factory/src/complex_mode.rs
@@ -83,13 +83,8 @@ where
 	let seed = factory_state.start_number() + factory_state.block_no();
 	let to = RA::gen_random_account_id(&seed);
 
-	let amount;
-	if factory_state.round() == RA::Number::zero() {
-		amount = RA::minimum_balance() * factory_state.rounds();
-	} else {
-		let rounds_left = factory_state.rounds() - factory_state.round();
-		amount = RA::minimum_balance() * rounds_left;
-	};
+	let rounds_left = factory_state.rounds() - factory_state.round();
+	let amount = RA::minimum_balance() * rounds_left.into();
 
 	let transfer = factory_state.transfer_extrinsic(
 		&from.0,

--- a/test-utils/transaction-factory/src/lib.rs
+++ b/test-utils/transaction-factory/src/lib.rs
@@ -21,7 +21,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::ops::Mul;
 use std::cmp::PartialOrd;
 use std::fmt::Display;
 
@@ -51,7 +50,7 @@ mod simple_modes;
 
 pub trait RuntimeAdapter {
 	type AccountId: Display;
-	type Balance: Display + Mul;
+	type Balance: Display + SimpleArithmetic + From<Self::Number>;
 	type Block: BlockT;
 	type Index: Copy;
 	type Number: Display + PartialOrd + SimpleArithmetic + Zero + One;
@@ -77,13 +76,13 @@ pub trait RuntimeAdapter {
 		sender: &Self::AccountId,
 		key: &Self::Secret,
 		destination: &Self::AccountId,
-		amount: &Self::Number,
+		amount: &Self::Balance,
 		prior_block_hash: &<Self::Block as BlockT>::Hash,
 	) -> <Self::Block as BlockT>::Extrinsic;
 
 	fn inherent_extrinsics(&self) -> InherentData;
 
-	fn minimum_balance() -> Self::Number;
+	fn minimum_balance() -> Self::Balance;
 	fn master_account_id() -> Self::AccountId;
 	fn master_account_secret() -> Self::Secret;
 	fn extract_index(&self, account_id: &Self::AccountId, block_hash: &<Self::Block as BlockT>::Hash) -> Self::Index;


### PR DESCRIPTION
There is currently an issue with the `substrate factory` CLI command (for dev chains) due to a hard-coded minimum balance. This fixes the issue so that the produced blocks are valid.

Also adds a new CLI flag for factory and import-blocks to set the execution engine.

These issues were surfaced during performance testing of Wasm execution.