### PR TITLE
Properly stop block import on error

### DIFF
--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -117,13 +117,17 @@ impl<B: Block> Link<B> for WaitLink {
 	fn blocks_processed(
 		&mut self,
 		imported: usize,
-		count: usize,
+		_count: usize,
 		results: Vec<(Result<BlockImportResult<NumberFor<B>>, BlockImportError>, B::Hash)>
 	) {
 		self.imported_blocks += imported as u64;
-		if results.iter().any(|(r, _)| r.is_err()) {
-			warn!("There was an error importing {} blocks", count);
-			self.has_error = true;
+
+		for result in results {
+			if let (Err(err), hash) = result {
+				warn!("There was an error importing block with hash {:?}: {:?}", hash, err);
+				self.has_error = true;
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
cc @jimpo 

Calling `import_blocks` returns a `Future` that imports the blocks passed as parameter into the database. However, at the moment, if an error happens in the import queue, that `Future` will just wait forever and never stop. This PR fixes this.

Additionally, improves the error being displayed on error.