### PR TITLE
srml: babe: add expected block time and epoch duration constants

### DIFF
--- a/core/consensus/babe/primitives/src/lib.rs
+++ b/core/consensus/babe/primitives/src/lib.rs
@@ -104,7 +104,10 @@ pub struct BabeConfiguration {
 
 	/// A constant value that is used in the threshold calculation formula.
 	/// Expressed as a fraction where the first member of the tuple is the
-	/// numerator and the second is the denominator.
+	/// numerator and the second is the denominator. The fraction should
+	/// represent a value between 0 and 1.
+	/// In the threshold formula calculation, `1 - c` represents the probability
+	/// of a slot being empty.
 	pub c: (u64, u64),
 
 	/// The minimum number of blocks that must be received before running the

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -362,10 +362,12 @@ impl srml_timestamp::Trait for Runtime {
 
 parameter_types! {
 	pub const EpochDuration: u64 = 6;
+	pub const ExpectedBlockTime: Moment = 10_000;
 }
 
 impl srml_babe::Trait for Runtime {
 	type EpochDuration = EpochDuration;
+	type ExpectedBlockTime = ExpectedBlockTime;
 }
 
 /// Adds one to the given input and returns the final result.

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -362,7 +362,7 @@ impl srml_timestamp::Trait for Runtime {
 
 parameter_types! {
 	pub const EpochDuration: u64 = 6;
-	pub const ExpectedBlockTime: Moment = 10_000;
+	pub const ExpectedBlockTime: u64 = 10_000;
 }
 
 impl srml_babe::Trait for Runtime {

--- a/node/runtime/src/constants.rs
+++ b/node/runtime/src/constants.rs
@@ -34,7 +34,8 @@ pub mod time {
 	/// by `SLOT_DURATION`, but some slots will not be allocated to any
 	/// authority and hence no block will be produced. We expect to have this
 	/// block time on average following the defined slot duration and the value
-	/// of `c` configured for BABE.
+	/// of `c` configured for BABE (where `1 - c` represents the probability of
+	/// a slot being empty).
 	/// This value is only used indirectly to define the unit constants below
 	/// that are expressed in blocks. The rest of the code should use
 	/// `SLOT_DURATION` instead (like the timestamp module for calculating the

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -128,10 +128,12 @@ impl system::Trait for Runtime {
 
 parameter_types! {
 	pub const EpochDuration: u64 = EPOCH_DURATION_IN_SLOTS;
+	pub const ExpectedBlockTime: Moment = MILLISECS_PER_BLOCK;
 }
 
 impl babe::Trait for Runtime {
 	type EpochDuration = EpochDuration;
+	type ExpectedBlockTime = ExpectedBlockTime;
 }
 
 impl indices::Trait for Runtime {

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -519,9 +519,10 @@ impl_runtime_apis! {
 
 	impl babe_primitives::BabeApi<Block> for Runtime {
 		fn startup_data() -> babe_primitives::BabeConfiguration {
-			// The choice of `c` parameter is done in accordance to
-			// the slot duration and expected target block time, for
-			// safely resisting network delays of maximum two seconds.
+			// The choice of `c` parameter (where `1 - c` represents the
+			// probability of a slot being empty), is done in accordance to the
+			// slot duration and expected target block time, for safely
+			// resisting network delays of maximum two seconds.
 			// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
 			babe_primitives::BabeConfiguration {
 				median_required_blocks: 1000,

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 122,
+	spec_version: 123,
 	impl_version: 123,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -164,7 +164,8 @@ decl_module! {
 		/// The expected average block time at which BABE should be creating
 		/// blocks. Since BABE is probabilistic it is not trivial to figure out
 		/// what the expected average block time should be based on the slot
-		/// duration and the security parameter `c`.
+		/// duration and the security parameter `c` (where `1 - c` represents
+		/// the probability of a slot being empty).
 		const ExpectedBlockTime: T::Moment = T::ExpectedBlockTime::get();
 
 		/// Initialization

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -109,6 +109,7 @@ impl ProvideInherentData for InherentDataProvider {
 
 pub trait Trait: timestamp::Trait {
 	type EpochDuration: Get<u64>;
+	type ExpectedBlockTime: Get<Self::Moment>;
 }
 
 /// The length of the BABE randomness
@@ -156,6 +157,12 @@ decl_storage! {
 decl_module! {
 	/// The BABE SRML module
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		/// The expected average block time at which BABE should be creating
+		/// blocks. Since BABE is probabilistic it is not trivial to figure out
+		/// what the expected average block time should be based on the slot
+		/// duration and the security parameter `c`.
+		const ExpectedBlockTime: T::Moment = T::ExpectedBlockTime::get();
+
 		/// Initialization
 		fn on_initialize() {
 			for digest in Self::get_inherent_digests()

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -157,6 +157,10 @@ decl_storage! {
 decl_module! {
 	/// The BABE SRML module
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		/// The number of **slots** that an epoch takes. We couple sessions to
+		/// epochs, i.e. we start a new session once the new epoch begins.
+		const EpochDuration: u64 = T::EpochDuration::get();
+
 		/// The expected average block time at which BABE should be creating
 		/// blocks. Since BABE is probabilistic it is not trivial to figure out
 		/// what the expected average block time should be based on the slot


### PR DESCRIPTION
Since BABE is probabilistic it is not trivial to figure out what the expected average block time should be based on slot duration and the security parameter `c`. Still this is useful for the dashboard to be able to show what the expected block time is (and maybe compare it with what we're actually getting), so this PR adds a constant field with this value to the BABE runtime module.

Additionally I also exposed the `EpochDuration` field since it is needed for the dashboard to calculate progress in current session.

cc @jacogr
