### PR TITLE
babe: Disable unused median calculation

### DIFF
--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -19,7 +19,6 @@
 //! BABE (Blind Assignment for Blockchain Extension) consensus in Substrate.
 
 #![forbid(unsafe_code, missing_docs, unused_must_use, unused_imports, unused_variables)]
-#![cfg_attr(not(test), forbid(dead_code))]
 pub use babe_primitives::*;
 pub use consensus_common::SyncOracle;
 use consensus_common::ImportResult;
@@ -581,7 +580,7 @@ impl<C> BabeVerifier<C> {
 	}
 }
 
-#[allow(unused)]
+#[allow(dead_code)]
 fn median_algorithm(
 	median_required_blocks: u64,
 	slot_duration: u64,

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -706,15 +706,6 @@ impl<B: BlockT, C> Verifier<B> for BabeVerifier<C> where
 					fork_choice: ForkChoiceStrategy::LongestChain,
 				};
 
-				// FIXME: this should eventually be moved to BabeBlockImport
-				median_algorithm(
-					self.config.0.median_required_blocks,
-					self.config.get(),
-					slot_number,
-					slot_now,
-					&mut *self.time_source.0.lock(),
-				);
-
 				Ok((import_block, Default::default()))
 			}
 			CheckedHeader::Deferred(a, b) => {

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -581,6 +581,7 @@ impl<C> BabeVerifier<C> {
 	}
 }
 
+#[allow(unused)]
 fn median_algorithm(
 	median_required_blocks: u64,
 	slot_duration: u64,
@@ -612,8 +613,12 @@ fn median_algorithm(
 			.get(num_timestamps / 2)
 			.expect("we have at least one timestamp, so this is a valid index; qed");
 
+		let now = Instant::now();
+		if now >= median {
+			time_source.0.replace(now - median);
+		}
+
 		time_source.1.clear();
-		time_source.0.replace(Instant::now() - median);
 	} else {
 		time_source.1.push((Instant::now(), slot_now))
 	}

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 123,
-	impl_version: 124,
+	impl_version: 125,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
The median calculation that is done to figure out at what time the current slot should start (i.e. offset) is currently not properly implemented. Since it is currently unused I have removed the call from verify to it to avoid any issues. I have also fixed an issue that caused it to panic.

Fixes #3248.