### PR TITLE
srml-contracts: Refactor away some duplication in runtime functions.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 135,
-	impl_version: 135,
+	impl_version: 136,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -528,10 +528,10 @@ decl_module! {
 			code: Vec<u8>
 		) -> Result {
 			let origin = ensure_signed(origin)?;
-			let schedule = <Module<T>>::current_schedule();
 
 			let (mut gas_meter, imbalance) = gas::buy_gas::<T>(&origin, gas_limit)?;
 
+			let schedule = <Module<T>>::current_schedule();
 			let result = wasm::save_code::<T>(code, &mut gas_meter, &schedule);
 			if let Ok(code_hash) = result {
 				Self::deposit_event(RawEvent::CodeStored(code_hash));
@@ -812,10 +812,9 @@ decl_storage! {
 
 impl<T: Trait> OnFreeBalanceZero<T::AccountId> for Module<T> {
 	fn on_free_balance_zero(who: &T::AccountId) {
-		if let Some(ContractInfo::Alive(info)) = <ContractInfoOf<T>>::get(who) {
+		if let Some(ContractInfo::Alive(info)) = <ContractInfoOf<T>>::take(who) {
 			child::kill_storage(&info.trie_id);
 		}
-		<ContractInfoOf<T>>::remove(who);
 	}
 }
 


### PR DESCRIPTION
The access pattern of reading sandbox memory and decoding is used a lot and pretty ugly. This cleans that up.

Also, two tiny and likely inconsequential storage access tweaks.

Was reminded of this during review of #3255.