### PR TITLE
Setup the telemetry in substrate-cli instead of substrate-service

### DIFF
--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -188,6 +188,7 @@ fn node_config<F: ServiceFactory> (
 		rpc_ws: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,
+		telemetry_connected_report: None,
 		default_heap_pages: None,
 		offchain_worker: false,
 		force_authoring: false,

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -188,8 +188,6 @@ fn node_config<F: ServiceFactory> (
 		rpc_ws: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,
-		telemetry_endpoints: None,
-		telemetry_external_transport: None,
 		default_heap_pages: None,
 		offchain_worker: false,
 		force_authoring: false,

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -63,10 +63,6 @@ fn run_until_exit<T, C, E>(
 	let informant = informant::build(&service);
 	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
-	// we eagerly drop the service so that the internal exit future is fired,
-	// but we need to keep holding a reference to the global telemetry guard
-	let _telemetry = service.telemetry();
-
 	let _ = runtime.block_on(service.select(e.into_exit()));
 	exit_send.fire();
 

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -234,10 +234,6 @@ fn run_until_exit<T, C, E>(
 	let informant = cli::informant::build(&service);
 	runtime.executor().spawn(exit.until(informant).map(|_| ()));
 
-	// we eagerly drop the service so that the internal exit future is fired,
-	// but we need to keep holding a reference to the global telemetry guard
-	let _telemetry = service.telemetry();
-
 	let _ = runtime.block_on(service.select(e.into_exit()));
 	exit_send.fire();
 


### PR DESCRIPTION
The situation right now is:

- We create the `Service`, passing to it a list of telemetry endpoints.
- The `Service` initializes the telemetry, and creates a task that processes said telemetry. This also registers the telemetry as the `slog` global logger. The `Telemetry` object acts as an RAII guard for said registration, and is kept inside the `Service`.
- The node extracts a copy of the telemetry guard from the service and keeps it alive during the service's destruction, so that the logger doesn't get unregistered towards `slog`. If otherwise the telemetry is unregistered, we will get a panic if we send out a telemetry message, which can happen during the service cleanup.
- Then finally the node destroys the telemetry at the very end.

After this PR:

- We initialize the telemetry from `substrate-cli`, before creating the service. The telemetry processing happens in a background thread. You might say: "but Pierre, aren't you trying to remove background threads for your browser thingy". To which I answer: "we won't use substrate-cli from within the browser". Also, theoretically, we would process the telemetry task in the same executor as the service, but doing so requires refactoring half of the code of substrate-cli. This will be the subject of further refactoring.
- We pass to the service a `Receiver`. Whenever a message is sent to it, the service sends out a `"system.connected"` message. I wrote a big chunk of documentation about this `Receiver` in the `Configuration` struct if you want details.
- The `Telemetry` object is kept alive by the background thread in `substrate-cli`.

In details, this PR shuffles a bit the telemetry-related fields of `Configuration`, and removes the `Service::telemetry()` function.
