### PR TITLE
Make staking add_reward_points_to_validator public

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 123,
-	impl_version: 125,
+	impl_version: 126,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -1403,7 +1403,7 @@ impl<T: Trait> Module<T> {
 	///
 	/// At the end of the era each the total payout will be distributed among validator
 	/// relatively to their points.
-	fn add_reward_points_to_validator(validator: T::AccountId, points: u32) {
+	pub fn add_reward_points_to_validator(validator: T::AccountId, points: u32) {
 		<Module<T>>::current_elected().iter()
 			.position(|elected| *elected == validator)
 			.map(|index| {

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -594,7 +594,7 @@ decl_storage! {
 		pub CurrentEraStartSessionIndex get(current_era_start_session_index): SessionIndex;
 
 		/// Rewards for the current era. Using indices of current elected set.
-		pub CurrentEraRewards: EraRewards;
+		CurrentEraRewards get(current_era_reward): EraRewards;
 
 		/// The amount of balance actively at stake for each validator slot, currently.
 		///


### PR DESCRIPTION
This is needed for other module to be able to call it.

Also the storage is now private as it shouldn't be written by other module directly