### PR TITLE
Telemetry connectivity issues are now WARN

### DIFF
--- a/core/telemetry/src/worker/node.rs
+++ b/core/telemetry/src/worker/node.rs
@@ -112,12 +112,12 @@ where TTrans: Clone + Unpin, TTrans::Dial: Unpin,
 		let mut socket = mem::replace(&mut self.socket, NodeSocket::Poisoned);
 		self.socket = loop {
 			match socket {
-				NodeSocket::Connected(mut conn) => 
+				NodeSocket::Connected(mut conn) =>
 					match NodeSocketConnected::poll(Pin::new(&mut conn), cx, &self.addr) {
 						Poll::Ready(Ok(v)) => match v {}
 						Poll::Pending => break NodeSocket::Connected(conn),
 						Poll::Ready(Err(err)) => {
-							debug!(target: "telemetry", "Disconnected from {}: {:?}", self.addr, err);
+							warn!(target: "telemetry", "Disconnected from {}: {:?}", self.addr, err);
 							let timeout = gen_rand_reconnect_delay();
 							self.socket = NodeSocket::WaitingReconnect(timeout);
 							return Poll::Ready(NodeEvent::Disconnected(err))
@@ -132,7 +132,7 @@ where TTrans: Clone + Unpin, TTrans::Dial: Unpin,
 					},
 					Poll::Pending => break NodeSocket::Dialing(s),
 					Poll::Ready(Err(err)) => {
-						debug!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
+						warn!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
 						let timeout = gen_rand_reconnect_delay();
 						socket = NodeSocket::WaitingReconnect(timeout);
 					}
@@ -143,7 +143,7 @@ where TTrans: Clone + Unpin, TTrans::Dial: Unpin,
 						socket = NodeSocket::Dialing(d.compat());
 					}
 					Err(err) => {
-						debug!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
+						warn!(target: "telemetry", "Error while dialing {}: {:?}", self.addr, err);
 						let timeout = gen_rand_reconnect_delay();
 						socket = NodeSocket::WaitingReconnect(timeout);
 					}


### PR DESCRIPTION
Change issues with connecting to a telemetry server from `DEBUG` to `WARN`.

Drawback: if we're offline, we'll get spammed with warnings about failing to reach the telemetry server. There's a delay of 5 to 10 seconds between two connection attempts, so it should be fine.