### PR TITLE
Bump schnorrkel to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4136,7 +4136,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "srml-balances 2.0.0",
  "srml-system 2.0.0",
@@ -4179,7 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4332,7 +4332,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-version 2.0.0",
@@ -4358,7 +4358,7 @@ name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
 dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
  "substrate-client 2.0.0",
@@ -4661,7 +4661,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
@@ -6239,7 +6239,7 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
-"checksum schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8dbbd10b71915a60017e5bb3accdbe4664ca1c52f5ff37fa94ea44f26819d72e"
+"checksum schnorrkel 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "547d3603273bf9e4086966bbf431a2335bafcc6c6ddff9755889c08b38c1c951"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f5adf8fbd58e1b1b52699dc8bed2630faecb6d8c7bee77d009d6bbe4af569b9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4136,7 +4136,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "srml-balances 2.0.0",
  "srml-system 2.0.0",
@@ -4179,7 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4332,7 +4332,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-version 2.0.0",
@@ -4358,7 +4358,7 @@ name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
 dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
  "substrate-client 2.0.0",
@@ -4661,7 +4661,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
@@ -6239,7 +6239,7 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
-"checksum schnorrkel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf8bb3d2b309218262456dd161b24456e977120f572e5ec5c6686dddad467e2"
+"checksum schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cd67bd20c59764fa16413abe3bc7278659d2877c8ec007e58e8fd35ebda44730"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f5adf8fbd58e1b1b52699dc8bed2630faecb6d8c7bee77d009d6bbe4af569b9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4136,7 +4136,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "srml-balances 2.0.0",
  "srml-system 2.0.0",
@@ -4179,7 +4179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4332,7 +4332,7 @@ dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-version 2.0.0",
@@ -4358,7 +4358,7 @@ name = "substrate-consensus-babe-primitives"
 version = "2.0.0"
 dependencies = [
  "parity-codec 4.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
  "substrate-client 2.0.0",
@@ -4661,7 +4661,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
@@ -6239,7 +6239,7 @@ dependencies = [
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
-"checksum schnorrkel 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cd67bd20c59764fa16413abe3bc7278659d2877c8ec007e58e8fd35ebda44730"
+"checksum schnorrkel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8dbbd10b71915a60017e5bb3accdbe4664ca1c52f5ff37fa94ea44f26819d72e"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f5adf8fbd58e1b1b52699dc8bed2630faecb6d8c7bee77d009d6bbe4af569b9"

--- a/core/consensus/babe/Cargo.toml
+++ b/core/consensus/babe/Cargo.toml
@@ -28,7 +28,7 @@ futures01 = { package = "futures", version = "0.1" }
 futures-timer = "0.2.1"
 parking_lot = "0.8.0"
 log = "0.4.6"
-schnorrkel = "0.8.0"
+schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"] }
 rand = "0.6.5"
 merlin = "1.0.3"
 

--- a/core/consensus/babe/Cargo.toml
+++ b/core/consensus/babe/Cargo.toml
@@ -28,7 +28,7 @@ futures01 = { package = "futures", version = "0.1" }
 futures-timer = "0.2.1"
 parking_lot = "0.8.0"
 log = "0.4.6"
-schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.8.3", features = ["preaudit_deprecated"] }
 rand = "0.6.5"
 merlin = "1.0.3"
 

--- a/core/consensus/babe/Cargo.toml
+++ b/core/consensus/babe/Cargo.toml
@@ -28,7 +28,7 @@ futures01 = { package = "futures", version = "0.1" }
 futures-timer = "0.2.1"
 parking_lot = "0.8.0"
 log = "0.4.6"
-schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"] }
 rand = "0.6.5"
 merlin = "1.0.3"
 

--- a/core/consensus/babe/primitives/Cargo.toml
+++ b/core/consensus/babe/primitives/Cargo.toml
@@ -12,7 +12,7 @@ sr-primitives = {  path = "../../../sr-primitives", default-features = false }
 primitives = { package = "substrate-primitives",  path = "../../../primitives", default-features = false }
 slots = { package = "substrate-consensus-slots", path = "../../slots", optional = true }
 parity-codec = { version = "4.1.1", default-features = false }
-schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"], optional = true }
 
 [features]
 default = ["std"]

--- a/core/consensus/babe/primitives/Cargo.toml
+++ b/core/consensus/babe/primitives/Cargo.toml
@@ -12,7 +12,7 @@ sr-primitives = {  path = "../../../sr-primitives", default-features = false }
 primitives = { package = "substrate-primitives",  path = "../../../primitives", default-features = false }
 slots = { package = "substrate-consensus-slots", path = "../../slots", optional = true }
 parity-codec = { version = "4.1.1", default-features = false }
-schnorrkel = { version = "0.8.0", optional = true }
+schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"], optional = true }
 
 [features]
 default = ["std"]

--- a/core/consensus/babe/primitives/Cargo.toml
+++ b/core/consensus/babe/primitives/Cargo.toml
@@ -12,7 +12,7 @@ sr-primitives = {  path = "../../../sr-primitives", default-features = false }
 primitives = { package = "substrate-primitives",  path = "../../../primitives", default-features = false }
 slots = { package = "substrate-consensus-slots", path = "../../slots", optional = true }
 parity-codec = { version = "4.1.1", default-features = false }
-schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.8.3", features = ["preaudit_deprecated"], optional = true }
 
 [features]
 default = ["std"]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -19,7 +19,7 @@ hash256-std-hasher = { version = "0.14.0", default-features = false }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 base58 = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2.18", optional = true }
-schnorrkel = { version = "0.8.0", optional = true }
+schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"], optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
 substrate-bip39 = { version = "0.3.1", optional = true }

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -19,7 +19,7 @@ hash256-std-hasher = { version = "0.14.0", default-features = false }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 base58 = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2.18", optional = true }
-schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"], optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
 substrate-bip39 = { version = "0.3.1", optional = true }

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -19,7 +19,7 @@ hash256-std-hasher = { version = "0.14.0", default-features = false }
 ed25519-dalek = { version = "1.0.0-pre.1", optional = true }
 base58 = { version = "0.1", optional = true }
 blake2-rfc = { version = "0.2.18", optional = true }
-schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.8.3", features = ["preaudit_deprecated"], optional = true }
 rand = { version = "0.6", optional = true }
 sha2 = { version = "0.8", optional = true }
 substrate-bip39 = { version = "0.3.1", optional = true }

--- a/core/primitives/src/sr25519.rs
+++ b/core/primitives/src/sr25519.rs
@@ -417,7 +417,7 @@ impl TraitPair for Pair {
 				Ok(Pair(
 					MiniSecretKey::from_bytes(seed)
 						.map_err(|_| SecretStringError::InvalidSeed)?
-						.expand_to_keypair(ExpansionMode::ExpansionMode)
+						.expand_to_keypair(ExpansionMode::Ed25519)
 				))
 			}
 			SECRET_KEY_LENGTH => {
@@ -513,7 +513,7 @@ impl Pair {
 		let mini_key: MiniSecretKey = mini_secret_from_entropy(entropy, password.unwrap_or(""))
 			.expect("32 bytes can always build a key; qed");
 
-		let kp = mini_key.expand_ed25519_to_keypair();
+		let kp = mini_key.expand_to_keypair(ExpansionMode::Ed25519);
 		(Pair(kp), mini_key.to_bytes())
 	}
 }

--- a/core/primitives/src/sr25519.rs
+++ b/core/primitives/src/sr25519.rs
@@ -615,33 +615,13 @@ mod test {
 
 	#[test]
 	fn derive_soft_known_pair_should_work() {
-		let path = Some(DeriveJunction::soft(hex!(
-			"0c666f6f00000000000000000000000000000000000000000000000000000000"
-		)));
-		let pair = Pair::from_seed(&hex!(
-			"9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"
-		));
-		let expected = hex!("40b9675df90efa6069ff623b0fdfcf706cd47ca7452a5056c7ad58194d23440a");
-		assert_eq!(pair.derive(path.into_iter()).unwrap().public().to_raw_vec(), expected);
-	}
-
-	#[test]
-	fn derive_soft_known_public_should_work() {
-		let path = Some(DeriveJunction::hard(hex!(
-			"0c666f6f00000000000000000000000000000000000000000000000000000000"
-		)));
-		let public = Public::from_raw(hex!(
-			"46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a"
-		));
-		let expected = hex!("40b9675df90efa6069ff623b0fdfcf706cd47ca7452a5056c7ad58194d23440a");
-		assert_eq!(public.derive(path.into_iter()).unwrap().to_raw_vec(), expected);
+		let pair = Pair::from_string(&format!("{}/Alice", DEV_PHRASE), None).unwrap();
+		let expected = hex!("d6c71059dbbe9ad2b0ed3f289738b800836eb425544ce694825285b958ca755e");
+		assert_eq!(pair.public().to_raw_vec(), expected);
 	}
 
 	#[test]
 	fn derive_hard_known_pair_should_work() {
-		// let path = Some(DeriveJunction::hard(hex!(
-		// 	"14416c6963650000000000000000000000000000000000000000000000000000"
-		// )));
 		let pair = Pair::from_string(&format!("{}//Alice", DEV_PHRASE), None).unwrap();
 		let expected = hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d");
 		assert_eq!(pair.public().to_raw_vec(), expected);

--- a/core/primitives/src/sr25519.rs
+++ b/core/primitives/src/sr25519.rs
@@ -481,8 +481,9 @@ impl TraitPair for Pair {
 			Err(_) => return false
 		};
 		match PublicKey::from_bytes(pubkey.as_ref().as_slice()) {
-			Ok(pk) => pk.verify(
-				signing_context(SIGNING_CTX).bytes(message.as_ref()),
+			Ok(pk) => pk.verify_simple(
+				SIGNING_CTX,
+				message.as_ref(),
 				&signature,
 			).is_ok(),
 			Err(_) => false,
@@ -496,8 +497,9 @@ impl TraitPair for Pair {
 			Err(_) => return false
 		};
 		match PublicKey::from_bytes(pubkey.as_ref()) {
-			Ok(pk) => pk.verify(
-				signing_context(SIGNING_CTX).bytes(message.as_ref()),
+			Ok(pk) => pk.verify_simple(
+				SIGNING_CTX,
+				message.as_ref(),
 				&signature,
 			).is_ok(),
 			Err(_) => false,
@@ -638,6 +640,19 @@ mod test {
 	}
 
 	#[test]
+	fn verify_known_message_should_work() {
+		let public = Public::from_raw(hex!(
+			"b4bfa1f7a5166695eb75299fd1c4c03ea212871c342f2c5dfea0902b2c246918"
+		));
+		let signature = Signature::from_raw(hex!(
+			"5a9755f069939f45d96aaf125cf5ce7ba1db998686f87f2fb3cbdea922078741a73891ba265f70c31436e18a9acd14d189d73c12317ab6c313285cd938453202"
+		));
+		let message = b"Verifying that I am the owner of 5G9hQLdsKQswNPgB499DeA5PkFBbgkLPJWkkS6FAM6xGQ8xD. Hash: 221455a3\n";
+
+		assert!(Pair::verify(&signature, &message[..], &public));
+	}
+
+	#[test]
 	fn generated_pair_should_work() {
 		let (pair, _) = Pair::generate();
 		let public = pair.public();
@@ -648,7 +663,6 @@ mod test {
 
 	#[test]
 	fn seeded_pair_should_work() {
-
 		let pair = Pair::from_seed(b"12345678901234567890123456789012");
 		let public = pair.public();
 		assert_eq!(

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
 substrate-bip39 = "0.3.1"
-schnorrkel = "0.8.0"
+schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"] }
 hex = "0.3"
 hex-literal = "0.2"
 parity-codec = "4.1.1"

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
 substrate-bip39 = "0.3.1"
-schnorrkel = { version = "0.8.1", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"] }
 hex = "0.3"
 hex-literal = "0.2"
 parity-codec = "4.1.1"

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
 substrate-bip39 = "0.3.1"
-schnorrkel = { version = "0.8.2", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.8.3", features = ["preaudit_deprecated"] }
 hex = "0.3"
 hex-literal = "0.2"
 parity-codec = "4.1.1"

--- a/subkey/Cargo.toml
+++ b/subkey/Cargo.toml
@@ -14,7 +14,6 @@ clap = { version = "~2.32", features = ["yaml"] }
 tiny-bip39 = "0.6.0"
 rustc-hex = "2.0"
 substrate-bip39 = "0.3.1"
-schnorrkel = { version = "0.8.3", features = ["preaudit_deprecated"] }
 hex = "0.3"
 hex-literal = "0.2"
 parity-codec = "4.1.1"


### PR DESCRIPTION
@bkchr This is intended to merge into your upgrade branch.

- allows for verification of 0.1.1 and 0.8.x signatures
- aligns derivation with 0.1.1
- aligns expansion of pairs with 0.1.1
