### PR TITLE
Fix staking

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 125,
+	spec_version: 126,
 	impl_version: 126,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -1202,7 +1202,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	fn slashable_balance_of(stash: &T::AccountId) -> BalanceOf<T> {
-		Self::bonded(stash).and_then(Self::ledger).map(|l| l.total).unwrap_or_default()
+		Self::bonded(stash).and_then(Self::ledger).map(|l| l.active).unwrap_or_default()
 	}
 
 	/// Select a new validator set from the assembled stakers and their role preferences.

--- a/srml/staking/src/phragmen.rs
+++ b/srml/staking/src/phragmen.rs
@@ -90,7 +90,7 @@ pub fn elect<T: Trait + 'static, FV, FN, FS>(
 	minimum_validator_count: usize,
 	validator_iter: FV,
 	nominator_iter: FN,
-	stash_of: FS,
+	slashable_balance_of: FS,
 ) -> Option<(Vec<T::AccountId>, Vec<(T::AccountId, Vec<RawAssignment<T>>)>)> where
 	FV: Iterator<Item=(T::AccountId, ValidatorPrefs<BalanceOf<T>>)>,
 	FN: Iterator<Item=(T::AccountId, Vec<T::AccountId>)>,
@@ -108,7 +108,7 @@ pub fn elect<T: Trait + 'static, FV, FN, FS>(
 	let mut nominators: Vec<Nominator<T::AccountId>> =
 		Vec::with_capacity(validator_iter.size_hint().0 + nominator_iter.size_hint().0);
 	let mut candidates = validator_iter.map(|(who, _)| {
-		let stash_balance = stash_of(&who);
+		let stash_balance = slashable_balance_of(&who);
 		(Candidate { who, ..Default::default() }, stash_balance)
 	})
 	.filter_map(|(mut c, s)| {
@@ -135,7 +135,7 @@ pub fn elect<T: Trait + 'static, FV, FN, FS>(
 	// 2- Collect the nominators with the associated votes.
 	// Also collect approval stake along the way.
 	nominators.extend(nominator_iter.map(|(who, nominees)| {
-		let nominator_stake = stash_of(&who);
+		let nominator_stake = slashable_balance_of(&who);
 		let mut edges: Vec<Edge<T::AccountId>> = Vec::with_capacity(nominees.len());
 		for n in &nominees {
 			if let Some(idx) = c_idx_cache.get(n) {

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -2100,3 +2100,16 @@ fn reward_from_authorship_event_handler_works() {
 		assert_eq!(CurrentEraRewards::get().total, 25);
 	})
 }
+
+#[test]
+fn unbonded_balance_is_not_slashable() {
+	with_externalities(&mut ExtBuilder::default().build(), || {
+		// total amount staked is slashable.
+		assert_eq!(Staking::slashable_balance_of(&11), 1000);
+
+		assert_ok!(Staking::unbond(Origin::signed(10),  800));
+
+		// only the active portion.
+		assert_eq!(Staking::slashable_balance_of(&11), 200);
+	})
+}


### PR DESCRIPTION
`total` (which includes the amounts that are being unstaked) is wrong when evaluating stakes of validators/nominators for Phragmen. Rather should be `active`.