### PR TITLE
node: use BABE predigest data to find authorship

### DIFF
--- a/core/consensus/babe/primitives/src/lib.rs
+++ b/core/consensus/babe/primitives/src/lib.rs
@@ -53,7 +53,7 @@ pub const VRF_PROOF_LENGTH: usize = 64;
 pub const PUBLIC_KEY_LENGTH: usize = 32;
 
 /// The index of an authority.
-pub type AuthorityIndex = u64;
+pub type AuthorityIndex = u32;
 
 /// A slot number.
 pub type SlotNumber = u64;

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -321,7 +321,7 @@ impl<Hash, H, B, C, E, I, Error, SO> SlotWorker<B> for BabeWorker<C, E, I, SO> w
 			let inherent_digest = BabePreDigest {
 				vrf_proof,
 				vrf_output: inout.to_output(),
-				authority_index: authority_index as u64,
+				authority_index: authority_index as u32,
 				slot_number,
 			};
 
@@ -491,7 +491,7 @@ fn check_header<B: BlockT + Sized, C: AuxStore>(
 	if slot_number > slot_now {
 		header.digest_mut().push(seal);
 		Ok(CheckedHeader::Deferred(header, slot_number))
-	} else if authority_index > authorities.len() as u64 {
+	} else if authority_index > authorities.len() as u32 {
 		Err(babe_err!("Slot author not found"))
 	} else {
 		let (pre_hash, author) = (header.hash(), &authorities[authority_index as usize].0);
@@ -1219,7 +1219,7 @@ pub mod test_helpers {
 			BabePreDigest {
 				vrf_proof,
 				vrf_output: inout.to_output(),
-				authority_index: authority_index as u64,
+				authority_index: authority_index as u32,
 				slot_number,
 			}
 		})

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,8 +79,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 126,
-	impl_version: 126,
+	spec_version: 127,
+	impl_version: 127,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -180,9 +180,8 @@ parameter_types! {
 	pub const UncleGenerations: u64 = 0;
 }
 
-// TODO: #2986 implement this properly
 impl authorship::Trait for Runtime {
-	type FindAuthor = ();
+	type FindAuthor = session::FindAccountFromAuthorIndex<Self, Babe>;
 	type UncleGenerations = UncleGenerations;
 	type FilterUncle = ();
 	type EventHandler = Staking;

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -202,8 +202,8 @@ impl<T: Trait> RandomnessBeacon for Module<T> {
 /// A BABE public key
 pub type BabeKey = [u8; PUBLIC_KEY_LENGTH];
 
-impl<T: Trait> FindAuthor<u64> for Module<T> {
-	fn find_author<'a, I>(digests: I) -> Option<u64> where
+impl<T: Trait> FindAuthor<u32> for Module<T> {
+	fn find_author<'a, I>(digests: I) -> Option<u32> where
 		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
 	{
 		for (id, mut data) in digests.into_iter() {
@@ -341,7 +341,7 @@ impl<T: Trait + staking::Trait> session::OneSessionHandler<T::AccountId> for Mod
 	}
 
 	fn on_disabled(i: usize) {
-		Self::deposit_consensus(ConsensusLog::OnDisabled(i as u64))
+		Self::deposit_consensus(ConsensusLog::OnDisabled(i as u32))
 	}
 }
 

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -544,7 +544,7 @@ impl<T: Trait> OnFreeBalanceZero<T::ValidatorId> for Module<T> {
 /// registering account-ID of that session key index.
 pub struct FindAccountFromAuthorIndex<T, Inner>(rstd::marker::PhantomData<(T, Inner)>);
 
-impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::ValidatorId>
+impl<T: Trait, Inner: FindAuthor<u64>> FindAuthor<T::ValidatorId>
 	for FindAccountFromAuthorIndex<T, Inner>
 {
 	fn find_author<'a, I>(digests: I) -> Option<T::ValidatorId>

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -544,7 +544,7 @@ impl<T: Trait> OnFreeBalanceZero<T::ValidatorId> for Module<T> {
 /// registering account-ID of that session key index.
 pub struct FindAccountFromAuthorIndex<T, Inner>(rstd::marker::PhantomData<(T, Inner)>);
 
-impl<T: Trait, Inner: FindAuthor<u64>> FindAuthor<T::ValidatorId>
+impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::ValidatorId>
 	for FindAccountFromAuthorIndex<T, Inner>
 {
 	fn find_author<'a, I>(digests: I) -> Option<T::ValidatorId>


### PR DESCRIPTION
We already had all the infrastructure in place to collect authorship data from BABE predigests but it wasn't wired in on the node runtime.

Fixes #2986.