### PR TITLE
Rename on_demand to light_dispatch and various minor changes

### DIFF
--- a/core/network/src/on_demand_layer.rs
+++ b/core/network/src/on_demand_layer.rs
@@ -16,7 +16,7 @@
 
 //! On-demand requests service.
 
-use crate::protocol::on_demand::RequestData;
+use crate::protocol::light_server::RequestData;
 use std::sync::Arc;
 use futures::{prelude::*, sync::mpsc, sync::oneshot};
 use futures03::compat::{Compat01As03, Future01CompatExt as _};

--- a/core/network/src/on_demand_layer.rs
+++ b/core/network/src/on_demand_layer.rs
@@ -16,7 +16,7 @@
 
 //! On-demand requests service.
 
-use crate::protocol::light_server::RequestData;
+use crate::protocol::light_dispatch::RequestData;
 use std::sync::Arc;
 use futures::{prelude::*, sync::mpsc, sync::oneshot};
 use futures03::compat::{Compat01As03, Future01CompatExt as _};

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -1053,7 +1053,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				peer.known_blocks.insert(hash.clone());
 			}
 		}
-		self.light_server.on_block_announce(LightServerIn {
+		self.light_server.update_best_number(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who.clone(), *header.number());

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -34,7 +34,7 @@ use message::{BlockAttributes, Direction, FromBlock, Message, RequestId};
 use message::generic::{Message as GenericMessage, ConsensusMessage};
 use event::Event;
 use consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
-use on_demand::{OnDemandCore, OnDemandNetwork, RequestData};
+use light_server::{LightServer, LightServerNetwork, RequestData};
 use specialization::NetworkSpecialization;
 use sync::{ChainSync, SyncState};
 use crate::service::{TransactionPool, ExHashT};
@@ -53,7 +53,7 @@ mod util;
 pub mod consensus_gossip;
 pub mod message;
 pub mod event;
-pub mod on_demand;
+pub mod light_server;
 pub mod specialization;
 pub mod sync;
 
@@ -96,8 +96,8 @@ pub struct Protocol<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> {
 	/// Interval at which we call `propagate_extrinsics`.
 	propagate_timeout: Box<dyn Stream<Item = (), Error = ()> + Send>,
 	config: ProtocolConfig,
-	/// Handler for on-demand requests.
-	on_demand_core: OnDemandCore<B>,
+	/// Handler for light client requests.
+	light_server: LightServer<B>,
 	genesis_hash: B::Hash,
 	sync: ChainSync<B>,
 	specialization: S,
@@ -149,12 +149,12 @@ pub struct PeerInfo<B: BlockT> {
 	pub best_number: <B::Header as HeaderT>::Number,
 }
 
-struct OnDemandIn<'a, B: BlockT> {
+struct LightServerIn<'a, B: BlockT> {
 	behaviour: &'a mut CustomProto<B, Substream<StreamMuxerBox>>,
 	peerset: peerset::PeersetHandle,
 }
 
-impl<'a, B: BlockT> OnDemandNetwork<B> for OnDemandIn<'a, B> {
+impl<'a, B: BlockT> LightServerNetwork<B> for LightServerIn<'a, B> {
 	fn report_peer(&mut self, who: &PeerId, reputation: i32) {
 		self.peerset.report_peer(who.clone(), reputation)
 	}
@@ -373,7 +373,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				peers: HashMap::new(),
 				chain,
 			},
-			on_demand_core: OnDemandCore::new(checker),
+			light_server: LightServer::new(checker),
 			genesis_hash: info.chain.genesis_hash,
 			sync,
 			specialization: specialization,
@@ -445,15 +445,15 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 	/// Starts a new data demand request.
 	///
 	/// The parameter contains a `Sender` where the result, once received, must be sent.
-	pub(crate) fn add_on_demand_request(&mut self, rq: RequestData<B>) {
-		self.on_demand_core.add_request(OnDemandIn {
+	pub(crate) fn add_light_client_request(&mut self, rq: RequestData<B>) {
+		self.light_server.add_request(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, rq);
 	}
 
-	fn is_on_demand_response(&self, who: &PeerId, response_id: message::RequestId) -> bool {
-		self.on_demand_core.is_on_demand_response(&who, response_id)
+	fn is_light_rq_response(&self, who: &PeerId, response_id: message::RequestId) -> bool {
+		self.light_server.is_light_rq_response(&who, response_id)
 	}
 
 	fn handle_response(
@@ -506,7 +506,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			GenericMessage::BlockRequest(r) => self.on_block_request(who, r),
 			GenericMessage::BlockResponse(r) => {
 				// Note, this is safe because only `ordinary bodies` and `remote bodies` are received in this matter.
-				if self.is_on_demand_response(&who, r.id) {
+				if self.is_light_rq_response(&who, r.id) {
 					self.on_remote_body_response(who, r);
 				} else {
 					if let Some(request) = self.handle_response(who.clone(), &r) {
@@ -629,7 +629,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			}
 			self.sync.peer_disconnected(peer.clone());
 			self.specialization.on_disconnect(&mut context, peer.clone());
-			self.on_demand_core.on_disconnect(OnDemandIn {
+			self.light_server.on_disconnect(LightServerIn {
 				behaviour: &mut self.behaviour,
 				peerset: self.peerset_handle.clone(),
 			}, peer);
@@ -793,7 +793,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			&mut ProtocolContext::new(&mut self.context_data, &mut self.behaviour, &self.peerset_handle)
 		);
 		self.maintain_peers();
-		self.on_demand_core.maintain_peers(OnDemandIn {
+		self.light_server.maintain_peers(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		});
@@ -914,7 +914,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		};
 
 		let info = self.context_data.peers.get(&who).expect("We just inserted above; QED").info.clone();
-		self.on_demand_core.on_connect(OnDemandIn {
+		self.light_server.on_connect(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who.clone(), status.roles, status.best_number);
@@ -1053,7 +1053,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				peer.known_blocks.insert(hash.clone());
 			}
 		}
-		self.on_demand_core.on_block_announce(OnDemandIn {
+		self.light_server.on_block_announce(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who.clone(), *header.number());
@@ -1253,7 +1253,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		response: message::RemoteCallResponse
 	) {
 		trace!(target: "sync", "Remote call response {} from {}", response.id, who);
-		self.on_demand_core.on_remote_call_response(OnDemandIn {
+		self.light_server.on_remote_call_response(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who, response);
@@ -1294,7 +1294,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		response: message::RemoteReadResponse
 	) {
 		trace!(target: "sync", "Remote read response {} from {}", response.id, who);
-		self.on_demand_core.on_remote_read_response(OnDemandIn {
+		self.light_server.on_remote_read_response(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who, response);
@@ -1335,7 +1335,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		response: message::RemoteHeaderResponse<B::Header>,
 	) {
 		trace!(target: "sync", "Remote header proof response {} from {}", response.id, who);
-		self.on_demand_core.on_remote_header_response(OnDemandIn {
+		self.light_server.on_remote_header_response(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who, response);
@@ -1401,7 +1401,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			who,
 			response.max
 		);
-		self.on_demand_core.on_remote_changes_response(OnDemandIn {
+		self.light_server.on_remote_changes_response(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, who, response);
@@ -1462,7 +1462,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		peer: PeerId,
 		response: message::BlockResponse<B>
 	) {
-		self.on_demand_core.on_remote_body_response(OnDemandIn {
+		self.light_server.on_remote_body_response(LightServerIn {
 			behaviour: &mut self.behaviour,
 			peerset: self.peerset_handle.clone(),
 		}, peer, response);

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -452,8 +452,8 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		}, rq);
 	}
 
-	fn is_light_rq_response(&self, who: &PeerId, response_id: message::RequestId) -> bool {
-		self.light_dispatch.is_light_rq_response(&who, response_id)
+	fn is_light_response(&self, who: &PeerId, response_id: message::RequestId) -> bool {
+		self.light_dispatch.is_light_response(&who, response_id)
 	}
 
 	fn handle_response(
@@ -506,7 +506,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			GenericMessage::BlockRequest(r) => self.on_block_request(who, r),
 			GenericMessage::BlockResponse(r) => {
 				// Note, this is safe because only `ordinary bodies` and `remote bodies` are received in this matter.
-				if self.is_light_rq_response(&who, r.id) {
+				if self.is_light_response(&who, r.id) {
 					self.on_remote_body_response(who, r);
 				} else {
 					if let Some(request) = self.handle_response(who.clone(), &r) {

--- a/core/network/src/protocol/light_dispatch.rs
+++ b/core/network/src/protocol/light_dispatch.rs
@@ -489,7 +489,7 @@ impl<B: BlockT> LightDispatch<B> where
 		})
 	}
 
-	pub fn is_light_rq_response(&self, peer: &PeerId, request_id: message::RequestId) -> bool {
+	pub fn is_light_response(&self, peer: &PeerId, request_id: message::RequestId) -> bool {
 		self.active_peers.get(&peer).map_or(false, |r| r.id == request_id)
 	}
 

--- a/core/network/src/protocol/light_server.rs
+++ b/core/network/src/protocol/light_server.rs
@@ -298,6 +298,7 @@ impl<B: BlockT> LightServer<B> where
 		self.dispatch(network);
 	}
 
+	/// Call this when we connect to a node on the network.
 	pub fn on_connect(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -321,11 +322,13 @@ impl<B: BlockT> LightServer<B> where
 		self.dispatch(network);
 	}
 
+	/// Call this when we disconnect from a node.
 	pub fn on_disconnect(&mut self, network: impl LightServerNetwork<B>, peer: PeerId) {
 		self.remove_peer(peer);
 		self.dispatch(network);
 	}
 
+	/// Must be called periodically in order to perform maintenance.
 	pub fn maintain_peers(&mut self, mut network: impl LightServerNetwork<B>) {
 		let now = Instant::now();
 
@@ -344,6 +347,7 @@ impl<B: BlockT> LightServer<B> where
 		self.dispatch(network);
 	}
 
+	/// Handles a remote header response message from on the network.
 	pub fn on_remote_header_response(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -367,6 +371,7 @@ impl<B: BlockT> LightServer<B> where
 		})
 	}
 
+	/// Handles a remote read response message from on the network.
 	pub fn on_remote_read_response(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -402,6 +407,7 @@ impl<B: BlockT> LightServer<B> where
 		})
 	}
 
+	/// Handles a remote call response message from on the network.
 	pub fn on_remote_call_response(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -421,6 +427,7 @@ impl<B: BlockT> LightServer<B> where
 		})
 	}
 
+	/// Handles a remote changes response message from on the network.
 	pub fn on_remote_changes_response(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -446,6 +453,7 @@ impl<B: BlockT> LightServer<B> where
 		})
 	}
 
+	/// Handles a remote body response message from on the network.
 	pub fn on_remote_body_response(
 		&mut self,
 		network: impl LightServerNetwork<B>,
@@ -498,7 +506,10 @@ impl<B: BlockT> LightServer<B> where
 		}
 	}
 
-	pub fn remove_peer(&mut self, peer: PeerId) {
+	/// Removes a peer from the list of known peers.
+	///
+	/// Puts back the active request that this node was performing into `pending_requests`.
+	fn remove_peer(&mut self, peer: PeerId) {
 		self.best_blocks.remove(&peer);
 
 		if let Some(request) = self.active_peers.remove(&peer) {
@@ -566,6 +577,8 @@ impl<B: BlockT> LightServer<B> where
 }
 
 impl<Block: BlockT> Request<Block> {
+	/// Returns the block that the remote needs to have in order to be able to fulfill
+	/// this request.
 	fn required_block(&self) -> NumberFor<Block> {
 		match self.data {
 			RequestData::RemoteHeader(ref data, _) => data.block,

--- a/core/network/src/protocol/light_server.rs
+++ b/core/network/src/protocol/light_server.rs
@@ -315,7 +315,8 @@ impl<B: BlockT> LightServer<B> where
 		self.dispatch(network);
 	}
 
-	pub fn on_block_announce(&mut self, network: impl LightServerNetwork<B>, peer: PeerId, best_number: NumberFor<B>) {
+	/// Sets the best seen block for the given node.
+	pub fn update_best_number(&mut self, network: impl LightServerNetwork<B>, peer: PeerId, best_number: NumberFor<B>) {
 		self.best_blocks.insert(peer, best_number);
 		self.dispatch(network);
 	}
@@ -1092,12 +1093,12 @@ pub mod tests {
 		assert_eq!(vec![peer1.clone(), peer2.clone()], light_server.idle_peers.iter().cloned().collect::<Vec<_>>());
 		assert_eq!(light_server.pending_requests.len(), 3);
 
-		light_server.on_block_announce(&mut network_interface, peer1.clone(), 250);
+		light_server.update_best_number(&mut network_interface, peer1.clone(), 250);
 
 		assert_eq!(vec![peer2.clone()], light_server.idle_peers.iter().cloned().collect::<Vec<_>>());
 		assert_eq!(light_server.pending_requests.len(), 2);
 
-		light_server.on_block_announce(&mut network_interface, peer2.clone(), 250);
+		light_server.update_best_number(&mut network_interface, peer2.clone(), 250);
 
 		assert!(!light_server.idle_peers.iter().any(|_| true));
 		assert_eq!(light_server.pending_requests.len(), 1);

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -47,7 +47,7 @@ use crate::config::{Params, TransportConfig};
 use crate::error::Error;
 use crate::protocol::{self, Protocol, Context, CustomMessageOutcome, PeerInfo};
 use crate::protocol::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
-use crate::protocol::{event::Event, light_server::{AlwaysBadChecker, RequestData}};
+use crate::protocol::{event::Event, light_dispatch::{AlwaysBadChecker, RequestData}};
 use crate::protocol::specialization::NetworkSpecialization;
 use crate::protocol::sync::SyncState;
 

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -47,7 +47,7 @@ use crate::config::{Params, TransportConfig};
 use crate::error::Error;
 use crate::protocol::{self, Protocol, Context, CustomMessageOutcome, PeerInfo};
 use crate::protocol::consensus_gossip::{ConsensusGossip, MessageRecipient as GossipMessageRecipient};
-use crate::protocol::{event::Event, on_demand::{AlwaysBadChecker, RequestData}};
+use crate::protocol::{event::Event, light_server::{AlwaysBadChecker, RequestData}};
 use crate::protocol::specialization::NetworkSpecialization;
 use crate::protocol::sync::SyncState;
 
@@ -241,7 +241,7 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkWorker
 			service,
 			import_queue: params.import_queue,
 			from_worker,
-			on_demand_in: params.on_demand.and_then(|od| od.extract_receiver()),
+			light_client_rqs: params.on_demand.and_then(|od| od.extract_receiver()),
 		})
 	}
 
@@ -585,8 +585,8 @@ pub struct NetworkWorker<B: BlockT + 'static, S: NetworkSpecialization<B>, H: Ex
 	import_queue: Box<dyn ImportQueue<B>>,
 	/// Messages from the `NetworkService` and that must be processed.
 	from_worker: mpsc::UnboundedReceiver<ServerToWorkerMsg<B, S>>,
-	/// Receiver for queries from the on-demand that must be processed.
-	on_demand_in: Option<mpsc::UnboundedReceiver<RequestData<B>>>,
+	/// Receiver for queries from the light client that must be processed.
+	light_client_rqs: Option<mpsc::UnboundedReceiver<RequestData<B>>>,
 }
 
 impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Future for NetworkWorker<B, S, H> {
@@ -602,10 +602,10 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Future for Ne
 			std::task::Poll::Pending::<Result<(), ()>>
 		}).compat().poll();
 
-		// Check for new incoming on-demand requests.
-		if let Some(on_demand_in) = self.on_demand_in.as_mut() {
-			while let Ok(Async::Ready(Some(rq))) = on_demand_in.poll() {
-				self.network_service.user_protocol_mut().add_on_demand_request(rq);
+		// Check for new incoming light client requests.
+		if let Some(light_client_rqs) = self.light_client_rqs.as_mut() {
+			while let Ok(Async::Ready(Some(rq))) = light_client_rqs.poll() {
+				self.network_service.user_protocol_mut().add_light_client_request(rq);
 			}
 		}
 


### PR DESCRIPTION
Can be reviewed commit by commit, but the PR is almost insubstantial and should be very straight-forward to review.

Does some basic house-keeping: renames `OnDemandCore` to `LightDispatch` in order to make what it is more explicit, and `on_block_announce` to `update_best_number` for the same reason.
Adds some documentation.

