### PR TITLE
srml-contracts: Contract calls/instantiations to return exit statuses

### DIFF
--- a/core/sr-sandbox/src/lib.rs
+++ b/core/sr-sandbox/src/lib.rs
@@ -53,8 +53,7 @@ mod imp {
 /// Error that can occur while using this crate.
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum Error {
-	/// Module is not valid, couldn't be instantiated or it's `start` function trapped
-	/// when executed.
+	/// Module is not valid, couldn't be instantiated.
 	Module,
 
 	/// Access to a memory or table was made with an address or an index which is out of bounds.
@@ -62,7 +61,7 @@ pub enum Error {
 	/// Note that if wasm module makes an out-of-bounds access then trap will occur.
 	OutOfBounds,
 
-	/// Failed to invoke an exported function for some reason.
+	/// Failed to invoke the start function or an exported function for some reason.
 	Execution,
 }
 

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -690,7 +690,7 @@ mod tests {
 	;; ) -> u32
 	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "deploy")
 	)
@@ -705,7 +705,7 @@ mod tests {
 				)
 			)
 
-			(call $ext_scratch_copy
+			(call $ext_scratch_read
 				(i32.const 0)
 				(i32.const 0)
 				(i32.const 4)

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 138,
-	impl_version: 138,
+	spec_version: 139,
+	impl_version: 139,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -379,6 +379,14 @@ This function copies slice of data from the scratch buffer to the sandbox memory
 
 **complexity**: The computing complexity of this function is proportional to the length of the slice. No additional memory is required.
 
+## ext_scratch_write
+
+This function copies slice of data from the sandbox memory to the scratch buffer. The calling code specifies the slice length. Execution of the function consists of the following steps:
+
+1. Loading a slice from the sandbox memory into the (see sandboxing memory get)
+
+**complexity**: Complexity is proportional to the length of the slice.
+
 ## ext_set_rent_allowance
 
 This function receives the following argument:

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -371,7 +371,7 @@ This function returns the size of the scratch buffer.
 
 **complexity**: This function is of constant complexity.
 
-## ext_scratch_copy
+## ext_scratch_read
 
 This function copies slice of data from the scratch buffer to the sandbox memory. The calling code specifies the slice length. Execution of the function consists of the following steps:
 

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -64,8 +64,8 @@ impl ExecReturnValue {
 #[cfg_attr(test, derive(Debug))]
 pub struct ExecError {
 	pub reason: &'static str,
-	/// This is an allocated buffer that may be reused. The buffer must be cleared be explicitly
-	/// cleared before reuse.
+	/// This is an allocated buffer that may be reused. The buffer must be cleared explicitly
+	/// before reuse.
 	pub buffer: Vec<u8>,
 }
 
@@ -383,7 +383,7 @@ where
 				Some(dest_code_hash) => {
 					let executable = try_or_exec_error!(
 						nested.loader.load_main(&dest_code_hash),
-						 input_data
+						input_data
 					);
 					nested.vm
 						.execute(

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -47,9 +47,25 @@ pub struct ExecReturnValue {
 #[cfg_attr(test, derive(Debug))]
 pub struct ExecError {
 	pub reason: &'static str,
+	/// This is an allocated buffer that may be reused. The buffer must be cleared be explicitly
+	/// cleared before reuse.
+	pub buffer: Vec<u8>,
 }
 
 pub type ExecResult = Result<ExecReturnValue, ExecError>;
+
+/// Evaluate an expression of type Result<_, &'static str> and either resolve to the value if Ok or
+/// wrap the error string into an ExecutionError with the provided buffer and return from the
+/// enclosing function. This macro is used instead of .map_err(..)? in order to avoid taking
+/// ownership of buffer unless there is an error.
+macro_rules! try_or_exec_error {
+	($e:expr, $buffer:expr) => {
+		match $e {
+			Ok(val) => val,
+			Err(reason) => return Err(ExecError { reason, buffer: $buffer }),
+		}
+	}
+}
 
 #[cfg_attr(test, derive(Debug))]
 pub struct InstantiateReceipt<AccountId> {
@@ -308,14 +324,20 @@ where
 		input_data: Vec<u8>,
 	) -> Result<CallReceipt, ExecError> {
 		if self.depth == self.config.max_depth as usize {
-			return Err(ExecError { reason: "reached maximum depth, cannot make a call" });
+			return Err(ExecError {
+				reason: "reached maximum depth, cannot make a call",
+				buffer: input_data,
+			});
 		}
 
 		if gas_meter
 			.charge(self.config, ExecFeeToken::Call)
 			.is_out_of_gas()
 		{
-			return Err(ExecError { reason: "not enough gas to pay base call fee" });
+			return Err(ExecError {
+				reason: "not enough gas to pay base call fee",
+				buffer: input_data,
+			});
 		}
 
 		// Assumption: pay_rent doesn't collide with overlay because
@@ -325,7 +347,10 @@ where
 
 		// Calls to dead contracts always fail.
 		if let Some(ContractInfo::Tombstone(_)) = contract_info {
-			return Err(ExecError { reason: "contract has been evicted" });
+			return Err(ExecError {
+				reason: "contract has been evicted",
+				buffer: input_data,
+			});
 		};
 
 		let caller = self.self_account.clone();
@@ -333,22 +358,27 @@ where
 
 		let output = self.with_nested_context(dest.clone(), dest_trie_id, |nested| {
 			if value > BalanceOf::<T>::zero() {
-				transfer(
-					gas_meter,
-					TransferCause::Call,
-					&caller,
-					&dest,
-					value,
-					nested,
-				).map_err(|reason| ExecError { reason })?;
+				try_or_exec_error!(
+					transfer(
+						gas_meter,
+						TransferCause::Call,
+						&caller,
+						&dest,
+						value,
+						nested,
+					),
+					input_data
+				);
 			}
 
 			// If code_hash is not none, then the destination account is a live contract, otherwise
 			// it is a regular account since tombstone accounts have already been rejected.
 			match nested.overlay.get_code_hash(&dest) {
 				Some(dest_code_hash) => {
-					let executable = nested.loader.load_main(&dest_code_hash)
-						.map_err(|reason| ExecError { reason })?;
+					let executable = try_or_exec_error!(
+						nested.loader.load_main(&dest_code_hash),
+						 input_data
+					);
 					nested.vm
 						.execute(
 							&executable,
@@ -372,14 +402,20 @@ where
 		input_data: Vec<u8>,
 	) -> Result<InstantiateReceipt<T::AccountId>, ExecError> {
 		if self.depth == self.config.max_depth as usize {
-			return Err(ExecError { reason: "reached maximum depth, cannot create" });
+			return Err(ExecError {
+				reason: "reached maximum depth, cannot create",
+				buffer: input_data,
+			});
 		}
 
 		if gas_meter
 			.charge(self.config, ExecFeeToken::Instantiate)
 			.is_out_of_gas()
 		{
-			return Err(ExecError { reason: "not enough gas to pay base instantiate fee" });
+			return Err(ExecError {
+				reason: "not enough gas to pay base instantiate fee",
+				buffer: input_data,
+			});
 		}
 
 		let caller = self.self_account.clone();
@@ -393,22 +429,29 @@ where
 		let dest_trie_id = None;
 
 		let _ = self.with_nested_context(dest.clone(), dest_trie_id, |nested| {
-			nested.overlay.create_contract(&dest, code_hash.clone())
-				.map_err(|reason| ExecError { reason })?;
+			try_or_exec_error!(
+				nested.overlay.create_contract(&dest, code_hash.clone()),
+				input_data
+			);
 
 			// Send funds unconditionally here. If the `endowment` is below existential_deposit
 			// then error will be returned here.
-			transfer(
-				gas_meter,
-				TransferCause::Instantiate,
-				&caller,
-				&dest,
-				endowment,
-				nested,
-			).map_err(|reason| ExecError { reason })?;
+			try_or_exec_error!(
+				transfer(
+					gas_meter,
+					TransferCause::Instantiate,
+					&caller,
+					&dest,
+					endowment,
+					nested,
+				),
+				input_data
+			);
 
-			let executable = nested.loader.load_init(&code_hash)
-				.map_err(|reason| ExecError { reason })?;
+			let executable = try_or_exec_error!(
+				nested.loader.load_init(&code_hash),
+				input_data
+			);
 			let output = nested.vm
 				.execute(
 					&executable,
@@ -1061,7 +1104,10 @@ mod tests {
 				vec![],
 			);
 
-			assert_matches!(result, Err(ExecError { reason: "balance too low to send value" }));
+			assert_matches!(
+				result,
+				Err(ExecError { reason: "balance too low to send value", buffer: _ })
+			);
 			assert_eq!(ctx.overlay.get_balance(&origin), 0);
 			assert_eq!(ctx.overlay.get_balance(&dest), 0);
 		});
@@ -1153,7 +1199,7 @@ mod tests {
 				// Verify that we've got proper error and set `reached_bottom`.
 				assert_matches!(
 					r,
-					Err(ExecError { reason: "reached maximum depth, cannot make a call" })
+					Err(ExecError { reason: "reached maximum depth, cannot make a call", buffer: _ })
 				);
 				*reached_bottom = true;
 			} else {
@@ -1401,7 +1447,9 @@ mod tests {
 		let vm = MockVm::new();
 
 		let mut loader = MockLoader::empty();
-		let dummy_ch = loader.insert(|_| Err(ExecError { reason: "It's a trap!" }));
+		let dummy_ch = loader.insert(
+			|_| Err(ExecError { reason: "It's a trap!", buffer: Vec::new() })
+		);
 		let creator_ch = loader.insert({
 			let dummy_ch = dummy_ch.clone();
 			move |ctx| {
@@ -1413,7 +1461,7 @@ mod tests {
 						ctx.gas_meter,
 						vec![]
 					),
-					Err(ExecError { reason: "It's a trap!" })
+					Err(ExecError { reason: "It's a trap!", buffer: _ })
 				);
 
 				exec_success()

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -89,7 +89,7 @@ mod rent;
 #[cfg(test)]
 mod tests;
 
-use crate::exec::ExecutionContext;
+use crate::exec::{ExecutionContext, ExecResult};
 use crate::account_db::{AccountDb, DirectAccountDb};
 pub use crate::gas::{Gas, GasMeter};
 use crate::wasm::{WasmLoader, WasmVm};
@@ -561,8 +561,6 @@ decl_module! {
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
 				ctx.call(dest, value, gas_meter, data)
-					.map(|_| ())
-					.map_err(|e| e.reason)
 			})
 		}
 
@@ -587,8 +585,7 @@ decl_module! {
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
 				ctx.instantiate(endowment, gas_meter, &code_hash, data)
-					.map(|_| ())
-					.map_err(|e| e.reason)
+					.map(|(_address, output)| output)
 			})
 		}
 
@@ -635,7 +632,7 @@ impl<T: Trait> Module<T> {
 	fn execute_wasm(
 		origin: T::AccountId,
 		gas_limit: Gas,
-		func: impl FnOnce(&mut ExecutionContext<T, WasmVm, WasmLoader>, &mut GasMeter<T>) -> Result
+		func: impl FnOnce(&mut ExecutionContext<T, WasmVm, WasmLoader>, &mut GasMeter<T>) -> ExecResult
 	) -> Result {
 		// Pay for the gas upfront.
 		//
@@ -650,7 +647,7 @@ impl<T: Trait> Module<T> {
 
 		let result = func(&mut ctx, &mut gas_meter);
 
-		if result.is_ok() {
+		if result.as_ref().map(|output| output.is_success()).unwrap_or(false) {
 			// Commit all changes that made it thus far into the persistent storage.
 			DirectAccountDb.commit(ctx.overlay.into_change_set());
 		}
@@ -692,6 +689,8 @@ impl<T: Trait> Module<T> {
 		});
 
 		result
+			.map(|_| ())
+			.map_err(|e| e.reason)
 	}
 
 	fn restore_to(

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -560,7 +560,7 @@ decl_module! {
 			let dest = T::Lookup::lookup(dest)?;
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
-				ctx.call(dest, value, gas_meter, &data, exec::EmptyOutputBuf::new()).map(|_| ())
+				ctx.call(dest, value, gas_meter, data).map(|_| ())
 			})
 		}
 
@@ -584,7 +584,7 @@ decl_module! {
 			let origin = ensure_signed(origin)?;
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
-				ctx.instantiate(endowment, gas_meter, &code_hash, &data).map(|_| ())
+				ctx.instantiate(endowment, gas_meter, &code_hash, data).map(|_| ())
 			})
 		}
 

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -560,7 +560,9 @@ decl_module! {
 			let dest = T::Lookup::lookup(dest)?;
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
-				ctx.call(dest, value, gas_meter, data).map(|_| ())
+				ctx.call(dest, value, gas_meter, data)
+					.map(|_| ())
+					.map_err(|e| e.reason)
 			})
 		}
 
@@ -584,7 +586,9 @@ decl_module! {
 			let origin = ensure_signed(origin)?;
 
 			Self::execute_wasm(origin, gas_limit, |ctx, gas_meter| {
-				ctx.instantiate(endowment, gas_meter, &code_hash, data).map(|_| ())
+				ctx.instantiate(endowment, gas_meter, &code_hash, data)
+					.map(|_| ())
+					.map_err(|e| e.reason)
 			})
 		}
 

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -698,7 +698,7 @@ const CODE_SET_RENT: &str = r#"
 	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
 	(import "env" "ext_set_rent_allowance" (func $ext_set_rent_allowance (param i32 i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; insert a value of 4 bytes into storage
@@ -781,7 +781,7 @@ const CODE_SET_RENT: &str = r#"
 			(i32.const 0)
 			(i32.const 4)
 		)
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 0)
 			(i32.const 0)
 			(get_local $input_size)
@@ -1173,7 +1173,7 @@ const CODE_CHECK_DEFAULT_RENT_ALLOWANCE: &str = r#"
 (module
 	(import "env" "ext_rent_allowance" (func $ext_rent_allowance))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -1200,7 +1200,7 @@ const CODE_CHECK_DEFAULT_RENT_ALLOWANCE: &str = r#"
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -1304,10 +1304,10 @@ const CODE_RESTORATION: &str = r#"
 	;; Address of bob
 	(data (i32.const 256) "\02\00\00\00\00\00\00\00")
 
-	;; Code hash of SET_CODE
+	;; Code hash of SET_RENT
 	(data (i32.const 264)
-		"\69\ae\df\b4\f6\c1\c3\98\e9\7f\8a\52\04\de\0f\95"
-		"\ad\5e\7d\c3\54\09\60\be\ab\11\a8\6c\56\9f\bf\cf"
+		"\14\eb\65\3c\86\98\d6\b2\3d\8d\3c\4a\54\c6\c4\71"
+		"\b9\fc\19\36\df\ca\a0\a1\f2\dc\ad\9d\e5\36\0b\25"
 	)
 
 	;; Rent allowance
@@ -1340,6 +1340,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 	let (restoration_wasm, restoration_code_hash) =
 		compile_module::<Test>(CODE_RESTORATION).unwrap();
 
+	println!("{:?}", set_rent_code_hash);
 	with_externalities(
 		&mut ExtBuilder::default().existential_deposit(50).build(),
 		|| {
@@ -1462,7 +1463,7 @@ const CODE_STORAGE_SIZE: &str = r#"
 	(import "env" "ext_get_storage" (func $ext_get_storage (param i32) (result i32)))
 	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 16 16))
 
 	(func $assert (param i32)
@@ -1484,7 +1485,7 @@ const CODE_STORAGE_SIZE: &str = r#"
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 32)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 4)		;; Count of bytes to copy.

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -1340,7 +1340,6 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 	let (restoration_wasm, restoration_code_hash) =
 		compile_module::<Test>(CODE_RESTORATION).unwrap();
 
-	println!("{:?}", set_rent_code_hash);
 	with_externalities(
 		&mut ExtBuilder::default().existential_deposit(50).build(),
 		|| {
@@ -1446,6 +1445,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			} else {
 				// Here we expect that the restoration is succeeded. Check that the restoration
 				// contract `DJANGO` ceased to exist and that `BOB` returned back.
+				println!("{:?}", ContractInfoOf::<Test>::get(BOB));
 				let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap()
 					.get_alive().unwrap();
 				assert_eq!(bob_contract.rent_allowance, 50);

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -22,7 +22,8 @@
 use crate::account_db::{AccountDb, DirectAccountDb, OverlayAccountDb};
 use crate::{
 	BalanceOf, ComputeDispatchFee, ContractAddressFor, ContractInfo, ContractInfoOf, GenesisConfig,
-	Module, RawAliveContractInfo, RawEvent, Trait, TrieId, TrieIdFromParentCounter, TrieIdGenerator,
+	Module, RawAliveContractInfo, RawEvent, Trait, TrieId, TrieIdFromParentCounter,
+	TrieIdGenerator, Schedule,
 };
 use assert_matches::assert_matches;
 use hex_literal::*;
@@ -279,7 +280,10 @@ impl ExtBuilder {
 			vesting: vec![],
 		}.assimilate_storage(&mut t).unwrap();
 		GenesisConfig::<Test> {
-			current_schedule: Default::default(),
+			current_schedule: Schedule {
+				enable_println: true,
+				..Default::default()
+			},
 			gas_price: self.gas_price,
 		}.assimilate_storage(&mut t).unwrap();
 		runtime_io::TestExternalities::new(t)
@@ -1564,6 +1568,360 @@ fn storage_max_value_limit() {
 				),
 				"during execution"
 			);
+		}
+	);
+}
+
+const CODE_RETURN_WITH_DATA: &str = r#"
+(module
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+	(import "env" "ext_scratch_write" (func $ext_scratch_write (param i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	;; Deploy routine is the same as call.
+	(func (export "deploy") (result i32)
+		(call $call)
+	)
+
+	;; Call reads the first 4 bytes (LE) as the exit status and returns the rest as output data.
+	(func $call (export "call") (result i32)
+		(local $buf_size i32)
+		(local $exit_status i32)
+
+		;; Find out the size of the scratch buffer
+		(set_local $buf_size (call $ext_scratch_size))
+
+		;; Copy scratch buffer into this contract memory.
+		(call $ext_scratch_read
+			(i32.const 0)		;; The pointer where to store the scratch buffer contents,
+			(i32.const 0)		;; Offset from the start of the scratch buffer.
+			(get_local $buf_size)		;; Count of bytes to copy.
+		)
+
+		;; Copy all but the first 4 bytes of the input data as the output data.
+		(call $ext_scratch_write
+			(i32.const 4)		;; Offset from the start of the scratch buffer.
+			(i32.sub		;; Count of bytes to copy.
+				(get_local $buf_size)
+				(i32.const 4)
+			)
+		)
+
+		;; Return the first 4 bytes of the input data as the exit status.
+		(i32.load (i32.const 0))
+	)
+)
+"#;
+
+const CODE_CALLER_CONTRACT: &str = r#"
+(module
+	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
+	(import "env" "ext_balance" (func $ext_balance))
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_create" (func $ext_create (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_println" (func $ext_println (param i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+	(func $assert (param i32)
+		(block $ok
+			(br_if $ok
+				(get_local 0)
+			)
+			(unreachable)
+		)
+	)
+
+	(func $current_balance (param $sp i32) (result i64)
+		(call $ext_balance)
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 8))
+		)
+		(call $ext_scratch_read
+			(i32.sub (get_local $sp) (i32.const 8))
+			(i32.const 0)
+			(i32.const 8)
+		)
+		(i64.load (i32.sub (get_local $sp) (i32.const 8)))
+	)
+
+	(func (export "deploy"))
+
+	(func (export "call")
+		(local $sp i32)
+		(local $exit_code i32)
+		(local $balance i64)
+
+		;; Input data is the code hash of the contract to be deployed.
+		(call $assert
+			(i32.eq
+				(call $ext_scratch_size)
+				(i32.const 32)
+			)
+		)
+
+		;; Copy code hash from scratch buffer into this contract's memory.
+		(call $ext_scratch_read
+			(i32.const 24)		;; The pointer where to store the scratch buffer contents,
+			(i32.const 0)		;; Offset from the start of the scratch buffer.
+			(i32.const 32)		;; Count of bytes to copy.
+		)
+
+		;; Read current balance into local variable.
+		(set_local $sp (i32.const 1024))
+		(set_local $balance
+			(call $current_balance (get_local $sp))
+		)
+
+		;; Fail to deploy the contract since it returns a non-zero exit status.
+		(set_local $exit_code
+			(call $ext_create
+				(i32.const 24)	;; Pointer to the code hash.
+				(i32.const 32)	;; Length of the code hash.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 9)	;; Pointer to input data buffer address
+				(i32.const 7)	;; Length of input data buffer
+			)
+		)
+
+		;; Check non-zero exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x11))
+		)
+
+		;; Check that scratch buffer is empty since contract instantiation failed.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 0))
+		)
+
+		;; Check that balance has not changed.
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+
+		;; Fail to deploy the contract due to insufficient gas.
+		(set_local $exit_code
+			(call $ext_create
+				(i32.const 24)	;; Pointer to the code hash.
+				(i32.const 32)	;; Length of the code hash.
+				(i64.const 200)	;; How much gas to devote for the execution.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+
+		;; Check for special trap exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x0100))
+		)
+
+		;; Check that scratch buffer is empty since contract instantiation failed.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 0))
+		)
+
+		;; Check that balance has not changed.
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+
+		;; Deploy the contract successfully.
+		(set_local $exit_code
+			(call $ext_create
+				(i32.const 24)	;; Pointer to the code hash.
+				(i32.const 32)	;; Length of the code hash.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+
+		;; Check for success exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x00))
+		)
+
+		;; Check that scratch buffer contains the address of the new contract.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 8))
+		)
+
+		;; Copy contract address from scratch buffer into this contract's memory.
+		(call $ext_scratch_read
+			(i32.const 16)		;; The pointer where to store the scratch buffer contents,
+			(i32.const 0)		;; Offset from the start of the scratch buffer.
+			(i32.const 8)		;; Count of bytes to copy.
+		)
+
+		;; Check that balance has been deducted.
+		(set_local $balance
+			(i64.sub (get_local $balance) (i64.load (i32.const 0)))
+		)
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+
+		;; Call the new contract and expect it to return failing exit code.
+		(set_local $exit_code
+			(call $ext_call
+				(i32.const 16)	;; Pointer to "callee" address.
+				(i32.const 8)	;; Length of "callee" address.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 9)	;; Pointer to input data buffer address
+				(i32.const 7)	;; Length of input data buffer
+			)
+		)
+
+		;; Check non-zero exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x11))
+		)
+
+		;; Check that scratch buffer contains the expected return data.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 3))
+		)
+		(i32.store
+			(i32.sub (get_local $sp) (i32.const 4))
+			(i32.const 0)
+		)
+		(call $ext_scratch_read
+			(i32.sub (get_local $sp) (i32.const 4))
+			(i32.const 0)
+			(i32.const 3)
+		)
+		(call $assert
+			(i32.eq
+				(i32.load (i32.sub (get_local $sp) (i32.const 4)))
+				(i32.const 0x00776655)
+			)
+		)
+
+		;; Check that balance has not changed.
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+
+		;; Fail to call the contract due to insufficient gas.
+		(set_local $exit_code
+			(call $ext_call
+				(i32.const 16)	;; Pointer to "callee" address.
+				(i32.const 8)	;; Length of "callee" address.
+				(i64.const 100)	;; How much gas to devote for the execution.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+
+		;; Check for special trap exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x0100))
+		)
+
+		;; Check that scratch buffer is empty since call trapped.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 0))
+		)
+
+		;; Check that balance has not changed.
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+
+		;; Call the contract successfully.
+		(set_local $exit_code
+			(call $ext_call
+				(i32.const 16)	;; Pointer to "callee" address.
+				(i32.const 8)	;; Length of "callee" address.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 0)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 8)	;; Pointer to input data buffer address
+				(i32.const 8)	;; Length of input data buffer
+			)
+		)
+
+		;; Check for success exit status.
+		(call $assert
+			(i32.eq (get_local $exit_code) (i32.const 0x00))
+		)
+
+		;; Check that scratch buffer contains the expected return data.
+		(call $assert
+			(i32.eq (call $ext_scratch_size) (i32.const 4))
+		)
+		(i32.store
+			(i32.sub (get_local $sp) (i32.const 4))
+			(i32.const 0)
+		)
+		(call $ext_scratch_read
+			(i32.sub (get_local $sp) (i32.const 4))
+			(i32.const 0)
+			(i32.const 4)
+		)
+		(call $assert
+			(i32.eq
+				(i32.load (i32.sub (get_local $sp) (i32.const 4)))
+				(i32.const 0x77665544)
+			)
+		)
+
+		;; Check that balance has been deducted.
+		(set_local $balance
+			(i64.sub (get_local $balance) (i64.load (i32.const 0)))
+		)
+		(call $assert
+			(i64.eq (get_local $balance) (call $current_balance (get_local $sp)))
+		)
+	)
+
+	(data (i32.const 0) "\00\80")		;; The value to transfer on instantiation and calls.
+										;; Chosen to be greater than existential deposit.
+	(data (i32.const 8) "\00\11\22\33\44\55\66\77")		;; The input data to instantiations and calls.
+)
+"#;
+
+#[test]
+fn deploy_and_call_other_contract() {
+	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_RETURN_WITH_DATA).unwrap();
+	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_CALLER_CONTRACT).unwrap();
+
+	with_externalities(
+		&mut ExtBuilder::default().existential_deposit(50).build(),
+		|| {
+			// Create
+			Balances::deposit_creating(&ALICE, 1_000_000);
+			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
+			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
+
+			assert_ok!(Contract::create(
+				Origin::signed(ALICE),
+				100_000,
+				100_000,
+				caller_code_hash.into(),
+				vec![],
+			));
+
+			// Call BOB contract, which attempts to instantiate and call the callee contract and
+			// makes various assertions on the results from those calls.
+			assert_ok!(Contract::call(
+				Origin::signed(ALICE),
+				BOB,
+				0,
+				200_000,
+				callee_code_hash.as_ref().to_vec(),
+			));
 		}
 	);
 }

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -625,7 +625,7 @@ mod tests {
 (module
 	(import "env" "ext_get_storage" (func $ext_get_storage (param i32) (result i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "ext_return" (func $ext_return (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
@@ -661,7 +661,7 @@ mod tests {
 		)
 
 		;; Copy scratch buffer into this contract memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 36)		;; The pointer where to store the scratch buffer contents,
 								;; 36 = 4 + 32
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
@@ -715,7 +715,7 @@ mod tests {
 (module
 	(import "env" "ext_caller" (func $ext_caller))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -740,7 +740,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -779,7 +779,7 @@ mod tests {
 (module
 	(import "env" "ext_address" (func $ext_address))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -804,7 +804,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -841,7 +841,7 @@ mod tests {
 (module
 	(import "env" "ext_balance" (func $ext_balance))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -866,7 +866,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -903,7 +903,7 @@ mod tests {
 (module
 	(import "env" "ext_gas_price" (func $ext_gas_price))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -928,7 +928,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -965,7 +965,7 @@ mod tests {
 (module
 	(import "env" "ext_gas_left" (func $ext_gas_left))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "ext_return" (func $ext_return (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
@@ -991,7 +991,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -1031,7 +1031,7 @@ mod tests {
 (module
 	(import "env" "ext_value_transferred" (func $ext_value_transferred))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -1056,7 +1056,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -1171,7 +1171,7 @@ mod tests {
 (module
 	(import "env" "ext_now" (func $ext_now))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -1196,7 +1196,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.
@@ -1233,7 +1233,7 @@ mod tests {
 (module
 	(import "env" "ext_random" (func $ext_random (param i32 i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "ext_return" (func $ext_return (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
@@ -1262,7 +1262,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 32)		;; Count of bytes to copy.
@@ -1448,7 +1448,7 @@ mod tests {
 (module
 	(import "env" "ext_block_number" (func $ext_block_number))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
-	(import "env" "ext_scratch_copy" (func $ext_scratch_copy (param i32 i32 i32)))
+	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -1473,7 +1473,7 @@ mod tests {
 		)
 
 		;; copy contents of the scratch buffer into the contract's memory.
-		(call $ext_scratch_copy
+		(call $ext_scratch_read
 			(i32.const 8)		;; Pointer in memory to the place where to copy.
 			(i32.const 0)		;; Offset from the start of the scratch buffer.
 			(i32.const 8)		;; Count of bytes to copy.

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -152,9 +152,7 @@ mod tests {
 	use super::*;
 	use std::collections::HashMap;
 	use primitives::H256;
-	use crate::exec::{
-		CallReceipt, Ext, InstantiateReceipt, StorageKey, ExecError, ExecReturnValue,
-	};
+	use crate::exec::{Ext, StorageKey, ExecError, ExecReturnValue};
 	use crate::gas::{Gas, GasMeter};
 	use crate::tests::{Test, Call};
 	use crate::wasm::prepare::prepare_contract;
@@ -221,7 +219,7 @@ mod tests {
 			endowment: u64,
 			gas_meter: &mut GasMeter<Test>,
 			data: Vec<u8>,
-		) -> Result<InstantiateReceipt<u64>, ExecError> {
+		) -> Result<(u64, ExecReturnValue), ExecError> {
 			self.creates.push(CreateEntry {
 				code_hash: code_hash.clone(),
 				endowment,
@@ -231,7 +229,7 @@ mod tests {
 			let address = self.next_account_id;
 			self.next_account_id += 1;
 
-			Ok(InstantiateReceipt { address })
+			Ok((address, ExecReturnValue { data: Vec::new() }))
 		}
 		fn call(
 			&mut self,
@@ -239,7 +237,7 @@ mod tests {
 			value: u64,
 			gas_meter: &mut GasMeter<Test>,
 			data: Vec<u8>,
-		) -> Result<CallReceipt, ExecError> {
+		) -> ExecResult {
 			self.transfers.push(TransferEntry {
 				to: *to,
 				value,
@@ -248,9 +246,7 @@ mod tests {
 			});
 			// Assume for now that it was just a plain transfer.
 			// TODO: Add tests for different call outcomes.
-			Ok(CallReceipt {
-				output_data: Vec::new(),
-			})
+			Ok(ExecReturnValue { data: Vec::new() })
 		}
 		fn note_dispatch_call(&mut self, call: Call) {
 			self.dispatches.push(DispatchEntry(call));
@@ -324,7 +320,7 @@ mod tests {
 			value: u64,
 			gas_meter: &mut GasMeter<Test>,
 			input_data: Vec<u8>,
-		) -> Result<InstantiateReceipt<u64>, ExecError> {
+		) -> Result<(u64, ExecReturnValue), ExecError> {
 			(**self).instantiate(code, value, gas_meter, input_data)
 		}
 		fn call(
@@ -333,7 +329,7 @@ mod tests {
 			value: u64,
 			gas_meter: &mut GasMeter<Test>,
 			input_data: Vec<u8>,
-		) -> Result<CallReceipt, ExecError> {
+		) -> ExecResult {
 			(**self).call(to, value, gas_meter, input_data)
 		}
 		fn note_dispatch_call(&mut self, call: Call) {

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -143,7 +143,7 @@ impl<'a, T: Trait> crate::exec::Vm<T> for WasmVm<'a> {
 		// entrypoint.
 		let result = sandbox::Instance::new(&exec.prefab_module.code, &imports, &mut runtime)
 			.and_then(|mut instance| instance.invoke(exec.entrypoint_name, &[], &mut runtime));
-		to_execution_result(runtime, result.err())
+		to_execution_result(runtime, result)
 	}
 }
 

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -152,7 +152,7 @@ mod tests {
 	use super::*;
 	use std::collections::HashMap;
 	use primitives::H256;
-	use crate::exec::{Ext, StorageKey, ExecError, ExecReturnValue};
+	use crate::exec::{Ext, StorageKey, ExecError, ExecReturnValue, STATUS_SUCCESS};
 	use crate::gas::{Gas, GasMeter};
 	use crate::tests::{Test, Call};
 	use crate::wasm::prepare::prepare_contract;
@@ -229,7 +229,7 @@ mod tests {
 			let address = self.next_account_id;
 			self.next_account_id += 1;
 
-			Ok((address, ExecReturnValue { data: Vec::new() }))
+			Ok((address, ExecReturnValue { status: STATUS_SUCCESS, data: Vec::new() }))
 		}
 		fn call(
 			&mut self,
@@ -246,7 +246,7 @@ mod tests {
 			});
 			// Assume for now that it was just a plain transfer.
 			// TODO: Add tests for different call outcomes.
-			Ok(ExecReturnValue { data: Vec::new() })
+			Ok(ExecReturnValue { status: STATUS_SUCCESS, data: Vec::new() })
 		}
 		fn note_dispatch_call(&mut self, call: Call) {
 			self.dispatches.push(DispatchEntry(call));
@@ -673,7 +673,7 @@ mod tests {
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();
 
-		assert_eq!(output, ExecReturnValue { data: [0x22; 32].to_vec() });
+		assert_eq!(output, ExecReturnValue { status: STATUS_SUCCESS, data: [0x22; 32].to_vec() });
 	}
 
 	/// calls `ext_caller`, loads the address from the scratch buffer and
@@ -1113,7 +1113,7 @@ mod tests {
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();
 
-		assert_eq!(output, ExecReturnValue { data: vec![1, 2, 3, 4] });
+		assert_eq!(output, ExecReturnValue { status: STATUS_SUCCESS, data: vec![1, 2, 3, 4] });
 	}
 
 	const CODE_TIMESTAMP_NOW: &str = r#"
@@ -1248,6 +1248,7 @@ mod tests {
 		assert_eq!(
 			output,
 			ExecReturnValue {
+				status: STATUS_SUCCESS,
 				data: hex!("000102030405060708090A0B0C0D0E0F000102030405060708090A0B0C0D0E0F").to_vec(),
 			},
 		);

--- a/srml/contracts/src/wasm/prepare.rs
+++ b/srml/contracts/src/wasm/prepare.rs
@@ -227,14 +227,20 @@ impl<'a> ContractModule<'a> {
 			};
 
 			// Then check the signature.
-			// Both "call" and "deploy" has a () -> () function type.
+			// Both "call" and "deploy" has a [] -> [] or [] -> [i32] function type.
+			//
+			// The [] -> [] signature predates the [] -> [i32] signature and is supported for
+			// backwards compatibility. This will likely be removed once ink! is updated to
+			// generate modules with the new function signatures.
 			let func_ty_idx = func_entries.get(fn_idx as usize)
 				.ok_or_else(|| "export refers to non-existent function")?
 				.type_ref();
 			let Type::Function(ref func_ty) = types
 				.get(func_ty_idx as usize)
 				.ok_or_else(|| "function has a non-existent type")?;
-			if !(func_ty.params().is_empty() && func_ty.return_type().is_none()) {
+			if !func_ty.params().is_empty() ||
+				!(func_ty.return_type().is_none() ||
+					func_ty.return_type() == Some(ValueType::I32)) {
 				return Err("entry point has wrong signature");
 			}
 		}

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -658,7 +658,7 @@ define_env!(Env, <E: Ext>,
 
 	// Returns the size of the scratch buffer.
 	//
-	// For more details on the scratch buffer see `ext_scratch_copy`.
+	// For more details on the scratch buffer see `ext_scratch_read`.
 	ext_scratch_size(ctx) -> u32 => {
 		Ok(ctx.scratch_buf.len() as u32)
 	},
@@ -669,7 +669,7 @@ define_env!(Env, <E: Ext>,
 	// In order to get size of the scratch buffer use `ext_scratch_size`. At the start of contract
 	// execution, the scratch buffer is filled with the input data. Whenever a contract calls
 	// function that uses the scratch buffer the contents of the scratch buffer are overwritten.
-	ext_scratch_copy(ctx, dest_ptr: u32, offset: u32, len: u32) => {
+	ext_scratch_read(ctx, dest_ptr: u32, offset: u32, len: u32) => {
 		let offset = offset as usize;
 		if offset > ctx.scratch_buf.len() {
 			// Offset can't be larger than scratch buffer length.

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -745,6 +745,15 @@ define_env!(Env, <E: Ext>,
 		Ok(())
 	},
 
+	// Copy data from contract memory starting from `src_ptr` with length `len` into the scratch
+	// buffer. This overwrites the entire scratch buffer and resizes to `len`. Specifying a `len`
+	// of zero clears the scratch buffer.
+	//
+	// This should be used before exiting a call or instantiation in order to set the return data.
+	ext_scratch_write(ctx, src_ptr: u32, len: u32) => {
+		read_sandbox_memory_into_scratch(ctx, src_ptr, len)
+	},
+
 	// Deposit a contract event with the data buffer and optional list of topics. There is a limit
 	// on the maximum number of topics specified by `max_event_topics`.
 	//

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -209,7 +209,7 @@ fn read_sandbox_memory<E: Ext>(
 	charge_gas(ctx.gas_meter, ctx.schedule, RuntimeToken::ReadMemory(len))?;
 
 	let mut buf = vec![0u8; len as usize];
-	ctx.memory().get(ptr, buf.as_mut_slice()).map_err(|_| sandbox::HostError)?;
+	ctx.memory.get(ptr, buf.as_mut_slice()).map_err(|_| sandbox::HostError)?;
 	Ok(buf)
 }
 
@@ -228,11 +228,8 @@ fn read_sandbox_memory_into_scratch<E: Ext>(
 ) -> Result<(), sandbox::HostError> {
 	charge_gas(ctx.gas_meter, ctx.schedule, RuntimeToken::ReadMemory(len))?;
 
-	let mut buf = mem::replace(&mut ctx.scratch_buf, Vec::new());
-	buf.resize(len as usize, 0);
-	ctx.memory().get(ptr, buf.as_mut_slice()).map_err(|_| sandbox::HostError)?;
-	let _  = mem::replace(&mut ctx.scratch_buf, buf);
-
+	ctx.scratch_buf.resize(len as usize, 0);
+	ctx.memory.get(ptr, ctx.scratch_buf.as_mut_slice()).map_err(|_| sandbox::HostError)?;
 	Ok(())
 }
 
@@ -251,7 +248,7 @@ fn read_sandbox_memory_into_buf<E: Ext>(
 ) -> Result<(), sandbox::HostError> {
 	charge_gas(ctx.gas_meter, ctx.schedule, RuntimeToken::ReadMemory(buf.len() as u32))?;
 
-	ctx.memory().get(ptr, buf).map_err(Into::into)
+	ctx.memory.get(ptr, buf).map_err(Into::into)
 }
 
 /// Read designated chunk from the sandbox memory, consuming an appropriate amount of

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -17,10 +17,7 @@
 //! Environment definition of the wasm smart-contract runtime.
 
 use crate::{Schedule, Trait, CodeHash, ComputeDispatchFee, BalanceOf};
-use crate::exec::{
-	Ext, ExecResult, ExecError, ExecReturnValue, CallReceipt, InstantiateReceipt,
-	StorageKey, TopicOf,
-};
+use crate::exec::{Ext, ExecResult, ExecError, ExecReturnValue, StorageKey, TopicOf};
 use crate::gas::{Gas, GasMeter, Token, GasMeterResult, approx_gas_for_balance};
 use sandbox;
 use system;
@@ -399,8 +396,8 @@ define_env!(Env, <E: Ext>,
 		});
 
 		match call_outcome {
-			Ok(CallReceipt { output_data }) => {
-				ctx.scratch_buf = output_data;
+			Ok(output) => {
+				ctx.scratch_buf = output.data;
 				Ok(0)
 			},
 			Err(mut buffer) => {
@@ -468,7 +465,7 @@ define_env!(Env, <E: Ext>,
 			}
 		});
 		match instantiate_outcome {
-			Ok(InstantiateReceipt { address }) => {
+			Ok((address, _output)) => {
 				// Write the address to the scratch buffer.
 				address.encode_to(&mut ctx.scratch_buf);
 				Ok(0)


### PR DESCRIPTION
This PR does two things

1. Refactor the exec logic so that a single allocated scratch buffer is used for all nested calls during a contract execution.
2. Allow the "call" and "deploy" functions in contracts to return an exit status and output data through the scratch buffer. This is an implementation of #3038.

The PR could be split into two if people prefer, but the status code changes somewhat motivate the other refactors.

### Global scratch buffer

The idea with the global scratch buffer is that a contract execution may invoke other nested executions through `ext_call` or `ext_create`. Each execution needs a scratch buffer. Notably, the scratch buffer is overwritten on both of these calls so it is possible to pass ownership of the same scratch buffer to the nested executions in order to reduce memory allocations. So this is ultimately a memory optimization.

I'm not sure how important it actually is given that each nested execution creates a new sandbox anyway which requires more memory, so that could just be priced into the imported function cost. But it does seem like kind of an obvious thing to do, and one that is partially implemented already using the `OutputBuffer`/`EmptyOutputBuffer`.

The downside is additional complexity as the buffer needs to be passed back even in the error case, requiring a custom error type. An alternative approach would be to pass around the scratch buffer in a `RefCell` instead of entirely through move semantics.

### Exit status

With this PR, the "call" and "deploy" functions exported from a contract can now return a 32-bit exit code. The low 8 bits of the exit code are the exit status, which is returned to the caller. The top 24 bits are currently unused and are reserved for interpretation by the contracts runtime. (See https://github.com/paritytech/substrate/issues/3038#issuecomment-516852022). If the exit status is 0, then the execution succeeds, otherwise the changes are reverted. If an exit status is returned, then the scratch buffer on exit is returned as output data, providing an alternative to `ext_return`.

This change is made in a backwards compatible way. `ext_return` still exists for now and if the "call" or "deploy" functions have an empty return type, then on exit they return a status of 0 with empty output data. Part of the motivation for backwards compatibility is so that this change does not need to be synchronized with `ink!`.  Going forward, allowing "call" and "deploy" to return unit might be desirable to keep around since it is a fairly common pattern, especially in the tests. But maybe we want to drop this and require them to return a status code.