### PR TITLE
Reintroduce mplex (revert #3312)

### DIFF
--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -89,6 +89,8 @@
 //!
 //! The following multiplexing protocols are supported:
 //!
+//! - [Mplex](https://github.com/libp2p/specs/tree/master/mplex). Support for mplex will likely
+//! be deprecated in the future.
 //! - [Yamux](https://github.com/hashicorp/yamux/blob/master/spec.md).
 //!
 //! ## Substreams

--- a/core/network/src/transport.rs
+++ b/core/network/src/transport.rs
@@ -17,14 +17,14 @@
 use futures::prelude::*;
 use libp2p::{
 	InboundUpgradeExt, OutboundUpgradeExt, PeerId, Transport,
-	identity, secio, yamux, bandwidth, wasm_ext
+	mplex, identity, secio, yamux, bandwidth, wasm_ext
 };
 #[cfg(not(target_os = "unknown"))]
 use libp2p::{tcp, dns, websocket, noise};
 #[cfg(not(target_os = "unknown"))]
 use libp2p::core::{upgrade, either::EitherError, either::EitherOutput};
 use libp2p::core::{self, transport::boxed::Boxed, transport::OptionalTransport, muxing::StreamMuxerBox};
-use std::{io, sync::Arc, time::Duration};
+use std::{io, sync::Arc, time::Duration, usize};
 
 pub use self::bandwidth::BandwidthSinks;
 
@@ -55,6 +55,9 @@ pub fn build_transport(
 	let secio_config = secio::SecioConfig::new(keypair);
 
 	// Build configuration objects for multiplexing mechanisms.
+	let mut mplex_config = mplex::MplexConfig::new();
+	mplex_config.max_buffer_len_behaviour(mplex::MaxBufferBehaviour::Block);
+	mplex_config.max_buffer_len(usize::MAX);
 	let yamux_config = yamux::Config::default();
 
 	// Build the base layer of the transport.
@@ -113,7 +116,7 @@ pub fn build_transport(
 	// Multiplexing
 	let transport = transport.and_then(move |(stream, peer_id), endpoint| {
 			let peer_id2 = peer_id.clone();
-			let upgrade = yamux_config
+			let upgrade = core::upgrade::SelectUpgrade::new(yamux_config, mplex_config)
 				.map_inbound(move |muxer| (peer_id, muxer))
 				.map_outbound(move |muxer| (peer_id2, muxer));
 


### PR DESCRIPTION
When opening #3312, I overlooked the fact that mplex is the only thing supported by Jaco's JS light client.