### PR TITLE
Make metadata sync.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 131,
-	impl_version: 132,
+	impl_version: 133,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/metadata/src/lib.rs
+++ b/srml/metadata/src/lib.rs
@@ -218,6 +218,9 @@ pub trait DefaultByte {
 #[derive(Clone)]
 pub struct DefaultByteGetter(pub &'static dyn DefaultByte);
 
+unsafe impl Send for DefaultByteGetter {}
+unsafe impl Sync for DefaultByteGetter {}
+
 /// Decode different for static lazy initiated byte value.
 pub type ByteGetter = DecodeDifferent<DefaultByteGetter, Vec<u8>>;
 


### PR DESCRIPTION
To return the MetadataPrefixed in a Future it has to be Sync. MetadataPrefixed is Sync, but rust can't figure it out since DefaultByte uses PhantomData.