### PR TITLE
Fix documentation set_controller

### DIFF
--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -953,7 +953,7 @@ decl_module! {
 			<Payee<T>>::insert(stash, payee);
 		}
 
-		/// (Re-)set the payment target for a controller.
+		/// (Re-)set the controller of a stash.
 		///
 		/// Effects will be felt at the beginning of the next era.
 		///


### PR DESCRIPTION
The documentation for the `set_controller` function was copied from the function above it, however it does not do the same thing. Fixed the documentation to fit the correct description of what `set_controller` does.
