### PR TITLE
grandpa: fix --no-grandpa flag breaking block production

### DIFF
--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -444,7 +444,7 @@ fn global_communication<Block: BlockT<Hash=H256>, B, E, N, RA>(
 
 /// Register the finality tracker inherent data provider (which is used by
 /// GRANDPA), if not registered already.
-fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT<Hash=H256>, RA>(
+pub fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT<Hash=H256>, RA>(
 	client: Arc<Client<B, E, Block, RA>>,
 	inherent_data_providers: &InherentDataProviders,
 ) -> Result<(), consensus_common::Error> where

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -170,6 +170,14 @@ construct_service_factory! {
 					}
 				}
 
+				// regardless of whether grandpa is started or not, when
+				// authoring blocks we expect inherent data regarding what our
+				// last finalized block is, to be available.
+				grandpa::register_finality_tracker_inherent_data_provider(
+					service.client(),
+					&service.config().custom.inherent_data_providers,
+				)?;
+
 				Ok(service)
 			}
 		},


### PR DESCRIPTION
Block production would break if `--no-grandpa` was passed since the finality tracker inherent provider was not registered.