### PR TITLE
node: Reintroduce `--validator` cli flag

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -438,11 +438,14 @@ where
 
 	let is_dev = cli.shared_params.dev;
 
-	let role = if cli.light {
-		service::Roles::LIGHT
-	} else {
-		service::Roles::AUTHORITY
-	};
+	let role =
+		if cli.light {
+			service::Roles::LIGHT
+		} else if cli.validator || is_dev {
+			service::Roles::AUTHORITY
+		} else {
+			service::Roles::FULL
+		};
 
 	let exec = cli.execution_strategies;
 	let exec_all_or = |strat: params::ExecutionStrategy| exec.execution.unwrap_or(strat).into();

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -297,7 +297,11 @@ pub struct ExecutionStrategies {
 /// The `run` command used to run a node.
 #[derive(Debug, StructOpt, Clone)]
 pub struct RunCmd {
-	/// Disable GRANDPA when running in validator mode
+	/// Enable validator mode
+	#[structopt(long = "validator")]
+	pub validator: bool,
+
+	/// Disable GRANDPA voter when running in validator mode, otherwise disables the GRANDPA observer
 	#[structopt(long = "no-grandpa")]
 	pub no_grandpa: bool,
 


### PR DESCRIPTION
Conflicts with #3348 but I think I prefer this one instead, because realistically no one will actually pass `--no-validator` and full nodes will be unnecessarily running validator code.

