### PR TITLE
node: exit on GRANDPA voter or BABE authoring error

### DIFF
--- a/core/cli/src/error.rs
+++ b/core/cli/src/error.rs
@@ -36,7 +36,17 @@ pub enum Error {
 	Input(String),
 	/// Invalid listen multiaddress
 	#[display(fmt="Invalid listen multiaddress")]
-	InvalidListenMultiaddress
+	InvalidListenMultiaddress,
+	/// Other uncategorized error.
+	Other(String),
+}
+
+/// Must be implemented explicitly because `derive_more` won't generate this
+/// case due to conflicting derive for `Other(String)`.
+impl std::convert::From<String> for Error {
+	fn from(s: String) -> Error {
+		Error::Input(s)
+	}
 }
 
 impl std::error::Error for Error {
@@ -48,6 +58,7 @@ impl std::error::Error for Error {
 			Error::Client(ref err) => Some(err),
 			Error::Input(_) => None,
 			Error::InvalidListenMultiaddress => None,
+			Error::Other(_) => None,
 		}
 	}
 }

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -680,8 +680,8 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 
 		poll_voter.select2(voter_commands_rx).then(move |res| match res {
 			Ok(future::Either::A(((), _))) => {
-				// voters don't conclude naturally; this could reasonably be an error.
-				Ok(FutureLoop::Break(()))
+				// voters don't conclude naturally
+				Err(Error::Safety("GRANDPA voter has concluded.".into()))
 			},
 			Err(future::Either::B(_)) => {
 				// the `voter_commands_rx` stream should not fail.

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -53,7 +53,7 @@
 //! included in the newly-finalized chain.
 
 use futures::prelude::*;
-use log::{debug, info, warn};
+use log::{debug, error, info};
 use futures::sync::mpsc;
 use client::{
 	BlockchainEvents, CallExecutor, Client, backend::Backend, error::Error as ClientError,
@@ -709,7 +709,7 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 	let voter_work = voter_work
 		.map(|_| ())
 		.map_err(|e| {
-			warn!("GRANDPA Voter failed: {:?}", e);
+			error!("GRANDPA Voter failed: {:?}", e);
 			telemetry!(CONSENSUS_WARN; "afg.voter_failed"; "e" => ?e);
 		});
 

--- a/core/service/src/components.rs
+++ b/core/service/src/components.rs
@@ -499,7 +499,7 @@ impl<Factory: ServiceFactory> DerefMut for FullComponents<Factory> {
 
 impl<Factory: ServiceFactory> Future for FullComponents<Factory> {
 	type Item = ();
-	type Error = ();
+	type Error = super::Error;
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		self.service.poll()
@@ -624,7 +624,7 @@ impl<Factory: ServiceFactory> DerefMut for LightComponents<Factory> {
 
 impl<Factory: ServiceFactory> Future for LightComponents<Factory> {
 	type Item = ();
-	type Error = ();
+	type Error = super::Error;
 
 	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		self.service.poll()

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -52,11 +52,11 @@ fn run_until_exit<T, C, E>(
 	mut runtime: Runtime,
 	service: T,
 	e: E,
-) -> error::Result<()>
-	where
-		T: Deref<Target=substrate_service::Service<C>> + Future<Item = (), Error = ()> + Send + 'static,
-		C: substrate_service::Components,
-		E: IntoExit,
+) -> error::Result<()> where
+	T: Deref<Target=substrate_service::Service<C>>,
+	T: Future<Item = (), Error = substrate_service::error::Error> + Send + 'static,
+	C: substrate_service::Components,
+	E: IntoExit,
 {
 	let (exit_send, exit) = exit_future::signal();
 
@@ -67,10 +67,19 @@ fn run_until_exit<T, C, E>(
 	// but we need to keep holding a reference to the global telemetry guard
 	let _telemetry = service.telemetry();
 
-	let _ = runtime.block_on(service.select(e.into_exit()));
+	let service_res = {
+		let exit = e.into_exit().map_err(|_| error::Error::Other("Exit future failed.".into()));
+		let service = service.map_err(|err| error::Error::Service(err));
+		let select = service.select(exit).map(|_| ()).map_err(|(err, _)| err);
+		runtime.block_on(select)
+	};
+
 	exit_send.fire();
 
-	Ok(())
+	// TODO [andre]: timeout this future #1318
+	let _ = runtime.shutdown_on_idle().wait();
+
+	service_res
 }
 
 // handles ctrl-c

--- a/node-template/src/main.rs
+++ b/node-template/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 	};
 
 	if let Err(e) = cli::run(::std::env::args(), cli::Exit, version) {
-		eprintln!("Error starting the node: {}\n\n{:?}", e, e);
+		eprintln!("Fatal error: {}\n\n{:?}", e, e);
 		std::process::exit(1)
 	}
 }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -223,11 +223,11 @@ fn run_until_exit<T, C, E>(
 	mut runtime: Runtime,
 	service: T,
 	e: E,
-) -> error::Result<()>
-	where
-		T: Deref<Target=substrate_service::Service<C>> + Future<Item = (), Error = ()> + Send + 'static,
-		C: substrate_service::Components,
-		E: IntoExit,
+) -> error::Result<()> where
+	T: Deref<Target=substrate_service::Service<C>>,
+	T: Future<Item = (), Error = substrate_service::error::Error> + Send + 'static,
+	C: substrate_service::Components,
+	E: IntoExit,
 {
 	let (exit_send, exit) = exit_future::signal();
 
@@ -238,11 +238,17 @@ fn run_until_exit<T, C, E>(
 	// but we need to keep holding a reference to the global telemetry guard
 	let _telemetry = service.telemetry();
 
-	let _ = runtime.block_on(service.select(e.into_exit()));
+	let service_res = {
+		let exit = e.into_exit().map_err(|_| error::Error::Other("Exit future failed.".into()));
+		let service = service.map_err(|err| error::Error::Service(err));
+		let select = service.select(exit).map(|_| ()).map_err(|(err, _)| err);
+		runtime.block_on(select)
+	};
+
 	exit_send.fire();
 
 	// TODO [andre]: timeout this future #1318
 	let _ = runtime.shutdown_on_idle().wait();
 
-	Ok(())
+	service_res
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
 	};
 
 	if let Err(e) = cli::run(::std::env::args(), Exit, version) {
-		eprintln!("Error starting the node: {}\n\n{:?}", e, e);
+		eprintln!("Fatal error: {}\n\n{:?}", e, e);
 		std::process::exit(1)
 	}
 }


### PR DESCRIPTION
Currently if either GRANDPA or BABE fails the node continues running, this behavior might be hard to spot by the users. For example, if the GRANDPA voter fails, the node might keep producing blocks but not observing finality anymore (and potentially not participating in the protocol). Most likely validators will have some process monitoring in place which will just restart the node afterwards.

In this PR when either of these validator tasks fails we shut down the service and exit cleanly.