### PR TITLE
node: setup disabled grandpa properly

### DIFF
--- a/core/network/src/protocol/consensus_gossip.rs
+++ b/core/network/src/protocol/consensus_gossip.rs
@@ -554,6 +554,28 @@ impl<B: BlockT> ConsensusGossip<B> {
 	}
 }
 
+/// A gossip message validator that discards all messages.
+pub struct DiscardAll;
+
+impl<B: BlockT> Validator<B> for DiscardAll {
+	fn validate(
+		&self,
+		_context: &mut dyn ValidatorContext<B>,
+		_sender: &PeerId,
+		_data: &[u8],
+	) -> ValidationResult<B::Hash> {
+		ValidationResult::Discard
+	}
+
+	fn message_expired<'a>(&'a self) -> Box<dyn FnMut(B::Hash, &[u8]) -> bool + 'a> {
+		Box::new(move |_topic, _data| true)
+	}
+
+	fn message_allowed<'a>(&'a self) -> Box<dyn FnMut(&PeerId, MessageIntent, &B::Hash, &[u8]) -> bool + 'a> {
+		Box::new(move |_who, _intent, _topic, _data| false)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use sr_primitives::testing::{H256, Block as RawBlock, ExtrinsicWrapper};

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -158,9 +158,6 @@ construct_service_factory! {
 							service.on_exit(),
 						)?));
 					},
-					(false, true) => {
-						// nothing to do here
-					},
 					(true, false) => {
 						// start the full GRANDPA voter
 						let telemetry_on_connect = TelemetryOnConnect {
@@ -176,15 +173,11 @@ construct_service_factory! {
 						};
 						service.spawn_task(Box::new(grandpa::run_grandpa_voter(grandpa_config)?));
 					},
-					(true, true) => {
-						// since we are an authority, when authoring blocks we
-						// expect inherent data regarding what our last
-						// finalized block is, to be available. since we don't
-						// start the grandpa voter, we need to register the
-						// inherent data provider ourselves.
-						grandpa::register_finality_tracker_inherent_data_provider(
+					(_, true) => {
+						grandpa::setup_disabled_grandpa(
 							service.client(),
 							&service.config().custom.inherent_data_providers,
+							service.network(),
 						)?;
 					},
 				}


### PR DESCRIPTION
When we run with GRANDPA disabled besides registering the finality tracker inherent provider we must also register a gossip validator for GRANDPA messages, otherwise we will ban peers who send us GRANDPA `Neighbor` messages since there's no validator associated with consensus engine id of message. I added a validator that just discards all messages. I tested this locally with 2 authorities (one running with `--no-grandpa`) and it works correctly now.
