### PR TITLE
Refactor parse_and_execute

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -274,8 +274,8 @@ impl<'a, RP> ParseAndPrepareRun<'a, RP> {
 		C: Default,
 		G: RuntimeGenesis,
 		E: IntoExit,
-		RS: FnOnce(E, RunCmd, RP, Configuration<C, G>) -> Result<(), String> {
-
+		RS: FnOnce(E, RunCmd, RP, Configuration<C, G>) -> Result<(), String>
+	{
 		let config = create_run_node_config(self.params.left.clone(), spec_factory, self.impl_name, self.version)?;
 
 		run_service(exit, self.params.left, self.params.right, config).map_err(Into::into)
@@ -295,8 +295,8 @@ impl<'a> ParseAndPrepareBuildSpec<'a> {
 		spec_factory: S
 	) -> error::Result<()>
 	where S: FnOnce(&str) -> Result<Option<ChainSpec<G>>, String>,
-		G: RuntimeGenesis {
-		
+		G: RuntimeGenesis
+	{
 		info!("Building chain spec");
 		let raw_output = self.params.raw;
 		let mut spec = load_spec(&self.params.shared_params, spec_factory)?;
@@ -324,8 +324,8 @@ impl<'a> ParseAndPrepareExport<'a> {
 	) -> error::Result<()>
 	where S: FnOnce(&str) -> Result<Option<ChainSpec<FactoryGenesis<F>>>, String>,
 		F: ServiceFactory,
-		E: IntoExit {
-
+		E: IntoExit
+	{
 		let config = create_config_with_db_path(spec_factory, &self.params.shared_params, self.version)?;
 
 		info!("DB path: {}", config.database_path.display());
@@ -359,8 +359,8 @@ impl<'a> ParseAndPrepareImport<'a> {
 	) -> error::Result<()>
 	where S: FnOnce(&str) -> Result<Option<ChainSpec<FactoryGenesis<F>>>, String>,
 		F: ServiceFactory,
-		E: IntoExit {
-		
+		E: IntoExit
+	{
 		let mut config = create_config_with_db_path(spec_factory, &self.params.shared_params, self.version)?;
 		config.execution_strategies = ExecutionStrategies {
 			importing: self.params.execution.into(),
@@ -396,12 +396,12 @@ impl<'a> ParseAndPreparePurge<'a> {
 		spec_factory: S
 	) -> error::Result<()>
 	where S: FnOnce(&str) -> Result<Option<ChainSpec<G>>, String>,
-		G: RuntimeGenesis {
-		
+		G: RuntimeGenesis
+	{
 		let config = create_config_with_db_path::<(), _, _>(spec_factory, &self.params.shared_params, self.version)?;
 		let db_path = config.database_path;
 
-		if self.params.yes == false {
+		if !self.params.yes {
 			print!("Are you sure to remove {:?}? (y/n)", &db_path);
 			stdout().flush().expect("failed to flush stdout");
 

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -467,6 +467,9 @@ impl<'a> ParseAndPrepareRevert<'a> {
 /// `RP` are custom parameters for the run command. This needs to be a `struct`! The custom
 /// parameters are visible to the user as if they were normal run command parameters. If no custom
 /// parameters are required, `NoCustom` can be used as type here.
+#[deprecated(
+	note = "Use parse_and_prepare instead; see the source code of parse_and_execute for how to transition"
+)]
 pub fn parse_and_execute<'a, F, CC, RP, S, RS, E, I, T>(
 	spec_factory: S,
 	version: &VersionInfo,

--- a/node-template/src/cli.rs
+++ b/node-template/src/cli.rs
@@ -3,7 +3,7 @@ use futures::{future, Future, sync::oneshot};
 use std::cell::RefCell;
 use tokio::runtime::Runtime;
 pub use substrate_cli::{VersionInfo, IntoExit, error};
-use substrate_cli::{informant, parse_and_execute, NoCustom};
+use substrate_cli::{informant, parse_and_prepare, ParseAndPrepare, NoCustom};
 use substrate_service::{ServiceFactory, Roles as ServiceRoles};
 use crate::chain_spec;
 use std::ops::Deref;
@@ -15,9 +15,8 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 	T: Into<std::ffi::OsString> + Clone,
 	E: IntoExit,
 {
-	parse_and_execute::<service::Factory, NoCustom, NoCustom, _, _, _, _, _>(
-		load_spec, &version, "substrate-node", args, exit,
-	 	|exit, _cli_args, _custom_args, config| {
+	match parse_and_prepare::<NoCustom, NoCustom, _>(&version, "substrate-node", args) {
+		ParseAndPrepare::Run(cmd) => cmd.run(load_spec, exit, |exit, _cli_args, _custom_args, config| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by {}, 2017, 2018", version.author);
@@ -37,8 +36,16 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 					exit
 				),
 			}.map_err(|e| format!("{:?}", e))
-		}
-	).map_err(Into::into).map(|_| ())
+		}),
+		ParseAndPrepare::BuildSpec(cmd) => cmd.run(load_spec),
+		ParseAndPrepare::ExportBlocks(cmd) => cmd.run::<service::Factory, _, _>(load_spec, exit),
+		ParseAndPrepare::ImportBlocks(cmd) => cmd.run::<service::Factory, _, _>(load_spec, exit),
+		ParseAndPrepare::PurgeChain(cmd) => cmd.run(load_spec),
+		ParseAndPrepare::RevertChain(cmd) => cmd.run::<service::Factory, _>(load_spec),
+		ParseAndPrepare::CustomCommand(_) => Ok(())
+	}?;
+
+	Ok(())
 }
 
 fn load_spec(id: &str) -> Result<Option<chain_spec::ChainSpec>, String> {

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -31,7 +31,7 @@ use substrate_service::{ServiceFactory, Roles as ServiceRoles};
 use std::ops::Deref;
 use log::info;
 use structopt::{StructOpt, clap::App};
-use cli::{AugmentClap, GetLogFilter};
+use cli::{AugmentClap, GetLogFilter, parse_and_prepare, ParseAndPrepare};
 use crate::factory_impl::FactoryState;
 use transaction_factory::RuntimeAdapter;
 use client::ExecutionStrategies;
@@ -158,9 +158,8 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 	T: Into<std::ffi::OsString> + Clone,
 	E: IntoExit,
 {
-	let ret = cli::parse_and_execute::<service::Factory, CustomSubcommands, NoCustom, _, _, _, _, _>(
-		load_spec, &version, "substrate-node", args, exit,
-		|exit, _cli_args, _custom_args, config| {
+	match parse_and_prepare::<CustomSubcommands, NoCustom, _>(&version, "substrate-node", args) {
+		ParseAndPrepare::Run(cmd) => cmd.run(load_spec, exit, |exit, _cli_args, _custom_args, config| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by Parity Technologies, 2017-2019");
@@ -181,11 +180,13 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 					exit
 				),
 			}.map_err(|e| format!("{:?}", e))
-		}
-	);
-
-	match &ret {
-		Ok(Some(CustomSubcommands::Factory(cli_args))) => {
+		}),
+		ParseAndPrepare::BuildSpec(cmd) => cmd.run(load_spec),
+		ParseAndPrepare::ExportBlocks(cmd) => cmd.run::<service::Factory, _, _>(load_spec, exit),
+		ParseAndPrepare::ImportBlocks(cmd) => cmd.run::<service::Factory, _, _>(load_spec, exit),
+		ParseAndPrepare::PurgeChain(cmd) => cmd.run(load_spec),
+		ParseAndPrepare::RevertChain(cmd) => cmd.run::<service::Factory, _>(load_spec),
+		ParseAndPrepare::CustomCommand(CustomSubcommands::Factory(cli_args)) => {
 			let mut config = cli::create_config_with_db_path(
 				load_spec,
 				&cli_args.shared_params,
@@ -214,8 +215,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: cli::VersionInfo) -> error::Resul
 			).map_err(|e| format!("Error in transaction factory: {}", e))?;
 
 			Ok(())
-		},
-		_ => ret.map_err(Into::into).map(|_| ())
+		}
 	}
 }
 


### PR DESCRIPTION
Deprecates `parse_and_execute` and replaces it with a new `parse_and_prepare` function whose control flow is in my opinion way easier to read.

I invite you to check out the third commit to see what the new code looks like.

The reason for this change is that I'd like to get rid of the `ServiceFactory` and `Components` traits, which `parse_and_execute` uses.
This PR instead moves the `ServiceFactory` trait usage to when the user calls `run()`, which makes it possible in the future to add functions other than `run()` that don't require this trait.
As an example, we could add a function to `ParseAndExecute::RevertChain` that simple requires passing a `Client` by parameter, instead of asking for a `ServiceFactory`.
