### PR TITLE
Implement Deserialize for SignedBlock and Header.

### DIFF
--- a/core/sr-primitives/src/generic/block.rs
+++ b/core/sr-primitives/src/generic/block.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 
 #[cfg(feature = "std")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use rstd::prelude::*;
 use crate::codec::{Codec, Encode, Decode};
@@ -62,7 +62,7 @@ impl<Block: BlockT> fmt::Display for BlockId<Block> {
 
 /// Abstraction over a substrate block.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", serde(deny_unknown_fields))]
 pub struct Block<Header, Extrinsic: MaybeSerialize> {
@@ -97,7 +97,7 @@ where
 
 /// Abstraction over a substrate block and justification.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", serde(deny_unknown_fields))]
 pub struct SignedBlock<Block> {

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -110,6 +110,17 @@ impl<Hash: Encode> ::serde::Serialize for DigestItem<Hash> {
 	}
 }
 
+#[cfg(feature = "std")]
+impl<'a, Hash: Decode> ::serde::Deserialize<'a> for DigestItem<Hash> {
+	fn deserialize<D>(de: D) -> Result<Self, D::Error> where
+		D: ::serde::Deserializer<'a>,
+	{
+		let r = ::primitives::bytes::deserialize(de)?;
+		Decode::decode(&mut &r[..])
+			.map_err(|e| ::serde::de::Error::custom(format!("Decode error: {}", e)))
+	}
+}
+
 /// A 'referencing view' for digest item. Does not own its contents. Used by
 /// final runtime implementations for encoding/decoding its log items.
 #[derive(PartialEq, Eq, Clone)]

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -102,22 +102,22 @@ pub enum DigestItem<Hash> {
 }
 
 #[cfg(feature = "std")]
-impl<Hash: Encode> ::serde::Serialize for DigestItem<Hash> {
-	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
+impl<Hash: Encode> serde::Serialize for DigestItem<Hash> {
+	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		self.using_encoded(|bytes| {
-			::primitives::bytes::serialize(bytes, seq)
+			primitives::bytes::serialize(bytes, seq)
 		})
 	}
 }
 
 #[cfg(feature = "std")]
-impl<'a, Hash: Decode> ::serde::Deserialize<'a> for DigestItem<Hash> {
+impl<'a, Hash: Decode> serde::Deserialize<'a> for DigestItem<Hash> {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error> where
-		D: ::serde::Deserializer<'a>,
+		D: serde::Deserializer<'a>,
 	{
-		let r = ::primitives::bytes::deserialize(de)?;
+		let r = primitives::bytes::deserialize(de)?;
 		Decode::decode(&mut &r[..])
-			.map_err(|e| ::serde::de::Error::custom(format!("Decode error: {}", e)))
+			.map_err(|e| serde::de::Error::custom(format!("Decode error: {}", e)))
 	}
 }
 

--- a/core/sr-primitives/src/generic/digest.rs
+++ b/core/sr-primitives/src/generic/digest.rs
@@ -17,7 +17,7 @@
 //! Generic implementation of a digest.
 
 #[cfg(feature = "std")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use rstd::prelude::*;
 
@@ -26,7 +26,7 @@ use crate::codec::{Decode, Encode, Input, Error};
 
 /// Generic header digest.
 #[derive(PartialEq, Eq, Clone, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 pub struct Digest<Hash: Encode + Decode> {
 	/// A list of logs in the digest.
 	pub logs: Vec<DigestItem<Hash>>,

--- a/core/sr-primitives/src/generic/header.rs
+++ b/core/sr-primitives/src/generic/header.rs
@@ -17,7 +17,7 @@
 //! Generic implementation of a block header.
 
 #[cfg(feature = "std")]
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "std")]
 use log::debug;
 use crate::codec::{Decode, Encode, Codec, Input, Output, HasCompact, EncodeAsRef, Error};
@@ -29,21 +29,21 @@ use crate::generic::Digest;
 
 /// Abstraction over a block header for a substrate chain.
 #[derive(PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize))]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", serde(deny_unknown_fields))]
 pub struct Header<Number: Copy + Into<u128>, Hash: HashT> {
 	/// The parent hash.
-	pub parent_hash: <Hash as HashT>::Output,
+	pub parent_hash: Hash::Output,
 	/// The block number.
 	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_number"))]
 	pub number: Number,
 	/// The state trie merkle root
-	pub state_root: <Hash as HashT>::Output,
+	pub state_root: Hash::Output,
 	/// The merkle root of the extrinsics.
-	pub extrinsics_root: <Hash as HashT>::Output,
+	pub extrinsics_root: Hash::Output,
 	/// A chain-specific digest of data useful for light clients or referencing auxiliary data.
-	pub digest: Digest<<Hash as HashT>::Output>,
+	pub digest: Digest<Hash::Output>,
 }
 
 #[cfg(feature = "std")]

--- a/core/sr-primitives/src/generic/header.rs
+++ b/core/sr-primitives/src/generic/header.rs
@@ -51,13 +51,17 @@ pub struct Header<Number: Copy + Into<U256> + TryFrom<U256>, Hash: HashT> {
 }
 
 #[cfg(feature = "std")]
-pub fn serialize_number<S, T: Copy + Into<U256> + TryFrom<U256>>(val: &T, s: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
+pub fn serialize_number<S, T: Copy + Into<U256> + TryFrom<U256>>(
+	val: &T, s: S,
+) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
 	let u256: U256 = (*val).into();
 	::serde::Serialize::serialize(&u256, s)
 }
 
 #[cfg(feature = "std")]
-pub fn deserialize_number<'a, D, T: Copy + Into<U256> + TryFrom<U256>>(d: D) -> Result<T, D::Error> where D: ::serde::Deserializer<'a> {
+pub fn deserialize_number<'a, D, T: Copy + Into<U256> + TryFrom<U256>>(
+	d: D,
+) -> Result<T, D::Error> where D: ::serde::Deserializer<'a> {
 	let u256: U256 = ::serde::Deserialize::deserialize(d)?;
 	TryFrom::try_from(u256).map_err(|_| ::serde::de::Error::custom("Try from failed"))
 }
@@ -99,9 +103,11 @@ impl<Number, Hash> codec::EncodeLike for Header<Number, Hash> where
 {}
 
 impl<Number, Hash> traits::Header for Header<Number, Hash> where
-	Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + MaybeDisplay + SimpleArithmetic + Codec + Copy + Into<U256> + TryFrom<U256>,
+	Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + MaybeDisplay +
+		SimpleArithmetic + Codec + Copy + Into<U256> + TryFrom<U256>,
 	Hash: HashT,
-	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeSerializeDebugButNotDeserialize + MaybeDisplay + SimpleBitOps + Codec,
+	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member +
+		MaybeSerializeDebugButNotDeserialize + MaybeDisplay + SimpleBitOps + Codec,
 {
 	type Number = Number;
 	type Hash = <Hash as HashT>::Output;

--- a/core/sr-primitives/src/generic/header.rs
+++ b/core/sr-primitives/src/generic/header.rs
@@ -53,17 +53,17 @@ pub struct Header<Number: Copy + Into<U256> + TryFrom<U256>, Hash: HashT> {
 #[cfg(feature = "std")]
 pub fn serialize_number<S, T: Copy + Into<U256> + TryFrom<U256>>(
 	val: &T, s: S,
-) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
+) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 	let u256: U256 = (*val).into();
-	::serde::Serialize::serialize(&u256, s)
+	serde::Serialize::serialize(&u256, s)
 }
 
 #[cfg(feature = "std")]
 pub fn deserialize_number<'a, D, T: Copy + Into<U256> + TryFrom<U256>>(
 	d: D,
-) -> Result<T, D::Error> where D: ::serde::Deserializer<'a> {
-	let u256: U256 = ::serde::Deserialize::deserialize(d)?;
-	TryFrom::try_from(u256).map_err(|_| ::serde::de::Error::custom("Try from failed"))
+) -> Result<T, D::Error> where D: serde::Deserializer<'a> {
+	let u256: U256 = serde::Deserialize::deserialize(d)?;
+	TryFrom::try_from(u256).map_err(|_| serde::de::Error::custom("Try from failed"))
 }
 
 impl<Number, Hash> Decode for Header<Number, Hash> where
@@ -103,10 +103,10 @@ impl<Number, Hash> codec::EncodeLike for Header<Number, Hash> where
 {}
 
 impl<Number, Hash> traits::Header for Header<Number, Hash> where
-	Number: Member + MaybeSerializeDebug + ::rstd::hash::Hash + MaybeDisplay +
+	Number: Member + MaybeSerializeDebug + rstd::hash::Hash + MaybeDisplay +
 		SimpleArithmetic + Codec + Copy + Into<U256> + TryFrom<U256>,
 	Hash: HashT,
-	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member +
+	Hash::Output: Default + rstd::hash::Hash + Copy + Member +
 		MaybeSerializeDebugButNotDeserialize + MaybeDisplay + SimpleBitOps + Codec,
 {
 	type Number = Number;
@@ -154,9 +154,9 @@ impl<Number, Hash> traits::Header for Header<Number, Hash> where
 }
 
 impl<Number, Hash> Header<Number, Hash> where
-	Number: Member + ::rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec + Into<U256> + TryFrom<U256>,
+	Number: Member + rstd::hash::Hash + Copy + MaybeDisplay + SimpleArithmetic + Codec + Into<U256> + TryFrom<U256>,
 	Hash: HashT,
-	Hash::Output: Default + ::rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Codec,
+	Hash::Output: Default + rstd::hash::Hash + Copy + Member + MaybeDisplay + SimpleBitOps + Codec,
  {
 	/// Convenience helper for computing the hash of the header without having
 	/// to import the trait.
@@ -174,7 +174,7 @@ mod tests {
 		fn serialize(num: u128) -> String {
 			let mut v = vec![];
 			{
-				let mut ser = ::serde_json::Serializer::new(::std::io::Cursor::new(&mut v));
+				let mut ser = serde_json::Serializer::new(std::io::Cursor::new(&mut v));
 				serialize_number(&num, &mut ser).unwrap();
 			}
 			String::from_utf8(v).unwrap()
@@ -189,7 +189,7 @@ mod tests {
 	#[test]
 	fn should_deserialize_number() {
 		fn deserialize(num: &str) -> u128 {
-			let mut der = ::serde_json::Deserializer::new(::serde_json::de::StrRead::new(num));
+			let mut der = serde_json::Deserializer::new(serde_json::de::StrRead::new(num));
 			deserialize_number(&mut der).unwrap()
 		}
 

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -824,6 +824,15 @@ impl ::serde::Serialize for OpaqueExtrinsic {
 	}
 }
 
+#[cfg(feature = "std")]
+impl<'a> ::serde::Deserialize<'a> for OpaqueExtrinsic {
+	fn deserialize<D>(de: D) -> Result<Self, D::Error> where D: ::serde::Deserializer<'a> {
+		let r = ::primitives::bytes::deserialize(de)?;
+		Decode::decode(&mut &r[..])
+			.map_err(|e| ::serde::de::Error::custom(format!("Decode error: {}", e)))
+	}
+}
+
 impl traits::Extrinsic for OpaqueExtrinsic {
 	type Call = ();
 


### PR DESCRIPTION
Required for sharing `SignedBlock` and `Header` with users so they don't have to redefine them.