### PR TITLE
subkey network default works

### DIFF
--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -41,7 +41,11 @@ trait Crypto {
 	}
 	fn ss58_from_pair(pair: &Self::Pair) -> String { pair.public().to_ss58check() }
 	fn public_from_pair(pair: &Self::Pair) -> Vec<u8> { pair.public().as_ref().to_owned() }
-	fn print_from_uri(uri: &str, password: Option<&str>) where <Self::Pair as Pair>::Public: Sized + Ss58Codec + AsRef<[u8]> {
+	fn print_from_uri(
+		uri: &str,
+		password: Option<&str>,
+		network_override: Option<Ss58AddressFormat>,
+	) where <Self::Pair as Pair>::Public: Sized + Ss58Codec + AsRef<[u8]> {
 		if let Ok((pair, seed)) = Self::Pair::from_phrase(uri, password) {
 			println!("Secret phrase `{}` is account:\n  Secret seed: 0x{}\n  Public key (hex): 0x{}\n  Address (SS58): {}",
 				uri,
@@ -56,9 +60,10 @@ trait Crypto {
 				Self::ss58_from_pair(&pair)
 			);
 		} else if let Ok((public, v)) = <Self::Pair as Pair>::Public::from_string_with_version(uri) {
+			let v = network_override.unwrap_or(v);
 			println!("Public Key URI `{}` is account:\n  Network ID/version: {}\n  Public key (hex): 0x{}\n  Address (SS58): {}",
 				uri,
-				String::from(Ss58AddressFormat::from(v)),
+				String::from(v),
 				HexDisplay::from(&public.as_ref()),
 				public.to_ss58check_with_version(v)
 			);
@@ -100,11 +105,12 @@ fn execute<C: Crypto>(matches: clap::ArgMatches) where
 		)
 	};
 	let password = matches.value_of("password");
-	let maybe_network = matches.value_of("network");
+	let maybe_network: Option<Ss58AddressFormat> = matches.value_of("network")
+		.map(|network| network.try_into()
+			.expect("Invalid network name: must be polkadot/substrate/kusama")
+		);
 	if let Some(network) = maybe_network {
-		let v = network.try_into()
-			.expect("Invalid network name: must be polkadot/substrate/kusama");
-		set_default_ss58_version(v);
+		set_default_ss58_version(network);
 	}
 	match matches.subcommand() {
 		("generate", Some(matches)) => {
@@ -115,17 +121,21 @@ fn execute<C: Crypto>(matches: clap::ArgMatches) where
 					.expect("Invalid number of words given for phrase: must be 12/15/18/21/24")
 				).unwrap_or(MnemonicType::Words12);
 			let mnemonic = Mnemonic::new(words, Language::English);
-			C::print_from_uri(mnemonic.phrase(), password);
+			C::print_from_uri(mnemonic.phrase(), password, maybe_network);
 		}
 		("inspect", Some(matches)) => {
 			let uri = matches.value_of("uri")
 				.expect("URI parameter is required; thus it can't be None; qed");
-			C::print_from_uri(uri, password);
+			C::print_from_uri(uri, password, maybe_network);
 		}
 		("vanity", Some(matches)) => {
 			let desired: String = matches.value_of("pattern").map(str::to_string).unwrap_or_default();
 			let result = vanity::generate_key::<C>(&desired).expect("Key generation failed");
-			C::print_from_uri(&format!("0x{}", HexDisplay::from(&result.seed.as_ref())), None);
+			C::print_from_uri(
+				&format!("0x{}", HexDisplay::from(&result.seed.as_ref())),
+				None,
+				maybe_network
+			);
 		}
 		("sign", Some(matches)) => {
 			let suri = matches.value_of("suri")


### PR DESCRIPTION
Old behaviour didn't take account of `--network` flag when inspecting a derived address.