### PR TITLE
Make sure that `srml-collective` does not initialize `Members` twice

### DIFF
--- a/srml/membership/src/lib.rs
+++ b/srml/membership/src/lib.rs
@@ -24,8 +24,7 @@
 
 use sr_std::prelude::*;
 use srml_support::{
-	StorageValue, decl_module, decl_storage, decl_event,
-	traits::{ChangeMembers}
+	StorageValue, decl_module, decl_storage, decl_event, traits::{ChangeMembers, InitializeMembers},
 };
 use system::ensure_root;
 use sr_primitives::{traits::EnsureOrigin, weights::SimpleDispatchInfo};
@@ -49,7 +48,7 @@ pub trait Trait<I=DefaultInstance>: system::Trait {
 	/// The receiver of the signal for when the membership has been initialized. This happens pre-
 	/// genesis and will usually be the same as `MembershipChanged`. If you need to do something
 	/// different on initialization, then you can change this accordingly.
-	type MembershipInitialized: ChangeMembers<Self::AccountId>;
+	type MembershipInitialized: InitializeMembers<Self::AccountId>;
 
 	/// The receiver of the signal for when the membership has changed.
 	type MembershipChanged: ChangeMembers<Self::AccountId>;
@@ -65,12 +64,12 @@ decl_storage! {
 		config(phantom): sr_std::marker::PhantomData<I>;
 		build(|
 			storage: &mut (sr_primitives::StorageOverlay, sr_primitives::ChildrenStorageOverlay),
-			config: &GenesisConfig<T, I>
+			config: &Self,
 		| {
 			sr_io::with_storage(storage, || {
 				let mut members = config.members.clone();
 				members.sort();
-				T::MembershipInitialized::set_members_sorted(&members[..], &[]);
+				T::MembershipInitialized::initialize_members(&members);
 				<Members<T, I>>::put(members);
 			});
 		})

--- a/srml/membership/src/lib.rs
+++ b/srml/membership/src/lib.rs
@@ -265,6 +265,11 @@ mod tests {
 			MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
 		}
 	}
+	impl InitializeMembers<u64> for TestChangeMembers {
+		fn initialize_members(members: &[u64]) {
+			MEMBERS.with(|m| *m.borrow_mut() = members.to_vec());
+		}
+	}
 
 	impl Trait for Test {
 		type Event = ();

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -684,14 +684,18 @@ pub trait ChangeMembers<AccountId: Clone + Ord> {
 	}
 }
 
-/// Trait for type that can handle the initialization of account IDs at genesis.
-pub trait InitializeMembers<AccountId: Clone + Ord> {
-	/// Initialize the members to the given `members`.
-	fn initialize_members(members: &[AccountId]);
-}
-
 impl<T: Clone + Ord> ChangeMembers<T> for () {
 	fn change_members(_: &[T], _: &[T], _: Vec<T>) {}
 	fn change_members_sorted(_: &[T], _: &[T], _: &[T]) {}
 	fn set_members_sorted(_: &[T], _: &[T]) {}
+}
+
+/// Trait for type that can handle the initialization of account IDs at genesis.
+pub trait InitializeMembers<AccountId> {
+	/// Initialize the members to the given `members`.
+	fn initialize_members(members: &[AccountId]);
+}
+
+impl<T> InitializeMembers<T> for () {
+	fn initialize_members(_: &[T]) {}
 }

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -684,6 +684,12 @@ pub trait ChangeMembers<AccountId: Clone + Ord> {
 	}
 }
 
+/// Trait for type that can handle the initialization of account IDs at genesis.
+pub trait InitializeMembers<AccountId: Clone + Ord> {
+	/// Initialize the members to the given `members`.
+	fn initialize_members(members: &[AccountId]);
+}
+
 impl<T: Clone + Ord> ChangeMembers<T> for () {
 	fn change_members(_: &[T], _: &[T], _: Vec<T>) {}
 	fn change_members_sorted(_: &[T], _: &[T], _: &[T]) {}


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/3373