### PR TITLE
Replace config field with default value (srml/im-online)

### DIFF
--- a/core/network/src/protocol/light_dispatch.rs
+++ b/core/network/src/protocol/light_dispatch.rs
@@ -668,7 +668,7 @@ pub mod tests {
 	use sr_primitives::traits::{Block as BlockT, NumberFor, Header as HeaderT};
 	use client::{error::{Error as ClientError, Result as ClientResult}};
 	use client::light::fetcher::{FetchChecker, RemoteHeaderRequest,
-		ChangesProof,	RemoteCallRequest, RemoteReadRequest,
+		ChangesProof, RemoteCallRequest, RemoteReadRequest,
 		RemoteReadChildRequest, RemoteChangesRequest, RemoteBodyRequest};
 	use crate::config::Roles;
 	use crate::message::{self, BlockAttributes, Direction, FromBlock, RequestId};

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -169,7 +169,6 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			authorities: initial_authorities.iter().map(|x| (x.3.clone(), 1)).collect(),
 		}),
 		im_online: Some(ImOnlineConfig {
-			gossip_at: 0,
 			keys: initial_authorities.iter().map(|x| x.4.clone()).collect(),
 		}),
 		grandpa: Some(GrandpaConfig {
@@ -302,7 +301,6 @@ pub fn testnet_genesis(
 			authorities: initial_authorities.iter().map(|x| (x.3.clone(), 1)).collect(),
 		}),
 		im_online: Some(ImOnlineConfig{
-			gossip_at: 0,
 			keys: initial_authorities.iter().map(|x| x.4.clone()).collect(),
 		}),
 		grandpa: Some(GrandpaConfig {

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -19,9 +19,9 @@
 use primitives::{Pair, Public, crypto::UncheckedInto};
 pub use node_primitives::{AccountId, Balance};
 use node_runtime::{
-	BabeConfig,	BalancesConfig, ContractsConfig, CouncilConfig, DemocracyConfig,
+	BabeConfig, BalancesConfig, ContractsConfig, CouncilConfig, DemocracyConfig,
 	ElectionsConfig, GrandpaConfig, ImOnlineConfig, IndicesConfig, Perbill,
-	SessionConfig,	SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
+	SessionConfig, SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
 	TechnicalCommitteeConfig, WASM_BINARY,
 };
 use node_runtime::constants::{time::*, currency::*};

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -436,7 +436,7 @@ construct_runtime!(
 		Treasury: treasury::{Module, Call, Storage, Event<T>},
 		Contracts: contracts,
 		Sudo: sudo,
-		ImOnline: im_online::{Module, Call, Storage, Event, ValidateUnsigned, Config<T>},
+		ImOnline: im_online::{Module, Call, Storage, Event, ValidateUnsigned, Config},
 	}
 );
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 140,
-	impl_version: 140,
+	impl_version: 141,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -35,7 +35,7 @@ use sr_primitives::traits::{BlakeTwo256, Hash, IdentityLookup};
 use sr_primitives::{Perbill, BuildStorage};
 use srml_support::{
 	assert_ok, assert_err, impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types,
-	storage::child,	StorageMap, StorageValue, traits::{Currency, Get},
+	storage::child, StorageMap, StorageValue, traits::{Currency, Get},
 };
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -70,7 +70,7 @@
 use primitives::offchain::{OpaqueNetworkState, StorageKind};
 use codec::{Encode, Decode};
 use sr_primitives::{
-	ApplyError, traits::{Extrinsic as ExtrinsicT, Zero},
+	ApplyError, traits::Extrinsic as ExtrinsicT,
 	transaction_validity::{TransactionValidity, TransactionLongevity, ValidTransaction},
 };
 use rstd::prelude::*;
@@ -174,7 +174,7 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as ImOnline {
 		/// The block number when we should gossip.
-		GossipAt get(gossip_at) build(|_| Zero::zero()): T::BlockNumber;
+		GossipAt get(gossip_at) : T::BlockNumber;
 
 		/// The current set of keys that may issue a heartbeat.
 		Keys get(keys) config(): Vec<AuthorityId>;

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -70,7 +70,7 @@
 use primitives::offchain::{OpaqueNetworkState, StorageKind};
 use codec::{Encode, Decode};
 use sr_primitives::{
-	ApplyError, traits::{Extrinsic as ExtrinsicT},
+	ApplyError, traits::{Extrinsic as ExtrinsicT, Zero},
 	transaction_validity::{TransactionValidity, TransactionLongevity, ValidTransaction},
 };
 use rstd::prelude::*;
@@ -174,7 +174,7 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as ImOnline {
 		/// The block number when we should gossip.
-		GossipAt get(gossip_at) config(): T::BlockNumber;
+		GossipAt get(gossip_at) build(|_| Zero::zero()): T::BlockNumber;
 
 		/// The current set of keys that may issue a heartbeat.
 		Keys get(keys) config(): Vec<AuthorityId>;

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -174,7 +174,7 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as ImOnline {
 		/// The block number when we should gossip.
-		GossipAt get(gossip_at) : T::BlockNumber;
+		GossipAt get(gossip_at): T::BlockNumber;
 
 		/// The current set of keys that may issue a heartbeat.
 		Keys get(keys) config(): Vec<AuthorityId>;


### PR DESCRIPTION
The behavior we want is for gossiping to occur automatically right at startup.

It's not necessary to make this configurable. Also it's possibly dangerous to make this configurable, since if misconfigured a heartbeat would only be sent out at the configured block ‒ possibly resulting in slashing if this block is greater than the session length.