### PR TITLE
Make inflation mod public to access inflation functions

### DIFF
--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -277,7 +277,7 @@ mod mock;
 mod tests;
 
 mod phragmen;
-mod inflation;
+pub mod inflation;
 
 #[cfg(all(feature = "bench", test))]
 mod benches;


### PR DESCRIPTION
This PR makes the inflation module public so that one can access the functions inside.

I am trying to access the inflation functions/rate in order to mint tokens for the Treasury. We would like to do so in different time intervals. My intuition is that if I provide a smaller interval I will still get roughly the same inflation rate as is created over an era.