### PR TITLE
sync: fix peer common number on block announce

### DIFF
--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -922,10 +922,10 @@ impl<B: BlockT> ChainSync<B> {
 		}
 		// We assume that the announced block is the latest they have seen, and so our common number
 		// is either one further ahead or it's the one they just announced, if we know about it.
-		if header.parent_hash() == &self.best_queued_hash || known_parent {
-			peer.common_number = number - One::one();
-		} else if known {
+		if known {
 			peer.common_number = number
+		} else if header.parent_hash() == &self.best_queued_hash || known_parent {
+			peer.common_number = number - One::one();
 		}
 		self.is_idle = false;
 


### PR DESCRIPTION
When we receive a new block announcement we check whether we already know the block or its parent in order to update common block number of the peer that sent the announcement. We were performing the check for `known_parent` first, which means that if we already knew the announced block (not its parent!) we would still set our common number to `announced - 1`, instead of `announced`. This lead to continuously downloading and importing the tip of the chain.

The fix is to change the order of the checks, so that the check for known announced block is done before the check for its parent.