### PR TITLE
session: add handler for genesis session

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -166,13 +166,13 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 			key: endowed_accounts[0].clone(),
 		}),
 		babe: Some(BabeConfig {
-			authorities: initial_authorities.iter().map(|x| (x.3.clone(), 1)).collect(),
+			authorities: vec![],
 		}),
 		im_online: Some(ImOnlineConfig {
-			keys: initial_authorities.iter().map(|x| x.4.clone()).collect(),
+			keys: vec![],
 		}),
 		grandpa: Some(GrandpaConfig {
-			authorities: initial_authorities.iter().map(|x| (x.2.clone(), 1)).collect(),
+			authorities: vec![],
 		}),
 		membership_Instance1: Some(Default::default()),
 	}

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -298,13 +298,13 @@ pub fn testnet_genesis(
 			key: root_key,
 		}),
 		babe: Some(BabeConfig {
-			authorities: initial_authorities.iter().map(|x| (x.3.clone(), 1)).collect(),
+			authorities: vec![],
 		}),
 		im_online: Some(ImOnlineConfig{
-			keys: initial_authorities.iter().map(|x| x.4.clone()).collect(),
+			keys: vec![],
 		}),
 		grandpa: Some(GrandpaConfig {
-			authorities: initial_authorities.iter().map(|x| (x.2.clone(), 1)).collect(),
+			authorities: vec![],
 		}),
 		membership_Instance1: Some(Default::default()),
 	}

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 142,
-	impl_version: 142,
+	spec_version: 143,
+	impl_version: 143,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 141,
-	impl_version: 141,
+	spec_version: 142,
+	impl_version: 142,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/aura/Cargo.toml
+++ b/srml/aura/Cargo.toml
@@ -12,7 +12,7 @@ rstd = { package = "sr-std", path = "../../core/sr-std", default-features = fals
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
 primitives = { package = "substrate-primitives",  path = "../../core/primitives", default-features = false }
 app-crypto = { package = "substrate-application-crypto",  path = "../../core/application-crypto", default-features = false }
-runtime_io = { package = "sr-io", path = "../../core/sr-io" }
+runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false, features = [ "wasm-nice-panic-message" ] }
 srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }

--- a/srml/aura/Cargo.toml
+++ b/srml/aura/Cargo.toml
@@ -12,6 +12,7 @@ rstd = { package = "sr-std", path = "../../core/sr-std", default-features = fals
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
 primitives = { package = "substrate-primitives",  path = "../../core/primitives", default-features = false }
 app-crypto = { package = "substrate-application-crypto",  path = "../../core/application-crypto", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io" }
 srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -188,6 +188,13 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = T::AuthorityId;
 
+	fn on_genesis_session<'a, I: 'a>(validators: I)
+		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
+	{
+		let authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
+		<Authorities<T>>::put(&authorities);
+	}
+
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, _queued_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
@@ -200,6 +207,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 			}
 		}
 	}
+
 	fn on_disabled(i: usize) {
 		let log: DigestItem<T::Hash> = DigestItem::Consensus(
 			AURA_ENGINE_ID,

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -191,6 +191,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
+		assert!(<Authorities<T>>::get().is_empty(), "Authorities are already initialized!");
 		let authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
 		<Authorities<T>>::put(&authorities);
 	}

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -123,7 +123,7 @@ decl_storage! {
 		pub EpochIndex get(epoch_index): u64;
 
 		/// Current epoch authorities.
-		pub Authorities get(authorities) config(): Vec<(AuthorityId, BabeWeight)>;
+		pub Authorities get(authorities): Vec<(AuthorityId, BabeWeight)>;
 
 		/// Slot at which the current epoch started. It is possible that no
 		/// block was authored at the given slot and the epoch change was
@@ -162,6 +162,18 @@ decl_storage! {
 		/// epoch.
 		SegmentIndex build(|_| 0): u32;
 		UnderConstruction: map u32 => Vec<[u8; 32 /* VRF_OUTPUT_LENGTH */]>;
+	}
+	add_extra_genesis {
+		config(authorities): Vec<(AuthorityId, BabeWeight)>;
+		build(|
+			storage: &mut (sr_primitives::StorageOverlay, sr_primitives::ChildrenStorageOverlay),
+			config: &GenesisConfig
+		| {
+			runtime_io::with_storage(
+				storage,
+				|| Module::<T>::initialize_authorities(&config.authorities),
+			);
+		})
 	}
 }
 
@@ -292,14 +304,11 @@ impl<T: Trait> Module<T> {
 		this_randomness
 	}
 
-	fn set_authorities<'a, I: 'a>(authorities: I)
-		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
-	{
-		let authorities = authorities.map(|(_account, k)| {
-			(k, 1)
-		}).collect::<Vec<_>>();
-
-		Authorities::put(authorities);
+	fn initialize_authorities(authorities: &[(AuthorityId, BabeWeight)]) {
+		if !authorities.is_empty() {
+			assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
+			Authorities::put_ref(authorities);
+		}
 	}
 }
 
@@ -313,8 +322,8 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
-		assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
-		Self::set_authorities(validators);
+		let authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
+		Self::initialize_authorities(&authorities);
 	}
 
 	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, queued_validators: I)
@@ -328,7 +337,11 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		EpochIndex::put(epoch_index);
 
 		// Update authorities.
-		Self::set_authorities(validators);
+		let authorities = validators.map(|(_account, k)| {
+			(k, 1)
+		}).collect::<Vec<_>>();
+
+		Authorities::put(authorities);
 
 		// Update epoch start slot.
 		let now = CurrentSlot::get();

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -313,6 +313,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
+		assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
 		Self::set_authorities(validators);
 	}
 

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -292,6 +292,15 @@ impl<T: Trait> Module<T> {
 		this_randomness
 	}
 
+	fn set_authorities<'a, I: 'a>(authorities: I)
+		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+	{
+		let authorities = authorities.map(|(_account, k)| {
+			(k, 1)
+		}).collect::<Vec<_>>();
+
+		Authorities::put(authorities);
+	}
 }
 
 impl<T: Trait> OnTimestampSet<T::Moment> for Module<T> {
@@ -300,6 +309,13 @@ impl<T: Trait> OnTimestampSet<T::Moment> for Module<T> {
 
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = AuthorityId;
+
+	fn on_genesis_session<'a, I: 'a>(validators: I)
+		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+	{
+		Self::set_authorities(validators);
+	}
+
 	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, queued_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
@@ -311,11 +327,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		EpochIndex::put(epoch_index);
 
 		// Update authorities.
-		let authorities = validators.map(|(_account, k)| {
-			(k, 1)
-		}).collect::<Vec<_>>();
-
-		Authorities::put(authorities);
+		Self::set_authorities(validators);
 
 		// Update epoch start slot.
 		let now = CurrentSlot::get();

--- a/srml/grandpa/Cargo.toml
+++ b/srml/grandpa/Cargo.toml
@@ -10,6 +10,7 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 primitives = { package = "substrate-primitives",  path = "../../core/primitives", default-features = false }
 substrate-finality-grandpa-primitives = { path = "../../core/finality-grandpa/primitives", default-features = false }
 rstd = { package = "sr-std", path = "../../core/sr-std", default-features = false }
+runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false, features = [ "wasm-nice-panic-message" ] }
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
 srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -133,7 +133,7 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as GrandpaFinality {
 		/// The current authority set.
-		Authorities get(authorities) config(): Vec<(AuthorityId, AuthorityWeight)>;
+		Authorities get(authorities): Vec<(AuthorityId, AuthorityWeight)>;
 
 		/// State of the current authority set.
 		State get(state): StoredState<T::BlockNumber> = StoredState::Live;
@@ -146,6 +146,18 @@ decl_storage! {
 
 		/// `true` if we are currently stalled.
 		Stalled get(stalled): Option<(T::BlockNumber, T::BlockNumber)>;
+	}
+	add_extra_genesis {
+		config(authorities): Vec<(AuthorityId, AuthorityWeight)>;
+		build(|
+			storage: &mut (sr_primitives::StorageOverlay, sr_primitives::ChildrenStorageOverlay),
+			config: &GenesisConfig
+		| {
+			runtime_io::with_storage(
+				storage,
+				|| Module::<T>::initialize_authorities(&config.authorities),
+			);
+		})
 	}
 }
 
@@ -310,6 +322,13 @@ impl<T: Trait> Module<T> {
 		let log: DigestItem<T::Hash> = DigestItem::Consensus(GRANDPA_ENGINE_ID, log.encode());
 		<system::Module<T>>::deposit_log(log.into());
 	}
+
+	fn initialize_authorities(authorities: &[(AuthorityId, AuthorityWeight)]) {
+		if !authorities.is_empty() {
+			assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
+			Authorities::put_ref(authorities);
+		}
+	}
 }
 
 impl<T: Trait> Module<T> {
@@ -349,9 +368,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
-		assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
-		let authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
-		Authorities::put(authorities);
+		Self::initialize_authorities(&validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>());
 	}
 
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, _queued_validators: I)

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -346,12 +346,19 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = AuthorityId;
 
+	fn on_genesis_session<'a, I: 'a>(validators: I)
+		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+	{
+		let authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
+		Authorities::put(authorities);
+	}
+
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, _queued_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
 		// instant changes
 		if changed {
-			let next_authorities = validators.map(|(_, k)| (k, 1u64)).collect::<Vec<_>>();
+			let next_authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
 			let last_authorities = <Module<T>>::grandpa_authorities();
 			if next_authorities != last_authorities {
 				if let Some((further_wait, median)) = <Stalled<T>>::take() {

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -349,6 +349,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
+		assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
 		let authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
 		Authorities::put(authorities);
 	}

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -368,7 +368,8 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
-		Self::initialize_authorities(&validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>());
+		let authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
+		Self::initialize_authorities(&authorities);
 	}
 
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, _queued_validators: I)

--- a/srml/grandpa/src/mock.rs
+++ b/srml/grandpa/src/mock.rs
@@ -85,7 +85,7 @@ pub fn new_test_ext(authorities: Vec<(u64, u64)>) -> runtime_io::TestExternaliti
 	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	GenesisConfig {
 		authorities: to_authorities(authorities),
-	}.assimilate_storage(&mut t).unwrap();
+	}.assimilate_storage::<Test>(&mut t).unwrap();
 	t.into()
 }
 

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -363,6 +363,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
+		assert!(Keys::get().is_empty(), "Keys are already initialized!");
 		Keys::put(validators.map(|x| x.1).collect::<Vec<_>>());
 	}
 

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -381,7 +381,8 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
-		Self::initialize_keys(&validators.map(|x| x.1).collect::<Vec<_>>());
+		let keys = validators.map(|x| x.1).collect::<Vec<_>>();
+		Self::initialize_keys(&keys);
 	}
 
 	fn on_new_session<'a, I: 'a>(_changed: bool, _validators: I, next_validators: I)

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -360,6 +360,12 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = AuthorityId;
 
+	fn on_genesis_session<'a, I: 'a>(validators: I)
+		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+	{
+		Keys::put(validators.map(|x| x.1).collect::<Vec<_>>());
+	}
+
 	fn on_new_session<'a, I: 'a>(_changed: bool, _validators: I, next_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -187,6 +187,12 @@ impl<A> OnSessionEnding<A> for () {
 
 /// Handler for when a session keys set changes.
 pub trait SessionHandler<ValidatorId> {
+	/// The given validator set will be used for the genesis session.
+	/// It is guaranteed that the given validator set will also be used
+	/// for the second session, therefore the first call to `on_new_session`
+	/// should provide the same validator set.
+	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(ValidatorId, Ks)]);
+
 	/// Session set has changed; act appropriately.
 	fn on_new_session<Ks: OpaqueKeys>(
 		changed: bool,
@@ -203,14 +209,19 @@ pub trait OneSessionHandler<ValidatorId> {
 	/// The key type expected.
 	type Key: Decode + Default + AppKey;
 
+	fn on_genesis_session<'a, I: 'a>(validators: I)
+		where I: Iterator<Item=(&'a ValidatorId, Self::Key)>, ValidatorId: 'a;
+
 	fn on_new_session<'a, I: 'a>(changed: bool, validators: I, queued_validators: I)
 		where I: Iterator<Item=(&'a ValidatorId, Self::Key)>, ValidatorId: 'a;
+
 	fn on_disabled(i: usize);
 }
 
 macro_rules! impl_session_handlers {
 	() => (
 		impl<AId> SessionHandler<AId> for () {
+			fn on_genesis_session<Ks: OpaqueKeys>(_: &[(AId, Ks)]) {}
 			fn on_new_session<Ks: OpaqueKeys>(_: bool, _: &[(AId, Ks)], _: &[(AId, Ks)]) {}
 			fn on_disabled(_: usize) {}
 		}
@@ -218,6 +229,15 @@ macro_rules! impl_session_handlers {
 
 	( $($t:ident)* ) => {
 		impl<AId, $( $t: OneSessionHandler<AId> ),*> SessionHandler<AId> for ( $( $t , )* ) {
+			fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(AId, Ks)]) {
+				$(
+					let our_keys: Box<dyn Iterator<Item=_>> = Box::new(validators.iter()
+						.map(|k| (&k.0, k.1.get::<$t::Key>(<$t::Key as AppKey>::ID)
+							.unwrap_or_default())));
+
+					$t::on_genesis_session(our_keys);
+				)*
+			}
 			fn on_new_session<Ks: OpaqueKeys>(
 				changed: bool,
 				validators: &[(AId, Ks)],
@@ -347,6 +367,9 @@ decl_storage! {
 						<Module<T>>::load_keys(&v).unwrap_or_default(),
 					))
 					.collect();
+
+				// Tell everyone about the genesis session keys
+				T::SessionHandler::on_genesis_session::<T::Keys>(&queued_keys);
 
 				<Validators<T>>::put(initial_validators);
 				<QueuedKeys<T>>::put(queued_keys);

--- a/srml/session/src/mock.rs
+++ b/srml/session/src/mock.rs
@@ -62,6 +62,7 @@ impl ShouldEndSession<u64> for TestShouldEndSession {
 
 pub struct TestSessionHandler;
 impl SessionHandler<u64> for TestSessionHandler {
+	fn on_genesis_session<T: OpaqueKeys>(validators: &[(u64, T)]) {}
 	fn on_new_session<T: OpaqueKeys>(
 		changed: bool,
 		validators: &[(u64, T)],

--- a/srml/session/src/mock.rs
+++ b/srml/session/src/mock.rs
@@ -62,7 +62,7 @@ impl ShouldEndSession<u64> for TestShouldEndSession {
 
 pub struct TestSessionHandler;
 impl SessionHandler<u64> for TestSessionHandler {
-	fn on_genesis_session<T: OpaqueKeys>(validators: &[(u64, T)]) {}
+	fn on_genesis_session<T: OpaqueKeys>(_validators: &[(u64, T)]) {}
 	fn on_new_session<T: OpaqueKeys>(
 		changed: bool,
 		validators: &[(u64, T)],

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -52,6 +52,8 @@ thread_local! {
 
 pub struct TestSessionHandler;
 impl session::SessionHandler<AccountId> for TestSessionHandler {
+	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(AccountId, Ks)]) {}
+
 	fn on_new_session<Ks: OpaqueKeys>(
 		_changed: bool,
 		validators: &[(AccountId, Ks)],

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -52,7 +52,7 @@ thread_local! {
 
 pub struct TestSessionHandler;
 impl session::SessionHandler<AccountId> for TestSessionHandler {
-	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(AccountId, Ks)]) {}
+	fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
 
 	fn on_new_session<Ks: OpaqueKeys>(
 		_changed: bool,


### PR DESCRIPTION
The `SessionHandler` is extended with a method for informing about the genesis validator set. This avoids having to configure all of the keys in the chain spec as they will all be initialized from the session module. I still kept the authorities configurable in the modules that interact with session (grandpa, babe, i'm online) because it is useful when using those modules without session.