### PR TITLE
im-online: use new session keys (not upcoming session)

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 141,
-	impl_version: 141,
+	spec_version: 142,
+	impl_version: 142,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -360,7 +360,7 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = AuthorityId;
 
-	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, _next_validators: I)
+	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, _queued_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
 		// Reset heartbeats

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -360,7 +360,7 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	type Key = AuthorityId;
 
-	fn on_new_session<'a, I: 'a>(_changed: bool, _validators: I, next_validators: I)
+	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, _next_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
 	{
 		// Reset heartbeats
@@ -370,7 +370,7 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		<GossipAt<T>>::put(<system::Module<T>>::block_number());
 
 		// Remember who the authorities are for the new session.
-		Keys::put(next_validators.map(|x| x.1).collect::<Vec<_>>());
+		Keys::put(validators.map(|x| x.1).collect::<Vec<_>>());
 	}
 
 	fn on_disabled(_i: usize) {


### PR DESCRIPTION
The session module peforms a "buffering" of validator sets, i.e. when we start session N, we already know the validator set for session N+1. The `on_new_session` handler gets as parameter the validator set for the session that's just starting (N), and what the validator set will be for the follow up session (N+1). Whenever the session changed, the i'm online module was setting the keys for the follow-up session (N+1) rather than for the session that was just starting. 