### PR TITLE
Reject transactions with no `provides` tags.

### DIFF
--- a/core/transaction-pool/graph/src/error.rs
+++ b/core/transaction-pool/graph/src/error.rs
@@ -30,6 +30,12 @@ pub enum Error {
 	/// Transaction is invalid.
 	#[display(fmt="Invalid Transaction. Error Code: {}", _0)]
 	InvalidTransaction(i8),
+	/// The transaction validity returned no "provides" tag.
+	///
+	/// Such transactions are not accepted to the pool, since we use those tags
+	/// to define identity of transactions (occupance of the same "slot").
+	#[display(fmt="The transaction does not provide any tags, so the pool can't identify it.")]
+	NoTagsProvided,
 	/// The transaction is temporarily banned.
 	#[display(fmt="Temporarily Banned")]
 	TemporarilyBanned,


### PR DESCRIPTION
We use `provides` tags to uniquely identify transactions (i.e. there can be many different transactiions with the same `hash`, that lead to the same effect - hence `provides`).
Transactions with no `provides` are effectively never evicted properly from the pool (they are only removed after some timeout), cause we currently don't do hash-based eviction, but rather provided-tags-based one.

This PR rejects immediately transactions with no `provides` tags to force runtime implementers to provide some.

Related to `claims` module issues in polkadot repo.

CC @jacogr 