### PR TITLE
Signed transactions now have affinity with runtime versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ dependencies = [
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
+ "sr-version 2.0.0",
  "srml-support 2.0.0",
  "substrate-primitives 2.0.0",
 ]

--- a/core/sr-version/src/lib.rs
+++ b/core/sr-version/src/lib.rs
@@ -62,7 +62,7 @@ macro_rules! create_apis_vec {
 /// This triplet have different semantics and mis-interpretation could cause problems.
 /// In particular: bug fixes should result in an increment of `spec_version` and possibly `authoring_version`,
 /// absolutely not `impl_version` since they change the semantics of the runtime.
-#[derive(Clone, PartialEq, Eq, Encode)]
+#[derive(Clone, PartialEq, Eq, Encode, Default)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize, Decode))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct RuntimeVersion {

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -373,6 +373,7 @@ impl srml_system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 
 impl srml_timestamp::Trait for Runtime {

--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -107,6 +107,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 1_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
+	pub const Version: RuntimeVersion = VERSION;
 }
 
 impl system::Trait for Runtime {
@@ -140,6 +141,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = Version;
 }
 
 impl aura::Trait for Runtime {

--- a/node-template/runtime/src/template.rs
+++ b/node-template/runtime/src/template.rs
@@ -107,6 +107,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	impl Trait for Test {
 		type Event = ();

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 146,
+	spec_version: 147,
 	impl_version: 147,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -108,6 +108,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 1_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
+	pub const Version: RuntimeVersion = VERSION;
 }
 
 impl system::Trait for Runtime {
@@ -126,6 +127,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = Version;
 }
 
 parameter_types! {

--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -277,6 +277,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 	impl Trait for Test {
 		type Event = ();

--- a/srml/aura/src/mock.rs
+++ b/srml/aura/src/mock.rs
@@ -60,6 +60,7 @@ impl system::Trait for Test {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
 }
 
 impl timestamp::Trait for Test {

--- a/srml/authorship/src/lib.rs
+++ b/srml/authorship/src/lib.rs
@@ -476,6 +476,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 
 	parameter_types! {

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -777,6 +777,7 @@ impl<T: Subtrait<I>, I: Instance> system::Trait for ElevatedTrait<T, I> {
 	type MaximumBlockWeight = T::MaximumBlockWeight;
 	type MaximumBlockLength = T::MaximumBlockLength;
 	type AvailableBlockRatio = T::AvailableBlockRatio;
+	type Version = T::Version;
 }
 impl<T: Subtrait<I>, I: Instance> Trait<I> for ElevatedTrait<T, I> {
 	type Balance = T::Balance;

--- a/srml/balances/src/mock.rs
+++ b/srml/balances/src/mock.rs
@@ -98,6 +98,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 impl Trait for Runtime {
 	type Balance = u64;

--- a/srml/collective/src/lib.rs
+++ b/srml/collective/src/lib.rs
@@ -419,6 +419,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	impl Trait<Instance1> for Test {
 		type Origin = Origin;

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -119,6 +119,7 @@ impl system::Trait for Test {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
 }
 impl balances::Trait for Test {
 	type Balance = u64;

--- a/srml/council/src/lib.rs
+++ b/srml/council/src/lib.rs
@@ -119,6 +119,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -1029,6 +1029,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/srml/elections/src/lib.rs
+++ b/srml/elections/src/lib.rs
@@ -1152,6 +1152,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -544,6 +544,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -402,6 +402,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;

--- a/srml/finality-tracker/src/lib.rs
+++ b/srml/finality-tracker/src/lib.rs
@@ -321,6 +321,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const WindowSize: u64 = 11;

--- a/srml/generic-asset/src/lib.rs
+++ b/srml/generic-asset/src/lib.rs
@@ -1063,6 +1063,7 @@ impl<T: Subtrait> system::Trait for ElevatedTrait<T> {
 	type AvailableBlockRatio = T::AvailableBlockRatio;
 	type WeightMultiplierUpdate = ();
 	type BlockHashCount = T::BlockHashCount;
+	type Version = T::Version;
 }
 impl<T: Subtrait> Trait for ElevatedTrait<T> {
 	type Balance = T::Balance;

--- a/srml/generic-asset/src/mock.rs
+++ b/srml/generic-asset/src/mock.rs
@@ -61,6 +61,7 @@ impl system::Trait for Test {
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type BlockHashCount = BlockHashCount;
+	type Version = ();
 }
 
 impl Trait for Test {

--- a/srml/grandpa/src/mock.rs
+++ b/srml/grandpa/src/mock.rs
@@ -63,6 +63,7 @@ impl system::Trait for Test {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 
 mod grandpa {

--- a/srml/indices/src/mock.rs
+++ b/srml/indices/src/mock.rs
@@ -87,6 +87,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 impl Trait for Runtime {
 	type AccountIndex = u64;

--- a/srml/membership/src/lib.rs
+++ b/srml/membership/src/lib.rs
@@ -238,6 +238,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const One: u64 = 1;

--- a/srml/offences/src/mock.rs
+++ b/srml/offences/src/mock.rs
@@ -84,6 +84,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 
 impl Trait for Runtime {

--- a/srml/session/src/mock.rs
+++ b/srml/session/src/mock.rs
@@ -151,6 +151,7 @@ impl system::Trait for Test {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
 }
 
 impl timestamp::Trait for Test {

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -125,6 +125,7 @@ impl system::Trait for Test {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type MaximumBlockLength = MaximumBlockLength;
+	type Version = ();
 }
 parameter_types! {
 	pub const TransferFee: Balance = 0;

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -32,6 +32,10 @@ pub trait Get<T> {
 	fn get() -> T;
 }
 
+impl<T: Default> Get<T> for () {
+	fn get() -> T { T::default() }
+}
+
 /// A trait for querying whether a type can be said to statically "contain" a value. Similar
 /// in nature to `Get`, except it is designed to be lazy rather than active (you can't ask it to
 /// enumerate all values that it contains) and work for multiple values rather than just one.

--- a/srml/system/Cargo.toml
+++ b/srml/system/Cargo.toml
@@ -12,6 +12,7 @@ primitives = { package = "substrate-primitives",  path = "../../core/primitives"
 rstd = { package = "sr-std", path = "../../core/sr-std", default-features = false }
 runtime_io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
+sr-version = { path = "../../core/sr-version", default-features = false }
 srml-support = { path = "../support", default-features = false }
 
 [dev-dependencies]
@@ -28,6 +29,7 @@ std = [
 	"runtime_io/std",
 	"srml-support/std",
 	"sr-primitives/std",
+	"sr-version/std",
 ]
 
 [[bench]]

--- a/srml/system/benches/bench.rs
+++ b/srml/system/benches/bench.rs
@@ -75,6 +75,7 @@ impl system::Trait for Runtime {
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
 }
 
 impl module::Trait for Runtime {

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -371,6 +371,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const MinimumPeriod: u64 = 5;

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -394,6 +394,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type MaximumBlockLength = MaximumBlockLength;
+		type Version = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 0;


### PR DESCRIPTION
This basically just ensures that transactions (or rather their signature) are linked to the runtime version for which they were intended. It will mean that signed transactions submitted before a runtime upgrade will need to be resubmitted if they don't get included prior to the runtime upgrade going through.

This is important since a runtime upgrade can alter the meaning of a transaction and we don't want a transaction signed for one purpose doing something else when finally executed.

It could have been done by adding a generic param `Get<RuntimeVersion>` to the `CheckVersion` struct, rather than as an associated type of the `system::Trait`, however I figure having the runtime version available to the system trait will probably be a useful thing to have in the future.