### PR TITLE
client: refuse to import blocks that revert finality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,6 +4365,7 @@ dependencies = [
  "substrate-telemetry 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-trie 2.0.0",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
  "substrate-telemetry 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-trie 2.0.0",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -29,7 +29,7 @@ sr-api-macros = { path = "../sr-api-macros" }
 
 [dev-dependencies]
 env_logger = "0.6"
-tempdir = "0.3"
+tempfile = "3.1"
 test-client = { package = "substrate-test-runtime-client", path = "../test-runtime/client" }
 kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 

--- a/core/client/Cargo.toml
+++ b/core/client/Cargo.toml
@@ -29,6 +29,7 @@ sr-api-macros = { path = "../sr-api-macros" }
 
 [dev-dependencies]
 env_logger = "0.6"
+tempdir = "0.3"
 test-client = { package = "substrate-test-runtime-client", path = "../test-runtime/client" }
 kvdb-memorydb = { git = "https://github.com/paritytech/parity-common", rev="b0317f649ab2c665b7987b8475878fc4d2e1f81d" }
 

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -2818,7 +2818,7 @@ pub(crate) mod tests {
 	#[test]
 	fn doesnt_import_blocks_that_revert_finality() {
 		let _ = env_logger::try_init();
-		let tmp = tempdir::TempDir::new("client-test").unwrap();
+		let tmp = tempfile::tempdir().unwrap();
 
 		// we need to run with archive pruning to avoid pruning non-canonical
 		// states
@@ -2827,7 +2827,7 @@ pub(crate) mod tests {
 				cache_size: None,
 				state_cache_size: 1 << 20,
 				state_cache_child_ratio: None,
-				path: tmp.into_path(),
+				path: tmp.path().into(),
 				pruning: PruningMode::ArchiveAll,
 			},
 			u64::max_value(),


### PR DESCRIPTION
When importing a new block we now check that it doesn't revert finality and in case it does we refuse to import the block. The number of the block being imported must be higher than the last finalized number (cheaper first check), and the imported block must be a descendant of the last finalized block.