### PR TITLE
Patch hashmap-core.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashmap_core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashmap_core 0.1.11 (git+https://github.com/paritytech/hashmap_core)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "hashmap_core"
 version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/paritytech/hashmap_core#2896e0ddec5c9d66808e9c266af8997e6dff74f0"
 
 [[package]]
 name = "heapsize"
@@ -2078,7 +2078,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hash-db 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashmap_core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashmap_core 0.1.11 (git+https://github.com/paritytech/hashmap_core)",
  "parity-util-mem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5562,7 +5562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashmap_core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashmap_core 0.1.11 (git+https://github.com/paritytech/hashmap_core)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6239,7 +6239,7 @@ dependencies = [
 "checksum hash-db 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32c87fec93c4a2d264483ef843ac1930ae7c7999d97d73721305a5188b4c23a4"
 "checksum hash256-std-hasher 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16293646125e09e5bc216d9f73fa81ab31c4f97007d56c036bbf15a58e970540"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
-"checksum hashmap_core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6852e5a86250521973b0c1d39677166d8a9c0047c908d7e04f1aa04177973c"
+"checksum hashmap_core 0.1.11 (git+https://github.com/paritytech/hashmap_core)" = "<none>"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,3 +112,7 @@ is-it-maintained-open-issues = { repository = "paritytech/substrate" }
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"
+
+# TODO [ToDr] Temporary workaround for nightly issues.
+[patch.crates-io]
+hashmap_core = { git = "https://github.com/paritytech/hashmap_core" }

--- a/core/utils/wasm-builder/src/wasm_project.rs
+++ b/core/utils/wasm-builder/src/wasm_project.rs
@@ -185,6 +185,10 @@ fn create_wasm_workspace_project(wasm_workspace: &Path) {
 
 				[workspace]
 				members = [ {members} ]
+
+				# TODO [ToDr] temporary measure to fix nightly builds.
+				[patch.crates-io]
+				hashmap_core = {{ git = "https://github.com/paritytech/hashmap_core" }}
 			"#,
 			members = members,
 		)


### PR DESCRIPTION
Temporary fix for building runtime for nightly until update upstream creates or switch to `hashbrown`.