### PR TITLE
sync: don't return on fork tree revert

### DIFF
--- a/core/network/src/protocol/sync/extra_requests.rs
+++ b/core/network/src/protocol/sync/extra_requests.rs
@@ -146,7 +146,6 @@ impl<B: BlockT> ExtraRequests<B> {
 				Err(fork_tree::Error::Revert) => {
 					// we might have finalized further already in which case we
 					// will get a `Revert` error which we can safely ignore.
-					return Ok(());
 				},
 				Err(err) => return Err(err),
 				Ok(_) => {},


### PR DESCRIPTION
We don't want to return immediately if we get a revert from the fork tree, we still want to update the internel state. I actually pushed this yesterday to #3437 but it didn't go through (shitty internet) and I didn't notice.