### PR TITLE
Introduce capabilities filtering for off-chain runtime calls.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "hex-literal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -27,8 +27,9 @@ use codec::{Encode, Decode};
 use hash_db::{Hasher, Prefix};
 use primitives::{
 	Blake2Hasher, H256, ChangesTrieConfiguration, convert_hash,
-	NeverNativeValue, ExecutionContext,
-	storage::{StorageKey, StorageData, well_known_keys}, NativeOrEncoded
+	NeverNativeValue, ExecutionContext, NativeOrEncoded,
+	storage::{StorageKey, StorageData, well_known_keys},
+	offchain,
 };
 use substrate_telemetry::{telemetry, SUBSTRATE_INFO};
 use sr_primitives::{
@@ -1471,7 +1472,7 @@ impl<B, E, Block, RA> CallRuntimeAt<Block> for Client<B, E, Block, RA> where
 		context: ExecutionContext,
 		recorder: &Option<Rc<RefCell<ProofRecorder<Block>>>>,
 	) -> error::Result<NativeOrEncoded<R>> {
-		let enable_keystore = context.enable_keystore();
+		let capabilities = context.capabilities();
 
 		let manager = match context {
 			ExecutionContext::BlockConstruction =>
@@ -1480,16 +1481,19 @@ impl<B, E, Block, RA> CallRuntimeAt<Block> for Client<B, E, Block, RA> where
 				self.execution_strategies.syncing.get_manager(),
 			ExecutionContext::Importing =>
 				self.execution_strategies.importing.get_manager(),
+			ExecutionContext::OffchainCall =>
+				self.execution_strategies.other.get_manager(),
+			ExecutionContext::RichOffchainCall(_) =>
+				self.execution_strategies.other.get_manager(),
 			ExecutionContext::OffchainWorker(_) =>
 				self.execution_strategies.offchain_worker.get_manager(),
-			ExecutionContext::Other =>
-				self.execution_strategies.other.get_manager(),
 		};
 
 		let mut offchain_extensions = match context {
-			ExecutionContext::OffchainWorker(ext) => Some(ext),
+			ExecutionContext::OffchainWorker(ext)
+			| ExecutionContext::RichOffchainCall(ext) => Some(ext),
 			_ => None,
-		};
+		}.map(|ext| offchain::LimitedExternalities::new(capabilities, ext));
 
 		self.executor.contextual_call::<_, _, fn(_,_) -> _,_,_>(
 			|| core_api.initialize_block(at, &self.prepare_environment_block(at)?),
@@ -1502,7 +1506,7 @@ impl<B, E, Block, RA> CallRuntimeAt<Block> for Client<B, E, Block, RA> where
 			native_call,
 			offchain_extensions.as_mut(),
 			recorder,
-			enable_keystore,
+			capabilities.has(offchain::Capability::Keystore),
 		)
 	}
 

--- a/core/offchain/src/lib.rs
+++ b/core/offchain/src/lib.rs
@@ -43,7 +43,7 @@ use client::runtime_api::ApiExt;
 use futures::future::Future;
 use log::{debug, warn};
 use network::NetworkStateInfo;
-use primitives::ExecutionContext;
+use primitives::{offchain, ExecutionContext};
 use sr_primitives::{generic::BlockId, traits::{self, ProvideRuntimeApi}};
 use transaction_pool::txpool::{Pool, ChainApi};
 
@@ -122,7 +122,7 @@ impl<Client, Storage, Block> OffchainWorkers<
 				debug!("Running offchain workers at {:?}", at);
 				let run = runtime.offchain_worker_with_context(
 					&at,
-					ExecutionContext::OffchainWorker(api),
+					ExecutionContext::OffchainCall(Some((api, offchain::Capabilities::all()))),
 					number,
 				);
 				if let Err(e) =	run {

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -13,6 +13,7 @@ twox-hash = { version = "1.2.0", optional = true }
 byteorder = { version = "1.3.1", default-features = false }
 primitive-types = { version = "0.5.0", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.1", optional = true }
+log = { version = "0.4", optional = true }
 wasmi = { version = "0.5.0", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
@@ -48,6 +49,7 @@ bench = false
 [features]
 default = ["std"]
 std = [
+	"log",
 	"wasmi",
 	"lazy_static",
     "parking_lot",

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -100,8 +100,10 @@ impl ExecutionContext {
 		use ExecutionContext::*;
 
 		match self {
-			Importing | Syncing | BlockConstruction | OffchainCall(None) =>
+			Importing | Syncing | BlockConstruction =>
 				offchain::Capabilities::none(),
+			// Enable keystore by default for offchain calls. CC @bkchr
+			OffchainCall(None) => [offchain::Capability::Keystore][..].into(),
 			OffchainCall(Some((_, capabilities))) => *capabilities,
 		}
 	}

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -115,7 +115,7 @@ impl ExecutionContext {
 			RichOffchainCall(_) => [
 				TransactionPool,
 				Keystore,
-				OffchainWorkerDb,
+				OffchainWorkerDbRead,
 			][..].into(),
 			OffchainWorker(_) => Capabilities::all(),
 		}

--- a/core/primitives/src/offchain.rs
+++ b/core/primitives/src/offchain.rs
@@ -236,16 +236,18 @@ impl Timestamp {
 pub enum Capability {
 	/// Access to transaction pool.
 	TransactionPool = 1,
-	/// Access to offchain worker DB.
-	OffchainWorkerDb = 2,
 	/// External http calls.
-	Http = 4,
+	Http = 2,
 	/// Keystore access.
-	Keystore = 8,
+	Keystore = 4,
 	/// Randomness source.
-	Randomness = 16,
+	Randomness = 8,
 	/// Access to opaque network state.
-	NetworkState = 32,
+	NetworkState = 16,
+	/// Access to offchain worker DB (read only).
+	OffchainWorkerDbRead = 32,
+	/// Access to offchain worker DB (writes).
+	OffchainWorkerDbWrite = 64,
 }
 
 /// A set of capabilities

--- a/core/primitives/src/offchain.rs
+++ b/core/primitives/src/offchain.rs
@@ -232,7 +232,7 @@ impl Timestamp {
 
 /// Execution context extra capabilities.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[repr(C)]
+#[repr(u8)]
 pub enum Capability {
 	/// Access to transaction pool.
 	TransactionPool = 1,

--- a/core/primitives/src/offchain.rs
+++ b/core/primitives/src/offchain.rs
@@ -548,7 +548,7 @@ impl<T: Externalities> Externalities for LimitedExternalities<T> {
 	}
 
 	fn local_storage_set(&mut self, kind: StorageKind, key: &[u8], value: &[u8]) {
-		if self.check(Capability::OffchainWorkerDb).is_ok() {
+		if self.check(Capability::OffchainWorkerDbWrite).is_ok() {
 			self.externalities.local_storage_set(kind, key, value)
 		}
 	}
@@ -560,7 +560,7 @@ impl<T: Externalities> Externalities for LimitedExternalities<T> {
 		old_value: Option<&[u8]>,
 		new_value: &[u8],
 	) -> bool {
-		if self.check(Capability::OffchainWorkerDb).is_ok() {
+		if self.check(Capability::OffchainWorkerDbWrite).is_ok() {
 			self.externalities.local_storage_compare_and_set(kind, key, old_value, new_value)
 		} else {
 			true
@@ -568,7 +568,7 @@ impl<T: Externalities> Externalities for LimitedExternalities<T> {
 	}
 
 	fn local_storage_get(&mut self, kind: StorageKind, key: &[u8]) -> Option<Vec<u8>> {
-		self.check(Capability::OffchainWorkerDb).ok()?;
+		self.check(Capability::OffchainWorkerDbRead).ok()?;
 		self.externalities.local_storage_get(kind, key)
 	}
 

--- a/core/primitives/src/offchain.rs
+++ b/core/primitives/src/offchain.rs
@@ -265,9 +265,26 @@ impl Capabilities {
 		Self(u8::max_value())
 	}
 
+	/// Return capabilities for rich offchain calls.
+	///
+	/// Those calls should be allowed to sign and submit transactions
+	/// and access offchain workers database (but read only!).
+	pub fn rich_offchain_call() -> Self {
+		[
+			Capability::TransactionPool,
+			Capability::Keystore,
+			Capability::OffchainWorkerDbRead,
+		][..].into()
+	}
+
 	/// Check if particular capability is enabled.
 	pub fn has(&self, capability: Capability) -> bool {
 		self.0 & capability as u8 != 0
+	}
+
+	/// Check if this capability object represents all capabilities.
+	pub fn has_all(&self) -> bool {
+		self == &Capabilities::all()
 	}
 }
 

--- a/core/sr-api-macros/src/decl_runtime_apis.rs
+++ b/core/sr-api-macros/src/decl_runtime_apis.rs
@@ -552,9 +552,9 @@ impl<'a> ToClientSideDecl<'a> {
 	fn fold_trait_item_method(&mut self, method: TraitItemMethod)
 		-> (TraitItemMethod, Option<TraitItemMethod>, TraitItemMethod) {
 		let crate_ = self.crate_;
-		let context_other = quote!( #crate_::runtime_api::ExecutionContext::OffchainCall );
+		let context = quote!( #crate_::runtime_api::ExecutionContext::OffchainCall );
 		let fn_impl = self.create_method_runtime_api_impl(method.clone());
-		let fn_decl = self.create_method_decl(method.clone(), context_other);
+		let fn_decl = self.create_method_decl(method.clone(), context);
 		let fn_decl_ctx = self.create_method_decl_with_context(method);
 
 		(fn_decl, fn_impl, fn_decl_ctx)

--- a/core/sr-api-macros/src/decl_runtime_apis.rs
+++ b/core/sr-api-macros/src/decl_runtime_apis.rs
@@ -552,7 +552,7 @@ impl<'a> ToClientSideDecl<'a> {
 	fn fold_trait_item_method(&mut self, method: TraitItemMethod)
 		-> (TraitItemMethod, Option<TraitItemMethod>, TraitItemMethod) {
 		let crate_ = self.crate_;
-		let context = quote!( #crate_::runtime_api::ExecutionContext::OffchainCall );
+		let context = quote!( #crate_::runtime_api::ExecutionContext::OffchainCall(None) );
 		let fn_impl = self.create_method_runtime_api_impl(method.clone());
 		let fn_decl = self.create_method_decl(method.clone(), context);
 		let fn_decl_ctx = self.create_method_decl_with_context(method);

--- a/core/sr-api-macros/src/decl_runtime_apis.rs
+++ b/core/sr-api-macros/src/decl_runtime_apis.rs
@@ -552,7 +552,7 @@ impl<'a> ToClientSideDecl<'a> {
 	fn fold_trait_item_method(&mut self, method: TraitItemMethod)
 		-> (TraitItemMethod, Option<TraitItemMethod>, TraitItemMethod) {
 		let crate_ = self.crate_;
-		let context_other = quote!( #crate_::runtime_api::ExecutionContext::Other );
+		let context_other = quote!( #crate_::runtime_api::ExecutionContext::OffchainCall );
 		let fn_impl = self.create_method_runtime_api_impl(method.clone());
 		let fn_decl = self.create_method_decl(method.clone(), context_other);
 		let fn_decl_ctx = self.create_method_decl_with_context(method);

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 148,
-	impl_version: 148,
+	impl_version: 149,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
If we call into the runtime, we can pass various `ExecutionContext`s to identify where is it coming from.
Initially this was only affecting how we run the call (a.k.a execution strategy = native / wasm), with introduction of `OffchainWorkers` this also controls the APIs that are available for that part of the runtime.

Recently in #3296 we've introduced additional keystore APIs that must not be available for consensus-critical code, but are very useful for off-chain calls, like rotating the keys - they are only valid in  `ExecutionContext::Other`.

This PR introduces a possibility to further control what APIs (`Capabilties`) are available for particular off-chain call and tries to make it more explicit. This will come handy to implement equivocation reporting for Grandpa/Babe, since we will be able to call into the runtime, produce, sign and submit transaction to the pool in one call. In the future we even want the off-chain call to be able to read (And possibly) write the offchain worker DB, for instance to retrieve the merkle proofs for session membership.