### PR TITLE
Clean runtime constants

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 149,
-	impl_version: 149,
+	impl_version: 150,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -48,7 +48,6 @@ use version::NativeVersion;
 use primitives::OpaqueMetadata;
 use grandpa::{AuthorityId as GrandpaId, AuthorityWeight as GrandpaWeight};
 use im_online::{AuthorityId as ImOnlineId};
-use finality_tracker::{DEFAULT_REPORT_LATENCY, DEFAULT_WINDOW_SIZE};
 
 #[cfg(any(feature = "std", test))]
 pub use sr_primitives::BuildStorage;
@@ -414,8 +413,8 @@ impl grandpa::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const WindowSize: BlockNumber = DEFAULT_WINDOW_SIZE.into();
-	pub const ReportLatency: BlockNumber = DEFAULT_REPORT_LATENCY.into();
+	pub const WindowSize: BlockNumber = 101;
+	pub const ReportLatency: BlockNumber = 1000;
 }
 
 impl finality_tracker::Trait for Runtime {

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -172,12 +172,6 @@ mod tests;
 
 pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 
-pub const DEFAULT_EXISTENTIAL_DEPOSIT: u32 = 0;
-pub const DEFAULT_TRANSFER_FEE: u32 = 0;
-pub const DEFAULT_CREATION_FEE: u32 = 0;
-pub const DEFAULT_TRANSACTION_BASE_FEE: u32 = 0;
-pub const DEFAULT_TRANSACTION_BYTE_FEE: u32 = 0;
-
 pub trait Subtrait<I: Instance = DefaultInstance>: system::Trait {
 	/// The balance of an account.
 	type Balance: Parameter + Member + SimpleArithmetic + Codec + Default + Copy +

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -174,13 +174,6 @@ impl Decode for Vote {
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
 
-pub const DEFAULT_ENACTMENT_PERIOD: u32 = 0;
-pub const DEFAULT_LAUNCH_PERIOD: u32 = 0;
-pub const DEFAULT_VOTING_PERIOD: u32 = 0;
-pub const DEFAULT_MINIMUM_DEPOSIT: u32 = 0;
-pub const DEFAULT_EMERGENCY_VOTING_PERIOD: u32 = 0;
-pub const DEFAULT_COOLOFF_PERIOD: u32 = 0;
-
 pub trait Trait: system::Trait + Sized {
 	type Proposal: Parameter + Dispatchable<Origin=Self::Origin>;
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;

--- a/srml/elections/src/lib.rs
+++ b/srml/elections/src/lib.rs
@@ -138,17 +138,7 @@ pub type VoteIndex = u32;
 
 // all three must be in sync.
 type ApprovalFlag = u32;
-pub const APPROVAL_FLAG_MASK: ApprovalFlag = 0x8000_0000;
 pub const APPROVAL_FLAG_LEN: usize = 32;
-
-pub const DEFAULT_CANDIDACY_BOND: u32 = 9;
-pub const DEFAULT_VOTING_BOND: u32 = 0;
-pub const DEFAULT_VOTING_FEE: u32 = 0;
-pub const DEFAULT_PRESENT_SLASH_PER_VOTER: u32 = 1;
-pub const DEFAULT_CARRY_COUNT: u32 = 2;
-pub const DEFAULT_INACTIVE_GRACE_PERIOD: u32 = 1;
-pub const DEFAULT_VOTING_PERIOD: u32 = 1000;
-pub const DEFAULT_DECAY_RATIO: u32 = 24;
 
 pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -465,9 +465,6 @@ type ExpoMap<T> = BTreeMap<
 	Exposure<<T as system::Trait>::AccountId, BalanceOf<T>>
 >;
 
-pub const DEFAULT_SESSIONS_PER_ERA: u32 = 3;
-pub const DEFAULT_BONDING_DURATION: u32 = 1;
-
 /// Means for interacting with a specialized version of the `session` trait.
 ///
 /// This is needed because `Staking` sets the `ValidatorIdOf` of the `session::Trait`

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -89,11 +89,6 @@ type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::
 
 const MODULE_ID: ModuleId = ModuleId(*b"py/trsry");
 
-pub const DEFAULT_PROPOSAL_BOND: u32 = 0;
-pub const DEFAULT_PROPOSAL_BOND_MINIMUM: u32 = 0;
-pub const DEFAULT_SPEND_PERIOD: u32 = 0;
-pub const DEFAULT_BURN: u32 = 0;
-
 pub trait Trait: system::Trait {
 	/// The staking balance.
 	type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;


### PR DESCRIPTION
I realized ([thorough a copypasta](https://github.com/paritytech/substrate/pull/3364#discussion_r313800241)) that they are sitting on top of a few runtime modules with no purpose whatsoever. My guess is that the original author intended to do something like they have done in `finality-tracker`: declaring a few `pub const DEFAULT_XXX` in each module and aggregating in `node/runtime` if needed. Either way, removed since not used. We also have `const.rs` for this.