### PR TITLE
Pluralise newHead RPC subscription

### DIFF
--- a/core/rpc/src/chain/mod.rs
+++ b/core/rpc/src/chain/mod.rs
@@ -67,19 +67,19 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 	#[pubsub(
 		subscription = "chain_newHead",
 		subscribe,
-		name = "chain_subscribeNewHead",
-		alias("subscribe_newHead")
+		name = "chain_subscribeNewHeads",
+		alias("subscribe_newHead", "chain_subscribeNewHead")
 	)]
-	fn subscribe_new_head(&self, metadata: Self::Metadata, subscriber: Subscriber<Header>);
+	fn subscribe_new_heads(&self, metadata: Self::Metadata, subscriber: Subscriber<Header>);
 
 	/// Unsubscribe from new head subscription.
 	#[pubsub(
 		subscription = "chain_newHead",
 		unsubscribe,
-		name = "chain_unsubscribeNewHead",
-		alias("unsubscribe_newHead")
+		name = "chain_unsubscribeNewHeads",
+		alias("unsubscribe_newHead", "chain_unsubscribeNewHead")
 	)]
-	fn unsubscribe_new_head(&self, metadata: Option<Self::Metadata>, id: SubscriptionId) -> RpcResult<bool>;
+	fn unsubscribe_new_heads(&self, metadata: Option<Self::Metadata>, id: SubscriptionId) -> RpcResult<bool>;
 
 	/// New head subscription
 	#[pubsub(
@@ -199,7 +199,7 @@ impl<B, E, Block, RA> ChainApi<NumberFor<Block>, Block::Hash, Block::Header, Sig
 		Ok(self.client.info().chain.finalized_hash)
 	}
 
-	fn subscribe_new_head(&self, _metadata: Self::Metadata, subscriber: Subscriber<Block::Header>) {
+	fn subscribe_new_heads(&self, _metadata: Self::Metadata, subscriber: Subscriber<Block::Header>) {
 		self.subscribe_headers(
 			subscriber,
 			|| self.block_hash(None.into()),
@@ -210,7 +210,7 @@ impl<B, E, Block, RA> ChainApi<NumberFor<Block>, Block::Hash, Block::Header, Sig
 		)
 	}
 
-	fn unsubscribe_new_head(&self, _metadata: Option<Self::Metadata>, id: SubscriptionId) -> RpcResult<bool> {
+	fn unsubscribe_new_heads(&self, _metadata: Option<Self::Metadata>, id: SubscriptionId) -> RpcResult<bool> {
 		Ok(self.subscriptions.cancel(id))
 	}
 

--- a/core/rpc/src/chain/tests.rs
+++ b/core/rpc/src/chain/tests.rs
@@ -202,7 +202,7 @@ fn should_notify_about_latest_block() {
 			subscriptions: Subscriptions::new(Arc::new(remote)),
 		};
 
-		api.subscribe_new_head(Default::default(), subscriber);
+		api.subscribe_new_heads(Default::default(), subscriber);
 
 		// assert id assigned
 		assert_eq!(core.block_on(id), Ok(Ok(SubscriptionId::Number(1))));


### PR DESCRIPTION
Closes #3431

The old name is available as an alias.
CC @jacogr 