### PR TITLE
decl_storage metadata: use spin instead of once_cell and make use of it in no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,11 +4178,11 @@ name = "srml-support"
 version = "2.0.0"
 dependencies = [
  "bitmask 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 149,
-	impl_version: 149,
+	impl_version: 150,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/support/Cargo.toml
+++ b/srml/support/Cargo.toml
@@ -15,7 +15,7 @@ primitives = { package = "substrate-primitives",  path = "../../core/primitives"
 inherents = { package = "substrate-inherents", path = "../../core/inherents", default-features = false }
 srml-support-procedural = { path = "./procedural" }
 paste = "0.1"
-once_cell = { version = "0.1.6", default-features = false, optional = true }
+spin = { version = "0.5.0" }
 bitmask = { version = "0.5", default-features = false }
 
 [dev-dependencies]
@@ -25,7 +25,6 @@ srml-system = { path = "../system" }
 [features]
 default = ["std"]
 std = [
-	"once_cell",
 	"bitmask/std",
 	"serde",
 	"runtime_io/std",

--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -1055,17 +1055,16 @@ fn store_functions_to_metadata (
 				#traitinstance, #instance #bound_instantiable #equal_default_instance
 			>(pub #scrate::rstd::marker::PhantomData<(#traitinstance #comma_instance)>);
 
-			#[cfg(feature = "std")]
 			#[allow(non_upper_case_globals)]
-			static #cache_name: #scrate::once_cell::sync::OnceCell<#scrate::rstd::vec::Vec<u8>> = #scrate::once_cell::sync::OnceCell::INIT;
+			static #cache_name: #scrate::spin::Once<#scrate::rstd::vec::Vec<u8>> =
+				#scrate::spin::Once::new();
 
-			#[cfg(feature = "std")]
 			impl<#traitinstance: #traittype, #instance #bound_instantiable> #scrate::metadata::DefaultByte
 				for #struct_name<#traitinstance, #instance> #where_clause
 			{
 				fn default_byte(&self) -> #scrate::rstd::vec::Vec<u8> {
 					use #scrate::codec::Encode;
-					#cache_name.get_or_init(|| {
+					#cache_name.call_once(|| {
 						let def_val: #value_type = #default;
 						<#value_type as Encode>::encode(&def_val)
 					}).clone()
@@ -1077,17 +1076,6 @@ fn store_functions_to_metadata (
 
 			unsafe impl<#traitinstance: #traittype, #instance #bound_instantiable> Sync
 				for #struct_name<#traitinstance, #instance> #where_clause {}
-
-			#[cfg(not(feature = "std"))]
-			impl<#traitinstance: #traittype, #instance #bound_instantiable> #scrate::metadata::DefaultByte
-				for #struct_name<#traitinstance, #instance> #where_clause
-			{
-				fn default_byte(&self) -> #scrate::rstd::vec::Vec<u8> {
-					use #scrate::codec::Encode;
-					let def_val: #value_type = #default;
-					<#value_type as Encode>::encode(&def_val)
-				}
-			}
 		};
 
 		default_getter_struct_def.extend(def_get);

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -30,9 +30,8 @@ pub use serde;
 pub use sr_std as rstd;
 #[doc(hidden)]
 pub use codec;
-#[cfg(feature = "std")]
 #[doc(hidden)]
-pub use once_cell;
+pub use spin;
 #[doc(hidden)]
 pub use paste;
 


### PR DESCRIPTION
previously the metadata was cached into a Once structure only on std by the use of the crate once_cell (which doesn't work on no_std).

Now it uses spin crate and implements the caching for both std and no_std.

Spin crate is used by lazy_static for no_std. (note: lazy_static doesn't use spin for std).

EDIT: Maybe there was a reason not to cache in no_std, but I'm not aware of it