### PR TITLE
Decl_storage: improve error msg on wrong closure signature

### DIFF
--- a/srml/support/procedural/src/storage/transformation.rs
+++ b/srml/support/procedural/src/storage/transformation.rs
@@ -35,7 +35,7 @@ use syn::{
 	},
 	parse_macro_input,
 };
-use quote::quote;
+use quote::{quote, quote_spanned};
 
 use super::*;
 
@@ -417,7 +417,16 @@ fn decl_store_extra_genesis(
 					}
 					assimilate_require_generic |= ext::expr_contains_ident(&expr.content, traitinstance);
 					let content = &expr.content;
-					scall = quote!( ( #content ) );
+					scall = quote_spanned! { expr.span() =>
+						let scall: fn(
+							&mut (
+								#scrate::sr_primitives::StorageOverlay,
+								#scrate::sr_primitives::ChildrenStorageOverlay
+							),
+							&Self
+						) = #content;
+						scall
+					};
 					has_scall = true;
 				},
 			}


### PR DESCRIPTION
defining the type allow better error message.
and having the span allow compiler to points to the closure.