### PR TITLE
Fix linkemap swap

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 149,
-	impl_version: 149,
+	impl_version: 150,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -343,6 +343,35 @@ mod tests {
 	}
 
 	#[test]
+	fn linked_map_swap_works() {
+		with_externalities(&mut new_test_ext(), || {
+			OptionLinkedMap::insert(0, 0);
+			OptionLinkedMap::insert(1, 1);
+			OptionLinkedMap::insert(2, 2);
+			OptionLinkedMap::insert(3, 3);
+
+			let collect = || OptionLinkedMap::enumerate().collect::<Vec<_>>();
+			assert_eq!(collect(), vec![(3, 3), (2, 2), (1, 1), (0, 0)]);
+
+			// Two existing
+			OptionLinkedMap::swap(1, 2);
+			assert_eq!(collect(), vec![(3, 3), (2, 1), (1, 2), (0, 0)]);
+
+			// Back to normal
+			OptionLinkedMap::swap(2, 1);
+			assert_eq!(collect(), vec![(3, 3), (2, 2), (1, 1), (0, 0)]);
+
+			// Left existing
+			OptionLinkedMap::swap(2, 5);
+			assert_eq!(collect(), vec![(5, 2), (3, 3), (1, 1), (0, 0)]);
+
+			// Right existing
+			OptionLinkedMap::swap(5, 2);
+			assert_eq!(collect(), vec![(2, 2), (3, 3), (1, 1), (0, 0)]);
+		});
+	}
+
+	#[test]
 	fn linked_map_basic_insert_remove_should_work() {
 		with_externalities(&mut new_test_ext(), || {
 			// initialized during genesis


### PR DESCRIPTION
### Context:

As for now default implementation of swap in srml-support/storage/hashed/generator breaks linked_map implementation of its linked list.

I'm not sure what are the most idiomatic rust but it feels to me in the future we should remove this default implementation of storage map as it is confusing with other implementation (such as linkedmap) which break assumptions of this default.

for me either we divide into two different trait or we make no default implementation.

But before this happens here is a fix in the current design.

### Done

default swap method in storagemap is override in the implementation for linkedmap made in decl_storage.

### Comments

* The changes or remains of order of the linked_list for a swap is not specified in the API. No guarantee must be made by user. maybe this should deserve a comment but at some point nothing has been stated in the whole API in this regards so I feel fine with this.