### PR TITLE
Require the `SelectChain` trait for the `SelectChain` associated type

### DIFF
--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -454,7 +454,7 @@ pub trait AbstractService: 'static + Future<Item = (), Error = Error> +
 	/// Configuration struct of the service.
 	type Config;
 	/// Chain selection algorithm.
-	type SelectChain;
+	type SelectChain: consensus_common::SelectChain<Self::Block>;
 	/// API of the transaction pool.
 	type TransactionPoolApi: ChainApi<Block = Self::Block>;
 	/// Network specialization.
@@ -524,7 +524,7 @@ where TCfg: 'static + Send,
 	TBackend: 'static + client::backend::Backend<TBl, Blake2Hasher>,
 	TExec: 'static + client::CallExecutor<TBl, Blake2Hasher> + Send + Sync + Clone,
 	TRtApi: 'static + Send + Sync,
-	TSc: 'static + Clone + Send,
+	TSc: consensus_common::SelectChain<TBl> + 'static + Clone + Send,
 	TExPoolApi: 'static + ChainApi<Block = TBl>,
 	TOc: 'static + Send + Sync,
 	TNetSpec: NetworkSpecialization<TBl>,


### PR DESCRIPTION
Require the `SelectChain` trait for the `SelectChain` associated type.
Minor tweak to make the `AbstractService` trait more usable.