### PR TITLE
babe: filter secondary slot uncles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "sr-primitives 2.0.0",
  "sr-staking-primitives 2.0.0",
  "sr-std 2.0.0",
+ "srml-authorship 0.1.0",
  "srml-session 2.0.0",
  "srml-support 2.0.0",
  "srml-system 2.0.0",

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,8 +79,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 153,
-	impl_version: 153,
+	spec_version: 154,
+	impl_version: 154,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -186,7 +186,7 @@ parameter_types! {
 impl authorship::Trait for Runtime {
 	type FindAuthor = session::FindAccountFromAuthorIndex<Self, Babe>;
 	type UncleGenerations = UncleGenerations;
-	type FilterUncle = ();
+	type FilterUncle = babe::OnlyPrimaryUncles;
 	type EventHandler = Staking;
 }
 

--- a/srml/babe/Cargo.toml
+++ b/srml/babe/Cargo.toml
@@ -12,6 +12,7 @@ inherents = { package = "substrate-inherents", path = "../../core/inherents", de
 rstd = { package = "sr-std", path = "../../core/sr-std", default-features = false }
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
 sr-staking-primitives = { path = "../../core/sr-staking-primitives", default-features = false }
+authorship = { package = "srml-authorship", path = "../authorship", default-features = false }
 srml-support = { path = "../support", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }
@@ -30,6 +31,7 @@ std = [
 	"serde",
 	"codec/std",
 	"rstd/std",
+	"authorship/std",
 	"srml-support/std",
 	"sr-primitives/std",
 	"sr-staking-primitives/std",


### PR DESCRIPTION
Filter babe uncles to ensure that only primary slot blocks can be included. Secondary slots have deterministic allocation therefore they should not clash with other secondary slots. They might clash with primary slots, but in this case we don't want the secondary slot block to be uncled since it was only a fallback for the primary slot block.
