### PR TITLE
im-online: use generic crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
+ "sr-staking-primitives 2.0.0",
  "sr-std 2.0.0",
  "srml-im-online 0.1.0",
  "srml-session 2.0.0",

--- a/core/application-crypto/src/traits.rs
+++ b/core/application-crypto/src/traits.rs
@@ -17,6 +17,7 @@
 use primitives::crypto::{KeyTypeId, CryptoType, IsWrappedBy, Public};
 #[cfg(feature = "std")]
 use primitives::crypto::Pair;
+use codec::Codec;
 
 /// An application-specific key.
 pub trait AppKey: 'static + Send + Sync + Sized + CryptoType + Clone {
@@ -72,7 +73,7 @@ pub trait AppSignature: AppKey + Eq + PartialEq + MaybeDebugHash {
 /// A runtime interface for a public key.
 pub trait RuntimePublic: Sized {
 	/// The signature that will be generated when signing with the corresponding private key.
-	type Signature;
+	type Signature: Codec + MaybeDebugHash + Eq + PartialEq + Clone;
 
 	/// Returns all public keys for the given key type in the keystore.
 	fn all(key_type: KeyTypeId) -> crate::Vec<Self>;
@@ -97,7 +98,7 @@ pub trait RuntimePublic: Sized {
 /// A runtime interface for an application's public key.
 pub trait RuntimeAppPublic: Sized {
 	/// The signature that will be generated when signing with the corresponding private key.
-	type Signature;
+	type Signature: Codec + MaybeDebugHash + Eq + PartialEq + Clone;
 
 	/// Returns all public keys for this application in the keystore.
 	fn all() -> crate::Vec<Self>;

--- a/core/consensus/aura/primitives/src/lib.rs
+++ b/core/consensus/aura/primitives/src/lib.rs
@@ -23,38 +23,38 @@ use substrate_client::decl_runtime_apis;
 use rstd::vec::Vec;
 use sr_primitives::ConsensusEngineId;
 
-mod app_sr25519 {
-	use app_crypto::{app_crypto, key_types::AURA, sr25519};
-	app_crypto!(sr25519, AURA);
-}
-
 pub mod sr25519 {
+	mod app_sr25519 {
+		use app_crypto::{app_crypto, key_types::AURA, sr25519};
+		app_crypto!(sr25519, AURA);
+	}
+
 	/// An Aura authority keypair using S/R 25519 as its crypto.
 	#[cfg(feature = "std")]
-	pub type AuthorityPair = super::app_sr25519::Pair;
+	pub type AuthorityPair = app_sr25519::Pair;
 
 	/// An Aura authority signature using S/R 25519 as its crypto.
-	pub type AuthoritySignature = super::app_sr25519::Signature;
+	pub type AuthoritySignature = app_sr25519::Signature;
 
 	/// An Aura authority identifier using S/R 25519 as its crypto.
-	pub type AuthorityId = super::app_sr25519::Public;
-}
-
-mod app_ed25519 {
-	use app_crypto::{app_crypto, key_types::AURA, ed25519};
-	app_crypto!(ed25519, AURA);
+	pub type AuthorityId = app_sr25519::Public;
 }
 
 pub mod ed25519 {
+	mod app_ed25519 {
+		use app_crypto::{app_crypto, key_types::AURA, ed25519};
+		app_crypto!(ed25519, AURA);
+	}
+
 	/// An Aura authority keypair using Ed25519 as its crypto.
 	#[cfg(feature = "std")]
-	pub type AuthorityPair = super::app_ed25519::Pair;
+	pub type AuthorityPair = app_ed25519::Pair;
 
 	/// An Aura authority signature using Ed25519 as its crypto.
-	pub type AuthoritySignature = super::app_ed25519::Signature;
+	pub type AuthoritySignature = app_ed25519::Signature;
 
 	/// An Aura authority identifier using Ed25519 as its crypto.
-	pub type AuthorityId = super::app_ed25519::Public;
+	pub type AuthorityId = app_ed25519::Public;
 }
 
 /// The `ConsensusEngineId` of AuRa.

--- a/core/rpc/src/author/mod.rs
+++ b/core/rpc/src/author/mod.rs
@@ -162,7 +162,7 @@ impl<B, E, P, RA> AuthorApi<ExHash<P>, BlockHash<P>> for Author<B, E, P, RA> whe
 			Some(public) => public.0,
 			None => {
 				let maybe_public = match key_type {
-					key_types::BABE | key_types::IM_ONLINE | key_types::SR25519 =>
+					key_types::BABE | key_types::SR25519 =>
 						sr25519::Pair::from_string(&suri, maybe_password)
 							.map(|pair| pair.public().to_raw_vec()),
 					key_types::GRANDPA | key_types::ED25519 =>

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -30,7 +30,7 @@ use hex_literal::hex;
 use substrate_telemetry::TelemetryEndpoints;
 use grandpa_primitives::{AuthorityId as GrandpaId};
 use babe_primitives::{AuthorityId as BabeId};
-use im_online::AuthorityId as ImOnlineId;
+use im_online::sr25519::{AuthorityId as ImOnlineId};
 use sr_primitives::Perbill;
 
 const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -47,7 +47,7 @@ use elections::VoteIndex;
 use version::NativeVersion;
 use primitives::OpaqueMetadata;
 use grandpa::{AuthorityId as GrandpaId, AuthorityWeight as GrandpaWeight};
-use im_online::{AuthorityId as ImOnlineId};
+use im_online::sr25519::{AuthorityId as ImOnlineId};
 
 #[cfg(any(feature = "std", test))]
 pub use sr_primitives::BuildStorage;
@@ -393,6 +393,7 @@ impl sudo::Trait for Runtime {
 }
 
 impl im_online::Trait for Runtime {
+	type AuthorityId = ImOnlineId;
 	type Call = Call;
 	type Event = Event;
 	type UncheckedExtrinsic = UncheckedExtrinsic;
@@ -447,8 +448,8 @@ construct_runtime!(
 		Treasury: treasury::{Module, Call, Storage, Event<T>},
 		Contracts: contracts,
 		Sudo: sudo,
-		ImOnline: im_online::{Module, Call, Storage, Event, ValidateUnsigned, Config},
-		AuthorityDiscovery: authority_discovery::{Module, Call, Config},
+		ImOnline: im_online::{Module, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},
+		AuthorityDiscovery: authority_discovery::{Module, Call, Config<T>},
 		Offences: offences::{Module, Call, Storage, Event},
 	}
 );
@@ -578,19 +579,19 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block, im_online::AuthorityId> for Runtime {
-		fn authority_id() -> Option<im_online::AuthorityId> {
+	impl authority_discovery_primitives::AuthorityDiscoveryApi<Block, ImOnlineId> for Runtime {
+		fn authority_id() -> Option<ImOnlineId> {
 			AuthorityDiscovery::authority_id()
 		}
-		fn authorities() -> Vec<im_online::AuthorityId> {
+		fn authorities() -> Vec<ImOnlineId> {
 			AuthorityDiscovery::authorities()
 		}
 
-		fn sign(payload: Vec<u8>, authority_id: im_online::AuthorityId) -> Option<Vec<u8>> {
+		fn sign(payload: Vec<u8>, authority_id: ImOnlineId) -> Option<Vec<u8>> {
 			AuthorityDiscovery::sign(payload, authority_id)
 		}
 
-		fn verify(payload: Vec<u8>, signature: Vec<u8>, public_key: im_online::AuthorityId) -> bool {
+		fn verify(payload: Vec<u8>, signature: Vec<u8>, public_key: ImOnlineId) -> bool {
 			AuthorityDiscovery::verify(payload, signature, public_key)
 		}
 	}

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 153,
+	spec_version: 154,
 	impl_version: 154,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/authority-discovery/Cargo.toml
+++ b/srml/authority-discovery/Cargo.toml
@@ -17,6 +17,9 @@ srml-support = { path = "../support", default-features = false }
 sr-io = { package = "sr-io", path = "../../core/sr-io", default-features = false }
 system = { package = "srml-system", path = "../system", default-features = false }
 
+[dev-dependencies]
+sr-staking-primitives = { path = "../../core/sr-staking-primitives", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/srml/authority-discovery/src/lib.rs
+++ b/srml/authority-discovery/src/lib.rs
@@ -191,9 +191,9 @@ mod tests {
 	}
 
 	impl im_online::Trait for Test {
+		type AuthorityId = AuthorityId;
 		type Call = im_online::Call<Test>;
 		type Event = ();
-		type AuthorityId = AuthorityId;
 		type UncheckedExtrinsic = UncheckedExtrinsic<(), im_online::Call<Test>, (), ()>;
 		type ReportUnresponsiveness = ();
 		type CurrentElectedSet = DummyCurrentElectedSet<AuthorityId>;

--- a/srml/authority-discovery/src/lib.rs
+++ b/srml/authority-discovery/src/lib.rs
@@ -33,18 +33,20 @@ use codec::{Decode, Encode};
 use rstd::prelude::*;
 use srml_support::{decl_module, decl_storage, StorageValue};
 
-pub trait Trait: system::Trait + session::Trait {}
+pub trait Trait: system::Trait + session::Trait + im_online::Trait {}
+
+type AuthorityIdFor<T> = <T as im_online::Trait>::AuthorityId;
 
 decl_storage! {
 	trait Store for Module<T: Trait> as AuthorityDiscovery {
 		/// The current set of keys that may issue a heartbeat.
-		Keys get(keys): Vec<im_online::AuthorityId>;
+		Keys get(keys): Vec<AuthorityIdFor<T>>;
 	}
 	add_extra_genesis {
-		config(keys): Vec<im_online::AuthorityId>;
+		config(keys): Vec<AuthorityIdFor<T>>;
 		build(|
 			  storage: &mut (sr_primitives::StorageOverlay, sr_primitives::ChildrenStorageOverlay),
-			  config: &GenesisConfig
+			  config: &GenesisConfig<T>,
 			  | {
 				  sr_io::with_storage(
 					  storage,
@@ -64,10 +66,10 @@ impl<T: Trait> Module<T> {
 	/// set, otherwise this function returns None. The restriction might be
 	/// softened in the future in case a consumer needs to learn own authority
 	/// identifier.
-	pub fn authority_id() -> Option<im_online::AuthorityId> {
-		let authorities = Keys::get();
+	pub fn authority_id() -> Option<AuthorityIdFor<T>> {
+		let authorities = Keys::<T>::get();
 
-		let local_keys = im_online::AuthorityId::all();
+		let local_keys = <AuthorityIdFor<T>>::all();
 
 		authorities.into_iter().find_map(|authority| {
 			if local_keys.contains(&authority) {
@@ -79,12 +81,12 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Retrieve authority identifiers of the current authority set.
-	pub fn authorities() -> Vec<im_online::AuthorityId> {
-		Keys::get()
+	pub fn authorities() -> Vec<AuthorityIdFor<T>> {
+		Keys::<T>::get()
 	}
 
 	/// Sign the given payload with the private key corresponding to the given authority id.
-	pub fn sign(payload: Vec<u8>, authority_id: im_online::AuthorityId) -> Option<Vec<u8>> {
+	pub fn sign(payload: Vec<u8>, authority_id: AuthorityIdFor<T>) -> Option<Vec<u8>> {
 		authority_id.sign(&payload).map(|s| s.encode())
 	}
 
@@ -93,27 +95,27 @@ impl<T: Trait> Module<T> {
 	pub fn verify(
 		payload: Vec<u8>,
 		signature: Vec<u8>,
-		authority_id: im_online::AuthorityId,
+		authority_id: AuthorityIdFor<T>,
 	) -> bool {
-		im_online::AuthoritySignature::decode(&mut &signature[..])
+		<AuthorityIdFor<T> as RuntimeAppPublic>::Signature::decode(&mut &signature[..])
 			.map(|s| authority_id.verify(&payload, &s))
 			.unwrap_or(false)
 	}
 
-	fn initialize_keys(keys: &[im_online::AuthorityId]) {
+	fn initialize_keys(keys: &[AuthorityIdFor<T>]) {
 		if !keys.is_empty() {
-			assert!(Keys::get().is_empty(), "Keys are already initialized!");
-			Keys::put_ref(keys);
+			assert!(Keys::<T>::get().is_empty(), "Keys are already initialized!");
+			Keys::<T>::put_ref(keys);
 		}
 	}
 }
 
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
-	type Key = im_online::AuthorityId;
+	type Key = AuthorityIdFor<T>;
 
 	fn on_genesis_session<'a, I: 'a>(validators: I)
 	where
-		I: Iterator<Item = (&'a T::AccountId, im_online::AuthorityId)>,
+		I: Iterator<Item = (&'a T::AccountId, Self::Key)>,
 	{
 		let keys = validators.map(|x| x.1).collect::<Vec<_>>();
 		Self::initialize_keys(&keys);
@@ -121,10 +123,10 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 
 	fn on_new_session<'a, I: 'a>(_changed: bool, _validators: I, next_validators: I)
 	where
-		I: Iterator<Item = (&'a T::AccountId, im_online::AuthorityId)>,
+		I: Iterator<Item = (&'a T::AccountId, Self::Key)>,
 	{
 		// Remember who the authorities are for the new session.
-		Keys::put(next_validators.map(|x| x.1).collect::<Vec<_>>());
+		Keys::<T>::put(next_validators.map(|x| x.1).collect::<Vec<_>>());
 	}
 
 	fn on_disabled(_i: usize) {
@@ -139,9 +141,11 @@ mod tests {
 	use primitives::testing::KeyStore;
 	use primitives::{crypto::key_types, sr25519, traits::BareCryptoStore, H256};
 	use sr_io::{with_externalities, TestExternalities};
+	use sr_primitives::generic::UncheckedExtrinsic;
 	use sr_primitives::testing::{Header, UintAuthorityId};
 	use sr_primitives::traits::{ConvertInto, IdentityLookup, OpaqueKeys};
 	use sr_primitives::Perbill;
+	use sr_staking_primitives::CurrentElectedSet;
 	use srml_support::{impl_outer_origin, parameter_types};
 
 	type AuthorityDiscovery = Module<Test>;
@@ -151,12 +155,21 @@ mod tests {
 	pub struct Test;
 	impl Trait for Test {}
 
+	type AuthorityId = im_online::sr25519::AuthorityId;
+
+	pub struct DummyCurrentElectedSet<T>(std::marker::PhantomData<T>);
+	impl<T> CurrentElectedSet<T> for DummyCurrentElectedSet<T> {
+		fn current_elected_set() -> Vec<T> {
+			vec![]
+		}
+	}
+
 	pub struct TestOnSessionEnding;
-	impl session::OnSessionEnding<im_online::AuthorityId> for TestOnSessionEnding {
+	impl session::OnSessionEnding<AuthorityId> for TestOnSessionEnding {
 		fn on_session_ending(
 			_: SessionIndex,
 			_: SessionIndex,
-		) -> Option<Vec<im_online::AuthorityId>> {
+		) -> Option<Vec<AuthorityId>> {
 			None
 		}
 	}
@@ -167,9 +180,23 @@ mod tests {
 		type ShouldEndSession = session::PeriodicSessions<Period, Offset>;
 		type SessionHandler = TestSessionHandler;
 		type Event = ();
-		type ValidatorId = im_online::AuthorityId;
+		type ValidatorId = AuthorityId;
 		type ValidatorIdOf = ConvertInto;
 		type SelectInitialValidators = ();
+	}
+
+	impl session::historical::Trait for Test {
+		type FullIdentification = ();
+		type FullIdentificationOf = ();
+	}
+
+	impl im_online::Trait for Test {
+		type Call = im_online::Call<Test>;
+		type Event = ();
+		type AuthorityId = AuthorityId;
+		type UncheckedExtrinsic = UncheckedExtrinsic<(), im_online::Call<Test>, (), ()>;
+		type ReportUnresponsiveness = ();
+		type CurrentElectedSet = DummyCurrentElectedSet<AuthorityId>;
 	}
 
 	pub type BlockNumber = u64;
@@ -191,7 +218,7 @@ mod tests {
 		type Call = ();
 		type Hash = H256;
 		type Hashing = ::sr_primitives::traits::BlakeTwo256;
-		type AccountId = im_online::AuthorityId;
+		type AccountId = AuthorityId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
 		type WeightMultiplierUpdate = ();
@@ -208,17 +235,17 @@ mod tests {
 	}
 
 	pub struct TestSessionHandler;
-	impl session::SessionHandler<im_online::AuthorityId> for TestSessionHandler {
+	impl session::SessionHandler<AuthorityId> for TestSessionHandler {
 		fn on_new_session<Ks: OpaqueKeys>(
 			_changed: bool,
-			_validators: &[(im_online::AuthorityId, Ks)],
-			_queued_validators: &[(im_online::AuthorityId, Ks)],
+			_validators: &[(AuthorityId, Ks)],
+			_queued_validators: &[(AuthorityId, Ks)],
 		) {
 		}
 
 		fn on_disabled(_validator_index: usize) {}
 
-		fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(im_online::AuthorityId, Ks)]) {}
+		fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AuthorityId, Ks)]) {}
 	}
 
 	#[test]
@@ -236,17 +263,17 @@ mod tests {
 			.sr25519_public_keys(key_types::IM_ONLINE)
 			.pop()
 			.unwrap();
-		let authority_id = im_online::AuthorityId::from(public_key);
+		let authority_id = AuthorityId::from(public_key);
 
 		// Build genesis.
 		let mut t = system::GenesisConfig::default()
 			.build_storage::<Test>()
 			.unwrap();
 
-		GenesisConfig {
+		GenesisConfig::<Test> {
 			keys: vec![authority_id.clone()],
 		}
-		.assimilate_storage::<Test>(&mut t)
+		.assimilate_storage(&mut t)
 		.unwrap();
 
 		// Create externalities.
@@ -279,11 +306,11 @@ mod tests {
 		let keys = vec![(); 5]
 			.iter()
 			.map(|_x| sr25519::Pair::generate_with_phrase(None).0.public())
-			.map(im_online::AuthorityId::from)
+			.map(AuthorityId::from)
 			.collect();
 
-		GenesisConfig { keys: keys }
-			.assimilate_storage::<Test>(&mut t)
+		GenesisConfig::<Test> { keys: keys }
+			.assimilate_storage(&mut t)
 			.unwrap();
 
 		// Create externalities.
@@ -310,17 +337,17 @@ mod tests {
 			.sr25519_public_keys(key_types::IM_ONLINE)
 			.pop()
 			.unwrap();
-		let authority_id = im_online::AuthorityId::from(public_key);
+		let authority_id = AuthorityId::from(public_key);
 
 		// Build genesis.
 		let mut t = system::GenesisConfig::default()
 			.build_storage::<Test>()
 			.unwrap();
 
-		GenesisConfig {
+		GenesisConfig::<Test> {
 			keys: vec![authority_id.clone()],
 		}
-		.assimilate_storage::<Test>(&mut t)
+		.assimilate_storage(&mut t)
 		.unwrap();
 
 		// Create externalities.

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -67,7 +67,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use app_crypto::RuntimeAppPublic;
+use app_crypto::{AppPublic, RuntimeAppPublic};
 use codec::{Encode, Decode};
 use primitives::offchain::{OpaqueNetworkState, StorageKind};
 use rstd::prelude::*;
@@ -75,7 +75,7 @@ use session::historical::IdentificationTuple;
 use sr_io::Printable;
 use sr_primitives::{
 	Perbill, ApplyError,
-	traits::{Extrinsic as ExtrinsicT, Convert},
+	traits::{Convert, Extrinsic as ExtrinsicT, Member},
 	transaction_validity::{TransactionValidity, TransactionLongevity, ValidTransaction},
 };
 use sr_staking_primitives::{
@@ -83,28 +83,44 @@ use sr_staking_primitives::{
 	offence::{ReportOffence, Offence, Kind},
 };
 use srml_support::{
-	StorageValue, decl_module, decl_event, decl_storage, StorageDoubleMap, print, ensure
+	decl_module, decl_event, decl_storage, print, ensure,
+	Parameter, StorageValue, StorageDoubleMap,
 };
 use system::ensure_none;
 
-mod app {
-	pub use app_crypto::sr25519 as crypto;
+mod app_sr25519 {
 	use app_crypto::{app_crypto, key_types::IM_ONLINE, sr25519};
-
 	app_crypto!(sr25519, IM_ONLINE);
 }
 
-/// A Babe authority keypair. Necessarily equivalent to the schnorrkel public key used in
-/// the main Babe module. If that ever changes, then this must, too.
-#[cfg(feature = "std")]
-pub type AuthorityPair = app::Pair;
+pub mod sr25519 {
+	/// An i'm online keypair using sr25519 as its crypto.
+	#[cfg(feature = "std")]
+	pub type AuthorityPair = super::app_sr25519::Pair;
 
-/// A Babe authority signature.
-pub type AuthoritySignature = app::Signature;
+	/// An i'm online signature using sr25519 as its crypto.
+	pub type AuthoritySignature = super::app_sr25519::Signature;
 
-/// A Babe authority identifier. Necessarily equivalent to the schnorrkel public key used in
-/// the main Babe module. If that ever changes, then this must, too.
-pub type AuthorityId = app::Public;
+	/// An i'm online identifier using sr25519 as its crypto.
+	pub type AuthorityId = super::app_sr25519::Public;
+}
+
+mod app_ed25519 {
+	use app_crypto::{app_crypto, key_types::IM_ONLINE, ed25519};
+	app_crypto!(ed25519, IM_ONLINE);
+}
+
+pub mod ed25519 {
+	/// An i'm online keypair using ed25519 as its crypto.
+	#[cfg(feature = "std")]
+	pub type AuthorityPair = super::app_ed25519::Pair;
+
+	/// An i'm online signature using ed25519 as its crypto.
+	pub type AuthoritySignature = super::app_ed25519::Signature;
+
+	/// An i'm online identifier using ed25519 as its crypto.
+	pub type AuthorityId = super::app_ed25519::Public;
+}
 
 // The local storage database key under which the worker progress status
 // is tracked.
@@ -158,8 +174,11 @@ pub struct Heartbeat<BlockNumber>
 }
 
 pub trait Trait: system::Trait + session::historical::Trait {
+	/// The identifier type for an authority.
+	type AuthorityId: Member + Parameter + AppPublic + RuntimeAppPublic + Default;
+
 	/// The overarching event type.
-	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
+	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 
 	/// The function call.
 	type Call: From<Call<Self>>;
@@ -181,7 +200,9 @@ pub trait Trait: system::Trait + session::historical::Trait {
 }
 
 decl_event!(
-	pub enum Event {
+	pub enum Event<T> where
+		<T as Trait>::AuthorityId,
+	{
 		/// A new heartbeat was received from `AuthorityId`
 		HeartbeatReceived(AuthorityId),
 	}
@@ -193,7 +214,7 @@ decl_storage! {
 		GossipAt get(gossip_at): T::BlockNumber;
 
 		/// The current set of keys that may issue a heartbeat.
-		Keys get(keys): Vec<AuthorityId>;
+		Keys get(keys): Vec<T::AuthorityId>;
 
 		/// For each session index we keep a mapping of `AuthorityId`
 		/// to `offchain::OpaqueNetworkState`.
@@ -201,10 +222,10 @@ decl_storage! {
 			blake2_256(AuthIndex) => Vec<u8>;
 	}
 	add_extra_genesis {
-		config(keys): Vec<AuthorityId>;
+		config(keys): Vec<T::AuthorityId>;
 		build(|
 			storage: &mut (sr_primitives::StorageOverlay, sr_primitives::ChildrenStorageOverlay),
-			config: &GenesisConfig
+			config: &GenesisConfig<T>
 		| {
 			sr_io::with_storage(
 				storage,
@@ -217,12 +238,12 @@ decl_storage! {
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-		fn deposit_event() = default;
+		fn deposit_event<T>() = default;
 
 		fn heartbeat(
 			origin,
 			heartbeat: Heartbeat<T::BlockNumber>,
-			signature: AuthoritySignature
+			signature: <T::AuthorityId as RuntimeAppPublic>::Signature
 		) {
 			ensure_none(origin)?;
 
@@ -298,7 +319,7 @@ impl<T: Trait> Module<T> {
 	fn do_gossip_at(block_number: T::BlockNumber) -> Result<(), OffchainErr> {
 		// we run only when a local authority key is configured
 		let authorities = Keys::get();
-		let mut local_keys = app::Public::all();
+		let mut local_keys = T::AuthorityId::all();
 		local_keys.sort();
 
 		for (authority_index, key) in authorities.into_iter()
@@ -389,7 +410,7 @@ impl<T: Trait> Module<T> {
 		}
 	}
 
-	fn initialize_keys(keys: &[AuthorityId]) {
+	fn initialize_keys(keys: &[T::AuthorityId]) {
 		if !keys.is_empty() {
 			assert!(Keys::get().is_empty(), "Keys are already initialized!");
 			Keys::put_ref(keys);
@@ -399,17 +420,17 @@ impl<T: Trait> Module<T> {
 
 impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 
-	type Key = AuthorityId;
+	type Key = T::AuthorityId;
 
 	fn on_genesis_session<'a, I: 'a>(validators: I)
-		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
 		let keys = validators.map(|x| x.1).collect::<Vec<_>>();
 		Self::initialize_keys(&keys);
 	}
 
 	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, _queued_validators: I)
-		where I: Iterator<Item=(&'a T::AccountId, AuthorityId)>
+		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
 		// Reset heartbeats
 		<ReceivedHeartbeats>::remove_prefix(&<session::Module<T>>::current_index());

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -88,38 +88,38 @@ use srml_support::{
 };
 use system::ensure_none;
 
-mod app_sr25519 {
-	use app_crypto::{app_crypto, key_types::IM_ONLINE, sr25519};
-	app_crypto!(sr25519, IM_ONLINE);
-}
-
 pub mod sr25519 {
+	mod app_sr25519 {
+		use app_crypto::{app_crypto, key_types::IM_ONLINE, sr25519};
+		app_crypto!(sr25519, IM_ONLINE);
+	}
+
 	/// An i'm online keypair using sr25519 as its crypto.
 	#[cfg(feature = "std")]
-	pub type AuthorityPair = super::app_sr25519::Pair;
+	pub type AuthorityPair = app_sr25519::Pair;
 
 	/// An i'm online signature using sr25519 as its crypto.
-	pub type AuthoritySignature = super::app_sr25519::Signature;
+	pub type AuthoritySignature = app_sr25519::Signature;
 
 	/// An i'm online identifier using sr25519 as its crypto.
-	pub type AuthorityId = super::app_sr25519::Public;
-}
-
-mod app_ed25519 {
-	use app_crypto::{app_crypto, key_types::IM_ONLINE, ed25519};
-	app_crypto!(ed25519, IM_ONLINE);
+	pub type AuthorityId = app_sr25519::Public;
 }
 
 pub mod ed25519 {
+	mod app_ed25519 {
+		use app_crypto::{app_crypto, key_types::IM_ONLINE, ed25519};
+		app_crypto!(ed25519, IM_ONLINE);
+	}
+
 	/// An i'm online keypair using ed25519 as its crypto.
 	#[cfg(feature = "std")]
-	pub type AuthorityPair = super::app_ed25519::Pair;
+	pub type AuthorityPair = app_ed25519::Pair;
 
 	/// An i'm online signature using ed25519 as its crypto.
-	pub type AuthoritySignature = super::app_ed25519::Signature;
+	pub type AuthoritySignature = app_ed25519::Signature;
 
 	/// An i'm online identifier using ed25519 as its crypto.
-	pub type AuthorityId = super::app_ed25519::Public;
+	pub type AuthorityId = app_ed25519::Public;
 }
 
 // The local storage database key under which the worker progress status

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -180,7 +180,7 @@ pub trait Trait: system::Trait + session::historical::Trait {
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 
-	/// The function call.
+	/// A dispatchable call type.
 	type Call: From<Call<Self>>;
 
 	/// A extrinsic right from the external world. This is unchecked and so


### PR DESCRIPTION
The i'm online module is hardcoded to use sr25519 keys but we have no specific requirement on crypto type. The crypto is now generic and we support ed25519 and sr25519 for the module. Additionally, I also had to change the `authority-discovery` module to depend on `im_online` and use it's generic public key type.

cc @drewstone 