### PR TITLE
Make it easier to just rebuild the WASM files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,7 +2467,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.2",
+ "substrate-wasm-builder-runner 1.0.3",
 ]
 
 [[package]]
@@ -2976,7 +2976,7 @@ name = "proc-macro-crate"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "sr-sandbox 2.0.0",
  "sr-std 2.0.0",
  "substrate-primitives 2.0.0",
- "substrate-wasm-builder-runner 1.0.2",
+ "substrate-wasm-builder-runner 1.0.3",
 ]
 
 [[package]]
@@ -5200,7 +5200,7 @@ dependencies = [
  "substrate-state-machine 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-trie 2.0.0",
- "substrate-wasm-builder-runner 1.0.2",
+ "substrate-wasm-builder-runner 1.0.3",
  "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5268,24 +5268,24 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.3"
 
 [[package]]
 name = "subtle"
@@ -5642,7 +5642,7 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5726,7 +5726,7 @@ dependencies = [
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6640,7 +6640,7 @@ dependencies = [
 "checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
-"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
+"checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum trie-bench 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3073600c543ed001319d7e092c46dfd8c245af1a218ec5c75eb01582660a2b3e"
 "checksum trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0b62d27e8aa1c07414549ac872480ac82380bab39e730242ab08d82d7cc098a"

--- a/README.adoc
+++ b/README.adoc
@@ -321,6 +321,8 @@ we support multiple environment variables:
 * `TRIGGER_WASM_BUILD` - Can be set to trigger a WASM build. On subsequent calls the value of the variable
                          needs to change. As WASM builder instructs `cargo` to watch for file changes
                          this environment variable should only be required in certain circumstances.
+* `WASM_TARGET_DIRECTORY` - Will copy any build WASM binary to the given directory. The path needs
+                            to be absolute.
 
 Each project can be skipped individually by using the environment variable `SKIP_PROJECT_NAME_WASM_BUILD`.
 Where `PROJECT_NAME` needs to be replaced by the name of the cargo project, e.g. `node-runtime` will

--- a/core/executor/runtime-test/build.rs
+++ b/core/executor/runtime-test/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../utils/wasm-builder",
-			version: "1.0.4",
+			version: "1.0.5",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/core/test-runtime/build.rs
+++ b/core/test-runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../utils/wasm-builder",
-			version: "1.0.4",
+			version: "1.0.5",
 		},
 		// Note that we set the stack-size to 1MB explicitly even though it is set
 		// to this value by default. This is because some of our tests (`restoration_of_globals`)

--- a/core/utils/wasm-builder-runner/Cargo.toml
+++ b/core/utils/wasm-builder-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder-runner"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Runner for substrate-wasm-builder"
 edition = "2018"

--- a/core/utils/wasm-builder-runner/src/lib.rs
+++ b/core/utils/wasm-builder-runner/src/lib.rs
@@ -30,9 +30,6 @@ use std::{env, process::{Command, self}, fs, path::{PathBuf, Path}};
 /// Environment variable that tells us to skip building the WASM binary.
 const SKIP_BUILD_ENV: &str = "SKIP_WASM_BUILD";
 
-/// Environment variable to extend the `RUSTFLAGS` variable given to the WASM build.
-const WASM_BUILD_RUSTFLAGS_ENV: &str = "WASM_BUILD_RUSTFLAGS";
-
 /// Environment variable that tells us to create a dummy WASM binary.
 ///
 /// This is useful for `cargo check` to speed-up the compilation.
@@ -102,22 +99,8 @@ impl WasmBuilderSource {
 pub fn build_current_project_with_rustflags(
 	file_name: &str,
 	wasm_builder_source: WasmBuilderSource,
-	rustflags: &str,
+	default_rustflags: &str,
 ) {
-	let given_rustflags = env::var(WASM_BUILD_RUSTFLAGS_ENV).unwrap_or_default();
-	env::set_var(WASM_BUILD_RUSTFLAGS_ENV, format!("{} {}", given_rustflags, rustflags));
-
-	build_current_project(file_name, wasm_builder_source)
-}
-
-/// Build the currently built project as WASM binary.
-///
-/// The current project is determined using the `CARGO_MANIFEST_DIR` environment variable.
-///
-/// `file_name` - The name of the file being generated in the `OUT_DIR`. The file contains the
-///               constant `WASM_BINARY` which contains the build wasm binary.
-/// `wasm_builder_path` - Path to the wasm-builder project, relative to `CARGO_MANIFEST_DIR`.
-pub fn build_current_project(file_name: &str, wasm_builder_source: WasmBuilderSource) {
 	if check_skip_build() {
 		// If we skip the build, we still want to make sure to be called when an env variable changes
 		generate_rerun_if_changed_instructions();
@@ -145,6 +128,7 @@ pub fn build_current_project(file_name: &str, wasm_builder_source: WasmBuilderSo
 			&manifest_dir,
 			wasm_builder_source,
 			&cargo_toml_path,
+			default_rustflags,
 		);
 		run_project(&project_folder);
 	}
@@ -152,6 +136,17 @@ pub fn build_current_project(file_name: &str, wasm_builder_source: WasmBuilderSo
 	// As last step we need to generate our `rerun-if-changed` stuff. If a build fails, we don't
 	// want to spam the output!
 	generate_rerun_if_changed_instructions();
+}
+
+/// Build the currently built project as WASM binary.
+///
+/// The current project is determined using the `CARGO_MANIFEST_DIR` environment variable.
+///
+/// `file_name` - The name of the file being generated in the `OUT_DIR`. The file contains the
+///               constant `WASM_BINARY` which contains the build wasm binary.
+/// `wasm_builder_path` - Path to the wasm-builder project, relative to `CARGO_MANIFEST_DIR`.
+pub fn build_current_project(file_name: &str, wasm_builder_source: WasmBuilderSource) {
+	build_current_project_with_rustflags(file_name, wasm_builder_source, "");
 }
 
 /// Returns the root path of the wasm-builder-runner workspace.
@@ -179,6 +174,7 @@ fn create_project(
 	manifest_dir: &Path,
 	wasm_builder_source: WasmBuilderSource,
 	cargo_toml_path: &Path,
+	default_rustflags: &str,
 ) {
 	fs::create_dir_all(project_folder.join("src"))
 		.expect("WASM build runner dir create can not fail; qed");
@@ -205,12 +201,19 @@ fn create_project(
 		project_folder.join("src/main.rs"),
 		format!(
 			r#"
+				use substrate_wasm_builder::build_project_with_default_rustflags;
+
 				fn main() {{
-					substrate_wasm_builder::build_project("{file_path}", "{cargo_toml_path}")
+					build_project_with_default_rustflags(
+						"{file_path}",
+						"{cargo_toml_path}",
+						"{default_rustflags}",
+					)
 				}}
 			"#,
 			file_path = replace_back_slashes(file_path.display()),
 			cargo_toml_path = replace_back_slashes(cargo_toml_path.display()),
+			default_rustflags = default_rustflags,
 		)
 	).expect("WASM build runner `main.rs` writing can not fail; qed");
 }

--- a/core/utils/wasm-builder/Cargo.toml
+++ b/core/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"
@@ -12,6 +12,6 @@ license = "GPL-3.0"
 build-helper = "0.1.1"
 cargo_metadata = "0.8"
 tempfile = "3.1.0"
-toml = "0.5.1"
-walkdir = "2.2.8"
+toml = "0.5.3"
+walkdir = "2.2.9"
 fs2 = "0.4.3"

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -130,7 +130,9 @@ pub fn build_project(file_name: &str, cargo_manifest: &str) {
 		process::exit(1);
 	}
 
-	let (wasm_binary, bloaty) = wasm_project::create_and_compile(&cargo_manifest);
+	let (wasm_binary, bloaty) = wasm_project::create_and_compile(
+		&cargo_manifest,
+	);
 
 	create_out_file(
 		file_name,

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -66,6 +66,8 @@
 //!                          needs to change. As WASM builder instructs `cargo` to watch for file changes
 //!                          this environment variable should only be required in certain circumstances.
 //! - `WASM_BUILD_RUSTFLAGS` - Extend `RUSTFLAGS` given to `cargo build` while building the WASM binary.
+//! - `WASM_TARGET_DIRECTORY` - Will copy any build WASM binary to the given directory. The path needs
+//!                            to be absolute.
 //!
 //! Each project can be skipped individually by using the environment variable `SKIP_PROJECT_NAME_WASM_BUILD`.
 //! Where `PROJECT_NAME` needs to be replaced by the name of the cargo project, e.g. `node-runtime` will
@@ -95,6 +97,11 @@ const WASM_BUILD_TYPE_ENV: &str = "WASM_BUILD_TYPE";
 
 /// Environment variable to extend the `RUSTFLAGS` variable given to the WASM build.
 const WASM_BUILD_RUSTFLAGS_ENV: &str = "WASM_BUILD_RUSTFLAGS";
+
+/// Environment variable to set the target directory to copy the final WASM binary.
+///
+/// The directory needs to be an absolute path.
+const WASM_TARGET_DIRECTORY: &str = "WASM_TARGET_DIRECTORY";
 
 /// Build the currently built project as WASM binary.
 ///
@@ -146,7 +153,7 @@ fn check_skip_build() -> bool {
 fn create_out_file(file_name: &str, content: String) {
 	fs::write(
 		file_name,
-		content
+		content,
 	).expect("Creating and writing can not fail; qed");
 }
 

--- a/core/utils/wasm-builder/src/wasm_project.rs
+++ b/core/utils/wasm-builder/src/wasm_project.rs
@@ -203,8 +203,6 @@ fn create_wasm_workspace_project(wasm_workspace: &Path) {
 	).expect("WASM workspace `Cargo.toml` writing can not fail; qed");
 }
 
-
-
 /// Create the project used to build the wasm binary.
 ///
 /// # Returns

--- a/node-template/runtime/build.rs
+++ b/node-template/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSourc
 fn main() {
 	build_current_project_with_rustflags(
 		"wasm_binary.rs",
-		WasmBuilderSource::Crates("1.0.4"),
+		WasmBuilderSource::Crates("1.0.5"),
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.
 		"-Clink-arg=--export=__heap_base",

--- a/node/runtime/build.rs
+++ b/node/runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../core/utils/wasm-builder",
-			version: "1.0.4",
+			version: "1.0.5",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/scripts/build-only-wasm.sh
+++ b/scripts/build-only-wasm.sh
@@ -23,8 +23,7 @@ if [ -d $WASM_BUILDER_RUNNER ]; then
   export DEBUG=false
   export OUT_DIR="$PROJECT_ROOT/target/release/build"
   cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
-    | grep -v "cargo:rerun-if-"                                         \
-    | grep -v "Executing build command"
+    | grep -vE "cargo:rerun-if-|Executing build command"                  \
 else
   cargo build --release -p $1
 fi

--- a/scripts/build-only-wasm.sh
+++ b/scripts/build-only-wasm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+# Script for building only the WASM binary of the given project.
+
+set -e
+
+PROJECT_ROOT=`git rev-parse --show-toplevel`
+
+if [ "$#" -lt 1 ]; then
+  echo "You need to pass the name of the crate you want to compile!"
+  exit 1
+fi
+
+WASM_BUILDER_RUNNER="$PROJECT_ROOT/target/release/wbuild-runner/$1"
+
+if [ -z "$2" ]; then
+  export WASM_TARGET_DIRECTORY=$(pwd)
+else
+  export WASM_TARGET_DIRECTORY=$2
+fi
+
+if [ -d $WASM_BUILDER_RUNNER ]; then
+  export DEBUG=false
+  export OUT_DIR="$PROJECT_ROOT/target/release/build"
+  cargo run --release --manifest-path="$WASM_BUILDER_RUNNER/Cargo.toml" \
+    | grep -v "cargo:rerun-if-"                                         \
+    | grep -v "Executing build command"
+else
+  cargo build --release -p $1
+fi


### PR DESCRIPTION
- Adds a new env variable `WASM_TARGET_DIRECTORY` that controls the target directory for copying the builded WASM binary
- Adds script `build-only-wasm.sh` to only build the WASM binary
- Further improvements to `wasm-builder` to reduce the number of required rebuilds