### PR TITLE
Publish minimum balance from within srml-contracts API

### DIFF
--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -154,6 +154,9 @@ pub trait Ext {
 	/// Returns a reference to the timestamp of the current block
 	fn now(&self) -> &MomentOf<Self::T>;
 
+	/// Returns the minimum balance that is required for creating an account.
+	fn minimum_balance(&self) -> BalanceOf<Self::T>;
+
 	/// Returns a random number for the current block with the given subject.
 	fn random(&self, subject: &[u8]) -> SeedOf<Self::T>;
 
@@ -764,6 +767,10 @@ where
 
 	fn now(&self) -> &T::Moment {
 		&self.timestamp
+	}
+
+	fn minimum_balance(&self) -> BalanceOf<T> {
+		self.ctx.config.existential_deposit
 	}
 
 	fn deposit_event(&mut self, topics: Vec<T::Hash>, data: Vec<u8>) {

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -611,6 +611,16 @@ define_env!(Env, <E: Ext>,
 		Ok(())
 	},
 
+	// Stores the minimum balance (a.k.a. existential deposit) into the scratch buffer.
+	//
+	// The data is encoded as T::Balance. The current contents of the scratch buffer are
+	// overwritten.
+	ext_minimum_balance(ctx) => {
+		ctx.scratch_buf.clear();
+		ctx.ext.minimum_balance().encode_to(&mut ctx.scratch_buf);
+		Ok(())
+	},
+
 	// Decodes the given buffer as a `T::Call` and adds it to the list
 	// of to-be-dispatched calls.
 	//


### PR DESCRIPTION
There are two changes separated by commits:

1. Introduction of a new srml-contracts API function `ext_minimum_balance`. Now contracts don't know the minimum amount of funds to create a contract. Contract writers can hardcode it, but then it is going to be problematic if the balance is increased. `ext_minimum_balance` returns the exact amount which is required for creation of an account.
2. Renaming `existential_deposit`to `minimum_balance`. The reason for this change is that `existential_balance` is the term of the `balances` module. However, we don't really interact with it directly and query `T::Currency::minimum_balance()`. So I guess `minimum_balance` is a better name.
