### PR TITLE
Add missing child trie rpc on_custom_message handler

### DIFF
--- a/core/client/src/genesis.rs
+++ b/core/client/src/genesis.rs
@@ -48,7 +48,7 @@ mod tests {
 		runtime::{Hash, Transfer, Block, BlockNumber, Header, Digest},
 		AccountKeyring, Sr25519Keyring,
 	};
-	use primitives::Blake2Hasher;
+	use primitives::{Blake2Hasher, map};
 	use hex::*;
 
 	native_executor_instance!(
@@ -152,8 +152,8 @@ mod tests {
 			vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 			1000,
 			None,
-			vec![],
-			Default::default(),
+			map![],
+			map![],
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 
@@ -182,8 +182,8 @@ mod tests {
 			vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 			1000,
 			None,
-			vec![],
-			Default::default(),
+			map![],
+			map![],
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 
@@ -212,8 +212,8 @@ mod tests {
 			vec![AccountKeyring::One.into(), AccountKeyring::Two.into()],
 			68,
 			None,
-			vec![],
-			Default::default(),
+			map![],
+			map![],
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 

--- a/core/client/src/genesis.rs
+++ b/core/client/src/genesis.rs
@@ -153,6 +153,7 @@ mod tests {
 			1000,
 			None,
 			vec![],
+			Default::default(),
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 
@@ -182,6 +183,7 @@ mod tests {
 			1000,
 			None,
 			vec![],
+			Default::default(),
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 
@@ -211,6 +213,7 @@ mod tests {
 			68,
 			None,
 			vec![],
+			Default::default(),
 		).genesis_map();
 		let genesis_hash = insert_genesis_block(&mut storage);
 

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -570,7 +570,8 @@ pub mod tests {
 		let remote_block_id = BlockId::Number(0);
 		let remote_block_hash = remote_client.block_hash(0).unwrap().unwrap();
 		let mut remote_block_header = remote_client.header(&remote_block_id).unwrap().unwrap();
-		remote_block_header.state_root = remote_client.state_at(&remote_block_id).unwrap().storage_root(::std::iter::empty()).0.into();
+		remote_block_header.state_root = remote_client.state_at(&remote_block_id).unwrap()
+			.storage_root(::std::iter::empty()).0.into();
 
 		// 'fetch' read proof from remote node
 		let heap_pages = remote_client.storage(&remote_block_id, &StorageKey(well_known_keys::HEAP_PAGES.to_vec()))
@@ -602,7 +603,8 @@ pub mod tests {
 		let remote_block_id = BlockId::Number(0);
 		let remote_block_hash = remote_client.block_hash(0).unwrap().unwrap();
 		let mut remote_block_header = remote_client.header(&remote_block_id).unwrap().unwrap();
-		remote_block_header.state_root = remote_client.state_at(&remote_block_id).unwrap().storage_root(::std::iter::empty()).0.into();
+		remote_block_header.state_root = remote_client.state_at(&remote_block_id).unwrap()
+			.storage_root(::std::iter::empty()).0.into();
 
 		// 'fetch' child read proof from remote node
 		let child_value = remote_client.child_storage(

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -592,6 +592,45 @@ pub mod tests {
 		(local_checker, remote_block_header, remote_read_proof, heap_pages)
 	}
 
+	fn prepare_for_read_child_proof_check() -> (TestChecker, Header, Vec<Vec<u8>>, Vec<u8>) {
+		use test_client::DefaultTestClientBuilderExt;
+		use test_client::TestClientBuilderExt;
+		// prepare remote client
+		let remote_client = test_client::TestClientBuilder::new()
+			.add_extra_child_storage(b":child_storage:default:child1".to_vec(), b"key1".to_vec(), b"value1".to_vec())
+			.build();
+		let remote_block_id = BlockId::Number(0);
+		let remote_block_hash = remote_client.block_hash(0).unwrap().unwrap();
+		let mut remote_block_header = remote_client.header(&remote_block_id).unwrap().unwrap();
+		remote_block_header.state_root = remote_client.state_at(&remote_block_id).unwrap().storage_root(::std::iter::empty()).0.into();
+
+		// 'fetch' child read proof from remote node
+		let child_value = remote_client.child_storage(
+			&remote_block_id,
+			&StorageKey(b":child_storage:default:child1".to_vec()),
+			&StorageKey(b"key1".to_vec()),
+		).unwrap().unwrap().0;
+		assert_eq!(b"value1"[..], child_value[..]);
+		let remote_read_proof = remote_client.read_child_proof(
+			&remote_block_id,
+			b":child_storage:default:child1",
+			b"key1",
+		).unwrap();
+
+		// check locally
+		let local_storage = InMemoryBlockchain::<Block>::new();
+		local_storage.insert(
+			remote_block_hash,
+			remote_block_header.clone(),
+			None,
+			None,
+			crate::backend::NewBlockState::Final,
+		).unwrap();
+		let local_executor = NativeExecutor::<test_client::LocalExecutor>::new(None);
+		let local_checker = LightDataChecker::new(Arc::new(DummyBlockchain::new(DummyStorage::new())), local_executor);
+		(local_checker, remote_block_header, remote_read_proof, child_value)
+	}
+
 	fn prepare_for_header_proof_check(insert_cht: bool) -> (TestChecker, Hash, Header, Vec<Vec<u8>>) {
 		// prepare remote client
 		let remote_client = test_client::new();
@@ -636,6 +675,26 @@ pub mod tests {
 			key: well_known_keys::HEAP_PAGES.to_vec(),
 			retry_count: None,
 		}, remote_read_proof).unwrap().unwrap()[0], heap_pages as u8);
+	}
+
+	#[test]
+	fn storage_child_read_proof_is_generated_and_checked() {
+		let (
+			local_checker,
+			remote_block_header,
+			remote_read_proof,
+			result,
+		) = prepare_for_read_child_proof_check();
+		assert_eq!((&local_checker as &dyn FetchChecker<Block>).check_read_child_proof(
+			&RemoteReadChildRequest::<Header> {
+				block: remote_block_header.hash(),
+				header: remote_block_header,
+				storage_key: b":child_storage:default:child1".to_vec(),
+				key: b"key1".to_vec(),
+				retry_count: None,
+			},
+			remote_read_proof
+		).unwrap().unwrap(), result);
 	}
 
 	#[test]

--- a/core/network/src/chain.rs
+++ b/core/network/src/chain.rs
@@ -51,6 +51,9 @@ pub trait Client<Block: BlockT>: Send + Sync {
 	/// Get storage read execution proof.
 	fn read_proof(&self, block: &Block::Hash, key: &[u8]) -> Result<Vec<Vec<u8>>, Error>;
 
+	/// Get child storage read execution proof.
+	fn read_child_proof(&self, block: &Block::Hash, storage_key: &[u8], key: &[u8]) -> Result<Vec<Vec<u8>>, Error>;
+
 	/// Get method execution proof.
 	fn execution_proof(&self, block: &Block::Hash, method: &str, data: &[u8]) -> Result<(Vec<u8>, Vec<Vec<u8>>), Error>;
 
@@ -111,6 +114,16 @@ impl<B, E, Block, RA> Client<Block> for SubstrateClient<B, E, Block, RA> where
 
 	fn read_proof(&self, block: &Block::Hash, key: &[u8]) -> Result<Vec<Vec<u8>>, Error> {
 		(self as &SubstrateClient<B, E, Block, RA>).read_proof(&BlockId::Hash(block.clone()), key)
+	}
+
+	fn read_child_proof(
+		&self,
+		block: &Block::Hash,
+		storage_key: &[u8],
+		key: &[u8]
+	) -> Result<Vec<Vec<u8>>, Error> {
+		(self as &SubstrateClient<B, E, Block, RA>)
+			.read_child_proof(&BlockId::Hash(block.clone()), storage_key, key)
 	}
 
 	fn execution_proof(&self, block: &Block::Hash, method: &str, data: &[u8]) -> Result<(Vec<u8>, Vec<Vec<u8>>), Error> {

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -548,6 +548,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			GenericMessage::FinalityProofResponse(response) =>
 				return self.on_finality_proof_response(who, response),
 			GenericMessage::RemoteReadChildRequest(_) => {}
+				self.on_remote_read_child_request(who, request),
 			GenericMessage::Consensus(msg) => {
 				if self.context_data.peers.get(&who).map_or(false, |peer| peer.info.protocol_version > 2) {
 					self.consensus_gossip.on_incoming(
@@ -1277,6 +1278,36 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				trace!(target: "sync", "Remote read request {} from {} ({} at {}) failed with: {}",
 					request.id,
 					who,
+					request.key.to_hex::<String>(),
+					request.block,
+					error
+				);
+				Default::default()
+			}
+		};
+		self.send_message(
+			who,
+			GenericMessage::RemoteReadResponse(message::RemoteReadResponse {
+				id: request.id,
+				proof,
+			}),
+		);
+	}
+
+	fn on_remote_read_child_request(
+		&mut self,
+		who: PeerId,
+		request: message::RemoteReadChildRequest<B::Hash>,
+	) {
+		trace!(target: "sync", "Remote read child request {} from {} ({} at {})",
+			request.id, who, request.key.to_hex::<String>(), request.block);
+		let proof = match self.context_data.chain.read_child_proof(&request.block, &request.storage_key, &request.key) {
+			Ok(proof) => proof,
+			Err(error) => {
+				trace!(target: "sync", "Remote read child request {} from {} ({} {} at {}) failed with: {}",
+					request.id,
+					who,
+					request.storage_key.to_hex::<String>(),
 					request.key.to_hex::<String>(),
 					request.block,
 					error

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -547,7 +547,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				self.on_finality_proof_request(who, request),
 			GenericMessage::FinalityProofResponse(response) =>
 				return self.on_finality_proof_response(who, response),
-			GenericMessage::RemoteReadChildRequest(_) => {}
+			GenericMessage::RemoteReadChildRequest(request) =>
 				self.on_remote_read_child_request(who, request),
 			GenericMessage::Consensus(msg) => {
 				if self.context_data.peers.get(&who).map_or(false, |peer| peer.info.protocol_version > 2) {
@@ -1299,8 +1299,8 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		who: PeerId,
 		request: message::RemoteReadChildRequest<B::Hash>,
 	) {
-		trace!(target: "sync", "Remote read child request {} from {} ({} at {})",
-			request.id, who, request.key.to_hex::<String>(), request.block);
+		trace!(target: "sync", "Remote read child request {} from {} ({} {} at {})",
+			request.id, who, request.storage_key.to_hex::<String>(), request.key.to_hex::<String>(), request.block);
 		let proof = match self.context_data.chain.read_child_proof(&request.block, &request.storage_key, &request.key) {
 			Ok(proof) => proof,
 			Err(error) => {

--- a/core/test-runtime/client/src/lib.rs
+++ b/core/test-runtime/client/src/lib.rs
@@ -23,7 +23,7 @@ pub mod trait_tests;
 mod block_builder_ext;
 
 use std::sync::Arc;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 pub use block_builder_ext::BlockBuilderExt;
 pub use generic_test_client::*;
 pub use runtime;
@@ -98,8 +98,8 @@ pub type LightExecutor = client::light::call_executor::RemoteOrLocalCallExecutor
 pub struct GenesisParameters {
 	support_changes_trie: bool,
 	heap_pages_override: Option<u64>,
-	extra_storage: Vec<(Vec<u8>, Vec<u8>)>,
-	child_extra_storage: BTreeMap<Vec<u8>, Vec<(Vec<u8>, Vec<u8>)>>,
+	extra_storage: HashMap<Vec<u8>, Vec<u8>>,
+	child_extra_storage: HashMap<Vec<u8>, HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl GenesisParameters {
@@ -229,7 +229,7 @@ impl<B> TestClientBuilderExt<B> for TestClientBuilder<
 	fn add_extra_storage<K: Into<Vec<u8>>, V: Into<Vec<u8>>>(mut self, key: K, value: V) -> Self {
 		let key = key.into();
 		assert!(!key.is_empty());
-		self.genesis_init_mut().extra_storage.push((key, value.into()));
+		self.genesis_init_mut().extra_storage.insert(key, value.into());
 		self
 	}
 
@@ -246,7 +246,7 @@ impl<B> TestClientBuilderExt<B> for TestClientBuilder<
 		self.genesis_init_mut().child_extra_storage
 			.entry(storage_key)
 			.or_insert_with(Default::default)
-			.push((key, value.into()));
+			.insert(key, value.into());
 		self
 	}
 

--- a/core/test-runtime/client/src/lib.rs
+++ b/core/test-runtime/client/src/lib.rs
@@ -23,6 +23,7 @@ pub mod trait_tests;
 mod block_builder_ext;
 
 use std::sync::Arc;
+use std::collections::BTreeMap;
 pub use block_builder_ext::BlockBuilderExt;
 pub use generic_test_client::*;
 pub use runtime;
@@ -98,6 +99,7 @@ pub struct GenesisParameters {
 	support_changes_trie: bool,
 	heap_pages_override: Option<u64>,
 	extra_storage: Vec<(Vec<u8>, Vec<u8>)>,
+	child_extra_storage: BTreeMap<Vec<u8>, Vec<(Vec<u8>, Vec<u8>)>>,
 }
 
 impl GenesisParameters {
@@ -117,6 +119,7 @@ impl GenesisParameters {
 			1000,
 			self.heap_pages_override,
 			self.extra_storage.clone(),
+			self.child_extra_storage.clone(),
 		)
 	}
 }
@@ -184,6 +187,18 @@ pub trait TestClientBuilderExt<B>: Sized {
 	/// # Panics
 	///
 	/// Panics if the key is empty.
+	fn add_extra_child_storage<SK: Into<Vec<u8>>, K: Into<Vec<u8>>, V: Into<Vec<u8>>>(
+		self,
+		storage_key: SK,
+		key: K,
+		value: V,
+	) -> Self;
+
+	/// Add an extra child value into the genesis storage.
+	///
+	/// # Panics
+	///
+	/// Panics if the key is empty.
 	fn add_extra_storage<K: Into<Vec<u8>>, V: Into<Vec<u8>>>(self, key: K, value: V) -> Self;
 
 	/// Build the test client.
@@ -217,6 +232,24 @@ impl<B> TestClientBuilderExt<B> for TestClientBuilder<
 		self.genesis_init_mut().extra_storage.push((key, value.into()));
 		self
 	}
+
+	fn add_extra_child_storage<SK: Into<Vec<u8>>, K: Into<Vec<u8>>, V: Into<Vec<u8>>>(
+		mut self,
+		storage_key: SK,
+		key: K,
+		value: V,
+	) -> Self {
+		let storage_key = storage_key.into();
+		let key = key.into();
+		assert!(!storage_key.is_empty());
+		assert!(!key.is_empty());
+		self.genesis_init_mut().child_extra_storage
+			.entry(storage_key)
+			.or_insert_with(Default::default)
+			.push((key, value.into()));
+		self
+	}
+
 
 	fn build_with_longest_chain(self) -> (Client<B>, client::LongestChain<B, runtime::Block>) {
 		self.build_with_native_executor(None)


### PR DESCRIPTION
@twittner find that on_custom_message for child trie read was missing. This PR adds it (see on_remote_read_child_request).

There is also additional test for child trie (requires a slight change to test genesis builder in order
to be able to init some children values).

Possible suggestion/change:
- merge child test with non child test (and use a store value different than heap for this one).
- use a single primitive and storage when using add_extra_data (with optional storagekey and none for top storage).