### PR TITLE
Removed superfluous safety check

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -917,19 +917,6 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 			return Err(error::Error::NotInFinalizedChain);
 		}
 
-		// find tree route from last finalized to given block.
-		let route_from_finalized = crate::blockchain::tree_route(
-			|id| self.header(&id)?.ok_or_else(|| Error::UnknownBlock(format!("{:?}", id))),
-			BlockId::Hash(info.finalized_hash),
-			BlockId::Hash(parent_hash),
-		)?;
-
-		// the block being imported retracts the last finalized block, refusing to
-		// import.
-		if !route_from_finalized.retracted().is_empty() {
-			return Err(error::Error::NotInFinalizedChain);
-		}
-
 		// this is a fairly arbitrary choice of where to draw the line on making notifications,
 		// but the general goal is to only make notifications when we are already fully synced
 		// and get a new chain head.


### PR DESCRIPTION
This check is a major performance hit because a tree route to the last finalized block may potentially contain thousands of blocks (as it does on kusama)
It is also unnecessary since the same condition is properly checked here: https://github.com/paritytech/substrate/blob/7276eeab7da8b78f007a99129aad6e89e9d588c7/core/client/db/src/lib.rs#L897-L904