### PR TITLE
Make light client backend only work with locally available data

### DIFF
--- a/core/client/src/light/call_executor.rs
+++ b/core/client/src/light/call_executor.rs
@@ -14,12 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Light client call executor. Executes methods on remote full nodes, fetching
-//! execution proof and checking it locally.
+//! Methods that light client could use to execute runtime calls.
 
 use std::{
 	collections::HashSet, sync::Arc, panic::UnwindSafe, result,
-	marker::PhantomData, cell::RefCell, rc::Rc,
+	cell::RefCell, rc::Rc,
 };
 
 use codec::{Encode, Decode};
@@ -29,218 +28,47 @@ use sr_primitives::traits::{One, Block as BlockT, Header as HeaderT};
 use state_machine::{
 	self, Backend as StateBackend, CodeExecutor, OverlayedChanges,
 	ExecutionStrategy, create_proof_check_backend,
-	execution_proof_check_on_trie_backend, ExecutionManager, NeverOffchainExt
+	execution_proof_check_on_trie_backend, ExecutionManager,
 };
 use hash_db::Hasher;
 
 use crate::runtime_api::{ProofRecorder, InitializeBlock};
 use crate::backend::RemoteBackend;
-use crate::blockchain::Backend as ChainBackend;
 use crate::call_executor::CallExecutor;
 use crate::error::{Error as ClientError, Result as ClientResult};
-use crate::light::fetcher::{Fetcher, RemoteCallRequest};
+use crate::light::fetcher::RemoteCallRequest;
 use executor::{RuntimeVersion, NativeVersion};
 use trie::MemoryDB;
 
-/// Call executor that executes methods on remote node, querying execution proof
-/// and checking proof by re-executing locally.
-pub struct RemoteCallExecutor<B, F> {
-	blockchain: Arc<B>,
-	fetcher: Arc<F>,
-}
-
-/// Remote or local call executor.
+/// Call executor that is able to execute calls only on genesis state.
 ///
-/// Calls are executed locally if state is available locally. Otherwise, calls
-/// are redirected to remote call executor.
-pub struct RemoteOrLocalCallExecutor<Block: BlockT<Hash=H256>, B, R, L> {
+/// Trying to execute call on non-genesis state leads to error.
+pub struct GenesisCallExecutor<B, L> {
 	backend: Arc<B>,
-	remote: R,
 	local: L,
-	_block: PhantomData<Block>,
 }
 
-impl<B, F> Clone for RemoteCallExecutor<B, F> {
+impl<B, L> GenesisCallExecutor<B, L> {
+	/// Create new genesis call executor.
+	pub fn new(backend: Arc<B>, local: L) -> Self {
+		Self { backend, local }
+	}
+}
+
+impl<B, L: Clone> Clone for GenesisCallExecutor<B, L> {
 	fn clone(&self) -> Self {
-		RemoteCallExecutor {
-			blockchain: self.blockchain.clone(),
-			fetcher: self.fetcher.clone(),
-		}
-	}
-}
-
-impl<B, F> RemoteCallExecutor<B, F> {
-	/// Creates new instance of remote call executor.
-	pub fn new(blockchain: Arc<B>, fetcher: Arc<F>) -> Self {
-		RemoteCallExecutor { blockchain, fetcher }
-	}
-}
-
-impl<B, F, Block> CallExecutor<Block, Blake2Hasher> for RemoteCallExecutor<B, F>
-where
-	Block: BlockT<Hash=H256>,
-	B: ChainBackend<Block>,
-	F: Fetcher<Block>,
-	Block::Hash: Ord,
-{
-	type Error = ClientError;
-
-	fn call<
-		O: offchain::Externalities,
-	>(
-		&self,
-		id: &BlockId<Block>,
-		method: &str,
-		call_data: &[u8],
-		_strategy: ExecutionStrategy,
-		_side_effects_handler: Option<&mut O>,
-	) -> ClientResult<Vec<u8>>
-	{
-		let block_hash = self.blockchain.expect_block_hash_from_id(id)?;
-		let block_header = self.blockchain.expect_header(id.clone())?;
-
-		futures03::executor::block_on(self.fetcher.remote_call(RemoteCallRequest {
-			block: block_hash,
-			header: block_header,
-			method: method.into(),
-			call_data: call_data.to_vec(),
-			retry_count: None,
-		}))
-	}
-
-	fn contextual_call<
-		'a,
-		O: offchain::Externalities,
-		IB: Fn() -> ClientResult<()>,
-		EM: Fn(
-			Result<NativeOrEncoded<R>, Self::Error>,
-			Result<NativeOrEncoded<R>, Self::Error>
-		) -> Result<NativeOrEncoded<R>, Self::Error>,
-		R: Encode + Decode + PartialEq,
-		NC,
-	>(
-		&self,
-		_initialize_block_fn: IB,
-		at: &BlockId<Block>,
-		method: &str,
-		call_data: &[u8],
-		changes: &RefCell<OverlayedChanges>,
-		initialize_block: InitializeBlock<'a, Block>,
-		execution_manager: ExecutionManager<EM>,
-		_native_call: Option<NC>,
-		side_effects_handler: Option<&mut O>,
-		_recorder: &Option<Rc<RefCell<ProofRecorder<Block>>>>,
-		_enable_keystore: bool,
-	) -> ClientResult<NativeOrEncoded<R>> where ExecutionManager<EM>: Clone {
-		let block_initialized = match initialize_block {
-			InitializeBlock::Do(ref init_block) => {
-				init_block.borrow().is_some()
-			},
-			InitializeBlock::Skip => false,
-		};
-
-		// it is only possible to execute contextual call if changes are empty
-		if !changes.borrow().is_empty() || block_initialized {
-			return Err(ClientError::NotAvailableOnLightClient.into());
-		}
-
-		self.call(
-			at,
-			method,
-			call_data,
-			(&execution_manager).into(),
-			side_effects_handler,
-		).map(NativeOrEncoded::Encoded)
-	}
-
-	fn runtime_version(&self, id: &BlockId<Block>) -> ClientResult<RuntimeVersion> {
-		let call_result = self.call(
-			id,
-			"Core_version",
-			&[],
-			ExecutionStrategy::NativeElseWasm,
-			NeverOffchainExt::new()
-		)?;
-		RuntimeVersion::decode(&mut call_result.as_slice())
-			.map_err(|_| ClientError::VersionInvalid.into())
-	}
-
-	fn call_at_state<
-		O: offchain::Externalities,
-		S: StateBackend<Blake2Hasher>,
-		FF: FnOnce(
-			Result<NativeOrEncoded<R>, Self::Error>,
-			Result<NativeOrEncoded<R>, Self::Error>
-		) -> Result<NativeOrEncoded<R>, Self::Error>,
-		R: Encode + Decode + PartialEq,
-		NC: FnOnce() -> result::Result<R, &'static str>,
-	>(&self,
-		_state: &S,
-		_changes: &mut OverlayedChanges,
-		_method: &str,
-		_call_data: &[u8],
-		_m: ExecutionManager<FF>,
-		_native_call: Option<NC>,
-		_side_effects_handler: Option<&mut O>,
-	) -> ClientResult<(
-		NativeOrEncoded<R>,
-		(S::Transaction, <Blake2Hasher as Hasher>::Out),
-		Option<MemoryDB<Blake2Hasher>>,
-	)> {
-		Err(ClientError::NotAvailableOnLightClient.into())
-	}
-
-	fn prove_at_trie_state<S: state_machine::TrieBackendStorage<Blake2Hasher>>(
-		&self,
-		_state: &state_machine::TrieBackend<S, Blake2Hasher>,
-		_changes: &mut OverlayedChanges,
-		_method: &str,
-		_call_data: &[u8]
-	) -> ClientResult<(Vec<u8>, Vec<Vec<u8>>)> {
-		Err(ClientError::NotAvailableOnLightClient.into())
-	}
-
-	fn native_runtime_version(&self) -> Option<&NativeVersion> {
-		None
-	}
-}
-
-impl<Block, B, R, L> Clone for RemoteOrLocalCallExecutor<Block, B, R, L>
-	where
-		Block: BlockT<Hash=H256>,
-		B: RemoteBackend<Block, Blake2Hasher>,
-		R: CallExecutor<Block, Blake2Hasher> + Clone,
-		L: CallExecutor<Block, Blake2Hasher> + Clone,
-{
-	fn clone(&self) -> Self {
-		RemoteOrLocalCallExecutor {
+		GenesisCallExecutor {
 			backend: self.backend.clone(),
-			remote: self.remote.clone(),
 			local: self.local.clone(),
-			_block: Default::default(),
 		}
 	}
 }
 
-impl<Block, B, Remote, Local> RemoteOrLocalCallExecutor<Block, B, Remote, Local>
+impl<Block, B, Local> CallExecutor<Block, Blake2Hasher> for
+	GenesisCallExecutor<B, Local>
 	where
 		Block: BlockT<Hash=H256>,
 		B: RemoteBackend<Block, Blake2Hasher>,
-		Remote: CallExecutor<Block, Blake2Hasher>,
-		Local: CallExecutor<Block, Blake2Hasher>,
-{
-	/// Creates new instance of remote/local call executor.
-	pub fn new(backend: Arc<B>, remote: Remote, local: Local) -> Self {
-		RemoteOrLocalCallExecutor { backend, remote, local, _block: Default::default(), }
-	}
-}
-
-impl<Block, B, Remote, Local> CallExecutor<Block, Blake2Hasher> for
-	RemoteOrLocalCallExecutor<Block, B, Remote, Local>
-	where
-		Block: BlockT<Hash=H256>,
-		B: RemoteBackend<Block, Blake2Hasher>,
-		Remote: CallExecutor<Block, Blake2Hasher>,
 		Local: CallExecutor<Block, Blake2Hasher>,
 {
 	type Error = ClientError;
@@ -257,7 +85,7 @@ impl<Block, B, Remote, Local> CallExecutor<Block, Blake2Hasher> for
 	) -> ClientResult<Vec<u8>> {
 		match self.backend.is_local_state_available(id) {
 			true => self.local.call(id, method, call_data, strategy, side_effects_handler),
-			false => self.remote.call(id, method, call_data, strategy, side_effects_handler),
+			false => Err(ClientError::NotAvailableOnLightClient),
 		}
 	}
 
@@ -312,36 +140,14 @@ impl<Block, B, Remote, Local> CallExecutor<Block, Blake2Hasher> for
 				recorder,
 				enable_keystore,
 			).map_err(|e| ClientError::Execution(Box::new(e.to_string()))),
-			false => CallExecutor::contextual_call::<
-				_,
-				_,
-				fn(
-					Result<NativeOrEncoded<R>, Remote::Error>,
-					Result<NativeOrEncoded<R>, Remote::Error>,
-				) -> Result<NativeOrEncoded<R>, Remote::Error>,
-				_,
-				NC
-			>(
-				&self.remote,
-				initialize_block_fn,
-				at,
-				method,
-				call_data,
-				changes,
-				initialize_block,
-				ExecutionManager::NativeWhenPossible,
-				native_call,
-				side_effects_handler,
-				recorder,
-				enable_keystore,
-			).map_err(|e| ClientError::Execution(Box::new(e.to_string()))),
+			false => Err(ClientError::NotAvailableOnLightClient),
 		}
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> ClientResult<RuntimeVersion> {
 		match self.backend.is_local_state_available(id) {
 			true => self.local.runtime_version(id),
-			false => self.remote.runtime_version(id),
+			false => Err(ClientError::NotAvailableOnLightClient),
 		}
 	}
 
@@ -355,50 +161,29 @@ impl<Block, B, Remote, Local> CallExecutor<Block, Blake2Hasher> for
 		R: Encode + Decode + PartialEq,
 		NC: FnOnce() -> result::Result<R, &'static str> + UnwindSafe,
 	>(&self,
-		state: &S,
-		changes: &mut OverlayedChanges,
-		method: &str,
-		call_data: &[u8],
+		_state: &S,
+		_changes: &mut OverlayedChanges,
+		_method: &str,
+		_call_data: &[u8],
 		_manager: ExecutionManager<FF>,
-		native_call: Option<NC>,
-		side_effects_handler: Option<&mut O>,
+		_native_call: Option<NC>,
+		_side_effects_handler: Option<&mut O>,
 	) -> ClientResult<(
 		NativeOrEncoded<R>,
 		(S::Transaction, <Blake2Hasher as Hasher>::Out),
 		Option<MemoryDB<Blake2Hasher>>,
 	)> {
-		// there's no actual way/need to specify native/wasm execution strategy on light node
-		// => we can safely ignore passed values
-
-		CallExecutor::call_at_state::<
-				_,
-				_,
-				fn(
-					Result<NativeOrEncoded<R>, Remote::Error>,
-					Result<NativeOrEncoded<R>, Remote::Error>,
-				) -> Result<NativeOrEncoded<R>, Remote::Error>,
-				_,
-				NC
-			>(
-				&self.remote,
-				state,
-				changes,
-				method,
-				call_data,
-				ExecutionManager::NativeWhenPossible,
-				native_call,
-				side_effects_handler,
-			).map_err(|e| ClientError::Execution(Box::new(e.to_string())))
+		Err(ClientError::NotAvailableOnLightClient)
 	}
 
 	fn prove_at_trie_state<S: state_machine::TrieBackendStorage<Blake2Hasher>>(
 		&self,
-		state: &state_machine::TrieBackend<S, Blake2Hasher>,
-		changes: &mut OverlayedChanges,
-		method: &str,
-		call_data: &[u8]
+		_state: &state_machine::TrieBackend<S, Blake2Hasher>,
+		_changes: &mut OverlayedChanges,
+		_method: &str,
+		_call_data: &[u8]
 	) -> ClientResult<(Vec<u8>, Vec<Vec<u8>>)> {
-		self.remote.prove_at_trie_state(state, changes, method, call_data)
+		Err(ClientError::NotAvailableOnLightClient)
 	}
 
 	fn native_runtime_version(&self) -> Option<&NativeVersion> {
@@ -498,12 +283,95 @@ pub fn check_execution_proof<Header, E, H>(
 #[cfg(test)]
 mod tests {
 	use consensus::BlockOrigin;
-	use test_client::{self, runtime::{Header, Digest}, ClientExt, TestClient};
+	use state_machine::NeverOffchainExt;
+	use test_client::{self, runtime::{Header, Digest, Block}, ClientExt, TestClient};
 	use executor::NativeExecutor;
 	use crate::backend::{Backend, NewBlockState};
 	use crate::in_mem::Backend as InMemBackend;
-	use crate::light::fetcher::tests::OkCallFetcher;
 	use super::*;
+
+	struct DummyCallExecutor;
+
+	impl CallExecutor<Block, Blake2Hasher> for DummyCallExecutor {
+		type Error = ClientError;
+
+		fn call<O: offchain::Externalities>(
+			&self,
+			_id: &BlockId<Block>,
+			_method: &str,
+			_call_data: &[u8],
+			_strategy: ExecutionStrategy,
+			_side_effects_handler: Option<&mut O>,
+		) -> Result<Vec<u8>, ClientError> {
+			Ok(vec![42])
+		}
+
+		fn contextual_call<
+			'a,
+			O: offchain::Externalities,
+			IB: Fn() -> ClientResult<()>,
+			EM: Fn(
+				Result<NativeOrEncoded<R>, Self::Error>,
+				Result<NativeOrEncoded<R>, Self::Error>
+			) -> Result<NativeOrEncoded<R>, Self::Error>,
+			R: Encode + Decode + PartialEq,
+			NC: FnOnce() -> result::Result<R, &'static str> + UnwindSafe,
+		>(
+			&self,
+			_initialize_block_fn: IB,
+			_at: &BlockId<Block>,
+			_method: &str,
+			_call_data: &[u8],
+			_changes: &RefCell<OverlayedChanges>,
+			_initialize_block: InitializeBlock<'a, Block>,
+			_execution_manager: ExecutionManager<EM>,
+			_native_call: Option<NC>,
+			_side_effects_handler: Option<&mut O>,
+			_proof_recorder: &Option<Rc<RefCell<ProofRecorder<Block>>>>,
+			_enable_keystore: bool,
+		) -> ClientResult<NativeOrEncoded<R>> where ExecutionManager<EM>: Clone {
+			unreachable!()
+		}
+
+		fn runtime_version(&self, _id: &BlockId<Block>) -> Result<RuntimeVersion, ClientError> {
+			unreachable!()
+		}
+
+		fn call_at_state<
+			O: offchain::Externalities,
+			S: state_machine::Backend<Blake2Hasher>,
+			F: FnOnce(
+				Result<NativeOrEncoded<R>, Self::Error>,
+				Result<NativeOrEncoded<R>, Self::Error>
+			) -> Result<NativeOrEncoded<R>, Self::Error>,
+			R: Encode + Decode + PartialEq,
+			NC: FnOnce() -> result::Result<R, &'static str> + UnwindSafe,
+		>(&self,
+			_state: &S,
+			_overlay: &mut OverlayedChanges,
+			_method: &str,
+			_call_data: &[u8],
+			_manager: ExecutionManager<F>,
+			_native_call: Option<NC>,
+			_side_effects_handler: Option<&mut O>,
+		) -> Result<(NativeOrEncoded<R>, (S::Transaction, H256), Option<MemoryDB<Blake2Hasher>>), ClientError> {
+			unreachable!()
+		}
+
+		fn prove_at_trie_state<S: state_machine::TrieBackendStorage<Blake2Hasher>>(
+			&self,
+			_trie_state: &state_machine::TrieBackend<S, Blake2Hasher>,
+			_overlay: &mut OverlayedChanges,
+			_method: &str,
+			_call_data: &[u8]
+		) -> Result<(Vec<u8>, Vec<Vec<u8>>), ClientError> {
+			unreachable!()
+		}
+
+		fn native_runtime_version(&self) -> Option<&NativeVersion> {
+			unreachable!()
+		}
+	}
 
 	#[test]
 	fn execution_proof_is_generated_and_checked() {
@@ -559,8 +427,8 @@ mod tests {
 	}
 
 	#[test]
-	fn code_is_executed_locally_or_remotely() {
-		let backend = Arc::new(InMemBackend::new());
+	fn code_is_executed_at_genesis_only() {
+		let backend = Arc::new(InMemBackend::<Block, Blake2Hasher>::new());
 		let def = H256::default();
 		let header0 = test_client::runtime::Header::new(0, def, def, def, Default::default());
 		let hash0 = header0.hash();
@@ -569,28 +437,29 @@ mod tests {
 		backend.blockchain().insert(hash0, header0, None, None, NewBlockState::Final).unwrap();
 		backend.blockchain().insert(hash1, header1, None, None, NewBlockState::Final).unwrap();
 
-		let local_executor = RemoteCallExecutor::new(Arc::new(backend.blockchain().clone()), Arc::new(OkCallFetcher::new(vec![1])));
-		let remote_executor = RemoteCallExecutor::new(Arc::new(backend.blockchain().clone()), Arc::new(OkCallFetcher::new(vec![2])));
-		let remote_or_local = RemoteOrLocalCallExecutor::new(backend, remote_executor, local_executor);
+		let genesis_executor = GenesisCallExecutor::new(backend, DummyCallExecutor);
 		assert_eq!(
-			remote_or_local.call(
+			genesis_executor.call(
 				&BlockId::Number(0),
 				"test_method",
 				&[],
 				ExecutionStrategy::NativeElseWasm,
 				NeverOffchainExt::new(),
 			).unwrap(),
-			vec![1],
+			vec![42],
 		);
-		assert_eq!(
-			remote_or_local.call(
-				&BlockId::Number(1),
-				"test_method",
-				&[],
-				ExecutionStrategy::NativeElseWasm,
-				NeverOffchainExt::new(),
-			).unwrap(),
-			vec![2],
+
+		let call_on_unavailable = genesis_executor.call(
+			&BlockId::Number(1),
+			"test_method",
+			&[],
+			ExecutionStrategy::NativeElseWasm,
+			NeverOffchainExt::new(),
 		);
+
+		match call_on_unavailable {
+			Err(ClientError::NotAvailableOnLightClient) => (),
+			_ => unreachable!("unexpected result: {:?}", call_on_unavailable),
+		}
 	}
 }

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -222,15 +222,15 @@ pub trait FetchChecker<Block: BlockT>: Send + Sync {
 }
 
 /// Remote data checker.
-pub struct LightDataChecker<E, H, B: BlockT, S: BlockchainStorage<B>, F> {
-	blockchain: Arc<Blockchain<S, F>>,
+pub struct LightDataChecker<E, H, B: BlockT, S: BlockchainStorage<B>> {
+	blockchain: Arc<Blockchain<S>>,
 	executor: E,
 	_hasher: PhantomData<(B, H)>,
 }
 
-impl<E, H, B: BlockT, S: BlockchainStorage<B>, F> LightDataChecker<E, H, B, S, F> {
+impl<E, H, B: BlockT, S: BlockchainStorage<B>> LightDataChecker<E, H, B, S> {
 	/// Create new light data checker.
-	pub fn new(blockchain: Arc<Blockchain<S, F>>, executor: E) -> Self {
+	pub fn new(blockchain: Arc<Blockchain<S>>, executor: E) -> Self {
 		Self {
 			blockchain, executor, _hasher: PhantomData
 		}
@@ -368,14 +368,13 @@ impl<E, H, B: BlockT, S: BlockchainStorage<B>, F> LightDataChecker<E, H, B, S, F
 	}
 }
 
-impl<E, Block, H, S, F> FetchChecker<Block> for LightDataChecker<E, H, Block, S, F>
+impl<E, Block, H, S> FetchChecker<Block> for LightDataChecker<E, H, Block, S>
 	where
 		Block: BlockT,
 		E: CodeExecutor<H>,
 		H: Hasher,
 		H::Out: Ord + 'static,
 		S: BlockchainStorage<Block>,
-		F: Send + Sync,
 {
 	fn check_header_proof(
 		&self,
@@ -564,7 +563,6 @@ pub mod tests {
 		Blake2Hasher,
 		Block,
 		DummyStorage,
-		OkCallFetcher,
 	>;
 
 	fn prepare_for_read_proof_check() -> (TestChecker, Header, Vec<Vec<u8>>, u32) {

--- a/core/client/src/light/mod.rs
+++ b/core/client/src/light/mod.rs
@@ -34,55 +34,48 @@ use crate::client::Client;
 use crate::error::Result as ClientResult;
 use crate::light::backend::Backend;
 use crate::light::blockchain::{Blockchain, Storage as BlockchainStorage};
-use crate::light::call_executor::{RemoteCallExecutor, RemoteOrLocalCallExecutor};
-use crate::light::fetcher::{Fetcher, LightDataChecker};
+use crate::light::call_executor::GenesisCallExecutor;
+use crate::light::fetcher::LightDataChecker;
 
 /// Create an instance of light client blockchain backend.
-pub fn new_light_blockchain<B: BlockT, S: BlockchainStorage<B>, F>(storage: S) -> Arc<Blockchain<S, F>> {
+pub fn new_light_blockchain<B: BlockT, S: BlockchainStorage<B>>(storage: S) -> Arc<Blockchain<S>> {
 	Arc::new(Blockchain::new(storage))
 }
 
 /// Create an instance of light client backend.
-pub fn new_light_backend<B, S, F>(blockchain: Arc<Blockchain<S, F>>, fetcher: Arc<F>) -> Arc<Backend<S, F, Blake2Hasher>>
+pub fn new_light_backend<B, S>(blockchain: Arc<Blockchain<S>>) -> Arc<Backend<S, Blake2Hasher>>
 	where
 		B: BlockT,
 		S: BlockchainStorage<B>,
-		F: Fetcher<B>,
 {
-	blockchain.set_fetcher(Arc::downgrade(&fetcher));
 	Arc::new(Backend::new(blockchain))
 }
 
 /// Create an instance of light client.
-pub fn new_light<B, S, F, GS, RA, E>(
-	backend: Arc<Backend<S, F, Blake2Hasher>>,
-	fetcher: Arc<F>,
+pub fn new_light<B, S, GS, RA, E>(
+	backend: Arc<Backend<S, Blake2Hasher>>,
 	genesis_storage: GS,
 	code_executor: E,
-) -> ClientResult<Client<Backend<S, F, Blake2Hasher>, RemoteOrLocalCallExecutor<
-	B,
-	Backend<S, F, Blake2Hasher>,
-	RemoteCallExecutor<Blockchain<S, F>, F>,
-	LocalCallExecutor<Backend<S, F, Blake2Hasher>, E>
+) -> ClientResult<Client<Backend<S, Blake2Hasher>, GenesisCallExecutor<
+	Backend<S, Blake2Hasher>,
+	LocalCallExecutor<Backend<S, Blake2Hasher>, E>
 >, B, RA>>
 	where
 		B: BlockT<Hash=H256>,
 		S: BlockchainStorage<B> + 'static,
-		F: Fetcher<B> + 'static,
 		GS: BuildStorage,
 		E: CodeExecutor<Blake2Hasher> + RuntimeInfo,
 {
-	let remote_executor = RemoteCallExecutor::new(backend.blockchain().clone(), fetcher);
 	let local_executor = LocalCallExecutor::new(backend.clone(), code_executor, None);
-	let executor = RemoteOrLocalCallExecutor::new(backend.clone(), remote_executor, local_executor);
+	let executor = GenesisCallExecutor::new(backend.clone(), local_executor);
 	Client::new(backend, executor, genesis_storage, Default::default())
 }
 
 /// Create an instance of fetch data checker.
-pub fn new_fetch_checker<E, B: BlockT, S: BlockchainStorage<B>, F>(
-	blockchain: Arc<Blockchain<S, F>>,
+pub fn new_fetch_checker<E, B: BlockT, S: BlockchainStorage<B>>(
+	blockchain: Arc<Blockchain<S>>,
 	executor: E,
-) -> LightDataChecker<E, Blake2Hasher, B, S, F>
+) -> LightDataChecker<E, Blake2Hasher, B, S>
 	where
 		E: CodeExecutor<Blake2Hasher>,
 {

--- a/core/service/src/builder.rs
+++ b/core/service/src/builder.rs
@@ -107,29 +107,18 @@ type TLightClient<TBl, TRtApi, TExecDisp> = Client<
 /// Light client backend type.
 type TLightBackend<TBl> = client::light::backend::Backend<
 	client_db::light::LightStorage<TBl>,
-	network::OnDemand<TBl>,
 	Blake2Hasher,
 >;
 
 /// Light call executor type.
-type TLightCallExecutor<TBl, TExecDisp> = client::light::call_executor::RemoteOrLocalCallExecutor<
-	TBl,
+type TLightCallExecutor<TBl, TExecDisp> = client::light::call_executor::GenesisCallExecutor<
 	client::light::backend::Backend<
 		client_db::light::LightStorage<TBl>,
-		network::OnDemand<TBl>,
 		Blake2Hasher
-	>,
-	client::light::call_executor::RemoteCallExecutor<
-		client::light::blockchain::Blockchain<
-			client_db::light::LightStorage<TBl>,
-			network::OnDemand<TBl>
-		>,
-		network::OnDemand<TBl>,
 	>,
 	client::LocalCallExecutor<
 		client::light::backend::Backend<
 			client_db::light::LightStorage<TBl>,
-			network::OnDemand<TBl>,
 			Blake2Hasher
 		>,
 		NativeExecutor<TExecDisp>
@@ -238,11 +227,10 @@ where TGen: Serialize + DeserializeOwned + BuildStorage {
 		let light_blockchain = client::light::new_light_blockchain(db_storage);
 		let fetch_checker = Arc::new(client::light::new_fetch_checker(light_blockchain.clone(), executor.clone()));
 		let fetcher = Arc::new(network::OnDemand::new(fetch_checker));
-		let backend = client::light::new_light_backend(light_blockchain, fetcher.clone());
+		let backend = client::light::new_light_backend(light_blockchain);
 		let remote_blockchain = backend.remote_blockchain();
 		let client = Arc::new(client::light::new_light(
 			backend.clone(),
-			fetcher.clone(),
 			&config.chain_spec,
 			executor,
 		)?);
@@ -452,15 +440,22 @@ impl<TBl, TRtApi, TCfg, TGen, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TNetP, TExPo
 	/// Defines which import queue to use.
 	pub fn with_import_queue_and_opt_fprb<UImpQu, UFprb>(
 		self,
-		builder: impl FnOnce(&Configuration<TCfg, TGen>, Arc<TCl>, Arc<Backend>, Option<TSc>, Arc<TExPool>)
-			-> Result<(UImpQu, Option<UFprb>), Error>
+		builder: impl FnOnce(
+			&Configuration<TCfg, TGen>,
+			Arc<TCl>,
+			Arc<Backend>,
+			Option<TFchr>,
+			Option<TSc>,
+			Arc<TExPool>,
+		) -> Result<(UImpQu, Option<UFprb>), Error>
 	) -> Result<ServiceBuilder<TBl, TRtApi, TCfg, TGen, TCl, TFchr, TSc, UImpQu, UFprb, TFpp,
 		TNetP, TExPool, TRpc, TRpcB, Backend>, Error>
-	where TSc: Clone {
+	where TSc: Clone, TFchr: Clone {
 		let (import_queue, fprb) = builder(
 			&self.config,
 			self.client.clone(),
 			self.backend.clone(),
+			self.fetcher.clone(),
 			self.select_chain.clone(),
 			self.transaction_pool.clone()
 		)?;
@@ -486,12 +481,21 @@ impl<TBl, TRtApi, TCfg, TGen, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TNetP, TExPo
 	/// Defines which import queue to use.
 	pub fn with_import_queue_and_fprb<UImpQu, UFprb>(
 		self,
-		builder: impl FnOnce(&Configuration<TCfg, TGen>, Arc<TCl>, Arc<Backend>, Option<TSc>, Arc<TExPool>)
-			-> Result<(UImpQu, UFprb), Error>
+		builder: impl FnOnce(
+			&Configuration<TCfg, TGen>,
+			Arc<TCl>,
+			Arc<Backend>,
+			Option<TFchr>,
+			Option<TSc>,
+			Arc<TExPool>,
+		) -> Result<(UImpQu, UFprb), Error>
 	) -> Result<ServiceBuilder<TBl, TRtApi, TCfg, TGen, TCl, TFchr, TSc, UImpQu, UFprb, TFpp,
 			TNetP, TExPool, TRpc, TRpcB, Backend>, Error>
-	where TSc: Clone {
-		self.with_import_queue_and_opt_fprb(|cfg, cl, b, sc, tx| builder(cfg, cl, b, sc, tx).map(|(q, f)| (q, Some(f))))
+	where TSc: Clone, TFchr: Clone {
+		self.with_import_queue_and_opt_fprb(|cfg, cl, b, f, sc, tx|
+			builder(cfg, cl, b, f, sc, tx)
+				.map(|(q, f)| (q, Some(f)))
+		)
 	}
 
 	/// Defines which transaction pool to use.

--- a/core/test-client/src/lib.rs
+++ b/core/test-client/src/lib.rs
@@ -47,7 +47,6 @@ use client::LocalCallExecutor;
 /// Test client light database backend.
 pub type LightBackend<Block> = client::light::backend::Backend<
 	client_db::light::LightStorage<Block>,
-	LightFetcher,
 	Blake2Hasher,
 >;
 

--- a/core/test-runtime/client/src/lib.rs
+++ b/core/test-runtime/client/src/lib.rs
@@ -73,20 +73,11 @@ pub type Executor = client::LocalCallExecutor<
 pub type LightBackend = generic_test_client::LightBackend<runtime::Block>;
 
 /// Test client light executor.
-pub type LightExecutor = client::light::call_executor::RemoteOrLocalCallExecutor<
-	runtime::Block,
+pub type LightExecutor = client::light::call_executor::GenesisCallExecutor<
 	LightBackend,
-	client::light::call_executor::RemoteCallExecutor<
-		client::light::blockchain::Blockchain<
-			client_db::light::LightStorage<runtime::Block>,
-			LightFetcher
-		>,
-		LightFetcher
-	>,
 	client::LocalCallExecutor<
 		client::light::backend::Backend<
 			client_db::light::LightStorage<runtime::Block>,
-			LightFetcher,
 			Blake2Hasher
 		>,
 		NativeExecutor<LocalExecutor>
@@ -271,22 +262,16 @@ pub fn new_light() -> (
 	let blockchain = Arc::new(client::light::blockchain::Blockchain::new(storage));
 	let backend = Arc::new(LightBackend::new(blockchain.clone()));
 	let executor = NativeExecutor::new(None);
-	let fetcher = Arc::new(LightFetcher);
-	let remote_call_executor = client::light::call_executor::RemoteCallExecutor::new(
-		blockchain.clone(),
-		fetcher,
-	);
 	let local_call_executor = client::LocalCallExecutor::new(backend.clone(), executor, None);
 	let call_executor = LightExecutor::new(
 		backend.clone(),
-		remote_call_executor,
 		local_call_executor,
 	);
 
-	(TestClientBuilder::with_backend(backend.clone())
-		.build_with_executor(call_executor)
-		.0,
-	backend,
+	(
+		TestClientBuilder::with_backend(backend.clone())
+			.build_with_executor(call_executor)
+			.0,
+		backend,
 	)
-
 }

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -197,9 +197,8 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 		.with_transaction_pool(|config, client|
 			Ok(TransactionPool::new(config, transaction_pool::ChainApi::new(client)))
 		)?
-		.with_import_queue_and_fprb(|_config, client, backend, _select_chain, transaction_pool| {
-			let fetch_checker = backend.blockchain().fetcher()
-				.upgrade()
+		.with_import_queue_and_fprb(|_config, client, backend, fetcher, _select_chain, transaction_pool| {
+			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
 			let block_import = grandpa::light_block_import::<_, _, _, RuntimeApi, _>(

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -228,9 +228,8 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 		.with_transaction_pool(|config, client|
 			Ok(TransactionPool::new(config, transaction_pool::ChainApi::new(client)))
 		)?
-		.with_import_queue_and_fprb(|_config, client, backend, _select_chain, transaction_pool| {
-			let fetch_checker = backend.blockchain().fetcher()
-				.upgrade()
+		.with_import_queue_and_fprb(|_config, client, backend, fetcher, _select_chain, transaction_pool| {
+			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
 			let block_import = grandpa::light_block_import::<_, _, _, RuntimeApi, _>(


### PR DESCRIPTION
Quote from #3480 (see description for details):

So the general idea is to:
1) ...
2) update light `Client` backend to work only with local database && fail with `NotAvailableOnLightClient` if it requires some data from remote node. Initially I thought about slightly different approach (which is implemented now), where `Client` itself would fallback to fetch-from-remote if anything isn't available locally. But this won't work from within executor threads. This will be fixed in follow-up PRs - it is going to be a quite large change, though mostly removing lines/code dependencies, etc