### PR TITLE
BABE: always fetch epoch from runtime

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -361,7 +361,7 @@ mod tests {
 		service_test::sync(
 			chain_spec::integration_test_config(),
 			|config| new_full(config),
-			|config| new_light(config),
+			|config| new_full(config), // light nodes unsupported
 			block_factory,
 			extrinsic_factory,
 		);
@@ -389,7 +389,7 @@ mod tests {
 		service_test::sync(
 			chain_spec,
 			|config| new_full!(config),
-			|config| new_light(config),
+			|config| new_full(config), // light nodes are unsupported
 			|service, inherent_data_providers| {
 				let mut inherent_data = inherent_data_providers
 					.create_inherent_data()
@@ -500,7 +500,7 @@ mod tests {
 		service_test::consensus(
 			crate::chain_spec::tests::integration_test_config_with_two_authorities(),
 			|config| new_full(config),
-			|config| new_light(config),
+			|config| new_full(config), // light nodes unsupported
 			vec![
 				"//Alice".into(),
 				"//Bob".into(),


### PR DESCRIPTION
This is in preparation for a PR that changes the workings of BABE to change epoch based purely on time-slot, not on block height. That would make the current block height caching of epoch invalid - so we strip it out as a first step.

Kusama has been tested to sync with this PR staged.