### PR TITLE
grandpa: don't require justification of consensus changes on full node

### DIFF
--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -497,6 +497,8 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> BlockImport<Block>
 						"Imported unjustified block #{} that enacts authority set change, waiting for finality for enactment.",
 						number,
 					);
+
+					imported_aux.needs_justification = true;
 				}
 
 				// we have imported block with consensus data changes, but without justification
@@ -504,8 +506,6 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> BlockImport<Block>
 				if enacts_consensus_change {
 					self.consensus_changes.lock().note_change((number, hash));
 				}
-
-				imported_aux.needs_justification = true;
 			}
 		}
 

--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -815,12 +815,7 @@ impl<B: BlockT> ChainSync<B> {
 	/// with or without errors.
 	pub fn on_justification_import(&mut self, hash: B::Hash, number: NumberFor<B>, success: bool) {
 		let finalization_result = if success { Ok((hash, number)) } else { Err(()) };
-		if !self.extra_justifications.try_finalize_root((hash, number), finalization_result, true) {
-			debug!(target: "sync", "Got justification import result for unknown justification {:?} {:?} request.",
-				hash,
-				number,
-			)
-		}
+		self.extra_justifications.try_finalize_root((hash, number), finalization_result, true);
 		self.is_idle = false;
 	}
 

--- a/core/network/src/protocol/sync/extra_requests.rs
+++ b/core/network/src/protocol/sync/extra_requests.rs
@@ -138,7 +138,7 @@ impl<B: BlockT> ExtraRequests<B> {
 		}
 
 		if best_finalized_number > self.best_seen_finalized_number {
-			match self.tree.finalize_with_ancestors(
+			match self.tree.finalize(
 				best_finalized_hash,
 				best_finalized_number,
 				&is_descendent_of,


### PR DESCRIPTION
Currently `GrandpaBlockImport` tracks authority set changes in `AuthoritySet`, we require a justification for blocks that enact an authority set change. Additionally, the GRANDPA voter will restrict its votes to blocks that enact an authority set change. This guarantees that said blocks, if finalized, will always have a justification. Additionally, `GrandpaBlockImport` keeps track of consensus changes, this is any kind of changes to the client cache (e.g. a BABE epoch change), and we also require justification for those blocks (added in #3301).

The problem with the current logic is that the sync code will always make the justification requests in-order, therefore if we cannot guarantee that a justification exists for a given block, we might get stuck requesting something endlessly. This is the case with BABE epoch changes since the GRANDPA voter won't limit its votes to these blocks.

This PR changes `GrandpaBlockImport` to only require a justification from sync for authority set changes (not consensus changes). I started by removing all of consensus changes from `GrandpaBlockImport` but this is still required so that we persist a justification for blocks that enact a consensus change (so that we can later on serve it to light clients).

I also changed the logic for finalizing pending requests in sync back to what it was before #3301. Since we only request justifications that **must** be satisfiable then we can also make sure that we finalize the requests in-order (i.e. `finalize_with_ancestors -> finalize`).
