### PR TITLE
grandpa: fix race condition

### DIFF
--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -590,9 +590,8 @@ where
 				info!(target: "finality", "Imported justification for block #{} that triggers \
 					command {}, signaling voter.", number, command);
 
-				if let Err(e) = self.send_voter_commands.unbounded_send(command) {
-					return Err(ConsensusError::ClientImport(e.to_string()).into());
-				}
+				// send the command to the voter
+				let _ = self.send_voter_commands.unbounded_send(command);
 			},
 			Err(CommandOrError::Error(e)) => {
 				return Err(match e {


### PR DESCRIPTION
Since we finalize blocks through sync (justification request) and GRANDPA we might run into a race condition when finalizing. All of the finality paths end up in `environment::finalize_block` and we already had a guard there against finalizing something lower than what the client reports as best finalized, but we could race on this check and try to finalize the same block twice (which will fail e.g. if it's an authority set change block). Instead of introducing a new lock I decided to just co-opt `SharedAuthoritySet` to do this synchronization.