### PR TITLE
client: only report block import to telemetry if new best

### DIFF
--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -49,6 +49,8 @@ pub struct ImportedAux {
 	pub bad_justification: bool,
 	/// Request a finality proof for the given block.
 	pub needs_finality_proof: bool,
+	/// Whether the block that was imported is the new best block.
+	pub is_new_best: bool,
 }
 
 impl Default for ImportedAux {
@@ -58,15 +60,20 @@ impl Default for ImportedAux {
 			needs_justification: false,
 			bad_justification: false,
 			needs_finality_proof: false,
+			is_new_best: false,
 		}
 	}
 }
 
 impl ImportResult {
-	/// Returns default value for `ImportResult::Imported` with both
-	/// `clear_justification_requests` and `needs_justification` set to false.
-	pub fn imported() -> ImportResult {
-		ImportResult::Imported(ImportedAux::default())
+	/// Returns default value for `ImportResult::Imported` with
+	/// `clear_justification_requests`, `needs_justification`,
+	/// `bad_justification` and `needs_finality_proof` set to false.
+	pub fn imported(is_new_best: bool) -> ImportResult {
+		let mut aux = ImportedAux::default();
+		aux.is_new_best = is_new_best;
+
+		ImportResult::Imported(aux)
 	}
 }
 

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -39,7 +39,7 @@ pub enum ImportResult {
 }
 
 /// Auxiliary data associated with an imported block result.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ImportedAux {
 	/// Clear all pending justification requests.
 	pub clear_justification_requests: bool,
@@ -51,18 +51,6 @@ pub struct ImportedAux {
 	pub needs_finality_proof: bool,
 	/// Whether the block that was imported is the new best block.
 	pub is_new_best: bool,
-}
-
-impl Default for ImportedAux {
-	fn default() -> ImportedAux {
-		ImportedAux {
-			clear_justification_requests: false,
-			needs_justification: false,
-			bad_justification: false,
-			needs_finality_proof: false,
-			is_new_best: false,
-		}
-	}
 }
 
 impl ImportResult {

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -467,7 +467,8 @@ fn do_finalize_block<B, C, Block: BlockT<Hash=H256>>(
 	// update last finalized block reference
 	data.last_finalized = hash;
 
-	Ok(ImportResult::imported())
+	// we just finalized this block, so if we were importing it, it is now the new best
+	Ok(ImportResult::imported(true))
 }
 
 /// Load light import aux data from the store.

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -680,6 +680,7 @@ pub mod tests {
 			needs_justification: false,
 			bad_justification: false,
 			needs_finality_proof: false,
+			is_new_best: true,
 		}));
 	}
 
@@ -691,6 +692,7 @@ pub mod tests {
 			needs_justification: false,
 			bad_justification: false,
 			needs_finality_proof: false,
+			is_new_best: true,
 		}));
 	}
 
@@ -703,6 +705,7 @@ pub mod tests {
 			needs_justification: false,
 			bad_justification: false,
 			needs_finality_proof: true,
+			is_new_best: true,
 		}));
 	}
 
@@ -718,6 +721,7 @@ pub mod tests {
 				needs_justification: false,
 				bad_justification: false,
 				needs_finality_proof: true,
+				is_new_best: false,
 			},
 		));
 	}

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -1006,6 +1006,7 @@ fn allows_reimporting_change_blocks() {
 			clear_justification_requests: false,
 			bad_justification: false,
 			needs_finality_proof: false,
+			is_new_best: true,
 		}),
 	);
 
@@ -1054,6 +1055,7 @@ fn test_bad_justification() {
 			needs_justification: true,
 			clear_justification_requests: false,
 			bad_justification: true,
+			is_new_best: true,
 			..Default::default()
 		}),
 	);

--- a/core/network/src/test/block_import.rs
+++ b/core/network/src/test/block_import.rs
@@ -16,8 +16,9 @@
 
 //! Testing block import logic.
 
+use consensus::ImportedAux;
 use consensus::import_queue::{
-	import_single_block, IncomingBlock, BasicQueue, BlockImportError, BlockImportResult
+	import_single_block, BasicQueue, BlockImportError, BlockImportResult, IncomingBlock,
 };
 use test_client::{self, prelude::*};
 use test_client::runtime::{Block, Hash};
@@ -45,9 +46,13 @@ fn prepare_good_block() -> (TestClient, Hash, u64, PeerId, IncomingBlock<Block>)
 #[test]
 fn import_single_good_block_works() {
 	let (_, _hash, number, peer_id, block) = prepare_good_block();
+
+	let mut expected_aux = ImportedAux::default();
+	expected_aux.is_new_best = true;
+
 	match import_single_block(&mut test_client::new(), BlockOrigin::File, block, &mut PassThroughVerifier(true)) {
 		Ok(BlockImportResult::ImportedUnknown(ref num, ref aux, ref org))
-			if *num == number && *aux == Default::default() && *org == Some(peer_id) => {}
+			if *num == number && *aux == expected_aux && *org == Some(peer_id) => {}
 		_ => panic!()
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate-telemetry/issues/175.

Right now we always report to telemetry when we import a new block. Telemetry assumes that this is the new best block which may not be true (we sync all forks we see). This leads the telemetry UI to show more "re-orgs" than actually exist, and also to always show the highest block number for a peer (instead of best). After this PR telemetry UI should always show the latest block notified by the peer (regardless of number), since that it will always be the best block.