### PR TITLE
WIP: new nightly srml int test job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -355,6 +355,11 @@ test-srml-contracts-waterfall:
     # spinning it up in background exposing RPC interface locally
     # then running yarn start, which uses the local RPC
   script:
+    - echo 'deb http://deb.debian.org/debian/ buster main' > /etc/apt/sources.list.d/wabt.list
+    - printf 'Package: *\nPin: release a=buster\nPin-Priority: 100\n' > /etc/apt/preferences.d/limit-buster
+    - apt update
+    - apt install wabt
+    - cargo install pwasm-utils-cli --bin wasm-prune --force
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall
     - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,6 +360,9 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
+    - cat ~/.cargo/env
+    - export PATH="$HOME/.cargo/bin:$PATH"
+    - source ~/.cargo/env
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall
     - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -356,7 +356,7 @@ test-srml-contracts-waterfall:
     # then running yarn start, which uses the local RPC
   script:
     - echo 'deb http://deb.debian.org/debian/ buster main' > /etc/apt/sources.list.d/wabt.list
-    - printf 'Package: *\nPin: release a=buster\nPin-Priority: 100\n' > /etc/apt/preferences.d/limit-buster
+    - "printf 'Package: *\nPin: release a=buster\nPin-Priority: 100\n' > /etc/apt/preferences.d/limit-buster"
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,7 +360,7 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
-    - cat ~/.cargo/env
+    # - cat ~/.cargo/env
     - export PATH="$HOME/.cargo/bin:$PATH"
     - source ~/.cargo/env
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,9 +360,6 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
-    # - cat ~/.cargo/env
-    - export PATH="$HOME/.cargo/bin:$PATH"
-    - source ~/.cargo/env
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall
     - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,6 +332,36 @@ check_warnings:
     - docker push $CONTAINER_IMAGE:$VERSION
     - docker push $CONTAINER_IMAGE:latest
 
+test-srml-contracts-waterfall:
+  stage:                           publish
+  # this is the set of integration tests for srml-contracts that requires the substrate binary
+  <<:                              *docker-env
+  dependencies:
+    - build-linux-substrate
+  only:
+    - nightly
+  variables:
+    GIT_STRATEGY:                  none
+
+  # integration tests for srml-contracts
+  # so the idea is that they would be coded in JS and they would speak with a running node in background
+  # the node would be a default node
+  # the rest is simple actually. Some rust (nightly most likely also some stable) code, potentially some AssemblyScript
+  # so more precisely something like this
+    # submodule update
+    # building all ink contracts (requires nightly rustc)
+    # doing yarn (= some npm/js magic)
+    # downloading a substrate-node
+    # spinning it up in background exposing RPC interface locally
+    # then running yarn start, which uses the local RPC
+  script:
+    - git clone https://github.com/paritytech/srml-contracts-waterfall.git .
+    - git submodule update --init
+    - ./build.sh
+    - ./artifacts/substrate/substrate purge-chain --dev -y
+    - ./artifacts/substrate/substrate --dev
+    - yarn && yarn test
+
 publish-docker-substrate:
   stage:                           publish
   <<:                              *publish-docker-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,6 +360,8 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
+    - which wasm-prune
+    - echo "PATH=/usr/local/cargo/bin:$PATH"
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall
     - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,7 +360,6 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
-    - which wasm-prune
     - echo "PATH=/usr/local/cargo/bin:$PATH"
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,7 +360,7 @@ test-srml-contracts-waterfall:
     - apt update
     - apt install wabt
     - cargo install pwasm-utils-cli --bin wasm-prune --force
-    - echo "PATH=/usr/local/cargo/bin:$PATH"
+    - export PATH=/usr/local/cargo/bin:$PATH
     - git clone https://github.com/paritytech/srml-contracts-waterfall.git
     - cd ./srml-contracts-waterfall
     - git submodule update --init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,28 +116,28 @@ cargo-check-subkey:
     - sccache -s
 
 
-test-linux-stable:                 &test-linux
-  stage:                           test
-  <<:                              *docker-env
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: -Cdebug-assertions=y
-  except:
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - time cargo test --all --release --verbose --locked |
-        tee output.log
-    - sccache -s
-  after_script:
-    - echo "___Collecting warnings for check_warnings job___"
-    - awk '/^warning:/,/^$/ { print }' output.log > ${CI_COMMIT_SHORT_SHA}_warnings.log
-  artifacts:
-    name:                          $CI_COMMIT_SHORT_SHA
-    expire_in:                     24 hrs
-    paths:
-      - ${CI_COMMIT_SHORT_SHA}_warnings.log
+# test-linux-stable:                 &test-linux
+#   stage:                           test
+#   <<:                              *docker-env
+#   variables:
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: -Cdebug-assertions=y
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - time cargo test --all --release --verbose --locked |
+#         tee output.log
+#     - sccache -s
+#   after_script:
+#     - echo "___Collecting warnings for check_warnings job___"
+#     - awk '/^warning:/,/^$/ { print }' output.log > ${CI_COMMIT_SHORT_SHA}_warnings.log
+#   artifacts:
+#     name:                          $CI_COMMIT_SHORT_SHA
+#     expire_in:                     24 hrs
+#     paths:
+#       - ${CI_COMMIT_SHORT_SHA}_warnings.log
 
 
 test-srml-staking:                 &test-srml-staking
@@ -161,28 +161,28 @@ test-srml-staking:                 &test-srml-staking
 
 
 
-test-linux-stable-int:
-  <<:                              *test-linux
-  except:
-    refs:
-      - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - echo "___Logs will be partly shown at the end in case of failure.___"
-    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
-    - RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-        time cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
-        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-    - sccache -s
-  after_script:
-    - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
-  artifacts:
-    name:                          $CI_COMMIT_SHORT_SHA
-    when:                          on_failure
-    expire_in:                     24 hrs
-    paths:
-      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
+# test-linux-stable-int:
+#   <<:                              *test-linux
+#   except:
+#     refs:
+#       - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - echo "___Logs will be partly shown at the end in case of failure.___"
+#     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
+#     - RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+#         time cargo test -p node-cli --release --verbose --locked -- --ignored --test-threads=1
+#         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+#     - sccache -s
+#   after_script:
+#     - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
+#   artifacts:
+#     name:                          $CI_COMMIT_SHORT_SHA
+#     when:                          on_failure
+#     expire_in:                     24 hrs
+#     paths:
+#       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 
 
 check-web-wasm:
@@ -223,7 +223,7 @@ build-linux-substrate:
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-only
+  # <<:                              *build-only
   except:
     variables:
       - $DEPLOY_TAG
@@ -286,24 +286,24 @@ build-rust-doc-release:
     - echo "<meta http-equiv=refresh content=0;url=substrate_service/index.html>" > ./crate-docs/index.html
     - sccache -s
 
-check_warnings:
-  stage:                           build
-  <<:                              *docker-env
-  except:
-    variables:
-      - $DEPLOY_TAG
-  variables:
-    GIT_STRATEGY:                  none
-  dependencies:
-    - test-linux-stable
-  script:
-    - if [ -s ${CI_COMMIT_SHORT_SHA}_warnings.log ]; then
-        cat ${CI_COMMIT_SHORT_SHA}_warnings.log;
-        exit 1;
-      else
-        echo "___No warnings___";
-      fi
-  allow_failure:                   true
+# check_warnings:
+#   stage:                           build
+#   <<:                              *docker-env
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   variables:
+#     GIT_STRATEGY:                  none
+#   dependencies:
+#     - test-linux-stable
+#   script:
+#     - if [ -s ${CI_COMMIT_SHORT_SHA}_warnings.log ]; then
+#         cat ${CI_COMMIT_SHORT_SHA}_warnings.log;
+#         exit 1;
+#       else
+#         echo "___No warnings___";
+#       fi
+#   allow_failure:                   true
 
 #### stage:                        publish
 
@@ -336,13 +336,13 @@ test-srml-contracts-waterfall:
   stage:                           publish
   # this is the set of integration tests for srml-contracts that requires the substrate binary
   <<:                              *docker-env
+  # <<:                              *build-only
   dependencies:
     - build-linux-substrate
-  only:
-    - nightly
+  # only:
+  #   - nightly
   variables:
     GIT_STRATEGY:                  none
-
   # integration tests for srml-contracts
   # so the idea is that they would be coded in JS and they would speak with a running node in background
   # the node would be a default node

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,36 +185,36 @@ test-srml-staking:                 &test-srml-staking
 #       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 
 
-check-web-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-  script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/substrate/issues/2416
-    - time cargo web build -p sr-io
-    - time cargo web build -p sr-primitives
-    - time cargo web build -p sr-std
-    - time cargo web build -p substrate-client
-    - time cargo web build -p substrate-consensus-aura
-    - time cargo web build -p substrate-consensus-babe
-    - time cargo web build -p substrate-consensus-common
-    - time cargo web build -p substrate-keyring
-    - time cargo web build -p substrate-keystore
-    - time cargo web build -p substrate-executor
-    - time cargo web build -p substrate-network
-    - time cargo web build -p substrate-panic-handler
-    - time cargo web build -p substrate-peerset
-    - time cargo web build -p substrate-primitives
-    # TODO: we can't use cargo web until https://github.com/paritytech/jsonrpc/pull/436 is deployed
-    - time cargo build -p substrate-rpc-servers --target wasm32-unknown-unknown
-    - time cargo web build -p substrate-serializer
-    - time cargo web build -p substrate-state-db
-    - time cargo web build -p substrate-state-machine
-    - time cargo web build -p substrate-telemetry
-    - time cargo web build -p substrate-trie
-    - sccache -s
+# check-web-wasm:
+#   stage:                           test
+#   <<:                              *docker-env
+#   except:
+#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+#   script:
+#     # WASM support is in progress. As more and more crates support WASM, we
+#     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
+#     - time cargo web build -p sr-io
+#     - time cargo web build -p sr-primitives
+#     - time cargo web build -p sr-std
+#     - time cargo web build -p substrate-client
+#     - time cargo web build -p substrate-consensus-aura
+#     - time cargo web build -p substrate-consensus-babe
+#     - time cargo web build -p substrate-consensus-common
+#     - time cargo web build -p substrate-keyring
+#     - time cargo web build -p substrate-keystore
+#     - time cargo web build -p substrate-executor
+#     - time cargo web build -p substrate-network
+#     - time cargo web build -p substrate-panic-handler
+#     - time cargo web build -p substrate-peerset
+#     - time cargo web build -p substrate-primitives
+#     # TODO: we can't use cargo web until https://github.com/paritytech/jsonrpc/pull/436 is deployed
+#     - time cargo build -p substrate-rpc-servers --target wasm32-unknown-unknown
+#     - time cargo web build -p substrate-serializer
+#     - time cargo web build -p substrate-state-db
+#     - time cargo web build -p substrate-state-machine
+#     - time cargo web build -p substrate-telemetry
+#     - time cargo web build -p substrate-trie
+#     - sccache -s
 
 
 #### stage:                        build
@@ -355,11 +355,12 @@ test-srml-contracts-waterfall:
     # spinning it up in background exposing RPC interface locally
     # then running yarn start, which uses the local RPC
   script:
-    - git clone https://github.com/paritytech/srml-contracts-waterfall.git .
+    - git clone https://github.com/paritytech/srml-contracts-waterfall.git
+    - cd ./srml-contracts-waterfall
     - git submodule update --init
     - ./build.sh
-    - ./artifacts/substrate/substrate purge-chain --dev -y
-    - ./artifacts/substrate/substrate --dev
+    - ../artifacts/substrate/substrate purge-chain --dev -y
+    - ../artifacts/substrate/substrate --dev
     - yarn && yarn test
 
 publish-docker-substrate:


### PR DESCRIPTION
https://github.com/paritytech/srml-contracts-waterfall
Integration tests for srml-contracts.
So the idea is that they would be coded in JS and they would speak with a running node in background
The node would be a default node.
The rest is simple actually. Some rust (nightly most likely also some stable) code, potentially some AssemblyScript
So more precisely something like this:
- submodule update
- building all ink contracts (requires nightly rustc)
- doing yarn (= some npm/js magic)
- downloading a substrate-node
- spinning it up in background exposing RPC interface locally
```
./target/release/substrate purge-chain --dev -y && ./target/release/substrate --dev
```
- then running yarn start, which uses the local RPC