### PR TITLE
Make Stash and Controller Roles Exclusive

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 155,
-	impl_version: 155,
+	spec_version: 156,
+	impl_version: 156,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -704,10 +704,18 @@ decl_module! {
 				return Err("stash already bonded")
 			}
 
+			if <Ledger<T>>::exists(&stash) {
+				return Err("stash already acting as a controller")
+			}
+
 			let controller = T::Lookup::lookup(controller)?;
 
 			if <Ledger<T>>::exists(&controller) {
 				return Err("controller already paired")
+			}
+
+			if <Bonded<T>>::exists(&controller) {
+				return Err("controller is already bonded as a stash")
 			}
 
 			// reject a bond which is considered to be _dust_.
@@ -947,6 +955,9 @@ decl_module! {
 			if <Ledger<T>>::exists(&controller) {
 				return Err("controller already paired")
 			}
+			if <Bonded<T>>::exists(&controller) {
+				return Err("controller is already bonded as a stash")
+			}
 			if controller != old_controller {
 				<Bonded<T>>::insert(&stash, &controller);
 				if let Some(l) = <Ledger<T>>::take(&old_controller) {
@@ -976,7 +987,7 @@ decl_module! {
 		}
 
 		/// Force there to be a new era at the end of the next session. After this, it will be
-		/// reset to normal (non-forced) behaviour.
+		/// reset to normal (non-forced) behavior.
 		///
 		/// # <weight>
 		/// - No arguments.

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -656,6 +656,28 @@ fn double_controlling_should_fail() {
 }
 
 #[test]
+fn bonding_controller_should_fail() {
+	with_externalities(&mut ExtBuilder::default()
+	.build(),
+	|| {
+		// put some money in accounts that we'll use
+		for i in 1..5 { let _ = Balances::make_free_balance_be(&i, 2000); }
+
+		// 1 = stash, 2 = controller, should work
+		assert_ok!(Staking::bond(Origin::signed(1), 2, 500, RewardDestination::default()));
+		// try to bond 2, should fail
+		assert_noop!(Staking::bond(Origin::signed(2), 3, 500, RewardDestination::default()), "stash already acting as a controller");
+		// try to bond 3 and set 1 as the controller, should fail
+		assert_noop!(Staking::bond(Origin::signed(3), 1, 500, RewardDestination::default()), "controller is already bonded as a stash");
+
+		// 3 = stash, 4 = controller, should work
+		assert_ok!(Staking::bond(Origin::signed(3), 4, 500, RewardDestination::default()));
+		// try to change the controller of 1 to 3, should fail
+		assert_noop!(Staking::set_controller(Origin::signed(1), 3), "controller is already bonded as a stash");
+	});
+}
+
+#[test]
 fn session_and_eras_work() {
 	with_externalities(&mut ExtBuilder::default()
 		.build(),

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -666,14 +666,17 @@ fn bonding_controller_should_fail() {
 		// 1 = stash, 2 = controller, should work
 		assert_ok!(Staking::bond(Origin::signed(1), 2, 500, RewardDestination::default()));
 		// try to bond 2, should fail
-		assert_noop!(Staking::bond(Origin::signed(2), 3, 500, RewardDestination::default()), "stash already acting as a controller");
+		assert_noop!(Staking::bond(Origin::signed(2), 3, 500, RewardDestination::default()),
+			"stash already acting as a controller");
 		// try to bond 3 and set 1 as the controller, should fail
-		assert_noop!(Staking::bond(Origin::signed(3), 1, 500, RewardDestination::default()), "controller is already bonded as a stash");
+		assert_noop!(Staking::bond(Origin::signed(3), 1, 500, RewardDestination::default()),
+			"controller is already bonded as a stash");
 
 		// 3 = stash, 4 = controller, should work
 		assert_ok!(Staking::bond(Origin::signed(3), 4, 500, RewardDestination::default()));
 		// try to change the controller of 1 to 3, should fail
-		assert_noop!(Staking::set_controller(Origin::signed(1), 3), "controller is already bonded as a stash");
+		assert_noop!(Staking::set_controller(Origin::signed(1), 3),
+			"controller is already bonded as a stash");
 	});
 }
 


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/3566

Prevents bonded accounts from becoming controllers. Likewise prevents controllers from bonding.