### PR TITLE
Fix node template build issue

### DIFF
--- a/core/authority-discovery/Cargo.toml
+++ b/core/authority-discovery/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 prost-build = "0.5"
 
 [dependencies]
-authority-discovery-primitives = { package = "substrate-authority-discovery-primitives", path = "./primitives", default-features = false }
+authority-discovery-primitives = { package = "substrate-authority-discovery-primitives", path = "./primitives" }
 bytes = "0.4"
 client = { package = "substrate-client", path = "../../core/client" }
 codec = { package = "parity-scale-codec", default-features = false, version = "1.0.3" }

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -6,7 +6,7 @@ use substrate_client::LongestChain;
 use babe::{import_queue, start_babe, Config};
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use futures::prelude::*;
-use node_template_runtime::{self, GenesisConfig, opaque::Block, RuntimeApi, WASM_BINARY};
+use node_template_runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
 use substrate_service::{error::{Error as ServiceError}, AbstractService, Configuration, ServiceBuilder};
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use inherents::InherentDataProviders;


### PR DESCRIPTION
I am getting this issue when using a project based off node-template and upgrade to latest substrate

```
  --> /Users/xiliangchen/.cargo/git/checkouts/substrate-7e08433d4c370a21/17e389d/core/authority-discovery/src/lib.rs:46:38
   |
46 | use authority_discovery_primitives::{AuthorityDiscoveryApi, AuthorityId, Signature};
   |                                      ^^^^^^^^^^^^^^^^^^^^^ no `AuthorityDiscoveryApi` in the root
```

This fixes the issue. Also fixed an unused var warning.

I guess CI should also be improved to make sure node-template builds?