### PR TITLE
Allow signing hex messages from stdin

### DIFF
--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -146,6 +146,11 @@ fn execute<C: Crypto>(matches: clap::ArgMatches) where
 			let mut message = vec![];
 			stdin().lock().read_to_end(&mut message).expect("Error reading from stdin");
 			if matches.is_present("hex") {
+				if let Some(last_char) = message.last() {
+					if *last_char == b'\n' {
+						message.pop();
+					}
+				}
 				message = hex::decode(&message).expect("Invalid hex in message");
 			}
 			let sig = pair.sign(&message);
@@ -264,6 +269,11 @@ fn execute<C: Crypto>(matches: clap::ArgMatches) where
 			let mut message = vec![];
 			stdin().lock().read_to_end(&mut message).expect("Error reading from stdin");
 			if matches.is_present("hex") {
+				if let Some(last_char) = message.last() {
+					if *last_char == b'\n' {
+						message.pop();
+					}
+				}
 				message = hex::decode(&message).expect("Invalid hex in message");
 			}
 			if <<C as Crypto>::Pair as Pair>::verify(&sig, &message, &pubkey) {


### PR DESCRIPTION
subkey can't sign or verify hex-encoded messages right now (using `-h`) because hex decoding chokes on the trailing newline. This PR strips the trailing newline only from hex messages; string messages will still have a trailing newline appended to them when signed.

Test with a burner key: 
```
echo "aaaa" | target/debug/subkey sign -h "absent caution helmet bar pelican draw require blood liar defense about sad"`

echo "aaaa" | target/debug/subkey verify -h 002b8513d3f1556017f7a41f8e9f9c848238dc7e0810aa3ad36b1948ad4e5d73073d9825c5bde558f15355ac6c5225d039f15f95dc706d0f2d2538c4a3b8738f "absent caution helmet bar pelican draw require blood liar defense about sad"
```
