### PR TITLE
Don't initialize block for offchain workers.

### DIFF
--- a/core/offchain/primitives/src/lib.rs
+++ b/core/offchain/primitives/src/lib.rs
@@ -26,6 +26,7 @@ decl_runtime_apis! {
 	/// The offchain worker api.
 	pub trait OffchainWorkerApi {
 		/// Starts the off-chain task for given block number.
+		#[skip_initialize_block]
 		fn offchain_worker(number: NumberFor<Block>);
 	}
 }


### PR DESCRIPTION
Offchain workers should be run in the context of block `X`, at the same state as it was after the block is imported. This allows us to inspect `system` module and for instance get events that were deposited by extrinsics in a block.

Having no `skip_initialize_block`, actually re-intializes the state with header at `X+1` so this useful data was being erased.