### PR TITLE
Move phragmen benchmarks out of Staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,7 +4182,6 @@ name = "srml-staking"
 version = "2.0.0"
 dependencies = [
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-io 2.0.0",
@@ -4989,6 +4988,8 @@ dependencies = [
 name = "substrate-phragmen"
 version = "2.0.0"
 dependencies = [
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
  "srml-support 2.0.0",

--- a/core/phragmen/Cargo.toml
+++ b/core/phragmen/Cargo.toml
@@ -9,7 +9,9 @@ sr-primitives = { path = "../sr-primitives", default-features = false }
 rstd = { package = "sr-std", path = "../sr-std", default-features = false }
 
 [dev-dependencies]
+runtime-io ={ package = "sr-io", path = "../sr-io" }
 support = { package = "srml-support", path = "../../srml/support" }
+rand = "0.7.0"
 
 [features]
 default = ["std"]

--- a/core/phragmen/benches/phragmen.rs
+++ b/core/phragmen/benches/phragmen.rs
@@ -152,9 +152,10 @@ macro_rules! phragmen_benches {
         #[bench]
         fn $name(b: &mut Bencher) {
 			let (v, n, t, e, eq_iter, eq_tol) = $tup;
-			println!("");
+			println!("----------------------");
 			println!(
-				r#"++ Benchmark: {} Validators // {} Nominators // {} Edges-per-nominator // {} total edges // electing {} // Equalize: {} iterations -- {} tolerance"#,
+				"++ Benchmark: {} Validators // {} Nominators // {} Edges-per-nominator // {} \
+				total edges // electing {} // Equalize: {} iterations -- {} tolerance",
 				v, n, e, e * n, t, eq_iter, eq_tol,
 			);
 			do_phragmen(b, v, n, t, e, eq_iter, eq_tol);

--- a/core/phragmen/benches/phragmen.rs
+++ b/core/phragmen/benches/phragmen.rs
@@ -23,20 +23,34 @@
 //!  cargo bench --features bench --color always
 //! ```
 
+#![feature(test)]
+
+extern crate test;
 use test::Bencher;
-use runtime_io::with_externalities;
-use mock::*;
-use super::*;
-use phragmen;
+
 use rand::{self, Rng};
+extern crate substrate_phragmen as phragmen;
+use phragmen::{Support, SupportMap, ACCURACY};
+
+use std::collections::BTreeMap;
+use sr_primitives::traits::{Convert, SaturatedConversion};
 
 const VALIDATORS: u64 = 1000;
 const NOMINATORS: u64 = 10_000;
 const EDGES: u64 = 2;
 const TO_ELECT: usize = 100;
-const STAKE: u64 = 1000;
+const STAKE: Balance = 1000;
 
-type C<T> = <T as Trait>::CurrencyToVote;
+type Balance = u128;
+type AccountId = u64;
+
+pub struct TestCurrencyToVote;
+impl Convert<Balance, u64> for TestCurrencyToVote {
+	fn convert(x: Balance) -> u64 { x.saturated_into() }
+}
+impl Convert<u128, Balance> for TestCurrencyToVote {
+	fn convert(x: u128) -> Balance { x.saturated_into() }
+}
 
 fn do_phragmen(
 	b: &mut Bencher,
@@ -47,84 +61,88 @@ fn do_phragmen(
 	eq_iters: usize,
 	_eq_tolerance: u128,
 ) {
-	with_externalities(&mut ExtBuilder::default().nominate(false).build(), || {
-		assert!(num_vals > votes_per);
-		let rr = |a, b| rand::thread_rng().gen_range(a as usize, b as usize) as u64;
+	assert!(num_vals > votes_per);
+	let rr = |a, b| rand::thread_rng().gen_range(a as usize, b as usize) as Balance;
 
-		// prefix to distinguish the validator and nominator account ranges.
-		let np = 10_000;
+	// prefix to distinguish the validator and nominator account ranges.
+	let np = 10_000;
 
-		(1 ..= 2*num_vals)
-			.step_by(2)
-			.for_each(|acc| bond_validator(acc, STAKE + rr(10, 50)));
+	let mut candidates = vec![];
+	let mut voters = vec![];
+	let mut slashable_balance_of: BTreeMap<AccountId, Balance> = BTreeMap::new();
 
-		(np ..= (np + 2*num_noms))
-			.step_by(2)
-			.for_each(|acc| {
-				let mut stashes_to_vote = (1 ..= 2*num_vals)
-					.step_by(2)
-					.map(|ctrl| ctrl + 1)
-					.collect::<Vec<AccountId>>();
-				let votes = (0 .. votes_per)
-					.map(|_| {
-						stashes_to_vote.remove(rr(0, stashes_to_vote.len()) as usize)
-					})
-					.collect::<Vec<AccountId>>();
-				bond_nominator(acc, STAKE + rr(10, 50), votes);
-			});
+	(1 ..= num_vals)
+		.for_each(|acc| {
+			candidates.push(acc);
+			slashable_balance_of.insert(acc, STAKE + rr(10, 50));
+		});
 
-		b.iter(|| {
-			let r = phragmen::elect::<_, _, _, <Test as Trait>::CurrencyToVote>(
-				count,
-				1_usize,
-				<Validators<Test>>::enumerate().map(|(who, _)| who).collect::<Vec<u64>>(),
-				<Nominators<Test>>::enumerate().collect(),
-				Staking::slashable_balance_of,
-				true,
-			).unwrap();
+	(np ..= (np + num_noms))
+		.for_each(|acc| {
+			let mut stashes_to_vote = candidates.clone();
+			let votes = (0 .. votes_per)
+				.map(|_| {
+					stashes_to_vote.remove(rr(0, stashes_to_vote.len()) as usize)
+				})
+				.collect::<Vec<AccountId>>();
+			voters.push((acc, votes));
+			slashable_balance_of.insert(acc, STAKE + rr(10, 50));
+		});
 
-			// Do the benchmarking with equalize.
-			if eq_iters > 0 {
-				let elected_stashes = r.winners;
-				let mut assignments = r.assignments;
+	let slashable_balance = |who: &AccountId| -> Balance {
+		*slashable_balance_of.get(who).unwrap()
+	};
 
-				let to_votes = |b: Balance|
-				<C<Test> as Convert<Balance, AccountId>>::convert(b) as ExtendedBalance;
-				let ratio_of = |b, r: ExtendedBalance| r.saturating_mul(to_votes(b)) / ACCURACY;
+	b.iter(|| {
+		let r = phragmen::elect::<AccountId, Balance, _, TestCurrencyToVote>(
+			count,
+			1_usize,
+			candidates.clone(),
+			voters.clone(),
+			slashable_balance,
+			true,
+		).unwrap();
 
-				// Initialize the support of each candidate.
-				let mut supports = <SupportMap<u64>>::new();
-				elected_stashes
-					.iter()
-					.map(|e| (e, to_votes(Staking::slashable_balance_of(e))))
-					.for_each(|(e, s)| {
-						let item = Support { own: s, total: s, ..Default::default() };
-						supports.insert(e.clone(), item);
-					});
+		// Do the benchmarking with equalize.
+		if eq_iters > 0 {
+			let elected_stashes = r.winners;
+			let mut assignments = r.assignments;
 
-				for (n, assignment) in assignments.iter_mut() {
-					for (c, r) in assignment.iter_mut() {
-						let nominator_stake = Staking::slashable_balance_of(n);
-						let other_stake = ratio_of(nominator_stake, *r);
-						if let Some(support) = supports.get_mut(c) {
-							support.total = support.total.saturating_add(other_stake);
-							support.others.push((n.clone(), other_stake));
-						}
-						*r = other_stake;
+			let to_votes = |b: Balance| <TestCurrencyToVote as Convert<Balance, u128>>::convert(b) as u128;
+			let ratio_of = |b, r: u128| r.saturating_mul(to_votes(b)) / ACCURACY;
+
+			// Initialize the support of each candidate.
+			let mut supports = <SupportMap<u64>>::new();
+			elected_stashes
+				.iter()
+				.map(|e| (e, to_votes(slashable_balance(e))))
+				.for_each(|(e, s)| {
+					let item = Support { own: s, total: s, ..Default::default() };
+					supports.insert(e.clone(), item);
+				});
+
+			for (n, assignment) in assignments.iter_mut() {
+				for (c, r) in assignment.iter_mut() {
+					let nominator_stake = slashable_balance(n);
+					let other_stake = ratio_of(nominator_stake, *r);
+					if let Some(support) = supports.get_mut(c) {
+						support.total = support.total.saturating_add(other_stake);
+						support.others.push((n.clone(), other_stake));
 					}
+					*r = other_stake;
 				}
-
-				let tolerance = 0_u128;
-				let iterations = 2_usize;
-				phragmen::equalize::<_, _, <Test as Trait>::CurrencyToVote, _>(
-					assignments,
-					&mut supports,
-					tolerance,
-					iterations,
-					Staking::slashable_balance_of,
-				);
 			}
-		})
+
+			let tolerance = 0_u128;
+			let iterations = 2_usize;
+			phragmen::equalize::<_, _, _, TestCurrencyToVote>(
+				assignments,
+				&mut supports,
+				tolerance,
+				iterations,
+				slashable_balance,
+			);
+		}
 	})
 }
 
@@ -136,9 +154,7 @@ macro_rules! phragmen_benches {
 			let (v, n, t, e, eq_iter, eq_tol) = $tup;
 			println!("");
 			println!(
-				r#"
-++ Benchmark: {} Validators // {} Nominators // {} Edges-per-nominator // {} total edges //
-electing {} // Equalize: {} iterations -- {} tolerance"#,
+				r#"++ Benchmark: {} Validators // {} Nominators // {} Edges-per-nominator // {} total edges // electing {} // Equalize: {} iterations -- {} tolerance"#,
 				v, n, e, e * n, t, eq_iter, eq_tol,
 			);
 			do_phragmen(b, v, n, t, e, eq_iter, eq_tol);

--- a/core/phragmen/src/lib.rs
+++ b/core/phragmen/src/lib.rs
@@ -355,7 +355,7 @@ pub fn elect<AccountId, Balance, FS, C>(
 /// * `tolerance`: maximum difference that can occur before an early quite happens.
 /// * `iterations`: maximum number of iterations that will be processed.
 /// * `stake_of`: something that can return the stake stake of a particular candidate or voter.
-pub fn equalize<Balance, AccountId, C, FS>(
+pub fn equalize<Balance, AccountId, FS, C>(
 	mut assignments: Vec<(AccountId, Vec<PhragmenAssignment<AccountId>>)>,
 	supports: &mut SupportMap<AccountId>,
 	tolerance: ExtendedBalance,
@@ -497,11 +497,11 @@ mod tests {
 	use rstd::collections::btree_map::BTreeMap;
 	use support::assert_eq_uvec;
 
-	pub struct C;
-	impl Convert<u64, u64> for C {
+	pub struct TestCurrencyToVote;
+	impl Convert<u64, u64> for TestCurrencyToVote {
 		fn convert(x: u64) -> u64 { x }
 	}
-	impl Convert<u128, u64> for C {
+	impl Convert<u128, u64> for TestCurrencyToVote {
 		fn convert(x: u128) -> u64 { x.saturated_into() }
 	}
 
@@ -699,7 +699,7 @@ mod tests {
 		];
 		let stake_of = |x: &u64| { if *x >= 10 { *x }  else { 0 }};
 		let PhragmenResult { winners, assignments } =
-			elect::<_, _, _, C>(2, 2, candidates, voters, stake_of, false).unwrap();
+			elect::<_, _, _, TestCurrencyToVote>(2, 2, candidates, voters, stake_of, false).unwrap();
 
 		assert_eq_uvec!(winners, vec![2, 3]);
 		assert_eq_uvec!(

--- a/srml/staking/Cargo.toml
+++ b/srml/staking/Cargo.toml
@@ -23,11 +23,9 @@ authorship = { package = "srml-authorship", path = "../authorship", default-feat
 primitives = { package = "substrate-primitives",  path = "../../core/primitives" }
 balances = { package = "srml-balances", path = "../balances" }
 timestamp = { package = "srml-timestamp", path = "../timestamp" }
-rand = "0.6.5"
 
 [features]
 equalize = []
-bench = []
 default = ["std", "equalize"]
 std = [
 	"serde",

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -243,21 +243,13 @@
 
 #![recursion_limit="128"]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(feature = "bench", test), feature(test))]
 
-#[cfg(all(feature = "bench", test))]
-extern crate test;
-
-#[cfg(any(feature = "bench", test))]
+#[cfg(test)]
 mod mock;
-
 #[cfg(test)]
 mod tests;
 
 pub mod inflation;
-
-#[cfg(all(feature = "bench", test))]
-mod benches;
 
 use rstd::{prelude::*, result};
 use codec::{HasCompact, Encode, Decode};
@@ -1291,7 +1283,7 @@ impl<T: Trait> Module<T> {
 			if cfg!(feature = "equalize") {
 				let tolerance = 0_u128;
 				let iterations = 2_usize;
-				equalize::<_, _, T::CurrencyToVote, _>(
+				equalize::<_, _, _, T::CurrencyToVote>(
 					assignments,
 					&mut supports,
 					tolerance,

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -1301,7 +1301,7 @@ fn phragmen_poc_works() {
 	// 40  has load  0 and supported
 	// 40  with stake  0
 
-	// 	Sequential Phragmén with post processing gives
+	// Sequential Phragmén with post processing gives
 	// 10  is elected with stake  1500.0 and score  0.0005
 	// 20  is elected with stake  1500.0 and score  0.00075
 	//
@@ -1402,58 +1402,6 @@ fn phragmen_poc_works() {
 		check_exposure_all();
 		check_nominator_all();
 	});
-}
-
-#[test]
-fn phragmen_poc_2_works() {
-	// tests the encapsulated phragmen::elect function.
-	// Votes  [
-	// 	('10', 1000, ['10']),
-	// 	('20', 1000, ['20']),
-	// 	('30', 1000, ['30']),
-	// 	('2', 50, ['10', '20']),
-	// 	('4', 1000, ['10', '30'])
-	// ]
-	// Sequential Phragmén gives
-	// 10  is elected with stake  1705.7377049180327 and score  0.0004878048780487805
-	// 30  is elected with stake  1344.2622950819673 and score  0.0007439024390243903
-	with_externalities(&mut ExtBuilder::default().nominate(false).build(), || {
-		// initial setup of 10 and 20, both validators
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
-
-		// Bond [30, 31] as the third validator
-		assert_ok!(Staking::bond_extra(Origin::signed(31), 999));
-		assert_ok!(Staking::validate(Origin::signed(30), ValidatorPrefs::default()));
-
-		// bond [2,1](A), [4,3](B), as 2 nominators
-		for i in &[1, 3] { let _ = Balances::deposit_creating(i, 2000); }
-
-		assert_ok!(Staking::bond(Origin::signed(1), 2, 50, RewardDestination::default()));
-		assert_ok!(Staking::nominate(Origin::signed(2), vec![11, 21]));
-
-		assert_ok!(Staking::bond(Origin::signed(3), 4, 1000, RewardDestination::default()));
-		assert_ok!(Staking::nominate(Origin::signed(4), vec![11, 31]));
-
-		let results = phragmen::elect::<_, _, _, <Test as Trait>::CurrencyToVote>(
-			2,
-			Staking::minimum_validator_count() as usize,
-			<Validators<Test>>::enumerate().map(|(who, _)| who).collect::<Vec<u64>>(),
-			<Nominators<Test>>::enumerate().collect(),
-			Staking::slashable_balance_of,
-			true,
-		);
-
-		let phragmen::PhragmenResult { winners, assignments } = results.unwrap();
-
-		// 10 and 30 must be the winners
-		assert_eq!(winners, vec![11, 31]);
-		assert_eq!(assignments, vec![
-			(3, vec![(11, 2816371998), (31, 1478595298)]),
-			(1, vec![(11, 4294967296)]),
-		]);
-		check_exposure_all();
-		check_nominator_all();
-	})
 }
 
 #[test]


### PR DESCRIPTION
Because there is no reason for them to be there anymore. 

Accomplishes the title already. 
Marked as `in-progress` because I want to try and add a float, truth-value implementation of the post-processing as well and then migrate more phragmen-related tests over. 