### PR TITLE
read_storage panics

### DIFF
--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -629,9 +629,9 @@ impl_wasm_host_interface! {
 			)?;
 
 			if let Some(value) = maybe_value {
-				let value = &value[value.len().min(value_offset as usize)..];
-				let written = std::cmp::min(value_len as usize, value.len());
-				context.write_memory(value_data, &value[..written])
+				let data = &value[value.len().min(value_offset as usize)..];
+				let written = std::cmp::min(value_len as usize, data.len());
+				context.write_memory(value_data, &data[..written])
 					.map_err(|_| "Invalid attempt to set value in ext_get_storage_into")?;
 				Ok(value.len() as u32)
 			} else {
@@ -658,11 +658,11 @@ impl_wasm_host_interface! {
 			)?;
 
 			if let Some(value) = maybe_value {
-				let value = &value[value.len().min(value_offset as usize)..];
-				let written = std::cmp::min(value_len as usize, value.len());
-				context.write_memory(value_data, &value[..written])
-					.map_err(|_| "Invalid attempt to set value in ext_get_child_storage_into")?;
-				Ok(value.len() as u32)
+				let data = &value[value.len().min(value_offset as usize)..];
+				let written = std::cmp::min(value_len as usize, data.len());
+				context.write_memory(value_data, &data[..written])
+					.map_err(|_| "Invalid attempt to get value in ext_get_child_storage_into")?;
+				Ok(data.len() as u32)
 			} else {
 				Ok(u32::max_value())
 			}

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -605,12 +605,10 @@ impl_wasm_host_interface! {
 			let maybe_value = runtime_io::storage(&key);
 
 			if let Some(value) = maybe_value {
-				if (value_offset as usize) < value.len() {
-					let value = &value[value_offset as usize..];
-					let written = std::cmp::min(value_len as usize, value.len());
-					context.write_memory(value_data, &value[..written])
-						.map_err(|_| "Invalid attempt to set value in ext_get_storage_into")?;
-				}
+				let value = &value[value.len().min(value_offset as usize)..];
+				let written = std::cmp::min(value_len as usize, value.len());
+				context.write_memory(value_data, &value[..written])
+					.map_err(|_| "Invalid attempt to set value in ext_get_storage_into")?;
 				Ok(value.len() as u32)
 			} else {
 				Ok(u32::max_value())
@@ -634,12 +632,10 @@ impl_wasm_host_interface! {
 			let maybe_value = runtime_io::child_storage(&storage_key, &key);
 
 			if let Some(value) = maybe_value {
-				if (value_offset as usize) < value.len() {
-					let value = &value[value_offset as usize..];
-					let written = std::cmp::min(value_len as usize, value.len());
-					context.write_memory(value_data, &value[..written])
-						.map_err(|_| "Invalid attempt to set value in ext_get_child_storage_into")?;
-				}
+				let value = &value[value.len().min(value_offset as usize)..];
+				let written = std::cmp::min(value_len as usize, value.len());
+				context.write_memory(value_data, &value[..written])
+					.map_err(|_| "Invalid attempt to set value in ext_get_child_storage_into")?;
 				Ok(value.len() as u32)
 			} else {
 				Ok(u32::max_value())

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -662,7 +662,7 @@ impl_wasm_host_interface! {
 				let written = std::cmp::min(value_len as usize, data.len());
 				context.write_memory(value_data, &data[..written])
 					.map_err(|_| "Invalid attempt to get value in ext_get_child_storage_into")?;
-				Ok(data.len() as u32)
+				Ok(value.len() as u32)
 			} else {
 				Ok(u32::max_value())
 			}

--- a/core/executor/src/wasm_executor.rs
+++ b/core/executor/src/wasm_executor.rs
@@ -31,8 +31,8 @@ use crate::error::{Error, Result};
 use codec::{Encode, Decode};
 use primitives::{
 	blake2_128, blake2_256, twox_64, twox_128, twox_256, ed25519, sr25519, Pair, crypto::KeyTypeId,
-	offchain, hexdisplay::HexDisplay, sandbox as sandbox_primitives, H256, Blake2Hasher,
-	traits::Externalities, child_storage_key::ChildStorageKey,
+	offchain, hexdisplay::HexDisplay, sandbox as sandbox_primitives, Blake2Hasher,
+	traits::Externalities,
 };
 use trie::{TrieConfiguration, trie_types::Layout};
 use crate::sandbox;
@@ -605,10 +605,12 @@ impl_wasm_host_interface! {
 			let maybe_value = runtime_io::storage(&key);
 
 			if let Some(value) = maybe_value {
-				let value = &value[value_offset as usize..];
-				let written = std::cmp::min(value_len as usize, value.len());
-				context.write_memory(value_data, &value[..written])
-					.map_err(|_| "Invalid attempt to set value in ext_get_storage_into")?;
+				if (value_offset as usize) < value.len() {
+					let value = &value[value_offset as usize..];
+					let written = std::cmp::min(value_len as usize, value.len());
+					context.write_memory(value_data, &value[..written])
+						.map_err(|_| "Invalid attempt to set value in ext_get_storage_into")?;
+				}
 				Ok(value.len() as u32)
 			} else {
 				Ok(u32::max_value())
@@ -632,10 +634,12 @@ impl_wasm_host_interface! {
 			let maybe_value = runtime_io::child_storage(&storage_key, &key);
 
 			if let Some(value) = maybe_value {
-				let value = &value[value_offset as usize..];
-				let written = std::cmp::min(value_len as usize, value.len());
-				context.write_memory(value_data, &value[..written])
-					.map_err(|_| "Invalid attempt to set value in ext_get_child_storage_into")?;
+				if (value_offset as usize) < value.len() {
+					let value = &value[value_offset as usize..];
+					let written = std::cmp::min(value_len as usize, value.len());
+					context.write_memory(value_data, &value[..written])
+						.map_err(|_| "Invalid attempt to set value in ext_get_child_storage_into")?;
+				}
 				Ok(value.len() as u32)
 			} else {
 				Ok(u32::max_value())

--- a/core/sr-io/with_std.rs
+++ b/core/sr-io/with_std.rs
@@ -54,11 +54,9 @@ impl StorageApi for () {
 
 	fn read_storage(key: &[u8], value_out: &mut [u8], value_offset: usize) -> Option<usize> {
 		ext::with(|ext| ext.storage(key).map(|value| {
-			if value_offset < value.len() {
-				let value = &value[value_offset..];
-				let written = std::cmp::min(value.len(), value_out.len());
-				value_out[..written].copy_from_slice(&value[..written]);
-			}
+			let value = &value[value_offset.min(value.len())..];
+			let written = std::cmp::min(value.len(), value_out.len());
+			value_out[..written].copy_from_slice(&value[..written]);
 			value.len()
 		})).expect("read_storage cannot be called outside of an Externalities-provided environment.")
 	}
@@ -87,11 +85,9 @@ impl StorageApi for () {
 			let storage_key = child_storage_key_or_panic(storage_key);
 			ext.child_storage(storage_key, key)
 				.map(|value| {
-					if value_offset < value.len() {
-						let value = &value[value_offset..];
-						let written = std::cmp::min(value.len(), value_out.len());
-						value_out[..written].copy_from_slice(&value[..written]);
-					}
+					let value = &value[value_offset.min(value.len())..];
+					let written = std::cmp::min(value.len(), value_out.len());
+					value_out[..written].copy_from_slice(&value[..written]);
 					value.len()
 				})
 		})

--- a/core/sr-io/with_std.rs
+++ b/core/sr-io/with_std.rs
@@ -54,9 +54,11 @@ impl StorageApi for () {
 
 	fn read_storage(key: &[u8], value_out: &mut [u8], value_offset: usize) -> Option<usize> {
 		ext::with(|ext| ext.storage(key).map(|value| {
-			let value = &value[value_offset..];
-			let written = std::cmp::min(value.len(), value_out.len());
-			value_out[..written].copy_from_slice(&value[..written]);
+			if value_offset < value.len() {
+				let value = &value[value_offset..];
+				let written = std::cmp::min(value.len(), value_out.len());
+				value_out[..written].copy_from_slice(&value[..written]);
+			}
 			value.len()
 		})).expect("read_storage cannot be called outside of an Externalities-provided environment.")
 	}
@@ -85,9 +87,11 @@ impl StorageApi for () {
 			let storage_key = child_storage_key_or_panic(storage_key);
 			ext.child_storage(storage_key, key)
 				.map(|value| {
-					let value = &value[value_offset..];
-					let written = std::cmp::min(value.len(), value_out.len());
-					value_out[..written].copy_from_slice(&value[..written]);
+					if value_offset < value.len() {
+						let value = &value[value_offset..];
+						let written = std::cmp::min(value.len(), value_out.len());
+						value_out[..written].copy_from_slice(&value[..written]);
+					}
 					value.len()
 				})
 		})

--- a/core/sr-io/with_std.rs
+++ b/core/sr-io/with_std.rs
@@ -54,9 +54,9 @@ impl StorageApi for () {
 
 	fn read_storage(key: &[u8], value_out: &mut [u8], value_offset: usize) -> Option<usize> {
 		ext::with(|ext| ext.storage(key).map(|value| {
-			let value = &value[value_offset.min(value.len())..];
-			let written = std::cmp::min(value.len(), value_out.len());
-			value_out[..written].copy_from_slice(&value[..written]);
+			let data = &value[value_offset.min(value.len())..];
+			let written = std::cmp::min(data.len(), value_out.len());
+			value_out[..written].copy_from_slice(&data[..written]);
 			value.len()
 		})).expect("read_storage cannot be called outside of an Externalities-provided environment.")
 	}
@@ -85,9 +85,9 @@ impl StorageApi for () {
 			let storage_key = child_storage_key_or_panic(storage_key);
 			ext.child_storage(storage_key, key)
 				.map(|value| {
-					let value = &value[value_offset.min(value.len())..];
-					let written = std::cmp::min(value.len(), value_out.len());
-					value_out[..written].copy_from_slice(&value[..written]);
+					let data = &value[value_offset.min(value.len())..];
+					let written = std::cmp::min(data.len(), value_out.len());
+					value_out[..written].copy_from_slice(&data[..written]);
 					value.len()
 				})
 		})

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -280,6 +280,8 @@ cfg_if! {
 				///
 				/// Returns the signature generated for the message `sr25519`.
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic);
+				/// Run various tests against storage.
+				fn test_storage();
 			}
 		}
 	} else {
@@ -322,6 +324,8 @@ cfg_if! {
 				///
 				/// Returns the signature generated for the message `sr25519`.
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic);
+				/// Run various tests against storage.
+				fn test_storage();
 			}
 		}
 	}
@@ -590,6 +594,10 @@ cfg_if! {
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 					test_sr25519_crypto()
 				}
+
+				fn test_storage() {
+					test_storage();
+				}
 			}
 
 			impl aura_primitives::AuraApi<Block, AuraId> for Runtime {
@@ -805,6 +813,10 @@ cfg_if! {
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 					test_sr25519_crypto()
 				}
+
+				fn test_storage() {
+					test_storage();
+				}
 			}
 
 			impl aura_primitives::AuraApi<Block, AuraId> for Runtime {
@@ -885,6 +897,26 @@ fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 	let signature = public0.sign(&"sr25519").expect("Generates a valid `sr25519` signature.");
 	assert!(public0.verify(&"sr25519", &signature));
 	(signature, public0)
+}
+
+fn test_storage() {
+	const KEY: &[u8] = b":test_storage";
+
+	runtime_io::set_storage(KEY, b"test");
+
+	let mut v = [0u8; 4];
+	let r = runtime_io::read_storage(
+		KEY,
+		&mut v,
+		0
+	);
+	assert_eq!(r, Some(4));
+	assert_eq!(&v, b"test");
+
+	let mut v = [0u8; 4];
+	let r = runtime_io::read_storage(KEY, &mut v, 8);
+	assert_eq!(r, Some(4));
+	assert_eq!(&v, &[0, 0, 0, 0]);
 }
 
 #[cfg(test)]
@@ -980,5 +1012,14 @@ mod tests {
 		// Allocation of 1024k while having ~2048k should succeed.
 		let ret = runtime_api.vec_with_capacity(&new_block_id, 1048576);
 		assert!(ret.is_ok());
+	}
+
+	#[test]
+	fn read_storage() {
+		let client = TestClientBuilder::new().build();
+		let runtime_api = client.runtime_api();
+		let block_id = BlockId::Number(client.info().chain.best_number);
+
+		runtime_api.test_storage(&block_id).unwrap();
 	}
 }

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -902,7 +902,7 @@ fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 }
 
 fn test_read_storage() {
-	const KEY: &[u8] = b":test_storage";
+	const KEY: &[u8] = b":read_storage";
 	runtime_io::set_storage(KEY, b"test");
 
 	let mut v = [0u8; 4];
@@ -921,8 +921,8 @@ fn test_read_storage() {
 }
 
 fn test_read_child_storage() {
-	const CHILD_KEY: &[u8] = b":default:mock";
-	const KEY: &[u8] = b":test_storage";
+	const CHILD_KEY: &[u8] = b":child_storage:default:read_child_storage";
+	const KEY: &[u8] = b":read_child_storage";
 	runtime_io::set_child_storage(CHILD_KEY, KEY, b"test");
 
 	let mut v = [0u8; 4];
@@ -1038,7 +1038,9 @@ mod tests {
 
 	#[test]
 	fn test_storage() {
-		let client = TestClientBuilder::new().build();
+		let client = TestClientBuilder::new()
+			.set_execution_strategy(ExecutionStrategy::Both)
+			.build();
 		let runtime_api = client.runtime_api();
 		let block_id = BlockId::Number(client.info().chain.best_number);
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 155,
-	impl_version: 155,
+	impl_version: 156,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
There is a problem with `read_storage`, if an offset passed that is out of bounds of the length of the value the implementation of an extrinsic will panic. This PR solves it.

There is another problem with the API itself: there is no way to indicate how many bytes were read. So even if we fix the panic, the API wouldn't be universally usable since the API cannot indicate how many bytes it wrote to the buffer.

The API is not used within Substrate, except for implementing `exists` (e.g. [this](https://github.com/paritytech/substrate/blob/b21d76db6edd4540ee9bd5ed2cbaef2b395a21f8/srml/support/src/storage/child.rs#L85)).
