### PR TITLE
Enable nice wasm panic messages by default

### DIFF
--- a/core/sr-io/Cargo.toml
+++ b/core/sr-io/Cargo.toml
@@ -37,6 +37,5 @@ std = [
 ]
 nightly = []
 strict = []
-wasm-nice-panic-message = []
 no_panic_handler = []
 no_oom = []

--- a/core/sr-io/without_std.rs
+++ b/core/sr-io/without_std.rs
@@ -28,19 +28,8 @@ use codec::Decode;
 #[no_mangle]
 pub fn panic(info: &PanicInfo) -> ! {
 	unsafe {
-		#[cfg(feature = "wasm-nice-panic-message")]
-		{
-			let message = rstd::alloc::format!("{}", info);
-			extern_functions_host_impl::ext_print_utf8(message.as_ptr() as *const u8, message.len() as u32);
-		}
-		#[cfg(not(feature = "wasm-nice-panic-message"))]
-		{
-			if let Some(loc) = info.location() {
-				extern_functions_host_impl::ext_print_utf8(loc.file().as_ptr() as *const u8, loc.file().len() as u32);
-				extern_functions_host_impl::ext_print_num(loc.line() as u64);
-				extern_functions_host_impl::ext_print_num(loc.column() as u64);
-			}
-		}
+		let message = rstd::alloc::format!("{}", info);
+		extern_functions_host_impl::ext_print_utf8(message.as_ptr() as *const u8, message.len() as u32);
 		intrinsics::abort()
 	}
 }

--- a/srml/aura/Cargo.toml
+++ b/srml/aura/Cargo.toml
@@ -13,7 +13,7 @@ rstd = { package = "sr-std", path = "../../core/sr-std", default-features = fals
 serde = { version = "1.0", optional = true }
 session = { package = "srml-session", path = "../session", default-features = false }
 sr-primitives = { path = "../../core/sr-primitives", default-features = false }
-runtime-io ={ package = "sr-io", path = "../../core/sr-io", default-features = false, features = [ "wasm-nice-panic-message" ] }
+runtime-io ={ package = "sr-io", path = "../../core/sr-io", default-features = false }
 support = { package = "srml-support", path = "../support", default-features = false }
 substrate-consensus-aura-primitives = { path = "../../core/consensus/aura/primitives", default-features = false}
 system = { package = "srml-system", path = "../system", default-features = false }

--- a/srml/babe/Cargo.toml
+++ b/srml/babe/Cargo.toml
@@ -17,7 +17,7 @@ system = { package = "srml-system", path = "../system", default-features = false
 timestamp = { package = "srml-timestamp", path = "../timestamp", default-features = false }
 session = { package = "srml-session", path = "../session", default-features = false }
 babe-primitives = { package = "substrate-consensus-babe-primitives", path = "../../core/consensus/babe/primitives", default-features = false }
-runtime-io ={ package = "sr-io", path = "../../core/sr-io", default-features = false, features = [ "wasm-nice-panic-message" ] }
+runtime-io ={ package = "sr-io", path = "../../core/sr-io", default-features = false }
 
 [dev-dependencies]
 lazy_static = "1.3.0"


### PR DESCRIPTION
By accident it was already enabled in master for quite some time. To
make sure that we don't blow up the wasm binary size, I compiled the
binary with the feature enabled and disabled. With nice panic messages
enabled, the binary size increases by 908 bytes. Given the value that
this feature brings, I think it is okay to have these panic messages
enabled by default.