### PR TITLE
Fix BABE epochs-transition logic on the core side

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1908,12 +1908,11 @@ pub mod utils {
 	/// represent the current block `hash` and its `parent hash`, if given the
 	/// function that's returned will assume that `hash` isn't part of the local DB
 	/// yet, and all searches in the DB will instead reference the parent.
-	pub fn is_descendent_of<'a, B, E, Block: BlockT<Hash=H256>, RA>(
-		client: &'a Client<B, E, Block, RA>,
+	pub fn is_descendent_of<'a, Block: BlockT<Hash=H256>, T>(
+		client: &'a T,
 		current: Option<(&'a H256, &'a H256)>,
 	) -> impl Fn(&H256, &H256) -> Result<bool, error::Error> + 'a
-		where B: Backend<Block, Blake2Hasher>,
-			  E: CallExecutor<Block, Blake2Hasher> + Send + Sync,
+		where T: ChainHeaderBackend<Block>,
 	{
 		move |base, hash| {
 			if base == hash { return Ok(false); }
@@ -1931,7 +1930,7 @@ pub mod utils {
 			}
 
 			let tree_route = blockchain::tree_route(
-				|id| client.header(&id)?.ok_or_else(|| Error::UnknownBlock(format!("{:?}", id))),
+				|id| client.header(id)?.ok_or_else(|| Error::UnknownBlock(format!("{:?}", id))),
 				BlockId::Hash(*hash),
 				BlockId::Hash(*base),
 			)?;

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1482,6 +1482,9 @@ impl<B, E, Block, RA> CallRuntimeAt<Block> for Client<B, E, Block, RA> where
 	}
 }
 
+/// NOTE: only use this implementation when you are sure there are NO consensus-level BlockImport
+/// objects. Otherwise, importing blocks directly into the client would be bypassing
+/// important verification work.
 impl<'a, B, E, Block, RA> consensus::BlockImport<Block> for &'a Client<B, E, Block, RA> where
 	B: backend::Backend<Block, Blake2Hasher>,
 	E: CallExecutor<Block, Blake2Hasher> + Clone + Send + Sync,
@@ -1491,6 +1494,13 @@ impl<'a, B, E, Block, RA> consensus::BlockImport<Block> for &'a Client<B, E, Blo
 
 	/// Import a checked and validated block. If a justification is provided in
 	/// `BlockImportParams` then `finalized` *must* be true.
+	///
+	/// NOTE: only use this implementation when there are NO consensus-level BlockImport
+	/// objects. Otherwise, importing blocks directly into the client would be bypassing
+	/// important verification work.
+	///
+	/// If you are not sure that there are no BlockImport objects provided by the consensus
+	/// algorithm, don't use this function.
 	fn import_block(
 		&mut self,
 		import_block: BlockImportParams<Block>,

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1899,8 +1899,9 @@ where
 /// Utility methods for the client.
 pub mod utils {
 	use super::*;
-	use crate::{backend::Backend, blockchain, error};
+	use crate::{blockchain, error};
 	use primitives::H256;
+	use std::borrow::Borrow;
 
 	/// Returns a function for checking block ancestry, the returned function will
 	/// return `true` if the given hash (second parameter) is a descendent of the
@@ -1908,14 +1909,16 @@ pub mod utils {
 	/// represent the current block `hash` and its `parent hash`, if given the
 	/// function that's returned will assume that `hash` isn't part of the local DB
 	/// yet, and all searches in the DB will instead reference the parent.
-	pub fn is_descendent_of<'a, Block: BlockT<Hash=H256>, T>(
+	pub fn is_descendent_of<'a, Block: BlockT<Hash=H256>, T, H: Borrow<H256> + 'a>(
 		client: &'a T,
-		current: Option<(&'a H256, &'a H256)>,
+		current: Option<(H, H)>,
 	) -> impl Fn(&H256, &H256) -> Result<bool, error::Error> + 'a
 		where T: ChainHeaderBackend<Block>,
 	{
 		move |base, hash| {
 			if base == hash { return Ok(false); }
+
+			let current = current.as_ref().map(|(c, p)| (c.borrow(), p.borrow()));
 
 			let mut hash = hash;
 			if let Some((current_hash, current_parent_hash)) = current {

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -740,7 +740,7 @@ mod tests {
 			}
 		}
 
-		fn make_verifier(&self, client: PeersClient, _cfg: &ProtocolConfig)
+		fn make_verifier(&self, client: PeersClient, _cfg: &ProtocolConfig, _peer_data: &())
 			-> Self::Verifier
 		{
 			match client {

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -217,7 +217,7 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 		self.block_import.clone()
 	}
 
-	fn epoch_data(&self, header: &B::Header) -> Result<Self::EpochData, consensus_common::Error> {
+	fn epoch_data(&self, header: &B::Header, _slot_number: u64) -> Result<Self::EpochData, consensus_common::Error> {
 		authorities(self.client.as_ref(), &BlockId::Hash(header.hash()))
 	}
 

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -217,8 +217,8 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 		self.block_import.clone()
 	}
 
-	fn epoch_data(&self, block: &B::Hash) -> Result<Self::EpochData, consensus_common::Error> {
-		authorities(self.client.as_ref(), &BlockId::Hash(*block))
+	fn epoch_data(&self, header: &B::Header) -> Result<Self::EpochData, consensus_common::Error> {
+		authorities(self.client.as_ref(), &BlockId::Hash(header.hash()))
 	}
 
 	fn authorities_len(&self, epoch_data: &Self::EpochData) -> usize {

--- a/core/consensus/babe/primitives/src/digest.rs
+++ b/core/consensus/babe/primitives/src/digest.rs
@@ -102,10 +102,15 @@ pub enum RawBabePreDigest {
 	/// A secondary deterministic slot assignment.
 	#[codec(index = "2")]
 	Secondary {
-		/// Authority index
-		authority_index: AuthorityIndex,
 		/// Slot number
 		slot_number: SlotNumber,
+		/// Authority index
+		///
+		/// This is not strictly-speaking necessary, since the secondary slots
+		/// are assigned based on slot number and epoch randomness. But including
+		/// it makes things easier for higher-level users of the chain data to
+		/// be aware of the author of a secondary-slot block.
+		authority_index: AuthorityIndex,
 	},
 }
 

--- a/core/consensus/babe/primitives/src/digest.rs
+++ b/core/consensus/babe/primitives/src/digest.rs
@@ -111,8 +111,6 @@ pub enum RawBabePreDigest {
 	/// A secondary deterministic slot assignment.
 	#[codec(index = "2")]
 	Secondary {
-		/// Slot number
-		slot_number: SlotNumber,
 		/// Authority index
 		///
 		/// This is not strictly-speaking necessary, since the secondary slots
@@ -120,6 +118,8 @@ pub enum RawBabePreDigest {
 		/// it makes things easier for higher-level users of the chain data to
 		/// be aware of the author of a secondary-slot block.
 		authority_index: AuthorityIndex,
+		/// Slot number
+		slot_number: SlotNumber,
 	},
 }
 

--- a/core/consensus/babe/primitives/src/digest.rs
+++ b/core/consensus/babe/primitives/src/digest.rs
@@ -79,6 +79,15 @@ impl BabePreDigest {
 			BabePreDigest::Secondary { slot_number, .. } => *slot_number,
 		}
 	}
+
+	/// Returns the weight _added_ by this digest, not the cumulative weight
+	/// of the chain.
+	pub fn added_weight(&self) -> crate::BabeBlockWeight {
+		match self {
+			BabePreDigest::Primary { .. } => 1,
+			BabePreDigest::Secondary { .. } => 0,
+		}
+	}
 }
 
 /// The prefix used by BABE for its VRF keys.

--- a/core/consensus/babe/primitives/src/lib.rs
+++ b/core/consensus/babe/primitives/src/lib.rs
@@ -85,13 +85,26 @@ pub struct Epoch {
 	/// The epoch index
 	pub epoch_index: u64,
 	/// The starting slot of the epoch,
-	pub start_slot: u64,
+	pub start_slot: SlotNumber,
 	/// The duration of this epoch
 	pub duration: SlotNumber,
 	/// The authorities and their weights
 	pub authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
 	/// Randomness for this epoch
 	pub randomness: [u8; VRF_OUTPUT_LENGTH],
+}
+
+impl Epoch {
+	/// "increment" the epoch, with given descriptor for the next.
+	pub fn increment(&self, descriptor: NextEpochDescriptor) -> Epoch {
+		Epoch {
+			epoch_index: self.epoch_index + 1,
+			start_slot: self.start_slot + self.duration,
+			duration: self.duration,
+			authorities: descriptor.authorities,
+			randomness: descriptor.randomness,
+		}
+	}
 }
 
 /// An consensus log item for BABE.
@@ -131,7 +144,7 @@ pub struct BabeConfiguration {
 	/// The authorities for the genesis epoch.
 	pub genesis_authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
 
-	/// The randomness for this epoch.
+	/// The randomness for the genesis epoch.
 	pub randomness: [u8; VRF_OUTPUT_LENGTH],
 
 	/// Whether this chain should run with secondary slots, which are assigned

--- a/core/consensus/babe/primitives/src/lib.rs
+++ b/core/consensus/babe/primitives/src/lib.rs
@@ -145,7 +145,7 @@ impl slots::SlotData for BabeConfiguration {
 		self.slot_duration
 	}
 
-	const SLOT_KEY: &'static [u8] = b"babe_bootstrap_data";
+	const SLOT_KEY: &'static [u8] = b"babe_configuration";
 }
 
 decl_runtime_apis! {

--- a/core/consensus/babe/src/aux_schema.rs
+++ b/core/consensus/babe/src/aux_schema.rs
@@ -22,12 +22,11 @@ use codec::{Decode, Encode};
 use client::backend::AuxStore;
 use client::error::{Result as ClientResult, Error as ClientError};
 use sr_primitives::traits::Block as BlockT;
-use babe_primitives::{BabeBlockWeight, BabeConfiguration};
+use babe_primitives::BabeBlockWeight;
 
 use super::{EpochChanges, SharedEpochChanges};
 
 const BABE_EPOCH_CHANGES: &[u8] = b"babe_epoch_changes";
-const BABE_CONFIG: &[u8] = b"babe_configuration";
 
 fn block_weight_key<H: Encode>(block_hash: H) -> Vec<u8> {
 	(b"block_weight", block_hash).encode()

--- a/core/consensus/babe/src/aux_schema.rs
+++ b/core/consensus/babe/src/aux_schema.rs
@@ -95,8 +95,8 @@ pub(crate) fn write_block_weight<H: Encode, F, R>(
 
 /// Load the weight associated with a block.
 pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
-	block_hash: H,
 	backend: &B,
+	block_hash: H,
 ) -> ClientResult<Option<BabeBlockWeight>> {
 	load_decode(backend, block_weight_key(block_hash).as_slice())
 }

--- a/core/consensus/babe/src/aux_schema.rs
+++ b/core/consensus/babe/src/aux_schema.rs
@@ -76,7 +76,7 @@ pub(crate) fn write_epoch_changes<Block: BlockT, F, R>(
 	)
 }
 
-/// Write the weight of a block ot aux storage.
+/// Write the cumulative chain-weight of a block ot aux storage.
 pub(crate) fn write_block_weight<H: Encode, F, R>(
 	block_hash: H,
 	block_weight: &BabeBlockWeight,
@@ -93,7 +93,7 @@ pub(crate) fn write_block_weight<H: Encode, F, R>(
 	)
 }
 
-/// Load the weight associated with a block.
+/// Load the cumulative chain-weight associated with a block.
 pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
 	backend: &B,
 	block_hash: H,

--- a/core/consensus/babe/src/aux_schema.rs
+++ b/core/consensus/babe/src/aux_schema.rs
@@ -100,25 +100,3 @@ pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
 ) -> ClientResult<Option<BabeBlockWeight>> {
 	load_decode(backend, block_weight_key(block_hash).as_slice())
 }
-
-/// Write the weight of a block ot aux storage.
-pub(crate) fn write_config<H: Encode, F, R>(
-	config: BabeConfiguration,
-	write_aux: F,
-) -> R where
-	F: FnOnce(&[(Vec<u8>, &[u8])]) -> R,
-{
-
-	config.using_encoded(|s|
-		write_aux(
-			&[(BABE_CONFIG.to_vec(), s)],
-		)
-	)
-}
-
-/// Load the BABE configuration from disk.
-pub(crate) fn load_config<H: Encode, B: AuxStore>(
-	backend: &B,
-) -> ClientResult<Option<BabeConfiguration>> {
-	load_decode(backend, BABE_CONFIG)
-}

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -96,10 +96,10 @@ impl<Block: BlockT> EpochChanges<Block> {
 		let is_descendent_of = descendent_of_builder
 			.build_is_descendent_of(None);
 
-		// prune everything except for the first node _above_ the just-finalized block
-		// because it may represent the epoch that descendents of the finalized block
-		// are in.
-		unimplemented!()
+		// prune any epochs which could not be _live_ as of the children of the
+		// finalized block.
+		// i.e. re-root the fork tree to the earliest ancestor of (hash, number)
+		// where epoch.start_slot + epoch.duration >= slot(hash)
 	}
 
 	/// Finds the epoch for a child of the given block, assuming the given slot number.

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -90,16 +90,19 @@ impl<Block: BlockT> EpochChanges<Block> {
 	pub fn prune_finalized<D: IsDescendentOfBuilder<Block>>(
 		&mut self,
 		descendent_of_builder: D,
-		hash: &Block::Hash,
-		number: NumberFor<Block>,
+		_hash: &Block::Hash,
+		_number: NumberFor<Block>,
 	) -> Result<(), fork_tree::Error<D::Error>> {
-		let is_descendent_of = descendent_of_builder
+		let _is_descendent_of = descendent_of_builder
 			.build_is_descendent_of(None);
 
+		// TODO:
 		// prune any epochs which could not be _live_ as of the children of the
 		// finalized block.
 		// i.e. re-root the fork tree to the earliest ancestor of (hash, number)
 		// where epoch.start_slot + epoch.duration >= slot(hash)
+
+		Ok(())
 	}
 
 	/// Finds the epoch for a child of the given block, assuming the given slot number.

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -80,6 +80,16 @@ impl<Block: BlockT> EpochChanges<Block> {
 			.and_then(|n| n)
 			.map(|n| n.data.clone())
 	}
+
+	/// Import a new epoch-change, signalled at the given block.
+	pub fn import(
+		&mut self,
+		hash: Block::Hash,
+		number: NumberFor<Block>,
+		epoch: Epoch,
+	) {
+		unimplemented!()
+	}
 }
 
 /// A shared epoch changes tree.

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -31,12 +31,12 @@ use client::blockchain::HeaderBackend;
 use primitives::H256;
 
 /// A builder for `is_descendent_of` functions.
-pub trait IsDescendentOfBuilder<'a, Block: BlockT> {
+pub trait IsDescendentOfBuilder<Block: BlockT> {
 	/// The error returned by the function.
-	type Error;
+	type Error: std::error::Error;
 	/// A function that can tell you if the second parameter is a descendent of
 	/// the first.
-	type IsDescendentOf: Fn(&Block::Hash, &Block::Hash) -> Result<bool, Self::Error> + 'a;
+	type IsDescendentOf: Fn(&Block::Hash, &Block::Hash) -> Result<bool, Self::Error>;
 
 	/// Build an `is_descendent_of` function.
 	///
@@ -44,19 +44,19 @@ pub trait IsDescendentOfBuilder<'a, Block: BlockT> {
 	/// details aren't yet stored, but its parent is.
 	///
 	/// The format of `current` when `Some` is `(current, current_parent)`.
-	fn build_is_descendent_of(&self, current: Option<(&'a Block::Hash, &'a Block::Hash)>)
+	fn build_is_descendent_of(&self, current: Option<(Block::Hash, Block::Hash)>)
 		-> Self::IsDescendentOf;
 }
 
 // TODO: relying on Hash = H256 is awful.
 // https://github.com/paritytech/substrate/issues/3624
-impl<'a, Block: BlockT<Hash=H256>, T> IsDescendentOfBuilder<'a, Block> for &'a T
+impl<'a, Block: BlockT<Hash=H256>, T> IsDescendentOfBuilder<Block> for &'a T
 	where T: HeaderBackend<Block>
 {
 	type Error = ClientError;
 	type IsDescendentOf = Box<dyn Fn(&H256, &H256) -> Result<bool, ClientError> + 'a>;
 
-	fn build_is_descendent_of(&self, current: Option<(&'a H256, &'a H256)>)
+	fn build_is_descendent_of(&self, current: Option<(H256, H256)>)
 		-> Self::IsDescendentOf
 	{
 		Box::new(client_utils::is_descendent_of(*self, current))
@@ -71,6 +71,15 @@ pub struct EpochChanges<Block: BlockT> {
 	inner: ForkTree<Block::Hash, NumberFor<Block>, Epoch>,
 }
 
+// create a fake header hash which hasn't been included in the chain.
+fn fake_head_hash<H: AsRef<[u8]> + AsMut<[u8]> + Clone>(parent_hash: &H) -> H {
+	let mut h = parent_hash.clone();
+	// dirty trick: flip the first bit of the parent hash to create a hash
+	// which has not been in the chain before (assuming a strong hash function).
+	h.as_mut()[0] ^= 0b10000000;
+	h
+}
+
 impl<Block: BlockT> EpochChanges<Block> {
 	/// Create a new epoch-change tracker.
 	fn new() -> Self {
@@ -78,60 +87,66 @@ impl<Block: BlockT> EpochChanges<Block> {
 	}
 
 	/// Prune out finalized epochs, except for the ancestor of the finalized block.
-	pub fn prune_finalized<'a>(
+	pub fn prune_finalized<D: IsDescendentOfBuilder<Block>>(
 		&mut self,
-		descendent_of_builder: impl IsDescendentOfBuilder<'a, Block>,
+		descendent_of_builder: D,
 		hash: &Block::Hash,
 		number: NumberFor<Block>,
-	) {
-		// TODO: needs "is-descendent-of"
+	) -> Result<(), fork_tree::Error<D::Error>> {
+		let is_descendent_of = descendent_of_builder
+			.build_is_descendent_of(None);
+
+		// prune everything except for the first node _above_ the just-finalized block
+		// because it may represent the epoch that descendents of the finalized block
+		// are in.
 		unimplemented!()
 	}
 
 	/// Finds the epoch for a child of the given block, assuming the given slot number.
-	pub fn epoch_for_child_of<'a>(
+	pub fn epoch_for_child_of<D: IsDescendentOfBuilder<Block>>(
 		&mut self,
-		descendent_of_builder: impl IsDescendentOfBuilder<'a, Block>,
+		descendent_of_builder: D,
 		parent_hash: &Block::Hash,
 		parent_number: NumberFor<Block>,
 		slot_number: SlotNumber,
-	) -> Option<Epoch> {
+	) -> Result<Option<Epoch>, fork_tree::Error<D::Error>> {
 		use sr_primitives::traits::One;
 
 		// find_node_where will give you the node in the fork-tree which is an ancestor
 		// of the `parent_hash` by default. if the last epoch was signalled at the parent_hash,
 		// then it won't be returned. we need to create a new fake chain head hash which
 		// "descends" from our parent-hash.
-		let fake_head_hash = {
-			let mut h = parent_hash.clone();
-			// dirty trick: flip the first bit of the parent hash to create a hash
-			// which has not been in the chain before (assuming a strong hash function).
-			h.as_mut()[0] ^= 0b10000000;
-			h
-		};
+		let fake_head_hash = fake_head_hash(parent_hash);
 
-		// TODO: let is_descendent_of = is_descendent_of(client, Some((&fake_head_hash, &parent_hash)));
-		let is_descendent_of = |a: &_, b: &_| { Ok(unimplemented!()) };
-		self.inner.find_node_where::<_, ClientError, _>(
+		let is_descendent_of = descendent_of_builder
+			.build_is_descendent_of(Some((fake_head_hash, *parent_hash)));
+
+		self.inner.find_node_where(
 			&fake_head_hash,
 			&(parent_number + One::one()),
 			&is_descendent_of,
 			&|epoch| epoch.start_slot <= slot_number,
 		)
-			.ok()
-			.and_then(|n| n)
-			.map(|n| n.data.clone())
+			.map(|n| n.map(|n| n.data.clone()))
 	}
 
 	/// Import a new epoch-change, signalled at the given block.
-	pub fn import<'a>(
+	pub fn import<D: IsDescendentOfBuilder<Block>>(
 		&mut self,
-		descendent_of_builder: impl IsDescendentOfBuilder<'a, Block>,
+		descendent_of_builder: D,
 		hash: Block::Hash,
 		number: NumberFor<Block>,
 		epoch: Epoch,
-	) {
-		unimplemented!()
+	) -> Result<(), fork_tree::Error<D::Error>> {
+		let is_descendent_of = descendent_of_builder
+			.build_is_descendent_of(None);
+
+		self.inner.import(
+			hash,
+			number,
+			epoch,
+			&is_descendent_of,
+		).map(|_| ())
 	}
 }
 

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -1,0 +1,109 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Handling epoch changes in BABE.
+//!
+//! This exposes the `SharedEpochChanges`, which is a wrapper around a
+//! persistent DAG superimposed over the forks of the blockchain.
+
+use std::sync::Arc;
+use babe_primitives::{Epoch, SlotNumber};
+use fork_tree::ForkTree;
+use parking_lot::{Mutex, MutexGuard};
+use sr_primitives::traits::{Block as BlockT, NumberFor};
+use codec::{Encode, Decode};
+use client::error::Error as ClientError;
+
+/// Tree of all epoch changes across all *seen* forks. Data stored in tree is
+/// the hash and block number of the block signaling the epoch change, and the
+/// epoch that was signalled at that block.
+#[derive(Clone, Encode, Decode)]
+pub struct EpochChanges<Block: BlockT> {
+	inner: ForkTree<Block::Hash, NumberFor<Block>, Epoch>,
+}
+
+impl<Block: BlockT> EpochChanges<Block> {
+	/// Create a new epoch-change tracker.
+	fn new() -> Self {
+		EpochChanges { inner: ForkTree::new() }
+	}
+
+	/// Prune out finalized epochs, except for the ancestor of the finalized block.
+	pub fn prune_finalized(&mut self, hash: &Block::Hash, number: NumberFor<Block>) {
+		// TODO: needs "is-descendent-of"
+		unimplemented!()
+	}
+
+	/// Finds the epoch for a child of the given block, assuming the given slot number.
+	pub fn epoch_for_child_of(
+		&mut self,
+		parent_hash: &Block::Hash,
+		parent_number: NumberFor<Block>,
+		slot_number: SlotNumber,
+	) -> Option<Epoch> {
+		use sr_primitives::traits::One;
+
+		// find_node_where will give you the node in the fork-tree which is an ancestor
+		// of the `parent_hash` by default. if the last epoch was signalled at the parent_hash,
+		// then it won't be returned. we need to create a new fake chain head hash which
+		// "descends" from our parent-hash.
+		let fake_head_hash = {
+			let mut h = parent_hash.clone();
+			// dirty trick: flip the first bit of the parent hash to create a hash
+			// which has not been in the chain before (assuming a strong hash function).
+			h.as_mut()[0] ^= 0b10000000;
+			h
+		};
+
+		// TODO: let is_descendent_of = is_descendent_of(client, Some((&fake_head_hash, &parent_hash)));
+		let is_descendent_of = |a: &_, b: &_| { Ok(unimplemented!()) };
+		self.inner.find_node_where::<_, ClientError, _>(
+			&fake_head_hash,
+			&(parent_number + One::one()),
+			&is_descendent_of,
+			&|epoch| epoch.start_slot <= slot_number,
+		)
+			.ok()
+			.and_then(|n| n)
+			.map(|n| n.data.clone())
+	}
+}
+
+/// A shared epoch changes tree.
+#[derive(Clone)]
+pub struct SharedEpochChanges<Block: BlockT> {
+	inner: Arc<Mutex<EpochChanges<Block>>>,
+}
+
+impl<Block: BlockT> SharedEpochChanges<Block> {
+	pub fn new() -> Self {
+		SharedEpochChanges {
+			inner: Arc::new(Mutex::new(EpochChanges::<Block>::new()))
+		}
+	}
+
+	pub fn lock(&self) -> MutexGuard<EpochChanges<Block>> {
+		self.inner.lock()
+	}
+}
+
+impl<Block: BlockT> From<EpochChanges<Block>> for SharedEpochChanges<Block> {
+	fn from(epoch_changes: EpochChanges<Block>) -> Self {
+		SharedEpochChanges {
+			inner: Arc::new(Mutex::new(epoch_changes))
+		}
+	}
+}

--- a/core/consensus/babe/src/epoch_changes.rs
+++ b/core/consensus/babe/src/epoch_changes.rs
@@ -89,12 +89,14 @@ pub struct SharedEpochChanges<Block: BlockT> {
 }
 
 impl<Block: BlockT> SharedEpochChanges<Block> {
+	/// Create a new instance of the `SharedEpochChanges`.
 	pub fn new() -> Self {
 		SharedEpochChanges {
 			inner: Arc::new(Mutex::new(EpochChanges::<Block>::new()))
 		}
 	}
 
+	/// Lock the shared epoch changes,
 	pub fn lock(&self) -> MutexGuard<EpochChanges<Block>> {
 		self.inner.lock()
 	}

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -302,7 +302,7 @@ impl<B, C, E, I, Error, SO> slots::SimpleSlotWorker<B> for BabeWorker<B, C, E, I
 		claim_slot(
 			slot_number,
 			epoch_data,
-			&self.config,
+			&*self.config,
 			&self.keystore,
 		)
 	}
@@ -956,7 +956,7 @@ fn calculate_primary_threshold(
 fn claim_slot(
 	slot_number: SlotNumber,
 	epoch: &Epoch,
-	config: &Config,
+	config: &BabeConfiguration,
 	keystore: &KeyStorePtr,
 ) -> Option<(BabePreDigest, AuthorityPair)> {
 	claim_primary_slot(slot_number, epoch, config.c, keystore)

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -107,7 +107,6 @@ use client::{
 };
 use slots::{CheckedHeader, check_equivocation};
 use futures::prelude::*;
-use futures01::Stream as _;
 use log::{warn, debug, info, trace};
 
 use slots::{SlotWorker, SlotData, SlotInfo, SlotCompatible};
@@ -238,7 +237,7 @@ pub fn start_babe<B, C, SC, E, I, SO, Error>(BabeParams {
 	E: Environment<B, Error=Error> + Send + Sync,
 	E::Proposer: Proposer<B, Error=Error>,
 	<E::Proposer as Proposer<B>>::Create: Unpin + Send + 'static,
-	I: BlockImport<B> + Send + Sync + 'static,
+	I: BlockImport<B,Error=ConsensusError> + Send + Sync + 'static,
 	Error: std::error::Error + Send + From<::consensus_common::Error> + From<I::Error> + 'static,
 	SO: SyncOracle + Send + Sync + Clone,
 {

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -1293,6 +1293,7 @@ impl<B, E, Block, I, RA, PRA> BlockImport<Block> for BabeBlockImport<B, E, Block
 				&*self.client,
 				hash,
 				number,
+				*block.header.parent_hash(),
 				next_epoch,
 			);
 

--- a/core/consensus/babe/src/tests.rs
+++ b/core/consensus/babe/src/tests.rs
@@ -375,7 +375,7 @@ fn can_author_block() {
 		.expect("Generates authority pair");
 
 	let mut i = 0;
-	let mut epoch = Epoch {
+	let epoch = Epoch {
 		start_slot: 0,
 		authorities: vec![(pair.public(), 1)],
 		randomness: [0; 32],
@@ -391,8 +391,6 @@ fn can_author_block() {
 		randomness: [0; 32],
 		secondary_slots: true,
 	};
-
-	let parent_weight = 0;
 
 	// with secondary slots enabled it should never be empty
 	match claim_slot(i, &epoch, &config, &keystore) {

--- a/core/consensus/babe/src/tests.rs
+++ b/core/consensus/babe/src/tests.rs
@@ -24,8 +24,12 @@ use super::*;
 use babe_primitives::AuthorityPair;
 use client::block_builder::BlockBuilder;
 use consensus_common::NoNetwork as DummyOracle;
+use consensus_common::import_queue::{
+	BoxBlockImport, BoxJustificationImport, BoxFinalityProofImport,
+};
 use network::test::*;
 use network::test::{Block as TestBlock, PeersClient};
+use network::config::BoxFinalityProofRequestBuilder;
 use sr_primitives::{generic::DigestItem, traits::{Block as BlockT, DigestFor}};
 use network::config::ProtocolConfig;
 use tokio::runtime::current_thread;
@@ -81,7 +85,7 @@ thread_local! {
 }
 
 pub struct BabeTestNet {
-	peers: Vec<Peer<(), DummySpecialization>>,
+	peers: Vec<Peer<Option<PeerData>, DummySpecialization>>,
 }
 
 type TestHeader = <TestBlock as BlockT>::Header;
@@ -94,7 +98,6 @@ pub struct TestVerifier {
 		TestBlock,
 		test_client::runtime::RuntimeApi,
 		PeersFullClient,
-		(),
 	>,
 	mutator: Mutator,
 }
@@ -116,10 +119,15 @@ impl Verifier<TestBlock> for TestVerifier {
 	}
 }
 
+pub struct PeerData {
+	link: BabeLink<TestBlock>,
+	inherent_data_providers: InherentDataProviders,
+}
+
 impl TestNetFactory for BabeTestNet {
 	type Specialization = DummySpecialization;
 	type Verifier = TestVerifier;
-	type PeerData = ();
+	type PeerData = Option<PeerData>;
 
 	/// Create new test network with peers and given config.
 	fn from_config(_config: &ProtocolConfig) -> Self {
@@ -129,29 +137,74 @@ impl TestNetFactory for BabeTestNet {
 		}
 	}
 
+	fn make_block_import(&self, client: PeersClient)
+		-> (
+			BoxBlockImport<Block>,
+			Option<BoxJustificationImport<Block>>,
+			Option<BoxFinalityProofImport<Block>>,
+			Option<BoxFinalityProofRequestBuilder<Block>>,
+			Option<PeerData>,
+		)
+	{
+		use futures01::Future;
+
+		let client = client.as_full().expect("only full clients are tested");
+		let inherent_data_providers = InherentDataProviders::new();
+
+		let config = Config::get_or_compute(&*client).expect("config available");
+
+		register_babe_inherent_data_provider(
+			&inherent_data_providers,
+			config.slot_duration,
+		).expect("Registers babe inherent data provider");
+
+		let (_queue, link, import, background) = crate::import_queue(
+			config,
+			client.clone(),
+			None,
+			None,
+			client.clone(),
+			client.clone(),
+			inherent_data_providers.clone(),
+		).expect("can initialize import queue");
+
+		std::thread::spawn(move || background.wait().unwrap());
+
+		(
+			Box::new(import),
+			None,
+			None,
+			None,
+			Some(PeerData { link, inherent_data_providers }),
+		)
+	}
+
 	/// KLUDGE: this function gets the mutator from thread-local storage.
-	fn make_verifier(&self, client: PeersClient, _cfg: &ProtocolConfig)
+	fn make_verifier(
+		&self,
+		client: PeersClient,
+		_cfg: &ProtocolConfig,
+		maybe_link: &Option<PeerData>,
+	)
 		-> Self::Verifier
 	{
 		let client = client.as_full().expect("only full clients are used in test");
 		trace!(target: "babe", "Creating a verifier");
 		let config = Config::get_or_compute(&*client)
 			.expect("slot duration available");
-		let inherent_data_providers = InherentDataProviders::new();
-		register_babe_inherent_data_provider(
-			&inherent_data_providers,
-			config.get()
-		).expect("Registers babe inherent data provider");
+
 		trace!(target: "babe", "Provider registered");
+
+		// ensure block import and verifier are linked correctly.
+		let data = maybe_link.as_ref().expect("babe link always provided to verifier instantiation");
 
 		TestVerifier {
 			inner: BabeVerifier {
 				client: client.clone(),
 				api: client,
-				inherent_data_providers,
+				inherent_data_providers: data.inherent_data_providers.clone(),
 				config,
-				time_source: Default::default(),
-				transaction_pool : Default::default(),
+				babe_link: data.link.clone(),
 			},
 			mutator: MUTATOR.with(|s| s.borrow().clone()),
 		}
@@ -221,11 +274,7 @@ fn run_one_test() {
 		);
 
 		let config = Config::get_or_compute(&*client).expect("slot duration available");
-
-		let inherent_data_providers = InherentDataProviders::new();
-		register_babe_inherent_data_provider(
-			&inherent_data_providers, config.get()
-		).expect("Registers babe inherent data provider");
+		let data = peer.data.as_ref().expect("babe link set up during initialization");
 
 		runtime.spawn(start_babe(BabeParams {
 			config,
@@ -234,9 +283,9 @@ fn run_one_test() {
 			client,
 			env: environ,
 			sync_oracle: DummyOracle,
-			inherent_data_providers,
+			inherent_data_providers: data.inherent_data_providers.clone(),
 			force_authoring: false,
-			time_source: Default::default(),
+			babe_link: data.link.clone(),
 			keystore,
 		}).expect("Starts babe"));
 	}
@@ -286,7 +335,7 @@ fn rejects_missing_consensus_digests() {
 	MUTATOR.with(|s| *s.borrow_mut() = Arc::new(move |header: &mut TestHeader| {
 		let v = std::mem::replace(&mut header.digest_mut().logs, vec![]);
 		header.digest_mut().logs = v.into_iter()
-			.filter(|v| v.as_babe_epoch().is_none())
+			.filter(|v| v.as_next_epoch_descriptor().is_none())
 			.collect()
 	}));
 	run_one_test()
@@ -332,22 +381,30 @@ fn can_author_block() {
 		randomness: [0; 32],
 		epoch_index: 1,
 		duration: 100,
+	};
+
+	let mut config = crate::BabeConfiguration {
+		slot_duration: 1000,
+		epoch_length: 100,
+		c: (3, 10),
+		genesis_authorities: Vec::new(),
+		randomness: [0; 32],
 		secondary_slots: true,
 	};
 
 	let parent_weight = 0;
 
 	// with secondary slots enabled it should never be empty
-	match claim_slot(i, parent_weight, &epoch, (3, 10), &keystore) {
+	match claim_slot(i, &epoch, &config, &keystore) {
 		None => i += 1,
 		Some(s) => debug!(target: "babe", "Authored block {:?}", s.0),
 	}
 
 	// otherwise with only vrf-based primary slots we might need to try a couple
 	// of times.
-	epoch.secondary_slots = false;
+	config.secondary_slots = false;
 	loop {
-		match claim_slot(i, parent_weight, &epoch, (3, 10), &keystore) {
+		match claim_slot(i, &epoch, &config, &keystore) {
 			None => i += 1,
 			Some(s) => {
 				debug!(target: "babe", "Authored block {:?}", s.0);
@@ -357,15 +414,15 @@ fn can_author_block() {
 	}
 }
 
-#[test]
-fn authorities_call_works() {
-	let _ = env_logger::try_init();
-	let client = test_client::new();
+// #[test]
+// fn authorities_call_works() {
+// 	let _ = env_logger::try_init();
+// 	let client = test_client::new();
 
-	assert_eq!(client.info().chain.best_number, 0);
-	assert_eq!(epoch(&client, &BlockId::Number(0)).unwrap().into_regular().unwrap().authorities, vec![
-		(Keyring::Alice.public().into(), 1),
-		(Keyring::Bob.public().into(), 1),
-		(Keyring::Charlie.public().into(), 1),
-	]);
-}
+// 	assert_eq!(client.info().chain.best_number, 0);
+// 	assert_eq!(epoch(&client, &BlockId::Number(0)).unwrap().into_regular().unwrap().authorities, vec![
+// 		(Keyring::Alice.public().into(), 1),
+// 		(Keyring::Bob.public().into(), 1),
+// 		(Keyring::Charlie.public().into(), 1),
+// 	]);
+// }

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -121,7 +121,8 @@ pub struct BlockImportParams<Block: BlockT> {
 	/// Contains a list of key-value pairs. If values are `None`, the keys
 	/// will be deleted.
 	pub auxiliary: Vec<(Vec<u8>, Option<Vec<u8>>)>,
-	/// Fork choice strategy of this import.
+	/// Fork choice strategy of this import. This should only be set by a
+	/// synchronous import, otherwise it may race against other imports.
 	pub fork_choice: ForkChoiceStrategy,
 }
 

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -187,7 +187,31 @@ pub trait BlockImport<B: BlockT> {
 	) -> Result<ImportResult, Self::Error>;
 }
 
-impl<B: BlockT, T, E: ::std::error::Error + Send + 'static> BlockImport<B> for Arc<T>
+impl<B: BlockT> BlockImport<B> for crate::import_queue::BoxBlockImport<B> {
+	type Error = crate::error::Error;
+
+	/// Check block preconditions.
+	fn check_block(
+		&mut self,
+		hash: B::Hash,
+		parent_hash: B::Hash,
+	) -> Result<ImportResult, Self::Error> {
+		(**self).check_block(hash, parent_hash)
+	}
+
+	/// Import a block.
+	///
+	/// Cached data can be accessed through the blockchain cache.
+	fn import_block(
+		&mut self,
+		block: BlockImportParams<B>,
+		cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
+	) -> Result<ImportResult, Self::Error> {
+		(**self).import_block(block, cache)
+	}
+}
+
+impl<B: BlockT, T, E: std::error::Error + Send + 'static> BlockImport<B> for Arc<T>
 where for<'r> &'r T: BlockImport<B, Error = E>
 {
 	type Error = E;

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -102,6 +102,7 @@ pub trait ImportQueue<B: BlockT>: Send {
 		number: NumberFor<B>,
 		finality_proof: Vec<u8>
 	);
+
 	/// Polls for actions to perform on the network.
 	///
 	/// This method should behave in a way similar to `Future::poll`. It can register the current

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -78,7 +78,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	fn block_import(&self) -> Arc<Mutex<Self::BlockImport>>;
 
 	/// Returns the epoch data necessary for authoring.
-	fn epoch_data(&self, block: &B::Hash) -> Result<Self::EpochData, consensus_common::Error>;
+	fn epoch_data(&self, header: &B::Header) -> Result<Self::EpochData, consensus_common::Error>;
 
 	/// Returns the number of authorities given the epoch data.
 	fn authorities_len(&self, epoch_data: &Self::EpochData) -> usize;
@@ -120,7 +120,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		let (timestamp, slot_number, slot_duration) =
 			(slot_info.timestamp, slot_info.number, slot_info.duration);
 
-		let epoch_data = match self.epoch_data(&chain_head.hash()) {
+		let epoch_data = match self.epoch_data(&chain_head) {
 			Ok(epoch_data) => epoch_data,
 			Err(err) => {
 				warn!("Unable to fetch epoch data at block {:?}: {:?}", chain_head.hash(), err);

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -77,8 +77,9 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	/// A handle to a `BlockImport`.
 	fn block_import(&self) -> Arc<Mutex<Self::BlockImport>>;
 
-	/// Returns the epoch data necessary for authoring.
-	fn epoch_data(&self, header: &B::Header) -> Result<Self::EpochData, consensus_common::Error>;
+	/// Returns the epoch data necessary for authoring. For time-dependent epochs,
+	/// use the provided slot number as a canonical source of time.
+	fn epoch_data(&self, header: &B::Header, slot_number: u64) -> Result<Self::EpochData, consensus_common::Error>;
 
 	/// Returns the number of authorities given the epoch data.
 	fn authorities_len(&self, epoch_data: &Self::EpochData) -> usize;
@@ -120,7 +121,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		let (timestamp, slot_number, slot_duration) =
 			(slot_info.timestamp, slot_info.number, slot_info.duration);
 
-		let epoch_data = match self.epoch_data(&chain_head) {
+		let epoch_data = match self.epoch_data(&chain_head, slot_number) {
 			Ok(epoch_data) => epoch_data,
 			Err(err) => {
 				warn!("Unable to fetch epoch data at block {:?}: {:?}", chain_head.hash(), err);

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -360,7 +360,8 @@ impl SlotData for u64 {
 }
 
 /// A slot duration. Create with `get_or_compute`.
-// The internal member should stay private here.
+// The internal member should stay private here to maintain invariants of
+// `get_or_compute`.
 #[derive(Clone, Copy, Debug, Encode, Decode, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct SlotDuration<T>(T);
 

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -906,7 +906,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 		let status = authority_set.apply_standard_changes(
 			hash,
 			number,
-			&is_descendent_of(client, None),
+			&is_descendent_of::<_, _, Block::Hash>(client, None),
 		).map_err(|e| Error::Safety(e.to_string()))?;
 
 		// check if this is this is the first finalization of some consensus changes

--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -294,7 +294,7 @@ where
 		// returns a function for checking whether a block is a descendent of another
 		// consistent with querying client directly after importing the block.
 		let parent_hash = *block.header.parent_hash();
-		let is_descendent_of = is_descendent_of(&self.inner, Some((&hash, &parent_hash)));
+		let is_descendent_of = is_descendent_of(&*self.inner, Some((&hash, &parent_hash)));
 
 		let mut guard = InnerGuard {
 			guard: Some(self.authority_set.inner().write()),

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -98,7 +98,12 @@ impl TestNetFactory for GrandpaTestNet {
 		}
 	}
 
-	fn make_verifier(&self, _client: PeersClient, _cfg: &ProtocolConfig) -> Self::Verifier {
+	fn make_verifier(
+		&self,
+		_client: PeersClient,
+		_cfg: &ProtocolConfig,
+		_: &PeerData,
+	) -> Self::Verifier {
 		PassThroughVerifier(false) // use non-instant finality.
 	}
 

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -459,7 +459,12 @@ pub trait TestNetFactory: Sized {
 
 	/// These two need to be implemented!
 	fn from_config(config: &ProtocolConfig) -> Self;
-	fn make_verifier(&self, client: PeersClient, config: &ProtocolConfig) -> Self::Verifier;
+	fn make_verifier(
+		&self,
+		client: PeersClient,
+		config: &ProtocolConfig,
+		peer_data: &Self::PeerData,
+	) -> Self::Verifier;
 
 	/// Get reference to peer.
 	fn peer(&mut self, i: usize) -> &mut Peer<Self::PeerData, Self::Specialization>;
@@ -507,11 +512,22 @@ pub trait TestNetFactory: Sized {
 		let backend = test_client_builder.backend();
 		let (c, longest_chain) = test_client_builder.build_with_longest_chain();
 		let client = Arc::new(c);
-		let verifier = self.make_verifier(PeersClient::Full(client.clone(), backend.clone()), config);
-		let verifier = VerifierAdapter(Arc::new(Mutex::new(Box::new(verifier) as Box<_>)));
-		let (block_import, justification_import, finality_proof_import, finality_proof_request_builder, data)
-			= self.make_block_import(PeersClient::Full(client.clone(), backend.clone()));
+
+		let (
+			block_import,
+			justification_import,
+			finality_proof_import,
+			finality_proof_request_builder,
+			data,
+		) = self.make_block_import(PeersClient::Full(client.clone(), backend.clone()));
 		let block_import = BlockImportAdapter(Arc::new(Mutex::new(block_import)));
+
+		let verifier = self.make_verifier(
+			PeersClient::Full(client.clone(), backend.clone()),
+			config,
+			&data,
+		);
+		let verifier = VerifierAdapter(Arc::new(Mutex::new(Box::new(verifier) as Box<_>)));
 
 		let import_queue = Box::new(BasicQueue::new(
 			verifier.clone(),
@@ -570,11 +586,21 @@ pub trait TestNetFactory: Sized {
 
 		let (c, backend) = test_client::new_light();
 		let client = Arc::new(c);
-		let verifier = self.make_verifier(PeersClient::Light(client.clone(), backend.clone()), &config);
-		let verifier = VerifierAdapter(Arc::new(Mutex::new(Box::new(verifier) as Box<_>)));
-		let (block_import, justification_import, finality_proof_import, finality_proof_request_builder, data)
-			= self.make_block_import(PeersClient::Light(client.clone(), backend.clone()));
+		let (
+			block_import,
+			justification_import,
+			finality_proof_import,
+			finality_proof_request_builder,
+			data,
+		) = self.make_block_import(PeersClient::Light(client.clone(), backend.clone()));
 		let block_import = BlockImportAdapter(Arc::new(Mutex::new(block_import)));
+
+		let verifier = self.make_verifier(
+			PeersClient::Light(client.clone(), backend.clone()),
+			&config,
+			&data,
+		);
+		let verifier = VerifierAdapter(Arc::new(Mutex::new(Box::new(verifier) as Box<_>)));
 
 		let import_queue = Box::new(BasicQueue::new(
 			verifier.clone(),
@@ -694,7 +720,7 @@ impl TestNetFactory for TestNet {
 		}
 	}
 
-	fn make_verifier(&self, _client: PeersClient, _config: &ProtocolConfig)
+	fn make_verifier(&self, _client: PeersClient, _config: &ProtocolConfig, _peer_data: &())
 		-> Self::Verifier
 	{
 		PassThroughVerifier(false)
@@ -740,8 +766,8 @@ impl TestNetFactory for JustificationTestNet {
 		JustificationTestNet(TestNet::from_config(config))
 	}
 
-	fn make_verifier(&self, client: PeersClient, config: &ProtocolConfig) -> Self::Verifier {
-		self.0.make_verifier(client, config)
+	fn make_verifier(&self, client: PeersClient, config: &ProtocolConfig, peer_data: &()) -> Self::Verifier {
+		self.0.make_verifier(client, config, peer_data)
 	}
 
 	fn peer(&mut self, i: usize) -> &mut Peer<Self::PeerData, Self::Specialization> {

--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -20,6 +20,7 @@ use crate::RuntimeGenesis;
 use crate::error;
 use crate::chain_spec::ChainSpec;
 
+/// Defines the logic for an operation exporting blocks within a range.
 #[macro_export]
 macro_rules! export_blocks {
 ($client:ident, $exit:ident, $output:ident, $from:ident, $to:ident, $json:ident) => {{
@@ -36,7 +37,7 @@ macro_rules! export_blocks {
 	}
 
 	let (exit_send, exit_recv) = std::sync::mpsc::channel();
-	::std::thread::spawn(move || {
+	std::thread::spawn(move || {
 		let _ = $exit.wait();
 		let _ = exit_send.send(());
 	});
@@ -75,6 +76,7 @@ macro_rules! export_blocks {
 }}
 }
 
+/// Defines the logic for an operation importing blocks from some known import.
 #[macro_export]
 macro_rules! import_blocks {
 ($block:ty, $client:ident, $queue:ident, $exit:ident, $input:ident) => {{
@@ -203,6 +205,7 @@ macro_rules! import_blocks {
 }}
 }
 
+/// Revert the chain some number of blocks.
 #[macro_export]
 macro_rules! revert_chain {
 ($client:ident, $blocks:ident) => {{

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -36,7 +36,7 @@ use service::{
 use network::{multiaddr, Multiaddr};
 use network::config::{NetworkConfiguration, TransportConfig, NodeKeyConfig, Secret, NonReservedPeerMode};
 use sr_primitives::{generic::BlockId, traits::Block as BlockT};
-use consensus::{BlockImportParams, BlockImport};
+use consensus::BlockImport;
 
 /// Maximum duration of single wait call.
 const MAX_WAIT_TIME: Duration = Duration::from_secs(60 * 3);
@@ -364,14 +364,14 @@ pub fn sync<G, Fb, F, Lb, L, B, E, U>(
 	spec: ChainSpec<G>,
 	full_builder: Fb,
 	light_builder: Lb,
-	mut block_factory: B,
+	mut make_block_and_import: B,
 	mut extrinsic_factory: E
 ) where
 	Fb: Fn(Configuration<(), G>) -> Result<(F, U), Error>,
 	F: AbstractService,
 	Lb: Fn(Configuration<(), G>) -> Result<L, Error>,
 	L: AbstractService,
-	B: FnMut(&F, &U) -> BlockImportParams<F::Block>,
+	B: FnMut(&F, &mut U),
 	E: FnMut(&F, &U) -> <F::Block as BlockT>::Extrinsic,
 	U: Clone + Send + 'static,
 {
@@ -392,15 +392,13 @@ pub fn sync<G, Fb, F, Lb, L, B, E, U>(
 	);
 	info!("Checking block sync");
 	let first_address = {
-		let first_service = &network.full_nodes[0].1;
-		let first_user_data = &network.full_nodes[0].2;
-		let mut client = first_service.get().client();
+		let &mut (_, ref first_service, ref mut first_user_data, _) = &mut network.full_nodes[0];
 		for i in 0 .. NUM_BLOCKS {
 			if i % 128 == 0 {
-				info!("Generating #{}", i);
+				info!("Generating #{}", i + 1);
 			}
-			let import_data = block_factory(&first_service.get(), first_user_data);
-			client.import_block(import_data, HashMap::new()).expect("Error importing test block");
+
+			make_block_and_import(&first_service.get(), first_user_data);
 		}
 		network.full_nodes[0].3.clone()
 	};

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -612,25 +612,15 @@ cfg_if! {
 			}
 
 			impl babe_primitives::BabeApi<Block> for Runtime {
-				fn startup_data() -> babe_primitives::BabeConfiguration {
+				fn configuration() -> babe_primitives::BabeConfiguration {
 					babe_primitives::BabeConfiguration {
-						median_required_blocks: 0,
-						slot_duration: 3000,
+						slot_duration: 1000,
+						epoch_length: EpochDuration::get(),
 						c: (3, 10),
-					}
-				}
-
-				fn epoch() -> babe_primitives::Epoch {
-					let authorities = system::authorities();
-					let authorities: Vec<_> = authorities.into_iter().map(|x|(x, 1)).collect();
-
-					babe_primitives::Epoch {
-						start_slot: <srml_babe::Module<Runtime>>::epoch_start_slot(),
-						authorities,
+						genesis_authorities: system::authorities()
+							.into_iter().map(|x|(x, 1)).collect(),
 						randomness: <srml_babe::Module<Runtime>>::randomness(),
-						epoch_index: <srml_babe::Module<Runtime>>::epoch_index(),
-						duration: EpochDuration::get(),
-						secondary_slots: <srml_babe::Module<Runtime>>::secondary_slots().0,
+						secondary_slots: true,
 					}
 				}
 			}
@@ -832,25 +822,15 @@ cfg_if! {
 			}
 
 			impl babe_primitives::BabeApi<Block> for Runtime {
-				fn startup_data() -> babe_primitives::BabeConfiguration {
+				fn configuration() -> babe_primitives::BabeConfiguration {
 					babe_primitives::BabeConfiguration {
-						median_required_blocks: 0,
 						slot_duration: 1000,
+						epoch_length: EpochDuration::get(),
 						c: (3, 10),
-					}
-				}
-
-				fn epoch() -> babe_primitives::Epoch {
-					let authorities = system::authorities();
-					let authorities: Vec<_> = authorities.into_iter().map(|x|(x, 1)).collect();
-
-					babe_primitives::Epoch {
-						start_slot: <srml_babe::Module<Runtime>>::epoch_start_slot(),
-						authorities,
+						genesis_authorities: system::authorities()
+							.into_iter().map(|x|(x, 1)).collect(),
 						randomness: <srml_babe::Module<Runtime>>::randomness(),
-						epoch_index: <srml_babe::Module<Runtime>>::epoch_index(),
-						duration: EpochDuration::get(),
-						secondary_slots: <srml_babe::Module<Runtime>>::secondary_slots().0,
+						secondary_slots: true,
 					}
 				}
 			}

--- a/core/utils/fork-tree/src/lib.rs
+++ b/core/utils/fork-tree/src/lib.rs
@@ -153,6 +153,8 @@ impl<H, N, V> ForkTree<H, N, V> where
 	/// should return `true` if the second hash (target) is a descendent of the
 	/// first hash (base). This method assumes that nodes in the same branch are
 	/// imported in order.
+	///
+	/// Returns `true` if the imported node is a root.
 	pub fn import<F, E>(
 		&mut self,
 		mut hash: H,

--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -374,27 +374,19 @@ impl_runtime_apis! {
 	}
 
 	impl babe_primitives::BabeApi<Block> for Runtime {
-		fn startup_data() -> babe_primitives::BabeConfiguration {
+		fn configuration() -> babe_primitives::BabeConfiguration {
 			// The choice of `c` parameter (where `1 - c` represents the
 			// probability of a slot being empty), is done in accordance to the
 			// slot duration and expected target block time, for safely
 			// resisting network delays of maximum two seconds.
 			// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
 			babe_primitives::BabeConfiguration {
-				median_required_blocks: 1000,
 				slot_duration: Babe::slot_duration(),
+				epoch_length: EpochDuration::get(),
 				c: PRIMARY_PROBABILITY,
-			}
-		}
-
-		fn epoch() -> babe_primitives::Epoch {
-			babe_primitives::Epoch {
-				start_slot: Babe::epoch_start_slot(),
-				authorities: Babe::authorities(),
-				epoch_index: Babe::epoch_index(),
+				genesis_authorities: Babe::authorities(),
 				randomness: Babe::randomness(),
-				duration: EpochDuration::get(),
-				secondary_slots: Babe::secondary_slots().0,
+				secondary_slots: true,
 			}
 		}
 	}

--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -404,6 +404,7 @@ pub(crate) mod tests {
 				config.roles = Roles::FULL;
 				new_full(config)
 			},
+			true,
 		);
 	}
 }

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -20,7 +20,7 @@
 
 use std::sync::Arc;
 
-use babe::{import_queue, Config};
+use babe;
 use client::{self, LongestChain};
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 use node_executor;
@@ -47,7 +47,6 @@ macro_rules! new_full_start {
 		type RpcExtension = jsonrpc_core::IoHandler<substrate_rpc::Metadata>;
 		let mut import_setup = None;
 		let inherent_data_providers = inherents::InherentDataProviders::new();
-		let mut tasks_to_spawn = Vec::new();
 
 		let builder = substrate_service::ServiceBuilder::new_full::<
 			node_primitives::Block, node_runtime::RuntimeApi, node_executor::Executor
@@ -58,36 +57,40 @@ macro_rules! new_full_start {
 			.with_transaction_pool(|config, client|
 				Ok(transaction_pool::txpool::Pool::new(config, transaction_pool::ChainApi::new(client)))
 			)?
-			.with_import_queue(|_config, client, mut select_chain, transaction_pool| {
+			.with_import_queue(|_config, client, mut select_chain, _transaction_pool| {
 				let select_chain = select_chain.take()
 					.ok_or_else(|| substrate_service::Error::SelectChainRequired)?;
-				let (block_import, link_half) =
+				let (grandpa_block_import, grandpa_link) =
 					grandpa::block_import::<_, _, _, node_runtime::RuntimeApi, _, _>(
 						client.clone(), client.clone(), select_chain
 					)?;
-				let justification_import = block_import.clone();
+				let justification_import = grandpa_block_import.clone();
 
-				let (import_queue, babe_link, babe_block_import, pruning_task) = babe::import_queue(
+				let (block_import, babe_link) = babe::block_import(
 					babe::Config::get_or_compute(&*client)?,
-					block_import,
+					grandpa_block_import,
+					client.clone(),
+					client.clone(),
+				)?;
+
+				let import_queue = babe::import_queue(
+					babe_link.clone(),
+					block_import.clone(),
 					Some(Box::new(justification_import)),
 					None,
 					client.clone(),
 					client,
 					inherent_data_providers.clone(),
-					Some(transaction_pool)
 				)?;
 
-				import_setup = Some((babe_block_import.clone(), link_half, babe_link));
-				tasks_to_spawn.push(Box::new(pruning_task));
-
+				import_setup = Some((block_import, grandpa_link, babe_link));
 				Ok(import_queue)
 			})?
 			.with_rpc_extensions(|client, pool| -> RpcExtension {
 				node_rpc::create(client, pool)
 			})?;
 
-		(builder, import_setup, inherent_data_providers, tasks_to_spawn)
+		(builder, import_setup, inherent_data_providers)
 	}}
 }
 
@@ -112,7 +115,7 @@ macro_rules! new_full {
 			$config.disable_grandpa
 		);
 
-		let (builder, mut import_setup, inherent_data_providers, tasks_to_spawn) = new_full_start!($config);
+		let (builder, mut import_setup, inherent_data_providers) = new_full_start!($config);
 
 		// Dht event channel from the network to the authority discovery module. Use bounded channel to ensure
 		// back-pressure. Authority discovery is triggering one event per authority within the current authority set.
@@ -128,11 +131,8 @@ macro_rules! new_full {
 			.with_dht_event_tx(dht_event_tx)?
 			.build()?;
 
-		let (link_half, babe_link) = import_setup.take()
+		let (block_import, grandpa_link, babe_link) = import_setup.take()
 				.expect("Link Half and Block Import are present for Full Services or setup failed before. qed");
-
-		// spawn any futures that were created in the previous setup steps
-		tasks_to_spawn.into_iter().for_each(|t| service.spawn_task(t));
 
 		if is_authority {
 			let proposer = substrate_basic_authorship::ProposerFactory {
@@ -145,14 +145,14 @@ macro_rules! new_full {
 				.ok_or(substrate_service::Error::SelectChainRequired)?;
 
 			let babe_config = babe::BabeParams {
-				config: babe::Config::get_or_compute(&*client)?,
 				keystore: service.keystore(),
 				client,
 				select_chain,
 				env: proposer,
+				block_import,
 				sync_oracle: service.network(),
 				inherent_data_providers: inherent_data_providers.clone(),
-				force_authoring: force_authoring,
+				force_authoring,
 				babe_link,
 			};
 
@@ -180,7 +180,7 @@ macro_rules! new_full {
 				// start the lightweight GRANDPA observer
 				service.spawn_task(Box::new(grandpa::run_grandpa_observer(
 					config,
-					link_half,
+					grandpa_link,
 					service.network(),
 					service.on_exit(),
 				)?));
@@ -189,7 +189,7 @@ macro_rules! new_full {
 				// start the full GRANDPA voter
 				let grandpa_config = grandpa::GrandpaParams {
 					config: config,
-					link: link_half,
+					link: grandpa_link,
 					network: service.network(),
 					inherent_data_providers: inherent_data_providers.clone(),
 					on_exit: service.on_exit(),
@@ -219,11 +219,8 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 /// Builds a new service for a light client.
 pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisConfig>)
 -> Result<impl AbstractService, ServiceError> {
-	use futures::Future;
-
 	type RpcExtension = jsonrpc_core::IoHandler<substrate_rpc::Metadata>;
 	let inherent_data_providers = InherentDataProviders::new();
-	let mut tasks_to_spawn = Vec::new();
 
 	let service = ServiceBuilder::new_light::<Block, RuntimeApi, node_executor::Executor>(config)?
 		.with_select_chain(|_config, backend| {
@@ -232,30 +229,34 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 		.with_transaction_pool(|config, client|
 			Ok(TransactionPool::new(config, transaction_pool::ChainApi::new(client)))
 		)?
-		.with_import_queue_and_fprb(|_config, client, backend, fetcher, _select_chain, transaction_pool| {
+		.with_import_queue_and_fprb(|_config, client, backend, fetcher, _select_chain, _tx_pool| {
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let block_import = grandpa::light_block_import::<_, _, _, RuntimeApi, _>(
+			let grandpa_block_import = grandpa::light_block_import::<_, _, _, RuntimeApi, _>(
 				client.clone(), backend, Arc::new(fetch_checker), client.clone()
 			)?;
 
-			let finality_proof_import = block_import.clone();
+			let finality_proof_import = grandpa_block_import.clone();
 			let finality_proof_request_builder =
 				finality_proof_import.create_finality_proof_request_builder();
 
-			let (import_queue, _, _, pruning_task) = import_queue(
-				Config::get_or_compute(&*client)?,
-				block_import,
+			let (babe_block_import, babe_link) = babe::block_import(
+				babe::Config::get_or_compute(&*client)?,
+				grandpa_block_import,
+				client.clone(),
+				client.clone(),
+			)?;
+
+			let import_queue = babe::import_queue(
+				babe_link,
+				babe_block_import,
 				None,
 				Some(Box::new(finality_proof_import)),
 				client.clone(),
 				client,
 				inherent_data_providers.clone(),
-				Some(transaction_pool)
 			)?;
-
-			tasks_to_spawn.push(Box::new(pruning_task));
 
 			Ok((import_queue, finality_proof_request_builder))
 		})?
@@ -267,15 +268,6 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 			node_rpc::create(client, pool)
 		})?
 		.build()?;
-
-	// spawn any futures that were created in the previous setup steps
-	for task in tasks_to_spawn.drain(..) {
-		service.spawn_task(
-			task.select(service.on_exit())
-				.map(|_| ())
-				.map_err(|_| ())
-		);
-	}
 
 	Ok(service)
 }

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -128,7 +128,7 @@ macro_rules! new_full {
 			.with_dht_event_tx(dht_event_tx)?
 			.build()?;
 
-		let (block_import, link_half, babe_link) = import_setup.take()
+		let (link_half, babe_link) = import_setup.take()
 				.expect("Link Half and Block Import are present for Full Services or setup failed before. qed");
 
 		// spawn any futures that were created in the previous setup steps
@@ -149,7 +149,6 @@ macro_rules! new_full {
 				keystore: service.keystore(),
 				client,
 				select_chain,
-				block_import,
 				env: proposer,
 				sync_oracle: service.network(),
 				inherent_data_providers: inherent_data_providers.clone(),

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -154,7 +154,7 @@ macro_rules! new_full {
 				sync_oracle: service.network(),
 				inherent_data_providers: inherent_data_providers.clone(),
 				force_authoring: force_authoring,
-				time_source: babe_link,
+				babe_link,
 			};
 
 			let babe = babe::start_babe(babe_config)?;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 158,
+	spec_version: 159,
 	impl_version: 159,
 	apis: RUNTIME_API_VERSIONS,
 };


### PR DESCRIPTION
This is the counterpart to the initial type-definition work done in #3611 on the core side.

Rough overview of changeset:
  - Extract `SharedEpochChanges` logic out to its own module in a way that can be more cleanly tested
  - Track chain total-weight offchain and handle it in the block-import worker
  - Define epoch 0 as starting at block 1. There might be multiple block 1s, so they might all kick off slightly competing epochs.
  - Allow epochs to change between blocks and grab epoch based on start slot as well as ancestry.
  - Detect that the first block in an epoch is such by comparing the epoch start slot to the parent block's slot. The first block in an epoch must issue a `NextEpochDescriptor` about the following epoch.
  - Does not define pruning of the epoch fork-tree at this point. That can come in a follow-up PR, since the logic is complex.
  - Fix BABE tests