### PR TITLE
Fix missing `contracts` RPC on a full node.

### DIFF
--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -83,11 +83,17 @@ macro_rules! new_full_start {
 				Ok(import_queue)
 			})?
 			.with_rpc_extensions(|client, pool| {
-				use node_rpc::accounts::{Accounts, AccountsApi};
+				use node_rpc::{
+					accounts::{Accounts, AccountsApi},
+					contracts::{Contracts, ContractsApi},
+				};
 
-				let mut io = jsonrpc_core::IoHandler::<substrate_service::RpcMetadata>::default();
+				let mut io = jsonrpc_core::IoHandler::default();
 				io.extend_with(
-					AccountsApi::to_delegate(Accounts::new(client, pool))
+					AccountsApi::to_delegate(Accounts::new(client.clone(), pool))
+				);
+				io.extend_with(
+					ContractsApi::to_delegate(Contracts::new(client))
 				);
 				io
 			})?;

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -44,6 +44,7 @@ construct_simple_protocol! {
 /// be able to perform chain operations.
 macro_rules! new_full_start {
 	($config:expr) => {{
+		type RpcExtension = jsonrpc_core::IoHandler<substrate_rpc::Metadata>;
 		let mut import_setup = None;
 		let inherent_data_providers = inherents::InherentDataProviders::new();
 		let mut tasks_to_spawn = Vec::new();
@@ -82,20 +83,8 @@ macro_rules! new_full_start {
 
 				Ok(import_queue)
 			})?
-			.with_rpc_extensions(|client, pool| {
-				use node_rpc::{
-					accounts::{Accounts, AccountsApi},
-					contracts::{Contracts, ContractsApi},
-				};
-
-				let mut io = jsonrpc_core::IoHandler::default();
-				io.extend_with(
-					AccountsApi::to_delegate(Accounts::new(client.clone(), pool))
-				);
-				io.extend_with(
-					ContractsApi::to_delegate(Contracts::new(client))
-				);
-				io
+			.with_rpc_extensions(|client, pool| -> RpcExtension {
+				node_rpc::create(client, pool)
 			})?;
 
 		(builder, import_setup, inherent_data_providers, tasks_to_spawn)
@@ -233,6 +222,7 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 -> Result<impl AbstractService, ServiceError> {
 	use futures::Future;
 
+	type RpcExtension = jsonrpc_core::IoHandler<substrate_rpc::Metadata>;
 	let inherent_data_providers = InherentDataProviders::new();
 	let mut tasks_to_spawn = Vec::new();
 
@@ -274,20 +264,8 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 		.with_finality_proof_provider(|client, backend|
 			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, client)) as _)
 		)?
-		.with_rpc_extensions(|client, pool| {
-			use node_rpc::{
-				accounts::{Accounts, AccountsApi},
-				contracts::{Contracts, ContractsApi},
-			};
-
-			let mut io = jsonrpc_core::IoHandler::default();
-			io.extend_with(
-				AccountsApi::to_delegate(Accounts::new(client.clone(), pool))
-			);
-			io.extend_with(
-				ContractsApi::to_delegate(Contracts::new(client))
-			);
-			io
+		.with_rpc_extensions(|client, pool| -> RpcExtension {
+			node_rpc::create(client, pool)
 		})?
 		.build()?;
 

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -29,6 +29,12 @@
 
 #![warn(missing_docs)]
 
+use std::sync::Arc;
+
+use node_primitives::{Block, AccountNonceApi, ContractsApi};
+use sr_primitives::traits::ProvideRuntimeApi;
+use transaction_pool::txpool::{ChainApi, Pool};
+
 pub mod accounts;
 pub mod contracts;
 
@@ -37,4 +43,28 @@ mod constants {
 	///
 	/// This typically means that the runtime trapped.
 	pub const RUNTIME_ERROR: i64 = 1;
+}
+
+/// Instantiate all RPC extensions.
+pub fn create<C, P, M>(client: Arc<C>, pool: Arc<Pool<P>>) -> jsonrpc_core::IoHandler<M> where
+	C: ProvideRuntimeApi,
+	C: client::blockchain::HeaderBackend<Block>,
+	C: Send + Sync + 'static,
+	C::Api: AccountNonceApi<Block> + ContractsApi<Block>,
+	P: ChainApi + Sync + Send + 'static,
+	M: jsonrpc_core::Metadata + Default,
+{
+	use self::{
+		accounts::{Accounts, AccountsApi},
+		contracts::{Contracts, ContractsApi},
+	};
+
+	let mut io = jsonrpc_core::IoHandler::default();
+	io.extend_with(
+		AccountsApi::to_delegate(Accounts::new(client.clone(), pool))
+	);
+	io.extend_with(
+		ContractsApi::to_delegate(Contracts::new(client))
+	);
+	io
 }


### PR DESCRIPTION
The `ContractsApi` was only created for light-client `rpc_extension`.
I've moved the instantiation to `node/rpc` crate, to avoid duplication.

CC @jacogr 