### PR TITLE
Suggest `--release` compilation

### DIFF
--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -208,6 +208,9 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			let slot_after_building = SignedDuration::default().slot_now(slot_duration);
 			if slot_after_building != slot_number {
 				info!("Discarding proposal for slot {}; block production took too long", slot_number);
+				// If the node was compiled with debug, tell the user to use release optimizations.
+				#[cfg(debug_assertions)]
+				info!("Recompile your node in `--release` mode to mitigate this problem.");
 				telemetry!(CONSENSUS_INFO; "slots.discarding_proposal_took_too_long";
 					"slot" => slot_number,
 				);


### PR DESCRIPTION
If the user sees a warning about `block production took too long` and we detect the user has compiled their node with `debug` mode, suggest to them to instead compile with `--release` mode for computational optimizations which could remove problems with block production taking too long.

```
2019-09-17 13:02:46 Discarding proposal for slot 522906053; block production took too long
2019-09-17 13:02:46 Recompile your node in `--release` mode to mitigate this problem.
2019-09-17 13:02:47 Starting consensus session on top of parent 0x059e1fd59e4e4829eaa33e61696da472b79109056845767965afd14ccaa95f2a
```