### PR TITLE
Properly detect debug build in slots

### DIFF
--- a/core/consensus/slots/Cargo.toml
+++ b/core/consensus/slots/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic slots-based utilities for consensus"
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/core/consensus/slots/build.rs
+++ b/core/consensus/slots/build.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::env;
+
+fn main() {
+	if let Ok(profile) = env::var("PROFILE") {
+		println!("cargo:rustc-cfg=build_type=\"{}\"", profile);
+	}
+}

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -209,7 +209,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			if slot_after_building != slot_number {
 				info!("Discarding proposal for slot {}; block production took too long", slot_number);
 				// If the node was compiled with debug, tell the user to use release optimizations.
-				#[cfg(debug_assertions)]
+				#[cfg(build_type="debug")]
 				info!("Recompile your node in `--release` mode to mitigate this problem.");
 				telemetry!(CONSENSUS_INFO; "slots.discarding_proposal_took_too_long";
 					"slot" => slot_number,
@@ -397,7 +397,7 @@ impl<T: Clone> SlotDuration<T> {
 			Some(v) => <T as codec::Decode>::decode(&mut &v[..])
 				.map(SlotDuration)
 				.map_err(|_| {
-					::client::error::Error::Backend({
+					client::error::Error::Backend({
 						error!(target: "slots", "slot duration kept in invalid format");
 						format!("slot duration kept in invalid format")
 					})


### PR DESCRIPTION
`debug-assertions` can also be enabled in for release builds. This
introduces a new build-script that extracts the build type from the
`PROFILE` env variable and sets the `build_type` cfg.

