### PR TITLE
add polkadot-v0.5 branch to the ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ variables:
     - schedules
     - web
     - /^[0-9]+$/                   # PRs
+    - polkadot-v0.5
   tags:
     - linux-docker
 
@@ -57,6 +58,7 @@ variables:
     - master
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
     - web
+    - polkadot-v0.5
 
 
 


### PR DESCRIPTION
this will enable the full pipeline for the `polkadot-v0.5` branch.

Reconsidering my question i think it will be useful to have binaries and docker images around.