### PR TITLE
Make `wasm-builder` check for `rust-lld`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -195,7 +195,7 @@ sudo apt install cmake pkg-config libssl-dev git clang libclang-dev
 
 - Linux on ARM:
 `rust-lld` is required for linking wasm, but is missing on non Tier 1 platforms.
-So, use this https://github.com/mcrosson/Plume/blob/dfa89e227a986d64c56b265490bf97e3597fc177/script/wasm-deps.sh[script]
+So, use this https://github.com/Plume-org/Plume/blob/master/script/wasm-deps.sh[script]
 to build `lld` and create the symlink `/usr/bin/rust-lld` to the build binary.
 
  - Mac:

--- a/README.adoc
+++ b/README.adoc
@@ -193,6 +193,11 @@ You will also need to install the following packages:
 [source, shell]
 sudo apt install cmake pkg-config libssl-dev git clang libclang-dev
 
+- Linux on ARM:
+`rust-lld` is required for linking wasm, but is missing on non Tier 1 platforms.
+So, use this https://github.com/mcrosson/Plume/blob/dfa89e227a986d64c56b265490bf97e3597fc177/script/wasm-deps.sh[script]
+to build `lld` and create the symlink `/usr/bin/rust-lld` to the build binary.
+
  - Mac:
 [source, shell]
 brew install cmake pkg-config openssl git llvm


### PR DESCRIPTION
Closes: https://github.com/paritytech/substrate/issues/3615

@akru could you check that the error message tells you to install `rust-lld` now? :) 