### PR TITLE
Remove the no_std feature from the WASM builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,7 +2548,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-wasm-builder-runner 1.0.3",
 ]
 
 [[package]]
@@ -5490,11 +5490,6 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "substrate-wasm-builder-runner"
 version = "1.0.3"
 
 [[package]]
@@ -6849,7 +6844,6 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-wasm-builder-runner 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f52ecbff6cc3d6e5c6401828e15937b680f459d6803ce238f01fe615bc40d071"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"

--- a/core/executor/runtime-test/Cargo.toml
+++ b/core/executor/runtime-test/Cargo.toml
@@ -18,4 +18,3 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 [features]
 default = [ "std" ]
 std = []
-no_std = []

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -44,7 +44,6 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 default = [
 	"std",
 ]
-no_std = []
 std = [
 	"log",
 	"serde",

--- a/core/utils/wasm-builder/src/wasm_project.rs
+++ b/core/utils/wasm-builder/src/wasm_project.rs
@@ -270,7 +270,7 @@ fn create_project(cargo_manifest: &Path, wasm_workspace: &Path) -> PathBuf {
 				crate-type = ["cdylib"]
 
 				[dependencies]
-				wasm_project = {{ package = "{crate_name}", path = "{crate_path}", default-features = false, features = [ "no_std" ] }}
+				wasm_project = {{ package = "{crate_name}", path = "{crate_path}", default-features = false }}
 			"#,
 			crate_name = crate_name,
 			crate_path = crate_path.display(),

--- a/node-template/runtime/Cargo.toml
+++ b/node-template/runtime/Cargo.toml
@@ -28,7 +28,7 @@ client = { package = "substrate-client", path = "../../core/client", default_fea
 offchain-primitives = { package = "substrate-offchain-primitives", path = "../../core/offchain/primitives", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../../core/utils/wasm-builder-runner" }
 
 [features]
 default = ["std"]
@@ -55,4 +55,3 @@ std = [
 	"offchain-primitives/std",
 	"substrate-session/std",
 ]
-no_std = []

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -30,7 +30,7 @@ authorship = { package = "srml-authorship", path = "../../srml/authorship", defa
 babe = { package = "srml-babe", path = "../../srml/babe", default-features = false }
 balances = { package = "srml-balances", path = "../../srml/balances", default-features = false }
 collective = { package = "srml-collective", path = "../../srml/collective", default-features = false }
-contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false }
+contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false, features = ["core"] }
 democracy = { package = "srml-democracy", path = "../../srml/democracy", default-features = false }
 elections = { package = "srml-elections", path = "../../srml/elections", default-features = false }
 executive = { package = "srml-executive", path = "../../srml/executive", default-features = false }
@@ -53,9 +53,6 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 
 [features]
 default = ["std"]
-no_std = [
-	"contracts/core",
-]
 std = [
 	"authority-discovery-primitives/std",
 	"authority-discovery/std",


### PR DESCRIPTION
Removes the fact that the WASM builder requires the `no_std` feature.

The motivation behind this change is the surprise effect. Why do I need a `no_std` feature in my runtime?
Additionally, semantically it's not a great idea to have a "no_std" feature. People might misuse it because they think it means "opposite of std feature", while it is not that at all. There is a history in the Rust ecosystem of misusing features named "no_std", and we're giving out a bad example.

In practice, Polkadot doesn't use that feature, only the Substrate runtime does.

The only consequence might be that we have to activate features on "std" that we wouldn't normally need, which will result in a very slightly larger binary size. I really don't think that's a problem.
