### PR TITLE
Remove the no_std feature from the WASM builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,7 +2548,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-wasm-builder-runner 1.0.3",
 ]
 
 [[package]]
@@ -5487,11 +5487,6 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "substrate-wasm-builder-runner"
 version = "1.0.3"
 
 [[package]]
@@ -6845,7 +6840,6 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-wasm-builder-runner 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f52ecbff6cc3d6e5c6401828e15937b680f459d6803ce238f01fe615bc40d071"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,7 +2548,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.3",
+ "substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5490,6 +5490,11 @@ name = "substrate-wasm-builder-runner"
 version = "1.0.3"
 
 [[package]]
+name = "substrate-wasm-builder-runner"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "substrate-wasm-interface"
 version = "2.0.0"
 dependencies = [
@@ -6840,6 +6845,7 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
+"checksum substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af21b27fad38b212c1919f700cb0def33c88cde14d22e0d1b17d4521f4eb8b40"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
 "checksum syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)" = "eadc09306ca51a40555dd6fc2b415538e9e18bc9f870e47b1a524a79fe2dcf5e"

--- a/core/executor/runtime-test/Cargo.toml
+++ b/core/executor/runtime-test/Cargo.toml
@@ -18,4 +18,3 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 [features]
 default = [ "std" ]
 std = []
-no_std = []

--- a/core/executor/runtime-test/build.rs
+++ b/core/executor/runtime-test/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../utils/wasm-builder",
-			version: "1.0.6",
+			version: "1.0.7",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -44,7 +44,6 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 default = [
 	"std",
 ]
-no_std = []
 std = [
 	"log",
 	"serde",

--- a/core/test-runtime/build.rs
+++ b/core/test-runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../utils/wasm-builder",
-			version: "1.0.6",
+			version: "1.0.7",
 		},
 		// Note that we set the stack-size to 1MB explicitly even though it is set
 		// to this value by default. This is because some of our tests (`restoration_of_globals`)

--- a/core/utils/wasm-builder/Cargo.toml
+++ b/core/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "1.0.6"
+version = "1.0.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"

--- a/core/utils/wasm-builder/README.md
+++ b/core/utils/wasm-builder/README.md
@@ -9,7 +9,6 @@ A project that should be compiled as a WASM binary needs to:
 
 1. Add a `build.rs` file.
 2. Add `substrate-wasm-builder-runner` as dependency into `build-dependencies`.
-3. Add a feature called `no-std`.
 
 The `build.rs` file needs to contain the following code:
 
@@ -25,8 +24,6 @@ fn main() {
 	);
 }
 ```
-
-The `no-std` feature will be enabled by WASM builder while compiling your project to WASM.
 
 As the final step, you need to add the following to your project:
 

--- a/core/utils/wasm-builder/src/lib.rs
+++ b/core/utils/wasm-builder/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 //! 1. Add a `build.rs` file.
 //! 2. Add `substrate-wasm-builder-runner` as dependency into `build-dependencies`.
-//! 3. Add a feature called `no-std`.
 //!
 //! The `build.rs` file needs to contain the following code:
 //!
@@ -41,8 +40,6 @@
 //! 	);
 //! }
 //! ```
-//!
-//! The `no-std` feature will be enabled by WASM builder while compiling your project to WASM.
 //!
 //! As the final step, you need to add the following to your project:
 //!

--- a/core/utils/wasm-builder/src/wasm_project.rs
+++ b/core/utils/wasm-builder/src/wasm_project.rs
@@ -270,7 +270,7 @@ fn create_project(cargo_manifest: &Path, wasm_workspace: &Path) -> PathBuf {
 				crate-type = ["cdylib"]
 
 				[dependencies]
-				wasm_project = {{ package = "{crate_name}", path = "{crate_path}", default-features = false, features = [ "no_std" ] }}
+				wasm_project = {{ package = "{crate_name}", path = "{crate_path}", default-features = false }}
 			"#,
 			crate_name = crate_name,
 			crate_path = crate_path.display(),

--- a/node-template/runtime/Cargo.toml
+++ b/node-template/runtime/Cargo.toml
@@ -28,7 +28,7 @@ client = { package = "substrate-client", path = "../../core/client", default_fea
 offchain-primitives = { package = "substrate-offchain-primitives", path = "../../core/offchain/primitives", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../../core/utils/wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2" }
 
 [features]
 default = ["std"]

--- a/node-template/runtime/Cargo.toml
+++ b/node-template/runtime/Cargo.toml
@@ -28,7 +28,7 @@ client = { package = "substrate-client", path = "../../core/client", default_fea
 offchain-primitives = { package = "substrate-offchain-primitives", path = "../../core/offchain/primitives", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../../core/utils/wasm-builder-runner" }
 
 [features]
 default = ["std"]
@@ -55,4 +55,3 @@ std = [
 	"offchain-primitives/std",
 	"substrate-session/std",
 ]
-no_std = []

--- a/node-template/runtime/build.rs
+++ b/node-template/runtime/build.rs
@@ -19,7 +19,11 @@ use wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSourc
 fn main() {
 	build_current_project_with_rustflags(
 		"wasm_binary.rs",
-		WasmBuilderSource::Crates("1.0.6"),
+		// Note: replace with `WasmBuilderSource::Crates("1.0.6")` if you copy-paste this template.
+		WasmBuilderSource::CratesOrPath {
+			path: "../../core/utils/wasm-builder",
+			version: "1.0.6",
+		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.
 		"-Clink-arg=--export=__heap_base",

--- a/node-template/runtime/build.rs
+++ b/node-template/runtime/build.rs
@@ -19,11 +19,7 @@ use wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSourc
 fn main() {
 	build_current_project_with_rustflags(
 		"wasm_binary.rs",
-		// Note: replace with `WasmBuilderSource::Crates("1.0.6")` if you copy-paste this template.
-		WasmBuilderSource::CratesOrPath {
-			path: "../../core/utils/wasm-builder",
-			version: "1.0.6",
-		},
+		WasmBuilderSource::Crates("1.0.7"),
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.
 		"-Clink-arg=--export=__heap_base",

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -30,7 +30,7 @@ authorship = { package = "srml-authorship", path = "../../srml/authorship", defa
 babe = { package = "srml-babe", path = "../../srml/babe", default-features = false }
 balances = { package = "srml-balances", path = "../../srml/balances", default-features = false }
 collective = { package = "srml-collective", path = "../../srml/collective", default-features = false }
-contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false, features = ["core"] }
+contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false }
 democracy = { package = "srml-democracy", path = "../../srml/democracy", default-features = false }
 elections = { package = "srml-elections", path = "../../srml/elections", default-features = false }
 executive = { package = "srml-executive", path = "../../srml/executive", default-features = false }

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -30,7 +30,7 @@ authorship = { package = "srml-authorship", path = "../../srml/authorship", defa
 babe = { package = "srml-babe", path = "../../srml/babe", default-features = false }
 balances = { package = "srml-balances", path = "../../srml/balances", default-features = false }
 collective = { package = "srml-collective", path = "../../srml/collective", default-features = false }
-contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false }
+contracts = { package = "srml-contracts", path = "../../srml/contracts", default-features = false, features = ["core"] }
 democracy = { package = "srml-democracy", path = "../../srml/democracy", default-features = false }
 elections = { package = "srml-elections", path = "../../srml/elections", default-features = false }
 executive = { package = "srml-executive", path = "../../srml/executive", default-features = false }
@@ -53,9 +53,6 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 
 [features]
 default = ["std"]
-no_std = [
-	"contracts/core",
-]
 std = [
 	"authority-discovery-primitives/std",
 	"authority-discovery/std",

--- a/node/runtime/build.rs
+++ b/node/runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../core/utils/wasm-builder",
-			version: "1.0.6",
+			version: "1.0.7",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/srml/contracts/Cargo.toml
+++ b/srml/contracts/Cargo.toml
@@ -28,9 +28,6 @@ hex = "0.3"
 
 [features]
 default = ["std"]
-core = [
-	"wasmi-validation/core",
-]
 std = [
 	"serde",
 	"codec/std",


### PR DESCRIPTION
(GitHub won't let me reopen #3637 because I force-pushed, so I have to create another PR)

Removes the fact that the WASM builder requires the no_std feature.

The motivation behind this change is the surprise effect. Why do I need a no_std feature in my runtime?
Additionally, semantically it's not a great idea to have a "no_std" feature. People might misuse it because they think it means "opposite of std feature", while it is not that at all. There is a history in the Rust ecosystem of misusing features named "no_std", and we're giving out a bad example.

In practice, Polkadot doesn't use that feature, only the Substrate runtime does.

The only consequence might be that we have to activate features on "std" that we wouldn't normally need, which will result in a very slightly larger binary size. I really don't think that's a problem.