### PR TITLE
core, subkey: allow to read Polkadot, Kusama, and Dothereum address types

### DIFF
--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -314,7 +314,7 @@ fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 #[cfg(feature = "std")]
 lazy_static::lazy_static! {
 	static ref DEFAULT_VERSION: Mutex<Ss58AddressFormat>
-		= Mutex::new(Ss58AddressFormat::SubstrateAccountDirect);
+		= Mutex::new(Ss58AddressFormat::DothereumAccountDirect);
 }
 
 /// A known address (sub)format/network ID for SS58.

--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -327,6 +327,8 @@ pub enum Ss58AddressFormat {
 	PolkadotAccountDirect,
 	/// Kusama Relay-chain, direct checksum, standard account (*25519).
 	KusamaAccountDirect,
+	/// Dothereum Para-chain, direct checksum, standard account (*25519).
+	DothereumAccountDirect,
 	/// Use a manually provided numeric value.
 	Custom(u8),
 }
@@ -338,6 +340,7 @@ impl From<Ss58AddressFormat> for u8 {
 			Ss58AddressFormat::SubstrateAccountDirect => 42,
 			Ss58AddressFormat::PolkadotAccountDirect => 0,
 			Ss58AddressFormat::KusamaAccountDirect => 2,
+			Ss58AddressFormat::DothereumAccountDirect => 4,
 			Ss58AddressFormat::Custom(n) => n,
 		}
 	}
@@ -351,6 +354,7 @@ impl TryFrom<u8> for Ss58AddressFormat {
 			42 => Ok(Ss58AddressFormat::SubstrateAccountDirect),
 			0 => Ok(Ss58AddressFormat::PolkadotAccountDirect),
 			2 => Ok(Ss58AddressFormat::KusamaAccountDirect),
+			4 => Ok(Ss58AddressFormat::DothereumAccountDirect),
 			_ => Err(()),
 		}
 	}
@@ -364,6 +368,7 @@ impl<'a> TryFrom<&'a str> for Ss58AddressFormat {
 			"substrate" => Ok(Ss58AddressFormat::SubstrateAccountDirect),
 			"polkadot" => Ok(Ss58AddressFormat::PolkadotAccountDirect),
 			"kusama" => Ok(Ss58AddressFormat::KusamaAccountDirect),
+			"dothereum" => Ok(Ss58AddressFormat::DothereumAccountDirect),
 			a => a.parse::<u8>().map(Ss58AddressFormat::Custom).map_err(|_| ()),
 		}
 	}
@@ -376,6 +381,7 @@ impl From<Ss58AddressFormat> for String {
 			Ss58AddressFormat::SubstrateAccountDirect => "substrate".into(),
 			Ss58AddressFormat::PolkadotAccountDirect => "polkadot".into(),
 			Ss58AddressFormat::KusamaAccountDirect => "kusama".into(),
+			Ss58AddressFormat::DothereumAccountDirect => "dothereum".into(),
 			Ss58AddressFormat::Custom(x) => x.to_string(),
 		}
 	}

--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -261,6 +261,9 @@ pub trait Ss58Codec: Sized {
 		Self::from_ss58check_with_version(s)
 			.and_then(|(r, v)| match v {
 				Ss58AddressFormat::SubstrateAccountDirect => Ok(r),
+				Ss58AddressFormat::PolkadotAccountDirect => Ok(r),
+				Ss58AddressFormat::KusamaAccountDirect => Ok(r),
+				Ss58AddressFormat::DothereumAccountDirect => Ok(r),
 				v if v == *DEFAULT_VERSION.lock() => Ok(r),
 				_ => Err(PublicError::UnknownVersion),
 			})
@@ -273,6 +276,9 @@ pub trait Ss58Codec: Sized {
 		Self::from_string_with_version(s)
 			.and_then(|(r, v)| match v {
 				Ss58AddressFormat::SubstrateAccountDirect => Ok(r),
+				Ss58AddressFormat::PolkadotAccountDirect => Ok(r),
+				Ss58AddressFormat::KusamaAccountDirect => Ok(r),
+				Ss58AddressFormat::DothereumAccountDirect => Ok(r),
 				v if v == *DEFAULT_VERSION.lock() => Ok(r),
 				_ => Err(PublicError::UnknownVersion),
 			})

--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -393,7 +393,8 @@ impl From<Ss58AddressFormat> for String {
 ///
 /// Current known "versions" are:
 /// - 0 direct (payload) checksum for 32-byte *25519 Polkadot addresses.
-/// - 2 direct (payload) checksum for 32-byte *25519 Polkadot Milestone 'K' addresses.
+/// - 2 direct (payload) checksum for 32-byte *25519 Kusama addresses.
+/// - 20 direct (payload) checksum for 32-byte *25519 Dothereum addresses.
 /// - 42 direct (payload) checksum for 32-byte *25519 addresses on any Substrate-based network.
 #[cfg(feature = "std")]
 pub fn set_default_ss58_version(version: Ss58AddressFormat) {

--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -314,7 +314,7 @@ fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 #[cfg(feature = "std")]
 lazy_static::lazy_static! {
 	static ref DEFAULT_VERSION: Mutex<Ss58AddressFormat>
-		= Mutex::new(Ss58AddressFormat::DothereumAccountDirect);
+		= Mutex::new(Ss58AddressFormat::SubstrateAccountDirect);
 }
 
 /// A known address (sub)format/network ID for SS58.

--- a/core/primitives/src/crypto.rs
+++ b/core/primitives/src/crypto.rs
@@ -340,7 +340,7 @@ impl From<Ss58AddressFormat> for u8 {
 			Ss58AddressFormat::SubstrateAccountDirect => 42,
 			Ss58AddressFormat::PolkadotAccountDirect => 0,
 			Ss58AddressFormat::KusamaAccountDirect => 2,
-			Ss58AddressFormat::DothereumAccountDirect => 4,
+			Ss58AddressFormat::DothereumAccountDirect => 20,
 			Ss58AddressFormat::Custom(n) => n,
 		}
 	}
@@ -354,7 +354,7 @@ impl TryFrom<u8> for Ss58AddressFormat {
 			42 => Ok(Ss58AddressFormat::SubstrateAccountDirect),
 			0 => Ok(Ss58AddressFormat::PolkadotAccountDirect),
 			2 => Ok(Ss58AddressFormat::KusamaAccountDirect),
-			4 => Ok(Ss58AddressFormat::DothereumAccountDirect),
+			20 => Ok(Ss58AddressFormat::DothereumAccountDirect),
 			_ => Err(()),
 		}
 	}

--- a/subkey/src/cli.yml
+++ b/subkey/src/cli.yml
@@ -23,7 +23,7 @@ args:
       long: network
       takes_value: true
       required: false
-      help: Specify a network. One of substrate (default), polkadot and kusama.
+      help: Specify a network. One of substrate (default), polkadot, kusama, or dothereum.
 subcommands:
   - generate:
       about: Generate a random account

--- a/subkey/src/main.rs
+++ b/subkey/src/main.rs
@@ -140,7 +140,7 @@ where
 	let maybe_network: Option<Ss58AddressFormat> = matches.value_of("network").map(|network| {
 		network
 			.try_into()
-			.expect("Invalid network name: must be polkadot/substrate/kusama")
+			.expect("Invalid network name: must be polkadot/substrate/kusama/dothereum")
 	});
 	if let Some(network) = maybe_network {
 		set_default_ss58_version(network);
@@ -382,7 +382,7 @@ fn create_extrinsic(
 	);
 	let signature = raw_payload.using_encoded(|payload| signer.sign(payload));
 	let (function, extra, _) = raw_payload.deconstruct();
-	
+
 	UncheckedExtrinsic::new_signed(
 		function,
 		signer.public().into(),


### PR DESCRIPTION
- What does it do?
  - Adds Polkadot, Kusama, and Dothereum to the list of default parsable address formats.
  - Sets the Dothereum address prefix to 20 in accordance with [External Address Format (SS58)](https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)).
  - Adds Dothereum to the list of supported networks for `subkey`.
- What important points reviewers should know?
  - Fixes #3641
  - Fixes https://github.com/paritytech/polkadot/issues/394
  - Required for the next iteration of the Dothereum testnet config coming with a custom address format (validators).
    - Ref https://github.com/dothereum/dothereum/pull/10
    - Ref https://github.com/dothereum/dothereum/issues/7
- Is there something left for follow-up PRs?
  - Partially addresses #3389, a follow-up could come up with a more generic solution.
  - Little refactoring is recommended in case more chains want to integrate with subkey in future.