### PR TITLE
srml-contract: Rename Contract::create to instantiate

### DIFF
--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -673,7 +673,7 @@ mod tests {
 				CheckedExtrinsic {
 					signed: Some((charlie(), signed_extra(1, 0))),
 					function: Call::Contracts(
-						contracts::Call::create::<Runtime>(1 * DOLLARS, 10_000, transfer_ch, Vec::new())
+						contracts::Call::instantiate::<Runtime>(1 * DOLLARS, 10_000, transfer_ch, Vec::new())
 					),
 				},
 				CheckedExtrinsic {

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 158,
-	impl_version: 159,
+	impl_version: 160,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -82,8 +82,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 158,
-	impl_version: 160,
+	spec_version: 159,
+	impl_version: 159,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -317,13 +317,13 @@ It consists of the following steps:
 1. Loading `init_code` buffer from the sandbox memory (see sandboxing memory get) and then decoding it.
 2. Loading `value` buffer from the sandbox memory and then decoding it.
 3. Loading `input_data` buffer from the sandbox memory.
-4. Invoking `create` executive function.
+4. Invoking `instantiate` executive function.
 
 Loading of `value` buffer should be charged. This is because the size of the buffer is specified by the calling code, even though marshaled representation is, essentially, of constant size. This can be fixed by assigning an upper bound for size for `Balance`.
 
 Loading `init_code` and `input_data` should be charged in any case.
 
-**complexity**: All complexity comes from loading buffers and executing `create` executive function. The former component is proportional to the sizes of `init_code`, `value` and `input_data` buffers. The latter component completely depends on the complexity of `create` executive function and also dominated by it.
+**complexity**: All complexity comes from loading buffers and executing `instantiate` executive function. The former component is proportional to the sizes of `init_code`, `value` and `input_data` buffers. The latter component completely depends on the complexity of `instantiate` executive function and also dominated by it.
 
 ## ext_return
 

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -59,7 +59,7 @@
 //! ### Dispatchable functions
 //!
 //! * `put_code` - Stores the given binary Wasm code into the chain's storage and returns its `code_hash`.
-//! * `create` - Deploys a new contract from the given `code_hash`, optionally transferring some balance.
+//! * `instantiate` - Deploys a new contract from the given `code_hash`, optionally transferring some balance.
 //! This creates a new smart contract account and calls its contract deploy handler to initialize the contract.
 //! * `call` - Makes a call to an account, optionally transferring some balance.
 //!
@@ -812,7 +812,7 @@ decl_event! {
 		<T as system::Trait>::AccountId,
 		<T as system::Trait>::Hash
 	{
-		/// Transfer happened `from` to `to` with given `value` as part of a `call` or `create`.
+		/// Transfer happened `from` to `to` with given `value` as part of a `call` or `instantiate`.
 		Transfer(AccountId, AccountId, Balance),
 
 		/// Contract deployed by address at the specified address.

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -590,7 +590,7 @@ decl_module! {
 		///   after the execution is saved as the `code` of the account. That code will be invoked
 		///   upon any call received by this account.
 		/// - The contract is initialized.
-		pub fn create(
+		pub fn instantiate(
 			origin,
 			#[compact] endowment: BalanceOf<T>,
 			#[compact] gas_limit: Gas,
@@ -1018,7 +1018,7 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckBlockGasLimit<T> {
 				Ok(ValidTransaction::default()),
 			Call::put_code(gas_limit, _)
 				| Call::call(_, _, gas_limit, _)
-				| Call::create(_, gas_limit, _, _)
+				| Call::instantiate(_, gas_limit, _, _)
 			=> {
 				// Check if the specified amount of gas is available in the current block.
 				// This cannot underflow since `gas_spent` is never greater than `T::BlockGasLimit`.

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -425,7 +425,7 @@ fn instantiate_and_call_and_deposit_event() {
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
 			// Check at the end to get hash on error easily
-			let creation = Contract::create(
+			let creation = Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000,
@@ -522,7 +522,7 @@ fn dispatch_call() {
 				},
 			]);
 
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000,
@@ -643,7 +643,7 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 				},
 			]);
 
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000,
@@ -859,7 +859,7 @@ fn storage_size() {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				30_000,
 				100_000, code_hash.into(),
@@ -889,7 +889,7 @@ fn deduct_blocks() {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				30_000,
 				100_000, code_hash.into(),
@@ -986,7 +986,7 @@ fn claim_surcharge(blocks: u64, trigger_call: impl Fn() -> bool, removes: bool) 
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000, code_hash.into(),
@@ -1022,7 +1022,7 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000, code_hash.into(),
@@ -1061,7 +1061,7 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				1_000,
 				100_000, code_hash.into(),
@@ -1099,7 +1099,7 @@ fn removals(trigger_call: impl Fn() -> bool) {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				50+Balances::minimum_balance(),
 				100_000, code_hash.into(),
@@ -1146,7 +1146,7 @@ fn call_removed_contract() {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100,
 				100_000, code_hash.into(),
@@ -1234,7 +1234,7 @@ fn default_rent_allowance_on_create() {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				30_000,
 				100_000,
@@ -1374,7 +1374,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 
 			// Create an account with address `BOB` with code `CODE_SET_RENT`.
 			// The input parameter sets the rent allowance to 0.
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				30_000,
 				100_000,
@@ -1411,7 +1411,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			/// Note that we can't use `ALICE` for creating `DJANGO` so we create yet another
 			/// account `CHARLIE` and create `DJANGO` with it.
 			Balances::deposit_creating(&CHARLIE, 1_000_000);
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(CHARLIE),
 				30_000,
 				100_000,
@@ -1537,7 +1537,7 @@ fn storage_max_value_limit() {
 			// Create
 			Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				30_000,
 				100_000,
@@ -1906,7 +1906,7 @@ fn deploy_and_call_other_contract() {
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
 
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100_000,
 				100_000,
@@ -2036,7 +2036,7 @@ fn self_destruct_by_draining_balance() {
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
 			// Instantiate the BOB contract.
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100_000,
 				100_000,
@@ -2075,7 +2075,7 @@ fn cannot_self_destruct_while_live() {
 			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
 			// Instantiate the BOB contract.
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				100_000,
 				100_000,
@@ -2280,7 +2280,7 @@ fn destroy_contract_and_transfer_funds() {
 
 			// This deploys the BOB contract, which in turn deploys the CHARLIE contract during
 			// construction.
-			assert_ok!(Contract::create(
+			assert_ok!(Contract::instantiate(
 				Origin::signed(ALICE),
 				200_000,
 				100_000,
@@ -2378,7 +2378,7 @@ fn cannot_self_destruct_in_constructor() {
 			// Fail to instantiate the BOB contract since its final balance is below existential
 			// deposit.
 			assert_err!(
-				Contract::create(
+				Contract::instantiate(
 					Origin::signed(ALICE),
 					100_000,
 					100_000,


### PR DESCRIPTION
See #2828. I'm not sure how much of the documentation needs updating.