### PR TITLE
Send local GRANDPA authority id to telemetry

### DIFF
--- a/core/finality-grandpa/src/aux_schema.rs
+++ b/core/finality-grandpa/src/aux_schema.rs
@@ -25,7 +25,6 @@ use fork_tree::ForkTree;
 use grandpa::round::State as RoundState;
 use sr_primitives::traits::{Block as BlockT, NumberFor};
 use log::{info, warn};
-use substrate_telemetry::{telemetry, CONSENSUS_INFO};
 use fg_primitives::{AuthorityId, AuthorityWeight, SetId, RoundNumber};
 
 use crate::authorities::{AuthoritySet, SharedAuthoritySet, PendingChange, DelayKind};
@@ -376,17 +375,6 @@ pub(crate) fn update_authority_set<Block: BlockT, F, R>(
 	let encoded_set = set.encode();
 
 	if let Some(new_set) = new_set {
-		telemetry!(CONSENSUS_INFO; "afg.authority_set";
-			"hash" => ?new_set.canon_hash,
-			"number" => ?new_set.canon_number,
-			"authority_set_id" => ?new_set.set_id,
-			"authorities" => {
-				let authorities: Vec<String> =
-					new_set.authorities.iter().map(|(id, _)| format!("{}", id)).collect();
-				format!("{:?}", authorities)
-			}
-		);
-
 		// we also overwrite the "last completed round" entry with a blank slate
 		// because from the perspective of the finality gadget, the chain has
 		// reset.

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -531,7 +531,7 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 				let maybe_authority_id = authority_id(&authorities.current_authorities(), &conf.keystore)
 					.unwrap_or(Default::default());
 				telemetry!(CONSENSUS_INFO; "afg.authority_set";
-					"authority_id" => format!("{}", maybe_authority_id),
+					"authority_id" => maybe_authority_id.to_string(),
 					"authority_set_id" => ?authorities.set_id(),
 					"authorities" => {
 						let curr = authorities.current_authorities();

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -534,10 +534,8 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 					"authority_id" => maybe_authority_id.to_string(),
 					"authority_set_id" => ?authorities.set_id(),
 					"authorities" => {
-						let curr = authorities.current_authorities();
-						let voters = curr.voters();
-						let authorities: Vec<String> =
-							voters.iter().map(|(id, _)| id.to_string()).collect();
+						let authorities: Vec<String> = curr.voters()
+							.iter().map(|(id, _)| id.to_string()).collect();
 						serde_json::to_string(&authorities)
 							.expect("authorities is always at least an empty vector; elements are always of type string")
 					}

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -528,15 +528,15 @@ pub fn run_grandpa_voter<B, E, Block: BlockT<Hash=H256>, N, RA, SC, X>(
 		let events = telemetry_on_connect
 			.for_each(move |_| {
 				telemetry!(CONSENSUS_INFO; "afg.authority_set";
-					 "authority_set_id" => ?authorities.set_id(),
-					 "authorities" => {
+					"authority_set_id" => ?authorities.set_id(),
+					"authorities" => {
 						let curr = authorities.current_authorities();
 						let voters = curr.voters();
 						let authorities: Vec<String> =
 							voters.iter().map(|(id, _)| id.to_string()).collect();
 						serde_json::to_string(&authorities)
 							.expect("authorities is always at least an empty vector; elements are always of type string")
-					 }
+					}
 				);
 				Ok(())
 			})


### PR DESCRIPTION
The authority id was previously sent to telemetry, but removed as part of the [key management refactoring](https://github.com/paritytech/substrate/commit/ed61b1fd98010b85d508bdd17867bf6bfb5cfee7#diff-16b4c34d50bdfcbf732c09c7be1fdcf9L468). It is needed for the consensus visualization.

The corresponding telemetry PR is https://github.com/paritytech/substrate-telemetry/pull/179.