### PR TITLE
fn import_block -> fn block_import_params in SimpleSlotWorker

### DIFF
--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -245,7 +245,7 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 		]
 	}
 
-	fn import_block(&self) -> Box<dyn Fn(
+	fn block_import_params(&self) -> Box<dyn Fn(
 		B::Header,
 		&B::Hash,
 		Vec<B::Extrinsic>,
@@ -541,7 +541,7 @@ impl<B: BlockT, C, P, T> Verifier<B> for AuraVerifier<C, P, T> where
 						_ => None,
 					});
 
-				let import_block = BlockImportParams {
+				let block_import_params = BlockImportParams {
 					origin,
 					header: pre_header,
 					post_digests: vec![seal],
@@ -552,7 +552,7 @@ impl<B: BlockT, C, P, T> Verifier<B> for AuraVerifier<C, P, T> where
 					fork_choice: ForkChoiceStrategy::LongestChain,
 				};
 
-				Ok((import_block, maybe_keys))
+				Ok((block_import_params, maybe_keys))
 			}
 			CheckedHeader::Deferred(a, b) => {
 				debug!(target: "aura", "Checking {:?} failed; {:?}, {:?}.", hash, a, b);

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -324,7 +324,7 @@ impl<H, B, C, E, I, Error, SO> slots::SimpleSlotWorker<B> for BabeWorker<C, E, I
 		]
 	}
 
-	fn import_block(&self) -> Box<dyn Fn(
+	fn block_import_params(&self) -> Box<dyn Fn(
 		B::Header,
 		&B::Hash,
 		Vec<B::Extrinsic>,
@@ -879,7 +879,7 @@ impl<B, E, Block, RA, PRA, T> Verifier<Block> for BabeVerifier<B, E, Block, RA, 
 					}
 				};
 
-				let import_block = BlockImportParams {
+				let block_import_params = BlockImportParams {
 					origin,
 					header: pre_header,
 					post_digests: vec![seal],
@@ -890,7 +890,7 @@ impl<B, E, Block, RA, PRA, T> Verifier<Block> for BabeVerifier<B, E, Block, RA, 
 					fork_choice: ForkChoiceStrategy::Custom(new_best),
 				};
 
-				Ok((import_block, Default::default()))
+				Ok((block_import_params, Default::default()))
 			}
 			CheckedHeader::Deferred(a, b) => {
 				debug!(target: "babe", "Checking {:?} failed; {:?}, {:?}.", hash, a, b);

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -95,7 +95,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	fn pre_digest_data(&self, slot_number: u64, claim: &Self::Claim) -> Vec<sr_primitives::DigestItem<B::Hash>>;
 
 	/// Returns a function which produces a `BlockImportParams`.
-	fn import_block(&self) -> Box<dyn Fn(
+	fn block_import_params(&self) -> Box<dyn Fn(
 		B::Header,
 		&B::Hash,
 		Vec<B::Extrinsic>,
@@ -198,7 +198,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			futures::future::Either::Right((Err(err), _)) => Err(err),
 		});
 
-		let import_block = self.import_block();
+		let block_import_params_maker = self.block_import_params();
 		let block_import = self.block_import();
 		let logging_target = self.logging_target();
 
@@ -223,7 +223,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			let header_hash = header.hash();
 			let parent_hash = header.parent_hash().clone();
 
-			let import_block = import_block(
+			let block_import_params = block_import_params_maker(
 				header,
 				&header_hash,
 				body,
@@ -232,17 +232,17 @@ pub trait SimpleSlotWorker<B: BlockT> {
 
 			info!("Pre-sealed block for proposal at {}. Hash now {:?}, previously {:?}.",
 					header_num,
-					import_block.post_header().hash(),
+					block_import_params.post_header().hash(),
 					header_hash,
 			);
 
 			telemetry!(CONSENSUS_INFO; "slots.pre_sealed_block";
 				"header_num" => ?header_num,
-				"hash_now" => ?import_block.post_header().hash(),
+				"hash_now" => ?block_import_params.post_header().hash(),
 				"hash_previously" => ?header_hash,
 			);
 
-			if let Err(err) = block_import.lock().import_block(import_block, Default::default()) {
+			if let Err(err) = block_import.lock().import_block(block_import_params, Default::default()) {
 				warn!(target: logging_target,
 					"Error with block built on {:?}: {:?}",
 					parent_hash,


### PR DESCRIPTION
#3158 

Rename confusing `import_block` function to `block_import_params`