### PR TITLE
Copy blockchain Info fields into ClientInfo

### DIFF
--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -40,7 +40,7 @@ pub fn build(service: &impl AbstractService) -> impl Future<Item = (), Error = (
 	let client = service.client();
 	let mut last_best = {
 		let info = client.info();
-		Some((info.chain.best_number, info.chain.best_hash))
+		Some((info.best_number, info.best_hash))
 	};
 
 	let display_block_import = client.import_notification_stream().map(|v| Ok::<_, ()>(v)).compat().for_each(move |n| {

--- a/core/cli/src/informant/display.rs
+++ b/core/cli/src/informant/display.rs
@@ -54,8 +54,8 @@ impl<B: BlockT> InformantDisplay<B> {
 
 	/// Displays the informant by calling `info!`.
 	pub fn display(&mut self, info: &ClientInfo<B>, net_status: NetworkStatus<B>) {
-		let best_number = info.chain.best_number;
-		let best_hash = info.chain.best_hash;
+		let best_number = info.best_number;
+		let best_hash = info.best_hash;
 		let speed = speed::<B>(best_number, self.last_number, self.last_update);
 		self.last_update = time::Instant::now();
 		self.last_number = Some(best_number);
@@ -74,8 +74,8 @@ impl<B: BlockT> InformantDisplay<B> {
 			Colour::White.bold().paint(format!("{}", net_status.num_connected_peers)),
 			Colour::White.paint(format!("{}", best_number)),
 			best_hash,
-			Colour::White.paint(format!("{}", info.chain.finalized_number)),
-			info.chain.finalized_hash,
+			Colour::White.paint(format!("{}", info.finalized_number)),
+			info.finalized_hash,
 			TransferRateFormat(net_status.average_download_per_sec),
 			TransferRateFormat(net_status.average_upload_per_sec),
 		);

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -172,7 +172,7 @@ pub struct ClientInfo<Block: BlockT> {
 	/// Genesis block hash.
 	pub genesis_hash: Block::Hash,
 	/// The head of the finalized chain.
-	pub finalied_hash: Block::Hash,
+	pub finalized_hash: Block::Hash,
 	/// Last finalized block number.
 	pub finalized_number: <<Block as BlockT>::Header as HeaderT>::Number,
 	/// State Cache Size currently used by the backend

--- a/core/client/src/light/fetcher.rs
+++ b/core/client/src/light/fetcher.rs
@@ -747,8 +747,8 @@ pub mod tests {
 			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
-		let max = remote_client.info().chain.best_number;
-		let max_hash = remote_client.info().chain.best_hash;
+		let max = remote_client.info().best_number;
+		let max_hash = remote_client.info().best_hash;
 
 		for (index, (begin, end, key, expected_result)) in test_cases.into_iter().enumerate() {
 			let begin_hash = remote_client.block_hash(begin).unwrap().unwrap();
@@ -845,8 +845,8 @@ pub mod tests {
 			NativeExecutor::<test_client::LocalExecutor>::new(None)
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
-		let max = remote_client.info().chain.best_number;
-		let max_hash = remote_client.info().chain.best_hash;
+		let max = remote_client.info().best_number;
+		let max_hash = remote_client.info().best_hash;
 
 		let (begin, end, key, _) = test_cases[0].clone();
 		let begin_hash = remote_client.block_hash(begin).unwrap().unwrap();

--- a/core/consensus/aura/src/lib.rs
+++ b/core/consensus/aura/src/lib.rs
@@ -850,7 +850,7 @@ mod tests {
 	fn authorities_call_works() {
 		let client = test_client::new();
 
-		assert_eq!(client.info().chain.best_number, 0);
+		assert_eq!(client.info().best_number, 0);
 		assert_eq!(authorities(&client, &BlockId::Number(0)).unwrap(), vec![
 			Keyring::Alice.public().into(),
 			Keyring::Bob.public().into(),

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -857,7 +857,7 @@ impl<B, E, Block, RA, PRA, T> Verifier<Block> for BabeVerifier<B, E, Block, RA, 
 				// chain.
 				let new_best = {
 					let (last_best, last_best_number) = {
-						let info = self.client.info().chain;
+						let info = self.client.info();
 						(info.best_hash, info.best_number)
 					};
 

--- a/core/consensus/babe/src/tests.rs
+++ b/core/consensus/babe/src/tests.rs
@@ -362,7 +362,7 @@ fn authorities_call_works() {
 	let _ = env_logger::try_init();
 	let client = test_client::new();
 
-	assert_eq!(client.info().chain.best_number, 0);
+	assert_eq!(client.info().best_number, 0);
 	assert_eq!(epoch(&client, &BlockId::Number(0)).unwrap().into_regular().unwrap().authorities, vec![
 		(Keyring::Alice.public().into(), 1),
 		(Keyring::Bob.public().into(), 1),

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -876,7 +876,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 	//       below.
 	let mut authority_set = authority_set.inner().write();
 
-	let status = client.info().chain;
+	let status = client.info();
 	if number <= status.finalized_number && client.hash(number)? == Some(hash) {
 		// This can happen after a forced change (triggered by the finality tracker when finality is stalled), since
 		// the voter will be restarted at the median last finalized block, which can be lower than the local best
@@ -949,7 +949,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 				// finalization to remote nodes
 				if !justification_required {
 					if let Some(justification_period) = justification_period {
-						let last_finalized_number = client.info().chain.finalized_number;
+						let last_finalized_number = client.info().finalized_number;
 						justification_required =
 							(!last_finalized_number.is_zero() || number - last_finalized_number == justification_period) &&
 							(last_finalized_number / justification_period != number / justification_period);

--- a/core/finality-grandpa/src/import.rs
+++ b/core/finality-grandpa/src/import.rs
@@ -94,7 +94,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, PRA, SC> JustificationImport<Block>
 
 	fn on_start(&mut self) -> Vec<(Block::Hash, NumberFor<Block>)> {
 		let mut out = Vec::new();
-		let chain_info = self.inner.info().chain;
+		let chain_info = self.inner.info();
 
 		// request justifications for all pending changes for which change blocks have already been imported
 		let authorities = self.authority_set.inner().read();
@@ -333,7 +333,7 @@ where
 					// for the canon block the new authority set should start
 					// with. we use the minimum between the median and the local
 					// best finalized block.
-					let best_finalized_number = self.inner.info().chain.finalized_number;
+					let best_finalized_number = self.inner.info().finalized_number;
 					let canon_number = best_finalized_number.min(median_last_finalized_number);
 					let canon_hash =
 						self.inner.header(&BlockId::Number(canon_number))

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -356,7 +356,7 @@ where
 	use sr_primitives::traits::Zero;
 
 	let chain_info = client.info();
-	let genesis_hash = chain_info.chain.genesis_hash;
+	let genesis_hash = chain_info.genesis_hash;
 
 	let persistent_data = aux_schema::load_persistent(
 		&*client,
@@ -451,7 +451,7 @@ fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT<Hash=H25
 			.register_provider(srml_finality_tracker::InherentDataProvider::new(move || {
 				#[allow(deprecated)]
 				{
-					let info = client.info().chain;
+					let info = client.info();
 					telemetry!(CONSENSUS_INFO; "afg.finalized";
 						"finalized_number" => ?info.finalized_number,
 						"finalized_hash" => ?info.finalized_hash,
@@ -637,8 +637,8 @@ where
 				let chain_info = self.env.inner.info();
 
 				let last_finalized = (
-					chain_info.chain.finalized_hash,
-					chain_info.chain.finalized_number,
+					chain_info.finalized_hash,
+					chain_info.finalized_number,
 				);
 
 				let global_comms = global_communication(

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -66,7 +66,7 @@ pub fn light_block_import<B, E, Block: BlockT<Hash=H256>, RA, PRA>(
 		PRA::Api: GrandpaApi<Block>,
 {
 	let info = client.info();
-	let import_data = load_aux_import_data(info.chain.finalized_hash, &*client, api)?;
+	let import_data = load_aux_import_data(info.finalized_hash, &*client, api)?;
 	Ok(GrandpaLightBlockImport {
 		client,
 		backend,
@@ -160,7 +160,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA> FinalityProofImport<Block>
 
 	fn on_start(&mut self) -> Vec<(Block::Hash, NumberFor<Block>)> {
 		let mut out = Vec::new();
-		let chain_info = self.client.info().chain;
+		let chain_info = self.client.info();
 
 		let data = self.data.read();
 		for (pending_number, pending_hash) in data.consensus_changes.pending_changes() {
@@ -653,7 +653,7 @@ pub mod tests {
 			origin: BlockOrigin::Own,
 			header: Header {
 				number: 1,
-				parent_hash: client.info().chain.best_hash,
+				parent_hash: client.info().best_hash,
 				state_root: Default::default(),
 				digest: Default::default(),
 				extrinsics_root: Default::default(),

--- a/core/finality-grandpa/src/observer.rs
+++ b/core/finality-grandpa/src/observer.rs
@@ -257,7 +257,7 @@ where
 			&self.keystore,
 		);
 
-		let last_finalized_number = self.client.info().chain.finalized_number;
+		let last_finalized_number = self.client.info().finalized_number;
 
 		// NOTE: since we are not using `round_communication` we have to
 		// manually note the round with the gossip validator, otherwise we won't

--- a/core/finality-grandpa/src/tests.rs
+++ b/core/finality-grandpa/src/tests.rs
@@ -460,7 +460,7 @@ fn finalize_3_voters_no_observers() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..3 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 20,
+		assert_eq!(net.peer(i).client().info().best_number, 20,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -583,7 +583,7 @@ fn transition_3_voters_twice_1_full_observer() {
 
 	for (i, peer) in net.lock().peers().iter().enumerate() {
 		let full_client = peer.client().as_full().expect("only full clients are used in test");
-		assert_eq!(full_client.info().chain.best_number, 1,
+		assert_eq!(full_client.info().best_number, 1,
 					"Peer #{} failed to sync", i);
 
 		let set: AuthoritySet<Hash, BlockNumber> = crate::aux_schema::load_authorities(&*full_client).unwrap();
@@ -799,7 +799,7 @@ fn sync_justifications_on_change_blocks() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..4 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 25,
+		assert_eq!(net.peer(i).client().info().best_number, 25,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -876,7 +876,7 @@ fn finalizes_multiple_pending_changes_in_order() {
 
 	// all peers imported both change blocks
 	for i in 0..6 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 30,
+		assert_eq!(net.peer(i).client().info().best_number, 30,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -897,7 +897,7 @@ fn doesnt_vote_on_the_tip_of_the_chain() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..3 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 100,
+		assert_eq!(net.peer(i).client().info().best_number, 100,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -933,7 +933,7 @@ fn force_change_to_new_set() {
 
 	{
 		// add a forced transition at block 12.
-		let parent_hash = net.lock().peer(0).client().info().chain.best_hash;
+		let parent_hash = net.lock().peer(0).client().info().best_hash;
 		forced_transitions.lock().insert(parent_hash, (0, ScheduledChange {
 			next_authorities: voters.clone(),
 			delay: 10,
@@ -950,7 +950,7 @@ fn force_change_to_new_set() {
 	net.lock().block_until_sync(&mut runtime);
 
 	for (i, peer) in net.lock().peers().iter().enumerate() {
-		assert_eq!(peer.client().info().chain.best_number, 26,
+		assert_eq!(peer.client().info().best_number, 26,
 				"Peer #{} failed to sync", i);
 
 		let full_client = peer.client().as_full().expect("only full clients are used in test");
@@ -1086,7 +1086,7 @@ fn voter_persists_its_votes() {
 	net.peer(0).push_blocks(20, false);
 	net.block_until_sync(&mut runtime);
 
-	assert_eq!(net.peer(0).client().info().chain.best_number, 20,
+	assert_eq!(net.peer(0).client().info().best_number, 20,
 			   "Peer #{} failed to sync", 0);
 
 
@@ -1246,7 +1246,7 @@ fn voter_persists_its_votes() {
 				let round_tx = round_tx.clone();
 				future::Either::A(tokio_timer::Interval::new_interval(Duration::from_millis(200))
 					.take_while(move |_| {
-						Ok(net2.lock().peer(1).client().info().chain.best_number != 40)
+						Ok(net2.lock().peer(1).client().info().best_number != 40)
 					})
 					.for_each(|_| Ok(()))
 					.and_then(move |_| {
@@ -1322,7 +1322,7 @@ fn finalize_3_voters_1_light_observer() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..4 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 20,
+		assert_eq!(net.peer(i).client().info().best_number, 20,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -1371,7 +1371,7 @@ fn finality_proof_is_fetched_by_light_client_when_consensus_data_changes() {
 
 	// check that the block#1 is finalized on light client
 	runtime.block_on(futures::future::poll_fn(move || -> std::result::Result<_, ()> {
-		if net.lock().peer(1).client().info().chain.finalized_number == 1 {
+		if net.lock().peer(1).client().info().finalized_number == 1 {
 			Ok(Async::Ready(()))
 		} else {
 			net.lock().poll();
@@ -1416,7 +1416,7 @@ fn empty_finality_proof_is_returned_to_light_client_when_authority_set_is_differ
 
 	// add a forced transition at block 5.
 	if FORCE_CHANGE {
-		let parent_hash = net.lock().peer(0).client().info().chain.best_hash;
+		let parent_hash = net.lock().peer(0).client().info().best_hash;
 		forced_transitions.lock().insert(parent_hash, (0, ScheduledChange {
 			next_authorities: voters.clone(),
 			delay: 3,
@@ -1441,7 +1441,7 @@ fn empty_finality_proof_is_returned_to_light_client_when_authority_set_is_differ
 
 	// check block, finalized on light client
 	assert_eq!(
-		net.lock().peer(3).client().info().chain.finalized_number,
+		net.lock().peer(3).client().info().finalized_number,
 		if FORCE_CHANGE { 0 } else { 10 },
 	);
 }

--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -382,7 +382,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				chain,
 			},
 			light_dispatch: LightDispatch::new(checker),
-			genesis_hash: info.chain.genesis_hash,
+			genesis_hash: info.genesis_hash,
 			sync,
 			specialization: specialization,
 			consensus_gossip: ConsensusGossip::new(),
@@ -883,7 +883,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 					.context_data
 					.chain
 					.info()
-					.chain.best_number;
+					.best_number;
 				let blocks_difference = self_best_block
 					.checked_sub(&status.best_number)
 					.unwrap_or_else(Zero::zero)
@@ -1028,7 +1028,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			return;
 		}
 
-		let is_best = self.context_data.chain.info().chain.best_hash == hash;
+		let is_best = self.context_data.chain.info().best_hash == hash;
 		debug!(target: "sync", "Reannouncing block {:?}", hash);
 		self.send_announcement(&header, is_best, true)
 	}
@@ -1064,10 +1064,10 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		let status = message::generic::Status {
 			version: CURRENT_VERSION,
 			min_supported_version: MIN_VERSION,
-			genesis_hash: info.chain.genesis_hash,
+			genesis_hash: info.genesis_hash,
 			roles: self.config.roles.into(),
-			best_number: info.chain.best_number,
-			best_hash: info.chain.best_hash,
+			best_number: info.best_number,
+			best_hash: info.best_hash,
 			chain_status: self.specialization.status(),
 		};
 

--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -283,8 +283,8 @@ impl<B: BlockT> ChainSync<B> {
 			client,
 			peers: HashMap::new(),
 			blocks: BlockCollection::new(),
-			best_queued_hash: info.chain.best_hash,
-			best_queued_number: info.chain.best_number,
+			best_queued_hash: info.best_hash,
+			best_queued_number: info.best_number,
 			extra_finality_proofs: ExtraRequests::new(),
 			extra_justifications: ExtraRequests::new(),
 			role,
@@ -1016,8 +1016,8 @@ impl<B: BlockT> ChainSync<B> {
 		self.best_importing_number = Zero::zero();
 		self.blocks.clear();
 		let info = self.client.info();
-		self.best_queued_hash = info.chain.best_hash;
-		self.best_queued_number = info.chain.best_number;
+		self.best_queued_hash = info.best_hash;
+		self.best_queued_number = info.best_number;
 		self.is_idle = false;
 		debug!(target:"sync", "Restarted with {} ({})", self.best_queued_number, self.best_queued_hash);
 		let old_peers = std::mem::replace(&mut self.peers, HashMap::new());

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -260,7 +260,7 @@ impl<D, S: NetworkSpecialization<Block>> Peer<D, S> {
 	pub fn generate_blocks<F>(&mut self, count: usize, origin: BlockOrigin, edit_block: F) -> H256
 		where F: FnMut(BlockBuilder<Block, PeersFullClient>) -> Block
 	{
-		let best_hash = self.client.info().chain.best_hash;
+		let best_hash = self.client.info().best_hash;
 		self.generate_blocks_at(BlockId::Hash(best_hash), count, origin, edit_block)
 	}
 
@@ -310,7 +310,7 @@ impl<D, S: NetworkSpecialization<Block>> Peer<D, S> {
 
 	/// Push blocks to the peer (simplified: with or without a TX)
 	pub fn push_blocks(&mut self, count: usize, with_tx: bool) -> H256 {
-		let best_hash = self.client.info().chain.best_hash;
+		let best_hash = self.client.info().best_hash;
 		self.push_blocks_at(BlockId::Hash(best_hash), count, with_tx)
 	}
 
@@ -638,7 +638,7 @@ pub trait TestNetFactory: Sized {
 			if peer.is_major_syncing() || peer.network.num_queued_blocks() != 0 {
 				return Async::NotReady
 			}
-			match (highest, peer.client.info().chain.best_number) {
+			match (highest, peer.client.info().best_number) {
 				(None, b) => highest = Some(b),
 				(Some(ref a), ref b) if a == b => {},
 				(Some(_), _) => return Async::NotReady,

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -367,8 +367,8 @@ fn own_blocks_are_announced() {
 
 	net.block_until_sync(&mut runtime);
 
-	assert_eq!(net.peer(0).client.info().chain.best_number, 1);
-	assert_eq!(net.peer(1).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(0).client.info().best_number, 1);
+	assert_eq!(net.peer(1).client.info().best_number, 1);
 	let peer0 = &net.peers()[0];
 	assert!(net.peers()[1].blockchain_canon_equals(peer0));
 	(net.peers()[2].blockchain_canon_equals(peer0));
@@ -389,9 +389,9 @@ fn blocks_are_not_announced_by_light_nodes() {
 
 	// Sync between 0 and 1.
 	net.peer(0).push_blocks(1, false);
-	assert_eq!(net.peer(0).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(0).client.info().best_number, 1);
 	net.block_until_sync(&mut runtime);
-	assert_eq!(net.peer(1).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(1).client.info().best_number, 1);
 
 	// Add another node and remove node 0.
 	net.add_full_peer(&ProtocolConfig::default());
@@ -403,7 +403,7 @@ fn blocks_are_not_announced_by_light_nodes() {
 		net.poll();
 		delay.poll().map_err(|_| ())
 	})).unwrap();
-	assert_eq!(net.peer(1).client.info().chain.best_number, 0);
+	assert_eq!(net.peer(1).client.info().best_number, 0);
 }
 
 #[test]
@@ -416,13 +416,13 @@ fn can_sync_small_non_best_forks() {
 
 	// small fork + reorg on peer 1.
 	net.peer(0).push_blocks_at(BlockId::Number(30), 2, true);
-	let small_hash = net.peer(0).client().info().chain.best_hash;
+	let small_hash = net.peer(0).client().info().best_hash;
 	net.peer(0).push_blocks_at(BlockId::Number(30), 10, false);
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	// peer 1 only ever had the long fork.
 	net.peer(1).push_blocks(10, false);
-	assert_eq!(net.peer(1).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(1).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_none());
@@ -439,7 +439,7 @@ fn can_sync_small_non_best_forks() {
 
 	// synchronization: 0 synced to longer chain and 1 didn't sync to small chain.
 
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(!net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
@@ -475,8 +475,8 @@ fn can_not_sync_from_light_peer() {
 	net.block_until_sync(&mut runtime);
 
 	// ensure #0 && #1 have the same best block
-	let full0_info = net.peer(0).client.info().chain;
-	let light_info = net.peer(1).client.info().chain;
+	let full0_info = net.peer(0).client.info();
+	let light_info = net.peer(1).client.info();
 	assert_eq!(full0_info.best_number, 1);
 	assert_eq!(light_info.best_number, 1);
 	assert_eq!(light_info.best_hash, full0_info.best_hash);

--- a/core/rpc/src/author/mod.rs
+++ b/core/rpc/src/author/mod.rs
@@ -101,7 +101,7 @@ impl<B, E, P, RA> AuthorApi<ExHash<P>, BlockHash<P>> for Author<B, E, P, RA> whe
 	}
 
 	fn rotate_keys(&self) -> Result<Bytes> {
-		let best_block_hash = self.client.info().chain.best_hash;
+		let best_block_hash = self.client.info().best_hash;
 		self.client.runtime_api().generate_session_keys(
 			&generic::BlockId::Hash(best_block_hash),
 			None,
@@ -110,7 +110,7 @@ impl<B, E, P, RA> AuthorApi<ExHash<P>, BlockHash<P>> for Author<B, E, P, RA> whe
 
 	fn submit_extrinsic(&self, ext: Bytes) -> Result<ExHash<P>> {
 		let xt = Decode::decode(&mut &ext[..])?;
-		let best_block_hash = self.client.info().chain.best_hash;
+		let best_block_hash = self.client.info().best_hash;
 		self.pool
 			.submit_one(&generic::BlockId::hash(best_block_hash), xt)
 			.map_err(|e| e.into_pool_error()
@@ -150,7 +150,7 @@ impl<B, E, P, RA> AuthorApi<ExHash<P>, BlockHash<P>> for Author<B, E, P, RA> whe
 		xt: Bytes
 	) {
 		let submit = || -> Result<_> {
-			let best_block_hash = self.client.info().chain.best_hash;
+			let best_block_hash = self.client.info().best_hash;
 			let dxt = <<P as PoolChainApi>::Block as traits::Block>::Extrinsic::decode(&mut &xt[..])?;
 			self.pool
 				.submit_and_watch(&generic::BlockId::hash(best_block_hash), dxt)

--- a/core/rpc/src/chain/mod.rs
+++ b/core/rpc/src/chain/mod.rs
@@ -63,7 +63,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 	/// Tries to unwrap passed block hash, or uses best block hash otherwise.
 	fn unwrap_or_best(&self, hash: Option<Block::Hash>) -> Block::Hash {
 		match hash.into() {
-			None => self.client().info().chain.best_hash,
+			None => self.client().info().best_hash,
 			Some(hash) => hash,
 		}
 	}
@@ -82,7 +82,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 		number: Option<number::NumberOrHex<NumberFor<Block>>>,
 	) -> Result<Option<Block::Hash>> {
 		Ok(match number {
-			None => Some(self.client().info().chain.best_hash),
+			None => Some(self.client().info().best_hash),
 			Some(num_or_hex) => self.client()
 				.header(&BlockId::number(num_or_hex.to_number()?))
 				.map_err(client_err)?
@@ -92,7 +92,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 
 	/// Get hash of the last finalized block in the canon chain.
 	fn finalized_head(&self) -> Result<Block::Hash> {
-		Ok(self.client().info().chain.finalized_hash)
+		Ok(self.client().info().finalized_hash)
 	}
 
 	/// New head subscription
@@ -105,7 +105,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 			self.client(),
 			self.subscriptions(),
 			subscriber,
-			|| self.client().info().chain.best_hash,
+			|| self.client().info().best_hash,
 			|| self.client().import_notification_stream()
 				.filter(|notification| future::ready(notification.is_new_best))
 				.map(|notification| Ok::<_, ()>(notification.header))
@@ -132,7 +132,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 			self.client(),
 			self.subscriptions(),
 			subscriber,
-			|| self.client().info().chain.finalized_hash,
+			|| self.client().info().finalized_hash,
 			|| self.client().finality_notification_stream()
 				.map(|notification| Ok::<_, ()>(notification.header))
 				.compat(),

--- a/core/rpc/src/state/mod.rs
+++ b/core/rpc/src/state/mod.rs
@@ -185,7 +185,7 @@ pub trait StateBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 				.filter_map(move |_| {
 					let info = client.info();
 					let version = client
-						.runtime_version_at(&BlockId::hash(info.chain.best_hash))
+						.runtime_version_at(&BlockId::hash(info.best_hash))
 						.map_err(client_err)
 						.map_err(Into::into);
 					if previous_version != version {
@@ -239,7 +239,7 @@ pub trait StateBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 		// initial values
 		let initial = stream::iter_result(keys
 			.map(|keys| {
-				let block = self.client().info().chain.best_hash;
+				let block = self.client().info().best_hash;
 				let changes = keys
 					.into_iter()
 					.map(|key| self.storage(Some(block.clone()).into(), key.clone())

--- a/core/rpc/src/state/state_full.rs
+++ b/core/rpc/src/state/state_full.rs
@@ -71,7 +71,7 @@ impl<B, E, Block: BlockT, RA> FullState<B, E, Block, RA>
 
 	/// Returns given block hash or best block hash if None is passed.
 	fn block_or_best(&self, hash: Option<Block::Hash>) -> ClientResult<Block::Hash> {
-		crate::helpers::unwrap_or_else(|| Ok(self.client.info().chain.best_hash), hash)
+		crate::helpers::unwrap_or_else(|| Ok(self.client.info().best_hash), hash)
 	}
 
 	/// Splits the `query_storage` block range into 'filtered' and 'unfiltered' subranges.

--- a/core/rpc/src/state/state_light.rs
+++ b/core/rpc/src/state/state_light.rs
@@ -73,7 +73,7 @@ impl<Block: BlockT, F: Fetcher<Block> + 'static, B, E, RA> LightState<Block, F, 
 
 	/// Returns given block hash or best block hash if None is passed.
 	fn block_or_best(&self, hash: Option<Block::Hash>) -> Block::Hash {
-		hash.unwrap_or_else(|| self.client.info().chain.best_hash)
+		hash.unwrap_or_else(|| self.client.info().best_hash)
 	}
 
 	/// Resolve header by hash.

--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -28,7 +28,7 @@ macro_rules! export_blocks {
 	let last = match $to {
 		Some(v) if v.is_zero() => One::one(),
 		Some(v) => v,
-		None => $client.info().chain.best_number,
+		None => $client.info().best_number,
 	};
 
 	if last < block {
@@ -194,7 +194,7 @@ macro_rules! import_blocks {
 			);
 		}
 		if link.imported_blocks >= count {
-			info!("Imported {} blocks. Best: #{}", block_count, $client.info().chain.best_number);
+			info!("Imported {} blocks. Best: #{}", block_count, $client.info().best_number);
 			Ok(Async::Ready(()))
 		} else {
 			Ok(Async::NotReady)
@@ -207,7 +207,7 @@ macro_rules! import_blocks {
 macro_rules! revert_chain {
 ($client:ident, $blocks:ident) => {{
 	let reverted = $client.revert($blocks)?;
-	let info = $client.info().chain;
+	let info = $client.info();
 
 	if reverted.is_zero() {
 		info!("There aren't any non-finalized blocks to revert.");

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -160,7 +160,7 @@ macro_rules! new_impl {
 			dht_event_tx,
 		) = $build_components(&$config)?;
 		let import_queue = Box::new(import_queue);
-		let chain_info = client.info().chain;
+		let chain_info = client.info();
 
 		let version = $config.full_version();
 		info!("Highest known block at #{}", chain_info.best_number);
@@ -295,11 +295,11 @@ macro_rules! new_impl {
 		network_status_sinks.lock().push(netstat_tx);
 		let tel_task = netstat_rx.for_each(move |(net_status, network_state)| {
 			let info = client_.info();
-			let best_number = info.chain.best_number.saturated_into::<u64>();
-			let best_hash = info.chain.best_hash;
+			let best_number = info.best_number.saturated_into::<u64>();
+			let best_hash = info.best_hash;
 			let num_peers = net_status.num_connected_peers;
 			let txpool_status = transaction_pool_.status();
-			let finalized_number: u64 = info.chain.finalized_number.saturated_into::<u64>();
+			let finalized_number: u64 = info.finalized_number.saturated_into::<u64>();
 			let bandwidth_download = net_status.average_download_per_sec;
 			let bandwidth_upload = net_status.average_upload_per_sec;
 
@@ -328,7 +328,7 @@ macro_rules! new_impl {
 				"cpu" => cpu_usage,
 				"memory" => memory,
 				"finalized_height" => finalized_number,
-				"finalized_hash" => ?info.chain.finalized_hash,
+				"finalized_hash" => ?info.finalized_hash,
 				"bandwidth_download" => bandwidth_download,
 				"bandwidth_upload" => bandwidth_upload,
 				"used_state_cache_size" => used_state_cache_size,
@@ -919,7 +919,7 @@ where
 		let encoded = transaction.encode();
 		match Decode::decode(&mut &encoded[..]) {
 			Ok(uxt) => {
-				let best_block_id = BlockId::hash(self.client.info().chain.best_hash);
+				let best_block_id = BlockId::hash(self.client.info().best_hash);
 				match self.pool.submit_one(&best_block_id, uxt) {
 					Ok(hash) => Some(hash),
 					Err(e) => match e.into_pool_error() {

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -414,15 +414,15 @@ pub fn sync<G, Fb, F, Lb, L, B, E, U>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.best_number == (NUM_BLOCKS as u32).into(),
+			service.get().client().info().best_number == (NUM_BLOCKS as u32).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number == (NUM_BLOCKS as u32).into(),
+			service.get().client().info().best_number == (NUM_BLOCKS as u32).into(),
 	);
 
 	info!("Checking extrinsic propagation");
 	let first_service = network.full_nodes[0].1.clone();
 	let first_user_data = &network.full_nodes[0].2;
-	let best_block = BlockId::number(first_service.get().client().info().chain.best_number);
+	let best_block = BlockId::number(first_service.get().client().info().best_number);
 	let extrinsic = extrinsic_factory(&first_service.get(), first_user_data);
 	first_service.get().transaction_pool().submit_one(&best_block, extrinsic).unwrap();
 	network.run_until_all_full(
@@ -468,9 +468,9 @@ pub fn consensus<G, Fb, F, Lb, L>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.finalized_number >= (NUM_BLOCKS as u32 / 2).into(),
+			service.get().client().info().finalized_number >= (NUM_BLOCKS as u32 / 2).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number >= (NUM_BLOCKS as u32 / 2).into(),
+			service.get().client().info().best_number >= (NUM_BLOCKS as u32 / 2).into(),
 	);
 
 	info!("Adding more peers");
@@ -490,8 +490,8 @@ pub fn consensus<G, Fb, F, Lb, L>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.finalized_number >= (NUM_BLOCKS as u32).into(),
+			service.get().client().info().finalized_number >= (NUM_BLOCKS as u32).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number >= (NUM_BLOCKS as u32).into(),
+			service.get().client().info().best_number >= (NUM_BLOCKS as u32).into(),
 	);
 }

--- a/core/session/src/lib.rs
+++ b/core/session/src/lib.rs
@@ -53,7 +53,7 @@ where
 	client::Client<B, E, Block, RA>: ProvideRuntimeApi,
 	<client::Client<B, E, Block, RA> as ProvideRuntimeApi>::Api: SessionKeys<Block>,
 {
-	let info = client.info().chain;
+	let info = client.info();
 	let runtime_api = client.runtime_api();
 
 	for seed in seeds {

--- a/core/sr-api-macros/benches/bench.rs
+++ b/core/sr-api-macros/benches/bench.rs
@@ -26,14 +26,14 @@ fn sr_api_benchmark(c: &mut Criterion) {
 	c.bench_function("add one with same runtime api", |b| {
 		let client = test_client::new();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		b.iter(|| runtime_api.benchmark_add_one(&block_id, &1))
 	});
 
 	c.bench_function("add one with recreating runtime api", |b| {
 		let client = test_client::new();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		b.iter(|| client.runtime_api().benchmark_add_one(&block_id, &1))
 	});
@@ -41,7 +41,7 @@ fn sr_api_benchmark(c: &mut Criterion) {
 	c.bench_function("vector add one with same runtime api", |b| {
 		let client = test_client::new();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 		let data = vec![0; 1000];
 
 		b.iter_with_large_drop(|| runtime_api.benchmark_vector_add_one(&block_id, &data))
@@ -49,7 +49,7 @@ fn sr_api_benchmark(c: &mut Criterion) {
 
 	c.bench_function("vector add one with recreating runtime api", |b| {
 		let client = test_client::new();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 		let data = vec![0; 1000];
 
 		b.iter_with_large_drop(|| client.runtime_api().benchmark_vector_add_one(&block_id, &data))
@@ -57,13 +57,13 @@ fn sr_api_benchmark(c: &mut Criterion) {
 
 	c.bench_function("calling function by function pointer in wasm", |b| {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 		b.iter(|| client.runtime_api().benchmark_indirect_call(&block_id).unwrap())
 	});
 
 	c.bench_function("calling function in wasm", |b| {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 		b.iter(|| client.runtime_api().benchmark_direct_call(&block_id).unwrap())
 	});
 }

--- a/core/sr-api-macros/tests/runtime_calls.rs
+++ b/core/sr-api-macros/tests/runtime_calls.rs
@@ -34,7 +34,7 @@ use codec::Encode;
 fn calling_function_with_strat(strat: ExecutionStrategy) {
 	let client = TestClientBuilder::new().set_execution_strategy(strat).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 
 	assert_eq!(runtime_api.benchmark_add_one(&block_id, &1).unwrap(), 2);
 }
@@ -54,7 +54,7 @@ fn calling_wasm_runtime_function() {
 fn calling_native_runtime_function_with_non_decodable_parameter() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	runtime_api.fail_convert_parameter(&block_id, DecodeFails::new()).unwrap();
 }
 
@@ -63,7 +63,7 @@ fn calling_native_runtime_function_with_non_decodable_parameter() {
 fn calling_native_runtime_function_with_non_decodable_return_value() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	runtime_api.fail_convert_return_value(&block_id).unwrap();
 }
 
@@ -71,7 +71,7 @@ fn calling_native_runtime_function_with_non_decodable_return_value() {
 fn calling_native_runtime_signature_changed_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 
 	assert_eq!(runtime_api.function_signature_changed(&block_id).unwrap(), 1);
 }
@@ -80,7 +80,7 @@ fn calling_native_runtime_signature_changed_function() {
 fn calling_wasm_runtime_signature_changed_old_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 
 	#[allow(deprecated)]
 	let res = runtime_api.function_signature_changed_before_version_2(&block_id).unwrap();
@@ -91,7 +91,7 @@ fn calling_wasm_runtime_signature_changed_old_function() {
 fn calling_with_both_strategy_and_fail_on_wasm_should_return_error() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert!(runtime_api.fail_on_wasm(&block_id).is_err());
 }
 
@@ -99,7 +99,7 @@ fn calling_with_both_strategy_and_fail_on_wasm_should_return_error() {
 fn calling_with_both_strategy_and_fail_on_native_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.fail_on_native(&block_id).unwrap(), 1);
 }
 
@@ -108,7 +108,7 @@ fn calling_with_both_strategy_and_fail_on_native_should_work() {
 fn calling_with_native_else_wasm_and_fail_on_wasm_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeElseWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.fail_on_wasm(&block_id).unwrap(), 1);
 }
 
@@ -116,7 +116,7 @@ fn calling_with_native_else_wasm_and_fail_on_wasm_should_work() {
 fn calling_with_native_else_wasm_and_fail_on_native_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeElseWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.fail_on_native(&block_id).unwrap(), 1);
 }
 
@@ -124,7 +124,7 @@ fn calling_with_native_else_wasm_and_fail_on_native_should_work() {
 fn use_trie_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.use_trie(&block_id).unwrap(), 2);
 }
 
@@ -132,7 +132,7 @@ fn use_trie_function() {
 fn initialize_block_works() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.get_block_number(&block_id).unwrap(), 1);
 }
 
@@ -140,7 +140,7 @@ fn initialize_block_works() {
 fn initialize_block_is_called_only_once() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert_eq!(runtime_api.take_block_number(&block_id).unwrap(), Some(1));
 	assert_eq!(runtime_api.take_block_number(&block_id).unwrap(), None);
 }
@@ -149,7 +149,7 @@ fn initialize_block_is_called_only_once() {
 fn initialize_block_is_skipped() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	assert!(runtime_api.without_initialize_block(&block_id).unwrap());
 }
 
@@ -159,7 +159,7 @@ fn record_proof_works() {
 		.set_execution_strategy(ExecutionStrategy::Both)
 		.build_with_longest_chain();
 
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.info().best_number);
 	let storage_root = longest_chain.best_chain().unwrap().state_root().clone();
 
 	let transaction = Transfer {

--- a/core/test-runtime/client/src/trait_tests.rs
+++ b/core/test-runtime/client/src/trait_tests.rs
@@ -44,7 +44,7 @@ pub fn test_leaves_for_backend<B: 'static>(backend: Arc<B>) where
 	let client = TestClientBuilder::with_backend(backend.clone()).build();
 	let blockchain = backend.blockchain();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.info().genesis_hash;
 
 	assert_eq!(
 		blockchain.leaves().unwrap(),
@@ -224,7 +224,7 @@ pub fn test_children_for_backend<B: 'static>(backend: Arc<B>) where
 	let d2 = builder.bake().unwrap();
 	client.import(BlockOrigin::Own, d2.clone()).unwrap();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.info().genesis_hash;
 
 	let children1 = blockchain.children(a4.hash()).unwrap();
 	assert_eq!(vec![a5.hash()], children1);
@@ -314,7 +314,7 @@ pub fn test_blockchain_query_by_number_gets_canonical<B: 'static>(backend: Arc<B
 	let d2 = builder.bake().unwrap();
 	client.import(BlockOrigin::Own, d2.clone()).unwrap();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.info().genesis_hash;
 
 	assert_eq!(blockchain.header(BlockId::Number(0)).unwrap().unwrap().hash(), genesis_hash);
 	assert_eq!(blockchain.hash(0).unwrap().unwrap(), genesis_hash);

--- a/core/test-runtime/src/lib.rs
+++ b/core/test-runtime/src/lib.rs
@@ -961,7 +961,7 @@ mod tests {
 	fn returns_mutable_static() {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		let ret = runtime_api.returns_mutable_static(&block_id).unwrap();
 		assert_eq!(ret, 33);
@@ -992,7 +992,7 @@ mod tests {
 			.set_heap_pages(REQUIRED_MEMORY_PAGES)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		// On the first invocation we allocate approx. 768KB (75%) of stack and then trap.
 		let ret = runtime_api.allocates_huge_stack_array(&block_id, true);
@@ -1013,7 +1013,7 @@ mod tests {
 			.set_heap_pages(8)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		// Try to allocate 1024k of memory on heap. This is going to fail since it is twice larger
 		// than the heap.
@@ -1042,7 +1042,7 @@ mod tests {
 			.set_execution_strategy(ExecutionStrategy::Both)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.info().best_number);
 
 		runtime_api.test_storage(&block_id).unwrap();
 	}

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -316,7 +316,7 @@ mod tests {
 		let keys: Vec<&ed25519::Pair> = vec![&*alice, &*bob];
 		let dummy_runtime = ::tokio::runtime::Runtime::new().unwrap();
 		let block_factory = |service: &<Factory as service::ServiceFactory>::FullService| {
-			let block_id = BlockId::number(service.client().info().chain.best_number);
+			let block_id = BlockId::number(service.client().info().best_number);
 			let parent_header = service.client().header(&block_id).unwrap().unwrap();
 			let consensus_net = ConsensusNetwork::new(service.network(), service.client().clone());
 			let proposer_factory = consensus::ProposerFactory {
@@ -394,7 +394,7 @@ mod tests {
 					.expect("Creates inherent data.");
 				inherent_data.replace_data(finality_tracker::INHERENT_IDENTIFIER, &1u64);
 
-				let parent_id = BlockId::number(service.client().info().chain.best_number);
+				let parent_id = BlockId::number(service.client().info().best_number);
 				let parent_header = service.client().header(&parent_id).unwrap().unwrap();
 				let mut proposer_factory = substrate_basic_authorship::ProposerFactory {
 					client: service.client(),
@@ -456,7 +456,7 @@ mod tests {
 				let to = AddressPublic::from_raw(bob.public().0);
 				let from = AddressPublic::from_raw(charlie.public().0);
 				let genesis_hash = service.client().block_hash(0).unwrap().unwrap();
-				let best_block_id = BlockId::number(service.client().info().chain.best_number);
+				let best_block_id = BlockId::number(service.client().info().best_number);
 				let version = service.client().runtime_version_at(&best_block_id).unwrap().spec_version;
 				let signer = charlie.clone();
 


### PR DESCRIPTION
Related to #1440. This cleans a lot of code up by removing the redundant `.chain` accesses. Currently I'm just coping the fields off the `Info` struct. It might be cleaner for `HeaderBackend::info` to return a `ClientInfo` and just set `used_state_cache_size` to `None` until it can be set by the backend.