### PR TITLE
find best_containing even if best chain is shorter

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1704,10 +1704,10 @@ where
 
 			let info = self.backend.blockchain().info();
 
-			let canon_hash = self.backend.blockchain().hash(*target_header.number())?
-				.ok_or_else(|| error::Error::from(format!("failed to get hash for block number {}", target_header.number())))?;
+			// this can be `None` if the best chain is shorter than the target header.
+			let maybe_canon_hash = self.backend.blockchain().hash(*target_header.number())?;
 
-			if canon_hash == target_hash {
+			if maybe_canon_hash.as_ref() == Some(&target_hash) {
 				// if a `max_number` is given we try to fetch the block at the
 				// given depth, if it doesn't exist or `max_number` is not
 				// provided, we continue to search from all leaves below.


### PR DESCRIPTION
the code as currently written assumes that the canonical chain has a block with the number of the requested block, which isn't guaranteed in all fork-choice rules.