### PR TITLE
Add a InherentDataProviderError trait for inherents error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,6 +5039,7 @@ dependencies = [
  "substrate-client 2.0.0",
  "substrate-consensus-babe-primitives 2.0.0",
  "substrate-consensus-common 2.0.0",
+ "substrate-inherents 2.0.0",
  "substrate-keyring 2.0.0",
  "substrate-peerset 2.0.0",
  "substrate-primitives 2.0.0",

--- a/core/consensus/babe/src/tests.rs
+++ b/core/consensus/babe/src/tests.rs
@@ -34,6 +34,7 @@ use client::BlockchainEvents;
 use test_client;
 use log::debug;
 use std::{time::Duration, borrow::Borrow, cell::RefCell};
+use inherents::InherentError;
 
 type Item = DigestItem<Hash>;
 
@@ -109,7 +110,7 @@ impl Verifier<TestBlock> for TestVerifier {
 		mut header: TestHeader,
 		justification: Option<Justification>,
 		body: Option<Vec<TestExtrinsic>>,
-	) -> Result<(BlockImportParams<TestBlock>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<TestBlock>, Option<Vec<(CacheKeyId, Vec<u8>)>>), InherentError> {
 		let cb: &(dyn Fn(&mut TestHeader) + Send + Sync) = self.mutator.borrow();
 		cb(&mut header);
 		Ok(self.inner.verify(origin, header, justification, body).expect("verification failed!"))

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -32,6 +32,7 @@ use crate::block_import::{
 	BlockImport, BlockOrigin, BlockImportParams, ImportedAux, JustificationImport, ImportResult,
 	FinalityProofImport,
 };
+use inherents::InherentError;
 
 pub use basic_queue::BasicQueue;
 
@@ -79,7 +80,7 @@ pub trait Verifier<B: BlockT>: Send + Sync {
 		header: B::Header,
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>,
-	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String>;
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), InherentError>;
 }
 
 /// Blocks import queue API.
@@ -229,7 +230,8 @@ pub fn import_single_block<B: BlockT, V: Verifier<B>>(
 			} else {
 				trace!(target: "sync", "Verifying {}({}) failed: {}", number, hash, msg);
 			}
-			BlockImportError::VerificationFailed(peer.clone(), msg)
+			// TODO: remove this `.to_string()` call
+			BlockImportError::VerificationFailed(peer.clone(), msg.to_string())
 		})?;
 
 	let mut cache = HashMap::new();

--- a/core/finality-grandpa/src/light_import.rs
+++ b/core/finality-grandpa/src/light_import.rs
@@ -326,7 +326,8 @@ fn do_import_finality_proof<B, C, Block: BlockT<Hash=H256>, J>(
 	let block_origin = BlockOrigin::NetworkBroadcast;
 	for header_to_import in finality_effects.headers_to_import {
 		let (block_to_import, new_authorities) = verifier.verify(block_origin, header_to_import, None, None)
-			.map_err(|e| ConsensusError::ClientImport(e))?;
+			// TODO: remove this `.to_string()` call
+			.map_err(|e| ConsensusError::ClientImport(e.to_string()))?;
 		assert!(block_to_import.justification.is_none(), "We have passed None as justification to verifier.verify");
 
 		let mut cache = HashMap::new();

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -45,6 +45,7 @@ erased-serde = "0.3.9"
 void = "1.0"
 zeroize = "0.9.0"
 babe-primitives = { package = "substrate-consensus-babe-primitives", path = "../consensus/babe/primitives" }
+inherents = { package = "substrate-inherents", path = "../../core/inherents" }
 
 [dev-dependencies]
 env_logger = { version = "0.6" }

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -58,6 +58,7 @@ use sr_primitives::Justification;
 use crate::service::TransactionPool;
 use crate::specialization::NetworkSpecialization;
 use test_client::{self, AccountKeyring};
+use inherents::InherentError;
 
 pub use test_client::runtime::{Block, Extrinsic, Hash, Transfer};
 pub use test_client::{TestClient, TestClientBuilder, TestClientBuilderExt};
@@ -79,7 +80,7 @@ impl<B: BlockT> Verifier<B> for PassThroughVerifier {
 		header: B::Header,
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>
-	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), InherentError> {
 		let maybe_keys = header.digest()
 			.log(|l| l.try_as_raw(OpaqueDigestItemId::Consensus(b"aura"))
 				.or_else(|| l.try_as_raw(OpaqueDigestItemId::Consensus(b"babe")))
@@ -449,7 +450,7 @@ impl<B: BlockT, T: ?Sized + Verifier<B>> Verifier<B> for VerifierAdapter<T> {
 		header: B::Header,
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>
-	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
+	) -> Result<(BlockImportParams<B>, Option<Vec<(CacheKeyId, Vec<u8>)>>), InherentError> {
 		self.0.lock().verify(origin, header, justification, body)
 	}
 }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -82,8 +82,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 159,
-	impl_version: 159,
+	spec_version: 160,
+	impl_version: 160,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -62,7 +62,7 @@ use timestamp::OnTimestampSet;
 use timestamp::TimestampInherentData;
 use inherents::{RuntimeString, InherentIdentifier, InherentData, ProvideInherent, MakeFatalError};
 #[cfg(feature = "std")]
-use inherents::{InherentDataProviders, ProvideInherentData};
+use inherents::{InherentDataProviders, ProvideInherentData, InherentError};
 use substrate_consensus_aura_primitives::{AURA_ENGINE_ID, ConsensusLog, AuthorityIndex};
 
 mod mock;
@@ -135,8 +135,10 @@ impl ProvideInherentData for InherentDataProvider {
 		inherent_data.put_data(INHERENT_IDENTIFIER, &slot_num)
 	}
 
-	fn error_to_string(&self, error: &[u8]) -> Option<String> {
-		RuntimeString::decode(&mut &error[..]).map(Into::into).ok()
+	fn decode_error(&self, error: &[u8]) -> Option<InherentError> {
+		RuntimeString::decode(&mut &error[..])
+			.map(|e| e.to_string().into())
+			.ok()
 	}
 }
 

--- a/srml/authorship/src/lib.rs
+++ b/srml/authorship/src/lib.rs
@@ -31,8 +31,10 @@ use sr_primitives::traits::{Header as HeaderT, One, Zero};
 use sr_primitives::weights::SimpleDispatchInfo;
 use inherents::{
 	RuntimeString, InherentIdentifier, ProvideInherent,
-	InherentData, MakeFatalError,
+	InherentData, MakeFatalError
 };
+#[cfg(feature = "std")]
+use inherents::InherentError;
 
 /// The identifier for the `uncles` inherent.
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"uncles00";
@@ -80,8 +82,8 @@ where F: Fn() -> Vec<H>
 		}
 	}
 
-	fn error_to_string(&self, _error: &[u8]) -> Option<String> {
-		Some(format!("no further information"))
+	fn decode_error(&self, _error: &[u8]) -> Option<InherentError> {
+		Some(format!("no further information").into())
 	}
 }
 

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -40,7 +40,7 @@ use timestamp::TimestampInherentData;
 use codec::{Encode, Decode};
 use inherents::{RuntimeString, InherentIdentifier, InherentData, ProvideInherent, MakeFatalError};
 #[cfg(feature = "std")]
-use inherents::{InherentDataProviders, ProvideInherentData};
+use inherents::{InherentDataProviders, ProvideInherentData, InherentError};
 use babe_primitives::{BABE_ENGINE_ID, ConsensusLog, BabeAuthorityWeight, Epoch, RawBabePreDigest};
 pub use babe_primitives::{AuthorityId, VRF_OUTPUT_LENGTH, PUBLIC_KEY_LENGTH};
 use system::ensure_root;
@@ -112,8 +112,10 @@ impl ProvideInherentData for InherentDataProvider {
 		inherent_data.put_data(INHERENT_IDENTIFIER, &slot_number)
 	}
 
-	fn error_to_string(&self, error: &[u8]) -> Option<String> {
-		RuntimeString::decode(&mut &error[..]).map(Into::into).ok()
+	fn decode_error(&self, error: &[u8]) -> Option<InherentError> {
+		RuntimeString::decode(&mut &error[..])
+			.map(|e| e.to_string().into())
+			.ok()
 	}
 }
 

--- a/srml/finality-tracker/src/lib.rs
+++ b/srml/finality-tracker/src/lib.rs
@@ -29,6 +29,8 @@ use codec::Decode;
 use support::{decl_module, decl_storage};
 use support::traits::Get;
 use srml_system::{ensure_none, Trait as SystemTrait};
+#[cfg(feature = "std")]
+use inherents::InherentError;
 
 #[cfg(feature = "std")]
 use codec::Encode;
@@ -76,8 +78,8 @@ impl<F, N: Encode> inherents::ProvideInherentData for InherentDataProvider<F, N>
 			.and_then(|n| inherent_data.put_data(INHERENT_IDENTIFIER, &n))
 	}
 
-	fn error_to_string(&self, _error: &[u8]) -> Option<String> {
-		Some(format!("no further information"))
+	fn decode_error(&self, _error: &[u8]) -> Option<InherentError> {
+		Some(format!("no further information").into())
 	}
 }
 


### PR DESCRIPTION
See #2688. Currently, `ProvideInherentData` uses `String`s for errors, which is not ideal. This commit introduces a `InherentDataProviderError` trait for errors and `InherentError` as a type alias for `Box<dyn InherentDataProviderError>`.