### PR TITLE
Fix invalid debug assertion.

### DIFF
--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -659,7 +659,7 @@ impl<B: BlockT> ChainSync<B> {
 			peer.state = PeerSyncState::Available;
 
 			// We only request one justification at a time
-			debug_assert_eq!(1, response.blocks.len());
+			debug_assert!(response.blocks.len() < 2);
 
 			if let Some(block) = response.blocks.into_iter().next() {
 				if hash != block.hash {


### PR DESCRIPTION
Context: https://github.com/paritytech/polkadot/issues/440

The current `debug_assert_eq!` is incorrect as the code is prepared to handle zero response blocks. What should have been expressed is that we expect 0 or 1 response blocks.

The assertion was introduced as part of #3105 to reify the a comment by @andresilva here: https://github.com/paritytech/substrate/pull/1410/files#diff-0c805d3ef65d16a3738f8270c6726d38R484. Please let me know if this was a bad idea.
