### PR TITLE
Rename more things related to contract instantiation

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -409,7 +409,7 @@ impl contracts::Trait for Runtime {
 	type TransactionByteFee = ContractTransactionByteFee;
 	type ContractFee = ContractFee;
 	type CallBaseFee = contracts::DefaultCallBaseFee;
-	type CreateBaseFee = contracts::DefaultCreateBaseFee;
+	type InstantiateBaseFee = contracts::DefaultInstantiateBaseFee;
 	type MaxDepth = contracts::DefaultMaxDepth;
 	type MaxValueSize = contracts::DefaultMaxValueSize;
 	type BlockGasLimit = contracts::DefaultBlockGasLimit;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 160,
+	spec_version: 161,
 	impl_version: 161,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/contracts/COMPLEXITY.md
+++ b/srml/contracts/COMPLEXITY.md
@@ -123,7 +123,7 @@ While these functions only modify the local `Map`, if changes made by them are c
 
 **complexity**: Each lookup has a logarithmical computing time to the number of already inserted entries. No additional memory is required.
 
-## create_contract
+## instantiate_contract
 
 Calls `contract_exists` and if it doesn't exist, do not modify the local `Map` similarly to `set_rent_allowance`.
 
@@ -174,7 +174,7 @@ Assuming marshaled size of a balance value is of the constant size we can neglec
 
 ## Initialization
 
-Before a call or create can be performed the execution context must be initialized.
+Before a call or instantiate can be performed the execution context must be initialized.
 
 For the first call or instantiation in the handling of an extrinsic, this involves two calls:
 
@@ -213,7 +213,7 @@ and on top of that at most once per block:
 - `kill_child_storage`
 - mutation of `ContractInfoOf`
 
-Loading code most likely will trigger a DB read, since the code is immutable and therefore will not get into the cache (unless a suicide removes it, or it has been created in the same call chain).
+Loading code most likely will trigger a DB read, since the code is immutable and therefore will not get into the cache (unless a suicide removes it, or it has been instantiated in the same call chain).
 
 Also, `transfer` can make up to 2 DB reads and up to 2 DB writes (if flushed to the storage) in the standard case. If removal of the source account takes place then it will additionally perform a DB write per one storage entry that the account has.
 
@@ -229,9 +229,9 @@ This function takes the code of the constructor and input data. Instantiation of
 
 1. Initialization of the execution context.
 2. Calling `DetermineContractAddress` hook to determine an address for the contract,
-3. `transfer`-ing funds between self and the newly created contract.
+3. `transfer`-ing funds between self and the newly instantiated contract.
 4. Executing the constructor code. This will yield the final code of the code.
-5. Storing the code for the newly created contract in the overlay.
+5. Storing the code for the newly instantiated contract in the overlay.
 6. Committing overlayed changed to the underlying `AccountDb`.
 
 **Note** that the complexity of executing the constructor code should be considered separately.

--- a/srml/contracts/src/account_db.rs
+++ b/srml/contracts/src/account_db.rs
@@ -37,7 +37,7 @@ pub struct ChangeEntry<T: Trait> {
 	/// If Some(_), then the account balance is modified to the value. If None and `reset` is false,
 	/// the balance unmodified. If None and `reset` is true, the balance is reset to 0.
 	balance: Option<BalanceOf<T>>,
-	/// If Some(_), then a contract is created with the code hash. If None and `reset` is false,
+	/// If Some(_), then a contract is instantiated with the code hash. If None and `reset` is false,
 	/// then the contract code is unmodified. If None and `reset` is true, the contract is deleted.
 	code_hash: Option<CodeHash<T>>,
 	/// If Some(_), then the rent allowance is set to the value. If None and `reset` is false, then
@@ -189,7 +189,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 							last_write: None,
 						}
 					}
-					// New contract is being created.
+					// New contract is being instantiated.
 					(_, None, Some(code_hash)) => {
 						AliveContractInfo::<T> {
 							code_hash,
@@ -200,7 +200,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 							last_write: None,
 						}
 					}
-					// There is no existing at the address nor a new one to be created.
+					// There is no existing at the address nor a new one to be instantiated.
 					(_, None, None) => continue,
 				};
 
@@ -278,7 +278,7 @@ impl<'a, T: Trait> OverlayAccountDb<'a, T> {
 	}
 
 	/// Return an error if contract already exists (either if it is alive or tombstone)
-	pub fn create_contract(
+	pub fn instantiate_contract(
 		&mut self,
 		account: &T::AccountId,
 		code_hash: CodeHash<T>,

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -1539,7 +1539,7 @@ mod tests {
 		let mut loader = MockLoader::empty();
 		let dummy_ch = loader.insert(|_| exec_success());
 		let instantiated_contract_address = Rc::new(RefCell::new(None::<u64>));
-		let creator_ch = loader.insert({
+		let instantiator_ch = loader.insert({
 			let dummy_ch = dummy_ch.clone();
 			let instantiated_contract_address = Rc::clone(&instantiated_contract_address);
 			move |ctx| {
@@ -1562,7 +1562,7 @@ mod tests {
 				let cfg = Config::preload();
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.instantiate_contract(&BOB, creator_ch).unwrap();
+				ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
 				assert_matches!(
 					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
@@ -1600,7 +1600,7 @@ mod tests {
 		let dummy_ch = loader.insert(
 			|_| Err(ExecError { reason: "It's a trap!", buffer: Vec::new() })
 		);
-		let creator_ch = loader.insert({
+		let instantiator_ch = loader.insert({
 			let dummy_ch = dummy_ch.clone();
 			move |ctx| {
 				// Instantiate a contract and save it's address in `instantiated_contract_address`.
@@ -1624,7 +1624,7 @@ mod tests {
 				let cfg = Config::preload();
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.instantiate_contract(&BOB, creator_ch).unwrap();
+				ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
 				assert_matches!(
 					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -421,7 +421,7 @@ where
 	) -> Result<(T::AccountId, ExecReturnValue), ExecError> {
 		if self.depth == self.config.max_depth as usize {
 			return Err(ExecError {
-				reason: "reached maximum depth, cannot create",
+				reason: "reached maximum depth, cannot instantiate",
 				buffer: input_data,
 			});
 		}

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -448,7 +448,7 @@ where
 
 		let output = self.with_nested_context(dest.clone(), dest_trie_id, |nested| {
 			try_or_exec_error!(
-				nested.overlay.create_contract(&dest, code_hash.clone()),
+				nested.overlay.instantiate_contract(&dest, code_hash.clone()),
 				input_data
 			);
 
@@ -941,7 +941,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, exec_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, exec_ch).unwrap();
 
 			assert_matches!(
 				ctx.call(BOB, value, &mut gas_meter, data),
@@ -1041,7 +1041,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, return_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 			ctx.overlay.set_balance(&origin, 100);
 			ctx.overlay.set_balance(&dest, 0);
 
@@ -1064,7 +1064,7 @@ mod tests {
 		let dest = BOB;
 
 		// This test sends 50 units of currency to a non-existent account.
-		// This should create lead to creation of a new account thus
+		// This should lead to creation of a new account thus
 		// a fee should be charged.
 		with_externalities(
 			&mut ExtBuilder::default().existential_deposit(15).build(),
@@ -1123,7 +1123,7 @@ mod tests {
 		);
 
 		// This test sends 50 units of currency as an endownment to a newly
-		// created contract.
+		// instantiated contract.
 		with_externalities(
 			&mut ExtBuilder::default().existential_deposit(15).build(),
 			|| {
@@ -1202,7 +1202,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, return_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 
 			let result = ctx.call(
 				dest,
@@ -1233,7 +1233,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, return_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
 
 			let result = ctx.call(
 				dest,
@@ -1261,7 +1261,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, input_data_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, input_data_ch).unwrap();
 
 			let result = ctx.call(
 				BOB,
@@ -1330,7 +1330,7 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, recurse_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, recurse_ch).unwrap();
 
 			let result = ctx.call(
 				BOB,
@@ -1375,8 +1375,8 @@ mod tests {
 			let cfg = Config::preload();
 
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&dest, bob_ch).unwrap();
-			ctx.overlay.create_contract(&CHARLIE, charlie_ch).unwrap();
+			ctx.overlay.instantiate_contract(&dest, bob_ch).unwrap();
+			ctx.overlay.instantiate_contract(&CHARLIE, charlie_ch).unwrap();
 
 			let result = ctx.call(
 				dest,
@@ -1416,8 +1416,8 @@ mod tests {
 		with_externalities(&mut ExtBuilder::default().build(), || {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-			ctx.overlay.create_contract(&BOB, bob_ch).unwrap();
-			ctx.overlay.create_contract(&CHARLIE, charlie_ch).unwrap();
+			ctx.overlay.instantiate_contract(&BOB, bob_ch).unwrap();
+			ctx.overlay.instantiate_contract(&CHARLIE, charlie_ch).unwrap();
 
 			let result = ctx.call(
 				BOB,
@@ -1472,7 +1472,7 @@ mod tests {
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
 
-				let created_contract_address = assert_matches!(
+				let instantiated_contract_address = assert_matches!(
 					ctx.instantiate(
 						100,
 						&mut GasMeter::<Test>::with_limit(10000, 1),
@@ -1484,14 +1484,14 @@ mod tests {
 
 				// Check that the newly created account has the expected code hash and
 				// there are instantiation event.
-				assert_eq!(ctx.overlay.get_code_hash(&created_contract_address).unwrap(), dummy_ch);
+				assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
 				assert_eq!(&ctx.events(), &[
 					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(ALICE, created_contract_address, 100),
+						event: RawEvent::Transfer(ALICE, instantiated_contract_address, 100),
 						topics: Vec::new(),
 					},
 					DeferredAction::DepositEvent {
-						event: RawEvent::Instantiated(ALICE, created_contract_address),
+						event: RawEvent::Instantiated(ALICE, instantiated_contract_address),
 						topics: Vec::new(),
 					}
 				]);
@@ -1515,7 +1515,7 @@ mod tests {
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
 
-				let created_contract_address = assert_matches!(
+				let instantiated_contract_address = assert_matches!(
 					ctx.instantiate(
 						100,
 						&mut GasMeter::<Test>::with_limit(10000, 1),
@@ -1526,7 +1526,7 @@ mod tests {
 				);
 
 				// Check that the account has not been created.
-				assert!(ctx.overlay.get_code_hash(&created_contract_address).is_none());
+				assert!(ctx.overlay.get_code_hash(&instantiated_contract_address).is_none());
 				assert!(ctx.events().is_empty());
 			}
 		);
@@ -1538,12 +1538,12 @@ mod tests {
 
 		let mut loader = MockLoader::empty();
 		let dummy_ch = loader.insert(|_| exec_success());
-		let created_contract_address = Rc::new(RefCell::new(None::<u64>));
+		let instantiated_contract_address = Rc::new(RefCell::new(None::<u64>));
 		let creator_ch = loader.insert({
 			let dummy_ch = dummy_ch.clone();
-			let created_contract_address = Rc::clone(&created_contract_address);
+			let instantiated_contract_address = Rc::clone(&instantiated_contract_address);
 			move |ctx| {
-				// Instantiate a contract and save it's address in `created_contract_address`.
+				// Instantiate a contract and save it's address in `instantiated_contract_address`.
 				let (address, output) = ctx.ext.instantiate(
 					&dummy_ch,
 					15u64,
@@ -1551,7 +1551,7 @@ mod tests {
 					vec![]
 				).unwrap();
 
-				*created_contract_address.borrow_mut() = address.into();
+				*instantiated_contract_address.borrow_mut() = address.into();
 				Ok(output)
 			}
 		});
@@ -1562,29 +1562,29 @@ mod tests {
 				let cfg = Config::preload();
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.create_contract(&BOB, creator_ch).unwrap();
+				ctx.overlay.instantiate_contract(&BOB, creator_ch).unwrap();
 
 				assert_matches!(
 					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
 					Ok(_)
 				);
 
-				let created_contract_address = created_contract_address.borrow().as_ref().unwrap().clone();
+				let instantiated_contract_address = instantiated_contract_address.borrow().as_ref().unwrap().clone();
 
 				// Check that the newly created account has the expected code hash and
 				// there are instantiation event.
-				assert_eq!(ctx.overlay.get_code_hash(&created_contract_address).unwrap(), dummy_ch);
+				assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
 				assert_eq!(&ctx.events(), &[
 					DeferredAction::DepositEvent {
 						event: RawEvent::Transfer(ALICE, BOB, 20),
 						topics: Vec::new(),
 					},
 					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(BOB, created_contract_address, 15),
+						event: RawEvent::Transfer(BOB, instantiated_contract_address, 15),
 						topics: Vec::new(),
 					},
 					DeferredAction::DepositEvent {
-						event: RawEvent::Instantiated(BOB, created_contract_address),
+						event: RawEvent::Instantiated(BOB, instantiated_contract_address),
 						topics: Vec::new(),
 					},
 				]);
@@ -1603,7 +1603,7 @@ mod tests {
 		let creator_ch = loader.insert({
 			let dummy_ch = dummy_ch.clone();
 			move |ctx| {
-				// Instantiate a contract and save it's address in `created_contract_address`.
+				// Instantiate a contract and save it's address in `instantiated_contract_address`.
 				assert_matches!(
 					ctx.ext.instantiate(
 						&dummy_ch,
@@ -1624,14 +1624,14 @@ mod tests {
 				let cfg = Config::preload();
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.create_contract(&BOB, creator_ch).unwrap();
+				ctx.overlay.instantiate_contract(&BOB, creator_ch).unwrap();
 
 				assert_matches!(
 					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
 					Ok(_)
 				);
 
-				// The contract wasn't created so we don't expect to see an instantiation
+				// The contract wasn't instantiated so we don't expect to see an instantiation
 				// event here.
 				assert_eq!(&ctx.events(), &[
 					DeferredAction::DepositEvent {

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -405,7 +405,7 @@ pub trait Trait: timestamp::Trait {
 	type CallBaseFee: Get<Gas>;
 
 	/// The base fee charged for instantiating a contract.
-	type InstantiationBaseFee: Get<Gas>;
+	type InstantiateBaseFee: Get<Gas>;
 
 	/// The maximum nesting level of a call/instantiate stack.
 	type MaxDepth: Get<u32>;
@@ -507,7 +507,7 @@ decl_module! {
 
 		/// The base fee charged for instantiating a contract. A reasonable default value
 		/// is 175.
-		const InstantiationBaseFee: Gas = T::InstantiationBaseFee::get();
+		const InstantiateBaseFee: Gas = T::InstantiateBaseFee::get();
 
 		/// The maximum nesting level of a call/instantiate stack. A reasonable default
 		/// value is 100.

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -25,14 +25,14 @@
 //!
 //! This module extends accounts based on the `Currency` trait to have smart-contract functionality. It can
 //! be used with other modules that implement accounts based on `Currency`. These "smart-contract accounts"
-//! have the ability to create smart-contracts and make calls to other contract and non-contract accounts.
+//! have the ability to instantiate smart-contracts and make calls to other contract and non-contract accounts.
 //!
 //! The smart-contract code is stored once in a `code_cache`, and later retrievable via its `code_hash`.
 //! This means that multiple smart-contracts can be instantiated from the same `code_cache`, without replicating
 //! the code each time.
 //!
 //! When a smart-contract is called, its associated code is retrieved via the code hash and gets executed.
-//! This call can alter the storage entries of the smart-contract account, create new smart-contracts,
+//! This call can alter the storage entries of the smart-contract account, instantiate new smart-contracts,
 //! or call other smart-contracts.
 //!
 //! Finally, when an account is reaped, its associated code and storage of the smart-contract account
@@ -60,7 +60,8 @@
 //!
 //! * `put_code` - Stores the given binary Wasm code into the chain's storage and returns its `code_hash`.
 //! * `instantiate` - Deploys a new contract from the given `code_hash`, optionally transferring some balance.
-//! This creates a new smart contract account and calls its contract deploy handler to initialize the contract.
+//! This instantiates a new smart contract account and calls its contract deploy handler to
+//! initialize the contract.
 //! * `call` - Makes a call to an account, optionally transferring some balance.
 //!
 //! ### Signed Extensions
@@ -74,8 +75,8 @@
 //!
 //! ## Usage
 //!
-//! The Contract module is a work in progress. The following examples show how this Contract module can be
-//! used to create and call contracts.
+//! The Contract module is a work in progress. The following examples show how this Contract module
+//! can be used to instantiate and call contracts.
 //!
 //! * [`ink`](https://github.com/paritytech/ink) is
 //! an [`eDSL`](https://wiki.haskell.org/Embedded_domain_specific_language) that enables writing
@@ -298,37 +299,37 @@ pub type NegativeImbalanceOf<T> =
 	<<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::NegativeImbalance;
 
 parameter_types! {
-	/// A resonable default value for [`Trait::SignedClaimedHandicap`].
+	/// A reasonable default value for [`Trait::SignedClaimedHandicap`].
 	pub const DefaultSignedClaimHandicap: u32 = 2;
-	/// A resonable default value for [`Trait::TombstoneDeposit`].
+	/// A reasonable default value for [`Trait::TombstoneDeposit`].
 	pub const DefaultTombstoneDeposit: u32 = 16;
-	/// A resonable default value for [`Trait::StorageSizeOffset`].
+	/// A reasonable default value for [`Trait::StorageSizeOffset`].
 	pub const DefaultStorageSizeOffset: u32 = 8;
-	/// A resonable default value for [`Trait::RentByteFee`].
+	/// A reasonable default value for [`Trait::RentByteFee`].
 	pub const DefaultRentByteFee: u32 = 4;
-	/// A resonable default value for [`Trait::RentDepositOffset`].
+	/// A reasonable default value for [`Trait::RentDepositOffset`].
 	pub const DefaultRentDepositOffset: u32 = 1000;
-	/// A resonable default value for [`Trait::SurchargeReward`].
+	/// A reasonable default value for [`Trait::SurchargeReward`].
 	pub const DefaultSurchargeReward: u32 = 150;
-	/// A resonable default value for [`Trait::TransferFee`].
+	/// A reasonable default value for [`Trait::TransferFee`].
 	pub const DefaultTransferFee: u32 = 0;
-	/// A resonable default value for [`Trait::CreationFee`].
-	pub const DefaultCreationFee: u32 = 0;
-	/// A resonable default value for [`Trait::TransactionBaseFee`].
+	/// A reasonable default value for [`Trait::InstantiationFee`].
+	pub const DefaultInstantiationFee: u32 = 0;
+	/// A reasonable default value for [`Trait::TransactionBaseFee`].
 	pub const DefaultTransactionBaseFee: u32 = 0;
-	/// A resonable default value for [`Trait::TransactionByteFee`].
+	/// A reasonable default value for [`Trait::TransactionByteFee`].
 	pub const DefaultTransactionByteFee: u32 = 0;
-	/// A resonable default value for [`Trait::ContractFee`].
+	/// A reasonable default value for [`Trait::ContractFee`].
 	pub const DefaultContractFee: u32 = 21;
-	/// A resonable default value for [`Trait::CallBaseFee`].
+	/// A reasonable default value for [`Trait::CallBaseFee`].
 	pub const DefaultCallBaseFee: u32 = 1000;
-	/// A resonable default value for [`Trait::CreateBaseFee`].
-	pub const DefaultCreateBaseFee: u32 = 1000;
-	/// A resonable default value for [`Trait::MaxDepth`].
+	/// A reasonable default value for [`Trait::InstantiateBaseFee`].
+	pub const DefaultInstantiateBaseFee: u32 = 1000;
+	/// A reasonable default value for [`Trait::MaxDepth`].
 	pub const DefaultMaxDepth: u32 = 1024;
-	/// A resonable default value for [`Trait::MaxValueSize`].
+	/// A reasonable default value for [`Trait::MaxValueSize`].
 	pub const DefaultMaxValueSize: u32 = 16_384;
-	/// A resonable default value for [`Trait::BlockGasLimit`].
+	/// A reasonable default value for [`Trait::BlockGasLimit`].
 	pub const DefaultBlockGasLimit: u32 = 10_000_000;
 }
 
@@ -341,13 +342,13 @@ pub trait Trait: timestamp::Trait {
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 
-	/// A function type to get the contract address given the creator.
+	/// A function type to get the contract address given the instantiator.
 	type DetermineContractAddress: ContractAddressFor<CodeHash<Self>, Self::AccountId>;
 
 	/// A function type that computes the fee for dispatching the given `Call`.
 	///
-	/// It is recommended (though not required) for this function to return a fee that would be taken
-	/// by the Executive module for regular dispatch.
+	/// It is recommended (though not required) for this function to return a fee that would be
+	/// taken by the Executive module for regular dispatch.
 	type ComputeDispatchFee: ComputeDispatchFee<<Self as Trait>::Call, BalanceOf<Self>>;
 
 	/// trie id generator
@@ -365,7 +366,7 @@ pub trait Trait: timestamp::Trait {
 	/// The minimum amount required to generate a tombstone.
 	type TombstoneDeposit: Get<BalanceOf<Self>>;
 
-	/// Size of a contract at the time of creation. This is a simple way to ensure
+	/// Size of a contract at the time of instantiation. This is a simple way to ensure
 	/// that empty contracts eventually gets deleted.
 	type StorageSizeOffset: Get<u32>;
 
@@ -397,16 +398,16 @@ pub trait Trait: timestamp::Trait {
 	/// The fee to be paid for making a transaction; the per-byte portion.
 	type TransactionByteFee: Get<BalanceOf<Self>>;
 
-	/// The fee required to create a contract instance.
+	/// The fee required to instantiate a contract instance.
 	type ContractFee: Get<BalanceOf<Self>>;
 
 	/// The base fee charged for calling into a contract.
 	type CallBaseFee: Get<Gas>;
 
-	/// The base fee charged for creating a contract.
-	type CreateBaseFee: Get<Gas>;
+	/// The base fee charged for instantiating a contract.
+	type InstantiationBaseFee: Get<Gas>;
 
-	/// The maximum nesting level of a call/create stack.
+	/// The maximum nesting level of a call/instantiate stack.
 	type MaxDepth: Get<u32>;
 
 	/// The maximum size of a storage value in bytes.
@@ -464,8 +465,8 @@ decl_module! {
 		/// The minimum amount required to generate a tombstone.
 		const TombstoneDeposit: BalanceOf<T> = T::TombstoneDeposit::get();
 
-		/// Size of a contract at the time of creation. This is a simple way to ensure
-		/// that empty contracts eventually gets deleted.
+		/// Size of a contract at the time of instantiaion. This is a simple way to ensure that
+		/// empty contracts eventually gets deleted.
 		const StorageSizeOffset: u32 = T::StorageSizeOffset::get();
 
 		/// Price of a byte of storage per one block interval. Should be greater than 0.
@@ -496,7 +497,7 @@ decl_module! {
 		/// The fee to be paid for making a transaction; the per-byte portion.
 		const TransactionByteFee: BalanceOf<T> = T::TransactionByteFee::get();
 
-		/// The fee required to create a contract instance. A reasonable default value
+		/// The fee required to instantiate a contract instance. A reasonable default value
 		/// is 21.
 		const ContractFee: BalanceOf<T> = T::ContractFee::get();
 
@@ -504,11 +505,11 @@ decl_module! {
 		/// value is 135.
 		const CallBaseFee: Gas = T::CallBaseFee::get();
 
-		/// The base fee charged for creating a contract. A reasonable default value
+		/// The base fee charged for instantiating a contract. A reasonable default value
 		/// is 175.
-		const CreateBaseFee: Gas = T::CreateBaseFee::get();
+		const InstantiationBaseFee: Gas = T::InstantiationBaseFee::get();
 
-		/// The maximum nesting level of a call/create stack. A reasonable default
+		/// The maximum nesting level of a call/instantiate stack. A reasonable default
 		/// value is 100.
 		const MaxDepth: u32 = T::MaxDepth::get();
 

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -155,7 +155,7 @@ parameter_types! {
 	pub const TransactionByteFee: u64 = 6;
 	pub const ContractFee: u64 = 21;
 	pub const CallBaseFee: u64 = 135;
-	pub const InstantiationBaseFee: u64 = 175;
+	pub const InstantiateBaseFee: u64 = 175;
 	pub const MaxDepth: u32 = 100;
 	pub const MaxValueSize: u32 = 16_384;
 }
@@ -179,7 +179,7 @@ impl Trait for Test {
 	type TransactionByteFee = TransactionByteFee;
 	type ContractFee = ContractFee;
 	type CallBaseFee = CallBaseFee;
-	type InstantiationBaseFee = InstantiationBaseFee;
+	type InstantiateBaseFee = InstantiateBaseFee;
 	type MaxDepth = MaxDepth;
 	type MaxValueSize = MaxValueSize;
 	type BlockGasLimit = BlockGasLimit;

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -69,7 +69,7 @@ impl_outer_dispatch! {
 thread_local! {
 	static EXISTENTIAL_DEPOSIT: RefCell<u64> = RefCell::new(0);
 	static TRANSFER_FEE: RefCell<u64> = RefCell::new(0);
-	static CREATION_FEE: RefCell<u64> = RefCell::new(0);
+	static INSTANTIATION_FEE: RefCell<u64> = RefCell::new(0);
 	static BLOCK_GAS_LIMIT: RefCell<u64> = RefCell::new(0);
 }
 
@@ -85,7 +85,7 @@ impl Get<u64> for TransferFee {
 
 pub struct CreationFee;
 impl Get<u64> for CreationFee {
-	fn get() -> u64 { CREATION_FEE.with(|v| *v.borrow()) }
+	fn get() -> u64 { INSTANTIATION_FEE.with(|v| *v.borrow()) }
 }
 
 pub struct BlockGasLimit;
@@ -155,7 +155,7 @@ parameter_types! {
 	pub const TransactionByteFee: u64 = 6;
 	pub const ContractFee: u64 = 21;
 	pub const CallBaseFee: u64 = 135;
-	pub const CreateBaseFee: u64 = 175;
+	pub const InstantiationBaseFee: u64 = 175;
 	pub const MaxDepth: u32 = 100;
 	pub const MaxValueSize: u32 = 16_384;
 }
@@ -179,7 +179,7 @@ impl Trait for Test {
 	type TransactionByteFee = TransactionByteFee;
 	type ContractFee = ContractFee;
 	type CallBaseFee = CallBaseFee;
-	type CreateBaseFee = CreateBaseFee;
+	type InstantiationBaseFee = InstantiationBaseFee;
 	type MaxDepth = MaxDepth;
 	type MaxValueSize = MaxValueSize;
 	type BlockGasLimit = BlockGasLimit;
@@ -233,7 +233,7 @@ pub struct ExtBuilder {
 	gas_price: u64,
 	block_gas_limit: u64,
 	transfer_fee: u64,
-	creation_fee: u64,
+	instantiation_fee: u64,
 }
 impl Default for ExtBuilder {
 	fn default() -> Self {
@@ -242,7 +242,7 @@ impl Default for ExtBuilder {
 			gas_price: 2,
 			block_gas_limit: 100_000_000,
 			transfer_fee: 0,
-			creation_fee: 0,
+			instantiation_fee: 0,
 		}
 	}
 }
@@ -263,14 +263,14 @@ impl ExtBuilder {
 		self.transfer_fee = transfer_fee;
 		self
 	}
-	pub fn creation_fee(mut self, creation_fee: u64) -> Self {
-		self.creation_fee = creation_fee;
+	pub fn instantiation_fee(mut self, instantiation_fee: u64) -> Self {
+		self.instantiation_fee = instantiation_fee;
 		self
 	}
 	pub fn set_associated_consts(&self) {
 		EXISTENTIAL_DEPOSIT.with(|v| *v.borrow_mut() = self.existential_deposit);
 		TRANSFER_FEE.with(|v| *v.borrow_mut() = self.transfer_fee);
-		CREATION_FEE.with(|v| *v.borrow_mut() = self.creation_fee);
+		INSTANTIATION_FEE.with(|v| *v.borrow_mut() = self.instantiation_fee);
 		BLOCK_GAS_LIMIT.with(|v| *v.borrow_mut() = self.block_gas_limit);
 	}
 	pub fn build(self) -> runtime_io::TestExternalities<Blake2Hasher> {
@@ -651,7 +651,7 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 				vec![],
 			));
 
-			// Call the newly created contract. The contract is expected to dispatch a call
+			// Call the newly instantiated contract. The contract is expected to dispatch a call
 			// and then trap.
 			assert_err!(
 				Contract::call(
@@ -1225,7 +1225,7 @@ const CODE_CHECK_DEFAULT_RENT_ALLOWANCE: &str = r#"
 "#;
 
 #[test]
-fn default_rent_allowance_on_create() {
+fn default_rent_allowance_on_instantiate() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_CHECK_DEFAULT_RENT_ALLOWANCE).unwrap();
 
 	with_externalities(

--- a/srml/contracts/src/wasm/mod.rs
+++ b/srml/contracts/src/wasm/mod.rs
@@ -173,7 +173,7 @@ mod tests {
 	}
 
 	#[derive(Debug, PartialEq, Eq)]
-	struct CreateEntry {
+	struct InstantiateEntry {
 		code_hash: H256,
 		endowment: u64,
 		data: Vec<u8>,
@@ -192,7 +192,7 @@ mod tests {
 	pub struct MockExt {
 		storage: HashMap<StorageKey, Vec<u8>>,
 		rent_allowance: u64,
-		creates: Vec<CreateEntry>,
+		instantiates: Vec<InstantiateEntry>,
 		transfers: Vec<TransferEntry>,
 		dispatches: Vec<DispatchEntry>,
 		restores: Vec<RestoreEntry>,
@@ -220,7 +220,7 @@ mod tests {
 			gas_meter: &mut GasMeter<Test>,
 			data: Vec<u8>,
 		) -> Result<(u64, ExecReturnValue), ExecError> {
-			self.creates.push(CreateEntry {
+			self.instantiates.push(InstantiateEntry {
 				code_hash: code_hash.clone(),
 				endowment,
 				data: data.to_vec(),
@@ -476,7 +476,7 @@ mod tests {
 		);
 	}
 
-	const CODE_CREATE: &str = r#"
+	const CODE_INSTANTIATE: &str = r#"
 (module
 	;; ext_instantiate(
 	;;     code_ptr: u32,
@@ -507,7 +507,7 @@ mod tests {
 	;; Amount of value to transfer.
 	;; Represented by u64 (8 bytes long) in little endian.
 	(data (i32.const 4) "\03\00\00\00\00\00\00\00")
-	;; Input data to pass to the contract being created.
+	;; Input data to pass to the contract being instantiated.
 	(data (i32.const 12) "\01\02\03\04")
 	;; Hash of code.
 	(data (i32.const 16)
@@ -518,18 +518,18 @@ mod tests {
 "#;
 
 	#[test]
-	fn contract_create() {
+	fn contract_instantiate() {
 		let mut mock_ext = MockExt::default();
 		let _ = execute(
-			CODE_CREATE,
+			CODE_INSTANTIATE,
 			vec![],
 			&mut mock_ext,
 			&mut GasMeter::with_limit(50_000, 1),
 		).unwrap();
 
 		assert_eq!(
-			&mock_ext.creates,
-			&[CreateEntry {
+			&mock_ext.instantiates,
+			&[InstantiateEntry {
 				code_hash: [0x11; 32].into(),
 				endowment: 3,
 				data: vec![1, 2, 3, 4],

--- a/srml/contracts/src/wasm/runtime.rs
+++ b/srml/contracts/src/wasm/runtime.rs
@@ -432,11 +432,12 @@ define_env!(Env, <E: Ext>,
 	// by the code hash.
 	//
 	// If the constructor runs to completion, then this returns the status code that the newly
-	// created contract returns on exit in the bottom 8 bits of the return value. The top 24 bits
-	// are 0s. A status code of 0 indicates success, and any other code indicates a failure. On
-	// failure, any state changes made by the called contract are reverted and the contract is not
-	// instantiated. On a success status, the scratch buffer is filled with the encoded address of
-	// the newly created contract. In the case of a failure status, the scratch buffer is cleared.
+	// instantiated contract returns on exit in the bottom 8 bits of the return value. The top 24
+	// bits are 0s. A status code of 0 indicates success, and any other code indicates a failure.
+	// On failure, any state changes made by the called contract are reverted and the contract is
+	// not instantiated. On a success status, the scratch buffer is filled with the encoded address
+	// of the newly instantiated contract. In the case of a failure status, the scratch buffer is
+	// cleared.
 	//
 	// If the contract traps during execution or otherwise fails to complete successfully, then
 	// this function clears the scratch buffer and returns 0x0100. As with a failure status, any
@@ -445,8 +446,9 @@ define_env!(Env, <E: Ext>,
 	// This function creates an account and executes initializer code. After the execution,
 	// the returned buffer is saved as the code of the created account.
 	//
-	// Returns 0 on the successful contract creation and puts the address of the created contract
-	// into the scratch buffer. Otherwise, returns non-zero value and clears the scratch buffer.
+	// Returns 0 on the successful contract instantiation and puts the address of the instantiated
+	// contract into the scratch buffer. Otherwise, returns non-zero value and clears the scratch
+	// buffer.
 	//
 	// - code_hash_ptr: a pointer to the buffer that contains the initializer code.
 	// - code_hash_len: length of the initializer code buffer.
@@ -535,9 +537,9 @@ define_env!(Env, <E: Ext>,
 
 	// Stores the address of the caller into the scratch buffer.
 	//
-	// If this is a top-level call (i.e. initiated by an extrinsic) the origin address of the extrinsic
-	// will be returned. Otherwise, if this call is initiated by another contract then the address
-	// of the contract will be returned.
+	// If this is a top-level call (i.e. initiated by an extrinsic) the origin address of the
+	// extrinsic will be returned. Otherwise, if this call is initiated by another contract then the
+	// address of the contract will be returned.
 	ext_caller(ctx) => {
 		ctx.scratch_buf.clear();
 		ctx.ext.caller().encode_to(&mut ctx.scratch_buf);
@@ -717,8 +719,8 @@ define_env!(Env, <E: Ext>,
 		Ok(ctx.scratch_buf.len() as u32)
 	},
 
-	// Copy data from the scratch buffer starting from `offset` with length `len` into the contract memory.
-	// The region at which the data should be put is specified by `dest_ptr`.
+	// Copy data from the scratch buffer starting from `offset` with length `len` into the contract
+	// memory. The region at which the data should be put is specified by `dest_ptr`.
 	//
 	// In order to get size of the scratch buffer use `ext_scratch_size`. At the start of contract
 	// execution, the scratch buffer is filled with the input data. Whenever a contract calls


### PR DESCRIPTION
Closes #3645

See #3645. I've tried to have 'instantiation' refer specifically to contracts while 'creation' refer to accounts. This gets a little tricky when you're talking about smart contract accounts, so I've kept lines like:

```
srml/contracts/src/lib.rs
392:	/// The fee required to create an account.
393:	type CreationFee: Get<BalanceOf<Self>>;
423:/// and the account id that requested the account creation.
491:		/// The fee required to create an account.
492:		const CreationFee: BalanceOf<T> = T::CreationFee::get();
568:		/// a regular account will be created and any value will be transferred.
589:		/// - The smart-contract account is created at the computed address.
590:		/// - The `ctor_code` is executed in the context of the newly-created account. Buffer returned
681:				// We don't have a spare buffer here in the first place, so create a new empty one.
803:		T::Currency::deposit_creating(&dest, origin_free_balance);
874:	pub account_create_fee: BalanceOf<T>,
886:			account_create_fee: T::CreationFee::get(),
```

Please don't merge until this issue is closed, thanks :^)