### PR TITLE
Fix head not hashed

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 162,
+	spec_version: 163,
 	impl_version: 163,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/support/procedural/src/storage/impls.rs
+++ b/srml/support/procedural/src/storage/impls.rs
@@ -257,14 +257,14 @@ impl<'a, I: Iterator<Item=syn::Meta>> Impls<'a, I> {
 		};
 
 		// make sure to use different prefix for head and elements.
-		let final_head_key = if let Some(instance) = instance {
+		let head_key = if let Some(instance) = instance {
 			let const_name = Ident::new(
 				&format!("{}{}", HEAD_KEY_FOR, name.to_string()), proc_macro2::Span::call_site()
 			);
 			quote!{ #instance::#const_name.as_bytes() }
 		} else {
-			let final_head_key = format!("head of {}", prefix);
-			quote!{ #final_head_key.as_bytes() }
+			let head_key = format!("head of {}", prefix);
+			quote!{ #head_key.as_bytes() }
 		};
 
 		let DeclStorageTypeInfos { typ, value_type, is_option, .. } = type_infos;
@@ -308,8 +308,8 @@ impl<'a, I: Iterator<Item=syn::Meta>> Impls<'a, I> {
 					#final_prefix
 				}
 
-				fn final_head_key() -> &'static [u8] {
-					#final_head_key
+				fn head_key() -> &'static [u8] {
+					#head_key
 				}
 
 				fn from_optional_value_to_query(v: Option<#typ>) -> Self::Query {

--- a/srml/support/src/storage/generator/linked_map.rs
+++ b/srml/support/src/storage/generator/linked_map.rs
@@ -36,7 +36,7 @@ pub trait StorageLinkedMap<K: Codec, V: Codec> {
 	fn prefix() -> &'static [u8];
 
 	/// Key used to store linked map head.
-	fn final_head_key() -> &'static [u8];
+	fn head_key() -> &'static [u8];
 
 	/// Convert an optionnal value retrieved from storage to the type queried.
 	fn from_optional_value_to_query(v: Option<V>) -> Self::Query;
@@ -52,6 +52,11 @@ pub trait StorageLinkedMap<K: Codec, V: Codec> {
 		let mut final_key = Self::prefix().to_vec();
 		key.borrow().encode_to(&mut final_key);
 		Self::Hasher::hash(&final_key)
+	}
+
+	/// Generate the hashed key for head
+	fn storage_linked_map_final_head_key() -> <Self::Hasher as StorageHasher>::Output {
+		Self::Hasher::hash(Self::head_key())
 	}
 }
 
@@ -181,7 +186,7 @@ where
 	V: Codec,
 	G: StorageLinkedMap<K, V>
 {
-	unhashed::get(G::final_head_key())
+	unhashed::get(G::storage_linked_map_final_head_key().as_ref())
 }
 
 /// Overwrite current head pointer.
@@ -194,8 +199,8 @@ where
 	G: StorageLinkedMap<K, V>
 {
 	match head {
-		Some(head) => unhashed::put(G::final_head_key(), head),
-		None => unhashed::kill(G::final_head_key()),
+		Some(head) => unhashed::put(G::storage_linked_map_final_head_key().as_ref(), head),
+		None => unhashed::kill(G::storage_linked_map_final_head_key().as_ref()),
 	}
 }
 

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -758,7 +758,7 @@ mod test3 {
 #[cfg(test)]
 #[allow(dead_code)]
 mod test_append_and_len {
-	use crate::storage::{StorageMap, StorageValue, StorageLinkedMap};
+	use crate::storage::{StorageMap, StorageValue};
 	use runtime_io::{with_externalities, TestExternalities};
 	use codec::{Encode, Decode};
 

--- a/srml/support/test/tests/final_keys.rs
+++ b/srml/support/test/tests/final_keys.rs
@@ -72,10 +72,14 @@ fn final_keys() {
 		k.extend(1u32.encode());
 		assert_eq!(unhashed::get::<u32>(&runtime_io::twox_128(&k)), Some(2u32));
 
+		let head = b"head of FinalKeys LinkedMap".to_vec();
+		assert_eq!(unhashed::get::<u32>(&runtime_io::blake2_256(&head)), None);
+
 		LinkedMap::insert(1, 2);
 		let mut k = b"FinalKeys LinkedMap".to_vec();
 		k.extend(1u32.encode());
 		assert_eq!(unhashed::get::<u32>(&runtime_io::blake2_256(&k)), Some(2u32));
+		assert_eq!(unhashed::get::<u32>(&runtime_io::blake2_256(&head)), Some(1u32));
 
 		LinkedMap2::insert(1, 2);
 		let mut k = b"FinalKeys LinkedMap2".to_vec();


### PR DESCRIPTION
in https://github.com/paritytech/substrate/pull/3344 I wrongly change the specification of linkedmap
before the key of the head of the linkedmap was stored at `$hash("head of " ++ module_name ++ " " ++ storoagename)` and after it was stored at `"head of " ++ module_name ++ " " ++ storoagename`.

Fix PR Fixes it.