### PR TITLE
Fix linkedmap instance head of

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 164,
-	impl_version: 164,
+	spec_version: 165,
+	impl_version: 165,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
Currently the head of a linked map for an instantiable module is put at: "Instance0head of MyModule MyStorage" instead of "head of Instance0MyModule MyStorage"

from the metadata user have the module name `Instance0MyModule` and the storage name `MyStorage` so he can't really get the head of the linkedmap.

I think this is a bug. fortunately there is no linked_map in instantiable module in substrate nor polkadot.

# Done

* fix the head key for instantiable module
* make test to test instantiable module with default instance and instance2