### PR TITLE
Use method instead of Secret::new

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -477,7 +477,7 @@ where
 				Ok(params.node_key_file
 					.or_else(|| net_config_file(net_config_dir, NODE_KEY_SECP256K1_FILE))
 					.map(network::config::Secret::File)
-					.unwrap_or(network::config::Secret::New)))
+					.unwrap_or(network::config::Secret::new_random_secp256k1())))
 				.map(NodeKeyConfig::Secp256k1),
 
 		NodeKeyType::Ed25519 =>
@@ -485,7 +485,7 @@ where
 				Ok(params.node_key_file
 					.or_else(|| net_config_file(net_config_dir, NODE_KEY_ED25519_FILE))
 					.map(network::config::Secret::File)
-					.unwrap_or(network::config::Secret::New)))
+					.unwrap_or(network::config::Secret::new_random_ed25519())))
 				.map(NodeKeyConfig::Ed25519)
 	}
 }
@@ -1001,10 +1001,8 @@ mod tests {
 				let typ = params.node_key_type;
 				node_key_config::<String>(params, &None)
 					.and_then(|c| match c {
-						NodeKeyConfig::Secp256k1(network::config::Secret::New)
-							if typ == NodeKeyType::Secp256k1 => Ok(()),
-						NodeKeyConfig::Ed25519(network::config::Secret::New)
-							if typ == NodeKeyType::Ed25519 => Ok(()),
+						NodeKeyConfig::Secp256k1(_) if typ == NodeKeyType::Secp256k1 => Ok(()),
+						NodeKeyConfig::Ed25519(_) if typ == NodeKeyType::Ed25519 => Ok(()),
 						_ => Err(error::Error::Input("Unexpected node key config".into()))
 					})
 			})

--- a/core/service/test/src/lib.rs
+++ b/core/service/test/src/lib.rs
@@ -148,7 +148,7 @@ fn node_config<G> (
 		],
 		public_addresses: vec![],
 		boot_nodes: vec![],
-		node_key: NodeKeyConfig::Ed25519(Secret::New),
+		node_key: NodeKeyConfig::Ed25519(Secret::new_random_ed25519()),
 		in_peers: 50,
 		out_peers: 450,
 		reserved_nodes: vec![],


### PR DESCRIPTION
By using a default method, each `NetworkConfiguration` instance now has
the same set of `node_key` keys as it previously couldn't be true for a cloned
`NodeKeyConfig::Ed25519/Secp256k1(Secret::New)` field