### PR TITLE
cli: clean up flag descriptions

### DIFF
--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -58,11 +58,11 @@ arg_enum! {
 /// Shared parameters used by all `CoreParams`.
 #[derive(Debug, StructOpt, Clone)]
 pub struct SharedParams {
-	/// Specify the chain specification (one of dev, local or staging)
+	/// Specify the chain specification (one of dev, local or staging).
 	#[structopt(long = "chain", value_name = "CHAIN_SPEC")]
 	pub chain: Option<String>,
 
-	/// Specify the development chain
+	/// Specify the development chain.
 	#[structopt(long = "dev")]
 	pub dev: bool,
 
@@ -70,7 +70,7 @@ pub struct SharedParams {
 	#[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
 	pub base_path: Option<PathBuf>,
 
-	/// Sets a custom logging filter
+	/// Sets a custom logging filter.
 	#[structopt(short = "l", long = "log", value_name = "LOG_PATTERN")]
 	pub log: Option<String>,
 }
@@ -84,32 +84,36 @@ impl GetLogFilter for SharedParams {
 /// Parameters used to create the network configuration.
 #[derive(Debug, StructOpt, Clone)]
 pub struct NetworkConfigurationParams {
-	/// Specify a list of bootnodes
+	/// Specify a list of bootnodes.
 	#[structopt(long = "bootnodes", value_name = "URL")]
 	pub bootnodes: Vec<String>,
 
-	/// Specify a list of reserved node addresses
+	/// Specify a list of reserved node addresses.
 	#[structopt(long = "reserved-nodes", value_name = "URL")]
 	pub reserved_nodes: Vec<String>,
 
-	/// Listen on this multiaddress
+	/// Listen on this multiaddress.
 	#[structopt(long = "listen-addr", value_name = "LISTEN_ADDR")]
 	pub listen_addr: Vec<String>,
 
-	/// Specify p2p protocol TCP port. Only used if --listen-addr is not specified.
+	/// Specify p2p protocol TCP port.
+	///
+	/// Only used if --listen-addr is not specified.
 	#[structopt(long = "port", value_name = "PORT")]
 	pub port: Option<u16>,
 
-	/// Specify the number of outgoing connections we're trying to maintain
+	/// Specify the number of outgoing connections we're trying to maintain.
 	#[structopt(long = "out-peers", value_name = "OUT_PEERS", default_value = "25")]
 	pub out_peers: u32,
 
-	/// Specify the maximum number of incoming connections we're accepting
+	/// Specify the maximum number of incoming connections we're accepting.
 	#[structopt(long = "in-peers", value_name = "IN_PEERS", default_value = "25")]
 	pub in_peers: u32,
 
-	/// By default, the network will use mDNS to discover other nodes on the local network. This
-	/// disables it. Automatically implied when using --dev.
+	/// Disable mDNS discovery.
+	///
+	/// By default, the network will use mDNS to discover other nodes on the
+	/// local network. This disables it. Automatically implied when using --dev.
 	#[structopt(long = "no-mdns")]
 	pub no_mdns: bool,
 
@@ -209,7 +213,7 @@ pub struct TransactionPoolParams {
 	#[structopt(long = "pool-limit", value_name = "COUNT", default_value = "512")]
 	pub pool_limit: usize,
 	/// Maximum number of kilobytes of all transactions stored in the pool.
-	#[structopt(long = "pool-kbytes", value_name = "COUNT", default_value="10240")]
+	#[structopt(long = "pool-kbytes", value_name = "COUNT", default_value = "10240")]
 	pub pool_kbytes: usize,
 }
 
@@ -298,39 +302,43 @@ pub struct ExecutionStrategies {
 /// The `run` command used to run a node.
 #[derive(Debug, StructOpt, Clone)]
 pub struct RunCmd {
-	/// Enable validator mode
+	/// Enable validator mode.
 	#[structopt(long = "validator")]
 	pub validator: bool,
 
-	/// Disable GRANDPA voter when running in validator mode, otherwise disables the GRANDPA observer
+	/// Disable GRANDPA voter when running in validator mode, otherwise disables the GRANDPA observer.
 	#[structopt(long = "no-grandpa")]
 	pub no_grandpa: bool,
 
-	/// Experimental: Run in light client mode
+	/// Experimental: Run in light client mode.
 	#[structopt(long = "light")]
 	pub light: bool,
 
-	/// Limit the memory the database cache can use
+	/// Limit the memory the database cache can use.
 	#[structopt(long = "db-cache", value_name = "MiB")]
 	pub database_cache_size: Option<u32>,
 
-	/// Specify the state cache size
+	/// Specify the state cache size.
 	#[structopt(long = "state-cache-size", value_name = "Bytes", default_value = "67108864")]
 	pub state_cache_size: usize,
 
-	/// Listen to all RPC interfaces (default is local)
+	/// Listen to all RPC interfaces.
+	///
+	/// Default is local.
 	#[structopt(long = "rpc-external")]
 	pub rpc_external: bool,
 
-	/// Listen to all Websocket interfaces (default is local)
+	/// Listen to all Websocket interfaces.
+	///
+	/// Default is local.
 	#[structopt(long = "ws-external")]
 	pub ws_external: bool,
 
-	/// Specify HTTP RPC server TCP port
+	/// Specify HTTP RPC server TCP port.
 	#[structopt(long = "rpc-port", value_name = "PORT")]
 	pub rpc_port: Option<u16>,
 
-	/// Specify WebSockets RPC server TCP port
+	/// Specify WebSockets RPC server TCP port.
 	#[structopt(long = "ws-port", value_name = "PORT")]
 	pub ws_port: Option<u16>,
 
@@ -339,33 +347,45 @@ pub struct RunCmd {
 	pub ws_max_connections: Option<usize>,
 
 	/// Specify browser Origins allowed to access the HTTP & WS RPC servers.
-	/// It's a comma-separated list of origins (protocol://domain or special `null` value).
-	/// Value of `all` will disable origin validation.
-	/// Default is to allow localhost, https://polkadot.js.org and https://substrate-ui.parity.io origins.
-	/// When running in --dev mode the default is to allow all origins.
+	///
+	/// A comma-separated list of origins (protocol://domain or special `null`
+	/// value). Value of `all` will disable origin validation. Default is to
+	/// allow localhost, https://polkadot.js.org and
+	/// https://substrate-ui.parity.io origins. When running in --dev mode the
+	/// default is to allow all origins.
 	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = "parse_cors"))]
 	pub rpc_cors: Option<Cors>,
 
-	/// Specify the pruning mode, a number of blocks to keep or 'archive'. Default is 256.
+	/// Specify the pruning mode, a number of blocks to keep or 'archive'.
+	///
+	/// Default is 256.
 	#[structopt(long = "pruning", value_name = "PRUNING_MODE")]
 	pub pruning: Option<String>,
 
-	/// The human-readable name for this node, as reported to the telemetry server, if enabled
+	/// The human-readable name for this node.
+	///
+	/// The node name will be reported to the telemetry server, if enabled.
 	#[structopt(long = "name", value_name = "NAME")]
 	pub name: Option<String>,
 
-	/// Disable connecting to the Substrate telemetry server (telemetry is on by default on global chains).
+	/// Disable connecting to the Substrate telemetry server.
+	///
+	/// Telemetry is on by default on global chains.
 	#[structopt(long = "no-telemetry")]
 	pub no_telemetry: bool,
 
-	/// The URL of the telemetry server to connect to. This flag can be passed multiple times
-	/// as a mean to specify multiple telemetry endpoints. Verbosity levels range from 0-9, with
-	/// 0 denoting the least verbosity. If no verbosity level is specified the default is 0.
+	/// The URL of the telemetry server to connect to.
+	///
+	/// This flag can be passed multiple times as a mean to specify multiple
+	/// telemetry endpoints. Verbosity levels range from 0-9, with 0 denoting
+	/// the least verbosity. If no verbosity level is specified the default is
+	/// 0.
 	#[structopt(long = "telemetry-url", value_name = "URL VERBOSITY", parse(try_from_str = "parse_telemetry_endpoints"))]
 	pub telemetry_endpoints: Vec<(String, u8)>,
 
-	/// Should execute offchain workers on every block. By default it's only enabled for nodes that are authoring new
-	/// blocks.
+	/// Should execute offchain workers on every block.
+	///
+	/// By default it's only enabled for nodes that are authoring new blocks.
 	#[structopt(
 		long = "offchain-worker",
 		value_name = "ENABLED",
@@ -584,11 +604,15 @@ pub struct ExportBlocksCmd {
 	#[structopt(parse(from_os_str))]
 	pub output: Option<PathBuf>,
 
-	/// Specify starting block number. 1 by default.
+	/// Specify starting block number.
+	///
+	/// Default is 1.
 	#[structopt(long = "from", value_name = "BLOCK")]
 	pub from: Option<u32>,
 
-	/// Specify last block number. Best block by default.
+	/// Specify last block number.
+	///
+	/// Default is best block.
 	#[structopt(long = "to", value_name = "BLOCK")]
 	pub to: Option<u32>,
 
@@ -610,7 +634,9 @@ pub struct ImportBlocksCmd {
 	#[structopt(parse(from_os_str))]
 	pub input: Option<PathBuf>,
 
-	/// The default number of 64KB pages to ever allocate for Wasm execution. Don't alter this unless you know what you're doing.
+	/// The default number of 64KB pages to ever allocate for Wasm execution.
+	///
+	/// Don't alter this unless you know what you're doing.
 	#[structopt(long = "default-heap-pages", value_name = "COUNT")]
 	pub default_heap_pages: Option<u32>,
 


### PR DESCRIPTION
Yesterday I learned that structopt makes a distinction between short and long parameter descriptions (`-h` vs `--help`). The distinction is made by adding an empty line in the middle of the parameter docs so I cleaned up some of the parameters with longer descriptions. I also made sure all descriptions were terminated with a dot (because OCD).