### PR TITLE
core/sr-api-macros/Cargo.toml: Pin protobuf version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,6 +3830,7 @@ dependencies = [
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4572,7 +4572,6 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-cli 2.0.0",
- "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,7 @@ dependencies = [
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-cli 2.0.0",
+ "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 cli = { package = "node-cli", path = "node/cli" }
 futures = "0.1"
 ctrlc = { version = "3.0", features = ["termination"] }
-protobuf = "~2.8.0"
 
 [build-dependencies]
 vergen = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 cli = { package = "node-cli", path = "node/cli" }
 futures = "0.1"
 ctrlc = { version = "3.0", features = ["termination"] }
+protobuf = "~2.8.0"
 
 [build-dependencies]
 vergen = "3"

--- a/core/sr-api-macros/Cargo.toml
+++ b/core/sr-api-macros/Cargo.toml
@@ -26,6 +26,10 @@ consensus_common = { package = "substrate-consensus-common", path = "../consensu
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 trybuild = "1.0"
 rustversion = "0.1"
+# The protobuf crate introduced a breaking change within its semver minor update
+# from 2.8.1 to 2.9.0. The dependency bound below ensures sr-api-macros uses
+# anything within the 2.8 minor releases. Remove once
+# https://github.com/stepancheg/rust-protobuf/issues/453 is resolved.
 protobuf = "~2.8.0"
 
 [[bench]]

--- a/core/sr-api-macros/Cargo.toml
+++ b/core/sr-api-macros/Cargo.toml
@@ -13,6 +13,7 @@ syn = { version = "^0.15.30", features = [ "full", "fold", "extra-traits", "visi
 proc-macro2 = "0.4"
 blake2-rfc = "0.2"
 proc-macro-crate = "0.1.3"
+protobuf = "~2.8.0"
 
 [dev-dependencies]
 client = { package = "substrate-client", path = "../client" }

--- a/core/sr-api-macros/Cargo.toml
+++ b/core/sr-api-macros/Cargo.toml
@@ -13,7 +13,6 @@ syn = { version = "^0.15.30", features = [ "full", "fold", "extra-traits", "visi
 proc-macro2 = "0.4"
 blake2-rfc = "0.2"
 proc-macro-crate = "0.1.3"
-protobuf = "~2.8.0"
 
 [dev-dependencies]
 client = { package = "substrate-client", path = "../client" }
@@ -27,6 +26,7 @@ consensus_common = { package = "substrate-consensus-common", path = "../consensu
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 trybuild = "1.0"
 rustversion = "0.1"
+protobuf = "~2.8.0"
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
The protobuf crate introduced a breaking change within its semver minor
update from 2.8.1 to 2.9.0. This commit ensures Substrate uses anything
within the 2.8 minor releases.
