### PR TITLE
srml: im-online: fix received heartbeats pruning

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 165,
-	impl_version: 167,
+	spec_version: 166,
+	impl_version: 166,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -437,9 +437,6 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 	fn on_new_session<'a, I: 'a>(_changed: bool, validators: I, _queued_validators: I)
 		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
-		// Reset heartbeats
-		<ReceivedHeartbeats>::remove_prefix(&<session::Module<T>>::current_index());
-
 		// Tell the offchain worker to start making the next session's heartbeats.
 		<GossipAt<T>>::put(<system::Module<T>>::block_number());
 
@@ -484,6 +481,10 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		};
 
 		T::ReportUnresponsiveness::report_offence(vec![], offence);
+
+		// Remove all received heartbeats from the current session, they have
+		// already been processed and won't be needed anymore.
+		<ReceivedHeartbeats>::remove_prefix(&<session::Module<T>>::current_index());
 	}
 
 	fn on_disabled(_i: usize) {

--- a/srml/im-online/src/tests.rs
+++ b/srml/im-online/src/tests.rs
@@ -216,3 +216,36 @@ fn should_generate_heartbeats() {
 		});
 	});
 }
+
+#[test]
+fn should_cleanup_received_heartbeats_on_session_end() {
+	let mut ext = new_test_ext();
+	let (offchain, state) = TestOffchainExt::new();
+	ext.set_offchain_externalities(offchain);
+
+	with_externalities(&mut new_test_ext(), || {
+		advance_session();
+
+		VALIDATORS.with(|l| *l.borrow_mut() = Some(vec![1, 2, 3]));
+		assert_eq!(Session::validators(), Vec::<u64>::new());
+
+		// enact the change and buffer another one
+		advance_session();
+
+		assert_eq!(Session::current_index(), 2);
+		assert_eq!(Session::validators(), vec![1, 2, 3]);
+
+		// send an heartbeat from authority id 0 at session 2
+		let _ = heartbeat(1, 2, 0, 1.into()).unwrap();
+
+		// the heartbeat is stored
+		assert!(!ImOnline::received_heartbeats(&2, &0).is_empty());
+
+		advance_session();
+
+		// after the session has ended we have already processed the heartbeat
+		// message, so any messages received on the previous session should have
+		// been pruned.
+		assert!(ImOnline::received_heartbeats(&2, &0).is_empty());
+	});
+}

--- a/srml/im-online/src/tests.rs
+++ b/srml/im-online/src/tests.rs
@@ -219,10 +219,6 @@ fn should_generate_heartbeats() {
 
 #[test]
 fn should_cleanup_received_heartbeats_on_session_end() {
-	let mut ext = new_test_ext();
-	let (offchain, state) = TestOffchainExt::new();
-	ext.set_offchain_externalities(offchain);
-
 	with_externalities(&mut new_test_ext(), || {
 		advance_session();
 


### PR DESCRIPTION
All of the heartbeat messages that were received at session `n` should be pruned after they have been processed and the session ends. Currently this was done on `on_new_session` but it was removing messages for the session that had just started and not the previous one. I moved this to `on_before_session_ending` so that we remove the messages right after they've been processed, also added a test for this.

This is the reason for the current flaming fir stall, since the double map is currently filled with all messages that were received in all session, the heartbeat extrinsic takes too long to execute and hence block production takes too long as well.