### PR TITLE
Revert "core/sr-api-macros/Cargo.toml: Pin protobuf version"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,7 +3830,6 @@ dependencies = [
  "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",

--- a/core/sr-api-macros/Cargo.toml
+++ b/core/sr-api-macros/Cargo.toml
@@ -26,11 +26,6 @@ consensus_common = { package = "substrate-consensus-common", path = "../consensu
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 trybuild = "1.0"
 rustversion = "0.1"
-# The protobuf crate introduced a breaking change within its semver minor update
-# from 2.8.1 to 2.9.0. The dependency bound below ensures sr-api-macros uses
-# anything within the 2.8 minor releases. Remove once
-# https://github.com/stepancheg/rust-protobuf/issues/453 is resolved.
-protobuf = "~2.8.0"
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
Reverts paritytech/substrate#3723

https://github.com/stepancheg/rust-protobuf/issues/453 was fixed, so we can revert this hack before it gets forgotten.