### PR TITLE
srml: system: add kill_prefix

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 166,
-	impl_version: 166,
+	spec_version: 167,
+	impl_version: 167,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -278,6 +278,13 @@ decl_module! {
 				storage::unhashed::kill(&key);
 			}
 		}
+
+		/// Kill all storage items with a key that starts with the given prefix.
+		#[weight = SimpleDispatchInfo::FixedOperational(10_000)]
+		fn kill_prefix(origin, prefix: Key) {
+			ensure_root(origin)?;
+			storage::unhashed::kill_prefix(&prefix);
+		}
 	}
 }
 


### PR DESCRIPTION
Add a `kill_prefix` extrinsic to system. This is useful to manually cleanup storage from double maps (needed as a result of #3724 but should be useful in general).