### PR TITLE
Remove unused imports

### DIFF
--- a/core/consensus/babe/src/tests.rs
+++ b/core/consensus/babe/src/tests.rs
@@ -30,7 +30,7 @@ use consensus_common::import_queue::{
 use network::test::*;
 use network::test::{Block as TestBlock, PeersClient};
 use network::config::BoxFinalityProofRequestBuilder;
-use sr_primitives::{generic::DigestItem, traits::{Block as BlockT, DigestFor, NumberFor}};
+use sr_primitives::{generic::DigestItem, traits::{Block as BlockT, DigestFor}};
 use network::config::ProtocolConfig;
 use tokio::runtime::current_thread;
 use client::BlockchainEvents;

--- a/srml/authority-discovery/src/lib.rs
+++ b/srml/authority-discovery/src/lib.rs
@@ -138,7 +138,6 @@ mod tests {
 	use primitives::testing::KeyStore;
 	use primitives::{crypto::key_types, sr25519, traits::BareCryptoStore, H256};
 	use runtime_io::{with_externalities, TestExternalities};
-	use sr_primitives::generic::UncheckedExtrinsic;
 	use sr_primitives::testing::{Header, UintAuthorityId};
 	use sr_primitives::traits::{ConvertInto, IdentityLookup, OpaqueKeys};
 	use sr_primitives::Perbill;

--- a/srml/generic-asset/src/lib.rs
+++ b/srml/generic-asset/src/lib.rs
@@ -166,7 +166,7 @@ use support::{
 		Currency, ExistenceRequirement, Imbalance, LockIdentifier, LockableCurrency, ReservableCurrency,
 		SignedImbalance, UpdateBalanceOutcome, WithdrawReason, WithdrawReasons,
 	},
-	Parameter, StorageDoubleMap, StorageMap, StorageValue,
+	Parameter, StorageMap,
 };
 use system::{ensure_signed, ensure_root};
 

--- a/srml/scored-pool/src/lib.rs
+++ b/srml/scored-pool/src/lib.rs
@@ -91,7 +91,7 @@ mod tests;
 use codec::FullCodec;
 use rstd::prelude::*;
 use support::{
-	StorageValue, StorageMap, decl_module, decl_storage, decl_event, ensure,
+	StorageValue, decl_module, decl_storage, decl_event, ensure,
 	traits::{ChangeMembers, InitializeMembers, Currency, Get, ReservableCurrency},
 };
 use system::{self, ensure_root, ensure_signed};

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -394,11 +394,6 @@ pub fn check_nominator_exposure(stash: u64) {
 	);
 }
 
-pub fn assert_total_expo(stash: u64, val: u64) {
-	let expo = Staking::stakers(&stash);
-	assert_eq!(expo.total, val, "total exposure mismatch {:?} != {:?}", expo.total, val);
-}
-
 pub fn assert_is_stash(acc: u64) {
 	assert!(Staking::bonded(&acc).is_some(), "Not a stash.");
 }

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -19,7 +19,7 @@
 //! This crate exports a macro `storage_items!` and traits describing behavior of generated
 //! structs.
 //!
-//! Three kinds of data types are currently supported:
+//! Two kinds of data types are currently supported:
 //!   - values
 //!   - maps
 //!
@@ -758,7 +758,7 @@ mod test3 {
 #[cfg(test)]
 #[allow(dead_code)]
 mod test_append_and_len {
-	use crate::storage::{StorageMap, StorageValue};
+	use crate::storage::{StorageValue};
 	use runtime_io::{with_externalities, TestExternalities};
 	use codec::{Encode, Decode};
 


### PR DESCRIPTION
Removes some unused imports that gave warnings when compiling `substrate`.

Plus there's a comment in `srml/support/src/storage/storage_items.rs` that refers to three data types being supported where it seems to be just two: `StorageValue` and `StorageMap`.
