### PR TITLE
Imply `--base-path ./.local` when `--dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ rls*.log
 *.orig
 *.rej
 **/wip/*.stderr
+.local/

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -140,13 +140,17 @@ fn load_spec<F, G, E>(cli: &SharedParams, factory: F) -> error::Result<ChainSpec
 fn base_path(cli: &SharedParams, version: &VersionInfo) -> PathBuf {
 	cli.base_path.clone()
 		.unwrap_or_else(||
-			app_dirs::get_app_root(
-				AppDataType::UserData,
-				&AppInfo {
-					name: version.executable_name,
-					author: version.author
-				}
-			).expect("app directories exist on all supported platforms; qed")
+			if cli.dev {
+				"./.local/".into()
+			} else {
+				app_dirs::get_app_root(
+					AppDataType::UserData,
+					&AppInfo {
+						name: version.executable_name,
+						author: version.author
+					}
+				).expect("app directories exist on all supported platforms; qed")
+			}
 		)
 }
 

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -58,15 +58,28 @@ arg_enum! {
 /// Shared parameters used by all `CoreParams`.
 #[derive(Debug, StructOpt, Clone)]
 pub struct SharedParams {
-	/// Specify the chain specification (one of dev, local or staging).
+	/// Specify the chain specification
+	///
+	/// Can be any of dev, local or staging or a path to a local json definition
 	#[structopt(long = "chain", value_name = "CHAIN_SPEC")]
 	pub chain: Option<String>,
 
-	/// Specify the development chain.
+	/// Specify to run in development setup.
+	///
+	/// It allows the chain to author even if no peers are present.
+	/// Unless any set otherwise, it also implies:
+	///   --chain dev
+	///   --alice
+	///   --base-path ./.local
+	///   --validator
+	///   --no-mdns
+	///   --rpc-cors *
 	#[structopt(long = "dev")]
 	pub dev: bool,
 
-	/// Specify custom base path.
+	/// Specify the base path for the database, keystore and other state
+    ///
+	/// Defaults to the operating systems default location for apps.
 	#[structopt(long = "base-path", short = "d", value_name = "PATH", parse(from_os_str))]
 	pub base_path: Option<PathBuf>,
 


### PR DESCRIPTION
`--dev` is inherently bound to my currently local run node. This PR adds an implied `./.local` base path when using the `--dev` flag. This came up at a workshop yesterday, when we noticed people having troubles - again - because they had used an earlier version of the workshop. `purge-chain` quickly resolved the - otherwise mysterious - error message of failing authoring and we were questioning whether it really makes sense to store the dev-chain in the user-global directory.

So this PR tries to lighten that problem by implying `--base-path ./.local` (unless set otherwise) when running `--dev`. This prevents new clones from ever interfering with other local clones of either substrate-node or similarly renamed projects (e.g. for workshops).

Additionally this:

 - improves the documentation and description of `--chain` and `--dev` and `--base-path`
 - adds `.local` to the `.gitignore`


//cc @shawntabrizi , @riusricardo