### PR TITLE
core/finality-grandpa: Gossip synced blocks via neighbor packets

### DIFF
--- a/core/finality-grandpa/primitives/src/lib.rs
+++ b/core/finality-grandpa/primitives/src/lib.rs
@@ -53,9 +53,11 @@ pub type AuthorityWeight = u64;
 pub type AuthorityIndex = u64;
 
 /// The identifier of a GRANDPA set.
+// TODO: Explain what a set is. A set of notes participating in the grandpa process?
 pub type SetId = u64;
 
 /// The round indicator.
+// TODO: Explain what a round is and how it relates to a set. A round in which each participant within the set votes?
 pub type RoundNumber = u64;
 
 /// A scheduled change of authority set.

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -896,6 +896,7 @@ impl<Block: BlockT> Inner<Block> {
 				round: local_view.round,
 				set_id: local_view.set_id,
 				commit_finalized_height: local_view.last_commit.unwrap_or(Zero::zero()),
+				known_vote_blocks: vec![],
 			};
 
 			let peers = self.peers.inner.keys().cloned().collect();
@@ -1066,6 +1067,7 @@ impl<Block: BlockT> network_gossip::Validator<Block> for GossipValidator<Block> 
 					round: v.round,
 					set_id: v.set_id,
 					commit_finalized_height: v.last_commit.unwrap_or(Zero::zero()),
+					known_vote_blocks: vec![],
 				}
 			})
 		};

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -299,6 +299,15 @@ pub(super) struct NeighborPacket<N> {
 	pub(super) set_id: SetId,
 	/// The highest finalizing commit observed.
 	pub(super) commit_finalized_height: N,
+	/// Hashes of the blocks which:
+	///
+	/// - the node has synced
+	///
+	/// - have been mentioned by nodes in vote (Prevote, Precommit) messages
+	///
+	/// - within the advertised Round set in `round` field.
+	// TODO: Replace `()` with some hash trait bound.
+	pub(super) known_vote_blocks: Vec<()>,
 }
 
 /// A versioned neighbor packet.

--- a/core/finality-grandpa/src/communication/periodic.rs
+++ b/core/finality-grandpa/src/communication/periodic.rs
@@ -26,7 +26,7 @@ use log::{debug, warn};
 use tokio_timer::Delay;
 
 use network::PeerId;
-use sr_primitives::traits::{NumberFor, Block as BlockT};
+use sr_primitives::traits::{Block as BlockT};
 use super::{gossip::{NeighborPacket, GossipMessage}, Network};
 
 // how often to rebroadcast, if no other
@@ -44,7 +44,7 @@ fn rebroadcast_instant() -> Instant {
 /// A sender used to send neighbor packets to a background job.
 #[derive(Clone)]
 pub(super) struct NeighborPacketSender<B: BlockT>(
-	mpsc::UnboundedSender<(Vec<PeerId>, NeighborPacket<NumberFor<B>>)>
+	mpsc::UnboundedSender<(Vec<PeerId>, NeighborPacket<B>)>
 );
 
 impl<B: BlockT> NeighborPacketSender<B> {
@@ -52,7 +52,7 @@ impl<B: BlockT> NeighborPacketSender<B> {
 	pub fn send(
 		&self,
 		who: Vec<network::PeerId>,
-		neighbor_packet: NeighborPacket<NumberFor<B>>,
+		neighbor_packet: NeighborPacket<B>,
 	) {
 		if let Err(err) = self.0.unbounded_send((who, neighbor_packet)) {
 			debug!(target: "afg", "Failed to send neighbor packet: {:?}", err);
@@ -72,7 +72,7 @@ pub(super) fn neighbor_packet_worker<B, N>(net: N) -> (
 	N: Network<B>,
 {
 	let mut last = None;
-	let (tx, mut rx) = mpsc::unbounded::<(Vec<PeerId>, NeighborPacket<NumberFor<B>>)>();
+	let (tx, mut rx) = mpsc::unbounded::<(Vec<PeerId>, NeighborPacket<B>)>();
 	let mut delay = Delay::new(rebroadcast_instant());
 
 	let work = futures::future::poll_fn(move || {

--- a/core/finality-grandpa/src/environment.rs
+++ b/core/finality-grandpa/src/environment.rs
@@ -375,7 +375,7 @@ pub(crate) struct Environment<B, E, Block: BlockT, N: Network<Block>, RA, SC> {
 	pub(crate) config: Config,
 	pub(crate) authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 	pub(crate) consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
-	pub(crate) network: crate::communication::NetworkBridge<Block, N>,
+	pub(crate) network: crate::communication::NetworkBridge<Block, N, Arc<Client<B, E, Block, RA>>>,
 	pub(crate) set_id: SetId,
 	pub(crate) voter_set_state: SharedVoterSetState<Block>,
 }

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -391,7 +391,7 @@ where
 	))
 }
 
-fn global_communication<Block: BlockT<Hash=H256>, B, E, N, RA>(
+fn global_communication<Block: BlockT<Hash=H256>, B: 'static, E: 'static, N, RA: 'static>(
 	set_id: SetId,
 	voters: &Arc<VoterSet<AuthorityId>>,
 	client: &Arc<Client<B, E, Block, RA>>,

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -887,13 +887,3 @@ fn authority_id<'a, I>(
 		None => None,
 	}
 }
-
-pub(crate) trait BlockImportedChecker<Block: BlockT> {
-	fn is_imported(h: Block::Hash) -> bool;
-}
-
-impl<Backend, E, Block: BlockT, RA> BlockImportedChecker<Block> for Arc<Client<Backend, E, Block, RA>>{
-	fn is_imported(_h: Block::Hash) -> bool {
-		false
-	}
-}

--- a/core/finality-grandpa/src/observer.rs
+++ b/core/finality-grandpa/src/observer.rs
@@ -177,6 +177,7 @@ pub fn run_grandpa_observer<B, E, Block: BlockT<Hash=H256>, N, RA, SC>(
 		persistent_data.set_state.clone(),
 		on_exit.clone(),
 		false,
+		client.clone(),
 	);
 
 	let observer_work = ObserverWork::new(
@@ -203,7 +204,7 @@ pub fn run_grandpa_observer<B, E, Block: BlockT<Hash=H256>, N, RA, SC>(
 struct ObserverWork<B: BlockT<Hash=H256>, N: Network<B>, E, Backend, RA> {
 	observer: Box<dyn Future<Item = (), Error = CommandOrError<B::Hash, NumberFor<B>>> + Send>,
 	client: Arc<Client<Backend, E, B, RA>>,
-	network: NetworkBridge<B, N>,
+	network: NetworkBridge<B, N, Arc<Client<Backend, E, B, RA>>>,
 	persistent_data: PersistentData<B>,
 	keystore: Option<keystore::KeyStorePtr>,
 	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,
@@ -221,7 +222,7 @@ where
 {
 	fn new(
 		client: Arc<Client<Bk, E, B, RA>>,
-		network: NetworkBridge<B, N>,
+		network: NetworkBridge<B, N, Arc<Client<Bk, E, B, RA>>>,
 		persistent_data: PersistentData<B>,
 		keystore: Option<keystore::KeyStorePtr>,
 		voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<B::Hash, NumberFor<B>>>,

--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -458,6 +458,7 @@ impl<B: BlockT> ChainSync<B> {
 		})
 	}
 
+	// TODO: We might want a way to extend the given set of nodes to sync from, not overwrite it.
 	/// Request syncing for the given block from given set of peers.
 	// The implementation is similar to on_block_announce with unknown parent hash.
 	pub fn set_sync_fork_request(&mut self, peers: Vec<PeerId>, hash: &B::Hash, number: NumberFor<B>) {
@@ -1325,4 +1326,3 @@ fn explicit_sync_request<B: BlockT>(
 	}
 	None
 }
-


### PR DESCRIPTION
## Goal

In order to participate in the *Grandpa* gossip process a *Grandpa* voter needs
to know:

1. Which blocks are relevant for the current round.

2. Where to retrieve these relevant blocks from.

*Grandpa* voters already exchange *neighbor packets* with each other in an
 epidemic fashion. This pull request extends the *neighbor packet* by a set of
 block hashes which:

1. The node has imported.

2. Have been mentioned by *Grandpa* *prevote* or *precommit* messages.

3. Within the current *Grandpa* round.

Listening to these extended *neighbor packets* a node can pass the information
down to the *network sync* service enabled through
https://github.com/paritytech/substrate/pull/3633.

This is part two of https://github.com/paritytech/substrate/issues/3629.


## Possible (current) solution

In order for a component within `core/finality-grandpa/src` to be able to
achieve the above goal it would need to:

(1) Receive *prevote* and *precommit* messages to keep track of the mentioned
block hashes.

(2) Somehow know whether a given block is available locally (is synced).

(3) Have access to a sink to send out the neighbor packets.

This pull request uses
`core/finality-grandpa/src/communication/gossip::GossipValidator` as it has
access to (1) and (3) and is already the component sending out
`NeighborPacket`s. We pass down a `Client` (stripped down version via
`BlockStatus` trait) through `NetworkBridge` into the `GossipValidator` thus
also achieving (2).


## Pull request status

For now this pull request is only a **draft**. I am opening it up at this point
to ease architectural discussions and to ask questions marked with `TODO`.

What do people think of the approach of extending the `GossipValidator`? Does
this stretch the responsibilities of a *network validator* a bit too much given
that the new logic is proactive?
