### PR TITLE
Use header metadata in babe verify.

### DIFF
--- a/core/client/db/src/lib.rs
+++ b/core/client/db/src/lib.rs
@@ -42,7 +42,7 @@ use client::backend::NewBlockState;
 use client::blockchain::{well_known_cache_keys, HeaderBackend};
 use client::{ForkBlocks, ExecutionStrategies};
 use client::backend::{StorageCollection, ChildStorageCollection};
-use client::error::Result as ClientResult;
+use client::error::{Result as ClientResult, Error as ClientError};
 use codec::{Decode, Encode};
 use hash_db::{Hasher, Prefix};
 use kvdb::{KeyValueDB, DBTransaction};
@@ -417,7 +417,7 @@ impl<Block: BlockT> HeaderMetadata<Block> for BlockchainDb<Block> {
 					header_metadata.clone(),
 				);
 				header_metadata
-			}).ok_or(client::error::Error::UnknownBlock("header not found in db".to_owned()))
+			}).ok_or(ClientError::UnknownBlock(format!("header not found in db: {}", hash)))
 		})
 	}
 

--- a/core/client/db/src/light.rs
+++ b/core/client/db/src/light.rs
@@ -207,7 +207,7 @@ impl<Block: BlockT> HeaderMetadata<Block> for LightStorage<Block> {
 					header_metadata.clone(),
 				);
 				header_metadata
-			}).ok_or(ClientError::UnknownBlock("header not found in db".to_owned()))
+			}).ok_or(ClientError::UnknownBlock(format!("header not found in db: {}", hash)))
 		})
 	}
 

--- a/core/client/src/in_mem.rs
+++ b/core/client/src/in_mem.rs
@@ -324,7 +324,7 @@ impl<Block: BlockT> HeaderMetadata<Block> for Blockchain<Block> {
 
 	fn header_metadata(&self, hash: Block::Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
 		self.header(BlockId::hash(hash))?.map(|header| CachedHeaderMetadata::from(&header))
-			.ok_or(error::Error::UnknownBlock("header not found".to_owned()))
+			.ok_or(error::Error::UnknownBlock(format!("header not found: {}", hash)))
 	}
 
 	fn insert_header_metadata(&self, _hash: Block::Hash, _metadata: CachedHeaderMetadata<Block>) {

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -611,8 +611,8 @@ impl<B, E, Block, RA, PRA> Verifier<Block> for BabeVerifier<B, E, Block, RA, PRA
 		let hash = header.hash();
 		let parent_hash = *header.parent_hash();
 
-		let parent_header = self.client.header_metadata(parent_hash)
-			.map_err(|e| format!("Could not fetch parent header {:?}: {:?}", parent_hash, e))?;
+		let parent_header_metadata = self.client.header_metadata(parent_hash)
+			.map_err(|e| format!("Could not fetch parent header: {:?}", e))?;
 
 		let pre_digest = find_pre_digest::<Block::Header>(&header)?;
 		let epoch = {
@@ -620,7 +620,7 @@ impl<B, E, Block, RA, PRA> Verifier<Block> for BabeVerifier<B, E, Block, RA, PRA
 			epoch_changes.epoch_for_child_of(
 				descendent_query(&*self.client),
 				&parent_hash,
-				parent_header.number,
+				parent_header_metadata.number,
 				pre_digest.slot_number(),
 				|slot| self.config.genesis_epoch(slot),
 			)

--- a/core/consensus/babe/src/lib.rs
+++ b/core/consensus/babe/src/lib.rs
@@ -611,9 +611,8 @@ impl<B, E, Block, RA, PRA> Verifier<Block> for BabeVerifier<B, E, Block, RA, PRA
 		let hash = header.hash();
 		let parent_hash = *header.parent_hash();
 
-		let parent_header = self.client.header(&BlockId::Hash(parent_hash))
-			.map_err(|e| format!("Could not fetch parent header {:?}: {:?}", parent_hash, e))?
-			.ok_or_else(|| format!("Parent header {:?} not found.", parent_hash))?;
+		let parent_header = self.client.header_metadata(parent_hash)
+			.map_err(|e| format!("Could not fetch parent header {:?}: {:?}", parent_hash, e))?;
 
 		let pre_digest = find_pre_digest::<Block::Header>(&header)?;
 		let epoch = {
@@ -621,7 +620,7 @@ impl<B, E, Block, RA, PRA> Verifier<Block> for BabeVerifier<B, E, Block, RA, PRA
 			epoch_changes.epoch_for_child_of(
 				descendent_query(&*self.client),
 				&parent_hash,
-				parent_header.number().clone(),
+				parent_header.number,
 				pre_digest.slot_number(),
 				|slot| self.config.genesis_epoch(slot),
 			)


### PR DESCRIPTION
`header_metadata` is more efficient and specific that `header` and therefore should be used whenever possible