### PR TITLE
Fix docker builds #3731

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,15 @@ FROM phusion/baseimage:0.10.2 as builder
 LABEL maintainer="chevdor@gmail.com"
 LABEL description="This is the build stage for Substrate. Here we create the binary."
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 ARG PROFILE=release
 WORKDIR /substrate
 
 COPY . /substrate
 
 RUN apt-get update && \
-	apt-get dist-upgrade -y && \
+	apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
 	apt-get install -y cmake pkg-config libssl-dev git clang
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \


### PR DESCRIPTION
Fixes #3731

The error `apt-get upgrade` is giving is due to not having `-o Dpkg::Options::="--force-confold"` to keep existing configurations. It is recommended by the Phusion docs to include this when doing an upgrade in a Dockerfile: https://github.com/phusion/passenger-docker#upgrading_os

Tested the build locally after updating `Dockerfile` and the error no longer occurs and image builds successfully.