### PR TITLE
Add `execute_with` to `TestExternalities`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,7 +3841,6 @@ dependencies = [
  "sr-io 2.0.0",
  "sr-std 2.0.0",
  "substrate-application-crypto 2.0.0",
- "substrate-externalities 2.0.0",
  "substrate-offchain 2.0.0",
  "substrate-primitives 2.0.0",
 ]

--- a/core/sr-primitives/Cargo.toml
+++ b/core/sr-primitives/Cargo.toml
@@ -16,7 +16,6 @@ runtime_io = { package = "sr-io", path = "../sr-io", default-features = false }
 log = { version = "0.4.8", optional = true }
 paste = "0.1.6"
 rand = { version = "0.7.2", optional = true }
-externalities = { package = "substrate-externalities", path = "../externalities", optional = true }
 impl-trait-for-tuples = "0.1.2"
 
 [dev-dependencies]
@@ -37,5 +36,4 @@ std = [
 	"primitives/std",
 	"app-crypto/std",
 	"rand",
-	"externalities",
 ]

--- a/core/sr-primitives/src/lib.rs
+++ b/core/sr-primitives/src/lib.rs
@@ -67,9 +67,6 @@ pub use sr_arithmetic::{
 /// Re-export 128 bit helpers from sr_arithmetic
 pub use sr_arithmetic::helpers_128bit;
 
-#[cfg(feature = "std")]
-pub use externalities::set_and_run_with_externalities;
-
 /// An abstraction over justification for a block's validity under a consensus algorithm.
 ///
 /// Essentially a finality proof. The exact formulation will vary between consensus

--- a/core/sr-primitives/src/offchain/http.rs
+++ b/core/sr-primitives/src/offchain/http.rs
@@ -512,7 +512,6 @@ impl<'a> HeadersIterator<'a> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::set_and_run_with_externalities;
 	use runtime_io::TestExternalities;
 	use substrate_offchain::testing;
 	use primitives::offchain::OffchainExt;
@@ -523,7 +522,7 @@ mod tests {
 		let mut t = TestExternalities::default();
 		t.register_extension(OffchainExt::new(offchain));
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			let request: Request = Request::get("http://localhost:1234");
 			let pending = request
 				.add_header("X-Auth", "hunter2")
@@ -564,7 +563,7 @@ mod tests {
 		let mut t = TestExternalities::default();
 		t.register_extension(OffchainExt::new(offchain));
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			let pending = Request::default()
 				.method(Method::Post)
 				.url("http://localhost:1234")

--- a/core/state-machine/src/testing.rs
+++ b/core/state-machine/src/testing.rs
@@ -113,6 +113,13 @@ impl<H: Hasher<Out=H256>, N: ChangesTrieBlockNumber> TestExternalities<H, N> {
 
 		self.backend.update(top.chain(children).collect())
 	}
+
+	/// Execute the given closure while `self` is set as externalities.
+	///
+	/// Returns the result of the given closure.
+	pub fn execute_with<R>(&mut self, execute: impl FnOnce() -> R) -> R {
+		externalities::set_and_run_with_externalities(self, execute)
+	}
 }
 
 impl<H: Hasher<Out=H256>, N: ChangesTrieBlockNumber> std::fmt::Debug for TestExternalities<H, N> {

--- a/core/test-runtime/src/system.rs
+++ b/core/test-runtime/src/system.rs
@@ -321,7 +321,6 @@ mod tests {
 
 	use runtime_io::TestExternalities;
 	use substrate_test_runtime_client::{AccountKeyring, Sr25519Keyring};
-	use sr_primitives::set_and_run_with_externalities;
 	use crate::{Header, Transfer, WASM_BINARY};
 	use primitives::{NeverNativeValue, map, traits::CodeExecutor};
 	use substrate_executor::{NativeExecutor, WasmExecutionMethod, native_executor_instance};
@@ -371,18 +370,14 @@ mod tests {
 			extrinsics: vec![],
 		};
 
-		set_and_run_with_externalities(&mut new_test_ext(), || polish_block(&mut b));
+		new_test_ext().execute_with(|| polish_block(&mut b));
 
 		block_executor(b, &mut new_test_ext());
 	}
 
 	#[test]
 	fn block_import_works_native() {
-		block_import_works(|b, ext| {
-			set_and_run_with_externalities(ext, || {
-				execute_block(b);
-			});
-		});
+		block_import_works(|b, ext| ext.execute_with(|| execute_block(b)));
 	}
 
 	#[test]
@@ -420,7 +415,7 @@ mod tests {
 		};
 
 		let mut dummy_ext = new_test_ext();
-		set_and_run_with_externalities(&mut dummy_ext, || polish_block(&mut b1));
+		dummy_ext.execute_with(|| polish_block(&mut b1));
 
 		let mut b2 = Block {
 			header: Header {
@@ -446,26 +441,26 @@ mod tests {
 			],
 		};
 
-		set_and_run_with_externalities(&mut dummy_ext, || polish_block(&mut b2));
+		dummy_ext.execute_with(|| polish_block(&mut b2));
 		drop(dummy_ext);
 
 		let mut t = new_test_ext();
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(balance_of(AccountKeyring::Alice.into()), 111);
 			assert_eq!(balance_of(AccountKeyring::Bob.into()), 0);
 		});
 
 		block_executor(b1, &mut t);
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(balance_of(AccountKeyring::Alice.into()), 42);
 			assert_eq!(balance_of(AccountKeyring::Bob.into()), 69);
 		});
 
 		block_executor(b2, &mut t);
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(balance_of(AccountKeyring::Alice.into()), 0);
 			assert_eq!(balance_of(AccountKeyring::Bob.into()), 42);
 			assert_eq!(balance_of(AccountKeyring::Charlie.into()), 69);
@@ -474,11 +469,7 @@ mod tests {
 
 	#[test]
 	fn block_import_with_transaction_works_native() {
-		block_import_with_transaction_works(|b, ext| {
-			set_and_run_with_externalities(ext, || {
-				execute_block(b);
-			});
-		});
+		block_import_with_transaction_works(|b, ext| ext.execute_with(|| execute_block(b)));
 	}
 
 	#[test]

--- a/node-template/runtime/src/template.rs
+++ b/node-template/runtime/src/template.rs
@@ -72,8 +72,7 @@ mod tests {
 	use primitives::H256;
 	use support::{impl_outer_origin, assert_ok, parameter_types};
 	use sr_primitives::{
-		set_and_run_with_externalities, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		weights::Weight, Perbill,
+		traits::{BlakeTwo256, IdentityLookup}, testing::Header, weights::Weight, Perbill,
 	};
 
 	impl_outer_origin! {
@@ -122,7 +121,7 @@ mod tests {
 
 	#[test]
 	fn it_works_for_default_value() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// Just a dummy test for the dummy funtion `do_something`
 			// calling the `do_something` function with a value 42
 			assert_ok!(TemplateModule::do_something(Origin::signed(1), 42));

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -226,7 +226,7 @@ mod tests {
 		).0;
 		assert!(r.is_ok());
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&alice()), 42 * DOLLARS - transfer_fee(&xt()));
 			assert_eq!(Balances::total_balance(&bob()), 69 * DOLLARS);
 		});
@@ -262,7 +262,7 @@ mod tests {
 		).0;
 		assert!(r.is_ok());
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&alice()), 42 * DOLLARS - transfer_fee(&xt()));
 			assert_eq!(Balances::total_balance(&bob()), 69 * DOLLARS);
 		});
@@ -433,7 +433,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&alice()), 42 * DOLLARS - transfer_fee(&xt()));
 			assert_eq!(Balances::total_balance(&bob()), 169 * DOLLARS);
 			let events = vec![
@@ -468,7 +468,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			// NOTE: fees differ slightly in tests that execute more than one block due to the
 			// weight update. Hence, using `assert_eq_error_rate`.
 			assert_eq_error_rate!(
@@ -540,7 +540,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&alice()), 42 * DOLLARS - transfer_fee(&xt()));
 			assert_eq!(Balances::total_balance(&bob()), 169 * DOLLARS);
 		});
@@ -553,7 +553,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq_error_rate!(
 				Balances::total_balance(&alice()),
 				32 * DOLLARS - 2 * transfer_fee(&xt()),
@@ -715,7 +715,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			// Verify that the contract constructor worked well and code of TRANSFER contract is actually deployed.
 			assert_eq!(
 				&contracts::ContractInfoOf::<Runtime>::get(addr)
@@ -836,7 +836,7 @@ mod tests {
 			.expect("Extrinsic could be applied")
 			.expect("Extrinsic did not fail");
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&alice()), 42 * DOLLARS - 1 * transfer_fee(&xt()));
 			assert_eq!(Balances::total_balance(&bob()), 69 * DOLLARS);
 		});
@@ -895,7 +895,7 @@ mod tests {
 
 		let mut prev_multiplier = WeightMultiplier::default();
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(System::next_weight_multiplier(), prev_multiplier);
 		});
 
@@ -947,7 +947,7 @@ mod tests {
 		).0.unwrap();
 
 		// weight multiplier is increased for next block.
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			let fm = System::next_weight_multiplier();
 			println!("After a big block: {:?} -> {:?}", prev_multiplier, fm);
 			assert!(fm > prev_multiplier);
@@ -964,7 +964,7 @@ mod tests {
 		).0.unwrap();
 
 		// weight multiplier is increased for next block.
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			let fm = System::next_weight_multiplier();
 			println!("After a small block: {:?} -> {:?}", prev_multiplier, fm);
 			assert!(fm < prev_multiplier);
@@ -1018,7 +1018,7 @@ mod tests {
 		).0;
 		assert!(r.is_ok());
 
-		sr_primitives::set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Balances::total_balance(&bob()), (10 + 69) * DOLLARS);
 			// Components deducted from alice's balances:
 			// - Weight fee

--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -244,10 +244,7 @@ mod tests {
 	use primitives::H256;
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
-	use sr_primitives::{
-		Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		set_and_run_with_externalities,
-	};
+	use sr_primitives::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 
 	impl_outer_origin! {
 		pub enum Origin for Test {}
@@ -297,7 +294,7 @@ mod tests {
 
 	#[test]
 	fn issuing_asset_units_to_issuer_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 		});
@@ -305,7 +302,7 @@ mod tests {
 
 	#[test]
 	fn querying_total_supply_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_ok!(Assets::transfer(Origin::signed(1), 0, 2, 50));
@@ -322,7 +319,7 @@ mod tests {
 
 	#[test]
 	fn transferring_amount_above_available_balance_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_ok!(Assets::transfer(Origin::signed(1), 0, 2, 50));
@@ -333,7 +330,7 @@ mod tests {
 
 	#[test]
 	fn transferring_amount_less_than_available_balance_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_ok!(Assets::transfer(Origin::signed(1), 0, 2, 50));
@@ -347,7 +344,7 @@ mod tests {
 
 	#[test]
 	fn transferring_less_than_one_unit_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_noop!(Assets::transfer(Origin::signed(1), 0, 2, 0), "transfer amount should be non-zero");
@@ -356,7 +353,7 @@ mod tests {
 
 	#[test]
 	fn transferring_more_units_than_total_supply_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_noop!(Assets::transfer(Origin::signed(1), 0, 2, 101), "origin account balance must be greater than or equal to the transfer amount");
@@ -365,7 +362,7 @@ mod tests {
 
 	#[test]
 	fn destroying_asset_balance_with_positive_balance_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);
 			assert_ok!(Assets::destroy(Origin::signed(1), 0));
@@ -374,7 +371,7 @@ mod tests {
 
 	#[test]
 	fn destroying_asset_balance_with_zero_balance_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 2), 0);
 			assert_noop!(Assets::destroy(Origin::signed(2), 0), "origin balance should be non-zero");

--- a/srml/aura/src/tests.rs
+++ b/srml/aura/src/tests.rs
@@ -18,12 +18,11 @@
 
 #![cfg(test)]
 
-use sr_primitives::set_and_run_with_externalities;
 use crate::mock::{Aura, new_test_ext};
 
 #[test]
 fn initial_values() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![0, 1, 2, 3]), || {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		assert_eq!(Aura::last(), 0u64);
 		assert_eq!(Aura::authorities().len(), 4);
 	});

--- a/srml/authority-discovery/src/lib.rs
+++ b/srml/authority-discovery/src/lib.rs
@@ -139,7 +139,7 @@ mod tests {
 	use runtime_io::TestExternalities;
 	use sr_primitives::{
 		testing::{Header, UintAuthorityId}, traits::{ConvertInto, IdentityLookup, OpaqueKeys},
-		Perbill, set_and_run_with_externalities,
+		Perbill,
 	};
 	use support::{impl_outer_origin, parameter_types};
 
@@ -263,7 +263,7 @@ mod tests {
 		let mut externalities = TestExternalities::new(t);
 		externalities.register_extension(KeystoreExt(key_store));
 
-		set_and_run_with_externalities(&mut externalities, || {
+		externalities.execute_with(|| {
 			assert_eq!(
 				authority_id,
 				AuthorityDiscovery::authority_id().expect("Retrieving public key.")
@@ -300,7 +300,7 @@ mod tests {
 		let mut externalities = TestExternalities::new(t);
 		externalities.register_extension(KeystoreExt(key_store));
 
-		set_and_run_with_externalities(&mut externalities, || {
+		externalities.execute_with(|| {
 			assert_eq!(None, AuthorityDiscovery::authority_id());
 		});
 	}
@@ -337,7 +337,7 @@ mod tests {
 		let mut externalities = TestExternalities::new(t);
 		externalities.register_extension(KeystoreExt(key_store));
 
-		set_and_run_with_externalities(&mut externalities, || {
+		externalities.execute_with(|| {
 			let payload = String::from("test payload").into_bytes();
 			let (sig, authority_id) = AuthorityDiscovery::sign(&payload).expect("signature");
 

--- a/srml/authorship/src/lib.rs
+++ b/srml/authorship/src/lib.rs
@@ -414,8 +414,7 @@ mod tests {
 	use super::*;
 	use primitives::H256;
 	use sr_primitives::{
-		set_and_run_with_externalities, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		generic::DigestItem, Perbill,
+		traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic::DigestItem, Perbill,
 	};
 	use support::{parameter_types, impl_outer_origin, ConsensusEngineId};
 
@@ -542,7 +541,7 @@ mod tests {
 	#[test]
 	fn prune_old_uncles_works() {
 		use UncleEntryItem::*;
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let hash = Default::default();
 			let author = Default::default();
 			let uncles = vec![
@@ -561,7 +560,7 @@ mod tests {
 
 	#[test]
 	fn rejects_bad_uncles() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let author_a = 69;
 
 			struct CanonChain {
@@ -674,7 +673,7 @@ mod tests {
 
 	#[test]
 	fn sets_author_lazily() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let author = 42;
 			let mut header = seal_header(
 				create_header(1, Default::default(), [1; 32].into()),

--- a/srml/babe/src/tests.rs
+++ b/srml/babe/src/tests.rs
@@ -18,9 +18,7 @@
 
 use super::*;
 use mock::{new_test_ext, Babe, Test};
-use sr_primitives::{
-	set_and_run_with_externalities, traits::OnFinalize, testing::{Digest, DigestItem},
-};
+use sr_primitives::{traits::OnFinalize, testing::{Digest, DigestItem}};
 use session::ShouldEndSession;
 
 const EMPTY_RANDOMNESS: [u8; 32] = [
@@ -54,14 +52,14 @@ fn empty_randomness_is_correct() {
 
 #[test]
 fn initial_values() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![0, 1, 2, 3]), || {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		assert_eq!(Babe::authorities().len(), 4)
 	})
 }
 
 #[test]
 fn check_module() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![0, 1, 2, 3]), || {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		assert!(!Babe::should_end_session(0), "Genesis does not change sessions");
 		assert!(!Babe::should_end_session(200000),
 			"BABE does not include the block number in epoch calculations");
@@ -72,7 +70,7 @@ type System = system::Module<Test>;
 
 #[test]
 fn first_block_epoch_zero_start() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![0, 1, 2, 3]), || {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		let genesis_slot = 100;
 		let first_vrf = [1; 32];
 		let pre_digest = make_pre_digest(
@@ -120,7 +118,7 @@ fn first_block_epoch_zero_start() {
 
 #[test]
 fn authority_index() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![0, 1, 2, 3]), || {
+	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
 		assert_eq!(
 			Babe::find_author((&[(BABE_ENGINE_ID, &[][..])]).into_iter().cloned()), None,
 			"Trivially invalid authorities are ignored")

--- a/srml/balances/src/tests.rs
+++ b/srml/balances/src/tests.rs
@@ -20,7 +20,6 @@
 
 use super::*;
 use mock::{Balances, ExtBuilder, Runtime, System, info_from_weight, CALL};
-use sr_primitives::set_and_run_with_externalities;
 use support::{
 	assert_noop, assert_ok, assert_err,
 	traits::{LockableCurrency, LockIdentifier, WithdrawReason, WithdrawReasons,
@@ -34,7 +33,7 @@ const ID_3: LockIdentifier = *b"3       ";
 
 #[test]
 fn basic_locking_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		assert_eq!(Balances::free_balance(&1), 10);
 		Balances::set_lock(ID_1, &1, 9, u64::max_value(), WithdrawReasons::all());
 		assert_noop!(
@@ -46,7 +45,7 @@ fn basic_locking_should_work() {
 
 #[test]
 fn partial_locking_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 5, u64::max_value(), WithdrawReasons::all());
 		assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1));
 	});
@@ -54,7 +53,7 @@ fn partial_locking_should_work() {
 
 #[test]
 fn lock_removal_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, u64::max_value(), u64::max_value(), WithdrawReasons::all());
 		Balances::remove_lock(ID_1, &1);
 		assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1));
@@ -63,7 +62,7 @@ fn lock_removal_should_work() {
 
 #[test]
 fn lock_replacement_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, u64::max_value(), u64::max_value(), WithdrawReasons::all());
 		Balances::set_lock(ID_1, &1, 5, u64::max_value(), WithdrawReasons::all());
 		assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1));
@@ -72,7 +71,7 @@ fn lock_replacement_should_work() {
 
 #[test]
 fn double_locking_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 5, u64::max_value(), WithdrawReasons::all());
 		Balances::set_lock(ID_2, &1, 5, u64::max_value(), WithdrawReasons::all());
 		assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1));
@@ -81,7 +80,7 @@ fn double_locking_should_work() {
 
 #[test]
 fn combination_locking_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, u64::max_value(), 0, WithdrawReasons::none());
 		Balances::set_lock(ID_2, &1, 0, u64::max_value(), WithdrawReasons::none());
 		Balances::set_lock(ID_3, &1, 0, 0, WithdrawReasons::all());
@@ -91,7 +90,7 @@ fn combination_locking_should_work() {
 
 #[test]
 fn lock_value_extension_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 5, u64::max_value(), WithdrawReasons::all());
 		assert_noop!(
 			<Balances as Currency<_>>::transfer(&1, &2, 6),
@@ -112,12 +111,12 @@ fn lock_value_extension_should_work() {
 
 #[test]
 fn lock_reasons_should_work() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(1)
-			.monied(true).transaction_fees(0, 1, 0)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.transaction_fees(0, 1, 0)
+		.build()
+		.execute_with(|| {
 			Balances::set_lock(ID_1, &1, 10, u64::max_value(), WithdrawReason::Transfer.into());
 			assert_noop!(
 				<Balances as Currency<_>>::transfer(&1, &2, 1),
@@ -157,13 +156,12 @@ fn lock_reasons_should_work() {
 				info_from_weight(1),
 				0,
 			).is_err());
-		}
-	);
+		});
 }
 
 #[test]
 fn lock_block_number_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 10, 2, WithdrawReasons::all());
 		assert_noop!(
 			<Balances as Currency<_>>::transfer(&1, &2, 1),
@@ -177,7 +175,7 @@ fn lock_block_number_should_work() {
 
 #[test]
 fn lock_block_number_extension_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 10, 2, WithdrawReasons::all());
 		assert_noop!(
 			<Balances as Currency<_>>::transfer(&1, &2, 6),
@@ -199,7 +197,7 @@ fn lock_block_number_extension_should_work() {
 
 #[test]
 fn lock_reasons_extension_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().existential_deposit(1).monied(true).build(), || {
+	ExtBuilder::default().existential_deposit(1).monied(true).build().execute_with(|| {
 		Balances::set_lock(ID_1, &1, 10, 10, WithdrawReason::Transfer.into());
 		assert_noop!(
 			<Balances as Currency<_>>::transfer(&1, &2, 6),
@@ -220,14 +218,12 @@ fn lock_reasons_extension_should_work() {
 
 #[test]
 fn default_indexing_on_new_accounts_should_not_work2() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(10)
-			.creation_fee(50)
-			.monied(true)
-			.build(),
-		|| {
-
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.creation_fee(50)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(Balances::is_dead_account(&5), true); // account 5 should not exist
 			// ext_deposit is 10, value is 9, not satisfies for ext_deposit
 			assert_noop!(
@@ -236,18 +232,16 @@ fn default_indexing_on_new_accounts_should_not_work2() {
 			);
 			assert_eq!(Balances::is_dead_account(&5), true); // account 5 should not exist
 			assert_eq!(Balances::free_balance(&1), 100);
-		},
-	);
+		});
 }
 
 #[test]
 fn reserved_balance_should_prevent_reclaim_count() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(256 * 1)
-			.monied(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(256 * 1)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			System::inc_account_nonce(&2);
 			assert_eq!(Balances::is_dead_account(&2), false);
 			assert_eq!(Balances::is_dead_account(&5), true);
@@ -274,14 +268,13 @@ fn reserved_balance_should_prevent_reclaim_count() {
 			assert_ok!(Balances::transfer(Some(4).into(), 6, 256 * 1 + 0x69));
 			assert_eq!(Balances::total_balance(&6), 256 * 1 + 0x69);
 			assert_eq!(Balances::is_dead_account(&6), false);
-		},
-	);
+		});
 }
 
 
 #[test]
 fn reward_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().monied(true).build(), || {
+	ExtBuilder::default().monied(true).build().execute_with(|| {
 		assert_eq!(Balances::total_balance(&1), 10);
 		assert_ok!(Balances::deposit_into_existing(&1, 10).map(drop));
 		assert_eq!(Balances::total_balance(&1), 20);
@@ -291,12 +284,11 @@ fn reward_should_work() {
 
 #[test]
 fn dust_account_removal_should_work() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(100)
-			.monied(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(100)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			System::inc_account_nonce(&2);
 			assert_eq!(System::account_nonce(&2), 1);
 			assert_eq!(Balances::total_balance(&2), 2000);
@@ -305,19 +297,17 @@ fn dust_account_removal_should_work() {
 			assert_eq!(Balances::total_balance(&2), 0);
 			assert_eq!(Balances::total_balance(&5), 1901);
 			assert_eq!(System::account_nonce(&2), 0);
-		},
-	);
+		});
 }
 
 #[test]
 fn dust_account_removal_should_work2() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(100)
-			.creation_fee(50)
-			.monied(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(100)
+		.creation_fee(50)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			System::inc_account_nonce(&2);
 			assert_eq!(System::account_nonce(&2), 1);
 			assert_eq!(Balances::total_balance(&2), 2000);
@@ -326,13 +316,12 @@ fn dust_account_removal_should_work2() {
 			assert_eq!(Balances::total_balance(&2), 0);
 			assert_eq!(Balances::total_balance(&5), 1851);
 			assert_eq!(System::account_nonce(&2), 0);
-		},
-	);
+		});
 }
 
 #[test]
 fn balance_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 42);
 		assert_eq!(Balances::free_balance(&1), 42);
 		assert_eq!(Balances::reserved_balance(&1), 0);
@@ -345,7 +334,7 @@ fn balance_works() {
 
 #[test]
 fn balance_transfer_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::transfer(Some(1).into(), 2, 69));
 		assert_eq!(Balances::total_balance(&1), 42);
@@ -355,7 +344,7 @@ fn balance_transfer_works() {
 
 #[test]
 fn force_transfer_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_noop!(
 			Balances::force_transfer(Some(2).into(), 1, 2, 69),
@@ -369,7 +358,7 @@ fn force_transfer_works() {
 
 #[test]
 fn reserving_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 
 		assert_eq!(Balances::total_balance(&1), 111);
@@ -386,7 +375,7 @@ fn reserving_balance_should_work() {
 
 #[test]
 fn balance_transfer_when_reserved_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 69));
 		assert_noop!(
@@ -398,7 +387,7 @@ fn balance_transfer_when_reserved_should_not_work() {
 
 #[test]
 fn deducting_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 69));
 		assert_eq!(Balances::free_balance(&1), 42);
@@ -407,7 +396,7 @@ fn deducting_balance_should_work() {
 
 #[test]
 fn refunding_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 42);
 		Balances::set_reserved_balance(&1, 69);
 		Balances::unreserve(&1, 69);
@@ -418,7 +407,7 @@ fn refunding_balance_should_work() {
 
 #[test]
 fn slashing_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 69));
 		assert!(Balances::slash(&1, 69).1.is_zero());
@@ -430,7 +419,7 @@ fn slashing_balance_should_work() {
 
 #[test]
 fn slashing_incomplete_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 42);
 		assert_ok!(Balances::reserve(&1, 21));
 		assert_eq!(Balances::slash(&1, 69).1, 27);
@@ -442,7 +431,7 @@ fn slashing_incomplete_balance_should_work() {
 
 #[test]
 fn unreserving_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 111));
 		Balances::unreserve(&1, 42);
@@ -453,7 +442,7 @@ fn unreserving_balance_should_work() {
 
 #[test]
 fn slashing_reserved_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 111));
 		assert_eq!(Balances::slash_reserved(&1, 42).1, 0);
@@ -465,7 +454,7 @@ fn slashing_reserved_balance_should_work() {
 
 #[test]
 fn slashing_incomplete_reserved_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 42));
 		assert_eq!(Balances::slash_reserved(&1, 69).1, 27);
@@ -477,7 +466,7 @@ fn slashing_incomplete_reserved_balance_should_work() {
 
 #[test]
 fn transferring_reserved_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 110);
 		let _ = Balances::deposit_creating(&2, 1);
 		assert_ok!(Balances::reserve(&1, 110));
@@ -491,7 +480,7 @@ fn transferring_reserved_balance_should_work() {
 
 #[test]
 fn transferring_reserved_balance_to_nonexistent_should_fail() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 111);
 		assert_ok!(Balances::reserve(&1, 111));
 		assert_noop!(Balances::repatriate_reserved(&1, &2, 42), "beneficiary account must pre-exist");
@@ -500,7 +489,7 @@ fn transferring_reserved_balance_to_nonexistent_should_fail() {
 
 #[test]
 fn transferring_incomplete_reserved_balance_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let _ = Balances::deposit_creating(&1, 110);
 		let _ = Balances::deposit_creating(&2, 1);
 		assert_ok!(Balances::reserve(&1, 41));
@@ -514,7 +503,7 @@ fn transferring_incomplete_reserved_balance_should_work() {
 
 #[test]
 fn transferring_too_high_value_should_not_panic() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		<FreeBalance<Runtime>>::insert(1, u64::max_value());
 		<FreeBalance<Runtime>>::insert(2, 1);
 
@@ -530,89 +519,76 @@ fn transferring_too_high_value_should_not_panic() {
 
 #[test]
 fn account_create_on_free_too_low_with_other() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(100).build(),
-		|| {
-			let _ = Balances::deposit_creating(&1, 100);
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 100);
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let _ = Balances::deposit_creating(&1, 100);
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 100);
 
-			// No-op.
-			let _ = Balances::deposit_creating(&2, 50);
-			assert_eq!(Balances::free_balance(&2), 0);
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 100);
-		}
-	)
+		// No-op.
+		let _ = Balances::deposit_creating(&2, 50);
+		assert_eq!(Balances::free_balance(&2), 0);
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 100);
+	})
 }
 
 
 #[test]
 fn account_create_on_free_too_low() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(100).build(),
-		|| {
-			// No-op.
-			let _ = Balances::deposit_creating(&2, 50);
-			assert_eq!(Balances::free_balance(&2), 0);
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 0);
-		}
-	)
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		// No-op.
+		let _ = Balances::deposit_creating(&2, 50);
+		assert_eq!(Balances::free_balance(&2), 0);
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 0);
+	})
 }
 
 #[test]
 fn account_removal_on_free_too_low() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(100).build(),
-		|| {
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 0);
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 0);
 
-			// Setup two accounts with free balance above the existential threshold.
-			let _ = Balances::deposit_creating(&1, 110);
-			let _ = Balances::deposit_creating(&2, 110);
+		// Setup two accounts with free balance above the existential threshold.
+		let _ = Balances::deposit_creating(&1, 110);
+		let _ = Balances::deposit_creating(&2, 110);
 
-			assert_eq!(Balances::free_balance(&1), 110);
-			assert_eq!(Balances::free_balance(&2), 110);
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 220);
+		assert_eq!(Balances::free_balance(&1), 110);
+		assert_eq!(Balances::free_balance(&2), 110);
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 220);
 
-			// Transfer funds from account 1 of such amount that after this transfer
-			// the balance of account 1 will be below the existential threshold.
-			// This should lead to the removal of all balance of this account.
-			assert_ok!(Balances::transfer(Some(1).into(), 2, 20));
+		// Transfer funds from account 1 of such amount that after this transfer
+		// the balance of account 1 will be below the existential threshold.
+		// This should lead to the removal of all balance of this account.
+		assert_ok!(Balances::transfer(Some(1).into(), 2, 20));
 
-			// Verify free balance removal of account 1.
-			assert_eq!(Balances::free_balance(&1), 0);
-			assert_eq!(Balances::free_balance(&2), 130);
+		// Verify free balance removal of account 1.
+		assert_eq!(Balances::free_balance(&1), 0);
+		assert_eq!(Balances::free_balance(&2), 130);
 
-			// Verify that TotalIssuance tracks balance removal when free balance is too low.
-			assert_eq!(<TotalIssuance<Runtime>>::get(), 130);
-		},
-	);
+		// Verify that TotalIssuance tracks balance removal when free balance is too low.
+		assert_eq!(<TotalIssuance<Runtime>>::get(), 130);
+	});
 }
 
 #[test]
 fn transfer_overflow_isnt_exploitable() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().creation_fee(50).build(),
-		|| {
-			// Craft a value that will overflow if summed with `creation_fee`.
-			let evil_value = u64::max_value() - 49;
+	ExtBuilder::default().creation_fee(50).build().execute_with(|| {
+		// Craft a value that will overflow if summed with `creation_fee`.
+		let evil_value = u64::max_value() - 49;
 
-			assert_err!(
-				Balances::transfer(Some(1).into(), 5, evil_value),
-				"got overflow after adding a fee to value",
-			);
-		}
-	);
+		assert_err!(
+			Balances::transfer(Some(1).into(), 5, evil_value),
+			"got overflow after adding a fee to value",
+		);
+	});
 }
 
 #[test]
 fn check_vesting_status() {
-		set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(256)
-			.monied(true)
-			.vesting(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(256)
+		.monied(true)
+		.vesting(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(System::block_number(), 1);
 			let user1_free_balance = Balances::free_balance(&1);
 			let user2_free_balance = Balances::free_balance(&2);
@@ -663,19 +639,17 @@ fn check_vesting_status() {
 			assert_eq!(Balances::vesting_balance(&2), 0); // Account 2 has fully vested by block 30
 			assert_eq!(Balances::vesting_balance(&12), 0); // Account 2 has fully vested by block 30
 
-		}
-	);
+		});
 }
 
 #[test]
 fn unvested_balance_should_not_transfer() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(10)
-			.monied(true)
-			.vesting(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.monied(true)
+		.vesting(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(System::block_number(), 1);
 			let user1_free_balance = Balances::free_balance(&1);
 			assert_eq!(user1_free_balance, 100); // Account 1 has free balance
@@ -685,38 +659,34 @@ fn unvested_balance_should_not_transfer() {
 				Balances::transfer(Some(1).into(), 2, 56),
 				"vesting balance too high to send value",
 			); // Account 1 cannot send more than vested amount
-		}
-	);
+		});
 }
 
 #[test]
 fn vested_balance_should_transfer() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(10)
-			.monied(true)
-			.vesting(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.monied(true)
+		.vesting(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(System::block_number(), 1);
 			let user1_free_balance = Balances::free_balance(&1);
 			assert_eq!(user1_free_balance, 100); // Account 1 has free balance
 			// Account 1 has only 5 units vested at block 1 (plus 50 unvested)
 			assert_eq!(Balances::vesting_balance(&1), 45);
 			assert_ok!(Balances::transfer(Some(1).into(), 2, 55));
-		}
-	);
+		});
 }
 
 #[test]
 fn extra_balance_should_transfer() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(10)
-			.monied(true)
-			.vesting(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.monied(true)
+		.vesting(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(System::block_number(), 1);
 			assert_ok!(Balances::transfer(Some(3).into(), 1, 100));
 			assert_ok!(Balances::transfer(Some(3).into(), 2, 100));
@@ -734,19 +704,17 @@ fn extra_balance_should_transfer() {
 			// Account 2 has no units vested at block 1, but gained 100
 			assert_eq!(Balances::vesting_balance(&2), 200);
 			assert_ok!(Balances::transfer(Some(2).into(), 3, 100)); // Account 2 can send extra units gained
-		}
-	);
+		});
 }
 
 #[test]
 fn liquid_funds_should_transfer_with_delayed_vesting() {
-		set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(256)
-			.monied(true)
-			.vesting(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(256)
+		.monied(true)
+		.vesting(true)
+		.build()
+		.execute_with(|| {
 			assert_eq!(System::block_number(), 1);
 			let user12_free_balance = Balances::free_balance(&12);
 
@@ -764,62 +732,64 @@ fn liquid_funds_should_transfer_with_delayed_vesting() {
 
 			// Account 12 can still send liquid funds
 			assert_ok!(Balances::transfer(Some(12).into(), 3, 256 * 5));
-		}
-	);
+		});
 }
 
 #[test]
 fn signed_extension_take_fees_work() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(10)
-			.transaction_fees(10, 1, 5)
-			.monied(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.transaction_fees(10, 1, 5)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			let len = 10;
-			assert!(TakeFees::<Runtime>::from(0).pre_dispatch(&1, CALL, info_from_weight(5), len).is_ok());
+			assert!(
+				TakeFees::<Runtime>::from(0)
+					.pre_dispatch(&1, CALL, info_from_weight(5), len)
+					.is_ok()
+			);
 			assert_eq!(Balances::free_balance(&1), 100 - 20 - 25);
-			assert!(TakeFees::<Runtime>::from(5 /* tipped */).pre_dispatch(&1, CALL, info_from_weight(3), len).is_ok());
+			assert!(
+				TakeFees::<Runtime>::from(5 /* tipped */)
+					.pre_dispatch(&1, CALL, info_from_weight(3), len)
+					.is_ok()
+			);
 			assert_eq!(Balances::free_balance(&1), 100 - 20 - 25 - 20 - 5 - 15);
-		}
-	);
+		});
 }
 
 #[test]
 fn signed_extension_take_fees_is_bounded() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.existential_deposit(1000)
-			.transaction_fees(0, 0, 1)
-			.monied(true)
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.existential_deposit(1000)
+		.transaction_fees(0, 0, 1)
+		.monied(true)
+		.build()
+		.execute_with(|| {
 			use sr_primitives::weights::Weight;
 
 			// maximum weight possible
-			assert!(TakeFees::<Runtime>::from(0).pre_dispatch(&1, CALL, info_from_weight(Weight::max_value()), 10).is_ok());
+			assert!(
+				TakeFees::<Runtime>::from(0)
+					.pre_dispatch(&1, CALL, info_from_weight(Weight::max_value()), 10)
+					.is_ok()
+			);
 			// fee will be proportional to what is the actual maximum weight in the runtime.
 			assert_eq!(
 				Balances::free_balance(&1),
 				(10000 - <Runtime as system::Trait>::MaximumBlockWeight::get()) as u64
 			);
-		}
-	);
+		});
 }
 
 #[test]
 fn burn_must_work() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.monied(true)
-			.build(),
-		|| {
-			let init_total_issuance = Balances::total_issuance();
-			let imbalance = Balances::burn(10);
-			assert_eq!(Balances::total_issuance(), init_total_issuance - 10);
-			drop(imbalance);
-			assert_eq!(Balances::total_issuance(), init_total_issuance);
-		}
-	);
+	ExtBuilder::default().monied(true).build().execute_with(|| {
+		let init_total_issuance = Balances::total_issuance();
+		let imbalance = Balances::burn(10);
+		assert_eq!(Balances::total_issuance(), init_total_issuance - 10);
+		drop(imbalance);
+		assert_eq!(Balances::total_issuance(), init_total_issuance);
+	});
 }

--- a/srml/collective/src/lib.rs
+++ b/srml/collective/src/lib.rs
@@ -384,8 +384,8 @@ mod tests {
 	use hex_literal::hex;
 	use primitives::H256;
 	use sr_primitives::{
-		set_and_run_with_externalities, Perbill,
-		traits::{BlakeTwo256, IdentityLookup, Block as BlockT}, testing::Header, BuildStorage,
+		Perbill, traits::{BlakeTwo256, IdentityLookup, Block as BlockT}, testing::Header,
+		BuildStorage,
 	};
 	use crate as collective;
 
@@ -451,7 +451,7 @@ mod tests {
 
 	#[test]
 	fn motions_basic_environment_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_eq!(Collective::members(), vec![1, 2, 3]);
 			assert_eq!(Collective::proposals(), Vec::<H256>::new());
@@ -464,7 +464,7 @@ mod tests {
 
 	#[test]
 	fn removal_of_old_voters_votes_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash = BlakeTwo256::hash_of(&proposal);
@@ -498,7 +498,7 @@ mod tests {
 
 	#[test]
 	fn removal_of_old_voters_votes_works_with_set_members() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash = BlakeTwo256::hash_of(&proposal);
@@ -532,7 +532,7 @@ mod tests {
 
 	#[test]
 	fn propose_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash = proposal.blake2_256().into();
@@ -561,7 +561,7 @@ mod tests {
 
 	#[test]
 	fn motions_ignoring_non_collective_proposals_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			assert_noop!(
@@ -573,29 +573,35 @@ mod tests {
 
 	#[test]
 	fn motions_ignoring_non_collective_votes_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash: H256 = proposal.blake2_256().into();
 			assert_ok!(Collective::propose(Origin::signed(1), 3, Box::new(proposal.clone())));
-			assert_noop!(Collective::vote(Origin::signed(42), hash.clone(), 0, true), "voter not a member");
+			assert_noop!(
+				Collective::vote(Origin::signed(42), hash.clone(), 0, true),
+				"voter not a member",
+			);
 		});
 	}
 
 	#[test]
 	fn motions_ignoring_bad_index_collective_vote_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(3);
 			let proposal = make_proposal(42);
 			let hash: H256 = proposal.blake2_256().into();
 			assert_ok!(Collective::propose(Origin::signed(1), 3, Box::new(proposal.clone())));
-			assert_noop!(Collective::vote(Origin::signed(2), hash.clone(), 1, true), "mismatched index");
+			assert_noop!(
+				Collective::vote(Origin::signed(2), hash.clone(), 1, true),
+				"mismatched index",
+			);
 		});
 	}
 
 	#[test]
 	fn motions_revoting_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash: H256 = proposal.blake2_256().into();
@@ -604,13 +610,19 @@ mod tests {
 				Collective::voting(&hash),
 				Some(Votes { index: 0, threshold: 2, ayes: vec![1], nays: vec![] })
 			);
-			assert_noop!(Collective::vote(Origin::signed(1), hash.clone(), 0, true), "duplicate vote ignored");
+			assert_noop!(
+				Collective::vote(Origin::signed(1), hash.clone(), 0, true),
+				"duplicate vote ignored",
+			);
 			assert_ok!(Collective::vote(Origin::signed(1), hash.clone(), 0, false));
 			assert_eq!(
 				Collective::voting(&hash),
 				Some(Votes { index: 0, threshold: 2, ayes: vec![], nays: vec![1] })
 			);
-			assert_noop!(Collective::vote(Origin::signed(1), hash.clone(), 0, false), "duplicate vote ignored");
+			assert_noop!(
+				Collective::vote(Origin::signed(1), hash.clone(), 0, false),
+				"duplicate vote ignored",
+			);
 
 			assert_eq!(System::events(), vec![
 				EventRecord {
@@ -640,7 +652,7 @@ mod tests {
 
 	#[test]
 	fn motions_disapproval_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash: H256 = proposal.blake2_256().into();
@@ -683,7 +695,7 @@ mod tests {
 
 	#[test]
 	fn motions_approval_works() {
-		set_and_run_with_externalities(&mut make_ext(), || {
+		make_ext().execute_with(|| {
 			System::set_block_number(1);
 			let proposal = make_proposal(42);
 			let hash: H256 = proposal.blake2_256().into();

--- a/srml/contracts/src/exec.rs
+++ b/srml/contracts/src/exec.rs
@@ -807,7 +807,6 @@ mod tests {
 		account_db::AccountDb, gas::GasMeter, tests::{ExtBuilder, Test},
 		exec::{ExecReturnValue, ExecError, STATUS_SUCCESS}, CodeHash, Config,
 	};
-	use sr_primitives::set_and_run_with_externalities;
 	use std::{cell::RefCell, rc::Rc, collections::HashMap, marker::PhantomData};
 	use assert_matches::assert_matches;
 
@@ -933,7 +932,7 @@ mod tests {
 			exec_success()
 		});
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, exec_ch).unwrap();
@@ -953,7 +952,7 @@ mod tests {
 		let dest = BOB;
 
 		// This test verifies that base fee for call is taken.
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let vm = MockVm::new();
 			let loader = MockLoader::empty();
 			let cfg = Config::preload();
@@ -971,7 +970,7 @@ mod tests {
 		});
 
 		// This test verifies that base fee for instantiation is taken.
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let mut loader = MockLoader::empty();
 			let code = loader.insert(|_| exec_success());
 
@@ -1001,7 +1000,7 @@ mod tests {
 		let vm = MockVm::new();
 		let loader = MockLoader::empty();
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			ctx.overlay.set_balance(&origin, 100);
@@ -1033,7 +1032,7 @@ mod tests {
 			|_| Ok(ExecReturnValue { status: 1, data: Vec::new() })
 		);
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
@@ -1061,93 +1060,84 @@ mod tests {
 		// This test sends 50 units of currency to a non-existent account.
 		// This should lead to creation of a new account thus
 		// a fee should be charged.
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let vm = MockVm::new();
-				let loader = MockLoader::empty();
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&origin, 100);
-				ctx.overlay.set_balance(&dest, 0);
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let vm = MockVm::new();
+			let loader = MockLoader::empty();
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&origin, 100);
+			ctx.overlay.set_balance(&dest, 0);
 
-				let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
+			let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
 
-				let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
-				assert_matches!(result, Ok(_));
+			let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
+			assert_matches!(result, Ok(_));
 
-				let mut toks = gas_meter.tokens().iter();
-				match_tokens!(
-					toks,
-					ExecFeeToken::Call,
-					TransferFeeToken {
-						kind: TransferFeeKind::AccountCreate,
-						gas_price: 1u64
-					},
-				);
-			},
-		);
+			let mut toks = gas_meter.tokens().iter();
+			match_tokens!(
+				toks,
+				ExecFeeToken::Call,
+				TransferFeeToken {
+					kind: TransferFeeKind::AccountCreate,
+					gas_price: 1u64
+				},
+			);
+		});
 
 		// This one is similar to the previous one but transfer to an existing account.
 		// In this test we expect that a regular transfer fee is charged.
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let vm = MockVm::new();
-				let loader = MockLoader::empty();
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&origin, 100);
-				ctx.overlay.set_balance(&dest, 15);
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let vm = MockVm::new();
+			let loader = MockLoader::empty();
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&origin, 100);
+			ctx.overlay.set_balance(&dest, 15);
 
-				let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
+			let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
 
-				let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
-				assert_matches!(result, Ok(_));
+			let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
+			assert_matches!(result, Ok(_));
 
-				let mut toks = gas_meter.tokens().iter();
-				match_tokens!(
-					toks,
-					ExecFeeToken::Call,
-					TransferFeeToken {
-						kind: TransferFeeKind::Transfer,
-						gas_price: 1u64
-					},
-				);
-			},
-		);
+			let mut toks = gas_meter.tokens().iter();
+			match_tokens!(
+				toks,
+				ExecFeeToken::Call,
+				TransferFeeToken {
+					kind: TransferFeeKind::Transfer,
+					gas_price: 1u64
+				},
+			);
+		});
 
 		// This test sends 50 units of currency as an endownment to a newly
 		// instantiated contract.
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let mut loader = MockLoader::empty();
-				let code = loader.insert(|_| exec_success());
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let mut loader = MockLoader::empty();
+			let code = loader.insert(|_| exec_success());
 
-				let vm = MockVm::new();
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
+			let vm = MockVm::new();
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 
-				ctx.overlay.set_balance(&origin, 100);
-				ctx.overlay.set_balance(&dest, 15);
+			ctx.overlay.set_balance(&origin, 100);
+			ctx.overlay.set_balance(&dest, 15);
 
-				let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
+			let mut gas_meter = GasMeter::<Test>::with_limit(1000, 1);
 
-				let result = ctx.instantiate(50, &mut gas_meter, &code, vec![]);
-				assert_matches!(result, Ok(_));
+			let result = ctx.instantiate(50, &mut gas_meter, &code, vec![]);
+			assert_matches!(result, Ok(_));
 
-				let mut toks = gas_meter.tokens().iter();
-				match_tokens!(
-					toks,
-					ExecFeeToken::Instantiate,
-					TransferFeeToken {
-						kind: TransferFeeKind::ContractInstantiate,
-						gas_price: 1u64
-					},
-				);
-			},
-		);
+			let mut toks = gas_meter.tokens().iter();
+			match_tokens!(
+				toks,
+				ExecFeeToken::Instantiate,
+				TransferFeeToken {
+					kind: TransferFeeKind::ContractInstantiate,
+					gas_price: 1u64
+				},
+			);
+		});
 	}
 
 	#[test]
@@ -1160,7 +1150,7 @@ mod tests {
 		let vm = MockVm::new();
 		let loader = MockLoader::empty();
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			ctx.overlay.set_balance(&origin, 0);
@@ -1194,7 +1184,7 @@ mod tests {
 			|_| Ok(ExecReturnValue { status: STATUS_SUCCESS, data: vec![1, 2, 3, 4] })
 		);
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
@@ -1225,7 +1215,7 @@ mod tests {
 			|_| Ok(ExecReturnValue { status: 1, data: vec![1, 2, 3, 4] })
 		);
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, return_ch).unwrap();
@@ -1253,7 +1243,7 @@ mod tests {
 		});
 
 		// This one tests passing the input data into a contract via call.
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, input_data_ch).unwrap();
@@ -1278,7 +1268,7 @@ mod tests {
 		});
 
 		// This one tests passing the input data into a contract via instantiate.
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 
@@ -1322,7 +1312,7 @@ mod tests {
 			exec_success()
 		});
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, recurse_ch).unwrap();
@@ -1366,7 +1356,7 @@ mod tests {
 			exec_success()
 		});
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
@@ -1408,7 +1398,7 @@ mod tests {
 			exec_success()
 		});
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 			ctx.overlay.instantiate_contract(&BOB, bob_ch).unwrap();
@@ -1432,23 +1422,20 @@ mod tests {
 		let mut loader = MockLoader::empty();
 		let dummy_ch = loader.insert(|_| exec_success());
 
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 
-				assert_matches!(
-					ctx.instantiate(
-						0, // <- zero endowment
-						&mut GasMeter::<Test>::with_limit(10000, 1),
-						&dummy_ch,
-						vec![],
-					),
-					Err(_)
-				);
-			}
-		);
+			assert_matches!(
+				ctx.instantiate(
+					0, // <- zero endowment
+					&mut GasMeter::<Test>::with_limit(10000, 1),
+					&dummy_ch,
+					vec![],
+				),
+				Err(_)
+			);
+		});
 	}
 
 	#[test]
@@ -1460,38 +1447,35 @@ mod tests {
 			|_| Ok(ExecReturnValue { status: STATUS_SUCCESS, data: vec![80, 65, 83, 83] })
 		);
 
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&ALICE, 1000);
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&ALICE, 1000);
 
-				let instantiated_contract_address = assert_matches!(
-					ctx.instantiate(
-						100,
-						&mut GasMeter::<Test>::with_limit(10000, 1),
-						&dummy_ch,
-						vec![],
-					),
-					Ok((address, ref output)) if output.data == vec![80, 65, 83, 83] => address
-				);
+			let instantiated_contract_address = assert_matches!(
+				ctx.instantiate(
+					100,
+					&mut GasMeter::<Test>::with_limit(10000, 1),
+					&dummy_ch,
+					vec![],
+				),
+				Ok((address, ref output)) if output.data == vec![80, 65, 83, 83] => address
+			);
 
-				// Check that the newly created account has the expected code hash and
-				// there are instantiation event.
-				assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
-				assert_eq!(&ctx.events(), &[
-					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(ALICE, instantiated_contract_address, 100),
-						topics: Vec::new(),
-					},
-					DeferredAction::DepositEvent {
-						event: RawEvent::Instantiated(ALICE, instantiated_contract_address),
-						topics: Vec::new(),
-					}
-				]);
-			}
-		);
+			// Check that the newly created account has the expected code hash and
+			// there are instantiation event.
+			assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
+			assert_eq!(&ctx.events(), &[
+				DeferredAction::DepositEvent {
+					event: RawEvent::Transfer(ALICE, instantiated_contract_address, 100),
+					topics: Vec::new(),
+				},
+				DeferredAction::DepositEvent {
+					event: RawEvent::Instantiated(ALICE, instantiated_contract_address),
+					topics: Vec::new(),
+				}
+			]);
+		});
 	}
 
 	#[test]
@@ -1503,28 +1487,25 @@ mod tests {
 			|_| Ok(ExecReturnValue { status: 1, data: vec![70, 65, 73, 76] })
 		);
 
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&ALICE, 1000);
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&ALICE, 1000);
 
-				let instantiated_contract_address = assert_matches!(
-					ctx.instantiate(
-						100,
-						&mut GasMeter::<Test>::with_limit(10000, 1),
-						&dummy_ch,
-						vec![],
-					),
-					Ok((address, ref output)) if output.data == vec![70, 65, 73, 76] => address
-				);
+			let instantiated_contract_address = assert_matches!(
+				ctx.instantiate(
+					100,
+					&mut GasMeter::<Test>::with_limit(10000, 1),
+					&dummy_ch,
+					vec![],
+				),
+				Ok((address, ref output)) if output.data == vec![70, 65, 73, 76] => address
+			);
 
-				// Check that the account has not been created.
-				assert!(ctx.overlay.get_code_hash(&instantiated_contract_address).is_none());
-				assert!(ctx.events().is_empty());
-			}
-		);
+			// Check that the account has not been created.
+			assert!(ctx.overlay.get_code_hash(&instantiated_contract_address).is_none());
+			assert!(ctx.events().is_empty());
+		});
 	}
 
 	#[test]
@@ -1551,40 +1532,37 @@ mod tests {
 			}
 		});
 
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&ALICE, 1000);
+			ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
-				assert_matches!(
-					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
-					Ok(_)
-				);
+			assert_matches!(
+				ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
+				Ok(_)
+			);
 
-				let instantiated_contract_address = instantiated_contract_address.borrow().as_ref().unwrap().clone();
+			let instantiated_contract_address = instantiated_contract_address.borrow().as_ref().unwrap().clone();
 
-				// Check that the newly created account has the expected code hash and
-				// there are instantiation event.
-				assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
-				assert_eq!(&ctx.events(), &[
-					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(ALICE, BOB, 20),
-						topics: Vec::new(),
-					},
-					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(BOB, instantiated_contract_address, 15),
-						topics: Vec::new(),
-					},
-					DeferredAction::DepositEvent {
-						event: RawEvent::Instantiated(BOB, instantiated_contract_address),
-						topics: Vec::new(),
-					},
-				]);
-			}
-		);
+			// Check that the newly created account has the expected code hash and
+			// there are instantiation event.
+			assert_eq!(ctx.overlay.get_code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
+			assert_eq!(&ctx.events(), &[
+				DeferredAction::DepositEvent {
+					event: RawEvent::Transfer(ALICE, BOB, 20),
+					topics: Vec::new(),
+				},
+				DeferredAction::DepositEvent {
+					event: RawEvent::Transfer(BOB, instantiated_contract_address, 15),
+					topics: Vec::new(),
+				},
+				DeferredAction::DepositEvent {
+					event: RawEvent::Instantiated(BOB, instantiated_contract_address),
+					topics: Vec::new(),
+				},
+			]);
+		});
 	}
 
 	#[test]
@@ -1613,29 +1591,26 @@ mod tests {
 			}
 		});
 
-		set_and_run_with_externalities(
-			&mut ExtBuilder::default().existential_deposit(15).build(),
-			|| {
-				let cfg = Config::preload();
-				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
-				ctx.overlay.set_balance(&ALICE, 1000);
-				ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
+		ExtBuilder::default().existential_deposit(15).build().execute_with(|| {
+			let cfg = Config::preload();
+			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
+			ctx.overlay.set_balance(&ALICE, 1000);
+			ctx.overlay.instantiate_contract(&BOB, instantiator_ch).unwrap();
 
-				assert_matches!(
-					ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
-					Ok(_)
-				);
+			assert_matches!(
+				ctx.call(BOB, 20, &mut GasMeter::<Test>::with_limit(1000, 1), vec![]),
+				Ok(_)
+			);
 
-				// The contract wasn't instantiated so we don't expect to see an instantiation
-				// event here.
-				assert_eq!(&ctx.events(), &[
-					DeferredAction::DepositEvent {
-						event: RawEvent::Transfer(ALICE, BOB, 20),
-						topics: Vec::new(),
-					},
-				]);
-			}
-		);
+			// The contract wasn't instantiated so we don't expect to see an instantiation
+			// event here.
+			assert_eq!(&ctx.events(), &[
+				DeferredAction::DepositEvent {
+					event: RawEvent::Transfer(ALICE, BOB, 20),
+					topics: Vec::new(),
+				},
+			]);
+		});
 	}
 
 	#[test]
@@ -1649,7 +1624,7 @@ mod tests {
 			exec_success()
 		});
 
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			let cfg = Config::preload();
 			let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 

--- a/srml/contracts/src/tests.rs
+++ b/srml/contracts/src/tests.rs
@@ -30,7 +30,7 @@ use codec::{Decode, Encode, KeyedVec};
 use sr_primitives::{
 	Perbill, BuildStorage, transaction_validity::{InvalidTransaction, ValidTransaction},
 	traits::{BlakeTwo256, Hash, IdentityLookup, SignedExtension},
-	weights::{DispatchInfo, DispatchClass}, set_and_run_with_externalities,
+	weights::{DispatchInfo, DispatchClass},
 	testing::{Digest, DigestItem, Header, UintAuthorityId, H256},
 };
 use support::{
@@ -304,7 +304,7 @@ fn compile_module<T>(wabt_module: &str)
 // Then we check that the all unused gas is refunded.
 #[test]
 fn refunds_unused_gas() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().gas_price(2).build(), || {
+	ExtBuilder::default().gas_price(2).build().execute_with(|| {
 		Balances::deposit_creating(&ALICE, 100_000_000);
 
 		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, Vec::new()));
@@ -316,70 +316,67 @@ fn refunds_unused_gas() {
 
 #[test]
 fn account_removal_removes_storage() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(100).build(),
-		|| {
-			let trie_id1 = <Test as Trait>::TrieIdGenerator::trie_id(&1);
-			let trie_id2 = <Test as Trait>::TrieIdGenerator::trie_id(&2);
-			let key1 = &[1; 32];
-			let key2 = &[2; 32];
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		let trie_id1 = <Test as Trait>::TrieIdGenerator::trie_id(&1);
+		let trie_id2 = <Test as Trait>::TrieIdGenerator::trie_id(&2);
+		let key1 = &[1; 32];
+		let key2 = &[2; 32];
 
-			// Set up two accounts with free balance above the existential threshold.
-			{
-				Balances::deposit_creating(&1, 110);
-				ContractInfoOf::<Test>::insert(1, &ContractInfo::Alive(RawAliveContractInfo {
-					trie_id: trie_id1.clone(),
-					storage_size: <Test as Trait>::StorageSizeOffset::get(),
-					deduct_block: System::block_number(),
-					code_hash: H256::repeat_byte(1),
-					rent_allowance: 40,
-					last_write: None,
-				}));
+		// Set up two accounts with free balance above the existential threshold.
+		{
+			Balances::deposit_creating(&1, 110);
+			ContractInfoOf::<Test>::insert(1, &ContractInfo::Alive(RawAliveContractInfo {
+				trie_id: trie_id1.clone(),
+				storage_size: <Test as Trait>::StorageSizeOffset::get(),
+				deduct_block: System::block_number(),
+				code_hash: H256::repeat_byte(1),
+				rent_allowance: 40,
+				last_write: None,
+			}));
 
-				let mut overlay = OverlayAccountDb::<Test>::new(&DirectAccountDb);
-				overlay.set_storage(&1, key1.clone(), Some(b"1".to_vec()));
-				overlay.set_storage(&1, key2.clone(), Some(b"2".to_vec()));
-				DirectAccountDb.commit(overlay.into_change_set());
+			let mut overlay = OverlayAccountDb::<Test>::new(&DirectAccountDb);
+			overlay.set_storage(&1, key1.clone(), Some(b"1".to_vec()));
+			overlay.set_storage(&1, key2.clone(), Some(b"2".to_vec()));
+			DirectAccountDb.commit(overlay.into_change_set());
 
-				Balances::deposit_creating(&2, 110);
-				ContractInfoOf::<Test>::insert(2, &ContractInfo::Alive(RawAliveContractInfo {
-					trie_id: trie_id2.clone(),
-					storage_size: <Test as Trait>::StorageSizeOffset::get(),
-					deduct_block: System::block_number(),
-					code_hash: H256::repeat_byte(2),
-					rent_allowance: 40,
-					last_write: None,
-				}));
+			Balances::deposit_creating(&2, 110);
+			ContractInfoOf::<Test>::insert(2, &ContractInfo::Alive(RawAliveContractInfo {
+				trie_id: trie_id2.clone(),
+				storage_size: <Test as Trait>::StorageSizeOffset::get(),
+				deduct_block: System::block_number(),
+				code_hash: H256::repeat_byte(2),
+				rent_allowance: 40,
+				last_write: None,
+			}));
 
-				let mut overlay = OverlayAccountDb::<Test>::new(&DirectAccountDb);
-				overlay.set_storage(&2, key1.clone(), Some(b"3".to_vec()));
-				overlay.set_storage(&2, key2.clone(), Some(b"4".to_vec()));
-				DirectAccountDb.commit(overlay.into_change_set());
-			}
+			let mut overlay = OverlayAccountDb::<Test>::new(&DirectAccountDb);
+			overlay.set_storage(&2, key1.clone(), Some(b"3".to_vec()));
+			overlay.set_storage(&2, key2.clone(), Some(b"4".to_vec()));
+			DirectAccountDb.commit(overlay.into_change_set());
+		}
 
-			// Transfer funds from account 1 of such amount that after this transfer
-			// the balance of account 1 will be below the existential threshold.
-			//
-			// This should lead to the removal of all storage associated with this account.
-			assert_ok!(Balances::transfer(Origin::signed(1), 2, 20));
+		// Transfer funds from account 1 of such amount that after this transfer
+		// the balance of account 1 will be below the existential threshold.
+		//
+		// This should lead to the removal of all storage associated with this account.
+		assert_ok!(Balances::transfer(Origin::signed(1), 2, 20));
 
-			// Verify that all entries from account 1 is removed, while
-			// entries from account 2 is in place.
-			{
-				assert!(<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &1, Some(&trie_id1), key1).is_none());
-				assert!(<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &1, Some(&trie_id1), key2).is_none());
+		// Verify that all entries from account 1 is removed, while
+		// entries from account 2 is in place.
+		{
+			assert!(<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &1, Some(&trie_id1), key1).is_none());
+			assert!(<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &1, Some(&trie_id1), key2).is_none());
 
-				assert_eq!(
-					<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &2, Some(&trie_id2), key1),
-					Some(b"3".to_vec())
-				);
-				assert_eq!(
-					<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &2, Some(&trie_id2), key2),
-					Some(b"4".to_vec())
-				);
-			}
-		},
-	);
+			assert_eq!(
+				<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &2, Some(&trie_id2), key1),
+				Some(b"3".to_vec())
+			);
+			assert_eq!(
+				<dyn AccountDb<Test>>::get_storage(&DirectAccountDb, &2, Some(&trie_id2), key2),
+				Some(b"4".to_vec())
+			);
+		}
+	});
 }
 
 const CODE_RETURN_FROM_START_FN: &str = r#"
@@ -416,61 +413,58 @@ const CODE_RETURN_FROM_START_FN: &str = r#"
 fn instantiate_and_call_and_deposit_event() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_RETURN_FROM_START_FN).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(100).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
+	ExtBuilder::default().existential_deposit(100).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
 
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Check at the end to get hash on error easily
-			let creation = Contract::instantiate(
-				Origin::signed(ALICE),
-				100,
-				100_000,
-				code_hash.into(),
-				vec![],
-			);
+		// Check at the end to get hash on error easily
+		let creation = Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000,
+			code_hash.into(),
+			vec![],
+		);
 
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(
-						balances::RawEvent::NewAccount(BOB, 100)
-					),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Contract(BOB, vec![1, 2, 3, 4])),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
-					topics: vec![],
-				}
-			]);
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(
+					balances::RawEvent::NewAccount(BOB, 100)
+				),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Contract(BOB, vec![1, 2, 3, 4])),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
+				topics: vec![],
+			}
+		]);
 
-			assert_ok!(creation);
-			assert!(ContractInfoOf::<Test>::exists(BOB));
-		},
-	);
+		assert_ok!(creation);
+		assert!(ContractInfoOf::<Test>::exists(BOB));
+	});
 }
 
 const CODE_DISPATCH_CALL: &str = r#"
@@ -499,98 +493,95 @@ fn dispatch_call() {
 
 	let (wasm, code_hash) = compile_module::<Test>(CODE_DISPATCH_CALL).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
 
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Let's keep this assert even though it's redundant. If you ever need to update the
-			// wasm source this test will fail and will show you the actual hash.
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-			]);
+		// Let's keep this assert even though it's redundant. If you ever need to update the
+		// wasm source this test will fail and will show you the actual hash.
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+		]);
 
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100,
-				100_000,
-				code_hash.into(),
-				vec![],
-			));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
 
-			assert_ok!(Contract::call(
-				Origin::signed(ALICE),
-				BOB, // newly created account
-				0,
-				100_000,
-				vec![],
-			));
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			BOB, // newly created account
+			0,
+			100_000,
+			vec![],
+		));
 
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(
-						balances::RawEvent::NewAccount(BOB, 100)
-					),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
-					topics: vec![],
-				},
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(
+					balances::RawEvent::NewAccount(BOB, 100)
+				),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
+				topics: vec![],
+			},
 
-				// Dispatching the call.
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(
-						balances::RawEvent::NewAccount(CHARLIE, 50)
-					),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(
-						balances::RawEvent::Transfer(BOB, CHARLIE, 50, 0)
-					),
-					topics: vec![],
-				},
+			// Dispatching the call.
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(
+					balances::RawEvent::NewAccount(CHARLIE, 50)
+				),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(
+					balances::RawEvent::Transfer(BOB, CHARLIE, 50, 0)
+				),
+				topics: vec![],
+			},
 
-				// Event emited as a result of dispatch.
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Dispatched(BOB, true)),
-					topics: vec![],
-				}
-			]);
-		},
-	);
+			// Event emited as a result of dispatch.
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Dispatched(BOB, true)),
+				topics: vec![],
+			}
+		]);
+	});
 }
 
 const CODE_DISPATCH_CALL_THEN_TRAP: &str = r#"
@@ -620,80 +611,77 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 
 	let (wasm, code_hash) = compile_module::<Test>(CODE_DISPATCH_CALL_THEN_TRAP).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
 
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Let's keep this assert even though it's redundant. If you ever need to update the
-			// wasm source this test will fail and will show you the actual hash.
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-			]);
+		// Let's keep this assert even though it's redundant. If you ever need to update the
+		// wasm source this test will fail and will show you the actual hash.
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+		]);
 
-			assert_ok!(Contract::instantiate(
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
+
+		// Call the newly instantiated contract. The contract is expected to dispatch a call
+		// and then trap.
+		assert_err!(
+			Contract::call(
 				Origin::signed(ALICE),
-				100,
+				BOB, // newly created account
+				0,
 				100_000,
-				code_hash.into(),
 				vec![],
-			));
-
-			// Call the newly instantiated contract. The contract is expected to dispatch a call
-			// and then trap.
-			assert_err!(
-				Contract::call(
-					Origin::signed(ALICE),
-					BOB, // newly created account
-					0,
-					100_000,
-					vec![],
+			),
+			"during execution"
+		);
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(
+					balances::RawEvent::NewAccount(BOB, 100)
 				),
-				"during execution"
-			);
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(
-						balances::RawEvent::NewAccount(BOB, 100)
-					),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
-					topics: vec![],
-				},
-				// ABSENCE of events which would be caused by dispatched Balances::transfer call
-			]);
-		},
-	);
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Transfer(ALICE, BOB, 100)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Instantiated(ALICE, BOB)),
+				topics: vec![],
+			},
+			// ABSENCE of events which would be caused by dispatched Balances::transfer call
+		]);
+	});
 }
 
 const CODE_SET_RENT: &str = r#"
@@ -823,28 +811,25 @@ fn test_set_rent_code_and_hash() {
 
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// If you ever need to update the wasm source this test will fail
-			// and will show you the actual hash.
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
-					topics: vec![],
-				},
-			]);
-		}
-	);
+		// If you ever need to update the wasm source this test will fail
+		// and will show you the actual hash.
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(code_hash.into())),
+				topics: vec![],
+			},
+		]);
+	});
 }
 
 #[test]
@@ -852,92 +837,86 @@ fn storage_size() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
 	// Storage size
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				30_000,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			30_000,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
 
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::set_storage_4_byte()));
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4 + 4);
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::set_storage_4_byte()));
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4 + 4);
 
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::remove_storage_4_byte()));
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
-		}
-	);
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::remove_storage_4_byte()));
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.storage_size, <Test as Trait>::StorageSizeOffset::get() + 4);
+	});
 }
 
 #[test]
 fn deduct_blocks() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				30_000,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			30_000,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
 
-			// Check creation
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, 1_000);
+		// Check creation
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, 1_000);
 
-			// Advance 4 blocks
-			System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance 4 blocks
+		System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		// Trigger rent through call
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
 
-			// Check result
-			let rent = (8 + 4 - 3) // storage size = size_offset + deploy_set_storage - deposit_offset
-				* 4 // rent byte price
-				* 4; // blocks to rent
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, 1_000 - rent);
-			assert_eq!(bob_contract.deduct_block, 5);
-			assert_eq!(Balances::free_balance(BOB), 30_000 - rent);
+		// Check result
+		let rent = (8 + 4 - 3) // storage size = size_offset + deploy_set_storage - deposit_offset
+			* 4 // rent byte price
+			* 4; // blocks to rent
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, 1_000 - rent);
+		assert_eq!(bob_contract.deduct_block, 5);
+		assert_eq!(Balances::free_balance(BOB), 30_000 - rent);
 
-			// Advance 7 blocks more
-			System::initialize(&12, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance 7 blocks more
+		System::initialize(&12, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		// Trigger rent through call
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
 
-			// Check result
-			let rent_2 = (8 + 4 - 2) // storage size = size_offset + deploy_set_storage - deposit_offset
-				* 4 // rent byte price
-				* 7; // blocks to rent
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, 1_000 - rent - rent_2);
-			assert_eq!(bob_contract.deduct_block, 12);
-			assert_eq!(Balances::free_balance(BOB), 30_000 - rent - rent_2);
+		// Check result
+		let rent_2 = (8 + 4 - 2) // storage size = size_offset + deploy_set_storage - deposit_offset
+			* 4 // rent byte price
+			* 7; // blocks to rent
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, 1_000 - rent - rent_2);
+		assert_eq!(bob_contract.deduct_block, 12);
+		assert_eq!(Balances::free_balance(BOB), 30_000 - rent - rent_2);
 
-			// Second call on same block should have no effect on rent
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		// Second call on same block should have no effect on rent
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
 
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, 1_000 - rent - rent_2);
-			assert_eq!(bob_contract.deduct_block, 12);
-			assert_eq!(Balances::free_balance(BOB), 30_000 - rent - rent_2);
-		}
-	);
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, 1_000 - rent - rent_2);
+		assert_eq!(bob_contract.deduct_block, 12);
+		assert_eq!(Balances::free_balance(BOB), 30_000 - rent - rent_2);
+	});
 }
 
 #[test]
@@ -979,32 +958,29 @@ fn claim_surcharge_malus() {
 fn claim_surcharge(blocks: u64, trigger_call: impl Fn() -> bool, removes: bool) {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
 
-			// Advance blocks
-			System::initialize(&blocks, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&blocks, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert!(trigger_call());
+		// Trigger rent through call
+		assert!(trigger_call());
 
-			if removes {
-				assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-			} else {
-				assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().is_some());
-			}
+		if removes {
+			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		} else {
+			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().is_some());
 		}
-	);
+	});
 }
 
 /// Test for all kind of removals for the given trigger:
@@ -1015,123 +991,114 @@ fn removals(trigger_call: impl Fn() -> bool) {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
 	// Balance reached and superior to subsistence threshold
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
 
-			let subsistence_threshold = 50 /*existential_deposit*/ + 16 /*tombstone_deposit*/;
+		let subsistence_threshold = 50 /*existential_deposit*/ + 16 /*tombstone_deposit*/;
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
-			assert_eq!(Balances::free_balance(&BOB), 100);
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
+		assert_eq!(Balances::free_balance(&BOB), 100);
 
-			// Advance blocks
-			System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-			assert_eq!(Balances::free_balance(&BOB), subsistence_threshold);
+		// Trigger rent through call
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		assert_eq!(Balances::free_balance(&BOB), subsistence_threshold);
 
-			// Advance blocks
-			System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-			assert_eq!(Balances::free_balance(&BOB), subsistence_threshold);
-		}
-	);
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		assert_eq!(Balances::free_balance(&BOB), subsistence_threshold);
+	});
 
 	// Allowance exceeded
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				1_000,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(100u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			1_000,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(100u32).encode() // rent allowance
+		));
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 100);
-			assert_eq!(Balances::free_balance(&BOB), 1_000);
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 100);
+		assert_eq!(Balances::free_balance(&BOB), 1_000);
 
-			// Advance blocks
-			System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-			// Balance should be initial balance - initial rent_allowance
-			assert_eq!(Balances::free_balance(&BOB), 900);
+		// Trigger rent through call
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		// Balance should be initial balance - initial rent_allowance
+		assert_eq!(Balances::free_balance(&BOB), 900);
 
-			// Advance blocks
-			System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-			assert_eq!(Balances::free_balance(&BOB), 900);
-		}
-	);
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		assert_eq!(Balances::free_balance(&BOB), 900);
+	});
 
 	// Balance reached and inferior to subsistence threshold
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				50+Balances::minimum_balance(),
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			50+Balances::minimum_balance(),
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
-			assert_eq!(Balances::free_balance(&BOB), 50 + Balances::minimum_balance());
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
+		assert_eq!(Balances::free_balance(&BOB), 50 + Balances::minimum_balance());
 
-			// Transfer funds
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::transfer()));
-			assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
-			assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
+		// Transfer funds
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::transfer()));
+		assert_eq!(ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap().rent_allowance, 1_000);
+		assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
 
-			// Advance blocks
-			System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).is_none());
-			assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
+		// Trigger rent through call
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).is_none());
+		assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
 
-			// Advance blocks
-			System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&20, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent must have no effect
-			assert!(trigger_call());
-			assert!(ContractInfoOf::<Test>::get(BOB).is_none());
-			assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
-		}
-	);
+		// Trigger rent must have no effect
+		assert!(trigger_call());
+		assert!(ContractInfoOf::<Test>::get(BOB).is_none());
+		assert_eq!(Balances::free_balance(&BOB), Balances::minimum_balance());
+	});
 }
 
 #[test]
@@ -1139,38 +1106,35 @@ fn call_removed_contract() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SET_RENT).unwrap();
 
 	// Balance reached and superior to subsistence threshold
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100,
-				100_000, code_hash.into(),
-				<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm.clone()));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100,
+			100_000, code_hash.into(),
+			<Test as balances::Trait>::Balance::from(1_000u32).encode() // rent allowance
+		));
 
-			// Calling contract should succeed.
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		// Calling contract should succeed.
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
 
-			// Advance blocks
-			System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&10, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Calling contract should remove contract and fail.
-			assert_err!(
-				Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
-				"contract has been evicted"
-			);
+		// Calling contract should remove contract and fail.
+		assert_err!(
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			"contract has been evicted"
+		);
 
- 			// Subsequent contract calls should also fail.
-			assert_err!(
-				Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
-				"contract has been evicted"
-			);
-		}
-	)
+ 		// Subsequent contract calls should also fail.
+		assert_err!(
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			"contract has been evicted"
+		);
+	})
 }
 
 const CODE_CHECK_DEFAULT_RENT_ALLOWANCE: &str = r#"
@@ -1227,35 +1191,32 @@ const CODE_CHECK_DEFAULT_RENT_ALLOWANCE: &str = r#"
 fn default_rent_allowance_on_instantiate() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_CHECK_DEFAULT_RENT_ALLOWANCE).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				30_000,
-				100_000,
-				code_hash.into(),
-				vec![],
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			30_000,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
 
-			// Check creation
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, <BalanceOf<Test>>::max_value());
+		// Check creation
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, <BalanceOf<Test>>::max_value());
 
-			// Advance blocks
-			System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		// Advance blocks
+		System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 
-			// Trigger rent through call
-			assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
+		// Trigger rent through call
+		assert_ok!(Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()));
 
-			// Check contract is still alive
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive();
-			assert!(bob_contract.is_some())
-		}
-	);
+		// Check contract is still alive
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive();
+		assert!(bob_contract.is_some())
+	});
 }
 
 const CODE_RESTORATION: &str = r#"
@@ -1344,122 +1305,119 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 	let (restoration_wasm, restoration_code_hash) =
 		compile_module::<Test>(CODE_RESTORATION).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, restoration_wasm));
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, set_rent_wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, restoration_wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, set_rent_wasm));
 
-			// If you ever need to update the wasm source this test will fail
-			// and will show you the actual hash.
-			assert_eq!(System::events(), vec![
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(restoration_code_hash.into())),
-					topics: vec![],
-				},
-				EventRecord {
-					phase: Phase::ApplyExtrinsic(0),
-					event: MetaEvent::contract(RawEvent::CodeStored(set_rent_code_hash.into())),
-					topics: vec![],
-				},
-			]);
+		// If you ever need to update the wasm source this test will fail
+		// and will show you the actual hash.
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::balances(balances::RawEvent::NewAccount(1, 1_000_000)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(restoration_code_hash.into())),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::CodeStored(set_rent_code_hash.into())),
+				topics: vec![],
+			},
+		]);
 
-			// Create an account with address `BOB` with code `CODE_SET_RENT`.
-			// The input parameter sets the rent allowance to 0.
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				30_000,
-				100_000,
-				set_rent_code_hash.into(),
-				<Test as balances::Trait>::Balance::from(0u32).encode()
-			));
+		// Create an account with address `BOB` with code `CODE_SET_RENT`.
+		// The input parameter sets the rent allowance to 0.
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			30_000,
+			100_000,
+			set_rent_code_hash.into(),
+			<Test as balances::Trait>::Balance::from(0u32).encode()
+		));
 
-			// Check if `BOB` was created successfully and that the rent allowance is
-			// set to 0.
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, 0);
+		// Check if `BOB` was created successfully and that the rent allowance is
+		// set to 0.
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, 0);
 
-			if test_different_storage {
-				assert_ok!(Contract::call(
-					Origin::signed(ALICE),
-					BOB, 0, 100_000,
-					call::set_storage_4_byte())
-				);
-			}
-
-			// Advance 4 blocks, to the 5th.
-			System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
-
-			// Call `BOB`, which makes it pay rent. Since the rent allowance is set to 0
-			// we expect that it will get removed leaving tombstone.
-			assert_err!(
-				Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
-				"contract has been evicted"
-			);
-			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-
-			/// Create another account with the address `DJANGO` with `CODE_RESTORATION`.
-			///
-			/// Note that we can't use `ALICE` for creating `DJANGO` so we create yet another
-			/// account `CHARLIE` and create `DJANGO` with it.
-			Balances::deposit_creating(&CHARLIE, 1_000_000);
-			assert_ok!(Contract::instantiate(
-				Origin::signed(CHARLIE),
-				30_000,
-				100_000,
-				restoration_code_hash.into(),
-				<Test as balances::Trait>::Balance::from(0u32).encode()
-			));
-
-			// Before performing a call to `DJANGO` save its original trie id.
-			let django_trie_id = ContractInfoOf::<Test>::get(DJANGO).unwrap()
-				.get_alive().unwrap().trie_id;
-
-			if !test_restore_to_with_dirty_storage {
-				// Advance 1 block, to the 6th.
-				System::initialize(&6, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
-			}
-
-			// Perform a call to `DJANGO`. This should either perform restoration successfully or
-			// fail depending on the test parameters.
+		if test_different_storage {
 			assert_ok!(Contract::call(
 				Origin::signed(ALICE),
-				DJANGO,
-				0,
-				100_000,
-				vec![],
-			));
-
-			if test_different_storage || test_restore_to_with_dirty_storage {
-				// Parametrization of the test imply restoration failure. Check that `DJANGO` aka
-				// restoration contract is still in place and also that `BOB` doesn't exist.
-				assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
-				let django_contract = ContractInfoOf::<Test>::get(DJANGO).unwrap()
-					.get_alive().unwrap();
-				assert_eq!(django_contract.storage_size, 16);
-				assert_eq!(django_contract.trie_id, django_trie_id);
-				assert_eq!(django_contract.deduct_block, System::block_number());
-			} else {
-				// Here we expect that the restoration is succeeded. Check that the restoration
-				// contract `DJANGO` ceased to exist and that `BOB` returned back.
-				println!("{:?}", ContractInfoOf::<Test>::get(BOB));
-				let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap()
-					.get_alive().unwrap();
-				assert_eq!(bob_contract.rent_allowance, 50);
-				assert_eq!(bob_contract.storage_size, 12);
-				assert_eq!(bob_contract.trie_id, django_trie_id);
-				assert_eq!(bob_contract.deduct_block, System::block_number());
-				assert!(ContractInfoOf::<Test>::get(DJANGO).is_none());
-			}
+				BOB, 0, 100_000,
+				call::set_storage_4_byte())
+			);
 		}
-	);
+
+		// Advance 4 blocks, to the 5th.
+		System::initialize(&5, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+
+		// Call `BOB`, which makes it pay rent. Since the rent allowance is set to 0
+		// we expect that it will get removed leaving tombstone.
+		assert_err!(
+			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
+			"contract has been evicted"
+		);
+		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+
+		/// Create another account with the address `DJANGO` with `CODE_RESTORATION`.
+		///
+		/// Note that we can't use `ALICE` for creating `DJANGO` so we create yet another
+		/// account `CHARLIE` and create `DJANGO` with it.
+		Balances::deposit_creating(&CHARLIE, 1_000_000);
+		assert_ok!(Contract::instantiate(
+			Origin::signed(CHARLIE),
+			30_000,
+			100_000,
+			restoration_code_hash.into(),
+			<Test as balances::Trait>::Balance::from(0u32).encode()
+		));
+
+		// Before performing a call to `DJANGO` save its original trie id.
+		let django_trie_id = ContractInfoOf::<Test>::get(DJANGO).unwrap()
+			.get_alive().unwrap().trie_id;
+
+		if !test_restore_to_with_dirty_storage {
+			// Advance 1 block, to the 6th.
+			System::initialize(&6, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+		}
+
+		// Perform a call to `DJANGO`. This should either perform restoration successfully or
+		// fail depending on the test parameters.
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			DJANGO,
+			0,
+			100_000,
+			vec![],
+		));
+
+		if test_different_storage || test_restore_to_with_dirty_storage {
+			// Parametrization of the test imply restoration failure. Check that `DJANGO` aka
+			// restoration contract is still in place and also that `BOB` doesn't exist.
+			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+			let django_contract = ContractInfoOf::<Test>::get(DJANGO).unwrap()
+				.get_alive().unwrap();
+			assert_eq!(django_contract.storage_size, 16);
+			assert_eq!(django_contract.trie_id, django_trie_id);
+			assert_eq!(django_contract.deduct_block, System::block_number());
+		} else {
+			// Here we expect that the restoration is succeeded. Check that the restoration
+			// contract `DJANGO` ceased to exist and that `BOB` returned back.
+			println!("{:?}", ContractInfoOf::<Test>::get(BOB));
+			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap()
+				.get_alive().unwrap();
+			assert_eq!(bob_contract.rent_allowance, 50);
+			assert_eq!(bob_contract.storage_size, 12);
+			assert_eq!(bob_contract.trie_id, django_trie_id);
+			assert_eq!(bob_contract.deduct_block, System::block_number());
+			assert!(ContractInfoOf::<Test>::get(DJANGO).is_none());
+		}
+	});
 }
 
 const CODE_STORAGE_SIZE: &str = r#"
@@ -1530,46 +1488,43 @@ const CODE_STORAGE_SIZE: &str = r#"
 fn storage_max_value_limit() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_STORAGE_SIZE).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				30_000,
-				100_000,
-				code_hash.into(),
-				vec![],
-			));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			30_000,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
 
-			// Check creation
-			let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
-			assert_eq!(bob_contract.rent_allowance, <BalanceOf<Test>>::max_value());
+		// Check creation
+		let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap().get_alive().unwrap();
+		assert_eq!(bob_contract.rent_allowance, <BalanceOf<Test>>::max_value());
 
-			// Call contract with allowed storage value.
-			assert_ok!(Contract::call(
+		// Call contract with allowed storage value.
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			BOB,
+			0,
+			100_000,
+			Encode::encode(&self::MaxValueSize::get()),
+		));
+
+		// Call contract with too large a storage value.
+		assert_err!(
+			Contract::call(
 				Origin::signed(ALICE),
 				BOB,
 				0,
 				100_000,
-				Encode::encode(&self::MaxValueSize::get()),
-			));
-
-			// Call contract with too large a storage value.
-			assert_err!(
-				Contract::call(
-					Origin::signed(ALICE),
-					BOB,
-					0,
-					100_000,
-					Encode::encode(&(self::MaxValueSize::get() + 1)),
-				),
-				"during execution"
-			);
-		}
-	);
+				Encode::encode(&(self::MaxValueSize::get() + 1)),
+			),
+			"during execution"
+		);
+	});
 }
 
 const CODE_RETURN_WITH_DATA: &str = r#"
@@ -1897,33 +1852,30 @@ fn deploy_and_call_other_contract() {
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_RETURN_WITH_DATA).unwrap();
 	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_CALLER_CONTRACT).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
 
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100_000,
-				100_000,
-				caller_code_hash.into(),
-				vec![],
-			));
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100_000,
+			100_000,
+			caller_code_hash.into(),
+			vec![],
+		));
 
-			// Call BOB contract, which attempts to instantiate and call the callee contract and
-			// makes various assertions on the results from those calls.
-			assert_ok!(Contract::call(
-				Origin::signed(ALICE),
-				BOB,
-				0,
-				200_000,
-				callee_code_hash.as_ref().to_vec(),
-			));
-		}
-	);
+		// Call BOB contract, which attempts to instantiate and call the callee contract and
+		// makes various assertions on the results from those calls.
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			BOB,
+			0,
+			200_000,
+			callee_code_hash.as_ref().to_vec(),
+		));
+	});
 }
 
 const CODE_SELF_DESTRUCT: &str = r#"
@@ -2028,86 +1980,80 @@ const CODE_SELF_DESTRUCT: &str = r#"
 #[test]
 fn self_destruct_by_draining_balance() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SELF_DESTRUCT).unwrap();
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Instantiate the BOB contract.
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				100_000,
-				100_000,
-				code_hash.into(),
-				vec![],
-			));
+		// Instantiate the BOB contract.
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100_000,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
 
-			// Check that the BOB contract has been instantiated.
-			assert_matches!(
-				ContractInfoOf::<Test>::get(BOB),
-				Some(ContractInfo::Alive(_))
-			);
+		// Check that the BOB contract has been instantiated.
+		assert_matches!(
+			ContractInfoOf::<Test>::get(BOB),
+			Some(ContractInfo::Alive(_))
+		);
 
-			// Call BOB with no input data, forcing it to self-destruct.
-			assert_ok!(Contract::call(
-				Origin::signed(ALICE),
-				BOB,
-				0,
-				100_000,
-				vec![],
-			));
+		// Call BOB with no input data, forcing it to self-destruct.
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			BOB,
+			0,
+			100_000,
+			vec![],
+		));
 
-			// Check that BOB is now dead.
-			assert!(ContractInfoOf::<Test>::get(BOB).is_none());
-		}
-	);
+		// Check that BOB is now dead.
+		assert!(ContractInfoOf::<Test>::get(BOB).is_none());
+	});
 }
 
 #[test]
 fn cannot_self_destruct_while_live() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SELF_DESTRUCT).unwrap();
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Instantiate the BOB contract.
-			assert_ok!(Contract::instantiate(
+		// Instantiate the BOB contract.
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			100_000,
+			100_000,
+			code_hash.into(),
+			vec![],
+		));
+
+		// Check that the BOB contract has been instantiated.
+		assert_matches!(
+			ContractInfoOf::<Test>::get(BOB),
+			Some(ContractInfo::Alive(_))
+		);
+
+		// Call BOB with input data, forcing it make a recursive call to itself to
+		// self-destruct, resulting in a trap.
+		assert_err!(
+			Contract::call(
 				Origin::signed(ALICE),
+				BOB,
+				0,
 				100_000,
-				100_000,
-				code_hash.into(),
-				vec![],
-			));
+				vec![0],
+			),
+			"during execution"
+		);
 
-			// Check that the BOB contract has been instantiated.
-			assert_matches!(
-				ContractInfoOf::<Test>::get(BOB),
-				Some(ContractInfo::Alive(_))
-			);
-
-			// Call BOB with input data, forcing it make a recursive call to itself to
-			// self-destruct, resulting in a trap.
-			assert_err!(
-				Contract::call(
-					Origin::signed(ALICE),
-					BOB,
-					0,
-					100_000,
-					vec![0],
-				),
-				"during execution"
-			);
-
-			// Check that BOB is still alive.
-			assert_matches!(
-				ContractInfoOf::<Test>::get(BOB),
-				Some(ContractInfo::Alive(_))
-			);
-		}
-	);
+		// Check that BOB is still alive.
+		assert_matches!(
+			ContractInfoOf::<Test>::get(BOB),
+			Some(ContractInfo::Alive(_))
+		);
+	});
 }
 
 const CODE_DESTROY_AND_TRANSFER: &str = r#"
@@ -2269,43 +2215,40 @@ fn destroy_contract_and_transfer_funds() {
 	let (callee_wasm, callee_code_hash) = compile_module::<Test>(CODE_SELF_DESTRUCT).unwrap();
 	let (caller_wasm, caller_code_hash) = compile_module::<Test>(CODE_DESTROY_AND_TRANSFER).unwrap();
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			// Create
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		// Create
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, callee_wasm));
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, caller_wasm));
 
-			// This deploys the BOB contract, which in turn deploys the CHARLIE contract during
-			// construction.
-			assert_ok!(Contract::instantiate(
-				Origin::signed(ALICE),
-				200_000,
-				100_000,
-				caller_code_hash.into(),
-				callee_code_hash.as_ref().to_vec(),
-			));
+		// This deploys the BOB contract, which in turn deploys the CHARLIE contract during
+		// construction.
+		assert_ok!(Contract::instantiate(
+			Origin::signed(ALICE),
+			200_000,
+			100_000,
+			caller_code_hash.into(),
+			callee_code_hash.as_ref().to_vec(),
+		));
 
-			// Check that the CHARLIE contract has been instantiated.
-			assert_matches!(
-				ContractInfoOf::<Test>::get(CHARLIE),
-				Some(ContractInfo::Alive(_))
-			);
+		// Check that the CHARLIE contract has been instantiated.
+		assert_matches!(
+			ContractInfoOf::<Test>::get(CHARLIE),
+			Some(ContractInfo::Alive(_))
+		);
 
-			// Call BOB, which calls CHARLIE, forcing CHARLIE to self-destruct.
-			assert_ok!(Contract::call(
-				Origin::signed(ALICE),
-				BOB,
-				0,
-				100_000,
-				CHARLIE.encode(),
-			));
+		// Call BOB, which calls CHARLIE, forcing CHARLIE to self-destruct.
+		assert_ok!(Contract::call(
+			Origin::signed(ALICE),
+			BOB,
+			0,
+			100_000,
+			CHARLIE.encode(),
+		));
 
-			// Check that CHARLIE has moved on to the great beyond (ie. died).
-			assert!(ContractInfoOf::<Test>::get(CHARLIE).is_none());
-		}
-	);
+		// Check that CHARLIE has moved on to the great beyond (ie. died).
+		assert!(ContractInfoOf::<Test>::get(CHARLIE).is_none());
+	});
 }
 
 const CODE_SELF_DESTRUCTING_CONSTRUCTOR: &str = r#"
@@ -2368,43 +2311,37 @@ const CODE_SELF_DESTRUCTING_CONSTRUCTOR: &str = r#"
 #[test]
 fn cannot_self_destruct_in_constructor() {
 	let (wasm, code_hash) = compile_module::<Test>(CODE_SELF_DESTRUCTING_CONSTRUCTOR).unwrap();
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().existential_deposit(50).build(),
-		|| {
-			Balances::deposit_creating(&ALICE, 1_000_000);
-			assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
+	ExtBuilder::default().existential_deposit(50).build().execute_with(|| {
+		Balances::deposit_creating(&ALICE, 1_000_000);
+		assert_ok!(Contract::put_code(Origin::signed(ALICE), 100_000, wasm));
 
-			// Fail to instantiate the BOB contract since its final balance is below existential
-			// deposit.
-			assert_err!(
-				Contract::instantiate(
-					Origin::signed(ALICE),
-					100_000,
-					100_000,
-					code_hash.into(),
-					vec![],
-				),
-				"insufficient remaining balance"
-			);
-		}
-	);
+		// Fail to instantiate the BOB contract since its final balance is below existential
+		// deposit.
+		assert_err!(
+			Contract::instantiate(
+				Origin::signed(ALICE),
+				100_000,
+				100_000,
+				code_hash.into(),
+				vec![],
+			),
+			"insufficient remaining balance"
+		);
+	});
 }
 
 #[test]
 fn check_block_gas_limit_works() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().block_gas_limit(50).build(),
-		|| {
-			let info = DispatchInfo { weight: 100, class: DispatchClass::Normal };
-			let check = CheckBlockGasLimit::<Test>(Default::default());
-			let call: Call = crate::Call::put_code(1000, vec![]).into();
+	ExtBuilder::default().block_gas_limit(50).build().execute_with(|| {
+		let info = DispatchInfo { weight: 100, class: DispatchClass::Normal };
+		let check = CheckBlockGasLimit::<Test>(Default::default());
+		let call: Call = crate::Call::put_code(1000, vec![]).into();
 
-			assert_eq!(
-				check.validate(&0, &call, info, 0), InvalidTransaction::ExhaustsResources.into(),
-			);
+		assert_eq!(
+			check.validate(&0, &call, info, 0), InvalidTransaction::ExhaustsResources.into(),
+		);
 
-			let call: Call = crate::Call::update_schedule(Default::default()).into();
-			assert_eq!(check.validate(&0, &call, info, 0), Ok(Default::default()));
-		}
-	);
+		let call: Call = crate::Call::update_schedule(Default::default()).into();
+		assert_eq!(check.validate(&0, &call, info, 0), Ok(Default::default()));
+	});
 }

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -976,10 +976,7 @@ mod tests {
 		traits::Contains
 	};
 	use primitives::H256;
-	use sr_primitives::{
-		set_and_run_with_externalities, traits::{BlakeTwo256, IdentityLookup, Bounded},
-		testing::Header, Perbill,
-	};
+	use sr_primitives::{traits::{BlakeTwo256, IdentityLookup, Bounded}, testing::Header, Perbill};
 	use balances::BalanceLock;
 	use system::EnsureSignedBy;
 
@@ -1101,7 +1098,7 @@ mod tests {
 
 	#[test]
 	fn params_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Democracy::referendum_count(), 0);
 			assert_eq!(Balances::free_balance(&42), 0);
 			assert_eq!(Balances::total_issuance(), 210);
@@ -1133,7 +1130,7 @@ mod tests {
 
 	#[test]
 	fn external_and_public_interleaving_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(Democracy::external_propose(
 				Origin::signed(2),
@@ -1246,7 +1243,7 @@ mod tests {
 
 	#[test]
 	fn emergency_cancel_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			let r = Democracy::inject_referendum(
 				2,
@@ -1275,7 +1272,7 @@ mod tests {
 
 	#[test]
 	fn veto_external_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(Democracy::external_propose(
 				Origin::signed(2),
@@ -1335,7 +1332,7 @@ mod tests {
 
 	#[test]
 	fn external_referendum_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_noop!(Democracy::external_propose(
 				Origin::signed(1),
@@ -1364,7 +1361,7 @@ mod tests {
 
 	#[test]
 	fn external_majority_referendum_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_noop!(Democracy::external_propose_majority(
 				Origin::signed(1),
@@ -1389,7 +1386,7 @@ mod tests {
 
 	#[test]
 	fn external_default_referendum_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_noop!(Democracy::external_propose_default(
 				Origin::signed(3),
@@ -1414,7 +1411,7 @@ mod tests {
 
 	#[test]
 	fn fast_track_referendum_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			let h = BlakeTwo256::hash_of(&set_balance_proposal(2));
 			assert_noop!(Democracy::fast_track(Origin::signed(5), h, 3, 2), "no proposal made");
@@ -1438,7 +1435,7 @@ mod tests {
 
 	#[test]
 	fn fast_track_referendum_fails_when_no_simple_majority() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			let h = BlakeTwo256::hash_of(&set_balance_proposal(2));
 			assert_ok!(Democracy::external_propose(
@@ -1454,7 +1451,7 @@ mod tests {
 
 	#[test]
 	fn locked_for_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_ok!(propose_set_balance(1, 2, 2));
 			assert_ok!(propose_set_balance(1, 4, 4));
@@ -1467,7 +1464,7 @@ mod tests {
 
 	#[test]
 	fn single_proposal_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(propose_set_balance(1, 2, 1));
 			assert!(Democracy::referendum_info(0).is_none());
@@ -1514,7 +1511,7 @@ mod tests {
 
 	#[test]
 	fn cancel_queued_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(propose_set_balance(1, 2, 1));
 
@@ -1538,7 +1535,7 @@ mod tests {
 
 	#[test]
 	fn proxy_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Democracy::proxy(10), None);
 			assert_ok!(Democracy::set_proxy(Origin::signed(1), 10));
 			assert_eq!(Democracy::proxy(10), Some(1));
@@ -1568,7 +1565,7 @@ mod tests {
 
 	#[test]
 	fn single_proposal_should_work_with_proxy() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(propose_set_balance(1, 2, 1));
 
@@ -1588,7 +1585,7 @@ mod tests {
 
 	#[test]
 	fn single_proposal_should_work_with_delegation() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 
 			assert_ok!(propose_set_balance(1, 2, 1));
@@ -1613,7 +1610,7 @@ mod tests {
 
 	#[test]
 	fn single_proposal_should_work_with_cyclic_delegation() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 
 			assert_ok!(propose_set_balance(1, 2, 1));
@@ -1640,7 +1637,7 @@ mod tests {
 	#[test]
 	/// If transactor already voted, delegated vote is overwriten.
 	fn single_proposal_should_work_with_vote_and_delegation() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 
 			assert_ok!(propose_set_balance(1, 2, 1));
@@ -1666,7 +1663,7 @@ mod tests {
 
 	#[test]
 	fn single_proposal_should_work_with_undelegation() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 
 			assert_ok!(propose_set_balance(1, 2, 1));
@@ -1695,7 +1692,7 @@ mod tests {
 	#[test]
 	/// If transactor voted, delegated vote is overwriten.
 	fn single_proposal_should_work_with_delegation_and_vote() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 
 			assert_ok!(propose_set_balance(1, 2, 1));
@@ -1726,7 +1723,7 @@ mod tests {
 
 	#[test]
 	fn deposit_for_proposals_should_be_taken() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_ok!(propose_set_balance(1, 2, 5));
 			assert_ok!(Democracy::second(Origin::signed(2), 0));
@@ -1741,7 +1738,7 @@ mod tests {
 
 	#[test]
 	fn deposit_for_proposals_should_be_returned() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_ok!(propose_set_balance(1, 2, 5));
 			assert_ok!(Democracy::second(Origin::signed(2), 0));
@@ -1757,7 +1754,7 @@ mod tests {
 
 	#[test]
 	fn proposal_with_deposit_below_minimum_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_noop!(propose_set_balance(1, 2, 0), "value too low");
 		});
@@ -1765,7 +1762,7 @@ mod tests {
 
 	#[test]
 	fn poor_proposer_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_noop!(propose_set_balance(1, 2, 11), "proposer\'s balance too low");
 		});
@@ -1773,7 +1770,7 @@ mod tests {
 
 	#[test]
 	fn poor_seconder_should_not_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			assert_ok!(propose_set_balance(2, 2, 11));
 			assert_noop!(Democracy::second(Origin::signed(1), 0), "seconder\'s balance too low");
@@ -1782,7 +1779,7 @@ mod tests {
 
 	#[test]
 	fn runners_up_should_come_after() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			assert_ok!(propose_set_balance(1, 2, 2));
 			assert_ok!(propose_set_balance(1, 4, 4));
@@ -1798,7 +1795,7 @@ mod tests {
 
 	#[test]
 	fn simple_passing_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1821,7 +1818,7 @@ mod tests {
 
 	#[test]
 	fn cancel_referendum_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1841,7 +1838,7 @@ mod tests {
 
 	#[test]
 	fn simple_failing_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1864,7 +1861,7 @@ mod tests {
 
 	#[test]
 	fn controversial_voting_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1890,7 +1887,7 @@ mod tests {
 
 	#[test]
 	fn delayed_enactment_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1918,7 +1915,7 @@ mod tests {
 
 	#[test]
 	fn controversial_low_turnout_voting_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,
@@ -1940,7 +1937,7 @@ mod tests {
 
 	#[test]
 	fn passing_low_turnout_voting_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Balances::free_balance(&42), 0);
 			assert_eq!(Balances::total_issuance(), 210);
 
@@ -1966,7 +1963,7 @@ mod tests {
 
 	#[test]
 	fn lock_voting_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(0);
 			let r = Democracy::inject_referendum(
 				1,
@@ -2026,7 +2023,7 @@ mod tests {
 
 	#[test]
 	fn lock_voting_should_work_with_delegation() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			let r = Democracy::inject_referendum(
 				1,

--- a/srml/elections-phragmen/src/lib.rs
+++ b/srml/elections-phragmen/src/lib.rs
@@ -594,7 +594,7 @@ mod tests {
 	use primitives::H256;
 	use sr_primitives::{
 		Perbill, testing::Header, BuildStorage,
-		traits::{BlakeTwo256, IdentityLookup, Block as BlockT}, set_and_run_with_externalities
+		traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
 	};
 	use crate as elections;
 
@@ -770,7 +770,7 @@ mod tests {
 
 	#[test]
 	fn params_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			System::set_block_number(1);
 			assert_eq!(Elections::desired_members(), 2);
 			assert_eq!(Elections::term_duration(), 5);
@@ -790,7 +790,7 @@ mod tests {
 
 	#[test]
 	fn simple_candidate_submission_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 			assert!(Elections::is_candidate(&1).is_err());
 			assert!(Elections::is_candidate(&2).is_err());
@@ -817,7 +817,7 @@ mod tests {
 
 	#[test]
 	fn simple_candidate_submission_with_no_votes_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 
 			assert_ok!(Elections::submit_candidacy(Origin::signed(1)));
@@ -844,7 +844,7 @@ mod tests {
 
 	#[test]
 	fn dupe_candidate_submission_should_not_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 			assert_ok!(Elections::submit_candidacy(Origin::signed(1)));
 			assert_eq!(Elections::candidates(), vec![1]);
@@ -858,7 +858,7 @@ mod tests {
 	#[test]
 	fn member_candidacy_submission_should_not_work() {
 		// critically important to make sure that outgoing candidates and losers are not mixed up.
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::vote(Origin::signed(2), vec![5], 20));
 
@@ -878,7 +878,7 @@ mod tests {
 
 	#[test]
 	fn poor_candidate_submission_should_not_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 			assert_noop!(
 				Elections::submit_candidacy(Origin::signed(7)),
@@ -889,7 +889,7 @@ mod tests {
 
 	#[test]
 	fn simple_voting_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 			assert_eq!(balances(&2), (20, 0));
 
@@ -903,7 +903,7 @@ mod tests {
 
 	#[test]
 	fn can_vote_with_custom_stake() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(Elections::candidates(), Vec::<u64>::new());
 			assert_eq!(balances(&2), (20, 0));
 
@@ -917,7 +917,7 @@ mod tests {
 
 	#[test]
 	fn can_update_votes_and_stake() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(balances(&2), (20, 0));
 
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
@@ -938,7 +938,7 @@ mod tests {
 
 	#[test]
 	fn cannot_vote_for_no_candidate() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
 				Elections::vote(Origin::signed(2), vec![], 20),
 				"cannot vote when no candidates or members exist"
@@ -949,7 +949,7 @@ mod tests {
 	#[test]
 	fn can_vote_for_old_members_even_when_no_new_candidates() {
 		// let allowed_votes = candidates_count as usize + Self::members().len()
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -967,7 +967,7 @@ mod tests {
 
 	#[test]
 	fn cannot_vote_for_more_than_candidates() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -980,7 +980,7 @@ mod tests {
 
 	#[test]
 	fn cannot_vote_for_less_than_ed() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().voter_bond(8).build(), || {
+		ExtBuilder::default().voter_bond(8).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -993,7 +993,7 @@ mod tests {
 
 	#[test]
 	fn can_vote_for_more_than_total_balance_but_moot() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1006,7 +1006,7 @@ mod tests {
 
 	#[test]
 	fn remove_voter_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().voter_bond(8).build(), || {
+		ExtBuilder::default().voter_bond(8).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 
 			assert_ok!(Elections::vote(Origin::signed(2), vec![5], 20));
@@ -1031,14 +1031,14 @@ mod tests {
 
 	#[test]
 	fn non_voter_remove_should_not_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(Elections::remove_voter(Origin::signed(3)), "must be a voter");
 		});
 	}
 
 	#[test]
 	fn dupe_remove_should_fail() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::vote(Origin::signed(2), vec![5], 20));
 
@@ -1051,7 +1051,7 @@ mod tests {
 
 	#[test]
 	fn removed_voter_should_not_be_counted() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1071,7 +1071,7 @@ mod tests {
 
 	#[test]
 	fn reporter_must_be_voter() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_noop!(
 				Elections::report_defunct_voter(Origin::signed(1), 2),
 				"reporter must be a voter",
@@ -1081,7 +1081,7 @@ mod tests {
 
 	#[test]
 	fn can_detect_defunct_voter() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1116,7 +1116,7 @@ mod tests {
 
 	#[test]
 	fn report_voter_should_work_and_earn_reward() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1148,8 +1148,7 @@ mod tests {
 
 	#[test]
 	fn report_voter_should_slash_when_bad_report() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
-			set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1174,13 +1173,12 @@ mod tests {
 			assert_eq!(balances(&4), (35, 5));
 			assert_eq!(balances(&5), (45, 3));
 		});
-		});
 	}
 
 
 	#[test]
 	fn simple_voting_rounds_should_work() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1215,7 +1213,7 @@ mod tests {
 
 	#[test]
 	fn defunct_voter_will_be_counted() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 
 			// This guy's vote is pointless for this round.
@@ -1243,7 +1241,7 @@ mod tests {
 
 	#[test]
 	fn only_desired_seats_are_chosen() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1264,7 +1262,7 @@ mod tests {
 
 	#[test]
 	fn phragmen_should_not_self_vote() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1279,7 +1277,7 @@ mod tests {
 
 	#[test]
 	fn runners_up_should_be_kept() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().desired_runners_up(2).build(), || {
+		ExtBuilder::default().desired_runners_up(2).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1306,7 +1304,7 @@ mod tests {
 
 	#[test]
 	fn runners_up_should_be_next_candidates() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().desired_runners_up(2).build(), || {
+		ExtBuilder::default().desired_runners_up(2).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1333,7 +1331,7 @@ mod tests {
 
 	#[test]
 	fn runners_up_lose_bond_once_outgoing() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().desired_runners_up(1).build(), || {
+		ExtBuilder::default().desired_runners_up(1).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(2)));
@@ -1364,7 +1362,7 @@ mod tests {
 
 	#[test]
 	fn current_members_are_always_implicitly_next_candidate() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1400,7 +1398,7 @@ mod tests {
 	fn election_state_is_uninterrupted() {
 		// what I mean by uninterrupted:
 		// given no input or stimulants the same members are re-elected.
-		set_and_run_with_externalities(&mut ExtBuilder::default().desired_runners_up(2).build(), || {
+		ExtBuilder::default().desired_runners_up(2).build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1433,7 +1431,7 @@ mod tests {
 
 	#[test]
 	fn remove_members_triggers_election() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 
@@ -1459,7 +1457,7 @@ mod tests {
 
 	#[test]
 	fn seats_should_be_released_when_no_vote() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
@@ -1493,7 +1491,7 @@ mod tests {
 
 	#[test]
 	fn outgoing_will_get_the_bond_back() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_eq!(balances(&5), (50, 0));
 
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
@@ -1519,7 +1517,7 @@ mod tests {
 
 	#[test]
 	fn losers_will_lose_the_bond() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
 
@@ -1542,7 +1540,7 @@ mod tests {
 
 	#[test]
 	fn incoming_outgoing_are_reported() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(5)));
 
@@ -1587,7 +1585,7 @@ mod tests {
 
 	#[test]
 	fn invalid_votes_are_moot() {
-		set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+		ExtBuilder::default().build().execute_with(|| {
 			assert_ok!(Elections::submit_candidacy(Origin::signed(4)));
 			assert_ok!(Elections::submit_candidacy(Origin::signed(3)));
 

--- a/srml/elections/src/mock.rs
+++ b/srml/elections/src/mock.rs
@@ -25,8 +25,7 @@ use support::{
 };
 use primitives::H256;
 use sr_primitives::{
-	Perbill, BuildStorage, set_and_run_with_externalities, testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
+	Perbill, BuildStorage, testing::Header, traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
 };
 use crate as elections;
 
@@ -283,7 +282,7 @@ pub(crate) fn locks(who: &u64) -> Vec<u64> {
 
 pub(crate) fn new_test_ext_with_candidate_holes() -> runtime_io::TestExternalities {
 	let mut t = ExtBuilder::default().build();
-	set_and_run_with_externalities(&mut t, || {
+	t.execute_with(|| {
 		<elections::Candidates<Test>>::put(vec![0, 0, 1]);
 		elections::CandidateCount::put(1);
 		<elections::RegisterInfoOf<Test>>::insert(1, (0, 2));

--- a/srml/elections/src/tests.rs
+++ b/srml/elections/src/tests.rs
@@ -22,11 +22,10 @@ use crate::mock::*;
 use crate::*;
 
 use support::{assert_ok, assert_err, assert_noop};
-use sr_primitives::set_and_run_with_externalities;
 
 #[test]
 fn params_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::next_vote_from(1), 4);
 		assert_eq!(Elections::next_vote_from(4), 4);
@@ -53,7 +52,7 @@ fn params_should_work() {
 
 #[test]
 fn chunking_bool_to_flag_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Elections::bool_to_flag(vec![]), vec![]);
 		assert_eq!(Elections::bool_to_flag(vec![false]), vec![0]);
 		assert_eq!(Elections::bool_to_flag(vec![true]), vec![1]);
@@ -98,7 +97,7 @@ fn chunking_bool_to_flag_should_work() {
 
 #[test]
 fn chunking_voter_set_growth_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		// create 65. 64 (set0) + 1 (set1)
@@ -122,7 +121,7 @@ fn chunking_voter_set_growth_should_work() {
 
 #[test]
 fn chunking_voter_set_reclaim_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		(1..=129).for_each(|i| vote(i, 0));
@@ -159,7 +158,7 @@ fn chunking_voter_set_reclaim_should_work() {
 
 #[test]
 fn chunking_approvals_set_growth_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		// create candidates and voters.
 		(1..=250).for_each(|i| create_candidate(i, (i-1) as u32));
 		(1..=250).for_each(|i| vote(i, i as usize));
@@ -221,7 +220,7 @@ fn chunking_approvals_set_growth_should_work() {
 
 #[test]
 fn chunking_cell_status_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		(1..=63).for_each(|i| vote(i, 0));
@@ -240,7 +239,7 @@ fn chunking_cell_status_works() {
 
 #[test]
 fn chunking_voter_index_does_not_take_holes_into_account() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		// create 65. 64 (set0) + 1 (set1)
@@ -265,7 +264,7 @@ fn chunking_voter_index_does_not_take_holes_into_account() {
 
 #[test]
 fn chunking_approval_storage_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::submit_candidacy(Origin::signed(3), 1));
 
@@ -285,7 +284,7 @@ fn chunking_approval_storage_should_work() {
 
 #[test]
 fn voting_initial_set_approvals_ignores_voter_index() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		// Last argument is essentially irrelevant. You might get or miss a tip.
@@ -299,7 +298,7 @@ fn voting_initial_set_approvals_ignores_voter_index() {
 }
 #[test]
 fn voting_bad_approval_index_slashes_voters_and_bond_reduces_stake() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().voting_fee(5).voter_bond(2).build(), || {
+	ExtBuilder::default().voting_fee(5).voter_bond(2).build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		(1..=63).for_each(|i| vote(i, 0));
@@ -329,7 +328,7 @@ fn voting_bad_approval_index_slashes_voters_and_bond_reduces_stake() {
 
 #[test]
 fn voting_subsequent_set_approvals_checks_voter_index() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		assert_ok!(Elections::set_approvals(Origin::signed(3), vec![], 0, 0, 30));
@@ -353,7 +352,7 @@ fn voting_subsequent_set_approvals_checks_voter_index() {
 
 #[test]
 fn voting_cannot_lock_less_than_limit() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		assert_noop!(
@@ -366,7 +365,7 @@ fn voting_cannot_lock_less_than_limit() {
 
 #[test]
 fn voting_locking_more_than_total_balance_is_moot() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().voter_bond(2).build(), || {
+	ExtBuilder::default().voter_bond(2).build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 
 		assert_eq!(balances(&3), (30, 0));
@@ -382,7 +381,7 @@ fn voting_locking_more_than_total_balance_is_moot() {
 
 #[test]
 fn voting_locking_stake_and_reserving_bond_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().voter_bond(2).build(), || {
+	ExtBuilder::default().voter_bond(2).build().execute_with(|| {
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
 
 		assert_eq!(balances(&2), (20, 0));
@@ -408,7 +407,7 @@ fn voting_locking_stake_and_reserving_bond_works() {
 
 #[test]
 fn voting_without_any_candidate_count_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_eq!(Elections::candidates().len(), 0);
@@ -422,7 +421,7 @@ fn voting_without_any_candidate_count_should_not_work() {
 
 #[test]
 fn voting_setting_an_approval_vote_count_more_than_candidate_count_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
@@ -437,7 +436,7 @@ fn voting_setting_an_approval_vote_count_more_than_candidate_count_should_not_wo
 
 #[test]
 fn voting_resubmitting_approvals_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
@@ -456,7 +455,7 @@ fn voting_resubmitting_approvals_should_work() {
 
 #[test]
 fn voting_retracting_voter_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
@@ -501,7 +500,7 @@ fn voting_retracting_voter_should_work() {
 
 #[test]
 fn voting_invalid_retraction_index_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(3), 0));
 
@@ -514,7 +513,7 @@ fn voting_invalid_retraction_index_should_not_work() {
 
 #[test]
 fn voting_overflow_retraction_index_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(3), 0));
 
@@ -525,7 +524,7 @@ fn voting_overflow_retraction_index_should_not_work() {
 
 #[test]
 fn voting_non_voter_retraction_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(3), 0));
 
@@ -536,7 +535,7 @@ fn voting_non_voter_retraction_should_not_work() {
 
 #[test]
 fn retracting_inactive_voter_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -570,7 +569,7 @@ fn retracting_inactive_voter_should_work() {
 
 #[test]
 fn retracting_inactive_voter_with_other_candidates_in_slots_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().voter_bond(2).build(), || {
+	ExtBuilder::default().voter_bond(2).build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -605,7 +604,7 @@ fn retracting_inactive_voter_with_other_candidates_in_slots_should_work() {
 
 #[test]
 fn retracting_inactive_voter_with_bad_reporter_index_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -634,7 +633,7 @@ fn retracting_inactive_voter_with_bad_reporter_index_should_not_work() {
 
 #[test]
 fn retracting_inactive_voter_with_bad_target_index_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -663,7 +662,7 @@ fn retracting_inactive_voter_with_bad_target_index_should_not_work() {
 
 #[test]
 fn retracting_active_voter_should_slash_reporter() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::submit_candidacy(Origin::signed(3), 1));
@@ -711,7 +710,7 @@ fn retracting_active_voter_should_slash_reporter() {
 
 #[test]
 fn retracting_inactive_voter_by_nonvoter_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -740,7 +739,7 @@ fn retracting_inactive_voter_by_nonvoter_should_not_work() {
 
 #[test]
 fn candidacy_simple_candidate_submission_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), Vec::<u64>::new());
 		assert_eq!(Elections::candidate_reg_info(1), None);
@@ -768,7 +767,7 @@ fn candidacy_simple_candidate_submission_should_work() {
 fn candidacy_submission_using_free_slot_should_work() {
 	let mut t = new_test_ext_with_candidate_holes();
 
-	set_and_run_with_externalities(&mut t, || {
+	t.execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), vec![0, 0, 1]);
 
@@ -784,7 +783,7 @@ fn candidacy_submission_using_free_slot_should_work() {
 fn candidacy_submission_using_alternative_free_slot_should_work() {
 	let mut t = new_test_ext_with_candidate_holes();
 
-	set_and_run_with_externalities(&mut t, || {
+	t.execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), vec![0, 0, 1]);
 
@@ -800,7 +799,7 @@ fn candidacy_submission_using_alternative_free_slot_should_work() {
 fn candidacy_submission_not_using_free_slot_should_not_work() {
 	let mut t = new_test_ext_with_candidate_holes();
 
-	set_and_run_with_externalities(&mut t, || {
+	t.execute_with(|| {
 		System::set_block_number(1);
 		assert_noop!(
 			Elections::submit_candidacy(Origin::signed(4), 3),
@@ -811,7 +810,7 @@ fn candidacy_submission_not_using_free_slot_should_not_work() {
 
 #[test]
 fn candidacy_bad_candidate_slot_submission_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), Vec::<u64>::new());
 		assert_noop!(
@@ -823,7 +822,7 @@ fn candidacy_bad_candidate_slot_submission_should_not_work() {
 
 #[test]
 fn candidacy_non_free_candidate_slot_submission_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), Vec::<u64>::new());
 		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
@@ -837,7 +836,7 @@ fn candidacy_non_free_candidate_slot_submission_should_not_work() {
 
 #[test]
 fn candidacy_dupe_candidate_submission_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), Vec::<u64>::new());
 		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
@@ -851,7 +850,7 @@ fn candidacy_dupe_candidate_submission_should_not_work() {
 
 #[test]
 fn candidacy_poor_candidate_submission_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 		assert_eq!(Elections::candidates(), Vec::<u64>::new());
 		assert_noop!(
@@ -863,7 +862,7 @@ fn candidacy_poor_candidate_submission_should_not_work() {
 
 #[test]
 fn election_voting_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
@@ -892,7 +891,7 @@ fn election_voting_should_work() {
 
 #[test]
 fn election_proxy_voting_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(1);
 
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 0));
@@ -933,7 +932,7 @@ fn election_proxy_voting_should_work() {
 
 #[test]
 fn election_simple_tally_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 
@@ -972,7 +971,7 @@ fn election_simple_tally_should_work() {
 
 #[test]
 fn election_seats_should_be_released() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
@@ -1006,7 +1005,7 @@ fn election_seats_should_be_released() {
 
 #[test]
 fn election_presentations_with_zero_staked_deposit_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -1022,7 +1021,7 @@ fn election_presentations_with_zero_staked_deposit_should_not_work() {
 
 #[test]
 fn election_double_presentations_should_be_punished() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert!(Balances::can_slash(&4, 10));
 
 		System::set_block_number(4);
@@ -1045,7 +1044,7 @@ fn election_double_presentations_should_be_punished() {
 
 #[test]
 fn election_presenting_for_double_election_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_eq!(Elections::submit_candidacy(Origin::signed(2), 0), Ok(()));
 		assert_ok!(Elections::set_approvals(Origin::signed(2), vec![true], 0, 0, 20));
@@ -1072,7 +1071,7 @@ fn election_presenting_for_double_election_should_not_work() {
 
 #[test]
 fn election_presenting_loser_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![true], 0, 0, 60));
@@ -1105,7 +1104,7 @@ fn election_presenting_loser_should_not_work() {
 
 #[test]
 fn election_presenting_loser_first_should_not_matter() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![true], 0, 0, 60));
@@ -1137,7 +1136,7 @@ fn election_presenting_loser_first_should_not_matter() {
 
 #[test]
 fn election_present_outside_of_presentation_period_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 		assert_noop!(
@@ -1149,7 +1148,7 @@ fn election_present_outside_of_presentation_period_should_not_work() {
 
 #[test]
 fn election_present_with_invalid_vote_index_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(2), 0));
 		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
@@ -1165,33 +1164,35 @@ fn election_present_with_invalid_vote_index_should_not_work() {
 #[test]
 fn election_present_when_presenter_is_poor_should_not_work() {
 	let test_present = |p| {
-		set_and_run_with_externalities(&mut ExtBuilder::default()
+		ExtBuilder::default()
 			.voting_fee(5)
 			.voter_bond(2)
 			.bad_presentation_punishment(p)
-			.build(),
-		|| {
-			System::set_block_number(4);
-			let _ = Balances::make_free_balance_be(&1, 15);
-			assert!(!Elections::presentation_active());
+			.build()
+			.execute_with(|| {
+				System::set_block_number(4);
+				let _ = Balances::make_free_balance_be(&1, 15);
+				assert!(!Elections::presentation_active());
 
-			assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0)); // -3
-			assert_eq!(Balances::free_balance(&1), 12);
-			assert_ok!(Elections::set_approvals(Origin::signed(1), vec![true], 0, 0, 15)); // -2 -5
-			assert_ok!(Elections::end_block(System::block_number()));
+ 				// -3
+				assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
+				assert_eq!(Balances::free_balance(&1), 12);
+ 				// -2 -5
+				assert_ok!(Elections::set_approvals(Origin::signed(1), vec![true], 0, 0, 15));
+				assert_ok!(Elections::end_block(System::block_number()));
 
-			System::set_block_number(6);
-			assert_eq!(Balances::free_balance(&1), 5);
-			assert_eq!(Balances::reserved_balance(&1), 5);
-			if p > 5 {
-				assert_noop!(Elections::present_winner(
-					Origin::signed(1), 1, 10, 0),
-					"presenter must have sufficient slashable funds"
-				);
-			} else {
-				assert_ok!(Elections::present_winner(Origin::signed(1), 1, 10, 0));
-			}
-		});
+				System::set_block_number(6);
+				assert_eq!(Balances::free_balance(&1), 5);
+				assert_eq!(Balances::reserved_balance(&1), 5);
+				if p > 5 {
+					assert_noop!(Elections::present_winner(
+						Origin::signed(1), 1, 10, 0),
+						"presenter must have sufficient slashable funds"
+					);
+				} else {
+					assert_ok!(Elections::present_winner(Origin::signed(1), 1, 10, 0));
+				}
+			});
 	};
 	test_present(4);
 	test_present(6);
@@ -1199,7 +1200,7 @@ fn election_present_when_presenter_is_poor_should_not_work() {
 
 #[test]
 fn election_invalid_present_tally_should_slash() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 		assert_eq!(Balances::total_balance(&4), 40);
@@ -1219,7 +1220,7 @@ fn election_invalid_present_tally_should_slash() {
 
 #[test]
 fn election_runners_up_should_be_kept() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 
@@ -1280,7 +1281,7 @@ fn election_runners_up_should_be_kept() {
 
 #[test]
 fn election_second_tally_should_use_runners_up() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		System::set_block_number(4);
 		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 0));
 		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![true], 0, 0, 60));
@@ -1335,7 +1336,7 @@ fn election_second_tally_should_use_runners_up() {
 
 #[test]
 fn election_loser_candidates_bond_gets_slashed() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().desired_seats(1).build(), || {
+	ExtBuilder::default().desired_seats(1).build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 
@@ -1374,7 +1375,7 @@ fn election_loser_candidates_bond_gets_slashed() {
 
 #[test]
 fn pot_accumulating_weight_and_decaying_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().balance_factor(10).build(), || {
+	ExtBuilder::default().balance_factor(10).build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 
@@ -1502,7 +1503,7 @@ fn pot_accumulating_weight_and_decaying_should_work() {
 
 #[test]
 fn pot_winning_resets_accumulated_pot() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().balance_factor(10).build(), || {
+	ExtBuilder::default().balance_factor(10).build().execute_with(|| {
 		System::set_block_number(4);
 		assert!(!Elections::presentation_active());
 
@@ -1564,72 +1565,88 @@ fn pot_winning_resets_accumulated_pot() {
 
 #[test]
 fn pot_resubmitting_approvals_stores_pot() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.voter_bond(0)
 		.voting_fee(0)
 		.balance_factor(10)
-		.build(),
-	|| { System::set_block_number(4);
-		assert!(!Elections::presentation_active());
+		.build()
+		.execute_with(|| {
+			System::set_block_number(4);
+			assert!(!Elections::presentation_active());
 
-		assert_ok!(Elections::submit_candidacy(Origin::signed(6), 0));
-		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
-		assert_ok!(Elections::submit_candidacy(Origin::signed(1), 2));
+			assert_ok!(Elections::submit_candidacy(Origin::signed(6), 0));
+			assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
+			assert_ok!(Elections::submit_candidacy(Origin::signed(1), 2));
 
-		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![true, false, false], 0, 0, 600));
-		assert_ok!(Elections::set_approvals(Origin::signed(5), vec![false, true, false], 0, 1, 500));
-		assert_ok!(Elections::set_approvals(Origin::signed(1), vec![false, false, true], 0, 2, 100));
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(6), vec![true, false, false], 0, 0, 600),
+			);
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(5), vec![false, true, false], 0, 1, 500),
+			);
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(1), vec![false, false, true], 0, 2, 100),
+			);
 
-		assert_ok!(Elections::end_block(System::block_number()));
+			assert_ok!(Elections::end_block(System::block_number()));
 
-		System::set_block_number(6);
-		assert!(Elections::presentation_active());
+			System::set_block_number(6);
+			assert!(Elections::presentation_active());
 
-		assert_eq!(Elections::present_winner(Origin::signed(6), 6, 600, 0), Ok(()));
-		assert_eq!(Elections::present_winner(Origin::signed(5), 5, 500, 0), Ok(()));
-		assert_eq!(Elections::present_winner(Origin::signed(1), 1, 100, 0), Ok(()));
-		assert_eq!(Elections::leaderboard(), Some(vec![(0, 0), (100, 1), (500, 5), (600, 6)]));
-		assert_ok!(Elections::end_block(System::block_number()));
+			assert_eq!(Elections::present_winner(Origin::signed(6), 6, 600, 0), Ok(()));
+			assert_eq!(Elections::present_winner(Origin::signed(5), 5, 500, 0), Ok(()));
+			assert_eq!(Elections::present_winner(Origin::signed(1), 1, 100, 0), Ok(()));
+			assert_eq!(Elections::leaderboard(), Some(vec![(0, 0), (100, 1), (500, 5), (600, 6)]));
+			assert_ok!(Elections::end_block(System::block_number()));
 
-		assert_eq!(Elections::members(), vec![(6, 11), (5, 11)]);
+			assert_eq!(Elections::members(), vec![(6, 11), (5, 11)]);
 
-		System::set_block_number(12);
-		assert_ok!(Elections::retract_voter(Origin::signed(6), 0));
-		assert_ok!(Elections::retract_voter(Origin::signed(5), 1));
-		assert_ok!(Elections::submit_candidacy(Origin::signed(6), 0));
-		assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
-		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![true, false, false], 1, 0, 600));
-		assert_ok!(Elections::set_approvals(Origin::signed(5), vec![false, true, false], 1, 1, 500));
-		// give 1 some new high balance
-		let _ = Balances::make_free_balance_be(&1, 997);
-		assert_ok!(Elections::set_approvals(Origin::signed(1), vec![false, false, true], 1, 2, 1000));
-		assert_eq!(Elections::voter_info(1).unwrap(),
-			VoterInfo {
-				stake: 1000, // 997 + 3 which is candidacy bond.
-				pot: Elections::get_offset(100, 1),
-				last_active: 1,
-				last_win: 1,
-			}
-		);
-		assert_ok!(Elections::end_block(System::block_number()));
+			System::set_block_number(12);
+			assert_ok!(Elections::retract_voter(Origin::signed(6), 0));
+			assert_ok!(Elections::retract_voter(Origin::signed(5), 1));
+			assert_ok!(Elections::submit_candidacy(Origin::signed(6), 0));
+			assert_ok!(Elections::submit_candidacy(Origin::signed(5), 1));
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(6), vec![true, false, false], 1, 0, 600),
+			);
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(5), vec![false, true, false], 1, 1, 500),
+			);
+			// give 1 some new high balance
+			let _ = Balances::make_free_balance_be(&1, 997);
+			assert_ok!(
+				Elections::set_approvals(Origin::signed(1), vec![false, false, true], 1, 2, 1000),
+			);
+			assert_eq!(Elections::voter_info(1).unwrap(),
+				VoterInfo {
+					stake: 1000, // 997 + 3 which is candidacy bond.
+					pot: Elections::get_offset(100, 1),
+					last_active: 1,
+					last_win: 1,
+				}
+			);
+			assert_ok!(Elections::end_block(System::block_number()));
 
-		assert_eq!(Elections::members(), vec![(6, 11), (5, 11)]);
+			assert_eq!(Elections::members(), vec![(6, 11), (5, 11)]);
 
-		System::set_block_number(14);
-		assert!(Elections::presentation_active());
-		assert_eq!(Elections::present_winner(Origin::signed(6), 6, 600, 1), Ok(()));
-		assert_eq!(Elections::present_winner(Origin::signed(5), 5, 500, 1), Ok(()));
-		assert_eq!(Elections::present_winner(Origin::signed(1), 1, 1000 + 96 /* pot */, 1), Ok(()));
-		assert_eq!(Elections::leaderboard(), Some(vec![(0, 0), (500, 5), (600, 6), (1096, 1)]));
-		assert_ok!(Elections::end_block(System::block_number()));
+			System::set_block_number(14);
+			assert!(Elections::presentation_active());
+			assert_eq!(Elections::present_winner(Origin::signed(6), 6, 600, 1), Ok(()));
+			assert_eq!(Elections::present_winner(Origin::signed(5), 5, 500, 1), Ok(()));
+			assert_eq!(
+				Elections::present_winner(Origin::signed(1), 1, 1000 + 96 /* pot */, 1),
+				Ok(()),
+			);
+			assert_eq!(Elections::leaderboard(), Some(vec![(0, 0), (500, 5), (600, 6), (1096, 1)]));
+			assert_ok!(Elections::end_block(System::block_number()));
 
-		assert_eq!(Elections::members(), vec![(1, 19), (6, 19)]);
-	})
+			assert_eq!(Elections::members(), vec![(1, 19), (6, 19)]);
+		})
 }
 
 #[test]
 fn pot_get_offset_should_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Elections::get_offset(100, 0), 0);
 		assert_eq!(Elections::get_offset(100, 1), 96);
 		assert_eq!(Elections::get_offset(100, 2), 96 + 93);
@@ -1653,7 +1670,7 @@ fn pot_get_offset_should_work() {
 
 #[test]
 fn pot_get_offset_with_zero_decay() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().decay_ratio(0).build(), || {
+	ExtBuilder::default().decay_ratio(0).build().execute_with(|| {
 		assert_eq!(Elections::get_offset(100, 0), 0);
 		assert_eq!(Elections::get_offset(100, 1), 0);
 		assert_eq!(Elections::get_offset(100, 2), 0);

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -638,7 +638,7 @@ mod tests {
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 	use sr_primitives::{
-		set_and_run_with_externalities, Perbill, weights::GetDispatchInfo, testing::Header,
+		Perbill, weights::GetDispatchInfo, testing::Header,
 		traits::{BlakeTwo256, OnInitialize, OnFinalize, IdentityLookup},
 	};
 
@@ -719,7 +719,7 @@ mod tests {
 
 	#[test]
 	fn it_works_for_optional_value() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// Check that GenesisBuilder works properly.
 			assert_eq!(Example::dummy(), Some(42));
 
@@ -740,7 +740,7 @@ mod tests {
 
 	#[test]
 	fn it_works_for_default_value() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Example::foo(), 24);
 			assert_ok!(Example::accumulate_foo(Origin::signed(1), 1));
 			assert_eq!(Example::foo(), 25);
@@ -749,7 +749,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_watch_dummy_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let call = <Call<Test>>::set_dummy(10);
 			let info = DispatchInfo::default();
 

--- a/srml/executive/src/lib.rs
+++ b/srml/executive/src/lib.rs
@@ -298,7 +298,6 @@ mod tests {
 		generic::Era, Perbill, DispatchError, weights::Weight, testing::{Digest, Header, Block},
 		traits::{Bounded, Header as HeaderT, BlakeTwo256, IdentityLookup, ConvertInto},
 		transaction_validity::{InvalidTransaction, UnknownTransaction}, ApplyError,
-		set_and_run_with_externalities,
 	};
 	use support::{
 		impl_outer_event, impl_outer_origin, parameter_types, impl_outer_dispatch,
@@ -420,7 +419,7 @@ mod tests {
 		let xt = sr_primitives::testing::TestXt(sign_extra(1, 0, 0), Call::Balances(BalancesCall::transfer(2, 69)));
 		let weight = xt.get_dispatch_info().weight as u64;
 		let mut t = runtime_io::TestExternalities::new(t);
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			Executive::initialize_block(&Header::new(
 				1,
 				H256::default(),
@@ -446,7 +445,7 @@ mod tests {
 
 	#[test]
 	fn block_import_works() {
-		set_and_run_with_externalities(&mut new_test_ext(1), || {
+		new_test_ext(1).execute_with(|| {
 			Executive::execute_block(Block {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
@@ -463,7 +462,7 @@ mod tests {
 	#[test]
 	#[should_panic]
 	fn block_import_of_bad_state_root_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(1), || {
+		new_test_ext(1).execute_with(|| {
 			Executive::execute_block(Block {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
@@ -480,7 +479,7 @@ mod tests {
 	#[test]
 	#[should_panic]
 	fn block_import_of_bad_extrinsic_root_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(1), || {
+		new_test_ext(1).execute_with(|| {
 			Executive::execute_block(Block {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
@@ -499,7 +498,7 @@ mod tests {
 		let mut t = new_test_ext(1);
 		// bad nonce check!
 		let xt = sr_primitives::testing::TestXt(sign_extra(1, 30, 0), Call::Balances(BalancesCall::transfer(33, 69)));
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			Executive::initialize_block(&Header::new(
 				1,
 				H256::default(),
@@ -521,7 +520,7 @@ mod tests {
 		let encoded_len = encoded.len() as Weight;
 		let limit = AvailableBlockRatio::get() * MaximumBlockWeight::get();
 		let num_to_exhaust_block = limit / encoded_len;
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			Executive::initialize_block(&Header::new(
 				1,
 				H256::default(),
@@ -557,7 +556,7 @@ mod tests {
 		let x2 = sr_primitives::testing::TestXt(sign_extra(1, 2, 0), Call::Balances(BalancesCall::transfer(33, 0)));
 		let len = xt.clone().encode().len() as u32;
 		let mut t = new_test_ext(1);
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(<system::Module<Runtime>>::all_extrinsics_weight(), 0);
 			assert_eq!(<system::Module<Runtime>>::all_extrinsics_weight(), 0);
 
@@ -581,7 +580,7 @@ mod tests {
 		let xt = sr_primitives::testing::TestXt(None, Call::Balances(BalancesCall::set_balance(33, 69, 69)));
 		let mut t = new_test_ext(1);
 
-		set_and_run_with_externalities(&mut t, || {
+		t.execute_with(|| {
 			assert_eq!(Executive::validate_transaction(xt.clone()), Ok(Default::default()));
 			assert_eq!(
 				Executive::apply_extrinsic(xt),
@@ -599,7 +598,7 @@ mod tests {
 		let id: LockIdentifier = *b"0       ";
 		let execute_with_lock = |lock: WithdrawReasons| {
 			let mut t = new_test_ext(1);
-			set_and_run_with_externalities(&mut t, || {
+			t.execute_with(|| {
 				<balances::Module<Runtime> as LockableCurrency<u64>>::set_lock(
 					id,
 					&1,

--- a/srml/finality-tracker/src/lib.rs
+++ b/srml/finality-tracker/src/lib.rs
@@ -250,7 +250,7 @@ mod tests {
 	use runtime_io::TestExternalities;
 	use primitives::H256;
 	use sr_primitives::{
-		set_and_run_with_externalities, testing::Header, Perbill,
+		testing::Header, Perbill,
 		traits::{BlakeTwo256, IdentityLookup, OnFinalize, Header as HeaderT},
 	};
 	use support::{assert_ok, impl_outer_origin, parameter_types};
@@ -322,7 +322,7 @@ mod tests {
 	#[test]
 	fn median_works() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			FinalityTracker::update_hint(Some(500));
 			assert_eq!(FinalityTracker::median(), 250);
 			assert!(NOTIFICATIONS.with(|n| n.borrow().is_empty()));
@@ -332,7 +332,7 @@ mod tests {
 	#[test]
 	fn notifies_when_stalled() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			let mut parent_hash = System::parent_hash();
 			for i in 2..106 {
 				System::initialize(&i, &parent_hash, &Default::default(), &Default::default());
@@ -351,7 +351,7 @@ mod tests {
 	#[test]
 	fn recent_notifications_prevent_stalling() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			let mut parent_hash = System::parent_hash();
 			for i in 2..106 {
 				System::initialize(&i, &parent_hash, &Default::default(), &Default::default());

--- a/srml/generic-asset/src/tests.rs
+++ b/srml/generic-asset/src/tests.rs
@@ -22,14 +22,13 @@
 
 use super::*;
 use crate::mock::{new_test_ext, ExtBuilder, GenericAsset, Origin, System, Test, TestEvent};
-use sr_primitives::set_and_run_with_externalities;
 use support::{assert_noop, assert_ok};
 
 #[test]
 fn issuing_asset_units_to_issuer_should_work() {
 	let balance = 100;
 
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((16000, 1, 100)).build(), || {
+	ExtBuilder::default().free_balance((16000, 1, 100)).build().execute_with(|| {
 		let default_permission = PermissionLatest {
 			update: Owner::Address(1),
 			mint: Owner::Address(1),
@@ -51,61 +50,55 @@ fn issuing_asset_units_to_issuer_should_work() {
 
 #[test]
 fn issuing_with_next_asset_id_overflow_should_not_work() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			NextAssetId::<Test>::put(u32::max_value());
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_noop!(
-				GenericAsset::create(
-					Origin::signed(1),
-					AssetOptions {
-						initial_issuance: 1,
-						permissions: default_permission
-					}
-				),
-				"No new assets id available."
-			);
-			assert_eq!(GenericAsset::next_asset_id(), u32::max_value());
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		NextAssetId::<Test>::put(u32::max_value());
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_noop!(
+			GenericAsset::create(
+				Origin::signed(1),
+				AssetOptions {
+					initial_issuance: 1,
+					permissions: default_permission
+				}
+			),
+			"No new assets id available."
+		);
+		assert_eq!(GenericAsset::next_asset_id(), u32::max_value());
+	});
 }
 
 #[test]
 fn querying_total_supply_should_work() {
 	let asset_id = 1000;
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: 100,
-					permissions: default_permission
-				}
-			));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
-			assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 2, 50));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
-			assert_eq!(GenericAsset::free_balance(&asset_id, &2), 50);
-			assert_ok!(GenericAsset::transfer(Origin::signed(2), asset_id, 3, 31));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
-			assert_eq!(GenericAsset::free_balance(&asset_id, &2), 19);
-			assert_eq!(GenericAsset::free_balance(&asset_id, &3), 31);
-			assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 1, 1));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: 100,
+				permissions: default_permission
+			}
+		));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
+		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 2, 50));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &2), 50);
+		assert_ok!(GenericAsset::transfer(Origin::signed(2), asset_id, 3, 31));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &2), 19);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &3), 31);
+		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 1, 1));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 50);
+	});
 }
 
 // Given
@@ -127,27 +120,24 @@ fn querying_total_supply_should_work() {
 fn transferring_amount_should_work() {
 	let asset_id = 1000;
 	let free_balance = 100;
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: free_balance,
-					permissions: default_permission
-				}
-			));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), free_balance);
-			assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 2, 40));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 60);
-			assert_eq!(GenericAsset::free_balance(&asset_id, &2), 40);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: free_balance,
+				permissions: default_permission
+			}
+		));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), free_balance);
+		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 2, 40));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 60);
+		assert_eq!(GenericAsset::free_balance(&asset_id, &2), 40);
+	});
 }
 
 // Given
@@ -168,55 +158,49 @@ fn transferring_amount_should_work() {
 #[test]
 fn transferring_amount_should_fail_when_transferring_more_than_free_balance() {
 	let asset_id = 1000;
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: 100,
-					permissions: default_permission
-				}
-			));
-			assert_noop!(
-				GenericAsset::transfer(Origin::signed(1), asset_id, 2, 2000),
-				"balance too low to send amount"
-			);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: 100,
+				permissions: default_permission
+			}
+		));
+		assert_noop!(
+			GenericAsset::transfer(Origin::signed(1), asset_id, 2, 2000),
+			"balance too low to send amount"
+		);
+	});
 }
 
 #[test]
 fn transferring_less_than_one_unit_should_not_work() {
 	let asset_id = 1000;
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: 100,
-					permissions: default_permission
-				}
-			));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
-			assert_noop!(
-				GenericAsset::transfer(Origin::signed(1), asset_id, 2, 0),
-				"cannot transfer zero amount"
-			);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: 100,
+				permissions: default_permission
+			}
+		));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
+		assert_noop!(
+			GenericAsset::transfer(Origin::signed(1), asset_id, 2, 0),
+			"cannot transfer zero amount"
+		);
+	});
 }
 
 // Given
@@ -233,60 +217,54 @@ fn self_transfer_should_fail() {
 	let asset_id = 1000;
 	let balance = 100;
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: balance,
-					permissions: default_permission
-				}
-			));
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: balance,
+				permissions: default_permission
+			}
+		));
 
-			let initial_free_balance = GenericAsset::free_balance(&asset_id, &1);
-			assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 1, 10));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), initial_free_balance);
-		},
-	);
+		let initial_free_balance = GenericAsset::free_balance(&asset_id, &1);
+		assert_ok!(GenericAsset::transfer(Origin::signed(1), asset_id, 1, 10));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), initial_free_balance);
+	});
 }
 
 #[test]
 fn transferring_more_units_than_total_supply_should_not_work() {
 	let asset_id = 1000;
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let default_permission = PermissionLatest {
-				update: Owner::Address(1),
-				mint: Owner::Address(1),
-				burn: Owner::Address(1),
-			};
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: 100,
-					permissions: default_permission
-				}
-			));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
-			assert_noop!(
-				GenericAsset::transfer(Origin::signed(1), asset_id, 2, 101),
-				"balance too low to send amount"
-			);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let default_permission = PermissionLatest {
+			update: Owner::Address(1),
+			mint: Owner::Address(1),
+			burn: Owner::Address(1),
+		};
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: 100,
+				permissions: default_permission
+			}
+		));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &1), 100);
+		assert_noop!(
+			GenericAsset::transfer(Origin::signed(1), asset_id, 2, 101),
+			"balance too low to send amount"
+		);
+	});
 }
 
 // Ensures it uses fake money for staking asset id.
 #[test]
 fn staking_asset_id_should_return_0() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(GenericAsset::staking_asset_id(), 16000);
 	});
 }
@@ -294,7 +272,7 @@ fn staking_asset_id_should_return_0() {
 // Ensures it uses fake money for spending asset id.
 #[test]
 fn spending_asset_id_should_return_10() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(GenericAsset::spending_asset_id(), 16001);
 	});
 }
@@ -305,7 +283,7 @@ fn spending_asset_id_should_return_10() {
 // -Â total_balance should return 0
 #[test]
 fn total_balance_should_be_zero() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		assert_eq!(GenericAsset::total_balance(&0, &0), 0);
 	});
 }
@@ -323,19 +301,16 @@ fn total_balance_should_be_equal_to_account_balance() {
 		mint: Owner::Address(1),
 		burn: Owner::Address(1),
 	};
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			assert_ok!(GenericAsset::create(
-				Origin::signed(1),
-				AssetOptions {
-					initial_issuance: 100,
-					permissions: default_permission
-				}
-			));
-			assert_eq!(GenericAsset::total_balance(&1000, &1), 100);
-		},
-	);
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		assert_ok!(GenericAsset::create(
+			Origin::signed(1),
+			AssetOptions {
+				initial_issuance: 100,
+				permissions: default_permission
+			}
+		));
+		assert_eq!(GenericAsset::total_balance(&1000, &1), 100);
+	});
 }
 
 // Given
@@ -348,7 +323,7 @@ fn total_balance_should_be_equal_to_account_balance() {
 // -Â free_balance should return 50.
 #[test]
 fn free_balance_should_only_return_account_free_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 50)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 50)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 70);
 		assert_eq!(GenericAsset::free_balance(&1, &0), 50);
 	});
@@ -363,7 +338,7 @@ fn free_balance_should_only_return_account_free_balance() {
 // -Â total_balance should equals to account balance + free balance.
 #[test]
 fn total_balance_should_be_equal_to_sum_of_account_balance_and_free_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 50)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 50)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 70);
 		assert_eq!(GenericAsset::total_balance(&1, &0), 120);
 	});
@@ -378,7 +353,7 @@ fn total_balance_should_be_equal_to_sum_of_account_balance_and_free_balance() {
 // - reserved_balance should return 70.
 #[test]
 fn reserved_balance_should_only_return_account_reserved_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 50)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 50)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 70);
 		assert_eq!(GenericAsset::reserved_balance(&1, &0), 70);
 	});
@@ -394,7 +369,7 @@ fn reserved_balance_should_only_return_account_reserved_balance() {
 // - reserved_balance = amount
 #[test]
 fn set_reserved_balance_should_add_balance_as_reserved() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 50);
 		assert_eq!(GenericAsset::reserved_balance(&1, &0), 50);
 	});
@@ -410,7 +385,7 @@ fn set_reserved_balance_should_add_balance_as_reserved() {
 // - New free_balance should replace older free_balance.
 #[test]
 fn set_free_balance_should_add_amount_as_free_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_free_balance(&1, &0, 50);
 		assert_eq!(GenericAsset::free_balance(&1, &0), 50);
 	});
@@ -429,7 +404,7 @@ fn set_free_balance_should_add_amount_as_free_balance() {
 // - new reserved_balance = original free balance + reserved amount
 #[test]
 fn reserve_should_moves_amount_from_balance_to_reserved_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		assert_ok!(GenericAsset::reserve(&1, &0, 70));
 		assert_eq!(GenericAsset::free_balance(&1, &0), 30);
 		assert_eq!(GenericAsset::reserved_balance(&1, &0), 70);
@@ -448,7 +423,7 @@ fn reserve_should_moves_amount_from_balance_to_reserved_balance() {
 // - Should throw an error.
 #[test]
 fn reserve_should_not_moves_amount_from_balance_to_reserved_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		assert_noop!(GenericAsset::reserve(&1, &0, 120), "not enough free funds");
 		assert_eq!(GenericAsset::free_balance(&1, &0), 100);
 		assert_eq!(GenericAsset::reserved_balance(&1, &0), 0);
@@ -466,7 +441,7 @@ fn reserve_should_not_moves_amount_from_balance_to_reserved_balance() {
 // - unreserved should return 20.
 #[test]
 fn unreserve_should_return_substratced_value_from_unreserved_amount_by_actual_acount_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::unreserve(&1, &0, 120), 20);
 	});
@@ -483,7 +458,7 @@ fn unreserve_should_return_substratced_value_from_unreserved_amount_by_actual_ac
 // - unreserved should return None.
 #[test]
 fn unreserve_should_return_none() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::unreserve(&1, &0, 50), 0);
 	});
@@ -500,7 +475,7 @@ fn unreserve_should_return_none() {
 // - free_balance should be 200.
 #[test]
 fn unreserve_should_increase_free_balance_by_reserved_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		GenericAsset::unreserve(&1, &0, 120);
 		assert_eq!(GenericAsset::free_balance(&1, &0), 200);
@@ -518,7 +493,7 @@ fn unreserve_should_increase_free_balance_by_reserved_balance() {
 // - reserved_balance should be 0.
 #[test]
 fn unreserve_should_deduct_reserved_balance_by_reserved_amount() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_free_balance(&1, &0, 100);
 		GenericAsset::unreserve(&1, &0, 120);
 		assert_eq!(GenericAsset::reserved_balance(&1, &0), 0);
@@ -536,7 +511,7 @@ fn unreserve_should_deduct_reserved_balance_by_reserved_amount() {
 // - slash should return None.
 #[test]
 fn slash_should_return_slash_reserved_amount() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().free_balance((1, 0, 100)).build(), || {
+	ExtBuilder::default().free_balance((1, 0, 100)).build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::slash(&1, &0, 70), None);
 	});
@@ -550,7 +525,7 @@ fn slash_should_return_slash_reserved_amount() {
 // - Should return slashed_reserved - reserved_balance.
 #[test]
 fn slash_reserved_should_deducts_up_to_amount_from_reserved_balance() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::slash_reserved(&1, &0, 150), Some(50));
 	});
@@ -564,7 +539,7 @@ fn slash_reserved_should_deducts_up_to_amount_from_reserved_balance() {
 // - Should return None.
 #[test]
 fn slash_reserved_should_return_none() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::slash_reserved(&1, &0, 100), None);
 	});
@@ -579,7 +554,7 @@ fn slash_reserved_should_return_none() {
 // - Should not return None.
 #[test]
 fn repatriate_reserved_return_amount_substracted_by_slash_amount() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::repatriate_reserved(&1, &0, &1, 130), 30);
 	});
@@ -594,7 +569,7 @@ fn repatriate_reserved_return_amount_substracted_by_slash_amount() {
 // - Should return None.
 #[test]
 fn repatriate_reserved_return_none() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		GenericAsset::set_reserved_balance(&1, &0, 100);
 		assert_eq!(GenericAsset::repatriate_reserved(&1, &0, &1, 90), 0);
 	});
@@ -608,7 +583,7 @@ fn repatriate_reserved_return_none() {
 // - Should create a new reserved asset.
 #[test]
 fn create_reserved_should_create_a_default_account_with_the_balance_given() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let default_permission = PermissionLatest {
 			update: Owner::Address(1),
 			mint: Owner::Address(1),
@@ -643,7 +618,7 @@ fn create_reserved_should_create_a_default_account_with_the_balance_given() {
 // - Should throw a permission error
 #[test]
 fn mint_should_throw_permission_error() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		let origin = 1;
 		let asset_id = 4;
 		let to_account = 2;
@@ -666,36 +641,33 @@ fn mint_should_throw_permission_error() {
 // - Should not change `origins`  free_balance.
 #[test]
 fn mint_should_increase_asset() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let to_account = 2;
-			let amount = 500;
-			let initial_issuance = 100;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let to_account = 2;
+		let amount = 500;
+		let initial_issuance = 100;
 
-			let default_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::Address(origin),
-				burn: Owner::Address(origin),
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::Address(origin),
+			burn: Owner::Address(origin),
+		};
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			}
+		));
 
-			assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), amount);
+		assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), amount);
 
-			// Origin's free_balance should not change.
-			assert_eq!(GenericAsset::free_balance(&asset_id, &origin), initial_issuance);
-		},
-	);
+		// Origin's free_balance should not change.
+		assert_eq!(GenericAsset::free_balance(&asset_id, &origin), initial_issuance);
+	});
 }
 
 // Given
@@ -707,20 +679,17 @@ fn mint_should_increase_asset() {
 // - Should throw a permission error.
 #[test]
 fn burn_should_throw_permission_error() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 4;
-			let to_account = 2;
-			let amount = 10;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 4;
+		let to_account = 2;
+		let amount = 10;
 
-			assert_noop!(
-				GenericAsset::burn(Origin::signed(origin), asset_id, to_account, amount),
-				"The origin does not have permission to burn an asset."
-			);
-		},
-	);
+		assert_noop!(
+			GenericAsset::burn(Origin::signed(origin), asset_id, to_account, amount),
+			"The origin does not have permission to burn an asset."
+		);
+	});
 }
 
 // Given
@@ -733,41 +702,38 @@ fn burn_should_throw_permission_error() {
 // - Should not change `origin`'s  free_balance.
 #[test]
 fn burn_should_burn_an_asset() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let to_account = 2;
-			let amount = 1000;
-			let initial_issuance = 100;
-			let burn_amount = 400;
-			let expected_amount = 600;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let to_account = 2;
+		let amount = 1000;
+		let initial_issuance = 100;
+		let burn_amount = 400;
+		let expected_amount = 600;
 
-			let default_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::Address(origin),
-				burn: Owner::Address(origin),
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::Address(origin),
+			burn: Owner::Address(origin),
+		};
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
-			assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			}
+		));
+		assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to_account, amount));
 
-			assert_ok!(GenericAsset::burn(
-				Origin::signed(origin),
-				asset_id,
-				to_account,
-				burn_amount
-			));
-			assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), expected_amount);
-		},
-	);
+		assert_ok!(GenericAsset::burn(
+			Origin::signed(origin),
+			asset_id,
+			to_account,
+			burn_amount
+		));
+		assert_eq!(GenericAsset::free_balance(&asset_id, &to_account), expected_amount);
+	});
 }
 
 // Given
@@ -779,41 +745,29 @@ fn burn_should_burn_an_asset() {
 // - The account origin should have burn, mint and update permissions.
 #[test]
 fn check_permission_should_return_correct_permission() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let initial_issuance = 100;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let initial_issuance = 100;
 
-			let default_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::Address(origin),
-				burn: Owner::Address(origin),
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::Address(origin),
+			burn: Owner::Address(origin),
+		};
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			},
+		));
 
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn),
-				true
-			);
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint),
-				true
-			);
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Update),
-				true
-			);
-		},
-	);
+		assert!(GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn));
+		assert!(GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint));
+		assert!(GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Update));
+	});
 }
 
 // Given
@@ -825,41 +779,29 @@ fn check_permission_should_return_correct_permission() {
 // - The account origin should not have burn, mint and update permissions.
 #[test]
 fn check_permission_should_return_false_for_no_permission() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let initial_issuance = 100;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let initial_issuance = 100;
 
-			let default_permission = PermissionLatest {
-				update: Owner::None,
-				mint: Owner::None,
-				burn: Owner::None,
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::None,
+			mint: Owner::None,
+			burn: Owner::None,
+		};
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			}
+		));
 
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn),
-				false
-			);
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint),
-				false
-			);
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Update),
-				false
-			);
-		},
-	);
+		assert!(!GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn));
+		assert!(!GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint));
+		assert!(!GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Update));
+	});
 }
 
 // Given
@@ -871,48 +813,39 @@ fn check_permission_should_return_false_for_no_permission() {
 // - The account origin should have update and mint permissions.
 #[test]
 fn update_permission_should_change_permission() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let initial_issuance = 100;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let initial_issuance = 100;
 
-			let default_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::None,
-				burn: Owner::None,
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::None,
+			burn: Owner::None,
+		};
 
-			let new_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::Address(origin),
-				burn: Owner::None,
-			};
+		let new_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::Address(origin),
+			burn: Owner::None,
+		};
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			}
+		));
 
-			assert_ok!(GenericAsset::update_permission(
-				Origin::signed(origin),
-				asset_id,
-				new_permission
-			));
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint),
-				true
-			);
-			assert_eq!(
-				GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn),
-				false
-			);
-		},
-	);
+		assert_ok!(GenericAsset::update_permission(
+			Origin::signed(origin),
+			asset_id,
+			new_permission,
+		));
+		assert!(GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Mint));
+		assert!(!GenericAsset::check_permission(&asset_id, &origin, &PermissionType::Burn));
+	});
 }
 
 // Given
@@ -923,41 +856,38 @@ fn update_permission_should_change_permission() {
 // - Should throw an error stating "Origin does not have enough permission to update permissions."
 #[test]
 fn update_permission_should_throw_error_when_lack_of_permissions() {
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().free_balance((16000, 1, 100000)).build(),
-		|| {
-			let origin = 1;
-			let asset_id = 1000;
-			let initial_issuance = 100;
+	ExtBuilder::default().free_balance((16000, 1, 100000)).build().execute_with(|| {
+		let origin = 1;
+		let asset_id = 1000;
+		let initial_issuance = 100;
 
-			let default_permission = PermissionLatest {
-				update: Owner::None,
-				mint: Owner::None,
-				burn: Owner::None,
-			};
+		let default_permission = PermissionLatest {
+			update: Owner::None,
+			mint: Owner::None,
+			burn: Owner::None,
+		};
 
-			let new_permission = PermissionLatest {
-				update: Owner::Address(origin),
-				mint: Owner::Address(origin),
-				burn: Owner::None,
-			};
+		let new_permission = PermissionLatest {
+			update: Owner::Address(origin),
+			mint: Owner::Address(origin),
+			burn: Owner::None,
+		};
 
-			let expected_error_message = "Origin does not have enough permission to update permissions.";
+		let expected_error_message = "Origin does not have enough permission to update permissions.";
 
-			assert_ok!(GenericAsset::create(
-				Origin::signed(origin),
-				AssetOptions {
-					initial_issuance: initial_issuance,
-					permissions: default_permission
-				}
-			));
+		assert_ok!(GenericAsset::create(
+			Origin::signed(origin),
+			AssetOptions {
+				initial_issuance: initial_issuance,
+				permissions: default_permission
+			},
+		));
 
-			assert_noop!(
-				GenericAsset::update_permission(Origin::signed(origin), asset_id, new_permission),
-				expected_error_message
-			);
-		},
-	);
+		assert_noop!(
+			GenericAsset::update_permission(Origin::signed(origin), asset_id, new_permission),
+			expected_error_message,
+		);
+	});
 }
 
 // Given
@@ -974,7 +904,7 @@ fn update_permission_should_throw_error_when_lack_of_permissions() {
 // - Permissions must have burn, mint and updatePermission for the given asset_id.
 #[test]
 fn create_asset_works_with_given_asset_id_and_from_account() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as system::Trait>::AccountId> = Some(1);
 
@@ -1011,7 +941,7 @@ fn create_asset_works_with_given_asset_id_and_from_account() {
 // - `create_asset` should not work.
 #[test]
 fn create_asset_with_non_reserved_asset_id_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as system::Trait>::AccountId> = Some(1);
 
@@ -1045,7 +975,7 @@ fn create_asset_with_non_reserved_asset_id_should_not_work() {
 // - `create_asset` should not work.
 #[test]
 fn create_asset_with_a_taken_asset_id_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as system::Trait>::AccountId> = Some(1);
 
@@ -1090,7 +1020,7 @@ fn create_asset_with_a_taken_asset_id_should_not_work() {
 // - Should create a reserved token.
 #[test]
 fn create_asset_should_create_a_reserved_asset_when_from_account_is_none() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as system::Trait>::AccountId> = None;
 
@@ -1133,7 +1063,7 @@ fn create_asset_should_create_a_reserved_asset_when_from_account_is_none() {
 // - Should not create a `reserved_asset`.
 #[test]
 fn create_asset_should_create_a_user_asset() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().next_asset_id(10).build(), || {
+	ExtBuilder::default().next_asset_id(10).build().execute_with(|| {
 		let origin = 1;
 		let from_account: Option<<Test as system::Trait>::AccountId> = None;
 
@@ -1180,12 +1110,11 @@ fn update_permission_should_raise_event() {
 		burn: Owner::Address(origin),
 	};
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.next_asset_id(asset_id)
-			.free_balance((staking_asset_id, origin, initial_balance))
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.next_asset_id(asset_id)
+		.free_balance((staking_asset_id, origin, initial_balance))
+		.build()
+		.execute_with(|| {
 			assert_ok!(GenericAsset::create(
 				Origin::signed(origin),
 				AssetOptions {
@@ -1201,9 +1130,11 @@ fn update_permission_should_raise_event() {
 				permissions.clone()
 			));
 
+			let expected_event = TestEvent::generic_asset(
+				RawEvent::PermissionUpdated(asset_id, permissions.clone()),
+			);
 			// Assert
-			assert!(System::events().iter().any(|record| record.event
-				== TestEvent::generic_asset(RawEvent::PermissionUpdated(asset_id, permissions.clone()))));
+			assert!(System::events().iter().any(|record| record.event == expected_event));
 		},
 	);
 }
@@ -1223,27 +1154,26 @@ fn mint_should_raise_event() {
 	let to = 2;
 	let amount = 100;
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.next_asset_id(asset_id)
-			.free_balance((staking_asset_id, origin, initial_balance))
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.next_asset_id(asset_id)
+		.free_balance((staking_asset_id, origin, initial_balance))
+		.build()
+		.execute_with(|| {
 			assert_ok!(GenericAsset::create(
 				Origin::signed(origin),
 				AssetOptions {
 					initial_issuance: 0,
 					permissions: permissions.clone(),
-				}
+				},
 			));
 
 			// Act
 			assert_ok!(GenericAsset::mint(Origin::signed(origin), asset_id, to, amount));
 
+			let expected_event = TestEvent::generic_asset(RawEvent::Minted(asset_id, to, amount));
+
 			// Assert
-			assert!(System::events()
-				.iter()
-				.any(|record| record.event == TestEvent::generic_asset(RawEvent::Minted(asset_id, to, amount))));
+			assert!(System::events().iter().any(|record| record.event == expected_event));
 		},
 	);
 }
@@ -1262,27 +1192,26 @@ fn burn_should_raise_event() {
 	};
 	let amount = 100;
 
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default()
-			.next_asset_id(asset_id)
-			.free_balance((staking_asset_id, origin, initial_balance))
-			.build(),
-		|| {
+	ExtBuilder::default()
+		.next_asset_id(asset_id)
+		.free_balance((staking_asset_id, origin, initial_balance))
+		.build()
+		.execute_with(|| {
 			assert_ok!(GenericAsset::create(
 				Origin::signed(origin),
 				AssetOptions {
 					initial_issuance: amount,
 					permissions: permissions.clone(),
-				}
+				},
 			));
 
 			// Act
 			assert_ok!(GenericAsset::burn(Origin::signed(origin), asset_id, origin, amount));
 
+			let expected_event = TestEvent::generic_asset(RawEvent::Burned(asset_id, origin, amount));
+
 			// Assert
-			assert!(System::events()
-				.iter()
-				.any(|record| record.event == TestEvent::generic_asset(RawEvent::Burned(asset_id, origin, amount))));
+			assert!(System::events().iter().any(|record| record.event == expected_event));
 		},
 	);
 }

--- a/srml/grandpa/src/tests.rs
+++ b/srml/grandpa/src/tests.rs
@@ -18,7 +18,7 @@
 
 #![cfg(test)]
 
-use sr_primitives::{set_and_run_with_externalities, testing::Digest, traits::{Header, OnFinalize}};
+use sr_primitives::{testing::Digest, traits::{Header, OnFinalize}};
 use crate::mock::*;
 use system::{EventRecord, Phase};
 use codec::{Decode, Encode};
@@ -27,7 +27,7 @@ use super::*;
 
 #[test]
 fn authorities_change_logged() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 0, None).unwrap();
 
@@ -55,7 +55,7 @@ fn authorities_change_logged() {
 
 #[test]
 fn authorities_change_logged_after_delay() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 1, None).unwrap();
 		Grandpa::on_finalize(1);
@@ -88,7 +88,7 @@ fn authorities_change_logged_after_delay() {
 
 #[test]
 fn cannot_schedule_change_when_one_pending() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_change(to_authorities(vec![(4, 1), (5, 1), (6, 1)]), 1, None).unwrap();
 		assert!(<PendingChange<Test>>::exists());
@@ -131,7 +131,7 @@ fn new_decodes_from_old() {
 
 #[test]
 fn dispatch_forced_change() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_change(
 			to_authorities(vec![(4, 1), (5, 1), (6, 1)]),
@@ -203,7 +203,7 @@ fn dispatch_forced_change() {
 
 #[test]
 fn schedule_pause_only_when_live() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		// we schedule a pause at block 1 with delay of 1
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 		Grandpa::schedule_pause(1).unwrap();
@@ -238,7 +238,7 @@ fn schedule_pause_only_when_live() {
 
 #[test]
 fn schedule_resume_only_when_paused() {
-	set_and_run_with_externalities(&mut new_test_ext(vec![(1, 1), (2, 1), (3, 1)]), || {
+	new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 		System::initialize(&1, &Default::default(), &Default::default(), &Default::default());
 
 		// the set is currently live, resuming it is an error

--- a/srml/im-online/src/tests.rs
+++ b/srml/im-online/src/tests.rs
@@ -23,8 +23,7 @@ use crate::mock::*;
 use offchain::testing::TestOffchainExt;
 use primitives::offchain::{OpaquePeerId, OffchainExt};
 use support::{dispatch, assert_noop};
-use sr_primitives::{set_and_run_with_externalities, testing::UintAuthorityId};
-
+use sr_primitives::testing::UintAuthorityId;
 
 #[test]
 fn test_unresponsiveness_slash_fraction() {
@@ -48,7 +47,7 @@ fn test_unresponsiveness_slash_fraction() {
 
 #[test]
 fn should_report_offline_validators() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let block = 1;
 		System::set_block_number(block);
@@ -124,7 +123,7 @@ fn heartbeat(
 
 #[test]
 fn should_mark_online_validator_when_heartbeat_is_received() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		advance_session();
 		// given
 		VALIDATORS.with(|l| *l.borrow_mut() = Some(vec![1, 2, 3, 4, 5, 6]));
@@ -159,7 +158,7 @@ fn should_mark_online_validator_when_heartbeat_is_received() {
 
 #[test]
 fn late_heartbeat_should_fail() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		advance_session();
 		// given
 		VALIDATORS.with(|l| *l.borrow_mut() = Some(vec![1, 2, 4, 4, 5, 6]));
@@ -182,7 +181,7 @@ fn should_generate_heartbeats() {
 	let (offchain, state) = TestOffchainExt::new();
 	ext.register_extension(OffchainExt::new(offchain));
 
-	set_and_run_with_externalities(&mut ext, || {
+	ext.execute_with(|| {
 		// given
 		let block = 1;
 		System::set_block_number(block);
@@ -218,7 +217,7 @@ fn should_generate_heartbeats() {
 
 #[test]
 fn should_cleanup_received_heartbeats_on_session_end() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		advance_session();
 
 		VALIDATORS.with(|l| *l.borrow_mut() = Some(vec![1, 2, 3]));

--- a/srml/indices/src/tests.rs
+++ b/srml/indices/src/tests.rs
@@ -20,61 +20,48 @@
 
 use super::*;
 use crate::mock::{Indices, new_test_ext, make_account, kill_account, TestIsDeadAccount};
-use sr_primitives::set_and_run_with_externalities;
 
 #[test]
 fn indexing_lookup_should_work() {
-	set_and_run_with_externalities(
-		&mut new_test_ext(),
-		|| {
-			assert_eq!(Indices::lookup_index(0), Some(1));
-			assert_eq!(Indices::lookup_index(1), Some(2));
-			assert_eq!(Indices::lookup_index(2), Some(3));
-			assert_eq!(Indices::lookup_index(3), Some(4));
-			assert_eq!(Indices::lookup_index(4), None);
-		},
-	);
+	new_test_ext().execute_with(|| {
+		assert_eq!(Indices::lookup_index(0), Some(1));
+		assert_eq!(Indices::lookup_index(1), Some(2));
+		assert_eq!(Indices::lookup_index(2), Some(3));
+		assert_eq!(Indices::lookup_index(3), Some(4));
+		assert_eq!(Indices::lookup_index(4), None);
+	});
 }
 
 #[test]
 fn default_indexing_on_new_accounts_should_work() {
-	set_and_run_with_externalities(
-		&mut new_test_ext(),
-		|| {
-			assert_eq!(Indices::lookup_index(4), None);
-			make_account(5);
-			assert_eq!(Indices::lookup_index(4), Some(5));
-		},
-	);
+	new_test_ext().execute_with(|| {
+		assert_eq!(Indices::lookup_index(4), None);
+		make_account(5);
+		assert_eq!(Indices::lookup_index(4), Some(5));
+	});
 }
 
 #[test]
 fn reclaim_indexing_on_new_accounts_should_work() {
-	set_and_run_with_externalities(
-		&mut new_test_ext(),
-		|| {
-			assert_eq!(Indices::lookup_index(1), Some(2));
-			assert_eq!(Indices::lookup_index(4), None);
+	new_test_ext().execute_with(|| {
+		assert_eq!(Indices::lookup_index(1), Some(2));
+		assert_eq!(Indices::lookup_index(4), None);
 
-			kill_account(2);					// index 1 no longer locked to id 2
+		kill_account(2);					// index 1 no longer locked to id 2
 
-			make_account(1 + 256);				// id 257 takes index 1.
-			assert_eq!(Indices::lookup_index(1), Some(257));
-		},
-	);
+		make_account(1 + 256);				// id 257 takes index 1.
+		assert_eq!(Indices::lookup_index(1), Some(257));
+	});
 }
 
 #[test]
 fn alive_account_should_prevent_reclaim() {
-	set_and_run_with_externalities(
-		&mut new_test_ext(),
-		|| {
-			assert!(!TestIsDeadAccount::is_dead_account(&2));
-			assert_eq!(Indices::lookup_index(1), Some(2));
-			assert_eq!(Indices::lookup_index(4), None);
+	new_test_ext().execute_with(|| {
+		assert!(!TestIsDeadAccount::is_dead_account(&2));
+		assert_eq!(Indices::lookup_index(1), Some(2));
+		assert_eq!(Indices::lookup_index(4), None);
 
-			make_account(1 + 256);				// id 257 takes index 1.
-			assert_eq!(Indices::lookup_index(4), Some(257));
-		},
-	);
+		make_account(1 + 256);				// id 257 takes index 1.
+		assert_eq!(Indices::lookup_index(4), Some(257));
+	});
 }

--- a/srml/membership/src/lib.rs
+++ b/srml/membership/src/lib.rs
@@ -196,10 +196,7 @@ mod tests {
 	use primitives::H256;
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are requried.
-	use sr_primitives::{
-		Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		set_and_run_with_externalities,
-	};
+	use sr_primitives::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 	use system::EnsureSignedBy;
 
 	impl_outer_origin! {
@@ -293,7 +290,7 @@ mod tests {
 
 	#[test]
 	fn query_membership_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Membership::members(), vec![10, 20, 30]);
 			assert_eq!(MEMBERS.with(|m| m.borrow().clone()), vec![10, 20, 30]);
 		});
@@ -301,7 +298,7 @@ mod tests {
 
 	#[test]
 	fn add_member_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Membership::add_member(Origin::signed(5), 15), "bad origin");
 			assert_noop!(Membership::add_member(Origin::signed(1), 10), "already a member");
 			assert_ok!(Membership::add_member(Origin::signed(1), 15));
@@ -312,7 +309,7 @@ mod tests {
 
 	#[test]
 	fn remove_member_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Membership::remove_member(Origin::signed(5), 20), "bad origin");
 			assert_noop!(Membership::remove_member(Origin::signed(2), 15), "not a member");
 			assert_ok!(Membership::remove_member(Origin::signed(2), 20));
@@ -323,7 +320,7 @@ mod tests {
 
 	#[test]
 	fn swap_member_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Membership::swap_member(Origin::signed(5), 10, 25), "bad origin");
 			assert_noop!(Membership::swap_member(Origin::signed(3), 15, 25), "not a member");
 			assert_noop!(Membership::swap_member(Origin::signed(3), 10, 30), "already a member");
@@ -337,7 +334,7 @@ mod tests {
 
 	#[test]
 	fn reset_members_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Membership::reset_members(Origin::signed(1), vec![20, 40, 30]), "bad origin");
 			assert_ok!(Membership::reset_members(Origin::signed(4), vec![20, 40, 30]));
 			assert_eq!(Membership::members(), vec![20, 30, 40]);

--- a/srml/offences/src/tests.rs
+++ b/srml/offences/src/tests.rs
@@ -24,11 +24,10 @@ use crate::mock::{
 	offence_reports,
 };
 use system::{EventRecord, Phase};
-use sr_primitives::set_and_run_with_externalities;
 
 #[test]
 fn should_report_an_authority_and_trigger_on_offence() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -51,7 +50,7 @@ fn should_report_an_authority_and_trigger_on_offence() {
 
 #[test]
 fn should_calculate_the_fraction_correctly() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -83,7 +82,7 @@ fn should_calculate_the_fraction_correctly() {
 
 #[test]
 fn should_not_report_the_same_authority_twice_in_the_same_slot() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -113,7 +112,7 @@ fn should_not_report_the_same_authority_twice_in_the_same_slot() {
 
 #[test]
 fn should_report_in_different_time_slot() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -143,7 +142,7 @@ fn should_report_in_different_time_slot() {
 
 #[test]
 fn should_deposit_event() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -171,7 +170,7 @@ fn should_deposit_event() {
 
 #[test]
 fn doesnt_deposit_event_for_dups() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);
@@ -208,7 +207,7 @@ fn doesnt_deposit_event_for_dups() {
 fn should_properly_count_offences() {
 	// We report two different authorities for the same issue. Ultimately, the 1st authority
 	// should have `count` equal 2 and the count of the 2nd one should be equal to 1.
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let time_slot = 42;
 		assert_eq!(offence_reports(KIND, time_slot), vec![]);

--- a/srml/randomness-collective-flip/src/lib.rs
+++ b/srml/randomness-collective-flip/src/lib.rs
@@ -164,7 +164,6 @@ mod tests {
 	use primitives::H256;
 	use sr_primitives::{
 		Perbill, traits::{BlakeTwo256, OnInitialize, Header as _, IdentityLookup}, testing::Header,
-		set_and_run_with_externalities,
 	};
 	use support::{impl_outer_origin, parameter_types};
 
@@ -231,7 +230,7 @@ mod tests {
 
 	#[test]
 	fn test_random_material_parital() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let genesis_hash = System::parent_hash();
 
 			setup_blocks(38);
@@ -245,7 +244,7 @@ mod tests {
 
 	#[test]
 	fn test_random_material_filled() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let genesis_hash = System::parent_hash();
 
 			setup_blocks(81);
@@ -260,7 +259,7 @@ mod tests {
 
 	#[test]
 	fn test_random_material_filled_twice() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let genesis_hash = System::parent_hash();
 
 			setup_blocks(162);
@@ -275,7 +274,7 @@ mod tests {
 
 	#[test]
 	fn test_random() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			setup_blocks(162);
 
 			assert_eq!(System::block_number(), 162);

--- a/srml/scored-pool/src/tests.rs
+++ b/srml/scored-pool/src/tests.rs
@@ -20,7 +20,7 @@ use super::*;
 use mock::*;
 
 use support::{assert_ok, assert_noop};
-use sr_primitives::{set_and_run_with_externalities, traits::OnInitialize};
+use sr_primitives::traits::OnInitialize;
 
 type ScoredPool = Module<Test>;
 type System = system::Module<Test>;
@@ -31,7 +31,7 @@ const INDEX_ERR: &str = "index does not match requested account";
 
 #[test]
 fn query_membership_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		assert_eq!(ScoredPool::members(), vec![20, 40]);
 		assert_eq!(Balances::reserved_balance(&31), CandidateDeposit::get());
 		assert_eq!(Balances::reserved_balance(&40), CandidateDeposit::get());
@@ -41,7 +41,7 @@ fn query_membership_works() {
 
 #[test]
 fn submit_candidacy_must_not_work() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		assert_noop!(
 			ScoredPool::submit_candidacy(Origin::signed(99)),
 			"balance too low to submit candidacy"
@@ -55,7 +55,7 @@ fn submit_candidacy_must_not_work() {
 
 #[test]
 fn submit_candidacy_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 15;
 
@@ -70,7 +70,7 @@ fn submit_candidacy_works() {
 
 #[test]
 fn scoring_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 15;
 		let score = 99;
@@ -88,7 +88,7 @@ fn scoring_works() {
 
 #[test]
 fn scoring_same_element_with_same_score_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 31;
 		let index = find_in_pool(who).expect("entity must be in pool") as u32;
@@ -108,7 +108,7 @@ fn scoring_same_element_with_same_score_works() {
 
 #[test]
 fn kicking_works_only_for_authorized() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		let who = 40;
 		let index = find_in_pool(who).expect("entity must be in pool") as u32;
 		assert_noop!(ScoredPool::kick(Origin::signed(99), who, index), "bad origin");
@@ -117,7 +117,7 @@ fn kicking_works_only_for_authorized() {
 
 #[test]
 fn kicking_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 40;
 		assert_eq!(Balances::reserved_balance(&who), CandidateDeposit::get());
@@ -137,7 +137,7 @@ fn kicking_works() {
 
 #[test]
 fn unscored_entities_must_not_be_used_for_filling_members() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		// we submit a candidacy, score will be `None`
 		assert_ok!(ScoredPool::submit_candidacy(Origin::signed(15)));
@@ -162,7 +162,7 @@ fn unscored_entities_must_not_be_used_for_filling_members() {
 
 #[test]
 fn refreshing_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 15;
 		assert_ok!(ScoredPool::submit_candidacy(Origin::signed(who)));
@@ -180,7 +180,7 @@ fn refreshing_works() {
 
 #[test]
 fn refreshing_happens_every_period() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		System::set_block_number(1);
 		assert_ok!(ScoredPool::submit_candidacy(Origin::signed(15)));
@@ -200,7 +200,7 @@ fn refreshing_happens_every_period() {
 
 #[test]
 fn withdraw_candidacy_must_only_work_for_members() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		let who = 77;
 		let index = 0;
 		assert_noop!( ScoredPool::withdraw_candidacy(Origin::signed(who), index), INDEX_ERR);
@@ -209,7 +209,7 @@ fn withdraw_candidacy_must_only_work_for_members() {
 
 #[test]
 fn oob_index_should_abort() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		let who = 40;
 		let oob_index = ScoredPool::pool().len() as u32;
 		assert_noop!(ScoredPool::withdraw_candidacy(Origin::signed(who), oob_index), OOB_ERR);
@@ -220,7 +220,7 @@ fn oob_index_should_abort() {
 
 #[test]
 fn index_mismatches_should_abort() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		let who = 40;
 		let index = 3;
 		assert_noop!(ScoredPool::withdraw_candidacy(Origin::signed(who), index), INDEX_ERR);
@@ -231,7 +231,7 @@ fn index_mismatches_should_abort() {
 
 #[test]
 fn withdraw_unscored_candidacy_must_work() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 5;
 
@@ -246,7 +246,7 @@ fn withdraw_unscored_candidacy_must_work() {
 
 #[test]
 fn withdraw_scored_candidacy_must_work() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 40;
 		assert_eq!(Balances::reserved_balance(&who), CandidateDeposit::get());
@@ -264,7 +264,7 @@ fn withdraw_scored_candidacy_must_work() {
 
 #[test]
 fn candidacy_resubmitting_works() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		// given
 		let who = 15;
 

--- a/srml/session/src/historical.rs
+++ b/srml/session/src/historical.rs
@@ -313,9 +313,7 @@ impl<T: Trait, D: AsRef<[u8]>> support::traits::KeyOwnerProofSystem<(KeyTypeId, 
 mod tests {
 	use super::*;
 	use primitives::crypto::key_types::DUMMY;
-	use sr_primitives::{
-		traits::OnInitialize, testing::UintAuthorityId, set_and_run_with_externalities,
-	};
+	use sr_primitives::{traits::OnInitialize, testing::UintAuthorityId};
 	use crate::mock::{
 		NEXT_VALIDATORS, force_new_session,
 		set_next_validators, Test, System, Session,
@@ -336,7 +334,7 @@ mod tests {
 
 	#[test]
 	fn generated_proof_is_good() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			set_next_validators(vec![1, 2]);
 			force_new_session();
 
@@ -377,7 +375,7 @@ mod tests {
 
 	#[test]
 	fn prune_up_to_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			for i in 1..101u64 {
 				set_next_validators(vec![i]);
 				force_new_session();

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -681,9 +681,7 @@ mod tests {
 	use super::*;
 	use support::assert_ok;
 	use primitives::crypto::key_types::DUMMY;
-	use sr_primitives::{
-		traits::OnInitialize, set_and_run_with_externalities, testing::UintAuthorityId,
-	};
+	use sr_primitives::{traits::OnInitialize, testing::UintAuthorityId};
 	use mock::{
 		NEXT_VALIDATORS, SESSION_CHANGED, TEST_SESSION_CHANGED, authorities, force_new_session,
 		set_next_validators, set_session_length, session_changed, Test, Origin, System, Session,
@@ -708,7 +706,7 @@ mod tests {
 
 	#[test]
 	fn simple_setup_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2), UintAuthorityId(3)]);
 			assert_eq!(Session::validators(), vec![1, 2, 3]);
 		});
@@ -716,7 +714,7 @@ mod tests {
 
 	#[test]
 	fn put_get_keys() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Session::put_keys(&10, &UintAuthorityId(10).into());
 			assert_eq!(Session::load_keys(&10), Some(UintAuthorityId(10).into()));
 		})
@@ -725,7 +723,7 @@ mod tests {
 	#[test]
 	fn keys_cleared_on_kill() {
 		let mut ext = new_test_ext();
-		set_and_run_with_externalities(&mut ext, || {
+		ext.execute_with(|| {
 			assert_eq!(Session::validators(), vec![1, 2, 3]);
 			assert_eq!(Session::load_keys(&1), Some(UintAuthorityId(1).into()));
 
@@ -742,7 +740,7 @@ mod tests {
 	fn authorities_should_track_validators() {
 		reset_before_session_end_called();
 
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			set_next_validators(vec![1, 2]);
 			force_new_session();
 			initialize_block(1);
@@ -793,7 +791,7 @@ mod tests {
 
 	#[test]
 	fn should_work_with_early_exit() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			set_session_length(10);
 
 			initialize_block(1);
@@ -816,7 +814,7 @@ mod tests {
 
 	#[test]
 	fn session_change_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// Block 1: No change
 			initialize_block(1);
 			assert_eq!(authorities(), vec![UintAuthorityId(1), UintAuthorityId(2), UintAuthorityId(3)]);
@@ -846,7 +844,7 @@ mod tests {
 
 	#[test]
 	fn duplicates_are_not_allowed() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::set_block_number(1);
 			Session::on_initialize(1);
 			assert!(Session::set_keys(Origin::signed(4), UintAuthorityId(1).into(), vec![]).is_err());
@@ -861,7 +859,7 @@ mod tests {
 	fn session_changed_flag_works() {
 		reset_before_session_end_called();
 
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			TEST_SESSION_CHANGED.with(|l| *l.borrow_mut() = true);
 
 			force_new_session();
@@ -950,7 +948,7 @@ mod tests {
 
 	#[test]
 	fn session_keys_generate_output_works_as_set_keys_input() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let new_keys = mock::MockSessionKeys::generate(None);
 			assert_ok!(
 				Session::set_keys(
@@ -964,7 +962,7 @@ mod tests {
 
 	#[test]
 	fn return_true_if_more_than_third_is_disabled() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			set_next_validators(vec![1, 2, 3, 4, 5, 6, 7]);
 			force_new_session();
 			initialize_block(1);
@@ -977,6 +975,5 @@ mod tests {
 			assert_eq!(Session::disable_index(2), true);
 			assert_eq!(Session::disable_index(3), true);
 		});
-
 	}
 }

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -340,8 +340,8 @@ impl ExtBuilder {
 			keys: validators.iter().map(|x| (*x, UintAuthorityId(*x))).collect(),
 		}.assimilate_storage(&mut storage);
 
-		let mut ext = storage.into();
-		sr_primitives::set_and_run_with_externalities(&mut ext, || {
+		let mut ext = runtime_io::TestExternalities::from(storage);
+		ext.execute_with(|| {
 			let validators = Session::validators();
 			SESSION.with(|x|
 				*x.borrow_mut() = (validators.clone(), HashSet::new())

--- a/srml/staking/src/tests.rs
+++ b/srml/staking/src/tests.rs
@@ -18,16 +18,14 @@
 
 use super::*;
 use mock::*;
-use sr_primitives::{assert_eq_error_rate, traits::OnInitialize, set_and_run_with_externalities};
+use sr_primitives::{assert_eq_error_rate, traits::OnInitialize};
 use sr_staking_primitives::offence::{OffenceDetails, OnOffenceHandler};
 use support::{assert_ok, assert_noop, assert_eq_uvec, traits::{Currency, ReservableCurrency}};
 
 #[test]
 fn basic_setup_works() {
 	// Verifies initial conditions of mock
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Account 11 is stashed and locked, and account 10 is the controller
 		assert_eq!(Staking::bonded(&11), Some(10));
 		// Account 21 is stashed and locked, and account 20 is the controller
@@ -107,8 +105,7 @@ fn basic_setup_works() {
 
 #[test]
 fn change_controller_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Staking::bonded(&11), Some(10));
 
 		assert!(<Validators<Test>>::enumerate().map(|(c, _)| c).collect::<Vec<u64>>().contains(&11));
@@ -134,10 +131,7 @@ fn rewards_should_work() {
 	// * rewards get recorded per session
 	// * rewards get paid per Era
 	// * Check that nominators are also rewarded
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		// Init some balances
 		let _ = Balances::make_free_balance_be(&2, 500);
 
@@ -215,10 +209,7 @@ fn multi_era_reward_should_work() {
 	// Should check that:
 	// The value of current_session_reward is set at the end of each era, based on
 	// slot_stake and session_reward.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		let init_balance_10 = Balances::total_balance(&10);
 
 		// Set payee to controller
@@ -258,122 +249,122 @@ fn staking_should_work() {
 	// * new validators can be added to the default set
 	// * new ones will be chosen per era
 	// * either one can unlock the stash and back-down from being a validator via `chill`ing.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.nominate(false)
 		.fair(false) // to give 20 more staked value
-		.build(),
-	|| {
-		Timestamp::set_timestamp(1); // Initialize time.
+		.build()
+		.execute_with(|| {
+			Timestamp::set_timestamp(1); // Initialize time.
 
-		// remember + compare this along with the test.
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
+			// remember + compare this along with the test.
+			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
-		// put some money in account that we'll use.
-		for i in 1..5 { let _ = Balances::make_free_balance_be(&i, 2000); }
+			// put some money in account that we'll use.
+			for i in 1..5 { let _ = Balances::make_free_balance_be(&i, 2000); }
 
-		// --- Block 1:
-		start_session(1);
-		// add a new candidate for being a validator. account 3 controlled by 4.
-		assert_ok!(Staking::bond(Origin::signed(3), 4, 1500, RewardDestination::Controller));
-		assert_ok!(Staking::validate(Origin::signed(4), ValidatorPrefs::default()));
+			// --- Block 1:
+			start_session(1);
+			// add a new candidate for being a validator. account 3 controlled by 4.
+			assert_ok!(Staking::bond(Origin::signed(3), 4, 1500, RewardDestination::Controller));
+			assert_ok!(Staking::validate(Origin::signed(4), ValidatorPrefs::default()));
 
-		// No effects will be seen so far.
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
+			// No effects will be seen so far.
+			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
-		// --- Block 2:
-		start_session(2);
+			// --- Block 2:
+			start_session(2);
 
-		// No effects will be seen so far. Era has not been yet triggered.
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
+			// No effects will be seen so far. Era has not been yet triggered.
+			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
 
-		// --- Block 3: the validators will now be queued.
-		start_session(3);
-		assert_eq!(Staking::current_era(), 1);
+			// --- Block 3: the validators will now be queued.
+			start_session(3);
+			assert_eq!(Staking::current_era(), 1);
 
-		// --- Block 4: the validators will now be changed.
-		start_session(4);
+			// --- Block 4: the validators will now be changed.
+			start_session(4);
 
-		assert_eq_uvec!(validator_controllers(), vec![20, 4]);
-		// --- Block 4: Unstake 4 as a validator, freeing up the balance stashed in 3
-		// 4 will chill
-		Staking::chill(Origin::signed(4)).unwrap();
+			assert_eq_uvec!(validator_controllers(), vec![20, 4]);
+			// --- Block 4: Unstake 4 as a validator, freeing up the balance stashed in 3
+			// 4 will chill
+			Staking::chill(Origin::signed(4)).unwrap();
 
-		// --- Block 5: nothing. 4 is still there.
-		start_session(5);
-		assert_eq_uvec!(validator_controllers(), vec![20, 4]);
+			// --- Block 5: nothing. 4 is still there.
+			start_session(5);
+			assert_eq_uvec!(validator_controllers(), vec![20, 4]);
 
-		// --- Block 6: 4 will not be a validator.
-		start_session(7);
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
+			// --- Block 6: 4 will not be a validator.
+			start_session(7);
+			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
-		// Note: the stashed value of 4 is still lock
-		assert_eq!(
-			Staking::ledger(&4),
-			Some(StakingLedger { stash: 3, total: 1500, active: 1500, unlocking: vec![] })
-		);
-		// e.g. it cannot spend more than 500 that it has free from the total 2000
-		assert_noop!(Balances::reserve(&3, 501), "account liquidity restrictions prevent withdrawal");
-		assert_ok!(Balances::reserve(&3, 409));
-	});
+			// Note: the stashed value of 4 is still lock
+			assert_eq!(
+				Staking::ledger(&4),
+				Some(StakingLedger { stash: 3, total: 1500, active: 1500, unlocking: vec![] })
+			);
+			// e.g. it cannot spend more than 500 that it has free from the total 2000
+			assert_noop!(Balances::reserve(&3, 501), "account liquidity restrictions prevent withdrawal");
+			assert_ok!(Balances::reserve(&3, 409));
+		});
 }
 
 #[test]
 fn less_than_needed_candidates_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.minimum_validator_count(1)
 		.validator_count(4)
 		.nominate(false)
 		.num_validators(3)
-		.build(),
-	|| {
-		assert_eq!(Staking::validator_count(), 4);
-		assert_eq!(Staking::minimum_validator_count(), 1);
-		assert_eq_uvec!(validator_controllers(), vec![30, 20, 10]);
+		.build()
+		.execute_with(|| {
+			assert_eq!(Staking::validator_count(), 4);
+			assert_eq!(Staking::minimum_validator_count(), 1);
+			assert_eq_uvec!(validator_controllers(), vec![30, 20, 10]);
 
-		start_era(1);
+			start_era(1);
 
-		// Previous set is selected. NO election algorithm is even executed.
-		assert_eq_uvec!(validator_controllers(), vec![30, 20, 10]);
+			// Previous set is selected. NO election algorithm is even executed.
+			assert_eq_uvec!(validator_controllers(), vec![30, 20, 10]);
 
-		// But the exposure is updated in a simple way. No external votes exists. This is purely self-vote.
-		assert_eq!(Staking::stakers(10).others.len(), 0);
-		assert_eq!(Staking::stakers(20).others.len(), 0);
-		assert_eq!(Staking::stakers(30).others.len(), 0);
-		check_exposure_all();
-		check_nominator_all();
-	});
+			// But the exposure is updated in a simple way. No external votes exists.
+			// This is purely self-vote.
+			assert_eq!(Staking::stakers(10).others.len(), 0);
+			assert_eq!(Staking::stakers(20).others.len(), 0);
+			assert_eq!(Staking::stakers(30).others.len(), 0);
+			check_exposure_all();
+			check_nominator_all();
+		});
 }
 
 #[test]
 fn no_candidate_emergency_condition() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.minimum_validator_count(10)
 		.validator_count(15)
 		.num_validators(4)
 		.validator_pool(true)
 		.nominate(false)
-		.build(),
-	|| {
+		.build()
+		.execute_with(|| {
+			// initial validators
+			assert_eq_uvec!(validator_controllers(), vec![10, 20, 30, 40]);
 
-		// initial validators
-		assert_eq_uvec!(validator_controllers(), vec![10, 20, 30, 40]);
+			// set the minimum validator count.
+			<Staking as crate::Store>::MinimumValidatorCount::put(10);
+			<Staking as crate::Store>::ValidatorCount::put(15);
+			assert_eq!(Staking::validator_count(), 15);
 
-		// set the minimum validator count.
-		<Staking as crate::Store>::MinimumValidatorCount::put(10);
-		<Staking as crate::Store>::ValidatorCount::put(15);
-		assert_eq!(Staking::validator_count(), 15);
+			let _ = Staking::chill(Origin::signed(10));
 
-		let _ = Staking::chill(Origin::signed(10));
+			// trigger era
+			System::set_block_number(1);
+			Session::on_initialize(System::block_number());
 
-		// trigger era
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
-
-		// Previous ones are elected. chill is invalidates. TODO: #2494
-		assert_eq_uvec!(validator_controllers(), vec![10, 20, 30, 40]);
-		assert_eq!(Staking::current_elected().len(), 0);
-	});
+			// Previous ones are elected. chill is invalidates. TODO: #2494
+			assert_eq_uvec!(validator_controllers(), vec![10, 20, 30, 40]);
+			assert_eq!(Staking::current_elected().len(), 0);
+		});
 }
 
 #[test]
@@ -413,181 +404,181 @@ fn nominating_and_rewards_should_work() {
 	// 10  with stake  400.0 20  with stake  600.0 30  with stake  0
 	// 4  has load  0.0005555555555555556 and supported
 	// 10  with stake  600.0 20  with stake  400.0 40  with stake  0.0
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.nominate(false)
 		.validator_pool(true)
-		.build(),
-	|| {
-		// initial validators -- everyone is actually even.
-		assert_eq_uvec!(validator_controllers(), vec![40, 30]);
+		.build()
+		.execute_with(|| {
+			// initial validators -- everyone is actually even.
+			assert_eq_uvec!(validator_controllers(), vec![40, 30]);
 
-		// Set payee to controller
-		assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Controller));
-		assert_ok!(Staking::set_payee(Origin::signed(20), RewardDestination::Controller));
-		assert_ok!(Staking::set_payee(Origin::signed(30), RewardDestination::Controller));
-		assert_ok!(Staking::set_payee(Origin::signed(40), RewardDestination::Controller));
+			// Set payee to controller
+			assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Controller));
+			assert_ok!(Staking::set_payee(Origin::signed(20), RewardDestination::Controller));
+			assert_ok!(Staking::set_payee(Origin::signed(30), RewardDestination::Controller));
+			assert_ok!(Staking::set_payee(Origin::signed(40), RewardDestination::Controller));
 
-		// give the man some money
-		let initial_balance = 1000;
-		for i in [1, 2, 3, 4, 5, 10, 11, 20, 21].iter() {
-			let _ = Balances::make_free_balance_be(i, initial_balance);
-		}
+			// give the man some money
+			let initial_balance = 1000;
+			for i in [1, 2, 3, 4, 5, 10, 11, 20, 21].iter() {
+				let _ = Balances::make_free_balance_be(i, initial_balance);
+			}
 
-		// bond two account pairs and state interest in nomination.
-		// 2 will nominate for 10, 20, 30
-		assert_ok!(Staking::bond(Origin::signed(1), 2, 1000, RewardDestination::Controller));
-		assert_ok!(Staking::nominate(Origin::signed(2), vec![11, 21, 31]));
-		// 4 will nominate for 10, 20, 40
-		assert_ok!(Staking::bond(Origin::signed(3), 4, 1000, RewardDestination::Controller));
-		assert_ok!(Staking::nominate(Origin::signed(4), vec![11, 21, 41]));
+			// bond two account pairs and state interest in nomination.
+			// 2 will nominate for 10, 20, 30
+			assert_ok!(Staking::bond(Origin::signed(1), 2, 1000, RewardDestination::Controller));
+			assert_ok!(Staking::nominate(Origin::signed(2), vec![11, 21, 31]));
+			// 4 will nominate for 10, 20, 40
+			assert_ok!(Staking::bond(Origin::signed(3), 4, 1000, RewardDestination::Controller));
+			assert_ok!(Staking::nominate(Origin::signed(4), vec![11, 21, 41]));
 
-		// the total reward for era 0
-		let total_payout_0 = current_total_payout_for_duration(3000);
-		assert!(total_payout_0 > 100); // Test is meaningfull if reward something
-		<Module<Test>>::reward_by_ids(vec![(41, 1)]);
-		<Module<Test>>::reward_by_ids(vec![(31, 1)]);
-		<Module<Test>>::reward_by_ids(vec![(21, 10)]); // must be no-op
-		<Module<Test>>::reward_by_ids(vec![(11, 10)]); // must be no-op
+			// the total reward for era 0
+			let total_payout_0 = current_total_payout_for_duration(3000);
+			assert!(total_payout_0 > 100); // Test is meaningfull if reward something
+			<Module<Test>>::reward_by_ids(vec![(41, 1)]);
+			<Module<Test>>::reward_by_ids(vec![(31, 1)]);
+			<Module<Test>>::reward_by_ids(vec![(21, 10)]); // must be no-op
+			<Module<Test>>::reward_by_ids(vec![(11, 10)]); // must be no-op
 
-		start_era(1);
+			start_era(1);
 
-		// 10 and 20 have more votes, they will be chosen by phragmen.
-		assert_eq_uvec!(validator_controllers(), vec![20, 10]);
+			// 10 and 20 have more votes, they will be chosen by phragmen.
+			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
-		// OLD validators must have already received some rewards.
-		assert_eq!(Balances::total_balance(&40), 1 + total_payout_0 / 2);
-		assert_eq!(Balances::total_balance(&30), 1 + total_payout_0 / 2);
+			// OLD validators must have already received some rewards.
+			assert_eq!(Balances::total_balance(&40), 1 + total_payout_0 / 2);
+			assert_eq!(Balances::total_balance(&30), 1 + total_payout_0 / 2);
 
-		// ------ check the staked value of all parties.
+			// ------ check the staked value of all parties.
 
-		if cfg!(feature = "equalize") {
-			// total expo of 10, with 1200 coming from nominators (externals), according to phragmen.
-			assert_eq!(Staking::stakers(11).own, 1000);
-			assert_eq_error_rate!(Staking::stakers(11).total, 1000 + 1000, 2);
-			// 2 and 4 supported 10, each with stake 600, according to phragmen.
-			assert_eq!(
-				Staking::stakers(11).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
-				vec![600, 400]
-			);
-			assert_eq!(
-				Staking::stakers(11).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
-				vec![3, 1]
-			);
-			// total expo of 20, with 500 coming from nominators (externals), according to phragmen.
-			assert_eq!(Staking::stakers(21).own, 1000);
-			assert_eq_error_rate!(Staking::stakers(21).total, 1000 + 1000, 2);
-			// 2 and 4 supported 20, each with stake 250, according to phragmen.
-			assert_eq!(
-				Staking::stakers(21).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
-				vec![400, 600]
-			);
-			assert_eq!(
-				Staking::stakers(21).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
-				vec![3, 1]
-			);
-		} else {
-			// total expo of 10, with 1200 coming from nominators (externals), according to phragmen.
-			assert_eq!(Staking::stakers(11).own, 1000);
-			assert_eq!(Staking::stakers(11).total, 1000 + 800);
-			// 2 and 4 supported 10, each with stake 600, according to phragmen.
-			assert_eq!(
-				Staking::stakers(11).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
-				vec![400, 400]
-			);
-			assert_eq!(
-				Staking::stakers(11).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
-				vec![3, 1]
-			);
-			// total expo of 20, with 500 coming from nominators (externals), according to phragmen.
-			assert_eq!(Staking::stakers(21).own, 1000);
-			assert_eq_error_rate!(Staking::stakers(21).total, 1000 + 1200, 2);
-			// 2 and 4 supported 20, each with stake 250, according to phragmen.
-			assert_eq!(
-				Staking::stakers(21).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
-				vec![600, 600]
-			);
-			assert_eq!(
-				Staking::stakers(21).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
-				vec![3, 1]
-			);
-		}
+			if cfg!(feature = "equalize") {
+				// total expo of 10, with 1200 coming from nominators (externals), according to phragmen.
+				assert_eq!(Staking::stakers(11).own, 1000);
+				assert_eq_error_rate!(Staking::stakers(11).total, 1000 + 1000, 2);
+				// 2 and 4 supported 10, each with stake 600, according to phragmen.
+				assert_eq!(
+					Staking::stakers(11).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
+					vec![600, 400]
+				);
+				assert_eq!(
+					Staking::stakers(11).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
+					vec![3, 1]
+				);
+				// total expo of 20, with 500 coming from nominators (externals), according to phragmen.
+				assert_eq!(Staking::stakers(21).own, 1000);
+				assert_eq_error_rate!(Staking::stakers(21).total, 1000 + 1000, 2);
+				// 2 and 4 supported 20, each with stake 250, according to phragmen.
+				assert_eq!(
+					Staking::stakers(21).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
+					vec![400, 600]
+				);
+				assert_eq!(
+					Staking::stakers(21).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
+					vec![3, 1]
+				);
+			} else {
+				// total expo of 10, with 1200 coming from nominators (externals), according to phragmen.
+				assert_eq!(Staking::stakers(11).own, 1000);
+				assert_eq!(Staking::stakers(11).total, 1000 + 800);
+				// 2 and 4 supported 10, each with stake 600, according to phragmen.
+				assert_eq!(
+					Staking::stakers(11).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
+					vec![400, 400]
+				);
+				assert_eq!(
+					Staking::stakers(11).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
+					vec![3, 1]
+				);
+				// total expo of 20, with 500 coming from nominators (externals), according to phragmen.
+				assert_eq!(Staking::stakers(21).own, 1000);
+				assert_eq_error_rate!(Staking::stakers(21).total, 1000 + 1200, 2);
+				// 2 and 4 supported 20, each with stake 250, according to phragmen.
+				assert_eq!(
+					Staking::stakers(21).others.iter().map(|e| e.value).collect::<Vec<BalanceOf<Test>>>(),
+					vec![600, 600]
+				);
+				assert_eq!(
+					Staking::stakers(21).others.iter().map(|e| e.who).collect::<Vec<u64>>(),
+					vec![3, 1]
+				);
+			}
 
-		// They are not chosen anymore
-		assert_eq!(Staking::stakers(31).total, 0);
-		assert_eq!(Staking::stakers(41).total, 0);
+			// They are not chosen anymore
+			assert_eq!(Staking::stakers(31).total, 0);
+			assert_eq!(Staking::stakers(41).total, 0);
 
-		// the total reward for era 1
-		let total_payout_1 = current_total_payout_for_duration(3000);
-		assert!(total_payout_1 > 100); // Test is meaningfull if reward something
-		<Module<Test>>::reward_by_ids(vec![(41, 10)]); // must be no-op
-		<Module<Test>>::reward_by_ids(vec![(31, 10)]); // must be no-op
-		<Module<Test>>::reward_by_ids(vec![(21, 2)]);
-		<Module<Test>>::reward_by_ids(vec![(11, 1)]);
+			// the total reward for era 1
+			let total_payout_1 = current_total_payout_for_duration(3000);
+			assert!(total_payout_1 > 100); // Test is meaningfull if reward something
+			<Module<Test>>::reward_by_ids(vec![(41, 10)]); // must be no-op
+			<Module<Test>>::reward_by_ids(vec![(31, 10)]); // must be no-op
+			<Module<Test>>::reward_by_ids(vec![(21, 2)]);
+			<Module<Test>>::reward_by_ids(vec![(11, 1)]);
 
-		start_era(2);
+			start_era(2);
 
-		// nothing else will happen, era ends and rewards are paid again,
-		// it is expected that nominators will also be paid. See below
+			// nothing else will happen, era ends and rewards are paid again,
+			// it is expected that nominators will also be paid. See below
 
-		let payout_for_10 = total_payout_1 / 3;
-		let payout_for_20 = 2 * total_payout_1 / 3;
-		if cfg!(feature = "equalize") {
-			// Nominator 2: has [400 / 2000 ~ 1 / 5 from 10] + [600 / 2000 ~ 3 / 10 from 20]'s reward.
-			assert_eq_error_rate!(
-				Balances::total_balance(&2),
-				initial_balance + payout_for_10 / 5 + payout_for_20 * 3 / 10,
-				2,
-			);
-			// Nominator 4: has [400 / 2000 ~ 1 / 5 from 20] + [600 / 2000 ~ 3 / 10 from 10]'s reward.
-			assert_eq_error_rate!(
-				Balances::total_balance(&4),
-				initial_balance + payout_for_20 / 5 + payout_for_10 * 3 / 10,
-				2,
-			);
+			let payout_for_10 = total_payout_1 / 3;
+			let payout_for_20 = 2 * total_payout_1 / 3;
+			if cfg!(feature = "equalize") {
+				// Nominator 2: has [400 / 2000 ~ 1 / 5 from 10] + [600 / 2000 ~ 3 / 10 from 20]'s reward.
+				assert_eq_error_rate!(
+					Balances::total_balance(&2),
+					initial_balance + payout_for_10 / 5 + payout_for_20 * 3 / 10,
+					2,
+				);
+				// Nominator 4: has [400 / 2000 ~ 1 / 5 from 20] + [600 / 2000 ~ 3 / 10 from 10]'s reward.
+				assert_eq_error_rate!(
+					Balances::total_balance(&4),
+					initial_balance + payout_for_20 / 5 + payout_for_10 * 3 / 10,
+					2,
+				);
 
-			// Validator 10: got 1000 / 2000 external stake.
-			assert_eq_error_rate!(
-				Balances::total_balance(&10),
-				initial_balance + payout_for_10 / 2,
-				1,
-			);
-			// Validator 20: got 1000 / 2000 external stake.
-			assert_eq_error_rate!(
-				Balances::total_balance(&20),
-				initial_balance + payout_for_20 / 2,
-				1,
-			);
-		} else {
-			// Nominator 2: has [400/1800 ~ 2/9 from 10] + [600/2200 ~ 3/11 from 20]'s reward. ==> 2/9 + 3/11
-			assert_eq_error_rate!(
-				Balances::total_balance(&2),
-				initial_balance + (2 * payout_for_10 / 9 + 3 * payout_for_20 / 11),
-				1,
-			);
-			// Nominator 4: has [400/1800 ~ 2/9 from 10] + [600/2200 ~ 3/11 from 20]'s reward. ==> 2/9 + 3/11
-			assert_eq_error_rate!(
-				Balances::total_balance(&4),
-				initial_balance + (2 * payout_for_10 / 9 + 3 * payout_for_20 / 11),
-				1,
-			);
+				// Validator 10: got 1000 / 2000 external stake.
+				assert_eq_error_rate!(
+					Balances::total_balance(&10),
+					initial_balance + payout_for_10 / 2,
+					1,
+				);
+				// Validator 20: got 1000 / 2000 external stake.
+				assert_eq_error_rate!(
+					Balances::total_balance(&20),
+					initial_balance + payout_for_20 / 2,
+					1,
+				);
+			} else {
+				// Nominator 2: has [400/1800 ~ 2/9 from 10] + [600/2200 ~ 3/11 from 20]'s reward. ==> 2/9 + 3/11
+				assert_eq_error_rate!(
+					Balances::total_balance(&2),
+					initial_balance + (2 * payout_for_10 / 9 + 3 * payout_for_20 / 11),
+					1,
+				);
+				// Nominator 4: has [400/1800 ~ 2/9 from 10] + [600/2200 ~ 3/11 from 20]'s reward. ==> 2/9 + 3/11
+				assert_eq_error_rate!(
+					Balances::total_balance(&4),
+					initial_balance + (2 * payout_for_10 / 9 + 3 * payout_for_20 / 11),
+					1,
+				);
 
-			// Validator 10: got 800 / 1800 external stake => 8/18 =? 4/9 => Validator's share = 5/9
-			assert_eq_error_rate!(
-				Balances::total_balance(&10),
-				initial_balance + 5 * payout_for_10 / 9,
-				1,
-			);
-			// Validator 20: got 1200 / 2200 external stake => 12/22 =? 6/11 => Validator's share = 5/11
-			assert_eq_error_rate!(
-				Balances::total_balance(&20),
-				initial_balance + 5 * payout_for_20 / 11,
-				1,
-			);
-		}
+				// Validator 10: got 800 / 1800 external stake => 8/18 =? 4/9 => Validator's share = 5/9
+				assert_eq_error_rate!(
+					Balances::total_balance(&10),
+					initial_balance + 5 * payout_for_10 / 9,
+					1,
+				);
+				// Validator 20: got 1200 / 2200 external stake => 12/22 =? 6/11 => Validator's share = 5/11
+				assert_eq_error_rate!(
+					Balances::total_balance(&20),
+					initial_balance + 5 * payout_for_20 / 11,
+					1,
+				);
+			}
 
-		check_exposure_all();
-		check_nominator_all();
-	});
+			check_exposure_all();
+			check_nominator_all();
+		});
 }
 
 #[test]
@@ -597,7 +588,7 @@ fn nominators_also_get_slashed() {
 	// 10 - is the controller of 11
 	// 11 - is the stash.
 	// 2 - is the nominator of 20, 10
-	set_and_run_with_externalities(&mut ExtBuilder::default().nominate(false).build(), || {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		assert_eq!(Staking::validator_count(), 2);
 
 		// Set payee to controller
@@ -657,53 +648,49 @@ fn double_staking_should_fail() {
 	// * an account already bonded as stash cannot be be stashed again.
 	// * an account already bonded as stash cannot nominate.
 	// * an account already bonded as controller can nominate.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-		|| {
-			let arbitrary_value = 5;
-			// 2 = controller, 1 stashed => ok
-			assert_ok!(
-				Staking::bond(Origin::signed(1), 2, arbitrary_value,
-				RewardDestination::default())
-			);
-			// 4 = not used so far, 1 stashed => not allowed.
-			assert_noop!(
-				Staking::bond(Origin::signed(1), 4, arbitrary_value,
-				RewardDestination::default()), "stash already bonded"
-			);
-			// 1 = stashed => attempting to nominate should fail.
-			assert_noop!(Staking::nominate(Origin::signed(1), vec![1]), "not a controller");
-			// 2 = controller  => nominating should work.
-			assert_ok!(Staking::nominate(Origin::signed(2), vec![1]));
-		});
+	ExtBuilder::default().build().execute_with(|| {
+		let arbitrary_value = 5;
+		// 2 = controller, 1 stashed => ok
+		assert_ok!(
+			Staking::bond(Origin::signed(1), 2, arbitrary_value,
+			RewardDestination::default())
+		);
+		// 4 = not used so far, 1 stashed => not allowed.
+		assert_noop!(
+			Staking::bond(Origin::signed(1), 4, arbitrary_value,
+			RewardDestination::default()), "stash already bonded"
+		);
+		// 1 = stashed => attempting to nominate should fail.
+		assert_noop!(Staking::nominate(Origin::signed(1), vec![1]), "not a controller");
+		// 2 = controller  => nominating should work.
+		assert_ok!(Staking::nominate(Origin::signed(2), vec![1]));
+	});
 }
 
 #[test]
 fn double_controlling_should_fail() {
 	// should test (in the same order):
 	// * an account already bonded as controller CANNOT be reused as the controller of another account.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-		|| {
-			let arbitrary_value = 5;
-			// 2 = controller, 1 stashed => ok
-			assert_ok!(
-				Staking::bond(Origin::signed(1), 2, arbitrary_value,
-				RewardDestination::default())
-			);
-			// 2 = controller, 3 stashed (Note that 2 is reused.) => no-op
-			assert_noop!(
-				Staking::bond(Origin::signed(3), 2, arbitrary_value, RewardDestination::default()),
-				"controller already paired"
-			);
-		});
+	ExtBuilder::default().build().execute_with(|| {
+		let arbitrary_value = 5;
+		// 2 = controller, 1 stashed => ok
+		assert_ok!(Staking::bond(
+			Origin::signed(1),
+			2,
+			arbitrary_value,
+			RewardDestination::default(),
+		));
+		// 2 = controller, 3 stashed (Note that 2 is reused.) => no-op
+		assert_noop!(
+			Staking::bond(Origin::signed(3), 2, arbitrary_value, RewardDestination::default()),
+			"controller already paired",
+		);
+	});
 }
 
 #[test]
 fn session_and_eras_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Staking::current_era(), 0);
 
 		// Block 1: No change.
@@ -745,7 +732,7 @@ fn session_and_eras_work() {
 
 #[test]
 fn forcing_new_era_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(),|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// normal flow of session.
 		assert_eq!(Staking::current_era(), 0);
 		start_session(0);
@@ -784,7 +771,7 @@ fn forcing_new_era_works() {
 #[test]
 fn cannot_transfer_staked_balance() {
 	// Tests that a stash account cannot transfer funds
-	set_and_run_with_externalities(&mut ExtBuilder::default().nominate(false).build(), || {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		// Confirm account 11 is stashed
 		assert_eq!(Staking::bonded(&11), Some(10));
 		// Confirm account 11 has some free balance
@@ -809,11 +796,7 @@ fn cannot_transfer_staked_balance_2() {
 	// Tests that a stash account cannot transfer funds
 	// Same test as above but with 20, and more accurate.
 	// 21 has 2000 free balance but 1000 at stake
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.fair(true)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).fair(true).build().execute_with(|| {
 		// Confirm account 21 is stashed
 		assert_eq!(Staking::bonded(&21), Some(20));
 		// Confirm account 21 has some free balance
@@ -832,7 +815,7 @@ fn cannot_transfer_staked_balance_2() {
 #[test]
 fn cannot_reserve_staked_balance() {
 	// Checks that a bonded account cannot reserve balance from free balance
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		// Confirm account 11 is stashed
 		assert_eq!(Staking::bonded(&11), Some(10));
 		// Confirm account 11 has some free balance
@@ -852,7 +835,7 @@ fn cannot_reserve_staked_balance() {
 #[test]
 fn reward_destination_works() {
 	// Rewards go to the correct destination as determined in Payee
-	set_and_run_with_externalities(&mut ExtBuilder::default().nominate(false).build(), || {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		// Check that account 11 is a validator
 		assert!(Staking::current_elected().contains(&11));
 		// Check the balance of the validator account
@@ -944,9 +927,7 @@ fn validator_payment_prefs_work() {
 	// Test that validator preferences are correctly honored
 	// Note: unstake threshold is being directly tested in slashing tests.
 	// This test will focus on validator payment.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Initial config
 		let validator_cut = 5;
 		let stash_initial_balance = Balances::total_balance(&11);
@@ -996,8 +977,7 @@ fn bond_extra_works() {
 	// Tests that extra `free_balance` in the stash can be added to stake
 	// NOTE: this tests only verifies `StakingLedger` for correct updates
 	// See `bond_extra_and_withdraw_unbonded_works` for more details and updates on `Exposure`.
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		// Check that account 10 is a validator
 		assert!(<Validators<Test>>::exists(11));
 		// Check that account 10 is bonded to account 11
@@ -1042,10 +1022,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 	// * It can add extra funds to the bonded account.
 	// * it can unbond a portion of its funds from the stash account.
 	// * Once the unbonding period is done, it can actually take the funds out of the stash.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		// Set payee to controller. avoids confusion
 		assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Controller));
 
@@ -1129,7 +1106,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 
 #[test]
 fn too_many_unbond_calls_should_not_work() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		// locked at era 0 until 3
 		for _ in 0..MAX_UNLOCKING_CHUNKS-1 {
 			assert_ok!(Staking::unbond(Origin::signed(10), 1));
@@ -1158,11 +1135,7 @@ fn too_many_unbond_calls_should_not_work() {
 fn slot_stake_is_least_staked_validator_and_exposure_defines_maximum_punishment() {
 	// Test that slot_stake is determined by the least staked validator
 	// Test that slot_stake is the maximum punishment that can happen to a validator
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.fair(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).fair(false).build().execute_with(|| {
 		// Confirm validator count is 2
 		assert_eq!(Staking::validator_count(), 2);
 		// Confirm account 10 and 20 are validators
@@ -1211,10 +1184,7 @@ fn slot_stake_is_least_staked_validator_and_exposure_defines_maximum_punishment(
 fn on_free_balance_zero_stash_removes_validator() {
 	// Tests that validator storage items are cleaned up when stash is empty
 	// Tests that storage items are untouched when controller is empty
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.existential_deposit(10)
-		.build(),
-	|| {
+	ExtBuilder::default().existential_deposit(10).build().execute_with(|| {
 		// Check the balance of the validator account
 		assert_eq!(Balances::free_balance(&10), 256);
 		// Check the balance of the stash account
@@ -1264,10 +1234,7 @@ fn on_free_balance_zero_stash_removes_validator() {
 fn on_free_balance_zero_stash_removes_nominator() {
 	// Tests that nominator storage items are cleaned up when stash is empty
 	// Tests that storage items are untouched when controller is empty
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.existential_deposit(10)
-		.build(),
-	|| {
+	ExtBuilder::default().existential_deposit(10).build().execute_with(|| {
 		// Make 10 a nominator
 		assert_ok!(Staking::nominate(Origin::signed(10), vec![20]));
 		// Check that account 10 is a nominator
@@ -1320,10 +1287,7 @@ fn on_free_balance_zero_stash_removes_nominator() {
 #[test]
 fn switching_roles() {
 	// Test that it should be possible to switch between roles (nominator, validator, idle) with minimal overhead.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		Timestamp::set_timestamp(1); // Initialize time.
 
 		// Reset reward destination
@@ -1389,11 +1353,7 @@ fn switching_roles() {
 
 #[test]
 fn wrong_vote_is_null() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.validator_pool(true)
-	.build(),
-	|| {
+	ExtBuilder::default().nominate(false).validator_pool(true).build().execute_with(|| {
 		assert_eq_uvec!(validator_controllers(), vec![40, 30]);
 
 		// put some money in account that we'll use.
@@ -1417,174 +1377,173 @@ fn wrong_vote_is_null() {
 fn bond_with_no_staked_value() {
 	// Behavior when someone bonds with no staked value.
 	// Particularly when she votes and the candidate is elected.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-	.validator_count(3)
-	.existential_deposit(5)
-	.nominate(false)
-	.minimum_validator_count(1)
-	.build(), || {
-		// Can't bond with 1
-		assert_noop!(
-			Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller),
-			"can not bond with value less than minimum balance"
-		);
-		// bonded with absolute minimum value possible.
-		assert_ok!(Staking::bond(Origin::signed(1), 2, 5, RewardDestination::Controller));
-		assert_eq!(Balances::locks(&1)[0].amount, 5);
+	ExtBuilder::default()
+		.validator_count(3)
+		.existential_deposit(5)
+		.nominate(false)
+		.minimum_validator_count(1)
+		.build()
+		.execute_with(|| {
+			// Can't bond with 1
+			assert_noop!(
+				Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller),
+				"can not bond with value less than minimum balance",
+			);
+			// bonded with absolute minimum value possible.
+			assert_ok!(Staking::bond(Origin::signed(1), 2, 5, RewardDestination::Controller));
+			assert_eq!(Balances::locks(&1)[0].amount, 5);
 
-		// unbonding even 1 will cause all to be unbonded.
-		assert_ok!(Staking::unbond(Origin::signed(2), 1));
-		assert_eq!(
-			Staking::ledger(2),
-			Some(StakingLedger {
-				stash: 1,
-				active: 0,
-				total: 5,
-				unlocking: vec![UnlockChunk {value: 5, era: 3}]
-			})
-		);
+			// unbonding even 1 will cause all to be unbonded.
+			assert_ok!(Staking::unbond(Origin::signed(2), 1));
+			assert_eq!(
+				Staking::ledger(2),
+				Some(StakingLedger {
+					stash: 1,
+					active: 0,
+					total: 5,
+					unlocking: vec![UnlockChunk {value: 5, era: 3}]
+				})
+			);
 
-		start_era(1);
-		start_era(2);
+			start_era(1);
+			start_era(2);
 
-		// not yet removed.
-		assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
-		assert!(Staking::ledger(2).is_some());
-		assert_eq!(Balances::locks(&1)[0].amount, 5);
+			// not yet removed.
+			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
+			assert!(Staking::ledger(2).is_some());
+			assert_eq!(Balances::locks(&1)[0].amount, 5);
 
-		start_era(3);
+			start_era(3);
 
-		// poof. Account 1 is removed from the staking system.
-		assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
-		assert!(Staking::ledger(2).is_none());
-		assert_eq!(Balances::locks(&1).len(), 0);
-	});
+			// poof. Account 1 is removed from the staking system.
+			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
+			assert!(Staking::ledger(2).is_none());
+			assert_eq!(Balances::locks(&1).len(), 0);
+		});
 }
 
 #[test]
 fn bond_with_little_staked_value_bounded_by_slot_stake() {
 	// Behavior when someone bonds with little staked value.
 	// Particularly when she votes and the candidate is elected.
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.validator_count(3)
 		.nominate(false)
 		.minimum_validator_count(1)
-		.build(),
-	|| {
+		.build()
+		.execute_with(|| {
+			// setup
+			assert_ok!(Staking::chill(Origin::signed(30)));
+			assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Controller));
+			let init_balance_2 = Balances::free_balance(&2);
+			let init_balance_10 = Balances::free_balance(&10);
 
-		// setup
-		assert_ok!(Staking::chill(Origin::signed(30)));
-		assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Controller));
-		let init_balance_2 = Balances::free_balance(&2);
-		let init_balance_10 = Balances::free_balance(&10);
+			// Stingy validator.
+			assert_ok!(Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller));
+			assert_ok!(Staking::validate(Origin::signed(2), ValidatorPrefs::default()));
 
-		// Stingy validator.
-		assert_ok!(Staking::bond(Origin::signed(1), 2, 1, RewardDestination::Controller));
-		assert_ok!(Staking::validate(Origin::signed(2), ValidatorPrefs::default()));
+			let total_payout_0 = current_total_payout_for_duration(3000);
+			assert!(total_payout_0 > 100); // Test is meaningfull if reward something
+			reward_all_elected();
+			start_era(1);
 
-		let total_payout_0 = current_total_payout_for_duration(3000);
-		assert!(total_payout_0 > 100); // Test is meaningfull if reward something
-		reward_all_elected();
-		start_era(1);
+			// 2 is elected.
+			// and fucks up the slot stake.
+			assert_eq_uvec!(validator_controllers(), vec![20, 10, 2]);
+			assert_eq!(Staking::slot_stake(), 1);
 
-		// 2 is elected.
-		// and fucks up the slot stake.
-		assert_eq_uvec!(validator_controllers(), vec![20, 10, 2]);
-		assert_eq!(Staking::slot_stake(), 1);
+			// Old ones are rewarded.
+			assert_eq!(Balances::free_balance(&10), init_balance_10 + total_payout_0 / 3);
+			// no rewards paid to 2. This was initial election.
+			assert_eq!(Balances::free_balance(&2), init_balance_2);
 
-		// Old ones are rewarded.
-		assert_eq!(Balances::free_balance(&10), init_balance_10 + total_payout_0 / 3);
-		// no rewards paid to 2. This was initial election.
-		assert_eq!(Balances::free_balance(&2), init_balance_2);
+			let total_payout_1 = current_total_payout_for_duration(3000);
+			assert!(total_payout_1 > 100); // Test is meaningfull if reward something
+			reward_all_elected();
+			start_era(2);
 
-		let total_payout_1 = current_total_payout_for_duration(3000);
-		assert!(total_payout_1 > 100); // Test is meaningfull if reward something
-		reward_all_elected();
-		start_era(2);
+			assert_eq_uvec!(validator_controllers(), vec![20, 10, 2]);
+			assert_eq!(Staking::slot_stake(), 1);
 
-		assert_eq_uvec!(validator_controllers(), vec![20, 10, 2]);
-		assert_eq!(Staking::slot_stake(), 1);
-
-		assert_eq!(Balances::free_balance(&2), init_balance_2 + total_payout_1 / 3);
-		assert_eq!(Balances::free_balance(&10), init_balance_10 + total_payout_0 / 3 + total_payout_1 / 3);
-		check_exposure_all();
-		check_nominator_all();
-	});
+			assert_eq!(Balances::free_balance(&2), init_balance_2 + total_payout_1 / 3);
+			assert_eq!(
+				Balances::free_balance(&10),
+				init_balance_10 + total_payout_0 / 3 + total_payout_1 / 3,
+			);
+			check_exposure_all();
+			check_nominator_all();
+		});
 }
 
 #[cfg(feature = "equalize")]
 #[test]
 fn phragmen_linear_worse_case_equalize() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.nominate(false)
 		.validator_pool(true)
 		.fair(true)
-		.build(),
-	|| {
+		.build()
+		.execute_with(|| {
+			bond_validator(50, 1000);
+			bond_validator(60, 1000);
+			bond_validator(70, 1000);
 
-		bond_validator(50, 1000);
-		bond_validator(60, 1000);
-		bond_validator(70, 1000);
+			bond_nominator(2, 2000, vec![11]);
+			bond_nominator(4, 1000, vec![11, 21]);
+			bond_nominator(6, 1000, vec![21, 31]);
+			bond_nominator(8, 1000, vec![31, 41]);
+			bond_nominator(110, 1000, vec![41, 51]);
+			bond_nominator(120, 1000, vec![51, 61]);
+			bond_nominator(130, 1000, vec![61, 71]);
 
-		bond_nominator(2, 2000, vec![11]);
-		bond_nominator(4, 1000, vec![11, 21]);
-		bond_nominator(6, 1000, vec![21, 31]);
-		bond_nominator(8, 1000, vec![31, 41]);
-		bond_nominator(110, 1000, vec![41, 51]);
-		bond_nominator(120, 1000, vec![51, 61]);
-		bond_nominator(130, 1000, vec![61, 71]);
+			for i in &[10, 20, 30, 40, 50, 60, 70] {
+				assert_ok!(Staking::set_payee(Origin::signed(*i), RewardDestination::Controller));
+			}
 
-		for i in &[10, 20, 30, 40, 50, 60, 70] {
-			assert_ok!(Staking::set_payee(Origin::signed(*i), RewardDestination::Controller));
-		}
+			assert_eq_uvec!(validator_controllers(), vec![40, 30]);
+			assert_ok!(Staking::set_validator_count(Origin::ROOT, 7));
 
-		assert_eq_uvec!(validator_controllers(), vec![40, 30]);
-		assert_ok!(Staking::set_validator_count(Origin::ROOT, 7));
+			start_era(1);
 
-		start_era(1);
+			assert_eq_uvec!(validator_controllers(), vec![10, 60, 40, 20, 50, 30, 70]);
 
-		assert_eq_uvec!(validator_controllers(), vec![10, 60, 40, 20, 50, 30, 70]);
+			assert_eq_error_rate!(Staking::stakers(11).total, 3000, 2);
+			assert_eq_error_rate!(Staking::stakers(21).total, 2255, 2);
+			assert_eq_error_rate!(Staking::stakers(31).total, 2255, 2);
+			assert_eq_error_rate!(Staking::stakers(41).total, 1925, 2);
+			assert_eq_error_rate!(Staking::stakers(51).total, 1870, 2);
+			assert_eq_error_rate!(Staking::stakers(61).total, 1890, 2);
+			assert_eq_error_rate!(Staking::stakers(71).total, 1800, 2);
 
-		assert_eq_error_rate!(Staking::stakers(11).total, 3000, 2);
-		assert_eq_error_rate!(Staking::stakers(21).total, 2255, 2);
-		assert_eq_error_rate!(Staking::stakers(31).total, 2255, 2);
-		assert_eq_error_rate!(Staking::stakers(41).total, 1925, 2);
-		assert_eq_error_rate!(Staking::stakers(51).total, 1870, 2);
-		assert_eq_error_rate!(Staking::stakers(61).total, 1890, 2);
-		assert_eq_error_rate!(Staking::stakers(71).total, 1800, 2);
-
-		check_exposure_all();
-		check_nominator_all();
-	})
+			check_exposure_all();
+			check_nominator_all();
+		})
 }
 
 #[test]
 fn new_era_elects_correct_number_of_validators() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
+	ExtBuilder::default()
 		.nominate(true)
 		.validator_pool(true)
 		.fair(true)
 		.validator_count(1)
-		.build(),
-	|| {
-		assert_eq!(Staking::validator_count(), 1);
-		assert_eq!(validator_controllers().len(), 1);
+		.build()
+		.execute_with(|| {
+			assert_eq!(Staking::validator_count(), 1);
+			assert_eq!(validator_controllers().len(), 1);
 
-		System::set_block_number(1);
-		Session::on_initialize(System::block_number());
+			System::set_block_number(1);
+			Session::on_initialize(System::block_number());
 
-		assert_eq!(validator_controllers().len(), 1);
-		check_exposure_all();
-		check_nominator_all();
-	})
+			assert_eq!(validator_controllers().len(), 1);
+			check_exposure_all();
+			check_nominator_all();
+		})
 }
 
 #[test]
 fn phragmen_should_not_overflow_validators() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		let _ = Staking::chill(Origin::signed(10));
 		let _ = Staking::chill(Origin::signed(20));
 
@@ -1607,10 +1566,7 @@ fn phragmen_should_not_overflow_validators() {
 
 #[test]
 fn phragmen_should_not_overflow_nominators() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		let _ = Staking::chill(Origin::signed(10));
 		let _ = Staking::chill(Origin::signed(20));
 
@@ -1632,10 +1588,7 @@ fn phragmen_should_not_overflow_nominators() {
 
 #[test]
 fn phragmen_should_not_overflow_ultimate() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.nominate(false)
-		.build(),
-	|| {
+	ExtBuilder::default().nominate(false).build().execute_with(|| {
 		bond_validator(2, u64::max_value());
 		bond_validator(4, u64::max_value());
 
@@ -1654,9 +1607,7 @@ fn phragmen_should_not_overflow_ultimate() {
 
 #[test]
 fn reward_validator_slashing_validator_doesnt_overflow() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		let stake = u32::max_value() as u64 * 2;
 		let reward_slash = u32::max_value() as u64 * 2;
 
@@ -1687,9 +1638,7 @@ fn reward_validator_slashing_validator_doesnt_overflow() {
 
 #[test]
 fn reward_from_authorship_event_handler_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		use authorship::EventHandler;
 
 		assert_eq!(<authorship::Module<Test>>::author(), 11);
@@ -1714,9 +1663,7 @@ fn reward_from_authorship_event_handler_works() {
 
 #[test]
 fn add_reward_points_fns_works() {
-	set_and_run_with_externalities(&mut ExtBuilder::default()
-		.build(),
-	|| {
+	ExtBuilder::default().build().execute_with(|| {
 		let validators = <Module<Test>>::current_elected();
 		// Not mandatory but must be coherent with rewards
 		assert_eq!(validators, vec![21, 11]);
@@ -1742,7 +1689,7 @@ fn add_reward_points_fns_works() {
 
 #[test]
 fn unbonded_balance_is_not_slashable() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		// total amount staked is slashable.
 		assert_eq!(Staking::slashable_balance_of(&11), 1000);
 
@@ -1757,7 +1704,7 @@ fn unbonded_balance_is_not_slashable() {
 fn era_is_always_same_length() {
 	// This ensures that the sessions is always of the same length if there is no forcing no
 	// session changes.
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		start_era(1);
 		assert_eq!(Staking::current_era_start_session_index(), SessionsPerEra::get());
 
@@ -1777,7 +1724,7 @@ fn era_is_always_same_length() {
 
 #[test]
 fn offence_forces_new_era() {
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		Staking::on_offence(
 			&[OffenceDetails {
 				offender: (
@@ -1797,7 +1744,7 @@ fn offence_forces_new_era() {
 fn slashing_performed_according_exposure() {
 	// This test checks that slashing is performed according the exposure (or more precisely,
 	// historical exposure), not the current balance.
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Staking::stakers(&11).own, 1000);
 
 		// Handle an offence with a historical exposure.
@@ -1825,7 +1772,7 @@ fn slashing_performed_according_exposure() {
 fn reporters_receive_their_slice() {
 	// This test verifies that the reporters of the offence receive their slice from the slashed
 	// amount.
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		// The reporters' reward is calculated from the total exposure.
 		#[cfg(feature = "equalize")]
 		let initial_balance = 1250;
@@ -1855,44 +1802,41 @@ fn reporters_receive_their_slice() {
 #[test]
 fn invulnerables_are_not_slashed() {
 	// For invulnerable validators no slashing is performed.
-	set_and_run_with_externalities(
-		&mut ExtBuilder::default().invulnerables(vec![11]).build(),
-		|| {
-			#[cfg(feature = "equalize")]
-			let initial_balance = 1250;
-			#[cfg(not(feature = "equalize"))]
-			let initial_balance = 1375;
+	ExtBuilder::default().invulnerables(vec![11]).build().execute_with(|| {
+		#[cfg(feature = "equalize")]
+		let initial_balance = 1250;
+		#[cfg(not(feature = "equalize"))]
+		let initial_balance = 1375;
 
-			assert_eq!(Balances::free_balance(&11), 1000);
-			assert_eq!(Balances::free_balance(&21), 2000);
-			assert_eq!(Staking::stakers(&21).total, initial_balance);
+		assert_eq!(Balances::free_balance(&11), 1000);
+		assert_eq!(Balances::free_balance(&21), 2000);
+		assert_eq!(Staking::stakers(&21).total, initial_balance);
 
-			Staking::on_offence(
-				&[
-					OffenceDetails {
-						offender: (11, Staking::stakers(&11)),
-						reporters: vec![],
-					},
-					OffenceDetails {
-						offender: (21, Staking::stakers(&21)),
-						reporters: vec![],
-					},
-				],
-				&[Perbill::from_percent(50), Perbill::from_percent(20)],
-			);
+		Staking::on_offence(
+			&[
+				OffenceDetails {
+					offender: (11, Staking::stakers(&11)),
+					reporters: vec![],
+				},
+				OffenceDetails {
+					offender: (21, Staking::stakers(&21)),
+					reporters: vec![],
+				},
+			],
+			&[Perbill::from_percent(50), Perbill::from_percent(20)],
+		);
 
-			// The validator 11 hasn't been slashed, but 21 has been.
-			assert_eq!(Balances::free_balance(&11), 1000);
-			// 2000 - (0.2 * initial_balance)
-			assert_eq!(Balances::free_balance(&21), 2000 - (2 * initial_balance / 10));
-		},
-	);
+		// The validator 11 hasn't been slashed, but 21 has been.
+		assert_eq!(Balances::free_balance(&11), 1000);
+		// 2000 - (0.2 * initial_balance)
+		assert_eq!(Balances::free_balance(&21), 2000 - (2 * initial_balance / 10));
+	});
 }
 
 #[test]
 fn dont_slash_if_fraction_is_zero() {
 	// Don't slash if the fraction is zero.
-	set_and_run_with_externalities(&mut ExtBuilder::default().build(), || {
+	ExtBuilder::default().build().execute_with(|| {
 		assert_eq!(Balances::free_balance(&11), 1000);
 
 		Staking::on_offence(

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -173,10 +173,10 @@ macro_rules! assert_err {
 #[macro_export]
 #[cfg(feature = "std")]
 macro_rules! assert_ok {
-	( $x:expr ) => {
+	( $x:expr $(,)? ) => {
 		assert_eq!($x, Ok(()));
 	};
-	( $x:expr, $y:expr ) => {
+	( $x:expr, $y:expr $(,)? ) => {
 		assert_eq!($x, Ok($y));
 	}
 }
@@ -236,7 +236,6 @@ pub use serde::{Serialize, Deserialize};
 mod tests {
 	use super::*;
 	use codec::{Codec, EncodeLike};
-	use sr_primitives::set_and_run_with_externalities;
 	use srml_metadata::{
 		DecodeDifferent, StorageEntryMetadata, StorageMetadata, StorageEntryType,
 		StorageEntryModifier, DefaultByteGetter, StorageHasher,
@@ -288,7 +287,7 @@ mod tests {
 
 	#[test]
 	fn linked_map_issue_3318() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			OptionLinkedMap::insert(1, 1);
 			assert_eq!(OptionLinkedMap::get(1), Some(1));
 			OptionLinkedMap::insert(1, 2);
@@ -298,7 +297,7 @@ mod tests {
 
 	#[test]
 	fn linked_map_swap_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			OptionLinkedMap::insert(0, 0);
 			OptionLinkedMap::insert(1, 1);
 			OptionLinkedMap::insert(2, 2);
@@ -327,7 +326,7 @@ mod tests {
 
 	#[test]
 	fn linked_map_basic_insert_remove_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// initialized during genesis
 			assert_eq!(Map::get(&15u32), 42u64);
 
@@ -353,7 +352,7 @@ mod tests {
 
 	#[test]
 	fn linked_map_enumeration_and_head_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Map::head(), Some(15));
 			assert_eq!(Map::enumerate().collect::<Vec<_>>(), vec![(15, 42)]);
 			// insert / remove
@@ -405,7 +404,7 @@ mod tests {
 
 	#[test]
 	fn double_map_basic_insert_remove_remove_prefix_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			type DoubleMap = DataDM;
 			// initialized during genesis
 			assert_eq!(DoubleMap::get(&15u32, &16u32), 42u64);
@@ -445,7 +444,7 @@ mod tests {
 
 	#[test]
 	fn double_map_append_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			type DoubleMap = AppendableDM<Test>;
 
 			let key1 = 17u32;

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -759,7 +759,6 @@ mod test3 {
 #[allow(dead_code)]
 mod test_append_and_len {
 	use runtime_io::TestExternalities;
-	use sr_primitives::set_and_run_with_externalities;
 	use codec::{Encode, Decode};
 
 	pub trait Trait {
@@ -801,7 +800,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn default_for_option() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			assert_eq!(OptionVec::get(), None);
 			assert_eq!(JustVec::get(), vec![]);
 		});
@@ -809,7 +808,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn append_works() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			let _ = MapVec::append(1, [1, 2, 3].iter());
 			let _ = MapVec::append(1, [4, 5].iter());
 			assert_eq!(MapVec::get(1), vec![1, 2, 3, 4, 5]);
@@ -822,7 +821,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn append_works_for_default() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			assert_eq!(JustVecWithDefault::get(), vec![6, 9]);
 			let _ = JustVecWithDefault::append([1].iter());
 			assert_eq!(JustVecWithDefault::get(), vec![6, 9, 1]);
@@ -839,7 +838,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn append_or_put_works() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			let _ = MapVec::append_or_insert(1, &[1, 2, 3][..]);
 			let _ = MapVec::append_or_insert(1, &[4, 5][..]);
 			assert_eq!(MapVec::get(1), vec![1, 2, 3, 4, 5]);
@@ -856,7 +855,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn len_works() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			JustVec::put(&vec![1, 2, 3, 4]);
 			OptionVec::put(&vec![1, 2, 3, 4, 5]);
 			MapVec::insert(1, &vec![1, 2, 3, 4, 5, 6]);
@@ -871,7 +870,7 @@ mod test_append_and_len {
 
 	#[test]
 	fn len_works_for_default() {
-		set_and_run_with_externalities(&mut TestExternalities::default(), || {
+		TestExternalities::default().execute_with(|| {
 			// vec
 			assert_eq!(JustVec::get(), vec![]);
 			assert_eq!(JustVec::decode_len(), Ok(0));

--- a/srml/support/test/tests/instance.rs
+++ b/srml/support/test/tests/instance.rs
@@ -15,10 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 #![recursion_limit="128"]
 
-use sr_primitives::{
-	generic, BuildStorage, traits::{BlakeTwo256, Block as _, Verify},
-	set_and_run_with_externalities,
-};
+use sr_primitives::{generic, BuildStorage, traits::{BlakeTwo256, Block as _, Verify}};
 use support::{
 	Parameter, traits::Get, parameter_types,
 	metadata::{
@@ -331,7 +328,7 @@ fn storage_instance_independance() {
 
 #[test]
 fn storage_with_instance_basic_operation() {
-	set_and_run_with_externalities(&mut new_test_ext(), || {
+	new_test_ext().execute_with(|| {
 		type Value = module2::Value<Runtime, module2::Instance1>;
 		type Map = module2::Map<module2::Instance1>;
 		type LinkedMap = module2::LinkedMap<module2::Instance1>;

--- a/srml/system/benches/bench.rs
+++ b/srml/system/benches/bench.rs
@@ -18,9 +18,7 @@ use criterion::{Criterion, criterion_group, criterion_main, black_box};
 use srml_system as system;
 use support::{decl_module, decl_event, impl_outer_origin, impl_outer_event};
 use primitives::H256;
-use sr_primitives::{
-	set_and_run_with_externalities, Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-};
+use sr_primitives::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 
 mod module {
 	use super::*;
@@ -89,7 +87,7 @@ fn new_test_ext() -> runtime_io::TestExternalities {
 
 fn deposit_events(n: usize) {
 	let mut t = new_test_ext();
-	set_and_run_with_externalities(&mut t, || {
+	t.execute_with(|| {
 		for _ in 0..n {
 			module::Module::<Runtime>::deposit_event(
 				module::Event::Complex(vec![1, 2, 3], 2, 3, 899)

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -1091,10 +1091,7 @@ impl<T: Trait> Lookup for ChainContext<T> {
 mod tests {
 	use super::*;
 	use primitives::H256;
-	use sr_primitives::{
-		traits::{BlakeTwo256, IdentityLookup}, testing::Header, DispatchError,
-		set_and_run_with_externalities,
-	};
+	use sr_primitives::{traits::{BlakeTwo256, IdentityLookup}, testing::Header, DispatchError};
 	use support::{impl_outer_origin, parameter_types};
 
 	impl_outer_origin! {
@@ -1164,7 +1161,7 @@ mod tests {
 
 	#[test]
 	fn deposit_event_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			System::initialize(&1, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
 			System::note_finished_extrinsics();
 			System::deposit_event(1u16);
@@ -1201,10 +1198,15 @@ mod tests {
 
 	#[test]
 	fn deposit_event_topics() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			const BLOCK_NUMBER: u64 = 1;
 
-			System::initialize(&BLOCK_NUMBER, &[0u8; 32].into(), &[0u8; 32].into(), &Default::default());
+			System::initialize(
+				&BLOCK_NUMBER,
+				&[0u8; 32].into(),
+				&[0u8; 32].into(),
+				&Default::default(),
+			);
 			System::note_finished_extrinsics();
 
 			let topics = vec![
@@ -1261,7 +1263,7 @@ mod tests {
 
 	#[test]
 	fn prunes_block_hash_mappings() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// simulate import of 15 blocks
 			for n in 1..=15 {
 				System::initialize(
@@ -1294,7 +1296,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_nonce_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			<AccountNonce<Test>>::insert(1, 1);
 			let info = DispatchInfo::default();
 			let len = 0_usize;
@@ -1312,7 +1314,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_works_normal_tx() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let normal_limit = normal_weight_limit();
 			let small = DispatchInfo { weight: 100, ..Default::default() };
 			let medium = DispatchInfo {
@@ -1339,7 +1341,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_fee_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let free = DispatchInfo { weight: 0, ..Default::default() };
 			let len = 0_usize;
 
@@ -1352,7 +1354,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_max_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let max = DispatchInfo { weight: Weight::max_value(), ..Default::default() };
 			let len = 0_usize;
 			let normal_limit = normal_weight_limit();
@@ -1366,7 +1368,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_works_operational_tx() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let normal = DispatchInfo { weight: 100, ..Default::default() };
 			let op = DispatchInfo { weight: 100, class: DispatchClass::Operational };
 			let len = 0_usize;
@@ -1389,7 +1391,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_priority_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let normal = DispatchInfo { weight: 100, class: DispatchClass::Normal };
 			let op = DispatchInfo { weight: 100, class: DispatchClass::Operational };
 			let len = 0_usize;
@@ -1410,7 +1412,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_weight_block_size_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let normal = DispatchInfo::default();
 			let normal_limit = normal_weight_limit() as usize;
 			let reset_check_weight = |tx, s, f| {
@@ -1434,7 +1436,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_era_should_work() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// future
 			assert_eq!(
 				CheckEra::<Test>::from(Era::mortal(4, 2)).additional_signed().err().unwrap(),
@@ -1450,7 +1452,7 @@ mod tests {
 
 	#[test]
 	fn signed_ext_check_era_should_change_longevity() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let normal = DispatchInfo { weight: 100, class: DispatchClass::Normal };
 			let len = 0_usize;
 			let ext = (

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -324,10 +324,7 @@ mod tests {
 	use support::{impl_outer_origin, assert_ok, parameter_types};
 	use runtime_io::TestExternalities;
 	use primitives::H256;
-	use sr_primitives::{
-		Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		set_and_run_with_externalities,
-	};
+	use sr_primitives::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 
 	impl_outer_origin! {
 		pub enum Origin for Test {}
@@ -372,7 +369,7 @@ mod tests {
 	#[test]
 	fn timestamp_works() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			Timestamp::set_timestamp(42);
 			assert_ok!(Timestamp::dispatch(Call::set(69), Origin::NONE));
 			assert_eq!(Timestamp::now(), 69);
@@ -383,7 +380,7 @@ mod tests {
 	#[should_panic(expected = "Timestamp must be updated only once in the block")]
 	fn double_timestamp_should_fail() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			Timestamp::set_timestamp(42);
 			assert_ok!(Timestamp::dispatch(Call::set(69), Origin::NONE));
 			let _ = Timestamp::dispatch(Call::set(70), Origin::NONE);
@@ -394,7 +391,7 @@ mod tests {
 	#[should_panic(expected = "Timestamp must increment by at least <MinimumPeriod> between sequential blocks")]
 	fn block_period_minimum_enforced() {
 		let t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		set_and_run_with_externalities(&mut TestExternalities::new(t), || {
+		TestExternalities::new(t).execute_with(|| {
 			Timestamp::set_timestamp(42);
 			let _ = Timestamp::dispatch(Call::set(46), Origin::NONE);
 		});

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -358,8 +358,7 @@ mod tests {
 	use support::{assert_noop, assert_ok, impl_outer_origin, parameter_types};
 	use primitives::H256;
 	use sr_primitives::{
-		traits::{BlakeTwo256, OnFinalize, IdentityLookup}, set_and_run_with_externalities,
-		testing::Header, assert_eq_error_rate,
+		traits::{BlakeTwo256, OnFinalize, IdentityLookup}, testing::Header, assert_eq_error_rate,
 	};
 
 	impl_outer_origin! {
@@ -446,7 +445,7 @@ mod tests {
 
 	#[test]
 	fn genesis_config_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Treasury::pot(), 0);
 			assert_eq!(Treasury::proposal_count(), 0);
 		});
@@ -454,7 +453,7 @@ mod tests {
 
 	#[test]
 	fn minting_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			// Check that accumulate works when we have Some value in Dummy already.
 			Treasury::on_dilution(100, 100);
 			assert_eq!(Treasury::pot(), 100);
@@ -465,7 +464,7 @@ mod tests {
 	fn minting_works_2() {
 		let tests = [(1, 10), (1, 20), (40, 130), (2, 66), (2, 67), (2, 100), (2, 101), (2, 134)];
 		for &(minted, portion) in &tests {
-			set_and_run_with_externalities(&mut new_test_ext(), || {
+			new_test_ext().execute_with(|| {
 				let init_total_issuance = Balances::total_issuance();
 				Treasury::on_dilution(minted, portion);
 
@@ -489,7 +488,7 @@ mod tests {
 
 	#[test]
 	fn spend_proposal_takes_min_deposit() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 1, 3));
 			assert_eq!(Balances::free_balance(&0), 99);
 			assert_eq!(Balances::reserved_balance(&0), 1);
@@ -498,7 +497,7 @@ mod tests {
 
 	#[test]
 	fn spend_proposal_takes_proportional_deposit() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 			assert_eq!(Balances::free_balance(&0), 95);
 			assert_eq!(Balances::reserved_balance(&0), 5);
@@ -507,14 +506,14 @@ mod tests {
 
 	#[test]
 	fn spend_proposal_fails_when_proposer_poor() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Treasury::propose_spend(Origin::signed(2), 100, 3), "Proposer's balance too low");
 		});
 	}
 
 	#[test]
 	fn accepted_spend_proposal_ignored_outside_spend_period() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
@@ -528,7 +527,7 @@ mod tests {
 
 	#[test]
 	fn unused_pot_should_diminish() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			let init_total_issuance = Balances::total_issuance();
 			Treasury::on_dilution(100, 100);
 			assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
@@ -541,7 +540,7 @@ mod tests {
 
 	#[test]
 	fn rejected_spend_proposal_ignored_on_spend_period() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
@@ -555,7 +554,7 @@ mod tests {
 
 	#[test]
 	fn reject_already_rejected_spend_proposal_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
@@ -566,21 +565,21 @@ mod tests {
 
 	#[test]
 	fn reject_non_existant_spend_proposal_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Treasury::reject_proposal(Origin::ROOT, 0), "No proposal at that index");
 		});
 	}
 
 	#[test]
 	fn accept_non_existant_spend_proposal_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_noop!(Treasury::approve_proposal(Origin::ROOT, 0), "No proposal at that index");
 		});
 	}
 
 	#[test]
 	fn accept_already_rejected_spend_proposal_fails() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
@@ -591,7 +590,7 @@ mod tests {
 
 	#[test]
 	fn accepted_spend_proposal_enacted_on_spend_period() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 			assert_eq!(Treasury::pot(), 100);
 
@@ -606,7 +605,7 @@ mod tests {
 
 	#[test]
 	fn pot_underflow_should_not_diminish() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));

--- a/srml/utility/src/lib.rs
+++ b/srml/utility/src/lib.rs
@@ -65,10 +65,7 @@ mod tests {
 
 	use support::{assert_ok, assert_noop, impl_outer_origin, parameter_types, impl_outer_dispatch};
 	use primitives::H256;
-	use sr_primitives::{
-		Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
-		set_and_run_with_externalities,
-	};
+	use sr_primitives::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 
 	impl_outer_origin! {
 		pub enum Origin for Test {}
@@ -150,7 +147,7 @@ mod tests {
 
 	#[test]
 	fn batch_works() {
-		set_and_run_with_externalities(&mut new_test_ext(), || {
+		new_test_ext().execute_with(|| {
 			assert_eq!(Balances::free_balance(1), 10);
 			assert_eq!(Balances::free_balance(2), 0);
 			assert_noop!(Utility::batch(Origin::signed(1), vec![


### PR DESCRIPTION
This function executes the given closure in a context where the test
externalities are set. This makes the srml tests easier to write, as the
test externalities need to be created anyway.

After having the discussion with @jimpo in my last pr about some function re-exporting, I came to this idea :) As written above, I think it makes tests more easily writable.

The diff is huge, but it is mostly just replacing function calls.