### PR TITLE
Allow zero fee transactions without a "live" account

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 174,
+	spec_version: 175,
 	impl_version: 175,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -1262,6 +1262,8 @@ impl<T: Trait<I>, I: Instance + Clone + Eq> SignedExtension for TakeFees<T, I> {
 			Ok(imbalance) => imbalance,
 			Err(msg) => {
 				// TODO: relying on string error is quite bad here.
+				// if we the transaction is operational, and the error is due to existential
+				// deposit, ignore it.
 				// not(operational && "would kill")
 				if info.class == DispatchClass::Normal || msg != "payment would kill account" {
 					return InvalidTransaction::Payment.into()

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -1261,7 +1261,7 @@ impl<T: Trait<I>, I: Instance + Clone + Eq> SignedExtension for TakeFees<T, I> {
 		) {
 			Ok(imbalance) => imbalance,
 			Err(msg) => {
-				// TODO: replying on string error is horrible here.
+				// TODO: relying on string error is quite bad here.
 				// not(operational && "would kill")
 				if info.class == DispatchClass::Normal || msg != "payment would kill account" {
 					return InvalidTransaction::Payment.into()

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -1264,11 +1264,11 @@ impl<T: Trait<I>, I: Instance + Clone + Eq> SignedExtension for TakeFees<T, I> {
 				// TODO: relying on string error is quite bad here.
 				// if we the transaction is operational, and the error is due to existential
 				// deposit, ignore it.
-				// not(operational && "would kill")
-				if info.class == DispatchClass::Normal || msg != "payment would kill account" {
+				if info.class == DispatchClass::Operational && msg == "payment would kill account" {
+					NegativeImbalance::zero()
+				} else {
 					return InvalidTransaction::Payment.into()
 				}
-				NegativeImbalance::zero()
 			},
 		};
 		T::TransactionPayment::on_unbalanced(imbalance);


### PR DESCRIPTION
At the moment, a free transactions will fail if origin has less than ED, or falls below it. This can easily be the case if you have just created an account and want to do something free. Quoting from @gnunicorn: you don't have to be forced to go to a bank if you want to buy something free. 

I am not sure if we want this. This allows all transactions that incur _zero fee_ to not be checked agains the internal logics of balances module (via `withdraw()`), including being checked for _minimum balance_. 

But, sudo is actually already `FreeOperational` and this is the reason it is not really _functional_ at the moment, if the sudo keys runs out of money.

cc @gnunicorn this solves your problem as well.

I will make a follow-up PR and organise some of the errors of [`Reservable`]`Currency` trait to make it look nicer. 