### PR TITLE
Fix treasury so pot can be spend entirely

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 174,
+	spec_version: 175,
 	impl_version: 175,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -315,7 +315,7 @@ impl<T: Trait> Module<T> {
 			&Self::account_id(),
 			imbalance,
 			WithdrawReason::Transfer,
-			ExistenceRequirement::KeepAlive
+			ExistenceRequirement::AllowDeath,
 		) {
 			print("Inconsistent state - couldn't settle imbalance for funds spent by treasury");
 			// Nothing else to do here.
@@ -392,7 +392,7 @@ mod tests {
 		type Version = ();
 	}
 	parameter_types! {
-		pub const ExistentialDeposit: u64 = 0;
+		pub const ExistentialDeposit: u64 = 1;
 		pub const TransferFee: u64 = 0;
 		pub const CreationFee: u64 = 0;
 		pub const TransactionBaseFee: u64 = 0;


### PR DESCRIPTION
### Context
When you change existencialDeposit to 1 then the test 

https://github.com/paritytech/substrate/blob/7adfd837565f870882cb9726e546dc9df6804885/srml/treasury/src/lib.rs#L591-L604

fails at 602 because treasury hasn't been withdrawn because it wasn't allowed to.

### Done

* fix the test suite to be more accurate
* fix the failing test resulting of it by changing treasury existence requirement.