### PR TITLE
Provide macro for exporting functions from wasm

### DIFF
--- a/core/executor/src/sandbox.rs
+++ b/core/executor/src/sandbox.rs
@@ -631,11 +631,11 @@ mod tests {
 				call $assert
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox", &code).unwrap(),
-			vec![1],
+			true.encode(),
 		);
 	}
 
@@ -673,7 +673,7 @@ mod tests {
 				call $assert
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		let res = call_wasm(&mut ext, 8, &test_code[..], "test_exhaust_heap", &code);
 		assert_eq!(res.is_err(), true);
@@ -718,11 +718,11 @@ mod tests {
 				call $assert
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox", &code).unwrap(),
-			vec![1],
+			true.encode(),
 		);
 	}
 
@@ -752,11 +752,11 @@ mod tests {
 				)
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_args", &code).unwrap(),
-			vec![1],
+			true.encode(),
 		);
 	}
 
@@ -774,11 +774,11 @@ mod tests {
 				)
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_return_val", &code).unwrap(),
-			vec![1],
+			true.encode(),
 		);
 	}
 
@@ -794,11 +794,11 @@ mod tests {
 			(func (export "call")
 			)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_instantiate", &code).unwrap(),
-			vec![1],
+			1u8.encode(),
 		);
 	}
 
@@ -808,11 +808,11 @@ mod tests {
 		let test_code = WASM_BINARY;
 
 		// Corrupted wasm file
-		let code = &[0, 0, 0, 0, 1, 0, 0, 0];
+		let code = vec![0u8, 0, 0, 0, 1, 0, 0, 0].encode();
 
 		assert_eq!(
-			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_instantiate", code).unwrap(),
-			vec![1],
+			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_instantiate", &code).unwrap(),
+			1u8.encode(),
 		);
 	}
 
@@ -831,11 +831,11 @@ mod tests {
 
 			(start $start)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_instantiate", &code).unwrap(),
-			vec![0],
+			0u8.encode(),
 		);
 	}
 
@@ -855,11 +855,11 @@ mod tests {
 
 			(start $start)
 		)
-		"#).unwrap();
+		"#).unwrap().encode();
 
 		assert_eq!(
 			call_wasm(&mut ext, 8, &test_code[..], "test_sandbox_instantiate", &code).unwrap(),
-			vec![2],
+			2u8.encode(),
 		);
 	}
 }

--- a/core/executor/src/wasmi_execution.rs
+++ b/core/executor/src/wasmi_execution.rs
@@ -662,6 +662,7 @@ mod tests {
 	use runtime_test::WASM_BINARY;
 	use substrate_offchain::testing;
 	use trie::{TrieConfiguration, trie_types::Layout};
+	use codec::{Encode, Decode};
 
 	type TestExternalities = CoreTestExternalities<Blake2Hasher, u64>;
 
@@ -694,10 +695,10 @@ mod tests {
 		let output = call(&mut ext, 8, &test_code[..], "test_panic", &[]);
 		assert!(output.is_err());
 
-		let output = call(&mut ext, 8, &test_code[..], "test_conditional_panic", &[]);
-		assert_eq!(output.unwrap(), vec![0u8; 0]);
+		let output = call(&mut ext, 8, &test_code[..], "test_conditional_panic", &[0]);
+		assert_eq!(Decode::decode(&mut &output.unwrap()[..]), Ok(Vec::<u8>::new()));
 
-		let output = call(&mut ext, 8, &test_code[..], "test_conditional_panic", &[2]);
+		let output = call(&mut ext, 8, &test_code[..], "test_conditional_panic", &vec![2].encode());
 		assert!(output.is_err());
 	}
 
@@ -707,9 +708,15 @@ mod tests {
 		ext.set_storage(b"foo".to_vec(), b"bar".to_vec());
 		let test_code = WASM_BINARY;
 
-		let output = call(&mut ext, 8, &test_code[..], "test_data_in", b"Hello world").unwrap();
+		let output = call(
+			&mut ext,
+			8,
+			&test_code[..],
+			"test_data_in",
+			&b"Hello world".to_vec().encode(),
+		).unwrap();
 
-		assert_eq!(output, b"all ok!".to_vec());
+		assert_eq!(output, b"all ok!".to_vec().encode());
 
 		let expected = TestExternalities::new((map![
 			b"input".to_vec() => b"Hello world".to_vec(),
@@ -730,9 +737,15 @@ mod tests {
 		let test_code = WASM_BINARY;
 
 		// This will clear all entries which prefix is "ab".
-		let output = call(&mut ext, 8, &test_code[..], "test_clear_prefix", b"ab").unwrap();
+		let output = call(
+			&mut ext,
+			8,
+			&test_code[..],
+			"test_clear_prefix",
+			&b"ab".to_vec().encode(),
+		).unwrap();
 
-		assert_eq!(output, b"all ok!".to_vec());
+		assert_eq!(output, b"all ok!".to_vec().encode());
 
 		let expected = TestExternalities::new((map![
 			b"aaa".to_vec() => b"1".to_vec(),
@@ -747,12 +760,18 @@ mod tests {
 		let mut ext = TestExternalities::default();
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_blake2_256", &[]).unwrap(),
-			blake2_256(&b""[..]).encode()
+			call(&mut ext, 8, &test_code[..], "test_blake2_256", &[0]).unwrap(),
+			blake2_256(&b""[..]).to_vec().encode(),
 		);
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_blake2_256", b"Hello world!").unwrap(),
-			blake2_256(&b"Hello world!"[..]).encode()
+			call(
+				&mut ext,
+				8,
+				&test_code[..],
+				"test_blake2_256",
+				&b"Hello world!".to_vec().encode(),
+			).unwrap(),
+			blake2_256(&b"Hello world!"[..]).to_vec().encode(),
 		);
 	}
 
@@ -761,12 +780,18 @@ mod tests {
 		let mut ext = TestExternalities::default();
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_blake2_128", &[]).unwrap(),
-			blake2_128(&b""[..]).encode()
+			call(&mut ext, 8, &test_code[..], "test_blake2_128", &[0]).unwrap(),
+			blake2_128(&b""[..]).to_vec().encode(),
 		);
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_blake2_128", b"Hello world!").unwrap(),
-			blake2_128(&b"Hello world!"[..]).encode()
+			call(
+				&mut ext,
+				8,
+				&test_code[..],
+				"test_blake2_128",
+				&b"Hello world!".to_vec().encode(),
+			).unwrap(),
+			blake2_128(&b"Hello world!"[..]).to_vec().encode(),
 		);
 	}
 
@@ -775,12 +800,22 @@ mod tests {
 		let mut ext = TestExternalities::default();
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_twox_256", &[]).unwrap(),
-			hex!("99e9d85137db46ef4bbea33613baafd56f963c64b1f3685a4eb4abd67ff6203a"),
+			call(&mut ext, 8, &test_code[..], "test_twox_256", &[0]).unwrap(),
+			hex!(
+				"99e9d85137db46ef4bbea33613baafd56f963c64b1f3685a4eb4abd67ff6203a"
+			).to_vec().encode(),
 		);
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_twox_256", b"Hello world!").unwrap(),
-			hex!("b27dfd7f223f177f2a13647b533599af0c07f68bda23d96d059da2b451a35a74"),
+			call(
+				&mut ext,
+				8,
+				&test_code[..],
+				"test_twox_256",
+				&b"Hello world!".to_vec().encode(),
+			).unwrap(),
+			hex!(
+				"b27dfd7f223f177f2a13647b533599af0c07f68bda23d96d059da2b451a35a74"
+			).to_vec().encode(),
 		);
 	}
 
@@ -789,12 +824,18 @@ mod tests {
 		let mut ext = TestExternalities::default();
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_twox_128", &[]).unwrap(),
-			hex!("99e9d85137db46ef4bbea33613baafd5")
+			call(&mut ext, 8, &test_code[..], "test_twox_128", &[0]).unwrap(),
+			hex!("99e9d85137db46ef4bbea33613baafd5").to_vec().encode(),
 		);
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_twox_128", b"Hello world!").unwrap(),
-			hex!("b27dfd7f223f177f2a13647b533599af")
+			call(
+				&mut ext,
+				8,
+				&test_code[..],
+				"test_twox_128",
+				&b"Hello world!".to_vec().encode(),
+			).unwrap(),
+			hex!("b27dfd7f223f177f2a13647b533599af").to_vec().encode(),
 		);
 	}
 
@@ -809,8 +850,8 @@ mod tests {
 		calldata.extend_from_slice(sig.as_ref());
 
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_ed25519_verify", &calldata).unwrap(),
-			vec![1]
+			call(&mut ext, 8, &test_code[..], "test_ed25519_verify", &calldata.encode()).unwrap(),
+			true.encode(),
 		);
 
 		let other_sig = key.sign(b"all is not ok!");
@@ -819,8 +860,8 @@ mod tests {
 		calldata.extend_from_slice(other_sig.as_ref());
 
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_ed25519_verify", &calldata).unwrap(),
-			vec![0]
+			call(&mut ext, 8, &test_code[..], "test_ed25519_verify", &calldata.encode()).unwrap(),
+			false.encode(),
 		);
 	}
 
@@ -835,8 +876,8 @@ mod tests {
 		calldata.extend_from_slice(sig.as_ref());
 
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_sr25519_verify", &calldata).unwrap(),
-			vec![1]
+			call(&mut ext, 8, &test_code[..], "test_sr25519_verify", &calldata.encode()).unwrap(),
+			true.encode(),
 		);
 
 		let other_sig = key.sign(b"all is not ok!");
@@ -845,8 +886,8 @@ mod tests {
 		calldata.extend_from_slice(other_sig.as_ref());
 
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_sr25519_verify", &calldata).unwrap(),
-			vec![0]
+			call(&mut ext, 8, &test_code[..], "test_sr25519_verify", &calldata.encode()).unwrap(),
+			false.encode(),
 		);
 	}
 
@@ -856,8 +897,8 @@ mod tests {
 		let trie_input = vec![b"zero".to_vec(), b"one".to_vec(), b"two".to_vec()];
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_ordered_trie_root", &[]).unwrap(),
-			Layout::<Blake2Hasher>::ordered_trie_root(trie_input.iter()).as_fixed_bytes().encode()
+			call(&mut ext, 8, &test_code[..], "test_ordered_trie_root", &[0]).unwrap(),
+			Layout::<Blake2Hasher>::ordered_trie_root(trie_input.iter()).as_bytes().encode(),
 		);
 	}
 
@@ -870,8 +911,8 @@ mod tests {
 		ext.register_extension(OffchainExt::new(offchain));
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_offchain_local_storage", &[]).unwrap(),
-			vec![0]
+			call(&mut ext, 8, &test_code[..], "test_offchain_local_storage", &[0]).unwrap(),
+			true.encode(),
 		);
 		assert_eq!(state.read().persistent_storage.get(b"", b"test"), Some(vec![]));
 	}
@@ -897,8 +938,8 @@ mod tests {
 
 		let test_code = WASM_BINARY;
 		assert_eq!(
-			call(&mut ext, 8, &test_code[..], "test_offchain_http", &[]).unwrap(),
-			vec![0]
+			call(&mut ext, 8, &test_code[..], "test_offchain_http", &[0]).unwrap(),
+			true.encode(),
 		);
 	}
 }

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -39,6 +39,7 @@ use std::borrow::Cow;
 use serde::{Serialize, Deserialize};
 #[cfg(feature = "std")]
 pub use serde;// << for macro
+#[doc(hidden)]
 pub use codec::{Encode, Decode};// << for macro
 
 #[cfg(feature = "std")]
@@ -81,6 +82,9 @@ pub use hash_db::Hasher;
 pub use self::hasher::blake2::Blake2Hasher;
 
 pub use primitives_storage as storage;
+
+#[doc(hidden)]
+pub use rstd;
 
 /// Context for executing a call into the runtime.
 pub enum ExecutionContext {

--- a/core/primitives/src/testing.rs
+++ b/core/primitives/src/testing.rs
@@ -129,12 +129,126 @@ impl crate::traits::BareCryptoStore for KeyStore {
 	}
 }
 
+/// Macro for exporting functions from wasm in with the expected signature for using it with the
+/// wasm executor. This is useful for tests where you need to call a function in wasm.
+///
+/// The input parameters are expected to be SCALE encoded and will be automatically decoded for you.
+/// The output value is also SCALE encoded when returned back to the host.
+///
+/// The functions are feature-gated with `#[cfg(not(feature = "std"))]`, so they are only available
+/// from within wasm.
+///
+/// # Example
+///
+/// ```
+/// # use substrate_primitives::wasm_export_functions;
+///
+/// wasm_export_functions! {
+///     fn test_in_wasm(value: bool, another_value: Vec<u8>) -> bool {
+///         value && another_value.is_empty()
+///     }
+///
+///     fn without_return_value() {
+///         // do something
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! wasm_export_functions {
+	(
+		$(
+			fn $name:ident (
+				$( $arg_name:ident: $arg_ty:ty ),* $(,)?
+			) $( -> $ret_ty:ty )? { $( $fn_impl:tt )* }
+		)*
+	) => {
+		$(
+			$crate::wasm_export_functions! {
+				@IMPL
+				fn $name (
+					$( $arg_name: $arg_ty ),*
+				) $( -> $ret_ty )? { $( $fn_impl )* }
+			}
+		)*
+	};
+	(@IMPL
+		fn $name:ident (
+				$( $arg_name:ident: $arg_ty:ty ),*
+		) { $( $fn_impl:tt )* }
+	) => {
+		#[no_mangle]
+		#[allow(unreachable_code)]
+		#[cfg(not(feature = "std"))]
+		pub fn $name(input_data: *mut u8, input_len: usize) -> u64 {
+			let input: &[u8] = if input_len == 0 {
+				&[0u8; 0]
+			} else {
+				unsafe {
+					$crate::rstd::slice::from_raw_parts(input_data, input_len)
+				}
+			};
+
+			{
+				let ($( $arg_name ),*) : ($( $arg_ty ),*) = $crate::Decode::decode(
+					&mut &input[..],
+				).expect("Input data is correctly encoded");
+
+				$( $fn_impl )*
+			}
+
+			// We need to return *something*
+			let output = Vec::<u8>::new();
+			let res = output.as_ptr() as u64 + ((output.len() as u64) << 32);
+
+			// Leak the output vector to avoid it being freed.
+			// This is fine in a WASM context since the heap
+			// will be discarded after the call.
+			$crate::rstd::mem::forget(output);
+			res
+		}
+	};
+	(@IMPL
+		fn $name:ident (
+				$( $arg_name:ident: $arg_ty:ty ),*
+		) $( -> $ret_ty:ty )? { $( $fn_impl:tt )* }
+	) => {
+		#[no_mangle]
+		#[allow(unreachable_code)]
+		#[cfg(not(feature = "std"))]
+		pub fn $name(input_data: *mut u8, input_len: usize) -> u64 {
+			let input: &[u8] = if input_len == 0 {
+				&[0u8; 0]
+			} else {
+				unsafe {
+					$crate::rstd::slice::from_raw_parts(input_data, input_len)
+				}
+			};
+
+			let output $( : $ret_ty )? = {
+				let ($( $arg_name ),*) : ($( $arg_ty ),*) = $crate::Decode::decode(
+					&mut &input[..],
+				).expect("Input data is correctly encoded");
+
+				$( $fn_impl )*
+			};
+
+			let output = $crate::Encode::encode(&output);
+			let res = output.as_ptr() as u64 + ((output.len() as u64) << 32);
+
+			// Leak the output vector to avoid it being freed.
+			// This is fine in a WASM context since the heap
+			// will be discarded after the call.
+			$crate::rstd::mem::forget(output);
+			res
+		}
+	};
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::sr25519;
 	use crate::testing::{ED25519, SR25519};
-
 
 	#[test]
 	fn store_key_and_extract() {


### PR DESCRIPTION
The macro generates the functions with the signature we expect for wasm
functions. This macro is useful for tests where we need to call into
wasm. Parameter passing is done by SCALE encoding the input and output
parameters.

CC @lamafab