### PR TITLE
It's Clippy time!

### DIFF
--- a/core/client/db/src/cache/mod.rs
+++ b/core/client/db/src/cache/mod.rs
@@ -207,7 +207,7 @@ impl<'a, Block: BlockT> DbCacheTransaction<'a, Block> {
 		// prepare list of caches that are not update
 		// (we might still need to do some cache maintenance in this case)
 		let missed_caches = self.cache.cache_at.keys()
-			.filter(|cache| !data_at.contains_key(cache.clone()))
+			.filter(|cache| !data_at.contains_key(*cache))
 			.cloned()
 			.collect::<Vec<_>>();
 

--- a/core/consensus/babe/primitives/src/digest.rs
+++ b/core/consensus/babe/primitives/src/digest.rs
@@ -91,7 +91,7 @@ impl BabePreDigest {
 }
 
 /// The prefix used by BABE for its VRF keys.
-pub const BABE_VRF_PREFIX: &'static [u8] = b"substrate-babe-vrf";
+pub const BABE_VRF_PREFIX: &[u8] = b"substrate-babe-vrf";
 
 /// A raw version of `BabePreDigest`, usable on `no_std`.
 #[derive(Copy, Clone, Encode, Decode)]

--- a/core/consensus/babe/src/aux_schema.rs
+++ b/core/consensus/babe/src/aux_schema.rs
@@ -38,7 +38,7 @@ fn load_decode<B, T>(backend: &B, key: &[u8]) -> ClientResult<Option<T>>
 		T: Decode,
 {
 	let corrupt = |e: codec::Error| {
-		ClientError::Backend(format!("BABE DB is corrupted. Decode error: {}", e.what())).into()
+		ClientError::Backend(format!("BABE DB is corrupted. Decode error: {}", e.what()))
 	};
 	match backend.get_aux(key)? {
 		None => Ok(None),

--- a/core/consensus/slots/src/aux_schema.rs
+++ b/core/consensus/slots/src/aux_schema.rs
@@ -38,7 +38,7 @@ fn load_decode<C, T>(backend: &C, key: &[u8]) -> ClientResult<Option<T>>
 		None => Ok(None),
 		Some(t) => T::decode(&mut &t[..])
 			.map_err(
-				|e| ClientError::Backend(format!("Slots DB is corrupted. Decode error: {}", e.what())).into(),
+				|e| ClientError::Backend(format!("Slots DB is corrupted. Decode error: {}", e.what())),
 			)
 			.map(Some)
 	}

--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -189,9 +189,9 @@ pub trait SimpleSlotWorker<B: BlockT> {
 					logs,
 				},
 				remaining_duration,
-			).map_err(|e| consensus_common::Error::ClientImport(format!("{:?}", e)).into()),
+			).map_err(|e| consensus_common::Error::ClientImport(format!("{:?}", e))),
 			Delay::new(remaining_duration)
-				.map_err(|err| consensus_common::Error::FaultyTimer(err).into())
+				.map_err(consensus_common::Error::FaultyTimer)
 		).map(|v| match v {
 			futures::future::Either::Left((b, _)) => b.map(|b| (b, claim)),
 			futures::future::Either::Right((Ok(_), _)) =>
@@ -220,9 +220,9 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			}
 
 			let (header, body) = block.deconstruct();
-			let header_num = header.number().clone();
+			let header_num = *header.number();
 			let header_hash = header.hash();
-			let parent_hash = header.parent_hash().clone();
+			let parent_hash = *header.parent_hash();
 
 			let block_import_params = block_import_params_maker(
 				header,
@@ -401,9 +401,8 @@ impl<T: Clone> SlotDuration<T> {
 				.map_err(|_| {
 					client::error::Error::Backend({
 						error!(target: "slots", "slot duration kept in invalid format");
-						format!("slot duration kept in invalid format")
+						"slot duration kept in invalid format".to_string()
 					})
-					.into()
 				}),
 			None => {
 				use sr_primitives::traits::Zero;

--- a/core/finality-grandpa/src/lib.rs
+++ b/core/finality-grandpa/src/lib.rs
@@ -822,7 +822,7 @@ where
 	}
 }
 
-#[deprecated(since = "1.1", note = "Please switch to run_grandpa_voter.")]
+#[deprecated(since = "1.1.0", note = "Please switch to run_grandpa_voter.")]
 pub fn run_grandpa<B, E, Block: BlockT<Hash=H256>, N, RA, SC, VR, X>(
 	grandpa_params: GrandpaParams<B, E, Block, N, RA, SC, VR, X>,
 ) -> ::client::error::Result<impl Future<Item=(),Error=()> + Send + 'static> where

--- a/core/primitives/src/ed25519.rs
+++ b/core/primitives/src/ed25519.rs
@@ -41,6 +41,7 @@ use crate::{crypto::{Public as TraitPublic, UncheckedFrom, CryptoType, Derive}};
 type Seed = [u8; 32];
 
 /// A public key.
+#[cfg_attr(feature = "std", derive(Hash))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default)]
 pub struct Public(pub [u8; 32]);
 
@@ -149,13 +150,6 @@ impl<'de> Deserialize<'de> for Public {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		Public::from_ss58check(&String::deserialize(deserializer)?)
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))
-	}
-}
-
-#[cfg(feature = "std")]
-impl std::hash::Hash for Public {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		self.0.hash(state);
 	}
 }
 

--- a/core/primitives/src/sr25519.rs
+++ b/core/primitives/src/sr25519.rs
@@ -47,6 +47,7 @@ use schnorrkel::keys::{MINI_SECRET_KEY_LENGTH, SECRET_KEY_LENGTH};
 const SIGNING_CTX: &[u8] = b"substrate";
 
 /// An Schnorrkel/Ristretto x25519 ("sr25519") public key.
+#[cfg_attr(feature = "std", derive(Hash))]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Encode, Decode, Default)]
 pub struct Public(pub [u8; 32]);
 
@@ -148,13 +149,6 @@ impl<'de> Deserialize<'de> for Public {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		Public::from_ss58check(&String::deserialize(deserializer)?)
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))
-	}
-}
-
-#[cfg(feature = "std")]
-impl std::hash::Hash for Public {
-	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-		self.0.hash(state);
 	}
 }
 

--- a/core/rpc-servers/src/lib.rs
+++ b/core/rpc-servers/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Substrate RPC servers.
 
-#[warn(missing_docs)]
+#![warn(missing_docs)]
 
 use std::io;
 use jsonrpc_core::IoHandlerExtension;

--- a/core/service/src/chain_ops.rs
+++ b/core/service/src/chain_ops.rs
@@ -46,7 +46,7 @@ macro_rules! export_blocks {
 		let last_: u64 = last.saturated_into::<u64>();
 		let block_: u64 = block.saturated_into::<u64>();
 		let len: u64 = last_ - block_ + 1;
-		$output.write(&len.encode())?;
+		$output.write_all(&len.encode())?;
 	}
 
 	loop {
@@ -59,7 +59,7 @@ macro_rules! export_blocks {
 					serde_json::to_writer(&mut $output, &block)
 						.map_err(|e| format!("Error writing JSON: {}", e))?;
 				} else {
-					$output.write(&block.encode())?;
+					$output.write_all(&block.encode())?;
 				}
 			},
 			None => break,

--- a/srml/support/src/hash.rs
+++ b/srml/support/src/hash.rs
@@ -59,7 +59,7 @@ impl StorageHasher for Twox64Concat {
 	type Output = Vec<u8>;
 	fn hash(x: &[u8]) -> Vec<u8> {
 		twox_64(x)
-			.into_iter()
+			.iter()
 			.chain(x.into_iter())
 			.cloned()
 			.collect::<Vec<_>>()

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -148,7 +148,7 @@ pub trait OnUnbalanced<Imbalance> {
 	fn on_unbalanced(amount: Imbalance);
 }
 
-impl<Imbalance: Drop> OnUnbalanced<Imbalance> for () {
+impl<Imbalance> OnUnbalanced<Imbalance> for () {
 	fn on_unbalanced(amount: Imbalance) { drop(amount); }
 }
 

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -567,7 +567,7 @@ impl<T: Trait> Module<T> {
 		// We perform early return if we've reached the maximum capacity of the event list,
 		// so `Events<T>` seems to be corrupted. Also, this has happened after the start of execution
 		// (since the event list is cleared at the block initialization).
-		if <Events<T>>::append([event].into_iter()).is_err() {
+		if <Events<T>>::append([event].iter()).is_err() {
 			// The most sensible thing to do here is to just ignore this event and wait until the
 			// new block.
 			return;


### PR DESCRIPTION
Compliance with all default hard errors and crates that are explicitly
using `#![deny(warnings)]`.
There are some legitimate warnings like `println!("")` -> `println!()` but
they aren't considered in this PR.