### PR TITLE
Fix #1536: do not require to construct a block for encoding it

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1059,10 +1059,10 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 					}
 				};
 
-				let encoded_block = <Block as BlockT>::new(
-					import_headers.pre().clone(),
-					body.unwrap_or_default(),
-				).encode();
+				let encoded_block = <Block as BlockT>::encode_from(
+					import_headers.pre(),
+					&body.unwrap_or_default()
+				);
 
 				let (_, storage_update, changes_update) = self.executor
 					.call_at_state::<_, _, NeverNativeValue, fn() -> _>(

--- a/core/sr-primitives/src/generic/block.rs
+++ b/core/sr-primitives/src/generic/block.rs
@@ -93,6 +93,9 @@ where
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self {
 		Block { header, extrinsics }
 	}
+	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8> {
+		(header, extrinsics).encode()
+	}
 }
 
 /// Abstraction over a substrate block and justification.

--- a/core/sr-primitives/src/generic/block.rs
+++ b/core/sr-primitives/src/generic/block.rs
@@ -93,7 +93,7 @@ where
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self {
 		Block { header, extrinsics }
 	}
-	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8> {
+	fn encode_from(header: &Self::Header, extrinsics: &[Self::Extrinsic]) -> Vec<u8> {
 		(header, extrinsics).encode()
 	}
 }

--- a/core/sr-primitives/src/testing.rs
+++ b/core/sr-primitives/src/testing.rs
@@ -259,6 +259,9 @@ impl<Xt: 'static + Codec + Sized + Send + Sync + Serialize + Clone + Eq + Debug 
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self {
 		Block { header, extrinsics }
 	}
+	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8> {
+		(header, extrinsics).encode()
+	}
 }
 
 impl<'a, Xt> Deserialize<'a> for Block<Xt> where Block<Xt>: Decode {

--- a/core/sr-primitives/src/testing.rs
+++ b/core/sr-primitives/src/testing.rs
@@ -259,7 +259,7 @@ impl<Xt: 'static + Codec + Sized + Send + Sync + Serialize + Clone + Eq + Debug 
 	fn new(header: Self::Header, extrinsics: Vec<Self::Extrinsic>) -> Self {
 		Block { header, extrinsics }
 	}
-	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8> {
+	fn encode_from(header: &Self::Header, extrinsics: &[Self::Extrinsic]) -> Vec<u8> {
 		(header, extrinsics).encode()
 	}
 }

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -687,8 +687,8 @@ pub trait Block: Clone + Send + Sync + Codec + Eq + MaybeSerializeDebugButNotDes
 	fn hash(&self) -> Self::Hash {
 		<<Self::Header as Header>::Hashing as Hash>::hash_of(self.header())
 	}
-	/// Encodes the block from header and extrinsics, that is without creating an instance of it.
-	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8>;
+	/// Create an encoded block from the given `header` and `extrinsics` without requiring to create an instance.
+	fn encode_from(header: &Self::Header, extrinsics: &[Self::Extrinsic]) -> Vec<u8>;
 }
 
 /// Something that acts like an `Extrinsic`.

--- a/core/sr-primitives/src/traits.rs
+++ b/core/sr-primitives/src/traits.rs
@@ -687,6 +687,8 @@ pub trait Block: Clone + Send + Sync + Codec + Eq + MaybeSerializeDebugButNotDes
 	fn hash(&self) -> Self::Hash {
 		<<Self::Header as Header>::Hashing as Hash>::hash_of(self.header())
 	}
+	/// Encodes the block from header and extrinsics, that is without creating an instance of it.
+	fn encode_from(header: &Self::Header, extrinsics: &Vec<Self::Extrinsic>) -> Vec<u8>;
 }
 
 /// Something that acts like an `Extrinsic`.

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 175,
-	impl_version: 175,
+	impl_version: 176,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
Fixes #1536.

_WARNING_: day 3 Rust developer and total Substrate newbie here, plus the proposed solution is surprisingly simple so it is entirely possible that, at this stage, this is just mindless babbling; I apologize in advance if that turns out to be the case.

This proposal follows from the fact that SCALE [encodes tuples and structs in the same way](https://substrate.dev/docs/en/overview/low-level-data-format#tuples-and-structures) and [`parity-scale-codec`](https://github.com/paritytech/parity-scale-codec) seems to [support tuple encoding](https://github.com/paritytech/parity-scale-codec/blob/4a559de5f6fece90205a159e008b86304d4c8750/src/codec.rs#L812).

Concretely I added an `encode_from(&header, &extrinsics) -> Vec<u8>` function to the `Block` trait and straightforwardly implemented it by just encoding a pair; finally I replaced `Block::new` with that function in `client.rs` (that seems so far the only code that copies the header to encode the block).

Other approaches I considered were:

- Just building a tuple in-place in `client.rs`: duplicates logic that should really be kept and maintained with `Block`.
- Exporting a `block_tuple` macro together with `Block` implementations: slightly more efficient but less clear and less structured, e.g. doesn't require impls. to provide one; less clear that it is available, as it requires a separate import and is not bundled with the trait, and also when it should be used.
- Defining a new `struct` (e.g. `BlockEnvelope`) that borrows the headers and adding codec support for it: encoding refs by expanding them into the actual content might be confusing and possibly incoherent with other cases (and so it might increase technical debt).
- Custom encoding function: less maintainable.