### PR TITLE
Auto import SimpleDispatchInfo

### DIFF
--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -179,7 +179,7 @@ use sr_primitives::{
 		Zero, SimpleArithmetic, StaticLookup, Member, CheckedAdd, CheckedSub, MaybeSerializeDebug,
 		Saturating, Bounded, SignedExtension, SaturatedConversion, Convert,
 	},
-	weights::{DispatchInfo, SimpleDispatchInfo, Weight},
+	weights::{DispatchInfo, Weight},
 };
 use system::{IsDeadAccount, OnNewAccount, ensure_signed, ensure_root};
 

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -259,7 +259,7 @@ use system::{ensure_signed, ensure_root};
 use codec::{Encode, Decode};
 use sr_primitives::{
 	traits::{SignedExtension, Bounded, SaturatedConversion},
-	weights::{SimpleDispatchInfo, DispatchInfo, DispatchClass, ClassifyDispatch, WeighData, Weight},
+	weights::{DispatchInfo, DispatchClass, ClassifyDispatch, WeighData, Weight},
 	transaction_validity::{
 		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
 	},

--- a/srml/support/src/dispatch.rs
+++ b/srml/support/src/dispatch.rs
@@ -629,7 +629,7 @@ macro_rules! decl_module {
 			{ $( $error_type )* }
 			[ $( $dispatchables )* ]
 			$(#[doc = $doc_attr])*
-			#[weight = $crate::dispatch::SimpleDispatchInfo::default()]
+			#[weight = SimpleDispatchInfo::default()]
 			$fn_vis fn $fn_name(
 				$from $(, $(#[$codec_attr])* $param_name : $param )*
 			) $( -> $result )* { $( $impl )* }
@@ -1068,6 +1068,8 @@ macro_rules! decl_module {
 		{ $( $constants:tt )* }
 		{ $error_type:ty }
 	) => {
+		// default weight import.
+		use $crate::dispatch::SimpleDispatchInfo;
 		$crate::__check_reserved_fn_name! { $( $fn_name )* }
 
 		// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
@@ -1170,7 +1172,7 @@ macro_rules! decl_module {
 				// implementation of `SimpleDispatchInfo`. Nonetheless, we create one if it does
 				// not exist.
 				let weight = <dyn $crate::dispatch::WeighData<_>>::weigh_data(
-					&$crate::dispatch::SimpleDispatchInfo::default(),
+					&SimpleDispatchInfo::default(),
 					()
 				);
 				let class = <dyn $crate::dispatch::ClassifyDispatch<_>>::classify_dispatch(

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -97,7 +97,7 @@ use rstd::marker::PhantomData;
 use sr_version::RuntimeVersion;
 use sr_primitives::{
 	generic::{self, Era}, Perbill, ApplyError, ApplyOutcome, DispatchError,
-	weights::{Weight, DispatchInfo, DispatchClass, WeightMultiplier, SimpleDispatchInfo},
+	weights::{Weight, DispatchInfo, DispatchClass, WeightMultiplier},
 	transaction_validity::{
 		ValidTransaction, TransactionPriority, TransactionLongevity, TransactionValidityError,
 		InvalidTransaction, TransactionValidity,


### PR DESCRIPTION
Similar to how we recently brought common things like `StorageValue, StorageMap,...` into scope, I assume it is good to use also do the same with `SimpleDispatchInfo` as it is used everywhere. 

Not sure if it is needed, some might say it is ambiguous. Hence, I only touched example, balances and system. If approved, will fix the rest of srml. 