### PR TITLE
Add a note about --document-private-items to the readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -459,6 +459,12 @@ node-cli, node-consensus, node-executor, node-network, node-primitives, node-run
 [source, shell]
 subkey
 
+To document Substrate's private items for internal development, add the `--document-private-items` flag:
+
+```
+cargo doc --package <spec> --open --document-private-items
+```
+
 === Contributing to documentation for Substrate packages
 
 https://doc.rust-lang.org/1.9.0/book/documentation.html[Document source code] for Substrate packages by annotating the source code with documentation comments.

--- a/README.adoc
+++ b/README.adoc
@@ -459,6 +459,8 @@ node-cli, node-consensus, node-executor, node-network, node-primitives, node-run
 [source, shell]
 subkey
 
+=== Viewing internal documentation
+
 To document Substrate's private items for internal development, add the `--document-private-items` flag:
 
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -459,7 +459,7 @@ node-cli, node-consensus, node-executor, node-network, node-primitives, node-run
 [source, shell]
 subkey
 
-=== Viewing internal documentation
+==== Viewing internal documentation
 
 To document Substrate's private items for internal development, add the `--document-private-items` flag:
 


### PR DESCRIPTION
I had totally forgotten about this flag, but it's quite useful, so it would be nice to have a note about it.