### PR TITLE
cli: disable pruning on validators

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -674,13 +674,6 @@ where
 	config.database_path = db_path(&base_path, config.chain_spec.id());
 	config.database_cache_size = cli.database_cache_size;
 	config.state_cache_size = cli.state_cache_size;
-	config.pruning = match cli.pruning {
-		Some(ref s) if s == "archive" => PruningMode::ArchiveAll,
-		None => PruningMode::default(),
-		Some(s) => PruningMode::keep_blocks(s.parse()
-			.map_err(|_| error::Error::Input("Invalid pruning mode specified".to_string()))?
-		),
-	};
 
 	let is_dev = cli.shared_params.dev;
 
@@ -692,6 +685,28 @@ where
 		} else {
 			service::Roles::FULL
 		};
+
+	// by default we disable pruning if the node is an authority (i.e.
+	// `ArchiveAll`), otherwise we keep state for the last 256 blocks. if the
+	// node is an authority and pruning is enabled explicitly, then we error
+	// unless `unsafe_pruning` is set.
+	config.pruning = match cli.pruning {
+		Some(ref s) if s == "archive" => PruningMode::ArchiveAll,
+		None if role == service::Roles::AUTHORITY => PruningMode::ArchiveAll,
+		None => PruningMode::default(),
+		Some(s) => {
+			if role == service::Roles::AUTHORITY && !cli.unsafe_pruning {
+				return Err(error::Error::Input(
+					"Validators should run with state pruning disabled (i.e. archive). \
+					You can ignore this check with `--unsafe-pruning`.".to_string()
+				));
+			}
+
+			PruningMode::keep_blocks(s.parse()
+				.map_err(|_| error::Error::Input("Invalid pruning mode specified".to_string()))?
+			)
+		},
+	};
 
 	config.wasm_method = cli.wasm_method.into();
 

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -366,11 +366,21 @@ pub struct RunCmd {
 	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = parse_cors))]
 	pub rpc_cors: Option<Cors>,
 
-	/// Specify the pruning mode, a number of blocks to keep or 'archive'.
+	/// Specify the state pruning mode, a number of blocks to keep or 'archive'.
 	///
-	/// Default is 256.
+	/// Default is to keep all block states if the node is running as a
+	/// validator (i.e. 'archive'), otherwise state is only kept for the last
+	/// 256 blocks.
 	#[structopt(long = "pruning", value_name = "PRUNING_MODE")]
 	pub pruning: Option<String>,
+
+	/// Force start with unsafe pruning settings.
+	///
+	/// When running as a validator it is highly recommended to disable state
+	/// pruning (i.e. 'archive') which is the default. The node will refuse to
+	/// start as a validator if pruning is enabled unless this option is set.
+	#[structopt(long = "unsafe-pruning")]
+	pub unsafe_pruning: bool,
 
 	/// The human-readable name for this node.
 	///


### PR DESCRIPTION
Currently GRANDPA needs to import all blocks that are voted on, and therefore requires to have state available for those blocks. During periods of long finality stalls we run the risk of state being pruned due to depth (we prune after 4096 blocks regardless of finality), or e.g. a short-lived fork being pruned out. This PR changes the default pruning mode to be set to archive if the node is a validator, otherwise it defaults to keeping state for the last 256 blocks. The node will refuse to start if the node is a validator and pruning is enabled, unless the flag `--unsafe-pruning` is given as well.

Currently the node doesn't seem to detect whether the existing database is an archive or pruned. This means that if you start with a pruned database, and restart the node as archive, the node will either crash due to missing state (if you are a validator trying to author), or it just won't import any blocks. The reverse (archive -> pruned) seems to work. This might be a bit confusing to end-users, especially if they just enable/disable `--validator` which implicitly switches the pruning mode.

cc @arkpar 