### PR TITLE
Use Bytes for contract rpc input_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,6 +4046,7 @@ dependencies = [
  "sr-primitives 2.0.0",
  "srml-contracts-rpc-runtime-api 2.0.0",
  "substrate-client 2.0.0",
+ "substrate-primitives 2.0.0",
  "substrate-rpc-primitives 2.0.0",
 ]
 

--- a/srml/contracts/rpc/Cargo.toml
+++ b/srml/contracts/rpc/Cargo.toml
@@ -10,8 +10,8 @@ codec = { package = "parity-scale-codec", version = "1.0.0" }
 jsonrpc-core = "13.2.0"
 jsonrpc-core-client = "13.2.0"
 jsonrpc-derive = "13.2.0"
+primitives = { package = "substrate-primitives",  path = "../../../core/primitives" }
 rpc-primitives = { package = "substrate-rpc-primitives", path = "../../../core/rpc/primitives" }
 serde = { version = "1.0.101", features = ["derive"] }
 sr-primitives = { path = "../../../core/sr-primitives" }
 srml-contracts-rpc-runtime-api = { path = "./runtime-api" }
-

--- a/srml/contracts/rpc/src/lib.rs
+++ b/srml/contracts/rpc/src/lib.rs
@@ -23,6 +23,7 @@ use client::blockchain::HeaderBackend;
 use codec::Codec;
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
+use primitives::Bytes;
 use sr_primitives::{
 	generic::BlockId,
 	traits::{Block as BlockT, ProvideRuntimeApi},
@@ -41,7 +42,7 @@ pub struct CallRequest<AccountId, Balance> {
 	dest: AccountId,
 	value: Balance,
 	gas_limit: number::NumberOrHex<u64>,
-	input_data: Vec<u8>,
+	input_data: Bytes
 }
 
 /// Contracts RPC methods.
@@ -111,7 +112,7 @@ where
 		})?;
 
 		let exec_result = api
-			.call(&at, origin, dest, value, gas_limit, input_data)
+			.call(&at, origin, dest, value, gas_limit, input_data.to_vec())
 			.map_err(|e| Error {
 				code: ErrorCode::ServerError(RUNTIME_ERROR),
 				message: "Runtime trapped while executing a contract.".into(),

--- a/srml/contracts/rpc/src/lib.rs
+++ b/srml/contracts/rpc/src/lib.rs
@@ -42,7 +42,7 @@ pub struct CallRequest<AccountId, Balance> {
 	dest: AccountId,
 	value: Balance,
 	gas_limit: number::NumberOrHex<u64>,
-	input_data: Bytes
+	input_data: Bytes,
 }
 
 /// Contracts RPC methods.


### PR DESCRIPTION
Switch to using Bytes for CallRequest.input_data in place of Vec<u8> for easier UI interaction