### PR TITLE
Remove "Call" from construct_runtime!

### DIFF
--- a/node-template/runtime/src/lib.rs
+++ b/node-template/runtime/src/lib.rs
@@ -280,7 +280,7 @@ construct_runtime!(
 		Sudo: sudo,
 		// Used for the module template in `./template.rs`
 		TemplateModule: template::{Module, Call, Storage, Event<T>},
-		RandomnessCollectiveFlip: randomness_collective_flip::{Module, Call, Storage},
+		RandomnessCollectiveFlip: randomness_collective_flip::{Module, Storage},
 	}
 );
 


### PR DESCRIPTION
Remove `Call` from `construct_runtime!` for `RandomnessCollectiveFlip` due to the following error:
```
error[E0277]: `srml_randomness_collective_flip::Call<Runtime>` doesn't implement `std::fmt::Debug`
```