### PR TITLE
Make build work with rustc 1.37 stable and RUSTC_BOOTSTRAP=1

### DIFF
--- a/core/sr-std/without_std.rs
+++ b/core/sr-std/without_std.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(feature = "nightly")]
 #[doc(hidden)]
 pub extern crate alloc;
 

--- a/core/utils/wasm-builder/src/prerequisites.rs
+++ b/core/utils/wasm-builder/src/prerequisites.rs
@@ -16,6 +16,7 @@
 
 use std::{process::{Command, Stdio}, fs};
 
+use std::env;
 use tempfile::tempdir;
 
 /// Checks that all prerequisites are installed.
@@ -23,7 +24,7 @@ use tempfile::tempdir;
 /// # Returns
 /// Returns `None` if everything was found and `Some(ERR_MSG)` if something could not be found.
 pub fn check() -> Option<&'static str> {
-	if !check_nightly_installed() {
+	if !rustc_stable_forced_to_nightly() && !check_nightly_installed(){
 		return Some("Rust nightly not installed, please install it!")
 	}
 
@@ -37,6 +38,10 @@ pub fn check() -> Option<&'static str> {
 	}
 
 	check_wasm_toolchain_installed()
+}
+
+fn rustc_stable_forced_to_nightly() -> bool {
+  env::var("RUSTC_BOOTSTRAP") == Ok("1".to_string())
 }
 
 fn check_nightly_installed() -> bool {

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 178,
-	impl_version: 178,
+	spec_version: 179,
+	impl_version: 179,
 	apis: RUNTIME_API_VERSIONS,
 };
 


### PR DESCRIPTION
By relaxing some checks we can easily make the build work using Debian's system rustc (which I maintain), avoiding having to install rustc nightly:

~~~~
$ apt install rustc libstd-rust-dev-wasm32-cross libssl-dev
$ RUSTC_BOOTSTRAP=1 cargo build
[..]
   Compiling transaction-factory v0.0.1 ($PWD/test-utils/transaction-factory)
    Finished dev [unoptimized + debuginfo] target(s) in 11m 07s
~~~~
