### PR TITLE
grandpa: don't expire next round messages

### DIFF
--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -1557,19 +1557,19 @@ mod tests {
 
 	#[test]
 	fn unanswerable_catch_up_requests_discarded() {
-		// create voter set state with round 1 completed
+		// create voter set state with round 2 completed
 		let set_state: SharedVoterSetState<Block> = {
 			let mut completed_rounds = voter_set_state().read().completed_rounds();
 
 			completed_rounds.push(environment::CompletedRound {
-				number: 1,
+				number: 2,
 				state: grandpa::round::State::genesis(Default::default()),
 				base: Default::default(),
 				votes: Default::default(),
 			});
 
 			let mut current_rounds = environment::CurrentRounds::new();
-			current_rounds.insert(2, environment::HasVoted::No);
+			current_rounds.insert(3, environment::HasVoted::No);
 
 			let set_state = environment::VoterSetState::<Block>::Live {
 				completed_rounds,
@@ -1590,7 +1590,7 @@ mod tests {
 		let peer = PeerId::random();
 
 		val.note_set(SetId(set_id), vec![auth.clone()], |_, _| {});
-		val.note_round(Round(2), |_, _| {});
+		val.note_round(Round(3), |_, _| {});
 
 		// add the peer making the request to the validator,
 		// otherwise it is discarded
@@ -1606,7 +1606,7 @@ mod tests {
 			&set_state,
 		);
 
-		// we're at round 2, a catch up request for round 10 is out of scope
+		// we're at round 3, a catch up request for round 10 is out of scope
 		assert!(res.0.is_none());
 		assert_eq!(res.1, Action::Discard(cost::OUT_OF_SCOPE_MESSAGE));
 
@@ -1614,16 +1614,16 @@ mod tests {
 			&peer,
 			CatchUpRequestMessage {
 				set_id: SetId(set_id),
-				round: Round(1),
+				round: Round(2),
 			},
 			&set_state,
 		);
 
-		// a catch up request for round 1 should be answered successfully
+		// a catch up request for round 2 should be answered successfully
 		match res.0.unwrap() {
 			GossipMessage::CatchUp(catch_up) => {
 				assert_eq!(catch_up.set_id, SetId(set_id));
-				assert_eq!(catch_up.message.round_number, 1);
+				assert_eq!(catch_up.message.round_number, 2);
 
 				assert_eq!(res.1, Action::Discard(cost::CATCH_UP_REPLY));
 			},

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -132,7 +132,7 @@ struct View<N> {
 impl<N> Default for View<N> {
 	fn default() -> Self {
 		View {
-			round: Round(0),
+			round: Round(1),
 			set_id: SetId(0),
 			last_commit: None,
 		}
@@ -144,7 +144,7 @@ impl<N: Ord> View<N> {
 	fn update_set(&mut self, set_id: SetId) {
 		if set_id != self.set_id {
 			self.set_id = set_id;
-			self.round = Round(0);
+			self.round = Round(1);
 		}
 	}
 
@@ -563,7 +563,7 @@ impl<Block: BlockT> Inner<Block> {
 		{
 			let local_view = match self.local_view {
 				ref mut x @ None => x.get_or_insert(View {
-					round: Round(0),
+					round: Round(1),
 					set_id,
 					last_commit: None,
 				}),
@@ -575,7 +575,7 @@ impl<Block: BlockT> Inner<Block> {
 			};
 
 			local_view.update_set(set_id);
-			self.live_topics.push(Round(0), set_id);
+			self.live_topics.push(Round(1), set_id);
 			self.authorities = authorities;
 		}
 		self.multicast_neighbor_packet()
@@ -1475,11 +1475,11 @@ mod tests {
 		let peer = PeerId::random();
 
 		val.note_set(SetId(set_id), vec![auth.clone()], |_, _| {});
-		val.note_round(Round(0), |_, _| {});
+		val.note_round(Round(1), |_, _| {});
 
 		let inner = val.inner.read();
 		let unknown_voter = inner.validate_round_message(&peer, &VoteOrPrecommitMessage {
-			round: Round(0),
+			round: Round(1),
 			set_id: SetId(set_id),
 			message: SignedMessage::<Block> {
 				message: grandpa::Message::Prevote(grandpa::Prevote {
@@ -1492,7 +1492,7 @@ mod tests {
 		});
 
 		let bad_sig = inner.validate_round_message(&peer, &VoteOrPrecommitMessage {
-			round: Round(0),
+			round: Round(1),
 			set_id: SetId(set_id),
 			message: SignedMessage::<Block> {
 				message: grandpa::Message::Prevote(grandpa::Prevote {
@@ -1521,7 +1521,7 @@ mod tests {
 		let peer = PeerId::random();
 
 		val.note_set(SetId(set_id), vec![auth.clone()], |_, _| {});
-		val.note_round(Round(0), |_, _| {});
+		val.note_round(Round(1), |_, _| {});
 
 		let validate_catch_up = || {
 			let mut inner = val.inner.write();

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -1872,6 +1872,7 @@ mod tests {
 		val.note_set(SetId(1), Vec::new(), |_, _| {});
 
 		// we are at round 10
+		val.note_round(Round(9), |_, _| {});
 		val.note_round(Round(10), |_, _| {});
 
 		let mut is_expired = val.message_expired();

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -203,8 +203,8 @@ impl<B: BlockT> KeepTopics<B> {
 		self.current_set = std::cmp::max(self.current_set, set_id);
 
 		// under normal operation the given round is already tracked (since we
-		// track one round ahead). if we skip rounds (with a catch up), or when
-		// starting a new set the given round topic might not be tracked yet.
+		// track one round ahead). if we skip rounds (with a catch up) the given
+		// round topic might not be tracked yet.
 		if !self.rounds.contains(&(round, set_id)) {
 			self.rounds.push_back((round, set_id));
 		}

--- a/core/finality-grandpa/src/communication/tests.rs
+++ b/core/finality-grandpa/src/communication/tests.rs
@@ -217,7 +217,7 @@ fn good_commit_leads_to_relay() {
 	let public = make_ids(&private[..]);
 	let voter_set = Arc::new(public.iter().cloned().collect::<VoterSet<AuthorityId>>());
 
-	let round = 0;
+	let round = 1;
 	let set_id = 1;
 
 	let commit = {
@@ -332,7 +332,7 @@ fn bad_commit_leads_to_report() {
 	let public = make_ids(&private[..]);
 	let voter_set = Arc::new(public.iter().cloned().collect::<VoterSet<AuthorityId>>());
 
-	let round = 0;
+	let round = 1;
 	let set_id = 1;
 
 	let commit = {


### PR DESCRIPTION
The GRANDPA gossip validator uses mainly two storage items to validate/expire messages: a topic tracker with hashes of the topics we're interested in, and a local view of the GRANDPA state (round and set number). When validating whether to accept a gossip message or not we check our round in the local view, and we accept messages for `R-1`, `R` and `R+1`. When checking whether a message is expired (or whether it is allowed to send to a given peer), we check whether the topic for that message is live in our topic tracker. The issue is that the topic tracker is currently only tracking topics `R, R-1, ..., R - KEEP_RECENT_ROUNDS`, and the next round topic isn't tracked there. This means that we can accept messages for the next round and subsequently expire them before processing them. In this case, we would never accept the messages again since the low level gossip layer maintains a cache of known messages.

This is a really nasty one that I managed to catch on the chaos net, and it's been lingering there since this code has been written. Not sure if we ever triggered it on a live network.