### PR TITLE
Fix typo

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1125,7 +1125,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		// then some other block is the common ancestor.
 		if route_from_best.common_block().hash != block {
 			// NOTE: we're setting the finalized block as best block, this might
-			// be slightly innacurate since we might have a "better" block
+			// be slightly inaccurate since we might have a "better" block
 			// further along this chain, but since best chain selection logic is
 			// pluggable we cannot make a better choice here. usages that need
 			// an accurate "best" block need to go through `SelectChain`


### PR DESCRIPTION
In `core/client/src/client.rs`: "innacurate" -> "inaccurate"
