### PR TITLE
Price to Weight ratio as type parameter

### DIFF
--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -56,7 +56,7 @@ mod tests {
 	use node_runtime::{
 		Header, Block, UncheckedExtrinsic, CheckedExtrinsic, Call, Runtime, Balances, BuildStorage,
 		System, TransactionPayment, Event, TransferFee, TransactionBaseFee, TransactionByteFee,
-		WeightToFee, constants::currency::*,
+		LinearWeightToFee, constants::currency::*,
 	};
 	use node_primitives::{Balance, Hash, BlockNumber};
 	use node_testing::keyring::*;
@@ -94,7 +94,7 @@ mod tests {
 			(extrinsic.encode().len() as Balance);
 
 		let weight = default_transfer_call().get_dispatch_info().weight;
-		let weight_fee = <Runtime as transaction_payment::Trait>::WeightToFee::convert(weight);
+		let weight_fee = <Runtime as transaction_payment::Trait>::LinearWeightToFee::convert(weight);
 
 		fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee) + TransferFee::get()
 	}
@@ -1046,7 +1046,7 @@ mod tests {
 			balance_alice -= length_fee;
 
 			let weight = default_transfer_call().get_dispatch_info().weight;
-			let weight_fee = WeightToFee::convert(weight);
+			let weight_fee = LinearWeightToFee::convert(weight);
 
 			// we know that weight to fee multiplier is effect-less in block 1.
 			assert_eq!(weight_fee as Balance, MILLICENTS);

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -56,8 +56,9 @@ mod tests {
 	use node_runtime::{
 		Header, Block, UncheckedExtrinsic, CheckedExtrinsic, Call, Runtime, Balances, BuildStorage,
 		System, TransactionPayment, Event, TransferFee, TransactionBaseFee, TransactionByteFee,
-		LinearWeightToFee, constants::currency::*,
+		WeightFeeCoefficient, constants::currency::*,
 	};
+	use node_runtime::impls::LinearWeightToFee;
 	use node_primitives::{Balance, Hash, BlockNumber};
 	use node_testing::keyring::*;
 	use wabt;
@@ -1046,7 +1047,7 @@ mod tests {
 			balance_alice -= length_fee;
 
 			let weight = default_transfer_call().get_dispatch_info().weight;
-			let weight_fee = LinearWeightToFee::convert(weight);
+			let weight_fee = LinearWeightToFee::<WeightFeeCoefficient>::convert(weight);
 
 			// we know that weight to fee multiplier is effect-less in block 1.
 			assert_eq!(weight_fee as Balance, MILLICENTS);

--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -94,7 +94,7 @@ mod tests {
 			(extrinsic.encode().len() as Balance);
 
 		let weight = default_transfer_call().get_dispatch_info().weight;
-		let weight_fee = <Runtime as transaction_payment::Trait>::LinearWeightToFee::convert(weight);
+		let weight_fee = <Runtime as transaction_payment::Trait>::WeightToFee::convert(weight);
 
 		fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee) + TransferFee::get()
 	}

--- a/node/runtime/src/impls.rs
+++ b/node/runtime/src/impls.rs
@@ -22,7 +22,7 @@ use sr_primitives::traits::{Convert, Saturating};
 use sr_primitives::{Fixed64, Perbill};
 use support::traits::{OnUnbalanced, Currency, Get};
 use crate::{
-	Balances, System, Authorship, MaximumBlockWeight, NegativeImbalance, WeightToFee,
+	Balances, System, Authorship, MaximumBlockWeight, NegativeImbalance,
 	TargetedFeeAdjustment,
 };
 
@@ -49,10 +49,17 @@ impl Convert<u128, Balance> for CurrencyToVoteHandler {
 	fn convert(x: u128) -> Balance { x * Self::factor() }
 }
 
-/// Simply multiply by a coefficient denoted by the `Get` implementation.
-impl Convert<Weight, Balance> for WeightToFee {
-	fn convert(x: Weight) -> Balance {
-		Balance::from(x).saturating_mul(Self::get())
+// M is the coefficient in units of currency / weight
+pub struct LinearWeight<Multiplier>(Multiplier);
+
+impl<Multiplier> Convert<Weight, Balance> for LinearWeight<Multiplier>
+ 	where Multiplier: Get<u128> {
+
+	fn convert(w: Weight) -> Balance {
+		// substrate-node a weight of 10_000 (smallest non-zero weight) to be mapped to 10^7 units of
+		// fees, hence:
+		let multiplier = Multiplier::get();
+		Balance::from(w).saturating_mul(multiplier)
 	}
 }
 

--- a/node/runtime/src/impls.rs
+++ b/node/runtime/src/impls.rs
@@ -50,17 +50,17 @@ impl Convert<u128, Balance> for CurrencyToVoteHandler {
 }
 
 /// Convert from weight to balance via a simple coefficient multiplication
-/// The associated type M encapsulates a constant in units of balance per weight
-pub struct LinearWeight<M>(M);
+/// The associated type C encapsulates a constant in units of balance per weight
+pub struct LinearWeightToFee<C>(C);
 
-impl<M> Convert<Weight, Balance> for LinearWeight<M>
- 	where M: Get<Balance> {
+impl<C> Convert<Weight, Balance> for LinearWeightToFee<C>
+ 	where C: Get<Balance> {
 
 	fn convert(w: Weight) -> Balance {
 		// substrate-node a weight of 10_000 (smallest non-zero weight) to be mapped to 10^7 units of
 		// fees, hence:
-		let multiplier = M::get();
-		Balance::from(w).saturating_mul(multiplier)
+		let coefficient = C::get();
+		Balance::from(w).saturating_mul(coefficient)
 	}
 }
 

--- a/node/runtime/src/impls.rs
+++ b/node/runtime/src/impls.rs
@@ -51,7 +51,7 @@ impl Convert<u128, Balance> for CurrencyToVoteHandler {
 
 /// Convert from weight to balance via a simple coefficient multiplication
 /// The associated type C encapsulates a constant in units of balance per weight
-pub struct LinearWeightToFee<C>(C);
+pub struct LinearWeightToFee<C>(rstd::marker::PhantomData<C>);
 
 impl<C> Convert<Weight, Balance> for LinearWeightToFee<C>
  	where C: Get<Balance> {

--- a/node/runtime/src/impls.rs
+++ b/node/runtime/src/impls.rs
@@ -49,16 +49,17 @@ impl Convert<u128, Balance> for CurrencyToVoteHandler {
 	fn convert(x: u128) -> Balance { x * Self::factor() }
 }
 
-// M is the coefficient in units of currency / weight
-pub struct LinearWeight<Multiplier>(Multiplier);
+/// Convert from weight to balance via a simple coefficient multiplication
+/// The associated type M encapsulates a constant in units of balance per weight
+pub struct LinearWeight<M>(M);
 
-impl<Multiplier> Convert<Weight, Balance> for LinearWeight<Multiplier>
- 	where Multiplier: Get<u128> {
+impl<M> Convert<Weight, Balance> for LinearWeight<M>
+ 	where M: Get<Balance> {
 
 	fn convert(w: Weight) -> Balance {
 		// substrate-node a weight of 10_000 (smallest non-zero weight) to be mapped to 10^7 units of
 		// fees, hence:
-		let multiplier = Multiplier::get();
+		let multiplier = M::get();
 		Balance::from(w).saturating_mul(multiplier)
 	}
 }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -65,7 +65,7 @@ pub use staking::StakerStatus;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
-use impls::{CurrencyToVoteHandler, Author, LinearWeight};
+use impls::{CurrencyToVoteHandler, Author, LinearWeightToFee};
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -178,7 +178,7 @@ parameter_types! {
 	pub const TransactionBaseFee: Balance = 1 * CENTS;
 	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 	// setting this to zero will disable the weight fee.
-	pub const TransactionWeightFee: Balance = 1_000;
+	pub const WeightFeeCoefficient: Balance = 1_000;
 	// for a sane configuration, this should always be less than `AvailableBlockRatio`.
 	pub const TargetedFeeAdjustment: Perbill = Perbill::from_percent(25);
 }
@@ -188,7 +188,7 @@ impl transaction_payment::Trait for Runtime {
 	type OnTransactionPayment = DealWithFees;
 	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = LinearWeight<TransactionWeightFee>;
+	type WeightToFee = LinearWeightToFee<WeightFeeCoefficient>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment;
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -65,7 +65,7 @@ pub use staking::StakerStatus;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
 pub mod impls;
-use impls::{CurrencyToVoteHandler, Author};
+use impls::{CurrencyToVoteHandler, Author, LinearWeight};
 
 /// Constant values used within the runtime.
 pub mod constants;
@@ -178,7 +178,7 @@ parameter_types! {
 	pub const TransactionBaseFee: Balance = 1 * CENTS;
 	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 	// setting this to zero will disable the weight fee.
-	pub const WeightToFee: Balance = 1_000;
+	pub const TransactionWeightFee: Balance = 1_000;
 	// for a sane configuration, this should always be less than `AvailableBlockRatio`.
 	pub const TargetedFeeAdjustment: Perbill = Perbill::from_percent(25);
 }
@@ -188,7 +188,7 @@ impl transaction_payment::Trait for Runtime {
 	type OnTransactionPayment = DealWithFees;
 	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = WeightToFee;
+	type WeightToFee = LinearWeight<TransactionWeightFee>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment;
 }
 


### PR DESCRIPTION
Builds on top of https://github.com/paritytech/substrate/pull/3823 but has _both_ desirable properties:
* All constants declared in `parameter_types!` are used as associated types with `get`
* All transaction fee calculation constants are in one place

@kianenigma and I had both previously wanted to use an _instance_ of a struct to calculate weight fees because we could give it a field to represent the slope. But `transaction_payment::Trait` requires an associated _type_. Generating a type when you really want a constant is exactly what `parameter_types!` is for. The solution is to make the fee:weight ratio itself a type parameter for the struct as I've done here.