### PR TITLE
Explicitly declare decl_storage! getters as functions

### DIFF
--- a/node-template/runtime/src/template.rs
+++ b/node-template/runtime/src/template.rs
@@ -24,8 +24,8 @@ decl_storage! {
 	trait Store for Module<T: Trait> as TemplateModule {
 		// Just a dummy storage item.
 		// Here we are declaring a StorageValue, `Something` as a Option<u32>
-		// `get(something)` is the default getter which returns either the stored `u32` or `None` if nothing stored
-		Something get(something): Option<u32>;
+		// `get(fn something)` is the default getter which returns either the stored `u32` or `None` if nothing stored
+		Something get(fn something): Option<u32>;
 	}
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 180,
-	impl_version: 180,
+	spec_version: 181,
+	impl_version: 181,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -215,7 +215,7 @@ decl_storage! {
 		/// The number of units of assets held by any given account.
 		Balances: map (T::AssetId, T::AccountId) => T::Balance;
 		/// The next asset identifier up for grabs.
-		NextAssetId get(next_asset_id): T::AssetId;
+		NextAssetId get(fn next_asset_id): T::AssetId;
 		/// The total unit supply of an asset.
 		TotalSupply: map T::AssetId => T::Balance;
 	}

--- a/srml/aura/src/lib.rs
+++ b/srml/aura/src/lib.rs
@@ -148,10 +148,10 @@ pub trait Trait: timestamp::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Aura {
 		/// The last timestamp.
-		LastTimestamp get(last) build(|_| 0.into()): T::Moment;
+		LastTimestamp get(fn last) build(|_| 0.into()): T::Moment;
 
 		/// The current authorities
-		pub Authorities get(authorities): Vec<T::AuthorityId>;
+		pub Authorities get(fn authorities): Vec<T::AuthorityId>;
 	}
 	add_extra_genesis {
 		config(authorities): Vec<T::AuthorityId>;

--- a/srml/authority-discovery/src/lib.rs
+++ b/srml/authority-discovery/src/lib.rs
@@ -41,7 +41,7 @@ pub trait Trait: system::Trait + session::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as AuthorityDiscovery {
 		/// The current set of keys that may issue a heartbeat.
-		Keys get(keys): Vec<T::AuthorityId>;
+		Keys get(fn keys): Vec<T::AuthorityId>;
 	}
 	add_extra_genesis {
 		config(keys): Vec<T::AuthorityId>;

--- a/srml/babe/src/lib.rs
+++ b/srml/babe/src/lib.rs
@@ -180,17 +180,17 @@ type MaybeVrf = Option<[u8; 32 /* VRF_OUTPUT_LENGTH */]>;
 decl_storage! {
 	trait Store for Module<T: Trait> as Babe {
 		/// Current epoch index.
-		pub EpochIndex get(epoch_index): u64;
+		pub EpochIndex get(fn epoch_index): u64;
 
 		/// Current epoch authorities.
-		pub Authorities get(authorities): Vec<(AuthorityId, BabeAuthorityWeight)>;
+		pub Authorities get(fn authorities): Vec<(AuthorityId, BabeAuthorityWeight)>;
 
 		/// The slot at which the first epoch actually started. This is 0
 		/// until the first block of the chain.
-		pub GenesisSlot get(genesis_slot): u64;
+		pub GenesisSlot get(fn genesis_slot): u64;
 
 		/// Current slot number.
-		pub CurrentSlot get(current_slot): u64;
+		pub CurrentSlot get(fn current_slot): u64;
 
 		/// The epoch randomness for the *current* epoch.
 		///
@@ -205,7 +205,7 @@ decl_storage! {
 		// NOTE: the following fields don't use the constants to define the
 		// array size because the metadata API currently doesn't resolve the
 		// variable to its underlying value.
-		pub Randomness get(randomness): [u8; 32 /* RANDOMNESS_LENGTH */];
+		pub Randomness get(fn randomness): [u8; 32 /* RANDOMNESS_LENGTH */];
 
 		/// Next epoch randomness.
 		NextRandomness: [u8; 32 /* RANDOMNESS_LENGTH */];
@@ -224,7 +224,7 @@ decl_storage! {
 
 		/// Temporary value (cleared at block finalization) which is `Some`
 		/// if per-block initialization has already been called for current block.
-		Initialized get(initialized): Option<MaybeVrf>;
+		Initialized get(fn initialized): Option<MaybeVrf>;
 	}
 	add_extra_genesis {
 		config(authorities): Vec<(AuthorityId, BabeAuthorityWeight)>;

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -295,12 +295,12 @@ pub struct BalanceLock<Balance, BlockNumber> {
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Balances {
 		/// The total units issued in the system.
-		pub TotalIssuance get(total_issuance) build(|config: &GenesisConfig<T, I>| {
+		pub TotalIssuance get(fn total_issuance) build(|config: &GenesisConfig<T, I>| {
 			config.balances.iter().fold(Zero::zero(), |acc: T::Balance, &(_, n)| acc + n)
 		}): T::Balance;
 
 		/// Information regarding the vesting of a given account.
-		pub Vesting get(vesting) build(|config: &GenesisConfig<T, I>| {
+		pub Vesting get(fn vesting) build(|config: &GenesisConfig<T, I>| {
 			// Generate initial vesting configuration
 			// * who - Account which we are generating vesting configuration for
 			// * begin - Block when the account will start to vest
@@ -337,7 +337,7 @@ decl_storage! {
 		///
 		/// `system::AccountNonce` is also deleted if `ReservedBalance` is also zero (it also gets
 		/// collapsed to zero if it ever becomes less than `ExistentialDeposit`.
-		pub FreeBalance get(free_balance)
+		pub FreeBalance get(fn free_balance)
 			build(|config: &GenesisConfig<T, I>| config.balances.clone()):
 			map T::AccountId => T::Balance;
 
@@ -352,10 +352,10 @@ decl_storage! {
 		///
 		/// `system::AccountNonce` is also deleted if `FreeBalance` is also zero (it also gets
 		/// collapsed to zero if it ever becomes less than `ExistentialDeposit`.)
-		pub ReservedBalance get(reserved_balance): map T::AccountId => T::Balance;
+		pub ReservedBalance get(fn reserved_balance): map T::AccountId => T::Balance;
 
 		/// Any liquidity locks on some account balances.
-		pub Locks get(locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
+		pub Locks get(fn locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
 	}
 	add_extra_genesis {
 		config(balances): Vec<(T::AccountId, T::Balance)>;

--- a/srml/collective/src/lib.rs
+++ b/srml/collective/src/lib.rs
@@ -86,15 +86,15 @@ pub struct Votes<AccountId> {
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Collective {
 		/// The hashes of the active proposals.
-		pub Proposals get(proposals): Vec<T::Hash>;
+		pub Proposals get(fn proposals): Vec<T::Hash>;
 		/// Actual proposal for a given hash, if it's current.
-		pub ProposalOf get(proposal_of): map T::Hash => Option<<T as Trait<I>>::Proposal>;
+		pub ProposalOf get(fn proposal_of): map T::Hash => Option<<T as Trait<I>>::Proposal>;
 		/// Votes on a given proposal, if it is ongoing.
-		pub Voting get(voting): map T::Hash => Option<Votes<T::AccountId>>;
+		pub Voting get(fn voting): map T::Hash => Option<Votes<T::AccountId>>;
 		/// Proposals so far.
-		pub ProposalCount get(proposal_count): u32;
+		pub ProposalCount get(fn proposal_count): u32;
 		/// The current members of the collective. This is stored sorted (just by value).
-		pub Members get(members): Vec<T::AccountId>;
+		pub Members get(fn members): Vec<T::AccountId>;
 	}
 	add_extra_genesis {
 		config(phantom): rstd::marker::PhantomData<I>;

--- a/srml/contracts/src/lib.rs
+++ b/srml/contracts/src/lib.rs
@@ -838,9 +838,9 @@ decl_event! {
 decl_storage! {
 	trait Store for Module<T: Trait> as Contract {
 		/// Gas spent so far in this block.
-		GasSpent get(gas_spent): Gas;
+		GasSpent get(fn gas_spent): Gas;
 		/// Current cost schedule for contracts.
-		CurrentSchedule get(current_schedule) config(): Schedule = Schedule::default();
+		CurrentSchedule get(fn current_schedule) config(): Schedule = Schedule::default();
 		/// A mapping from an original code hash to the original code, untouched by instrumentation.
 		pub PristineCode: map CodeHash<T> => Option<Vec<u8>>;
 		/// A mapping between an original code hash and instrumented wasm code, ready for execution.
@@ -850,7 +850,7 @@ decl_storage! {
 		/// The code associated with a given account.
 		pub ContractInfoOf: map T::AccountId => Option<ContractInfo<T>>;
 		/// The price of one unit of gas.
-		GasPrice get(gas_price) config(): BalanceOf<T> = 1.into();
+		GasPrice get(fn gas_price) config(): BalanceOf<T> = 1.into();
 	}
 }
 

--- a/srml/democracy/src/lib.rs
+++ b/srml/democracy/src/lib.rs
@@ -259,38 +259,38 @@ impl<BlockNumber: Parameter, Proposal: Parameter> ReferendumInfo<BlockNumber, Pr
 decl_storage! {
 	trait Store for Module<T: Trait> as Democracy {
 		/// The number of (public) proposals that have been made so far.
-		pub PublicPropCount get(public_prop_count) build(|_| 0 as PropIndex) : PropIndex;
+		pub PublicPropCount get(fn public_prop_count) build(|_| 0 as PropIndex) : PropIndex;
 		/// The public proposals. Unsorted.
-		pub PublicProps get(public_props): Vec<(PropIndex, T::Proposal, T::AccountId)>;
+		pub PublicProps get(fn public_props): Vec<(PropIndex, T::Proposal, T::AccountId)>;
 		/// Those who have locked a deposit.
-		pub DepositOf get(deposit_of): map PropIndex => Option<(BalanceOf<T>, Vec<T::AccountId>)>;
+		pub DepositOf get(fn deposit_of): map PropIndex => Option<(BalanceOf<T>, Vec<T::AccountId>)>;
 
 		/// The next free referendum index, aka the number of referenda started so far.
-		pub ReferendumCount get(referendum_count) build(|_| 0 as ReferendumIndex): ReferendumIndex;
+		pub ReferendumCount get(fn referendum_count) build(|_| 0 as ReferendumIndex): ReferendumIndex;
 		/// The next referendum index that should be tallied.
-		pub NextTally get(next_tally) build(|_| 0 as ReferendumIndex): ReferendumIndex;
+		pub NextTally get(fn next_tally) build(|_| 0 as ReferendumIndex): ReferendumIndex;
 		/// Information concerning any given referendum.
-		pub ReferendumInfoOf get(referendum_info):
+		pub ReferendumInfoOf get(fn referendum_info):
 			map ReferendumIndex => Option<(ReferendumInfo<T::BlockNumber, T::Proposal>)>;
 		/// Queue of successful referenda to be dispatched.
-		pub DispatchQueue get(dispatch_queue):
+		pub DispatchQueue get(fn dispatch_queue):
 			map T::BlockNumber => Vec<Option<(T::Proposal, ReferendumIndex)>>;
 
 		/// Get the voters for the current proposal.
-		pub VotersFor get(voters_for): map ReferendumIndex => Vec<T::AccountId>;
+		pub VotersFor get(fn voters_for): map ReferendumIndex => Vec<T::AccountId>;
 
 		/// Get the vote in a given referendum of a particular voter. The result is meaningful only
 		/// if `voters_for` includes the voter when called with the referendum (you'll get the
 		/// default `Vote` value otherwise). If you don't want to check `voters_for`, then you can
 		/// also check for simple existence with `VoteOf::exists` first.
-		pub VoteOf get(vote_of): map (ReferendumIndex, T::AccountId) => Vote;
+		pub VoteOf get(fn vote_of): map (ReferendumIndex, T::AccountId) => Vote;
 
 		/// Who is able to vote for whom. Value is the fund-holding account, key is the
 		/// vote-transaction-sending account.
-		pub Proxy get(proxy): map T::AccountId => Option<T::AccountId>;
+		pub Proxy get(fn proxy): map T::AccountId => Option<T::AccountId>;
 
 		/// Get the account (and lock periods) to which another account is delegating vote.
-		pub Delegations get(delegations): linked_map T::AccountId => (T::AccountId, Conviction);
+		pub Delegations get(fn delegations): linked_map T::AccountId => (T::AccountId, Conviction);
 
 		/// True if the last referendum tabled was submitted externally. False if it was a public
 		/// proposal.
@@ -304,7 +304,7 @@ decl_storage! {
 
 		/// A record of who vetoed what. Maps proposal hash to a possible existent block number
 		/// (until when it may not be resubmitted) and who vetoed it.
-		pub Blacklist get(blacklist): map T::Hash => Option<(T::BlockNumber, Vec<T::AccountId>)>;
+		pub Blacklist get(fn blacklist): map T::Hash => Option<(T::BlockNumber, Vec<T::AccountId>)>;
 
 		/// Record of all proposals that have been subject to emergency cancellation.
 		pub Cancellations: map T::Hash => bool;

--- a/srml/elections-phragmen/src/lib.rs
+++ b/srml/elections-phragmen/src/lib.rs
@@ -132,29 +132,29 @@ decl_storage! {
 	trait Store for Module<T: Trait> as PhragmenElection {
 		// ---- parameters
 		/// Number of members to elect.
-		pub DesiredMembers get(desired_members) config(): u32;
+		pub DesiredMembers get(fn desired_members) config(): u32;
 		/// Number of runners_up to keep.
-		pub DesiredRunnersUp get(desired_runners_up) config(): u32;
+		pub DesiredRunnersUp get(fn desired_runners_up) config(): u32;
 		/// How long each seat is kept. This defines the next block number at which an election
 		/// round will happen.
-		pub TermDuration get(term_duration) config(): T::BlockNumber;
+		pub TermDuration get(fn term_duration) config(): T::BlockNumber;
 
 		// ---- State
 		/// The current elected membership. Sorted based on account id.
-		pub Members get(members) config(): Vec<T::AccountId>;
+		pub Members get(fn members) config(): Vec<T::AccountId>;
 		/// The current runners_up. Sorted based on low to high merit (worse to best runner).
-		pub RunnersUp get(runners_up): Vec<T::AccountId>;
+		pub RunnersUp get(fn runners_up): Vec<T::AccountId>;
 		/// The total number of vote rounds that have happened, excluding the upcoming one.
-		pub ElectionRounds get(election_rounds): u32 = Zero::zero();
+		pub ElectionRounds get(fn election_rounds): u32 = Zero::zero();
 
 		/// Votes of a particular voter, with the round index of the votes.
-		pub VotesOf get(votes_of): linked_map T::AccountId => Vec<T::AccountId>;
+		pub VotesOf get(fn votes_of): linked_map T::AccountId => Vec<T::AccountId>;
 		/// Locked stake of a voter.
-		pub StakeOf get(stake_of): map T::AccountId => BalanceOf<T>;
+		pub StakeOf get(fn stake_of): map T::AccountId => BalanceOf<T>;
 
 		/// The present candidate list. Sorted based on account id. A current member can never enter
 		/// this vector and is always implicitly assumed to be a candidate.
-		pub Candidates get(candidates): Vec<T::AccountId>;
+		pub Candidates get(fn candidates): Vec<T::AccountId>;
 	}
 }
 

--- a/srml/elections/src/lib.rs
+++ b/srml/elections/src/lib.rs
@@ -213,11 +213,11 @@ decl_storage! {
 		// ---- parameters
 
 		/// How long to give each top candidate to present themselves after the vote ends.
-		pub PresentationDuration get(presentation_duration) config(): T::BlockNumber;
+		pub PresentationDuration get(fn presentation_duration) config(): T::BlockNumber;
 		/// How long each position is active for.
-		pub TermDuration get(term_duration) config(): T::BlockNumber;
+		pub TermDuration get(fn term_duration) config(): T::BlockNumber;
 		/// Number of accounts that should constitute the collective.
-		pub DesiredSeats get(desired_seats) config(): u32;
+		pub DesiredSeats get(fn desired_seats) config(): u32;
 
 		// ---- permanent state (always relevant, changes only at the finalization of voting)
 
@@ -225,9 +225,9 @@ decl_storage! {
 		///  executive matters. The block number (second element in the tuple) is the block that
 		///  their position is active until (calculated by the sum of the block number when the
 		///  member was elected and their term duration).
-		pub Members get(members) config(): Vec<(T::AccountId, T::BlockNumber)>;
+		pub Members get(fn members) config(): Vec<(T::AccountId, T::BlockNumber)>;
 		/// The total number of vote rounds that have happened or are in progress.
-		pub VoteCount get(vote_index): VoteIndex;
+		pub VoteCount get(fn vote_index): VoteIndex;
 
 		// ---- persistent state (always relevant, changes constantly)
 
@@ -235,35 +235,35 @@ decl_storage! {
 		// bit-wise manner. In order to get a human-readable representation (`Vec<bool>`), use
 		// [`all_approvals_of`]. Furthermore, each vector of scalars is chunked with the cap of
 		// `APPROVAL_SET_SIZE`.
-		pub ApprovalsOf get(approvals_of): map (T::AccountId, SetIndex) => Vec<ApprovalFlag>;
+		pub ApprovalsOf get(fn approvals_of): map (T::AccountId, SetIndex) => Vec<ApprovalFlag>;
 		/// The vote index and list slot that the candidate `who` was registered or `None` if they
 		/// are not currently registered.
-		pub RegisterInfoOf get(candidate_reg_info): map T::AccountId => Option<(VoteIndex, u32)>;
+		pub RegisterInfoOf get(fn candidate_reg_info): map T::AccountId => Option<(VoteIndex, u32)>;
 		/// Basic information about a voter.
-		pub VoterInfoOf get(voter_info): map T::AccountId => Option<VoterInfo<BalanceOf<T>>>;
+		pub VoterInfoOf get(fn voter_info): map T::AccountId => Option<VoterInfo<BalanceOf<T>>>;
 		/// The present voter list (chunked and capped at [`VOTER_SET_SIZE`]).
-		pub Voters get(voters): map SetIndex => Vec<Option<T::AccountId>>;
+		pub Voters get(fn voters): map SetIndex => Vec<Option<T::AccountId>>;
 		/// the next free set to store a voter in. This will keep growing.
-		pub NextVoterSet get(next_nonfull_voter_set): SetIndex = 0;
+		pub NextVoterSet get(fn next_nonfull_voter_set): SetIndex = 0;
 		/// Current number of Voters.
-		pub VoterCount get(voter_count): SetIndex = 0;
+		pub VoterCount get(fn voter_count): SetIndex = 0;
 		/// The present candidate list.
-		pub Candidates get(candidates): Vec<T::AccountId>; // has holes
+		pub Candidates get(fn candidates): Vec<T::AccountId>; // has holes
 		/// Current number of active candidates
-		pub CandidateCount get(candidate_count): u32;
+		pub CandidateCount get(fn candidate_count): u32;
 
 		// ---- temporary state (only relevant during finalization/presentation)
 
 		/// The accounts holding the seats that will become free on the next tally.
-		pub NextFinalize get(next_finalize): Option<(T::BlockNumber, u32, Vec<T::AccountId>)>;
+		pub NextFinalize get(fn next_finalize): Option<(T::BlockNumber, u32, Vec<T::AccountId>)>;
 		/// Get the leaderboard if we're in the presentation phase. The first element is the weight
 		/// of each entry; It may be the direct summed approval stakes, or a weighted version of it.
 		/// Sorted from low to high.
-		pub Leaderboard get(leaderboard): Option<Vec<(BalanceOf<T>, T::AccountId)> >;
+		pub Leaderboard get(fn leaderboard): Option<Vec<(BalanceOf<T>, T::AccountId)> >;
 
 		/// Who is able to vote for whom. Value is the fund-holding account, key is the
 		/// vote-transaction-sending account.
-		pub Proxy get(proxy): map T::AccountId => Option<T::AccountId>;
+		pub Proxy get(fn proxy): map T::AccountId => Option<T::AccountId>;
 	}
 }
 

--- a/srml/example/src/lib.rs
+++ b/srml/example/src/lib.rs
@@ -318,7 +318,7 @@ decl_storage! {
 	// keep things around between blocks.
 	trait Store for Module<T: Trait> as Example {
 		// Any storage declarations of the form:
-		//   `pub? Name get(getter_name)? [config()|config(myname)] [build(|_| {...})] : <type> (= <new_default_value>)?;`
+		//   `pub? Name get(fn getter_name)? [config()|config(myname)] [build(|_| {...})] : <type> (= <new_default_value>)?;`
 		// where `<type>` is either:
 		//   - `Type` (a basic value item); or
 		//   - `map KeyType => ValueType` (a map item).
@@ -331,7 +331,7 @@ decl_storage! {
 		//   - `Foo::put(1); Foo::get()` returns `1`;
 		//   - `Foo::kill(); Foo::get()` returns `0` (u32::default()).
 		// e.g. Foo: u32;
-		// e.g. pub Bar get(bar): map T::AccountId => Vec<(T::Balance, u64)>;
+		// e.g. pub Bar get(fn bar): map T::AccountId => Vec<(T::Balance, u64)>;
 		//
 		// For basic value items, you'll get a type which implements
 		// `support::StorageValue`. For map items, you'll get a type which
@@ -340,13 +340,13 @@ decl_storage! {
 		// If they have a getter (`get(getter_name)`), then your module will come
 		// equipped with `fn getter_name() -> Type` for basic value items or
 		// `fn getter_name(key: KeyType) -> ValueType` for map items.
-		Dummy get(dummy) config(): Option<T::Balance>;
+		Dummy get(fn dummy) config(): Option<T::Balance>;
 
 		// A map that has enumerable entries.
-		Bar get(bar) config(): linked_map T::AccountId => T::Balance;
+		Bar get(fn bar) config(): linked_map T::AccountId => T::Balance;
 
 		// this one uses the default, we'll demonstrate the usage of 'mutate' API.
-		Foo get(foo) config(): T::Balance;
+		Foo get(fn foo) config(): T::Balance;
 	}
 }
 

--- a/srml/finality-tracker/src/lib.rs
+++ b/srml/finality-tracker/src/lib.rs
@@ -96,17 +96,17 @@ pub trait Trait: SystemTrait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Timestamp {
 		/// Recent hints.
-		RecentHints get(recent_hints) build(|_| vec![T::BlockNumber::zero()]): Vec<T::BlockNumber>;
+		RecentHints get(fn recent_hints) build(|_| vec![T::BlockNumber::zero()]): Vec<T::BlockNumber>;
 		/// Ordered recent hints.
-		OrderedHints get(ordered_hints) build(|_| vec![T::BlockNumber::zero()]): Vec<T::BlockNumber>;
+		OrderedHints get(fn ordered_hints) build(|_| vec![T::BlockNumber::zero()]): Vec<T::BlockNumber>;
 		/// The median.
-		Median get(median) build(|_| T::BlockNumber::zero()): T::BlockNumber;
+		Median get(fn median) build(|_| T::BlockNumber::zero()): T::BlockNumber;
 
 		/// Final hint to apply in the block. `None` means "same as parent".
 		Update: Option<T::BlockNumber>;
 
 		// when initialized through config this is set in the beginning.
-		Initialized get(initialized) build(|_| false): bool;
+		Initialized get(fn initialized) build(|_| false): bool;
 	}
 }
 

--- a/srml/generic-asset/src/lib.rs
+++ b/srml/generic-asset/src/lib.rs
@@ -447,7 +447,7 @@ pub struct BalanceLock<Balance, BlockNumber> {
 decl_storage! {
 	trait Store for Module<T: Trait> as GenericAsset {
 		/// Total issuance of a given asset.
-		pub TotalIssuance get(total_issuance) build(|config: &GenesisConfig<T>| {
+		pub TotalIssuance get(fn total_issuance) build(|config: &GenesisConfig<T>| {
 			let issuance = config.initial_balance * (config.endowed_accounts.len() as u32).into();
 			config.assets.iter().map(|id| (id.clone(), issuance)).collect::<Vec<_>>()
 		}): map T::AssetId => T::Balance;
@@ -459,19 +459,19 @@ decl_storage! {
 		pub ReservedBalance: double_map T::AssetId, twox_128(T::AccountId) => T::Balance;
 
 		/// Next available ID for user-created asset.
-		pub NextAssetId get(next_asset_id) config(): T::AssetId;
+		pub NextAssetId get(fn next_asset_id) config(): T::AssetId;
 
 		/// Permission options for a given asset.
-		pub Permissions get(get_permission): map T::AssetId => PermissionVersions<T::AccountId>;
+		pub Permissions get(fn get_permission): map T::AssetId => PermissionVersions<T::AccountId>;
 
 		/// Any liquidity locks on some account balances.
-		pub Locks get(locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
+		pub Locks get(fn locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
 
 		/// The identity of the asset which is the one that is designated for the chain's staking system.
-		pub StakingAssetId get(staking_asset_id) config(): T::AssetId;
+		pub StakingAssetId get(fn staking_asset_id) config(): T::AssetId;
 
 		/// The identity of the asset which is the one that is designated for paying the chain's transaction fee.
-		pub SpendingAssetId get(spending_asset_id) config(): T::AssetId;
+		pub SpendingAssetId get(fn spending_asset_id) config(): T::AssetId;
 	}
 	add_extra_genesis {
 		config(assets): Vec<T::AssetId>;

--- a/srml/grandpa/src/lib.rs
+++ b/srml/grandpa/src/lib.rs
@@ -138,26 +138,26 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as GrandpaFinality {
 		/// The current authority set.
-		Authorities get(authorities): Vec<(AuthorityId, AuthorityWeight)>;
+		Authorities get(fn authorities): Vec<(AuthorityId, AuthorityWeight)>;
 
 		/// State of the current authority set.
-		State get(state): StoredState<T::BlockNumber> = StoredState::Live;
+		State get(fn state): StoredState<T::BlockNumber> = StoredState::Live;
 
 		/// Pending change: (signaled at, scheduled change).
 		PendingChange: Option<StoredPendingChange<T::BlockNumber>>;
 
 		/// next block number where we can force a change.
-		NextForced get(next_forced): Option<T::BlockNumber>;
+		NextForced get(fn next_forced): Option<T::BlockNumber>;
 
 		/// `true` if we are currently stalled.
-		Stalled get(stalled): Option<(T::BlockNumber, T::BlockNumber)>;
+		Stalled get(fn stalled): Option<(T::BlockNumber, T::BlockNumber)>;
 
 		/// The number of changes (both in terms of keys and underlying economic responsibilities)
 		/// in the "set" of Grandpa validators from genesis.
-		CurrentSetId get(current_set_id) build(|_| fg_primitives::SetId::default()): SetId;
+		CurrentSetId get(fn current_set_id) build(|_| fg_primitives::SetId::default()): SetId;
 
 		/// A mapping from grandpa set ID to the index of the *most recent* session for which its members were responsible.
-		SetIdSession get(session_for_set): map SetId => Option<SessionIndex>;
+		SetIdSession get(fn session_for_set): map SetId => Option<SessionIndex>;
 	}
 	add_extra_genesis {
 		config(authorities): Vec<(AuthorityId, AuthorityWeight)>;

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -221,14 +221,14 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as ImOnline {
 		/// The block number when we should gossip.
-		GossipAt get(gossip_at): T::BlockNumber;
+		GossipAt get(fn gossip_at): T::BlockNumber;
 
 		/// The current set of keys that may issue a heartbeat.
-		Keys get(keys): Vec<T::AuthorityId>;
+		Keys get(fn keys): Vec<T::AuthorityId>;
 
 		/// For each session index we keep a mapping of `AuthorityId`
 		/// to `offchain::OpaqueNetworkState`.
-		ReceivedHeartbeats get(received_heartbeats): double_map SessionIndex,
+		ReceivedHeartbeats get(fn received_heartbeats): double_map SessionIndex,
 			blake2_256(AuthIndex) => Vec<u8>;
 	}
 	add_extra_genesis {

--- a/srml/indices/src/lib.rs
+++ b/srml/indices/src/lib.rs
@@ -93,12 +93,12 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as Indices {
 		/// The next free enumeration set.
-		pub NextEnumSet get(next_enum_set) build(|config: &GenesisConfig<T>| {
+		pub NextEnumSet get(fn next_enum_set) build(|config: &GenesisConfig<T>| {
 			(config.ids.len() as u32 / ENUM_SET_SIZE).into()
 		}): T::AccountIndex;
 
 		/// The enumeration sets.
-		pub EnumSet get(enum_set) build(|config: &GenesisConfig<T>| {
+		pub EnumSet get(fn enum_set) build(|config: &GenesisConfig<T>| {
 			(0..((config.ids.len() as u32) + ENUM_SET_SIZE - 1) / ENUM_SET_SIZE)
 				.map(|i| (
 					i.into(),

--- a/srml/membership/src/lib.rs
+++ b/srml/membership/src/lib.rs
@@ -57,7 +57,7 @@ pub trait Trait<I=DefaultInstance>: system::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Membership {
 		/// The current membership, stored as an ordered Vec.
-		Members get(members): Vec<T::AccountId>;
+		Members get(fn members): Vec<T::AccountId>;
 	}
 	add_extra_genesis {
 		config(members): Vec<T::AccountId>;

--- a/srml/offences/src/lib.rs
+++ b/srml/offences/src/lib.rs
@@ -59,7 +59,7 @@ pub trait Trait: system::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Offences {
 		/// The primary structure that holds all offence records keyed by report identifiers.
-		Reports get(reports): map ReportIdOf<T> => Option<OffenceDetails<T::AccountId, T::IdentificationTuple>>;
+		Reports get(fn reports): map ReportIdOf<T> => Option<OffenceDetails<T::AccountId, T::IdentificationTuple>>;
 
 		/// A vector of reports of the same kind that happened at the same time slot.
 		ConcurrentReportsIndex: double_map Kind, blake2_256(OpaqueTimeSlot) => Vec<ReportIdOf<T>>;

--- a/srml/randomness-collective-flip/src/lib.rs
+++ b/srml/randomness-collective-flip/src/lib.rs
@@ -87,7 +87,7 @@ decl_storage! {
 		/// Series of block headers from the last 81 blocks that acts as random seed material. This
 		/// is arranged as a ring buffer with `block_number % 81` being the index into the `Vec` of
 		/// the oldest hash.
-		RandomMaterial get(random_material): Vec<T::Hash>;
+		RandomMaterial get(fn random_material): Vec<T::Hash>;
 	}
 }
 

--- a/srml/scored-pool/src/lib.rs
+++ b/srml/scored-pool/src/lib.rs
@@ -154,20 +154,20 @@ decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as ScoredPool {
 		/// The current pool of candidates, stored as an ordered Vec
 		/// (ordered descending by score, `None` last, highest first).
-		Pool get(pool) config(): PoolT<T, I>;
+		Pool get(fn pool) config(): PoolT<T, I>;
 
 		/// A Map of the candidates. The information in this Map is redundant
 		/// to the information in the `Pool`. But the Map enables us to easily
 		/// check if a candidate is already in the pool, without having to
 		/// iterate over the entire pool (the `Pool` is not sorted by
 		/// `T::AccountId`, but by `T::Score` instead).
-		CandidateExists get(candidate_exists): map T::AccountId => bool;
+		CandidateExists get(fn candidate_exists): map T::AccountId => bool;
 
 		/// The current membership, stored as an ordered Vec.
-		Members get(members): Vec<T::AccountId>;
+		Members get(fn members): Vec<T::AccountId>;
 
 		/// Size of the `Members` set.
-		MemberCount get(member_count) config(): u32;
+		MemberCount get(fn member_count) config(): u32;
 	}
 	add_extra_genesis {
 		config(members): Vec<T::AccountId>;

--- a/srml/session/src/historical.rs
+++ b/srml/session/src/historical.rs
@@ -56,9 +56,9 @@ pub trait Trait: super::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Session {
 		/// Mapping from historical session indices to session-data root hash and validator count.
-		HistoricalSessions get(historical_root): map SessionIndex => Option<(T::Hash, ValidatorCount)>;
+		HistoricalSessions get(fn historical_root): map SessionIndex => Option<(T::Hash, ValidatorCount)>;
 		/// Queued full identifications for queued sessions whose validators have become obsolete.
-		CachedObsolete get(cached_obsolete): map SessionIndex
+		CachedObsolete get(fn cached_obsolete): map SessionIndex
 			=> Option<Vec<(T::ValidatorId, T::FullIdentification)>>;
 		/// The range of historical sessions we store. [first, last)
 		StoredRange: Option<(SessionIndex, SessionIndex)>;

--- a/srml/session/src/lib.rs
+++ b/srml/session/src/lib.rs
@@ -349,10 +349,10 @@ const DEDUP_KEY_PREFIX: &[u8] = b":session:keys";
 decl_storage! {
 	trait Store for Module<T: Trait> as Session {
 		/// The current set of validators.
-		Validators get(validators): Vec<T::ValidatorId>;
+		Validators get(fn validators): Vec<T::ValidatorId>;
 
 		/// Current index of the session.
-		CurrentIndex get(current_index): SessionIndex;
+		CurrentIndex get(fn current_index): SessionIndex;
 
 		/// True if the underlying economic identities or weighting behind the validators
 		/// has changed in the queued validator set.
@@ -360,12 +360,12 @@ decl_storage! {
 
 		/// The queued keys for the next session. When the next session begins, these keys
 		/// will be used to determine the validator's session keys.
-		QueuedKeys get(queued_keys): Vec<(T::ValidatorId, T::Keys)>;
+		QueuedKeys get(fn queued_keys): Vec<(T::ValidatorId, T::Keys)>;
 
 		/// Indices of disabled validators.
 		///
 		/// The set is cleared when `on_session_ending` returns a new set of identities.
-		DisabledValidators get(disabled_validators): Vec<u32>;
+		DisabledValidators get(fn disabled_validators): Vec<u32>;
 
 		/// The next session keys for a validator.
 		///

--- a/srml/staking/src/lib.rs
+++ b/srml/staking/src/lib.rs
@@ -551,72 +551,72 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Staking {
 
 		/// The ideal number of staking participants.
-		pub ValidatorCount get(validator_count) config(): u32;
+		pub ValidatorCount get(fn validator_count) config(): u32;
 		/// Minimum number of staking participants before emergency conditions are imposed.
-		pub MinimumValidatorCount get(minimum_validator_count) config():
+		pub MinimumValidatorCount get(fn minimum_validator_count) config():
 			u32 = DEFAULT_MINIMUM_VALIDATOR_COUNT;
 
 		/// Any validators that may never be slashed or forcibly kicked. It's a Vec since they're
 		/// easy to initialize and the performance hit is minimal (we expect no more than four
 		/// invulnerables) and restricted to testnets.
-		pub Invulnerables get(invulnerables) config(): Vec<T::AccountId>;
+		pub Invulnerables get(fn invulnerables) config(): Vec<T::AccountId>;
 
 		/// Map from all locked "stash" accounts to the controller account.
-		pub Bonded get(bonded): map T::AccountId => Option<T::AccountId>;
+		pub Bonded get(fn bonded): map T::AccountId => Option<T::AccountId>;
 		/// Map from all (unlocked) "controller" accounts to the info regarding the staking.
-		pub Ledger get(ledger):
+		pub Ledger get(fn ledger):
 			map T::AccountId => Option<StakingLedger<T::AccountId, BalanceOf<T>>>;
 
 		/// Where the reward payment should be made. Keyed by stash.
-		pub Payee get(payee): map T::AccountId => RewardDestination;
+		pub Payee get(fn payee): map T::AccountId => RewardDestination;
 
 		/// The map from (wannabe) validator stash key to the preferences of that validator.
-		pub Validators get(validators): linked_map T::AccountId => ValidatorPrefs<BalanceOf<T>>;
+		pub Validators get(fn validators): linked_map T::AccountId => ValidatorPrefs<BalanceOf<T>>;
 
 		/// The map from nominator stash key to the set of stash keys of all validators to nominate.
-		pub Nominators get(nominators): linked_map T::AccountId => Vec<T::AccountId>;
+		pub Nominators get(fn nominators): linked_map T::AccountId => Vec<T::AccountId>;
 
 		/// Nominators for a particular account that is in action right now. You can't iterate
 		/// through validators here, but you can find them in the Session module.
 		///
 		/// This is keyed by the stash account.
-		pub Stakers get(stakers): map T::AccountId => Exposure<T::AccountId, BalanceOf<T>>;
+		pub Stakers get(fn stakers): map T::AccountId => Exposure<T::AccountId, BalanceOf<T>>;
 
 		/// The currently elected validator set keyed by stash account ID.
-		pub CurrentElected get(current_elected): Vec<T::AccountId>;
+		pub CurrentElected get(fn current_elected): Vec<T::AccountId>;
 
 		/// The current era index.
-		pub CurrentEra get(current_era) config(): EraIndex;
+		pub CurrentEra get(fn current_era) config(): EraIndex;
 
 		/// The start of the current era.
-		pub CurrentEraStart get(current_era_start): MomentOf<T>;
+		pub CurrentEraStart get(fn current_era_start): MomentOf<T>;
 
 		/// The session index at which the current era started.
-		pub CurrentEraStartSessionIndex get(current_era_start_session_index): SessionIndex;
+		pub CurrentEraStartSessionIndex get(fn current_era_start_session_index): SessionIndex;
 
 		/// Rewards for the current era. Using indices of current elected set.
-		CurrentEraPointsEarned get(current_era_reward): EraPoints;
+		CurrentEraPointsEarned get(fn current_era_reward): EraPoints;
 
 		/// The amount of balance actively at stake for each validator slot, currently.
 		///
 		/// This is used to derive rewards and punishments.
-		pub SlotStake get(slot_stake) build(|config: &GenesisConfig<T>| {
+		pub SlotStake get(fn slot_stake) build(|config: &GenesisConfig<T>| {
 			config.stakers.iter().map(|&(_, _, value, _)| value).min().unwrap_or_default()
 		}): BalanceOf<T>;
 
 		/// True if the next session change will be a new era regardless of index.
-		pub ForceEra get(force_era) config(): Forcing;
+		pub ForceEra get(fn force_era) config(): Forcing;
 
 		/// The percentage of the slash that is distributed to reporters.
 		///
 		/// The rest of the slashed value is handled by the `Slash`.
-		pub SlashRewardFraction get(slash_reward_fraction) config(): Perbill;
+		pub SlashRewardFraction get(fn slash_reward_fraction) config(): Perbill;
 
 		/// A mapping from still-bonded eras to the first session index of that era.
 		BondedEras: Vec<(EraIndex, SessionIndex)>;
 
 		/// All slashes that have occurred in a given era.
-		EraSlashJournal get(era_slash_journal):
+		EraSlashJournal get(fn era_slash_journal):
 			map EraIndex => Vec<SlashJournalEntry<T::AccountId, BalanceOf<T>>>;
 	}
 	add_extra_genesis {

--- a/srml/sudo/src/lib.rs
+++ b/srml/sudo/src/lib.rs
@@ -200,6 +200,6 @@ decl_event!(
 decl_storage! {
 	trait Store for Module<T: Trait> as Sudo {
 		/// The `AccountId` of the sudo key.
-		Key get(key) config(): T::AccountId;
+		Key get(fn key) config(): T::AccountId;
 	}
 }

--- a/srml/support/procedural/src/lib.rs
+++ b/srml/support/procedural/src/lib.rs
@@ -33,7 +33,7 @@ use proc_macro::TokenStream;
 /// ```nocompile
 /// decl_storage! {
 /// 	trait Store for Module<T: Trait> as Example {
-/// 		Foo get(foo) config(): u32=12;
+/// 		Foo get(fn foo) config(): u32=12;
 /// 		Bar: map u32 => u32;
 /// 		pub Zed build(|config| vec![(0, 0)]): linked_map u32 => u32;
 /// 	}
@@ -120,7 +120,7 @@ use proc_macro::TokenStream;
 ///
 /// Basic storage can be extended as such:
 ///
-/// `#vis #name get(#getter) config(#field_name) build(#closure): #type = #default;`
+/// `#vis #name get(fn #getter) config(#field_name) build(#closure): #type = #default;`
 ///
 /// * `#vis`: Set the visibility of the structure. `pub` or nothing.
 /// * `#name`: Name of the storage item, used as a prefix in storage.

--- a/srml/support/procedural/src/lib.rs
+++ b/srml/support/procedural/src/lib.rs
@@ -124,7 +124,7 @@ use proc_macro::TokenStream;
 ///
 /// * `#vis`: Set the visibility of the structure. `pub` or nothing.
 /// * `#name`: Name of the storage item, used as a prefix in storage.
-/// * [optional] `get(#getter)`: Implements the function #getter to `Module`.
+/// * [optional] `get(fn #getter)`: Implements the function #getter to `Module`.
 /// * [optional] `config(#field_name)`: `field_name` is optional if get is set.
 /// Will include the item in `GenesisConfig`.
 /// * [optional] `build(#closure)`: Closure called with storage overlays.

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -518,6 +518,15 @@ mod tests {
 					documentation: DecodeDifferent::Encode(&[]),
 				},
 				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GetterNoFnKeyword"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGetterNoFnKeyword(PhantomData::<Test>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
 					name: DecodeDifferent::Encode("DataDM"),
 					modifier: StorageEntryModifier::Default,
 					ty: StorageEntryType::DoubleMap{

--- a/srml/support/src/lib.rs
+++ b/srml/support/src/lib.rs
@@ -260,10 +260,11 @@ mod tests {
 
 	decl_storage! {
 		trait Store for Module<T: Trait> as Example {
-			pub Data get(data) build(|_| vec![(15u32, 42u64)]): linked_map hasher(twox_64_concat) u32 => u64;
+			pub Data get(fn data) build(|_| vec![(15u32, 42u64)]): linked_map hasher(twox_64_concat) u32 => u64;
 			pub OptionLinkedMap: linked_map u32 => Option<u32>;
-			pub GenericData get(generic_data): linked_map hasher(twox_128) T::BlockNumber => T::BlockNumber;
-			pub GenericData2 get(generic_data2): linked_map T::BlockNumber => Option<T::BlockNumber>;
+			pub GenericData get(fn generic_data): linked_map hasher(twox_128) T::BlockNumber => T::BlockNumber;
+			pub GenericData2 get(fn generic_data2): linked_map T::BlockNumber => Option<T::BlockNumber>;
+			pub GetterNoFnKeyword get(no_fn): Option<u32>;
 
 			pub DataDM config(test_config) build(|_| vec![(15u32, 16u32, 42u64)]):
 				double_map hasher(twox_64_concat) u32, blake2_256(u32) => u64;

--- a/srml/support/src/storage/storage_items.rs
+++ b/srml/support/src/storage/storage_items.rs
@@ -307,15 +307,15 @@ mod tests {
 
 			// getters: pub / $default
 			// we need at least one type which uses T, otherwise GenesisConfig will complain.
-			GETU32 get(u32_getter): T::Origin;
-			pub PUBGETU32 get(pub_u32_getter) build(|config: &GenesisConfig| config.u32_getter_with_config): u32;
-			GETU32WITHCONFIG get(u32_getter_with_config) config(): u32;
-			pub PUBGETU32WITHCONFIG get(pub_u32_getter_with_config) config(): u32;
-			GETU32MYDEF get(u32_getter_mydef): Option<u32>;
-			pub PUBGETU32MYDEF get(pub_u32_getter_mydef) config(): u32 = 3;
-			GETU32WITHCONFIGMYDEF get(u32_getter_with_config_mydef) config(): u32 = 2;
-			pub PUBGETU32WITHCONFIGMYDEF get(pub_u32_getter_with_config_mydef) config(): u32 = 1;
-			PUBGETU32WITHCONFIGMYDEFOPT get(pub_u32_getter_with_config_mydef_opt) config(): Option<u32>;
+			GETU32 get(fn u32_getter): T::Origin;
+			pub PUBGETU32 get(fn pub_u32_getter) build(|config: &GenesisConfig| config.u32_getter_with_config): u32;
+			GETU32WITHCONFIG get(fn u32_getter_with_config) config(): u32;
+			pub PUBGETU32WITHCONFIG get(fn pub_u32_getter_with_config) config(): u32;
+			GETU32MYDEF get(fn u32_getter_mydef): Option<u32>;
+			pub PUBGETU32MYDEF get(fn pub_u32_getter_mydef) config(): u32 = 3;
+			GETU32WITHCONFIGMYDEF get(fn u32_getter_with_config_mydef) config(): u32 = 2;
+			pub PUBGETU32WITHCONFIGMYDEF get(fn pub_u32_getter_with_config_mydef) config(): u32 = 1;
+			PUBGETU32WITHCONFIGMYDEFOPT get(fn pub_u32_getter_with_config_mydef_opt) config(): Option<u32>;
 
 			// map non-getters: pub / $default
 			MAPU32 : map u32 => Option<String>;
@@ -324,17 +324,17 @@ mod tests {
 			pub PUBMAPU32MYDEF : map u32 => Option<String>;
 
 			// map getters: pub / $default
-			GETMAPU32 get(map_u32_getter): map u32 => String;
-			pub PUBGETMAPU32 get(pub_map_u32_getter): map u32 => String;
+			GETMAPU32 get(fn map_u32_getter): map u32 => String;
+			pub PUBGETMAPU32 get(fn pub_map_u32_getter): map u32 => String;
 
-			GETMAPU32MYDEF get(map_u32_getter_mydef): map u32 => String = "map".into();
-			pub PUBGETMAPU32MYDEF get(pub_map_u32_getter_mydef): map u32 => String = "pubmap".into();
+			GETMAPU32MYDEF get(fn map_u32_getter_mydef): map u32 => String = "map".into();
+			pub PUBGETMAPU32MYDEF get(fn pub_map_u32_getter_mydef): map u32 => String = "pubmap".into();
 
 			// linked map
 			LINKEDMAPU32 : linked_map u32 => Option<String>;
 			pub PUBLINKEDMAPU32MYDEF : linked_map u32 => Option<String>;
-			GETLINKEDMAPU32 get(linked_map_u32_getter): linked_map u32 => String;
-			pub PUBGETLINKEDMAPU32MYDEF get(pub_linked_map_u32_getter_mydef): linked_map u32 => String = "pubmap".into();
+			GETLINKEDMAPU32 get(fn linked_map_u32_getter): linked_map u32 => String;
+			pub PUBGETLINKEDMAPU32MYDEF get(fn pub_linked_map_u32_getter_mydef): linked_map u32 => String = "pubmap".into();
 
 			COMPLEXTYPE1: ::std::vec::Vec<<T as Trait>::Origin>;
 			COMPLEXTYPE2: (Vec<Vec<(u16,Box<(  )>)>>, u32);
@@ -741,7 +741,7 @@ mod test3 {
 	}
 	crate::decl_storage! {
 		trait Store for Module<T: Trait> as Test {
-			Foo get(foo) config(initial_foo): u32;
+			Foo get(fn foo) config(initial_foo): u32;
 		}
 	}
 

--- a/srml/support/test/tests/final_keys.rs
+++ b/srml/support/test/tests/final_keys.rs
@@ -44,8 +44,8 @@ mod no_instance {
 			pub DoubleMap: double_map u32, blake2_256(u32) => u32;
 			pub DoubleMap2: double_map hasher(twox_128) u32, blake2_128(u32) => u32;
 
-			pub TestGenericValue get(test_generic_value) config(): Option<T::BlockNumber>;
-			pub TestGenericDoubleMap get(foo2) config(test_generic_double_map):
+			pub TestGenericValue get(fn test_generic_value) config(): Option<T::BlockNumber>;
+			pub TestGenericDoubleMap get(fn foo2) config(test_generic_double_map):
 				double_map u32, blake2_256(T::BlockNumber) => Option<u32>;
 		}
 	}
@@ -74,8 +74,8 @@ mod instance {
 			pub DoubleMap: double_map u32, blake2_256(u32) => u32;
 			pub DoubleMap2: double_map hasher(twox_128) u32, blake2_128(u32) => u32;
 
-			pub TestGenericValue get(test_generic_value) config(): Option<T::BlockNumber>;
-			pub TestGenericDoubleMap get(foo2) config(test_generic_double_map):
+			pub TestGenericValue get(fn test_generic_value) config(): Option<T::BlockNumber>;
+			pub TestGenericDoubleMap get(fn foo2) config(test_generic_double_map):
 				double_map u32, blake2_256(T::BlockNumber) => Option<u32>;
 		}
 		add_extra_genesis {

--- a/srml/support/test/tests/issue2219.rs
+++ b/srml/support/test/tests/issue2219.rs
@@ -102,7 +102,7 @@ mod module {
 	support::decl_storage! {
 		trait Store for Module<T: Trait> as Actors {
 			/// requirements to enter and maintain status in roles
-			pub Parameters get(parameters) build(|config: &GenesisConfig| {
+			pub Parameters get(fn parameters) build(|config: &GenesisConfig| {
 				if config.enable_storage_role {
 					let storage_params: RoleParameters<T> = Default::default();
 					vec![(Role::Storage, storage_params)]
@@ -112,7 +112,7 @@ mod module {
 			}): map Role => Option<RoleParameters<T>>;
 
 			/// the roles members can enter into
-			pub AvailableRoles get(available_roles) build(|config: &GenesisConfig| {
+			pub AvailableRoles get(fn available_roles) build(|config: &GenesisConfig| {
 				if config.enable_storage_role {
 					vec![(Role::Storage)]
 				} else {
@@ -121,13 +121,13 @@ mod module {
 			}): Vec<Role>;
 
 			/// Actors list
-			pub ActorAccountIds get(actor_account_ids) : Vec<T::AccountId>;
+			pub ActorAccountIds get(fn actor_account_ids) : Vec<T::AccountId>;
 
 			/// actor accounts associated with a role
-			pub AccountIdsByRole get(account_ids_by_role) : map Role => Vec<T::AccountId>;
+			pub AccountIdsByRole get(fn account_ids_by_role) : map Role => Vec<T::AccountId>;
 
 			/// tokens locked until given block number
-			pub Bondage get(bondage) : map T::AccountId => T::BlockNumber;
+			pub Bondage get(fn bondage) : map T::AccountId => T::BlockNumber;
 
 			/// First step before enter a role is registering intent with a new account/key.
 			/// This is done by sending a role_entry_request() from the new account.
@@ -135,10 +135,10 @@ mod module {
 			/// The account making the request will be bonded and must have
 			/// sufficient balance to cover the minimum stake for the role.
 			/// Bonding only occurs after successful entry into a role.
-			pub RoleEntryRequests get(role_entry_requests) : Requests<T>;
+			pub RoleEntryRequests get(fn role_entry_requests) : Requests<T>;
 
 			/// Entry request expires after this number of blocks
-			pub RequestLifeTime get(request_life_time) config(request_life_time) : u64 = 0;
+			pub RequestLifeTime get(fn request_life_time) config(request_life_time) : u64 = 0;
 		}
 		add_extra_genesis {
 			config(enable_storage_role): bool;

--- a/srml/system/src/lib.rs
+++ b/srml/system/src/lib.rs
@@ -366,7 +366,7 @@ type EventIndex = u32;
 decl_storage! {
 	trait Store for Module<T: Trait> as System {
 		/// Extrinsics nonce for accounts.
-		pub AccountNonce get(account_nonce): map T::AccountId => T::Index;
+		pub AccountNonce get(fn account_nonce): map T::AccountId => T::Index;
 		/// Total extrinsics count for the current block.
 		ExtrinsicCount: Option<u32>;
 		/// Total weight for all extrinsics put together, for the current block.
@@ -374,21 +374,21 @@ decl_storage! {
 		/// Total length (in bytes) for all extrinsics put together, for the current block.
 		AllExtrinsicsLen: Option<u32>;
 		/// Map of block numbers to block hashes.
-		pub BlockHash get(block_hash) build(|_| vec![(T::BlockNumber::zero(), hash69())]): map T::BlockNumber => T::Hash;
+		pub BlockHash get(fn block_hash) build(|_| vec![(T::BlockNumber::zero(), hash69())]): map T::BlockNumber => T::Hash;
 		/// Extrinsics data for the current block (maps an extrinsic's index to its data).
-		ExtrinsicData get(extrinsic_data): map u32 => Vec<u8>;
+		ExtrinsicData get(fn extrinsic_data): map u32 => Vec<u8>;
 		/// The current block number being processed. Set by `execute_block`.
-		Number get(block_number) build(|_| 1.into()): T::BlockNumber;
+		Number get(fn block_number) build(|_| 1.into()): T::BlockNumber;
 		/// Hash of the previous block.
-		ParentHash get(parent_hash) build(|_| hash69()): T::Hash;
+		ParentHash get(fn parent_hash) build(|_| hash69()): T::Hash;
 		/// Extrinsics root of the current block, also part of the block header.
-		ExtrinsicsRoot get(extrinsics_root): T::Hash;
+		ExtrinsicsRoot get(fn extrinsics_root): T::Hash;
 		/// Digest of the current block, also part of the block header.
-		Digest get(digest): DigestOf<T>;
+		Digest get(fn digest): DigestOf<T>;
 		/// Events deposited for the current block.
-		Events get(events): Vec<EventRecord<T::Event, T::Hash>>;
+		Events get(fn events): Vec<EventRecord<T::Event, T::Hash>>;
 		/// The number of events in the `Events<T>` list.
-		EventCount get(event_count): EventIndex;
+		EventCount get(fn event_count): EventIndex;
 
 		// TODO: https://github.com/paritytech/substrate/issues/2553
 		// Possibly, we can improve it by using something like:
@@ -408,7 +408,7 @@ decl_storage! {
 		/// The value has the type `(T::BlockNumber, EventIndex)` because if we used only just
 		/// the `EventIndex` then in case if the topic has the same contents on the next block
 		/// no notification will be triggered thus the event might be lost.
-		EventTopics get(event_topics): double_map hasher(blake2_256) (), blake2_256(T::Hash)
+		EventTopics get(fn event_topics): double_map hasher(blake2_256) (), blake2_256(T::Hash)
 			=> Vec<(T::BlockNumber, EventIndex)>;
 	}
 	add_extra_genesis {

--- a/srml/timestamp/src/lib.rs
+++ b/srml/timestamp/src/lib.rs
@@ -244,7 +244,7 @@ decl_module! {
 decl_storage! {
 	trait Store for Module<T: Trait> as Timestamp {
 		/// Current time for the current block.
-		pub Now get(now) build(|_| 0.into()): T::Moment;
+		pub Now get(fn now) build(|_| 0.into()): T::Moment;
 
 		/// Did the timestamp get updated in this block?
 		DidUpdate: bool;

--- a/srml/transaction-payment/src/lib.rs
+++ b/srml/transaction-payment/src/lib.rs
@@ -76,7 +76,7 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Balances {
-		NextFeeMultiplier get(next_fee_multiplier): Multiplier = Multiplier::from_parts(0);
+		NextFeeMultiplier get(fn next_fee_multiplier): Multiplier = Multiplier::from_parts(0);
 	}
 }
 

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -225,13 +225,13 @@ pub struct Proposal<AccountId, Balance> {
 decl_storage! {
 	trait Store for Module<T: Trait> as Treasury {
 		/// Number of proposals that have been made.
-		ProposalCount get(proposal_count): ProposalIndex;
+		ProposalCount get(fn proposal_count): ProposalIndex;
 
 		/// Proposals that have been made.
-		Proposals get(proposals): map ProposalIndex => Option<Proposal<T::AccountId, BalanceOf<T>>>;
+		Proposals get(fn proposals): map ProposalIndex => Option<Proposal<T::AccountId, BalanceOf<T>>>;
 
 		/// Proposal indices that have been approved but not yet awarded.
-		Approvals get(approvals): Vec<ProposalIndex>;
+		Approvals get(fn approvals): Vec<ProposalIndex>;
 	}
 }
 


### PR DESCRIPTION
This is a backwards-compatible (test included) convenience improvement for `decl_storage!`.

Instead of declaring a field as 

```rust
MyField get(getter_name): ...;
```

we can declare as 

```rust
MyField get(fn getter_name): ...;
```

This makes it clear that a function is being declared, and also means that searches for `fn getter_name` don't come up empty when reading code and looking for definitions. I also ported over all our SRML modules to follow this pattern.