### PR TITLE
Fix treasury kept and spend when emptied

### DIFF
--- a/node/cli/src/chain_spec.rs
+++ b/node/cli/src/chain_spec.rs
@@ -264,6 +264,7 @@ pub fn testnet_genesis(
 			authorities: vec![],
 		}),
 		membership_Instance1: Some(Default::default()),
+		treasury: Some(Default::default()),
 	}
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -521,7 +521,7 @@ construct_runtime!(
 		TechnicalMembership: membership::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
 		FinalityTracker: finality_tracker::{Module, Call, Inherent},
 		Grandpa: grandpa::{Module, Call, Storage, Config, Event},
-		Treasury: treasury::{Module, Call, Storage, Event<T>},
+		Treasury: treasury::{Module, Call, Storage, Config, Event<T>},
 		Contracts: contracts,
 		Sudo: sudo,
 		ImOnline: im_online::{Module, Call, Storage, Event<T>, ValidateUnsigned, Config<T>},

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,8 +84,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 181,
-	impl_version: 181,
+	spec_version: 182,
+	impl_version: 182,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/node/testing/src/genesis.rs
+++ b/node/testing/src/genesis.rs
@@ -96,5 +96,6 @@ pub fn config(support_changes_trie: bool, code: Option<&[u8]>) -> GenesisConfig 
 		membership_Instance1: Some(Default::default()),
 		elections: Some(Default::default()),
 		sudo: Some(Default::default()),
+		treasury: Some(Default::default()),
 	}
 }

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -345,7 +345,7 @@ impl<T: Trait> Module<T> {
 
 impl<T: Trait> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
 	fn on_unbalanced(amount: NegativeImbalanceOf<T>) {
-		// Must resolve into existing but better be safe.
+		// Must resolve into existing but better to be safe.
 		let _ = T::Currency::resolve_creating(&Self::account_id(), amount);
 	}
 }

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -237,7 +237,7 @@ decl_storage! {
 		build(|_config| {
 			// Create Treasury account
 			let _ = T::Currency::make_free_balance_be(
-				&MODULE_ID.into_account(),
+				&<Module<T>>::account_id(),
 				T::Currency::minimum_balance(),
 			);
 		});

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -240,7 +240,6 @@ decl_storage! {
 				&MODULE_ID.into_account(),
 				T::Currency::minimum_balance(),
 			);
-			println!("toto");
 		});
 	}
 }

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -320,7 +320,10 @@ impl<T: Trait> Module<T> {
 			Self::deposit_event(RawEvent::Burnt(burn))
 		}
 
-		// Budget doesn't include existential deposit thus the account must stay alive.
+		// Must never be an error, but better to be safe.
+		// proof: budget_remaining is account free balance minus ED;
+		// Thus we can't spend more than account free balance minus ED;
+		// Thus account is kept alive; qed;
 		if let Err(problem) = T::Currency::settle(
 			&Self::account_id(),
 			imbalance,
@@ -336,6 +339,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Return the amount of money in the pot.
+	// The existential deposit is not part of the pot so treasury account never gets deleted.
 	fn pot() -> BalanceOf<T> {
 		T::Currency::free_balance(&Self::account_id())
 			// Must never be less than 0 but better be safe.

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -626,17 +626,18 @@ mod tests {
 	fn pot_underflow_should_not_diminish() {
 		new_test_ext().execute_with(|| {
 			Treasury::on_dilution(100, 100);
+			assert_eq!(Treasury::pot(), 100);
 
 			assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));
 			assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 
 			<Treasury as OnFinalize<u64>>::on_finalize(2);
-			assert_eq!(Treasury::pot(), 100);
+			assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 			Treasury::on_dilution(100, 100);
 			<Treasury as OnFinalize<u64>>::on_finalize(4);
-			assert_eq!(Balances::free_balance(&3), 150);
-			assert_eq!(Treasury::pot(), 75);
+			assert_eq!(Balances::free_balance(&3), 150); // Fund has been spent
+			assert_eq!(Treasury::pot(), 75); // Pot has finally changed
 		});
 	}
 }

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -661,6 +661,7 @@ mod tests {
 
 			<Treasury as OnFinalize<u64>>::on_finalize(4);
 			assert_eq!(Treasury::pot(), 0); // Pot is emptied
+			assert_eq!(Balances::free_balance(&Treasury::account_id()), 1); // but the account is still there 
 		});
 	}
 


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/3879
Superseed https://github.com/paritytech/substrate/pull/3797

## Done:

* treasury account is created at genesis config.
* pot doesn't include existential deposit thus pot can be entirely spend with no issue.

## TODO:

* [ ] update polkadot: just includes Config in construct_runtime
* [x] fix some tests using runtime genesis config

## Alternatives:

* we could also keep old behavior with treasury being created when it happens that dilution is more than ED. but seem better that we create it once and for all.

## Notes:

* I still kept resolve_creating to ensure it still works on Kusama if there is no treasury account then it will just get created once on_dilution mint more than ED instead of never be created.
  Also in case someone forget to include Config in construct runtime (thus account is not created) then this account can be created later as well.