### PR TITLE
support: BuildStorage methods to take self reference

### DIFF
--- a/core/chain-spec/src/chain_spec.rs
+++ b/core/chain-spec/src/chain_spec.rs
@@ -71,7 +71,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 }
 
 impl<'a, G: RuntimeGenesis, E> BuildStorage for &'a ChainSpec<G, E> {
-	fn build_storage(self) -> Result<(StorageOverlay, ChildrenStorageOverlay), String> {
+	fn build_storage(&self) -> Result<(StorageOverlay, ChildrenStorageOverlay), String> {
 		match self.genesis.resolve()? {
 			Genesis::Runtime(gc) => gc.build_storage(),
 			Genesis::Raw(map, children_map) => Ok((
@@ -85,7 +85,7 @@ impl<'a, G: RuntimeGenesis, E> BuildStorage for &'a ChainSpec<G, E> {
 	}
 
 	fn assimilate_storage(
-		self,
+		&self,
 		_: &mut (StorageOverlay, ChildrenStorageOverlay)
 	) -> Result<(), String> {
 		Err("`assimilate_storage` not implemented for `ChainSpec`.".into())
@@ -289,11 +289,11 @@ mod tests {
 
 	impl BuildStorage for Genesis {
 		fn assimilate_storage(
-			self,
+			&self,
 			storage: &mut (StorageOverlay, ChildrenStorageOverlay),
 		) -> Result<(), String> {
 			storage.0.extend(
-				self.0.into_iter().map(|(a, b)| (a.into_bytes(), b.into_bytes()))
+				self.0.iter().map(|(a, b)| (a.clone().into_bytes(), b.clone().into_bytes()))
 			);
 			Ok(())
 		}

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -84,7 +84,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 184,
-	impl_version: 184,
+	impl_version: 185,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/srml/support/procedural/src/storage/genesis_config/builder_def.rs
+++ b/srml/support/procedural/src/storage/genesis_config/builder_def.rs
@@ -51,7 +51,7 @@ impl BuilderDef {
 				is_generic |= ext::expr_contains_ident(&builder, &def.module_runtime_generic);
 				is_generic |= line.is_generic;
 
-				data = Some(quote_spanned!(builder.span() => &(#builder)(&self)));
+				data = Some(quote_spanned!(builder.span() => &(#builder)(self)));
 			} else if let Some(config) = &line.config {
 				is_generic |= line.is_generic;
 
@@ -98,7 +98,7 @@ impl BuilderDef {
 
 			blocks.push(quote_spanned! { builder.span() =>
 				let extra_genesis_builder: fn(&Self) = #builder;
-				extra_genesis_builder(&self);
+				extra_genesis_builder(self);
 			});
 		}
 

--- a/srml/support/procedural/src/storage/genesis_config/mod.rs
+++ b/srml/support/procedural/src/storage/genesis_config/mod.rs
@@ -138,7 +138,7 @@ fn impl_build_storage(
 	quote!{
 		#[cfg(feature = "std")]
 		impl#genesis_impl GenesisConfig#genesis_struct #genesis_where_clause {
-			pub fn build_storage #fn_generic (self) -> std::result::Result<
+			pub fn build_storage #fn_generic (&self) -> std::result::Result<
 				(
 					#scrate::sr_primitives::StorageOverlay,
 					#scrate::sr_primitives::ChildrenStorageOverlay,
@@ -152,7 +152,7 @@ fn impl_build_storage(
 
 			/// Assimilate the storage for this module into pre-existing overlays.
 			pub fn assimilate_storage #fn_generic (
-				self,
+				&self,
 				tuple_storage: &mut (
 					#scrate::sr_primitives::StorageOverlay,
 					#scrate::sr_primitives::ChildrenStorageOverlay,
@@ -170,7 +170,7 @@ fn impl_build_storage(
 			#where_clause
 		{
 			fn build_module_genesis_storage(
-				self,
+				&self,
 				storage: &mut (
 					#scrate::sr_primitives::StorageOverlay,
 					#scrate::sr_primitives::ChildrenStorageOverlay,


### PR DESCRIPTION
There is no reason to consume the GenesisConfig when using it to initialize a new storage backend. Instead, build_storage and assimilate_storage now operator on self references.

The motivation is benchmarks that need to repeatedly initialize new storage backends. It would be nice to do so without rebuilding the config each time (which involves key generation).