### PR TITLE
Split the telemetry net status report in two

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5539,6 +5539,7 @@ dependencies = [
  "substrate-transaction-pool 2.0.0",
  "sysinfo 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/core/cli/src/informant.rs
+++ b/core/cli/src/informant.rs
@@ -22,6 +22,7 @@ use futures03::{StreamExt as _, TryStreamExt as _};
 use log::{info, warn};
 use sr_primitives::traits::Header;
 use service::AbstractService;
+use std::time::Duration;
 
 mod display;
 
@@ -31,11 +32,13 @@ pub fn build(service: &impl AbstractService) -> impl Future<Item = (), Error = (
 
 	let mut display = display::InformantDisplay::new();
 
-	let display_notifications = service.network_status().for_each(move |(net_status, _)| {
-		let info = client.info();
-		display.display(&info, net_status);
-		Ok(())
-	});
+	let display_notifications = service
+		.network_status(Duration::from_millis(5000))
+		.for_each(move |(net_status, _)| {
+			let info = client.info();
+			display.display(&info, net_status);
+			Ok(())
+		});
 
 	let client = service.client();
 	let mut last_best = {

--- a/core/service/Cargo.toml
+++ b/core/service/Cargo.toml
@@ -49,3 +49,4 @@ node-runtime = { path = "../../node/runtime" }
 babe-primitives = { package = "substrate-consensus-babe-primitives", path = "../../core/consensus/babe/primitives" }
 grandpa = { package = "substrate-finality-grandpa", path = "../../core/finality-grandpa" }
 grandpa-primitives = { package = "substrate-finality-grandpa-primitives", path = "../../core/finality-grandpa/primitives" }
+tokio = "0.1"

--- a/core/service/src/builder.rs
+++ b/core/service/src/builder.rs
@@ -17,6 +17,7 @@
 use crate::{NewService, NetworkStatus, NetworkState, error::{self, Error}, DEFAULT_PROTOCOL_ID};
 use crate::{SpawnTaskHandle, start_rpc_servers, build_network_future, TransactionPoolAdapter};
 use crate::TaskExecutor;
+use crate::status_sinks;
 use crate::config::Configuration;
 use client::{
 	BlockchainEvents, Client, runtime_api,

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -776,7 +776,7 @@ fn build_network_future<
 					};
 					let state = network.network_state();
 
-					if status_sinks[n].1.unbounded_send((status.clone(), state.clone())).is_err() {
+					if status_sinks[n].1.unbounded_send((status, state)).is_err() {
 						status_sinks.remove(n);
 						continue;
 					}

--- a/core/service/src/lib.rs
+++ b/core/service/src/lib.rs
@@ -776,7 +776,7 @@ fn build_network_future<
 					};
 					let state = network.network_state();
 
-					if !status_sinks[n].1.unbounded_send((status.clone(), state.clone())).is_ok() {
+					if status_sinks[n].1.unbounded_send((status.clone(), state.clone())).is_err() {
 						status_sinks.remove(n);
 						continue;
 					}

--- a/core/service/src/status_sinks.rs
+++ b/core/service/src/status_sinks.rs
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// Copyright 2019 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
 // Substrate is free software: you can redistribute it and/or modify

--- a/core/service/src/status_sinks.rs
+++ b/core/service/src/status_sinks.rs
@@ -1,0 +1,106 @@
+// Copyright 2017-2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use futures::prelude::*;
+use futures::sync::mpsc;
+use futures::stream::futures_unordered::FuturesUnordered;
+use std::time::{Duration, Instant};
+use tokio_timer::Delay;
+
+/// Holds a list of `UnboundedSender`s, each associated with a certain time period. Every time the
+/// period elapses, we push an element on the sender.
+///
+/// Senders are removed only when they are closed.
+pub struct StatusSinks<T> {
+	entries: FuturesUnordered<YieldAfter<T>>,
+}
+
+struct YieldAfter<T> {
+	delay: tokio_timer::Delay,
+	interval: Duration,
+	sender: Option<mpsc::UnboundedSender<T>>,
+}
+
+impl<T> StatusSinks<T> {
+	/// Builds a new empty collection.
+	pub fn new() -> StatusSinks<T> {
+		StatusSinks {
+			entries: FuturesUnordered::new(),
+		}
+	}
+
+	/// Adds a sender to the collection.
+	///
+	/// The `interval` is the time period between two pushes on the sender.
+	pub fn push(&mut self, interval: Duration, sender: mpsc::UnboundedSender<T>) {
+		self.entries.push(YieldAfter {
+			delay: Delay::new(Instant::now() + interval),
+			interval,
+			sender: Some(sender),
+		})
+	}
+
+	/// Processes all the senders. If any sender is ready, calls the `status_grab` function and
+	/// pushes what it returns to the sender.
+	///
+	/// This function doesn't return anything, but it should be treated as if it implicitly
+	/// returns `Ok(Async::NotReady)`. In particular, it should be called again when the task
+	/// is waken up.
+	///
+	/// # Panic
+	///
+	/// Panics if not called within the context of a task.
+	pub fn poll(&mut self, mut status_grab: impl FnMut() -> T) {
+		loop {
+			match self.entries.poll() {
+				Ok(Async::Ready(Some((sender, interval)))) => {
+					let status = status_grab();
+					if sender.unbounded_send(status).is_ok() {
+						self.entries.push(YieldAfter {
+							// Note that since there's a small delay between the moment a task is
+							// waken up and the moment it is polled, the period is actually not
+							// `interval` but `interval + <delay>`. We ignore this problem in
+							// practice.
+							delay: Delay::new(Instant::now() + interval),
+							interval,
+							sender: Some(sender),
+						});
+					}
+				}
+				Err(()) |
+				Ok(Async::Ready(None)) |
+				Ok(Async::NotReady) => break,
+			}
+		}
+	}
+}
+
+impl<T> Future for YieldAfter<T> {
+	type Item = (mpsc::UnboundedSender<T>, Duration);
+	type Error = ();
+
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+		match self.delay.poll() {
+			Ok(Async::NotReady) => Ok(Async::NotReady),
+			Ok(Async::Ready(())) => {
+				let sender = self.sender.take()
+					.expect("sender is always Some unless the future is finished; qed");
+				Ok(Async::Ready((sender, self.interval)))
+			},
+			Err(_) => Err(()),
+		}
+	}
+}


### PR DESCRIPTION
Fix #3541 

Two changes:

- The `network_state()` method on the `AbstractService` trait now takes a `Duration` for the interval at which the state should be reported. This is IMO a more sensible design, as it allows the informant to decide how often it should be displayed.

- Splits the `"system.interval"` telemetry report in two: the `"system.interval"` report no longer contains the `"network_state"` field. Instead, there's a new `"system.network_state"` message that contains a single field named `"state"`. This new message is sent only every 30 seconds.

The telemetry backend should obviously be updated accordingly. cc @maciejhirsz 