### PR TITLE
Fix srml assets compilation with `std` feature

### DIFF
--- a/srml/assets/Cargo.toml
+++ b/srml/assets/Cargo.toml
@@ -27,5 +27,4 @@ std = [
 	"sr-primitives/std",
 	"support/std",
 	"system/std",
-	"runtime-io/std",
 ]


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/3889