### PR TITLE
Wasm-builder-runner unset `CARGO_TARGET_DIR` and release 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,7 +2511,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.3",
+ "substrate-wasm-builder-runner 1.0.4",
 ]
 
 [[package]]
@@ -2572,7 +2572,7 @@ dependencies = [
  "substrate-offchain-primitives 2.0.0",
  "substrate-primitives 2.0.0",
  "substrate-session 2.0.0",
- "substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-wasm-builder-runner 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5484,7 +5484,7 @@ dependencies = [
  "sr-sandbox 2.0.0",
  "sr-std 2.0.0",
  "substrate-primitives 2.0.0",
- "substrate-wasm-builder-runner 1.0.3",
+ "substrate-wasm-builder-runner 1.0.4",
 ]
 
 [[package]]
@@ -5672,7 +5672,7 @@ dependencies = [
  "substrate-state-machine 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-trie 2.0.0",
- "substrate-wasm-builder-runner 1.0.3",
+ "substrate-wasm-builder-runner 1.0.4",
  "trie-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5754,11 +5754,11 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.3"
+version = "1.0.4"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -7148,7 +7148,7 @@ dependencies = [
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
 "checksum strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47cd23f5c7dee395a00fa20135e2ec0fffcdfa151c56182966d7a3261343432e"
 "checksum substrate-bip39 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
-"checksum substrate-wasm-builder-runner 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af21b27fad38b212c1919f700cb0def33c88cde14d22e0d1b17d4521f4eb8b40"
+"checksum substrate-wasm-builder-runner 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bd48273fe9d7f92c1f7d6c1c537bb01c8068f925b47ad2cd8367e11dc32f8550"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/core/executor/runtime-test/Cargo.toml
+++ b/core/executor/runtime-test/Cargo.toml
@@ -13,7 +13,7 @@ primitives = { package = "substrate-primitives",  path = "../../primitives", def
 sr-primitives = { package = "sr-primitives",  path = "../../sr-primitives", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../../utils/wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4", path = "../../utils/wasm-builder-runner" }
 
 [features]
 default = [ "std" ]

--- a/core/test-runtime/Cargo.toml
+++ b/core/test-runtime/Cargo.toml
@@ -39,7 +39,7 @@ substrate-test-runtime-client = { path = "./client" }
 state_machine = { package = "substrate-state-machine", path = "../state-machine" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../utils/wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4", path = "../utils/wasm-builder-runner" }
 
 [features]
 default = [

--- a/core/utils/wasm-builder-runner/Cargo.toml
+++ b/core/utils/wasm-builder-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder-runner"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Runner for substrate-wasm-builder"
 edition = "2018"

--- a/core/utils/wasm-builder-runner/src/lib.rs
+++ b/core/utils/wasm-builder-runner/src/lib.rs
@@ -227,6 +227,11 @@ fn run_project(project_folder: &Path) {
 		cmd.arg("--release");
 	}
 
+	// Unset the `CARGO_TARGET_DIR` to prevent a cargo deadlock (cargo locks a target dir exclusive).
+	// The runner project is created in `CARGO_TARGET_DIR` and executing it will create a sub target
+	// directory inside of `CARGO_TARGET_DIR`.
+	cmd.env_remove("CARGO_TARGET_DIR");
+
 	if !cmd.status().map(|s| s.success()).unwrap_or(false) {
 		// Don't spam the output with backtraces when a build failed!
 		process::exit(1);
@@ -255,7 +260,7 @@ fn check_provide_dummy_wasm_binary() -> bool {
 fn provide_dummy_wasm_binary(file_path: &Path) {
 	fs::write(
 		file_path,
-		"pub const WASM_BINARY: &[u8] = &[]; pub const WASM_BINARY_BLOATY: &[u8] = &[];"
+		"pub const WASM_BINARY: &[u8] = &[]; pub const WASM_BINARY_BLOATY: &[u8] = &[];",
 	).expect("Writing dummy WASM binary should not fail");
 }
 

--- a/node-template/runtime/Cargo.toml
+++ b/node-template/runtime/Cargo.toml
@@ -30,7 +30,7 @@ client = { package = "substrate-client", path = "../../core/client", default_fea
 offchain-primitives = { package = "substrate-offchain-primitives", path = "../../core/offchain/primitives", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4" }
 
 [features]
 default = ["std"]

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -55,7 +55,7 @@ utility = { package = "srml-utility", path = "../../srml/utility", default-featu
 transaction-payment = { package = "srml-transaction-payment", path = "../../srml/transaction-payment", default-features = false }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.2", path = "../../core/utils/wasm-builder-runner" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4", path = "../../core/utils/wasm-builder-runner" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
`CARGO_TARGET_DIR` needs to be unset or otherwise cargo deadlocks,
because cargo always holds an exclusive lock on target dir.
