### PR TITLE
Remove support for secp256k1 for network keys

### DIFF
--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -68,11 +68,6 @@ use substrate_telemetry::TelemetryEndpoints;
 /// The maximum number of characters for a node name.
 const NODE_NAME_MAX_LENGTH: usize = 32;
 
-/// The file name of the node's Secp256k1 secret key inside the chain-specific
-/// network config directory, if neither `--node-key` nor `--node-key-file`
-/// is specified in combination with `--node-key-type=secp256k1`.
-const NODE_KEY_SECP256K1_FILE: &str = "secret";
-
 /// The file name of the node's Ed25519 secret key inside the chain-specific
 /// network config directory, if neither `--node-key` nor `--node-key-file`
 /// is specified in combination with `--node-key-type=ed25519`.
@@ -492,14 +487,6 @@ where
 	P: AsRef<Path>
 {
 	match params.node_key_type {
-		NodeKeyType::Secp256k1 =>
-			params.node_key.as_ref().map(parse_secp256k1_secret).unwrap_or_else(||
-				Ok(params.node_key_file
-					.or_else(|| net_config_file(net_config_dir, NODE_KEY_SECP256K1_FILE))
-					.map(network::config::Secret::File)
-					.unwrap_or(network::config::Secret::New)))
-				.map(NodeKeyConfig::Secp256k1),
-
 		NodeKeyType::Ed25519 =>
 			params.node_key.as_ref().map(parse_ed25519_secret).unwrap_or_else(||
 				Ok(params.node_key_file
@@ -520,14 +507,6 @@ where
 /// Create an error caused by an invalid node key argument.
 fn invalid_node_key(e: impl std::fmt::Display) -> error::Error {
 	error::Error::Input(format!("Invalid node key: {}", e))
-}
-
-/// Parse a Secp256k1 secret key from a hex string into a `network::Secret`.
-fn parse_secp256k1_secret(hex: &String) -> error::Result<network::config::Secp256k1Secret> {
-	H256::from_str(hex).map_err(invalid_node_key).and_then(|bytes|
-		network::config::identity::secp256k1::SecretKey::from_bytes(bytes)
-			.map(network::config::Secret::Input)
-			.map_err(invalid_node_key))
 }
 
 /// Parse a Ed25519 secret key from a hex string into a `network::Secret`.
@@ -950,7 +929,7 @@ fn kill_color(s: &str) -> String {
 mod tests {
 	use super::*;
 	use tempdir::TempDir;
-	use network::config::identity::{secp256k1, ed25519};
+	use network::config::identity::ed25519;
 
 	#[test]
 	fn tests_node_name_good() {
@@ -973,7 +952,6 @@ mod tests {
 			NodeKeyType::variants().into_iter().try_for_each(|t| {
 				let node_key_type = NodeKeyType::from_str(t).unwrap();
 				let sk = match node_key_type {
-					NodeKeyType::Secp256k1 => secp256k1::SecretKey::generate().to_bytes().to_vec(),
 					NodeKeyType::Ed25519 => ed25519::SecretKey::generate().as_ref().to_vec()
 				};
 				let params = NodeKeyParams {
@@ -982,9 +960,6 @@ mod tests {
 					node_key_file: None
 				};
 				node_key_config(params, &net_config_dir).and_then(|c| match c {
-					NodeKeyConfig::Secp256k1(network::config::Secret::Input(ref ski))
-						if node_key_type == NodeKeyType::Secp256k1 &&
-							&sk[..] == ski.to_bytes() => Ok(()),
 					NodeKeyConfig::Ed25519(network::config::Secret::Input(ref ski))
 						if node_key_type == NodeKeyType::Ed25519 &&
 							&sk[..] == ski.as_ref() => Ok(()),
@@ -1010,8 +985,6 @@ mod tests {
 					node_key_file: Some(file.clone())
 				};
 				node_key_config(params, &net_config_dir).and_then(|c| match c {
-					NodeKeyConfig::Secp256k1(network::config::Secret::File(ref f))
-						if node_key_type == NodeKeyType::Secp256k1 && f == &file => Ok(()),
 					NodeKeyConfig::Ed25519(network::config::Secret::File(ref f))
 						if node_key_type == NodeKeyType::Ed25519 && f == &file => Ok(()),
 					_ => Err(error::Error::Input("Unexpected node key config".into()))
@@ -1044,8 +1017,6 @@ mod tests {
 				let typ = params.node_key_type;
 				node_key_config::<String>(params, &None)
 					.and_then(|c| match c {
-						NodeKeyConfig::Secp256k1(network::config::Secret::New)
-							if typ == NodeKeyType::Secp256k1 => Ok(()),
 						NodeKeyConfig::Ed25519(network::config::Secret::New)
 							if typ == NodeKeyType::Ed25519 => Ok(()),
 						_ => Err(error::Error::Input("Unexpected node key config".into()))
@@ -1059,9 +1030,6 @@ mod tests {
 				let typ = params.node_key_type;
 				node_key_config(params, &Some(net_config_dir.clone()))
 					.and_then(move |c| match c {
-						NodeKeyConfig::Secp256k1(network::config::Secret::File(ref f))
-							if typ == NodeKeyType::Secp256k1 &&
-								f == &dir.join(NODE_KEY_SECP256K1_FILE) => Ok(()),
 						NodeKeyConfig::Ed25519(network::config::Secret::File(ref f))
 							if typ == NodeKeyType::Ed25519 &&
 								f == &dir.join(NODE_KEY_ED25519_FILE) => Ok(()),

--- a/core/cli/src/params.rs
+++ b/core/cli/src/params.rs
@@ -150,7 +150,6 @@ arg_enum! {
 	#[allow(missing_docs)]
 	#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 	pub enum NodeKeyType {
-		Secp256k1,
 		Ed25519
 	}
 }
@@ -163,10 +162,6 @@ pub struct NodeKeyParams {
 	///
 	/// The value is a string that is parsed according to the choice of
 	/// `--node-key-type` as follows:
-	///
-	///   `secp256k1`:
-	///   The value is parsed as a hex-encoded Secp256k1 32 bytes secret key,
-	///   i.e. 64 hex characters.
 	///
 	///   `ed25519`:
 	///   The value is parsed as a hex-encoded Ed25519 32 bytes secret key,
@@ -198,10 +193,6 @@ pub struct NodeKeyParams {
 	///
 	/// The node's secret key determines the corresponding public key and hence the
 	/// node's peer ID in the context of libp2p.
-	///
-	/// NOTE: The current default key type is `secp256k1` for a transition period only
-	/// but will eventually change to `ed25519` in a future release. To continue using
-	/// `secp256k1` keys, use `--node-key-type=secp256k1`.
 	#[structopt(
 		long = "node-key-type",
 		value_name = "TYPE",
@@ -215,9 +206,6 @@ pub struct NodeKeyParams {
 	///
 	/// The contents of the file are parsed according to the choice of `--node-key-type`
 	/// as follows:
-	///
-	///   `secp256k1`:
-	///   The file must contain an unencoded 32 bytes Secp256k1 secret key.
 	///
 	///   `ed25519`:
 	///   The file must contain an unencoded 32 bytes Ed25519 secret key.

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -22,7 +22,7 @@ linked_hash_set = "0.1.3"
 lru-cache = "0.1.2"
 rustc-hex = "2.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.12.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
+libp2p = { version = "0.12.0", default-features = false, features = ["libp2p-websocket"] }
 fork-tree = { path = "../../core/utils/fork-tree" }
 consensus = { package = "substrate-consensus-common", path = "../../core/consensus/common" }
 client = { package = "substrate-client", path = "../../core/client" }

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -29,7 +29,7 @@ use bitflags::bitflags;
 use consensus::{block_validation::BlockAnnounceValidator, import_queue::ImportQueue};
 use sr_primitives::traits::{Block as BlockT};
 use std::sync::Arc;
-use libp2p::identity::{Keypair, secp256k1, ed25519};
+use libp2p::identity::{Keypair, ed25519};
 use libp2p::wasm_ext;
 use libp2p::{PeerId, Multiaddr, multiaddr};
 use std::error::Error;
@@ -364,14 +364,9 @@ impl NonReservedPeerMode {
 /// the evaluation of the node key configuration.
 #[derive(Clone)]
 pub enum NodeKeyConfig {
-	/// A Secp256k1 secret key configuration.
-	Secp256k1(Secret<secp256k1::SecretKey>),
 	/// A Ed25519 secret key configuration.
 	Ed25519(Secret<ed25519::SecretKey>)
 }
-
-/// The options for obtaining a Secp256k1 secret key.
-pub type Secp256k1Secret = Secret<secp256k1::SecretKey>;
 
 /// The options for obtaining a Ed25519 secret key.
 pub type Ed25519Secret = Secret<ed25519::SecretKey>;
@@ -385,7 +380,6 @@ pub enum Secret<K> {
 	/// it is created with a newly generated secret key `K`. The format
 	/// of the file is determined by `K`:
 	///
-	///   * `secp256k1::SecretKey`: An unencoded 32 bytes Secp256k1 secret key.
 	///   * `ed25519::SecretKey`: An unencoded 32 bytes Ed25519 secret key.
 	File(PathBuf),
 	/// Always generate a new secret key `K`.
@@ -406,20 +400,6 @@ impl NodeKeyConfig {
 	pub fn into_keypair(self) -> io::Result<Keypair> {
 		use NodeKeyConfig::*;
 		match self {
-			Secp256k1(Secret::New) =>
-				Ok(Keypair::generate_secp256k1()),
-
-			Secp256k1(Secret::Input(k)) =>
-				Ok(Keypair::Secp256k1(k.into())),
-
-			Secp256k1(Secret::File(f)) =>
-				get_secret(f,
-					|mut b| secp256k1::SecretKey::from_bytes(&mut b),
-					secp256k1::SecretKey::generate,
-					|b| b.to_bytes().to_vec())
-				.map(secp256k1::Keypair::from)
-				.map(Keypair::Secp256k1),
-
 			Ed25519(Secret::New) =>
 				Ok(Keypair::generate_ed25519()),
 
@@ -526,9 +506,9 @@ mod tests {
 
 	#[test]
 	fn test_secret_input() {
-		let sk = secp256k1::SecretKey::generate();
-		let kp1 = NodeKeyConfig::Secp256k1(Secret::Input(sk.clone())).into_keypair().unwrap();
-		let kp2 = NodeKeyConfig::Secp256k1(Secret::Input(sk)).into_keypair().unwrap();
+		let sk = ed25519::SecretKey::generate();
+		let kp1 = NodeKeyConfig::Ed25519(Secret::Input(sk.clone())).into_keypair().unwrap();
+		let kp2 = NodeKeyConfig::Ed25519(Secret::Input(sk)).into_keypair().unwrap();
 		assert!(secret_bytes(&kp1) == secret_bytes(&kp2));
 	}
 

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -24,9 +24,7 @@
 //! # Node identities and addresses
 //!
 //! In a decentralized network, each node possesses a network private key and a network public key.
-//! In Substrate, the keys are based on the ed25519 curve. As of the writing of this documentation,
-//! the secp256k1 curve can also be used, but is deprecated. Our local node's keypair must be
-//! passed as part of the network configuration.
+//! In Substrate, the keys are based on the ed25519 curve.
 //!
 //! From a node's public key, we can derive its *identity*. In Substrate and libp2p, a node's
 //! identity is represented with the [`PeerId`] struct. All network communications between nodes on

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -42,7 +42,7 @@ use sr_primitives::{traits::{Block as BlockT, NumberFor}, ConsensusEngineId};
 
 use crate::{behaviour::{Behaviour, BehaviourOut}, config::{parse_str_addr, parse_addr}};
 use crate::{NetworkState, NetworkStateNotConnectedPeer, NetworkStatePeer};
-use crate::{transport, config::NodeKeyConfig, config::NonReservedPeerMode};
+use crate::{transport, config::NonReservedPeerMode};
 use crate::config::{Params, TransportConfig};
 use crate::error::Error;
 use crate::protocol::{self, Protocol, Context, CustomMessageOutcome, PeerInfo};
@@ -171,9 +171,6 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> NetworkWorker
 		};
 
 		// Private and public keys configuration.
-		if let NodeKeyConfig::Secp256k1(_) = params.network_config.node_key {
-			warn!(target: "sub-libp2p", "Secp256k1 keys are deprecated in favour of ed25519");
-		}
 		let local_identity = params.network_config.node_key.clone().into_keypair()?;
 		let local_public = local_identity.public();
 		let local_peer_id = local_public.clone().into_peer_id();


### PR DESCRIPTION
We've deprecated secp256k1 keys and defaulted to ed25519 keys a long time ago. This PR removes support for secp256k1.

Note that we still support situations where a remote node supports secp256k1 keys. This only removes support for using a secp256k1 key on your local node.

I wasn't sure whether to keep the infrastructure for `--node-key-type` or if this should be removed altogether. For now I kept it.
