### PR TITLE
node: spawn grandpa voter as essential task

### DIFF
--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -115,11 +115,11 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 			service.keystore(),
 		)?;
 
-		let select = aura.select(service.on_exit()).then(|_| Ok(()));
+		let aura = aura.select(service.on_exit()).then(|_| Ok(()));
 
 		// the AURA authoring task is considered essential, i.e. if it
 		// fails we take down the service with it.
-		service.spawn_essential_task(select);
+		service.spawn_essential_task(aura);
 	}
 
 	let grandpa_config = grandpa::Config {
@@ -133,12 +133,12 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 	match (is_authority, disable_grandpa) {
 		(false, false) => {
 			// start the lightweight GRANDPA observer
-			service.spawn_task(Box::new(grandpa::run_grandpa_observer(
+			service.spawn_task(grandpa::run_grandpa_observer(
 				grandpa_config,
 				grandpa_link,
 				service.network(),
 				service.on_exit(),
-			)?));
+			)?);
 		},
 		(true, false) => {
 			// start the full GRANDPA voter

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -109,7 +109,6 @@ macro_rules! new_full_start {
 /// concrete types instead.
 macro_rules! new_full {
 	($config:expr, $with_startup_data: expr) => {{
-		use futures::future::Future;
 		use futures::sync::mpsc;
 		use network::DhtEvent;
 
@@ -169,7 +168,6 @@ macro_rules! new_full {
 			};
 
 			let babe = babe::start_babe(babe_config)?;
-			let babe = babe.select(service.on_exit()).then(|_| Ok(()));
 			service.spawn_essential_task(babe);
 
 			let authority_discovery = authority_discovery::AuthorityDiscovery::new(

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -207,7 +207,9 @@ macro_rules! new_full {
 					telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
 					voting_rule: grandpa::VotingRulesBuilder::default().build(),
 				};
-				service.spawn_task(Box::new(grandpa::run_grandpa_voter(grandpa_config)?));
+				// the GRANDPA voter task is considered infallible, i.e.
+				// if it fails we take down the service with it.
+				service.spawn_essential_task(grandpa::run_grandpa_voter(grandpa_config)?);
 			},
 			(_, true) => {
 				grandpa::setup_disabled_grandpa(

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -109,6 +109,7 @@ macro_rules! new_full_start {
 /// concrete types instead.
 macro_rules! new_full {
 	($config:expr, $with_startup_data: expr) => {{
+		use futures::future::Future;
 		use futures::sync::mpsc;
 		use network::DhtEvent;
 
@@ -168,6 +169,7 @@ macro_rules! new_full {
 			};
 
 			let babe = babe::start_babe(babe_config)?;
+			let babe = babe.select(service.on_exit()).then(|_| Ok(()));
 			service.spawn_essential_task(babe);
 
 			let authority_discovery = authority_discovery::AuthorityDiscovery::new(
@@ -175,6 +177,7 @@ macro_rules! new_full {
 				service.network(),
 				dht_event_rx,
 			);
+
 			service.spawn_task(authority_discovery);
 		}
 

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -192,12 +192,12 @@ macro_rules! new_full {
 		match (is_authority, disable_grandpa) {
 			(false, false) => {
 				// start the lightweight GRANDPA observer
-				service.spawn_task(Box::new(grandpa::run_grandpa_observer(
+				service.spawn_task(grandpa::run_grandpa_observer(
 					config,
 					grandpa_link,
 					service.network(),
 					service.on_exit(),
-				)?));
+				)?);
 			},
 			(true, false) => {
 				// start the full GRANDPA voter


### PR DESCRIPTION
This used to be correctly spawned as an essential task but was changed back in #3382 (probably when handling merge conflicts).