### PR TITLE
node-template: remove unnecessary on_exit guard

### DIFF
--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -115,8 +115,6 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 			service.keystore(),
 		)?;
 
-		let aura = aura.select(service.on_exit()).then(|_| Ok(()));
-
 		// the AURA authoring task is considered essential, i.e. if it
 		// fails we take down the service with it.
 		service.spawn_essential_task(aura);


### PR DESCRIPTION
Tasks spawned by `spawn_task`/`spawn_essential_task` are already guarded by `on_exit`.