### PR TITLE
Bump transaction version

### DIFF
--- a/core/sr-primitives/src/generic/unchecked_extrinsic.rs
+++ b/core/sr-primitives/src/generic/unchecked_extrinsic.rs
@@ -25,7 +25,7 @@ use crate::{
 	generic::CheckedExtrinsic, transaction_validity::{TransactionValidityError, InvalidTransaction},
 };
 
-const TRANSACTION_VERSION: u8 = 3;
+const TRANSACTION_VERSION: u8 = 4;
 
 /// A extrinsic right from the external world. This is unchecked and so
 /// can contain a signature.


### PR DESCRIPTION
Update the transaction version after #3861 since the over-the-wire formats between the current and the previous v3 are not compatible.