### PR TITLE
Rename node template's runtime dependency "node-template-runtime" -> "runtime"

### DIFF
--- a/node-template/Cargo.toml
+++ b/node-template/Cargo.toml
@@ -33,7 +33,7 @@ grandpa = { package = "substrate-finality-grandpa", path = "../core/finality-gra
 grandpa-primitives = { package = "substrate-finality-grandpa-primitives", path = "../core/finality-grandpa/primitives" }
 substrate-client = {  path = "../core/client" }
 basic-authorship = { package = "substrate-basic-authorship", path = "../core/basic-authorship" }
-node-template-runtime = { path = "runtime" }
+runtime = { package = "node-template-runtime", path = "runtime" }
 
 [build-dependencies]
 vergen = "3.0.4"

--- a/node-template/src/chain_spec.rs
+++ b/node-template/src/chain_spec.rs
@@ -1,5 +1,5 @@
 use primitives::{Pair, Public};
-use node_template_runtime::{
+use runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
 	SudoConfig, IndicesConfig, SystemConfig, WASM_BINARY, 
 };

--- a/node-template/src/service.rs
+++ b/node-template/src/service.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use substrate_client::LongestChain;
 use futures::prelude::*;
-use node_template_runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
+use runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
 use substrate_service::{error::{Error as ServiceError}, AbstractService, Configuration, ServiceBuilder};
 use transaction_pool::{self, txpool::{Pool as TransactionPool}};
 use inherents::InherentDataProviders;
@@ -17,8 +17,8 @@ use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
 // Our native executor instance.
 native_executor_instance!(
 	pub Executor,
-	node_template_runtime::api::dispatch,
-	node_template_runtime::native_version,
+	runtime::api::dispatch,
+	runtime::native_version,
 );
 
 construct_simple_protocol! {
@@ -36,7 +36,7 @@ macro_rules! new_full_start {
 		let inherent_data_providers = inherents::InherentDataProviders::new();
 
 		let builder = substrate_service::ServiceBuilder::new_full::<
-			node_template_runtime::opaque::Block, node_template_runtime::RuntimeApi, crate::service::Executor
+			runtime::opaque::Block, runtime::RuntimeApi, crate::service::Executor
 		>($config)?
 			.with_select_chain(|_config, backend| {
 				Ok(substrate_client::LongestChain::new(backend.clone()))
@@ -49,7 +49,7 @@ macro_rules! new_full_start {
 					.ok_or_else(|| substrate_service::Error::SelectChainRequired)?;
 
 				let (grandpa_block_import, grandpa_link) =
-					grandpa::block_import::<_, _, _, node_template_runtime::RuntimeApi, _, _>(
+					grandpa::block_import::<_, _, _, runtime::RuntimeApi, _, _>(
 						client.clone(), &*client, select_chain
 					)?;
 


### PR DESCRIPTION
This PR makes an insubstantial change to how the node-template imports it's runtime. In Cargo.toml

```diff
- node-template-runtime = { path = "runtime" }
+ runtime = { package = "node-template-runtime", path = "runtime" }
```

While small, this change has two positive effects downstream.
1. When a developer starts a project from the node template, and later choose to rename it, they change the name in fewer places. (They no longer have to touch `service.rs` at all.)
2. When changing the template to use a runtime from an external crate (as is done in [recipes](https://github.com/substrate-developer-hub/recipes/blob/ec8c53d01f1888bbb50b3acc466f2f2967c4b663/kitchen/node/Cargo.toml#L37-L40) and [joystream](https://github.com/Joystream/substrate-node-joystream/blob/master/Cargo.toml#L47)), they only need to change Cargo.toml.
