### PR TITLE
Fix test description.

### DIFF
--- a/srml/assets/src/lib.rs
+++ b/srml/assets/src/lib.rs
@@ -328,7 +328,7 @@ mod tests {
 	}
 
 	#[test]
-	fn transferring_amount_less_than_available_balance_should_not_work() {
+	fn transferring_amount_more_than_available_balance_should_not_work() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(Assets::issue(Origin::signed(1), 100));
 			assert_eq!(Assets::balance(0, 1), 100);


### PR DESCRIPTION
Change `less than` to be `more than` to reflect the test purpose.