### PR TITLE
Implement Debug for some structures

### DIFF
--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -234,7 +234,7 @@ impl From<multiaddr::Error> for ParseErr {
 }
 
 /// Network service configuration.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NetworkConfiguration {
 	/// Directory path to store general network configuration. None means nothing will be saved.
 	pub config_path: Option<String>,
@@ -317,7 +317,7 @@ impl NetworkConfiguration {
 }
 
 /// Configuration for the transport layer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum TransportConfig {
 	/// Normal transport mode.
 	Normal {
@@ -362,7 +362,7 @@ impl NonReservedPeerMode {
 /// The configuration of a node's secret key, describing the type of key
 /// and how it is obtained. A node's identity keypair is the result of
 /// the evaluation of the node key configuration.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum NodeKeyConfig {
 	/// A Ed25519 secret key configuration.
 	Ed25519(Secret<ed25519::SecretKey>)
@@ -372,7 +372,7 @@ pub enum NodeKeyConfig {
 pub type Ed25519Secret = Secret<ed25519::SecretKey>;
 
 /// The configuration options for obtaining a secret key `K`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Secret<K> {
 	/// Use the given secret key `K`.
 	Input(K),

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -371,7 +371,7 @@ pub enum NodeKeyConfig {
 pub type Ed25519Secret = Secret<ed25519::SecretKey>;
 
 /// The configuration options for obtaining a secret key `K`.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum Secret<K> {
 	/// Use the given secret key `K`.
 	Input(K),
@@ -383,6 +383,16 @@ pub enum Secret<K> {
 	File(PathBuf),
 	/// Always generate a new secret key `K`.
 	New
+}
+
+impl<K> fmt::Debug for Secret<K> {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			Secret::Input(_) => f.debug_tuple("Secret::Input").finish(),
+			Secret::File(path) => f.debug_tuple("Secret::File").field(path).finish(),
+			Secret::New => f.debug_tuple("Secret::New").finish(),
+		}
+	}
 }
 
 impl NodeKeyConfig {

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -28,12 +28,11 @@ use crate::service::{ExHashT, TransactionPool};
 use bitflags::bitflags;
 use consensus::{block_validation::BlockAnnounceValidator, import_queue::ImportQueue};
 use sr_primitives::traits::{Block as BlockT};
-use std::sync::Arc;
 use libp2p::identity::{Keypair, ed25519};
 use libp2p::wasm_ext;
 use libp2p::{PeerId, Multiaddr, multiaddr};
-use std::error::Error;
-use std::{io::{self, Write}, iter, fmt, fs, net::Ipv4Addr, path::{Path, PathBuf}};
+use core::{fmt, iter};
+use std::{error::Error, fs, io::{self, Write}, net::Ipv4Addr, path::{Path, PathBuf}, sync::Arc};
 use zeroize::Zeroize;
 
 /// Network initialization parameters.


### PR DESCRIPTION
`NetworkConfiguration`, `TransportConfig`, `NodeKeyConfig` and `Secret`.

Needs a new release of the `rust-libp2p` crate. This PR is just a
reminder.
