### PR TITLE
test-utils/chain-spec-builder: Add note to run builder in release mode

### DIFF
--- a/test-utils/chain-spec-builder/Cargo.toml
+++ b/test-utils/chain-spec-builder/Cargo.toml
@@ -3,6 +3,7 @@ name = "chain-spec-builder"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 ansi_term = "0.12.1"

--- a/test-utils/chain-spec-builder/build.rs
+++ b/test-utils/chain-spec-builder/build.rs
@@ -1,0 +1,23 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::env;
+
+fn main() {
+	if let Ok(profile) = env::var("PROFILE") {
+		println!("cargo:rustc-cfg=build_type=\"{}\"", profile);
+	}
+}

--- a/test-utils/chain-spec-builder/src/main.rs
+++ b/test-utils/chain-spec-builder/src/main.rs
@@ -207,6 +207,13 @@ fn print_seeds(
 }
 
 fn main() -> Result<(), String> {
+	#[cfg(build_type="debug")]
+	println!(
+		"The chain spec builder builds a chain specification that includes a Substrate runtime compiled as WASM. To \
+		 ensure proper functioning of the included runtime compile (or run) the chain spec builder binary in \
+		 `--release` mode.\n",
+	);
+
 	let builder = ChainSpecBuilder::from_args();
 	let chain_spec_path = builder.chain_spec_path().to_path_buf();
 


### PR DESCRIPTION
One should use the chain spec builder test util in `--release` mode to produce a proper chain specification. This pull requests makes the builder print a warning whenever not run in `--release` mode.
