### PR TITLE
Make substrate-offchain compile for WASM again

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -204,6 +204,7 @@ check-web-wasm:
     - time cargo web build -p substrate-keystore
     - time cargo web build -p substrate-executor
     - time cargo web build -p substrate-network
+    - time cargo web build -p substrate-offchain
     - time cargo web build -p substrate-panic-handler
     - time cargo web build -p substrate-peerset
     - time cargo web build -p substrate-primitives

--- a/core/offchain/Cargo.toml
+++ b/core/offchain/Cargo.toml
@@ -13,8 +13,6 @@ fnv = "1.0.6"
 futures01 = { package = "futures", version = "0.1" }
 futures-preview = "0.3.0-alpha.19"
 futures-timer = "0.4.0"
-hyper = "0.12.35"
-hyper-tls = "0.3.2"
 log = "0.4.8"
 threadpool = "1.7"
 num_cpus = "1.10"
@@ -27,6 +25,10 @@ sr-primitives = { path = "../../core/sr-primitives" }
 transaction_pool = { package = "substrate-transaction-pool", path = "../../core/transaction-pool" }
 network = { package = "substrate-network", path = "../../core/network" }
 keystore = { package = "substrate-keystore", path = "../keystore" }
+
+[target.'cfg(not(target_os = "unknown"))'.dependencies]
+hyper = "0.12.35"
+hyper-tls = "0.3.2"
 
 [dev-dependencies]
 env_logger = "0.7.0"

--- a/core/offchain/src/api.rs
+++ b/core/offchain/src/api.rs
@@ -33,7 +33,14 @@ use primitives::offchain::{
 use sr_primitives::{generic::BlockId, traits::{self, Extrinsic}};
 use transaction_pool::txpool::{Pool, ChainApi};
 
+#[cfg(not(target_os = "unknown"))]
 mod http;
+
+#[cfg(target_os = "unknown")]
+use http_dummy as http;
+#[cfg(target_os = "unknown")]
+mod http_dummy;
+
 mod timestamp;
 
 /// A message between the offchain extension and the processing thread.

--- a/core/offchain/src/api/http_dummy.rs
+++ b/core/offchain/src/api/http_dummy.rs
@@ -1,0 +1,104 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Contains the same API as the `http` module, except that everything returns an error.
+
+use primitives::offchain::{HttpRequestId, Timestamp, HttpRequestStatus, HttpError};
+use std::{future::Future, pin::Pin, task::Context, task::Poll};
+
+/// Creates a pair of [`HttpApi`] and [`HttpWorker`].
+pub fn http() -> (HttpApi, HttpWorker) {
+	(HttpApi, HttpWorker)
+}
+
+/// Dummy implementation of HTTP capabilities.
+#[derive(Debug)]
+pub struct HttpApi;
+
+/// Dummy implementation of HTTP capabilities.
+#[derive(Debug)]
+pub struct HttpWorker;
+
+impl HttpApi {
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn request_start(
+		&mut self,
+		_: &str,
+		_: &str
+	) -> Result<HttpRequestId, ()> {
+		Err(())
+	}
+
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn request_add_header(
+		&mut self,
+		_: HttpRequestId,
+		_: &str,
+		_: &str
+	) -> Result<(), ()> {
+		unreachable!("Creating a request always fails, thus this function will \
+			never be called; qed")
+	}
+
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn request_write_body(
+		&mut self,
+		_: HttpRequestId,
+		_: &[u8],
+		_: Option<Timestamp>
+	) -> Result<(), HttpError> {
+		unreachable!("Creating a request always fails, thus this function will \
+			never be called; qed")
+	}
+
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn response_wait(
+		&mut self,
+		_: &[HttpRequestId],
+		_: Option<Timestamp>
+	) -> Vec<HttpRequestStatus> {
+		unreachable!("Creating a request always fails, thus this function will \
+			never be called; qed")
+	}
+
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn response_headers(
+		&mut self,
+		_: HttpRequestId
+	) -> Vec<(Vec<u8>, Vec<u8>)> {
+		unreachable!("Creating a request always fails, thus this function will \
+			never be called; qed")
+	}
+
+	/// Mimicks the corresponding method in the offchain API.
+	pub fn response_read_body(
+		&mut self,
+		_: HttpRequestId,
+		_: &mut [u8],
+		_: Option<Timestamp>
+	) -> Result<usize, HttpError> {
+		unreachable!("Creating a request always fails, thus this function will \
+			never be called; qed")
+	}
+}
+
+impl Future for HttpWorker {
+	type Output = ();
+
+	fn poll(self: Pin<&mut Self>, _: &mut Context) -> Poll<Self::Output> {
+		Poll::Ready(())
+	}
+}

--- a/core/offchain/src/api/http_dummy.rs
+++ b/core/offchain/src/api/http_dummy.rs
@@ -39,6 +39,7 @@ impl HttpApi {
 		_: &str,
 		_: &str
 	) -> Result<HttpRequestId, ()> {
+		/// Because this always returns an error, none of the other methods should ever be called.
 		Err(())
 	}
 
@@ -67,11 +68,15 @@ impl HttpApi {
 	/// Mimicks the corresponding method in the offchain API.
 	pub fn response_wait(
 		&mut self,
-		_: &[HttpRequestId],
+		requests: &[HttpRequestId],
 		_: Option<Timestamp>
 	) -> Vec<HttpRequestStatus> {
-		unreachable!("Creating a request always fails, thus this function will \
-			never be called; qed")
+		if requests.is_empty() {
+			Vec::new()
+		} else {
+			unreachable!("Creating a request always fails, thus the list of requests should \
+				always be empty; qed")
+		}
 	}
 
 	/// Mimicks the corresponding method in the offchain API.


### PR DESCRIPTION
cc #2416

When compiling for an unknown OS, we use a dummy non-working implementation of HTTP instead of hyper.
This dummy implementation always fails to create an HTTP request.
