### PR TITLE
Fix compiling substrate-chain-spec for WASM

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,6 +196,7 @@ check-web-wasm:
     - time cargo web build -p sr-io
     - time cargo web build -p sr-primitives
     - time cargo web build -p sr-std
+    - time cargo web build -p substrate-chain-spec
     - time cargo web build -p substrate-client
     - time cargo web build -p substrate-consensus-aura
     - time cargo web build -p substrate-consensus-babe

--- a/core/chain-spec/Cargo.toml
+++ b/core/chain-spec/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-chain-spec-derive = { package = "substrate-chain-spec-derive", path = "./derive" }
+substrate-chain-spec-derive = { path = "./derive" }
 impl-trait-for-tuples = "0.1.2"
 network = { package = "substrate-network", path = "../../core/network" }
 primitives = { package = "substrate-primitives", path = "../primitives" }

--- a/core/chain-spec/src/extension.rs
+++ b/core/chain-spec/src/extension.rs
@@ -253,7 +253,7 @@ impl<B, E> Extension for Forks<B, E> where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use chain_spec_derive::{ChainSpecGroup, ChainSpecExtension};
+	use substrate_chain_spec_derive::{ChainSpecGroup, ChainSpecExtension};
 	// Make the proc macro work for tests and doc tests.
 	use crate as substrate_chain_spec;
 

--- a/core/chain-spec/src/lib.rs
+++ b/core/chain-spec/src/lib.rs
@@ -113,7 +113,7 @@ mod extension;
 
 pub use chain_spec::{ChainSpec, Properties, NoExtension};
 pub use extension::{Group, Fork, Forks, Extension};
-pub use chain_spec_derive::{ChainSpecExtension, ChainSpecGroup};
+pub use substrate_chain_spec_derive::{ChainSpecExtension, ChainSpecGroup};
 
 use serde::{Serialize, de::DeserializeOwned};
 use sr_primitives::BuildStorage;


### PR DESCRIPTION
Compiling the `substrate-chain-spec` crate for WASM triggers an ICE at the moment.
See https://github.com/rust-lang/rust/issues/65971

The ICE is caused by renaming `substrate-chain-spec-derive` to `chain-spec-derive`.
This PR bypasses this issue by not renaming.