### PR TITLE
Remove NetworkSpecialization::on_event

### DIFF
--- a/core/network/src/protocol.rs
+++ b/core/network/src/protocol.rs
@@ -515,10 +515,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		self.context_data.peers.iter().map(|(id, peer)| (id, &peer.info))
 	}
 
-	pub fn on_event(&mut self, event: Event) {
-		self.specialization.on_event(event);
-	}
-
 	pub fn on_custom_message(
 		&mut self,
 		who: PeerId,

--- a/core/network/src/protocol/specialization.rs
+++ b/core/network/src/protocol/specialization.rs
@@ -42,7 +42,8 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	);
 
 	/// Called when a network-specific event arrives.
-	fn on_event(&mut self, event: Event);
+	#[deprecated(note = "This method is never called; please use `with_dht_event_tx` when building the service")]
+	fn on_event(&mut self, event: Event) {}
 
 	/// Called on abort.
 	#[deprecated(note = "This method is never called; aborting corresponds to dropping the object")]

--- a/core/network/src/test/mod.rs
+++ b/core/network/src/test/mod.rs
@@ -124,11 +124,6 @@ impl NetworkSpecialization<Block> for DummySpecialization {
 		_peer_id: PeerId,
 		_message: Vec<u8>,
 	) {}
-
-	fn on_event(
-		&mut self,
-		_event: crate::specialization::Event
-	) {}
 }
 
 pub type PeersFullClient =


### PR DESCRIPTION
Some refactoring/clean-up.

Calling `NetworkSpecialization::on_event` was initially the way that we had planned to receive DHT events.
However the `NetworkWorker` will now generate these DHT events on its stream output, and these events can be made accessible by passing a channel when building the `Service` (using `with_dht_event_tx` method).

This PR consequently deprecates `on_event`, with the intent of removing it in the not-so-far future.

I don't think Polkadot needs DHT events, but if there's ever a need for them that isn't satisfied with `with_dht_event_tx`, we can always revisit this.
