### PR TITLE
Expose backend to rpc builder

### DIFF
--- a/core/service/src/builder.rs
+++ b/core/service/src/builder.rs
@@ -568,10 +568,10 @@ impl<TBl, TRtApi, TCfg, TGen, TCSExt, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TNet
 	/// Defines the RPC extensions to use.
 	pub fn with_rpc_extensions<URpc>(
 		self,
-		rpc_ext_builder: impl FnOnce(Arc<TCl>, Arc<TExPool>) -> URpc
+		rpc_ext_builder: impl FnOnce(Arc<TCl>, Arc<TExPool>, Arc<Backend>) -> URpc
 	) -> Result<ServiceBuilder<TBl, TRtApi, TCfg, TGen, TCSExt, TCl, TFchr, TSc, TImpQu, TFprb, TFpp,
 		TNetP, TExPool, URpc, Backend>, Error> {
-		let rpc_extensions = rpc_ext_builder(self.client.clone(), self.transaction_pool.clone());
+		let rpc_extensions = rpc_ext_builder(self.client.clone(), self.transaction_pool.clone(), self.backend.clone());
 
 		Ok(ServiceBuilder {
 			config: self.config,

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -95,7 +95,7 @@ macro_rules! new_full_start {
 				import_setup = Some((block_import, grandpa_link, babe_link));
 				Ok(import_queue)
 			})?
-			.with_rpc_extensions(|client, pool| -> RpcExtension {
+			.with_rpc_extensions(|client, pool, _backend| -> RpcExtension {
 				node_rpc::create(client, pool)
 			})?;
 
@@ -322,7 +322,7 @@ pub fn new_light<C: Send + Default + 'static>(config: NodeConfiguration<C>)
 		.with_finality_proof_provider(|client, backend|
 			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, client)) as _)
 		)?
-		.with_rpc_extensions(|client, pool| -> RpcExtension {
+		.with_rpc_extensions(|client, pool, _backend| -> RpcExtension {
 			node_rpc::create(client, pool)
 		})?
 		.build()?;


### PR DESCRIPTION
Some RPC functions need to access backend (for e.g. to store info or communicate with the offchain worker). The proper way to do that now is holding a reference during setup phase - this PR exposes the backend-reference to the rpc_extension-builder function.

Probably needs an update in polkadot as well. Investigating and will follow asap.