### PR TITLE
Possible fix to storage cache

### DIFF
--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -321,27 +321,27 @@ impl<H: Hasher, B: BlockT> CacheChanges<H, B> {
 		// Propagate cache only if committing on top of the latest canonical state
 		// blocks are ordered by number and only one block with a given number is marked as canonical
 		// (contributed to canonical state cache)
-		if let Some(_) = self.parent_hash {
-			let mut local_cache = self.local_cache.write();
-			if is_best {
-				trace!(
-					"Committing {} local, {} hashes, {} modified root entries, {} modified child entries",
-					local_cache.storage.len(),
-					local_cache.hashes.len(),
-					changes.len(),
-					child_changes.iter().map(|v|v.1.len()).sum::<usize>(),
-				);
-				for (k, v) in local_cache.storage.drain() {
-					cache.lru_storage.add(k, v);
-				}
-				for (k, v) in local_cache.child_storage.drain() {
-					cache.lru_child_storage.add(k, v);
-				}
-				for (k, v) in local_cache.hashes.drain() {
-					cache.lru_hashes.add(k, OptionHOut(v));
-				}
-			}
-		}
+		// if let Some(_) = self.parent_hash {
+		// 	let mut local_cache = self.local_cache.write();
+		// 	if is_best {
+		// 		trace!(
+		// 			"Committing {} local, {} hashes, {} modified root entries, {} modified child entries",
+		// 			local_cache.storage.len(),
+		// 			local_cache.hashes.len(),
+		// 			changes.len(),
+		// 			child_changes.iter().map(|v|v.1.len()).sum::<usize>(),
+		// 		);
+		// 		for (k, v) in local_cache.storage.drain() {
+					// cache.lru_storage.add(k, v);
+				// }
+				// for (k, v) in local_cache.child_storage.drain() {
+					// cache.lru_child_storage.add(k, v);
+				// }
+				// for (k, v) in local_cache.hashes.drain() {
+					// cache.lru_hashes.add(k, OptionHOut(v));
+		// 		}
+		// 	}
+		// }
 
 		if let (
 			Some(ref number), Some(ref hash), Some(ref parent))

--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -22,6 +22,7 @@ use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use linked_hash_map::{LinkedHashMap, Entry};
 use hash_db::Hasher;
 use sr_primitives::traits::{Block as BlockT, Header};
+use primitives::hexdisplay::HexDisplay;
 use state_machine::{backend::Backend as StateBackend, TrieBackend};
 use log::trace;
 use super::{StorageCollection, ChildStorageCollection};
@@ -168,7 +169,7 @@ impl<B: BlockT, H: Hasher> Cache<B, H> {
 					trace!("Reverting enacted block {:?}", block);
 					m.is_canon = true;
 					for a in &m.storage {
-						trace!("Reverting enacted key {:?}", a);
+						trace!("Reverting enacted key {:?}", HexDisplay::from(a));
 						self.lru_storage.remove(a);
 					}
 					for a in &m.child_storage {
@@ -188,7 +189,7 @@ impl<B: BlockT, H: Hasher> Cache<B, H> {
 					trace!("Retracting block {:?}", block);
 					m.is_canon = false;
 					for a in &m.storage {
-						trace!("Retracted key {:?}", a);
+						trace!("Retracted key {:?}", HexDisplay::from(a));
 						self.lru_storage.remove(a);
 					}
 					for a in &m.child_storage {
@@ -321,8 +322,6 @@ impl<H: Hasher, B: BlockT> CacheChanges<H, B> {
 		// Propagate cache only if committing on top of the latest canonical state
 		// blocks are ordered by number and only one block with a given number is marked as canonical
 		// (contributed to canonical state cache)
-
-		// TODO: Uncomment this if block to make the test pass.
 		if let Some(_) = self.parent_hash {
 			let mut local_cache = self.local_cache.write();
 			if is_best {
@@ -418,21 +417,16 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> CachingState<H, S, B> {
 		key: Option<&[u8]>,
 		child_key: Option<&ChildStorageKey>,
 		parent_hash: &Option<B::Hash>,
-		modifications:
-		&VecDeque<BlockChanges<B::Header>>
+		modifications: &VecDeque<BlockChanges<B::Header>>
 	) -> bool
 	{
 		let mut parent = match *parent_hash {
 			None => {
-				trace!("Cache lookup skipped for {:?}: no parent hash", key);
+				trace!("Cache lookup skipped for {:?}: no parent hash", key.as_ref().map(HexDisplay::from));
 				return false;
 			}
 			Some(ref parent) => parent,
 		};
-		if modifications.is_empty() {
-			trace!("Cache lookup allowed for {:?}", key);
-			return true;
-		}
 		// Ignore all storage modified in later blocks
 		// Modifications contains block ordered by the number
 		// We search for our parent in that list first and then for
@@ -447,7 +441,7 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> CachingState<H, S, B> {
 			}
 			if let Some(key) = key {
 				if m.storage.contains(key) {
-					trace!("Cache lookup skipped for {:?}: modified in a later block", key);
+					trace!("Cache lookup skipped for {:?}: modified in a later block", HexDisplay::from(&key));
 					return false;
 				}
 			}
@@ -458,7 +452,7 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> CachingState<H, S, B> {
 				}
 			}
 		}
-		trace!("Cache lookup skipped for {:?}: parent hash is unknown", key);
+		trace!("Cache lookup skipped for {:?}: parent hash is unknown", key.as_ref().map(HexDisplay::from));
 		false
 	}
 
@@ -477,17 +471,17 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> StateBackend<H> for CachingState<
 		let local_cache = self.cache.local_cache.upgradable_read();
 		// Note that local cache makes that lru is not refreshed
 		if let Some(entry) = local_cache.storage.get(key).cloned() {
-			trace!("Found in local cache: {:?}", key);
+			trace!("Found in local cache: {:?}", HexDisplay::from(&key));
 			return Ok(entry)
 		}
 		let mut cache = self.cache.shared_cache.lock();
 		if Self::is_allowed(Some(key), None, &self.cache.parent_hash, &cache.modifications) {
 			if let Some(entry) = cache.lru_storage.get(key).map(|a| a.clone()) {
-				trace!("Found in shared cache: {:?}", key);
+				trace!("Found in shared cache: {:?}", HexDisplay::from(&key));
 				return Ok(entry)
 			}
 		}
-		trace!("Cache miss: {:?}", key);
+		trace!("Cache miss: {:?}", HexDisplay::from(&key));
 		let value = self.state.storage(key)?;
 		RwLockUpgradableReadGuard::upgrade(local_cache).storage.insert(key.to_vec(), value.clone());
 		Ok(value)
@@ -496,17 +490,17 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> StateBackend<H> for CachingState<
 	fn storage_hash(&self, key: &[u8]) -> Result<Option<H::Out>, Self::Error> {
 		let local_cache = self.cache.local_cache.upgradable_read();
 		if let Some(entry) = local_cache.hashes.get(key).cloned() {
-			trace!("Found hash in local cache: {:?}", key);
+			trace!("Found hash in local cache: {:?}", HexDisplay::from(&key));
 			return Ok(entry)
 		}
 		let mut cache = self.cache.shared_cache.lock();
 		if Self::is_allowed(Some(key), None, &self.cache.parent_hash, &cache.modifications) {
 			if let Some(entry) = cache.lru_hashes.get(key).map(|a| a.0.clone()) {
-				trace!("Found hash in shared cache: {:?}", key);
+				trace!("Found hash in shared cache: {:?}", HexDisplay::from(&key));
 				return Ok(entry)
 			}
 		}
-		trace!("Cache hash miss: {:?}", key);
+		trace!("Cache hash miss: {:?}", HexDisplay::from(&key));
 		let hash = self.state.storage_hash(key)?;
 		RwLockUpgradableReadGuard::upgrade(local_cache).hashes.insert(key.to_vec(), hash.clone());
 		Ok(hash)
@@ -733,6 +727,7 @@ mod tests {
 
 	#[test]
 	fn fix_storage_mismatch_issue() {
+		let _ = ::env_logger::try_init();
 		let root_parent = H256::random();
 
 		let key = H256::random()[..].to_vec();
@@ -740,7 +735,7 @@ mod tests {
 		let h0 = H256::random();
 		let h1 = H256::random();
 
-		let shared = new_shared_cache::<Block, Blake2Hasher>(256*1024, (0,1));
+		let shared = new_shared_cache::<Block, Blake2Hasher>(256*1024, (0, 1));
 		let mut s = CachingState::new(InMemory::<Blake2Hasher>::default(), shared.clone(), Some(root_parent.clone()));
 		s.cache.sync_cache(&[], &[], vec![(key.clone(), Some(vec![2]))], vec![], Some(h0.clone()), Some(0), || true);
 
@@ -766,9 +761,6 @@ mod tests {
 		// New value is propagated.
 		s.cache.sync_cache(&[], &[], vec![], vec![], None, None, || true);
 
-		// Wrongly get new value 42. It should instead return None or old value 3 at block h1.
-		let mut s = CachingState::new(InMemory::<Blake2Hasher>::default(), shared.clone(), Some(h1.clone()));
-		s.cache.sync_cache(&[], &[], vec![], vec![], None, None, || false);
-		assert_eq!(s.storage(&key).unwrap(), Some(vec![42]));
-	}
+		let s = CachingState::new(InMemory::<Blake2Hasher>::default(), shared.clone(), Some(h1.clone()));
+		assert_eq!(s.storage(&key).unwrap(), None);}
 }

--- a/core/client/db/src/storage_cache.rs
+++ b/core/client/db/src/storage_cache.rs
@@ -762,5 +762,6 @@ mod tests {
 		s.cache.sync_cache(&[], &[], vec![], vec![], None, None, || true);
 
 		let s = CachingState::new(InMemory::<Blake2Hasher>::default(), shared.clone(), Some(h1.clone()));
-		assert_eq!(s.storage(&key).unwrap(), None);}
+		assert_eq!(s.storage(&key).unwrap(), None);
+	}
 }


### PR DESCRIPTION
This is a possible fix to an issue that causes sync to stall in some cases.

In order to reproduce the issue you can create a fork (using `--reserved-only` or Blockade partitions) and then join the network. Depending on the length of the fork it may delay or stall sync, producing an error similar to `Thread 'import-queue-worker-0' panicked at 'Storage root must match that calculated.', srml/executive/src/lib.rs:271`.

#### Detailed (possible) explanation:
- After creating the forks, restart the clients removing `--reserved-only`, joining the network.
- When restarting the nodes `cache.modifications` will be empty.
- We can get cache misses while executing best block, filling `local_cache`.
- When other node is discovered, it imports and execute common ancestor block.
- Since `cache.modifications` is still empty, `is_allowed()` returns `true`, and we can retrieve a wrong value for the key, when querying at the ancestor block.

**Disclaimer**: I'm not very familiar with this code so the explanation may be wrong.

#### Possible solutions:
- As in the current version of the PR, eliminate the propagation of `local_cache` into `cache.lru_*`. This fixes the bug but looks like it doesn't  make full use of the caches. 
- Inserting the modification when propagating. Here I'm not sure from where should I take the `commit_hash` and `commit_number`. Well, I could take it from parent, but then probably I need to add some logic.
- Just remove the `return true` form `is_allowed` when `modifications` is empty.

\cc @arkpar , @cheme 

Closes: #3695,  #3580, https://github.com/paritytech/polkadot/issues/413
Related: #3628
