### PR TITLE
refactor code: remove unused import

### DIFF
--- a/core/authority-discovery/src/lib.rs
+++ b/core/authority-discovery/src/lib.rs
@@ -57,7 +57,7 @@ use futures::Future;
 use futures_timer::Interval;
 
 use authority_discovery_primitives::{AuthorityDiscoveryApi, AuthorityId, Signature};
-use client::{blockchain::HeaderBackend, runtime_api::StorageProof};
+use client::blockchain::HeaderBackend;
 use error::{Error, Result};
 use log::{debug, error, log_enabled, warn};
 use network::specialization::NetworkSpecialization;

--- a/core/authority-discovery/src/lib.rs
+++ b/core/authority-discovery/src/lib.rs
@@ -404,7 +404,7 @@ fn hash_authority_id(id: &[u8]) -> Result<libp2p::kad::record::Key> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use client::runtime_api::{ApiExt, Core, RuntimeVersion};
+	use client::runtime_api::{ApiExt, Core, RuntimeVersion, StorageProof};
 	use futures::channel::mpsc::channel;
 	use futures::executor::block_on;
 	use futures::future::poll_fn;


### PR DESCRIPTION
Refactor code, remove unused import: `runtime_api::StorageProof`