### PR TITLE
Limit longevity of im-online heartbeats.

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -419,12 +419,17 @@ impl sudo::Trait for Runtime {
 
 type SubmitTransaction = TransactionSubmitter<ImOnlineId, Runtime, UncheckedExtrinsic>;
 
+parameter_types! {
+	pub const SessionDuration: BlockNumber = EPOCH_DURATION_IN_SLOTS as _;
+}
+
 impl im_online::Trait for Runtime {
 	type AuthorityId = ImOnlineId;
 	type Call = Call;
 	type Event = Event;
 	type SubmitTransaction = SubmitTransaction;
 	type ReportUnresponsiveness = Offences;
+	type SessionDuration = SessionDuration;
 }
 
 impl offences::Trait for Runtime {

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -79,7 +79,7 @@ use sr_primitives::{
 	RuntimeDebug,
 	traits::{Convert, Member, Printable, Saturating}, Perbill,
 	transaction_validity::{
-		TransactionValidity, TransactionLongevity, ValidTransaction, InvalidTransaction,
+		TransactionValidity, ValidTransaction, InvalidTransaction,
 		TransactionPriority,
 	},
 };

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -74,6 +74,7 @@ use app_crypto::RuntimeAppPublic;
 use codec::{Encode, Decode};
 use primitives::offchain::{OpaqueNetworkState, StorageKind};
 use rstd::prelude::*;
+use rstd::convert::TryInto;
 use session::historical::IdentificationTuple;
 use sr_primitives::{
 	RuntimeDebug,
@@ -88,7 +89,8 @@ use sr_staking_primitives::{
 	offence::{ReportOffence, Offence, Kind},
 };
 use support::{
-	decl_module, decl_event, decl_storage, print, Parameter, debug
+	decl_module, decl_event, decl_storage, print, Parameter, debug,
+	traits::Get,
 };
 use system::ensure_none;
 use system::offchain::SubmitUnsignedTransaction;
@@ -187,6 +189,12 @@ pub trait Trait: system::Trait + session::historical::Trait {
 
 	/// A transaction submitter.
 	type SubmitTransaction: SubmitUnsignedTransaction<Self, <Self as Trait>::Call>;
+
+	/// An expected duration of the session.
+	///
+	/// This parameter is used to determine the longevity of `heartbeat` transaction
+	/// and a rough time when the heartbeat should be sent.
+	type SessionDuration: Get<Self::BlockNumber>;
 
 	/// A type that gives us the ability to submit unresponsiveness offence reports.
 	type ReportUnresponsiveness:
@@ -519,7 +527,11 @@ impl<T: Trait> session::OneSessionHandler<T::AccountId> for Module<T> {
 		where I: Iterator<Item=(&'a T::AccountId, T::AuthorityId)>
 	{
 		// Tell the offchain worker to start making the next session's heartbeats.
-		<GossipAt<T>>::put(<system::Module<T>>::block_number());
+		// Since we consider producing blocks as being online,
+		// the hearbeat is defered a bit to prevent spaming.
+		let block_number = <system::Module<T>>::block_number();
+		let half_session = T::SessionDuration::get() / 2.into();
+		<GossipAt<T>>::put(block_number + half_session);
 
 		// Remember who the authorities are for the new session.
 		Keys::<T>::put(validators.map(|x| x.1).collect::<Vec<_>>());
@@ -596,7 +608,7 @@ impl<T: Trait> support::unsigned::ValidateUnsigned for Module<T> {
 				priority: TransactionPriority::max_value(),
 				requires: vec![],
 				provides: vec![(current_session, authority_id).encode()],
-				longevity: 128,
+				longevity: TryInto::<u64>::try_into(T::SessionDuration::get() / 2.into()).unwrap_or(64_u64),
 				propagate: true,
 			})
 		} else {

--- a/srml/im-online/src/lib.rs
+++ b/srml/im-online/src/lib.rs
@@ -596,7 +596,7 @@ impl<T: Trait> support::unsigned::ValidateUnsigned for Module<T> {
 				priority: TransactionPriority::max_value(),
 				requires: vec![],
 				provides: vec![(current_session, authority_id).encode()],
-				longevity: TransactionLongevity::max_value(),
+				longevity: 128,
 				propagate: true,
 			})
 		} else {

--- a/srml/im-online/src/mock.rs
+++ b/srml/im-online/src/mock.rs
@@ -162,6 +162,7 @@ impl Trait for Runtime {
 	type Call = Call;
 	type SubmitTransaction = SubmitTransaction;
 	type ReportUnresponsiveness = OffenceHandler;
+	type SessionDuration = Period;
 }
 
 /// Im Online module.


### PR DESCRIPTION
By talking with @jacogr I realised that the heartbeat transactions effectively live forever in the pool (as we issue `immortal` transactions in the runtime). This PR limits the longevity of those transactions to 128 blocks (~13mins with 6s block time).