### PR TITLE
Don't re-compile on every `cargo run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,6 +2672,7 @@ dependencies = [
  "srml-transaction-payment 2.0.0",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-basic-authorship 2.0.0",
+ "substrate-build-script-utils 2.0.0",
  "substrate-chain-spec 2.0.0",
  "substrate-cli 2.0.0",
  "substrate-client 2.0.0",
@@ -2836,6 +2837,7 @@ dependencies = [
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "substrate-basic-authorship 2.0.0",
+ "substrate-build-script-utils 2.0.0",
  "substrate-cli 2.0.0",
  "substrate-client 2.0.0",
  "substrate-consensus-aura 2.0.0",
@@ -5218,6 +5220,10 @@ dependencies = [
  "schnorrkel 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "substrate-build-script-utils"
+version = "2.0.0"
 
 [[package]]
 name = "substrate-chain-spec"

--- a/core/utils/build-script-utils/Cargo.toml
+++ b/core/utils/build-script-utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "substrate-build-script-utils"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]

--- a/core/utils/build-script-utils/src/lib.rs
+++ b/core/utils/build-script-utils/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Crate with utility functions for `build.rs` scripts.
+
+use std::{env, path::PathBuf};
+
+/// Make sure the calling `build.rs` script is rerun when `.git/HEAD` changed.
+///
+/// The file is searched from the `CARGO_MANIFEST_DIR` upwards. If the file can not be found,
+/// a warning is generated.
+pub fn rerun_if_git_head_changed() {
+	let mut manifest_dir = PathBuf::from(
+		env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo.")
+	);
+	let manifest_dir_copy = manifest_dir.clone();
+
+	while manifest_dir.parent().is_some() {
+		if manifest_dir.join(".git/HEAD").exists() {
+			println!("cargo:rerun-if-changed={}", manifest_dir.join(".git/HEAD").display());
+			return
+		}
+
+		manifest_dir.pop();
+	}
+
+	println!(
+		"cargo:warning=Could not find `.git/HEAD` searching from `{}` upwards!",
+		manifest_dir_copy.display(),
+	);
+}

--- a/node-template/Cargo.toml
+++ b/node-template/Cargo.toml
@@ -38,3 +38,4 @@ sr-primitives = { path = "../core/sr-primitives" }
 
 [build-dependencies]
 vergen = "3.0.4"
+build-script-utils = { package = "substrate-build-script-utils", path = "../core/utils/build-script-utils" }

--- a/node-template/build.rs
+++ b/node-template/build.rs
@@ -7,18 +7,5 @@ const ERROR_MSG: &str = "Failed to generate metadata files";
 fn main() {
 	generate_cargo_keys(ConstantsFlags::SHA_SHORT).expect(ERROR_MSG);
 
-	let mut manifest_dir = PathBuf::from(
-		env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo.")
-	);
-
-	while manifest_dir.parent().is_some() {
-		if manifest_dir.join(".git/HEAD").exists() {
-			println!("cargo:rerun-if-changed={}", manifest_dir.join(".git/HEAD").display());
-			return
-		}
-
-		manifest_dir.pop();
-	}
-
-	println!("cargo:warning=Could not find `.git/HEAD` from manifest dir!");
+	build_script_utils::rerun_if_git_head_changed();
 }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -91,6 +91,7 @@ tempfile = "3.1.0"
 
 [build-dependencies]
 substrate-cli = { package = "substrate-cli", path = "../../core/cli" }
+build-script-utils = { package = "substrate-build-script-utils", path = "../../core/utils/build-script-utils" }
 structopt = "0.3.3"
 vergen = "3.0.4"
 
@@ -118,7 +119,7 @@ cli = [
 ]
 wasmtime = [
 	"cli",
-    "node-executor/wasmtime",
-    "substrate-cli/wasmtime",
-    "substrate-service/wasmtime",
+	"node-executor/wasmtime",
+	"substrate-cli/wasmtime",
+	"substrate-service/wasmtime",
 ]

--- a/node/cli/build.rs
+++ b/node/cli/build.rs
@@ -21,9 +21,9 @@ use vergen::{ConstantsFlags, generate_cargo_keys};
 
 fn main() {
 	build_shell_completion();
-	generate_cargo_keys(ConstantsFlags::all())
-		.expect("Failed to generate metadata files");
-	println!("cargo:rerun-if-changed=.git/HEAD");
+	generate_cargo_keys(ConstantsFlags::all()).expect("Failed to generate metadata files");
+
+	build_script_utils::rerun_if_git_head_changed();
 }
 
 /// Build shell completion scripts for all known shells


### PR DESCRIPTION
- Add new crate `substrate-build-script-utils` to unify the code of
`node`, `node-template` and `polkadot-node`.
- The `node-cli` build script needs to search upwards for the
`.git/HEAD` file to find it.
