### PR TITLE
Correctly serialize code in chain spec as hex

### DIFF
--- a/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
+++ b/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
@@ -23,9 +23,9 @@ use quote::quote;
 use super::super::{DeclStorageDefExt, StorageLineTypeDef};
 
 pub struct GenesisConfigFieldDef {
-	pub doc: Vec<syn::Meta>,
 	pub name: syn::Ident,
 	pub typ: syn::Type,
+	pub attrs: Vec<syn::Meta>,
 	pub default: TokenStream,
 }
 
@@ -114,17 +114,16 @@ impl GenesisConfigDef {
 				.unwrap_or_else(|| quote!( Default::default() ));
 
 			config_field_defs.push(GenesisConfigFieldDef {
-				doc: line.doc_attrs.clone(),
 				name: config_field,
 				typ,
+				attrs: line.doc_attrs.clone(),
 				default,
 			});
 		}
 
 		for line in &def.extra_genesis_config_lines {
-			let doc = line.attrs.iter()
-				.filter_map(|a| a.parse_meta().ok())
-				.filter(|m| m.name() == "doc")
+			let attrs = line.attrs.iter()
+				.map(|a| a.parse_meta().expect("attribute cannot be parsed"))
 				.collect();
 
 			let default = line.default.as_ref().map(|e| quote!( #e ))
@@ -132,9 +131,9 @@ impl GenesisConfigDef {
 
 
 			config_field_defs.push(GenesisConfigFieldDef {
-				doc,
 				name: line.name.clone(),
 				typ: line.typ.clone(),
+				attrs,
 				default,
 			});
 		}

--- a/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
+++ b/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
@@ -127,14 +127,13 @@ impl GenesisConfigDef {
 			let attrs = line.attrs.iter()
 				.map(|attr| {
 					let meta = attr.parse_meta()?;
-					if meta.path().is_ident("doc") || meta.path().is_ident("serde") {
-						Ok(meta)
-					} else {
-						Err(syn::Error::new(
+					if meta.path().is_ident("cfg") {
+						return Err(syn::Error::new(
 							meta.span(),
-							"extra genesis config item only supports `doc` and `serde` attributes"
-						))
+							"extra genesis config items do not support `cfg` attribute"
+						));
 					}
+					Ok(meta)
 				})
 				.collect::<syn::Result<_>>()?;
 

--- a/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
+++ b/srml/support/procedural/src/storage/genesis_config/genesis_config_def.rs
@@ -123,7 +123,8 @@ impl GenesisConfigDef {
 
 		for line in &def.extra_genesis_config_lines {
 			let attrs = line.attrs.iter()
-				.map(|a| a.parse_meta().expect("attribute cannot be parsed"))
+				.filter_map(|a| a.parse_meta().ok())
+				.filter(|m| m.name() == "doc" || m.name() == "serde")
 				.collect();
 
 			let default = line.default.as_ref().map(|e| quote!( #e ))

--- a/srml/support/procedural/src/storage/genesis_config/mod.rs
+++ b/srml/support/procedural/src/storage/genesis_config/mod.rs
@@ -188,10 +188,13 @@ pub fn genesis_config_and_build_storage(
 ) -> TokenStream {
 	let builders = BuilderDef::from_def(scrate, def);
 	if !builders.blocks.is_empty() {
-		let genesis_config = &GenesisConfigDef::from_def(def);
+		let genesis_config = match GenesisConfigDef::from_def(def) {
+			Ok(genesis_config) => genesis_config,
+			Err(err) => return err.to_compile_error(),
+		};
 		let decl_genesis_config_and_impl_default =
-			decl_genesis_config_and_impl_default(scrate, genesis_config);
-		let impl_build_storage = impl_build_storage(scrate, def, genesis_config, &builders);
+			decl_genesis_config_and_impl_default(scrate, &genesis_config);
+		let impl_build_storage = impl_build_storage(scrate, def, &genesis_config, &builders);
 
 		quote!{
 			#decl_genesis_config_and_impl_default

--- a/srml/support/procedural/src/storage/genesis_config/mod.rs
+++ b/srml/support/procedural/src/storage/genesis_config/mod.rs
@@ -33,13 +33,13 @@ fn decl_genesis_config_and_impl_default(
 	genesis_config: &GenesisConfigDef,
 ) -> TokenStream {
 	let config_fields = genesis_config.fields.iter().map(|field| {
-		let (name, typ, doc) = (&field.name, &field.typ, &field.doc);
-		quote!( #( #[ #doc] )* pub #name: #typ, )
+		let (name, typ, attrs) = (&field.name, &field.typ, &field.attrs);
+		quote!( #( #[ #attrs] )* pub #name: #typ, )
 	});
 
 	let config_field_defaults = genesis_config.fields.iter().map(|field| {
-		let (name, default, doc) = (&field.name, &field.default, &field.doc);
-		quote!( #( #[ #doc] )* #name: #default, )
+		let (name, default) = (&field.name, &field.default);
+		quote!( #name: #default, )
 	});
 
 	let serde_bug_bound = if !genesis_config.fields.is_empty() {


### PR DESCRIPTION
Due to a bug, the runtime code was previously serialized as a JSON array of numbers, pretty printed one byte per line. This could be seen by running `$ substrate build-spec`.

This fixes the `decl_storage!` proc macro so that the `serde` directive [already in the SRML system module code](https://github.com/paritytech/substrate/blob/master/srml/system/src/lib.rs#L421) is not ignored.