### PR TITLE
Treasury rewards should pay the remainder of the 10%

### DIFF
--- a/node/executor/src/lib.rs
+++ b/node/executor/src/lib.rs
@@ -468,11 +468,16 @@ mod tests {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(1),
+					event: Event::treasury(treasury::RawEvent::Deposit(1984800000000)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
 					event: Event::balances(balances::RawEvent::Transfer(
 						alice().into(),
 						bob().into(),
 						69 * DOLLARS,
-						1 * CENTS
+						1 * CENTS,
 					)),
 					topics: vec![],
 				},
@@ -512,6 +517,11 @@ mod tests {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(1),
+					event: Event::treasury(treasury::RawEvent::Deposit(1984780231392)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(1),
 					event: Event::balances(
 						balances::RawEvent::Transfer(
 							bob().into(),
@@ -525,6 +535,11 @@ mod tests {
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(1),
 					event: Event::system(system::Event::ExtrinsicSuccess),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(2),
+					event: Event::treasury(treasury::RawEvent::Deposit(1984780231392)),
 					topics: vec![],
 				},
 				EventRecord {

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -241,7 +241,7 @@ impl session::historical::Trait for Runtime {
 srml_staking_reward_curve::build! {
 	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
 		min_inflation: 0_025_000,
-		max_inflation: 0_100_000,
+		max_inflation: 0_100_000,   // 10% - must be equal to MaxReward below.
 		ideal_stake: 0_500_000,
 		falloff: 0_050_000,
 		max_piece_count: 40,
@@ -253,13 +253,15 @@ parameter_types! {
 	pub const SessionsPerEra: sr_staking_primitives::SessionIndex = 6;
 	pub const BondingDuration: staking::EraIndex = 24 * 28;
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
+	pub const MaxReward: Perbill = Perbill::from_percent(10);
+	// ^^^ 10% - must be equal to max_inflation, above.
 }
 
 impl staking::Trait for Runtime {
 	type Currency = Balances;
 	type Time = Timestamp;
 	type CurrencyToVote = CurrencyToVoteHandler;
-	type OnRewardMinted = Treasury;
+	type RewardRemainder = Treasury;
 	type Event = Event;
 	type Slash = Treasury; // send the slashed funds to the treasury.
 	type Reward = (); // rewards are minted from the void
@@ -267,6 +269,7 @@ impl staking::Trait for Runtime {
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type RewardCurve = RewardCurve;
+	type MaxPossibleReward = MaxReward;
 }
 
 parameter_types! {

--- a/srml/staking/src/mock.rs
+++ b/srml/staking/src/mock.rs
@@ -192,12 +192,13 @@ parameter_types! {
 	pub const SessionsPerEra: SessionIndex = 3;
 	pub const BondingDuration: EraIndex = 3;
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
+	pub const MaxReward: Perbill = Perbill::from_percent(10);
 }
 impl Trait for Test {
 	type Currency = balances::Module<Self>;
 	type Time = timestamp::Module<Self>;
 	type CurrencyToVote = CurrencyToVoteHandler;
-	type OnRewardMinted = ();
+	type RewardRemainder = ();
 	type Event = ();
 	type Slash = ();
 	type Reward = ();
@@ -205,6 +206,7 @@ impl Trait for Test {
 	type BondingDuration = BondingDuration;
 	type SessionInterface = Self;
 	type RewardCurve = RewardCurve;
+	type MaxPossibleReward = MaxReward;
 }
 
 pub struct ExtBuilder {

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -69,17 +69,6 @@ pub trait OnFreeBalanceZero<AccountId> {
 	fn on_free_balance_zero(who: &AccountId);
 }
 
-/// Trait for a hook to get called when some balance has been minted, causing dilution.
-pub trait OnDilution<Balance> {
-	/// Some `portion` of the total balance just "grew" by `minted`. `portion` is the pre-growth
-	/// amount (it doesn't take account of the recent growth).
-	fn on_dilution(minted: Balance, portion: Balance);
-}
-
-impl<Balance> OnDilution<Balance> for () {
-	fn on_dilution(_minted: Balance, _portion: Balance) {}
-}
-
 /// Outcome of a balance update.
 pub enum UpdateBalanceOutcome {
 	/// Account balance was simply updated.

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -41,16 +41,6 @@
 //! respectively.
 //! - **Pot:** Unspent funds accumulated by the treasury module.
 //!
-//! ### Implementations
-//!
-//! The treasury module provides an implementation for the following trait:
-//!
-//! - `OnDilution` - When new funds are minted to reward the deployment of other existing funds,
-//! a corresponding amount of tokens are minted into the treasury so that the tokens being rewarded
-//! do not represent a higher portion of total supply. For example, in the default substrate node,
-//! when validators are rewarded new tokens for staking, they do not hold a higher portion of total
-//! tokens. Rather, tokens are added to the treasury to keep the portion of tokens staked constant.
-//!
 //! ## Interface
 //!
 //! ### Dispatchable Functions

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -257,6 +257,8 @@ decl_event!(
 		Burnt(Balance),
 		/// Spending has finished; this is the amount that rolls over until next spend.
 		Rollover(Balance),
+		/// Some funds have been deposited.
+		Deposit(Balance),
 	}
 );
 
@@ -346,8 +348,12 @@ impl<T: Trait> Module<T> {
 
 impl<T: Trait> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
 	fn on_unbalanced(amount: NegativeImbalanceOf<T>) {
+		let numeric_amount = amount.peek();
+
 		// Must resolve into existing but better to be safe.
 		let _ = T::Currency::resolve_creating(&Self::account_id(), amount);
+
+		Self::deposit_event(RawEvent::Deposit(numeric_amount));
 	}
 }
 


### PR DESCRIPTION
This alters the functionality of staking so that 10% inflation per year is fixed and any of the 10% not paid to stakers instead goes to the treasury.

It no longer attempts to keep stakers "only at" the level of inflation, as before.

This also adds a new event to the `treasury` called `Deposit`, given out when funds are received through the `Treasury` imbalance handler.