### PR TITLE
Also replace paths in [build-dependencies]

### DIFF
--- a/scripts/node-template-release/src/main.rs
+++ b/scripts/node-template-release/src/main.rs
@@ -88,33 +88,35 @@ fn replace_path_dependencies_with_git(cargo_toml_path: &Path, commit_id: &str, c
 	// remove `Cargo.toml`
 	cargo_toml_path.pop();
 
-	let mut dependencies: toml::value::Table = match cargo_toml
-		.remove("dependencies")
-		.and_then(|v| v.try_into().ok()) {
-		Some(deps) => deps,
-		None => return,
-	};
+	for table in vec!["dependencies", "build-dependencies"] {
+		let mut dependencies: toml::value::Table = match cargo_toml
+			.remove(table)
+			.and_then(|v| v.try_into().ok()) {
+			Some(deps) => deps,
+			None => return,
+		};
 
-	let deps_rewritten = dependencies
-		.iter()
-		.filter_map(|(k, v)| v.clone().try_into::<toml::value::Table>().ok().map(move |v| (k, v)))
-		.filter(|t| t.1.contains_key("path"))
-		.filter(|t| {
-			// if the path does not exists, we need to add this as git dependency
-			t.1.get("path").unwrap().as_str().map(|path| !cargo_toml_path.join(path).exists()).unwrap_or(false)
-		})
-		.map(|(k, mut v)| {
-			// remove `path` and add `git` and `rev`
-			v.remove("path");
-			v.insert("git".into(), SUBSTRATE_GIT_URL.into());
-			v.insert("rev".into(), commit_id.into());
+		let deps_rewritten = dependencies
+			.iter()
+			.filter_map(|(k, v)| v.clone().try_into::<toml::value::Table>().ok().map(move |v| (k, v)))
+			.filter(|t| t.1.contains_key("path"))
+			.filter(|t| {
+				// if the path does not exists, we need to add this as git dependency
+				t.1.get("path").unwrap().as_str().map(|path| !cargo_toml_path.join(path).exists()).unwrap_or(false)
+			})
+			.map(|(k, mut v)| {
+				// remove `path` and add `git` and `rev`
+				v.remove("path");
+				v.insert("git".into(), SUBSTRATE_GIT_URL.into());
+				v.insert("rev".into(), commit_id.into());
 
-			(k.clone(), v.into())
-		}).collect::<HashMap<_, _>>();
+				(k.clone(), v.into())
+			}).collect::<HashMap<_, _>>();
 
-	dependencies.extend(deps_rewritten.into_iter());
+		dependencies.extend(deps_rewritten.into_iter());
 
-	cargo_toml.insert("dependencies".into(), dependencies.into());
+		cargo_toml.insert(table.into(), dependencies.into());
+	}
 }
 
 /// Update the top level (workspace) `Cargo.toml` file.

--- a/scripts/node-template-release/src/main.rs
+++ b/scripts/node-template-release/src/main.rs
@@ -88,7 +88,7 @@ fn replace_path_dependencies_with_git(cargo_toml_path: &Path, commit_id: &str, c
 	// remove `Cargo.toml`
 	cargo_toml_path.pop();
 
-	for &table in &["dependencies", "build-dependencies"] {
+	for table in &["dependencies", "build-dependencies"] {
 		let mut dependencies: toml::value::Table = match cargo_toml
 			.remove(table)
 			.and_then(|v| v.try_into().ok()) {

--- a/scripts/node-template-release/src/main.rs
+++ b/scripts/node-template-release/src/main.rs
@@ -93,7 +93,7 @@ fn replace_path_dependencies_with_git(cargo_toml_path: &Path, commit_id: &str, c
 			.remove(table)
 			.and_then(|v| v.try_into().ok()) {
 			Some(deps) => deps,
-			None => return,
+			None => continue,
 		};
 
 		let deps_rewritten = dependencies

--- a/scripts/node-template-release/src/main.rs
+++ b/scripts/node-template-release/src/main.rs
@@ -88,7 +88,7 @@ fn replace_path_dependencies_with_git(cargo_toml_path: &Path, commit_id: &str, c
 	// remove `Cargo.toml`
 	cargo_toml_path.pop();
 
-	for table in vec!["dependencies", "build-dependencies"] {
+	for &table in &["dependencies", "build-dependencies"] {
 		let mut dependencies: toml::value::Table = match cargo_toml
 			.remove(table)
 			.and_then(|v| v.try_into().ok()) {


### PR DESCRIPTION
fix the following error:
```
$ ./scripts/node-template-release.sh substrate-node-template.tar.gz
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/node-template-release /Users/ys/Desktop/polkadot/substrate/node-template /Users/ys/Desktop/polkadot/substrate/substrate-node-template.tar.gz`
error: failed to read `/private/var/folders/vm/yzhl_9_959gchmw245_0l4dw0000gn/T/.tmpIpC397/core/utils/build-script-utils/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
thread 'main' panicked at 'assertion failed: Command::new("cargo").args(&["build",
                             "--all"]).current_dir(path).status().expect("Compiles node").success()', src/main.rs:165:2
```
