### PR TITLE
grandpa: progressively increase target gossip peers

### DIFF
--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -1019,10 +1019,12 @@ impl<Block: BlockT> Inner<Block> {
         }
 
         if peer.roles.is_authority() {
+            let authorities = self.peers.authorities();
+
             // the target node is an authority, on the first attempt we start by
             // sending the message to only `sqrt(authorities)`.
-            if previous_attempts == 0 {
-                let authorities = self.peers.authorities() as f64;
+            if previous_attempts == 0 && authorities > 5 {
+                let authorities = authorities as f64;
                 let p = authorities.sqrt() / authorities;
                 rand::thread_rng().gen_bool(p)
             } else {

--- a/core/finality-grandpa/src/communication/gossip.rs
+++ b/core/finality-grandpa/src/communication/gossip.rs
@@ -991,7 +991,7 @@ impl<Block: BlockT> Inner<Block> {
 	}
 
     /// The initial logic for filtering messages follows the given state
-    /// transitions.
+    /// transitions:
     ///
     /// - State 0: not allowed to anyone (only if our local node is not an authority)
     /// - State 1: allowed to random `sqrt(authorities)`

--- a/core/network/src/protocol/consensus_gossip.rs
+++ b/core/network/src/protocol/consensus_gossip.rs
@@ -623,7 +623,9 @@ impl<B: BlockT> ConsensusGossip<B> {
 
 		trace!(target: "gossip", "Sending direct to {}: {:?}", who, message);
 
+		peer.filtered_messages.remove(&message_hash);
 		peer.known_messages.insert(message_hash);
+
 		protocol.send_consensus(who.clone(), message.clone());
 	}
 }

--- a/core/network/src/protocol/consensus_gossip.rs
+++ b/core/network/src/protocol/consensus_gossip.rs
@@ -73,7 +73,7 @@ const UNREGISTERED_TOPIC_REPUTATION_CHANGE: i32 = -(1 << 10);
 
 struct PeerConsensus<H> {
 	known_messages: HashSet<H>,
-    filtered_messages: HashMap<H, usize>,
+	filtered_messages: HashMap<H, usize>,
 	roles: Roles,
 }
 
@@ -336,7 +336,7 @@ impl<B: BlockT> ConsensusGossip<B> {
 		trace!(target:"gossip", "Registering {:?} {}", roles, who);
 		self.peers.insert(who.clone(), PeerConsensus {
 			known_messages: HashSet::new(),
-            filtered_messages: HashMap::new(),
+			filtered_messages: HashMap::new(),
 			roles,
 		});
 		for (engine_id, v) in self.validators.clone() {


### PR DESCRIPTION
Currently in GRANDPA gossip we have the notion of politeness to restrict who we should gossip messages to (i.e. only send messages to nodes that are close to the messages' round). Still, assuming that all nodes are up-to-date with the latest round we will potentially gossip messages to all of the peers we are connected to. This results in a lot of churn in the network as we keep receiving the same message multiple times from different peers.

This PR adds logic for restricting the number of peers we gossip to and progressively increase the set as necessary (i.e. if GRANDPA doesn't make any progress). The logic for filtering peers follows the given state transitions:
- State 0: don't send to anyone (only if our local node is not an authority)
- State 1: send to random `sqrt(authorities)`
- State 2: send to all authorities
- State 3: send to random `sqrt(non-authorities)`
- State 4: send to all non-authorities

Transitions will be triggered on repropagation attempts by the underlying gossip layer, which should happen every 30 seconds. Assuming GRANDPA is live and making progress these messages should be expired before any repropagation attempts happen.

The current implementation is a bit hackish, but as we have already discussed refactoring consensus gossip to extract it from the network layer, we should have more control over the implementation and be able to implement this logic more cleanly afterwards.