### PR TITLE
Separate thread pool for transaction verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,29 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-channel-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1232,11 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-core-preview"
@@ -1225,6 +1253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-executor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-executor-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,9 +1274,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-io-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures-preview"
@@ -1253,8 +1308,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-sink-preview"
 version = "0.3.0-alpha.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-task"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1265,6 +1330,24 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3266,6 +3349,11 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -6069,7 +6157,7 @@ name = "substrate-transaction-pool"
 version = "2.0.0"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7390,14 +7478,23 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum futures 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98fcd817da24593c8e88e1be8a8d7371d87f777285b9324634e4f05d2c1dc266"
+"checksum futures-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f9d78ee44e3067fa297c8c2c2313b98d014be8a3783387c500b50d7b769603"
 "checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
+"checksum futures-core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30f0ab78f035d7ed5d52689f4b05a56c15ad80097f1d860e644bdc9dba3831f2"
 "checksum futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-executor 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e36969e0468b1725a2db2930039be052459f40a8aa00070c02de8ceb3673c100"
 "checksum futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
+"checksum futures-io 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3376fa54783931f5d59e44ff3b95ff9762ba191674bf23c0e16cdcf1faf49b99"
 "checksum futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
+"checksum futures-macro 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7c97ef88dd44b07643c0667d3cfdac3bb6d8ca96940df755934e0c94047d1ac"
 "checksum futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
+"checksum futures-sink 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "346db18b3daf3e81f94023cd628230a01f34b1e64c5849f2a8308e678e1a21de"
 "checksum futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "86f148ef6b69f75bb610d4f9a2336d4fc88c4b5b67129d1a340dd0fd362efeec"
+"checksum futures-task 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ace133f7db73ad31e358cf07b495e45dd767c552f321602b8158da059359a2"
 "checksum futures-timer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "878f1d2fc31355fa02ed2372e741b0c17e58373341e6a122569b4623a14a7d33"
+"checksum futures-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4c1d6c4ceb5fcff9e8d84d76bc20ed918c61d64fe68325c0c3b611b3d9cffe"
 "checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -7566,6 +7663,7 @@ dependencies = [
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "114cdf1f426eb7f550f01af5f53a33c0946156f6814aec939b3bd77e844f9a9d"
+"checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"

--- a/core/transaction-pool/Cargo.toml
+++ b/core/transaction-pool/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 derive_more = "0.15.0"
 log = "0.4.8"
-futures-preview = "0.3.0-alpha.19"
+futures = { version = "0.3.0", features = ["thread-pool"] }
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 parking_lot = "0.9.0"
 sr-primitives = { path = "../sr-primitives" }

--- a/core/transaction-pool/src/api.rs
+++ b/core/transaction-pool/src/api.rs
@@ -17,11 +17,17 @@
 //! Chain api required for the transaction pool.
 
 use std::{
-	sync::Arc,
 	marker::PhantomData,
+	pin::Pin,
+	sync::Arc,
 };
 use client::{runtime_api::TaggedTransactionQueue, blockchain::HeaderBackend};
 use codec::Encode;
+use futures::{
+	channel::oneshot,
+	executor::{ThreadPool, ThreadPoolBuilder},
+	future::Future,
+};
 use txpool;
 use primitives::{
 	H256,
@@ -39,6 +45,7 @@ use crate::error;
 /// The transaction pool logic
 pub struct FullChainApi<T, Block> {
 	client: Arc<T>,
+	pool: ThreadPool,
 	_marker: PhantomData<Block>,
 }
 
@@ -49,6 +56,11 @@ impl<T, Block> FullChainApi<T, Block> where
 	pub fn new(client: Arc<T>) -> Self {
 		FullChainApi {
 			client,
+			pool: ThreadPoolBuilder::new()
+				.pool_size(2)
+				.name_prefix("txpool-verifier")
+				.create()
+				.expect("Failed to spawn verifier threads, that are critical for node operation."),
 			_marker: Default::default()
 		}
 	}
@@ -56,20 +68,36 @@ impl<T, Block> FullChainApi<T, Block> where
 
 impl<T, Block> txpool::ChainApi for FullChainApi<T, Block> where
 	Block: traits::Block<Hash=H256>,
-	T: traits::ProvideRuntimeApi + HeaderBackend<Block>,
+	T: traits::ProvideRuntimeApi + HeaderBackend<Block> + 'static,
 	T::Api: TaggedTransactionQueue<Block>
 {
 	type Block = Block;
 	type Hash = H256;
 	type Error = error::Error;
-	type ValidationFuture = futures::future::Ready<error::Result<TransactionValidity>>;
+	type ValidationFuture = Pin<Box<dyn Future<Output=error::Result<TransactionValidity>> + Send>>;
 
 	fn validate_transaction(
 		&self,
 		at: &BlockId<Self::Block>,
 		uxt: txpool::ExtrinsicFor<Self>,
 	) -> Self::ValidationFuture {
-		futures::future::ready(self.client.runtime_api().validate_transaction(at, uxt).map_err(Into::into))
+		let (tx, rx) = oneshot::channel();
+		let client = self.client.clone();
+		let at = at.clone();
+
+		self.pool.spawn_ok(async move {
+			let res = client.runtime_api().validate_transaction(&at, uxt).map_err(Into::into);
+			if let Err(e) = tx.send(res) {
+				log::warn!("Unable to send a validate transaction result: {:?}", e);
+			}
+		});
+
+		Box::pin(async move {
+			match rx.await {
+				Ok(r) => r,
+				Err(e) => Err(client::error::Error::Msg(format!("{}", e)))?,
+			}
+		})
 	}
 
 	fn block_id_to_number(&self, at: &BlockId<Self::Block>) -> error::Result<Option<txpool::NumberFor<Self>>> {


### PR DESCRIPTION
Since currently the full client requires a synchronous runtime call to validate transaction it might take a lot of time.
Transaction verification is being triggered from the network stack it may block all the tokio runtime threads and cause issues with networking (potentially a reason why some nodes fall behind the sync).