### PR TITLE
Fix sync downloading ancient chains

### DIFF
--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -1037,7 +1037,7 @@ impl<B: BlockT> ChainSync<B> {
 			peer.recently_announced.pop_front();
 		}
 		peer.recently_announced.push_back(hash.clone());
-		if is_best && number > peer.best_number {
+		if is_best {
 			// update their best block
 			peer.best_number = number;
 			peer.best_hash = hash;


### PR DESCRIPTION
Recently we've introduced an`is_best` flag to the block announcement to keep track of peer's best block. Before that we've assumed that the best block is always with the highest number, which is not the case with BABE. 

When peer announces a known ancient block with `best` flag, we would not update their best block, but rather common block. Which effectively makes sync think they are on a huge fork and try to sync it. 

This PR removes the incorrect assumption that best block number can't decrease, effectively preventing sync to such peers.