### PR TITLE
Change max width to 100.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ tab_width=4
 end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
-max_line_length=120
+max_line_length=100
 insert_final_newline=true
 
 [*.yml]


### PR DESCRIPTION
Sine we allow lines longer than 100 only in "exceptional circumstances" let's lower the `max_width` in `.editorconfig` to make the editors automatically wrap beyond that point.