### PR TITLE
Allow ancient fork download after ancestry search

### DIFF
--- a/core/network/src/protocol/sync.rs
+++ b/core/network/src/protocol/sync.rs
@@ -704,12 +704,8 @@ impl<B: BlockT> ChainSync<B> {
 								matching_hash,
 								peer.common_number,
 							);
-							let client = &self.client;
 							if peer.common_number < peer.best_number
 								&& peer.best_number < self.best_queued_number
-								&& matching_hash.and_then(
-									|h| client.block_status(&BlockId::Hash(h)).ok()
-								).unwrap_or(BlockStatus::Unknown) != BlockStatus::InChainPruned
 							{
 								trace!(target: "sync", "Added fork target {} for {}" , peer.best_hash, who);
 								self.fork_targets

--- a/core/network/src/test/sync.rs
+++ b/core/network/src/test/sync.rs
@@ -617,9 +617,9 @@ fn syncs_header_only_forks() {
 	net.peer(1).push_blocks(4, false);
 
 	net.block_until_sync(&mut runtime);
-	// Peer 1 won't sync the small fork because common block state is missing
+	// Peer 1 will sync the small fork even though common block state is missing
 	assert_eq!(9, net.peer(0).blocks_count());
-	assert_eq!(7, net.peer(1).blocks_count());
+	assert_eq!(9, net.peer(1).blocks_count());
 
 	// Request explicit header-only sync request for the ancient fork.
 	let first_peer_id = net.peer(0).id();


### PR DESCRIPTION
The check is obsolete now that we support downloading with missing state. It also interferes with parallel block downloading.