### PR TITLE
core/consensus: fix console output for slot duration

### DIFF
--- a/core/consensus/slots/src/lib.rs
+++ b/core/consensus/slots/src/lib.rs
@@ -410,7 +410,7 @@ impl<T: Clone> SlotDuration<T> {
 					cb(client.runtime_api(), &BlockId::number(Zero::zero()))?;
 
 				info!(
-					"Loaded block-time = {:?} seconds from genesis on first-launch",
+					"Loaded block-time = {:?} milliseconds from genesis on first-launch",
 					genesis_slot_duration
 				);
 


### PR DESCRIPTION
```
2019-11-11 12:15:30 Initializing Genesis block/state (state: 0x5b7a…35d9, header-hash: 0xf4fa…d66d)
2019-11-11 12:15:30 Loading GRANDPA authority set from genesis on what appears to be first startup.
2019-11-11 12:15:30 Loaded block-time = 15000 seconds from genesis on first-launch
2019-11-11 12:15:30 Highest known block at #0
2019-11-11 12:15:30 Using default protocol ID "sup" because none is configured in the chain specs
2019-11-11 12:15:30 Local node identity is: QmWDyvCu283NQQ3ZstJu4t2Yy8FuJ9SiiqCtjbq4u42N5g
```

The slot duration is denoted in milliseconds not seconds. This PR simply fixes the console output.

Alternatively, one could divide the slot duration by 1_000. I'm not sold on any approach.