### PR TITLE
Do nothing for zero imbalances

### DIFF
--- a/node/runtime/src/impls.rs
+++ b/node/runtime/src/impls.rs
@@ -25,7 +25,7 @@ use crate::{Balances, System, Authorship, MaximumBlockWeight, NegativeImbalance}
 
 pub struct Author;
 impl OnUnbalanced<NegativeImbalance> for Author {
-	fn on_unbalanced(amount: NegativeImbalance) {
+	fn on_nonzero_unbalanced(amount: NegativeImbalance) {
 		Balances::resolve_creating(&Authorship::author(), amount);
 	}
 }

--- a/srml/balances/src/lib.rs
+++ b/srml/balances/src/lib.rs
@@ -153,7 +153,7 @@ use codec::{Codec, Encode, Decode};
 use support::{
 	StorageValue, Parameter, decl_event, decl_storage, decl_module,
 	traits::{
-		UpdateBalanceOutcome, Currency, OnFreeBalanceZero, OnUnbalanced,
+		UpdateBalanceOutcome, Currency, OnFreeBalanceZero, OnUnbalanced, TryDrop,
 		WithdrawReason, WithdrawReasons, LockIdentifier, LockableCurrency, ExistenceRequirement,
 		Imbalance, SignedImbalance, ReservableCurrency, Get,
 	},
@@ -603,7 +603,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 mod imbalances {
 	use super::{
 		result, Subtrait, DefaultInstance, Imbalance, Trait, Zero, Instance, Saturating,
-		StorageValue,
+		StorageValue, TryDrop,
 	};
 	use rstd::mem;
 
@@ -628,6 +628,12 @@ mod imbalances {
 		/// Create a new negative imbalance from a balance.
 		pub fn new(amount: T::Balance) -> Self {
 			NegativeImbalance(amount)
+		}
+	}
+
+	impl<T: Trait<I>, I: Instance> TryDrop for PositiveImbalance<T, I> {
+		fn try_drop(self) -> result::Result<(), Self> {
+			self.drop_zero()
 		}
 	}
 
@@ -673,6 +679,12 @@ mod imbalances {
 		}
 		fn peek(&self) -> T::Balance {
 			self.0.clone()
+		}
+	}
+
+	impl<T: Trait<I>, I: Instance> TryDrop for NegativeImbalance<T, I> {
+		fn try_drop(self) -> result::Result<(), Self> {
+			self.drop_zero()
 		}
 	}
 

--- a/srml/support/src/traits.rs
+++ b/srml/support/src/traits.rs
@@ -132,13 +132,19 @@ pub trait KeyOwnerProofSystem<Key> {
 ///
 /// - Someone got slashed.
 /// - Someone paid for a transaction to be included.
-pub trait OnUnbalanced<Imbalance> {
+pub trait OnUnbalanced<Imbalance: TryDrop> {
 	/// Handler for some imbalance. Infallible.
-	fn on_unbalanced(amount: Imbalance);
+	fn on_unbalanced(amount: Imbalance) {
+		amount.try_drop().unwrap_or_else(Self::on_nonzero_unbalanced)
+	}
+
+	/// Actually handle a non-zero imbalance. You probably want to implement this rather than
+	/// `on_unbalanced`.
+	fn on_nonzero_unbalanced(amount: Imbalance);
 }
 
-impl<Imbalance> OnUnbalanced<Imbalance> for () {
-	fn on_unbalanced(amount: Imbalance) { drop(amount); }
+impl<Imbalance: TryDrop> OnUnbalanced<Imbalance> for () {
+	fn on_nonzero_unbalanced(amount: Imbalance) { drop(amount); }
 }
 
 /// Simple boolean for whether an account needs to be kept in existence.
@@ -151,6 +157,12 @@ pub enum ExistenceRequirement {
 	KeepAlive,
 	/// Operation may result in account going out of existence.
 	AllowDeath,
+}
+
+/// A type for which some values make sense to be able to drop without further consideration.
+pub trait TryDrop: Sized {
+	/// Drop an instance cleanly. Only works if its value represents "no-operation".
+	fn try_drop(self) -> Result<(), Self>;
 }
 
 /// A trait for a not-quite Linear Type that tracks an imbalance.
@@ -182,14 +194,14 @@ pub enum ExistenceRequirement {
 ///
 /// You can always retrieve the raw balance value using `peek`.
 #[must_use]
-pub trait Imbalance<Balance>: Sized {
+pub trait Imbalance<Balance>: Sized + TryDrop {
 	/// The oppositely imbalanced type. They come in pairs.
 	type Opposite: Imbalance<Balance>;
 
 	/// The zero imbalance. Can be destroyed with `drop_zero`.
 	fn zero() -> Self;
 
-	/// Drop an instance cleanly. Only works if its `value()` is zero.
+	/// Drop an instance cleanly. Only works if its `self.value()` is zero.
 	fn drop_zero(self) -> Result<(), Self>;
 
 	/// Consume `self` and return two independent instances; the first
@@ -297,7 +309,7 @@ impl<
 	Target2: OnUnbalanced<I>,
 > OnUnbalanced<I> for SplitTwoWays<Balance, I, Part1, Target1, Part2, Target2>
 {
-	fn on_unbalanced(amount: I) {
+	fn on_nonzero_unbalanced(amount: I) {
 		let total: u32 = Part1::VALUE + Part2::VALUE;
 		let amount1 = amount.peek().saturating_mul(Part1::VALUE.into()) / total.into();
 		let (imb1, imb2) = amount.split(amount1);

--- a/srml/treasury/src/lib.rs
+++ b/srml/treasury/src/lib.rs
@@ -337,7 +337,7 @@ impl<T: Trait> Module<T> {
 }
 
 impl<T: Trait> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
-	fn on_unbalanced(amount: NegativeImbalanceOf<T>) {
+	fn on_nonzero_unbalanced(amount: NegativeImbalanceOf<T>) {
 		let numeric_amount = amount.peek();
 
 		// Must resolve into existing but better to be safe.


### PR DESCRIPTION
Closes #4088 
Introduce a new `TryDrop` trait to get around the fact that `Imbalance` trait is itself generic. Then always `try_drop` before actually acting on the imbalance. This means that zero imbalances will be silently dropped without being explicitly handled, as they should be.