### PR TITLE
Fix sync stalling on moving head (best block) prior to the tip of the chain sometimes

### DIFF
--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1923,7 +1923,7 @@ pub(crate) mod tests {
 	use super::*;
 	use primitives::blake2_256;
 	use sr_primitives::DigestItem;
-	use consensus::{BlockOrigin, SelectChain};
+	use consensus::{BlockOrigin, SelectChain, BlockImport};
 	use test_client::{
 		prelude::*,
 		client_db::{Backend, DatabaseSettings, DatabaseSettingsSrc, PruningMode},
@@ -2892,5 +2892,104 @@ pub(crate) mod tests {
 			import_err.to_string(),
 			expected_err.to_string(),
 		);
+	}
+
+	#[test]
+	fn returns_status_for_pruned_blocks() {
+		let _ = env_logger::try_init();
+		let tmp = tempfile::tempdir().unwrap();
+
+		// set to prune after 1 block
+		// states
+		let backend = Arc::new(Backend::new(
+				DatabaseSettings {
+					state_cache_size: 1 << 20,
+					state_cache_child_ratio: None,
+					pruning: PruningMode::keep_blocks(1),
+					source: DatabaseSettingsSrc::Path {
+						path: tmp.path().into(),
+						cache_size: None,
+					}
+				},
+				u64::max_value(),
+		).unwrap());
+
+		let mut client = TestClientBuilder::with_backend(backend).build();
+
+		let a1 = client.new_block_at(&BlockId::Number(0), Default::default())
+			.unwrap().bake().unwrap();
+
+		let mut b1 = client.new_block_at(&BlockId::Number(0), Default::default()).unwrap();
+
+		// b1 is created, but not imported
+		b1.push_transfer(Transfer {
+			from: AccountKeyring::Alice.into(),
+			to: AccountKeyring::Ferdie.into(),
+			amount: 1,
+			nonce: 0,
+		}).unwrap();
+		let b1 = b1.bake().unwrap();
+
+		let check_block_a1 = BlockCheckParams {
+			hash: a1.hash().clone(),
+			number: 0,
+			parent_hash: a1.header().parent_hash().clone(),
+			allow_missing_state: false
+		};
+
+		assert_eq!(client.check_block(check_block_a1.clone()).unwrap(), ImportResult::imported(false));
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a1.hash)).unwrap(), BlockStatus::Unknown);
+
+		client.import_as_final(BlockOrigin::Own, a1.clone()).unwrap();
+
+		assert_eq!(client.check_block(check_block_a1.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a1.hash)).unwrap(), BlockStatus::InChainWithState);
+
+		let a2 = client.new_block_at(&BlockId::Hash(a1.hash()), Default::default())
+			.unwrap().bake().unwrap();
+		client.import_as_final(BlockOrigin::Own, a2.clone()).unwrap();
+
+		let check_block_a2 = BlockCheckParams {
+			hash: a2.hash().clone(),
+			number: 1,
+			parent_hash: a1.header().parent_hash().clone(),
+			allow_missing_state: false
+		};
+
+		assert_eq!(client.check_block(check_block_a1.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a1.hash)).unwrap(), BlockStatus::InChainPruned);
+		assert_eq!(client.check_block(check_block_a2.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a2.hash)).unwrap(), BlockStatus::InChainWithState);
+
+		let a3 = client.new_block_at(&BlockId::Hash(a2.hash()), Default::default())
+			.unwrap().bake().unwrap();
+
+		client.import_as_final(BlockOrigin::Own, a3.clone()).unwrap();
+		let check_block_a3 = BlockCheckParams {
+			hash: a3.hash().clone(),
+			number: 2,
+			parent_hash: a2.header().parent_hash().clone(),
+			allow_missing_state: false
+		};
+
+		// a1 and a2 are both pruned at this point
+		assert_eq!(client.check_block(check_block_a1.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a1.hash)).unwrap(), BlockStatus::InChainPruned);
+		assert_eq!(client.check_block(check_block_a2.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a2.hash)).unwrap(), BlockStatus::InChainPruned);
+		assert_eq!(client.check_block(check_block_a3.clone()).unwrap(), ImportResult::AlreadyInChain);
+		assert_eq!(client.block_status(&BlockId::hash(check_block_a3.hash)).unwrap(), BlockStatus::InChainWithState);
+
+		let mut check_block_b1 = BlockCheckParams {
+			hash: b1.hash().clone(),
+			number: 0,
+			parent_hash: b1.header().parent_hash().clone(),
+			allow_missing_state: false
+		};
+		assert_eq!(client.check_block(check_block_b1.clone()).unwrap(), ImportResult::MissingState);
+		check_block_b1.allow_missing_state = true;
+		assert_eq!(client.check_block(check_block_b1.clone()).unwrap(), ImportResult::imported(false));
+		check_block_b1.parent_hash = H256::random();
+		assert_eq!(client.check_block(check_block_b1.clone()).unwrap(), ImportResult::UnknownParent);
 	}
 }

--- a/core/client/src/client.rs
+++ b/core/client/src/client.rs
@@ -1593,7 +1593,8 @@ impl<'a, B, E, Block, RA> consensus::BlockImport<Block> for &'a Client<B, E, Blo
 			.map_err(|e| ConsensusError::ClientImport(e.to_string()))?
 		{
 			BlockStatus::InChainWithState | BlockStatus::Queued => return Ok(ImportResult::AlreadyInChain),
-			BlockStatus::Unknown | BlockStatus::InChainPruned => {},
+			BlockStatus::InChainPruned => return Ok(ImportResult::AlreadyInChain),
+			BlockStatus::Unknown => {},
 			BlockStatus::KnownBad => return Ok(ImportResult::KnownBad),
 		}
 

--- a/core/consensus/common/src/block_import.rs
+++ b/core/consensus/common/src/block_import.rs
@@ -95,6 +95,7 @@ pub enum ForkChoiceStrategy {
 }
 
 /// Data required to check validity of a Block.
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BlockCheckParams<Block: BlockT> {
 	/// Hash of the block that we verify.
 	pub hash: Block::Hash,

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -163,6 +163,8 @@ pub enum BlockImportError {
 	VerificationFailed(Option<Origin>, String),
 	/// Block is known to be Bad
 	BadBlock(Option<Origin>),
+	/// Parent state is missing.
+	MissingState,
 	/// Block has an unknown parent
 	UnknownParent,
 	/// Block import has been cancelled. This can happen if the parent block fails to be imported.
@@ -207,7 +209,7 @@ pub fn import_single_block<B: BlockT, V: Verifier<B>>(
 			Ok(ImportResult::Imported(aux)) => Ok(BlockImportResult::ImportedUnknown(number, aux, peer.clone())),
 			Ok(ImportResult::MissingState) => {
 				debug!(target: "sync", "Parent state is missing for {}: {:?}, parent: {:?}", number, hash, parent_hash);
-				Err(BlockImportError::UnknownParent)
+				Err(BlockImportError::MissingState)
 			},
 			Ok(ImportResult::UnknownParent) => {
 				debug!(target: "sync", "Block with unknown parent {}: {:?}, parent: {:?}", number, hash, parent_hash);

--- a/core/test-client/src/client_ext.rs
+++ b/core/test-client/src/client_ext.rs
@@ -38,6 +38,10 @@ pub trait ClientExt<Block: BlockT>: Sized {
 	fn import_as_best(&self, origin: BlockOrigin, block: Block)
 		-> Result<(), ConsensusError>;
 
+	/// Import a block and finalize it.
+	fn import_as_final(&self, origin: BlockOrigin, block: Block)
+		-> Result<(), ConsensusError>;
+
 	/// Import block with justification, finalizes block.
 	fn import_justified(
 		&self,
@@ -94,6 +98,25 @@ impl<B, E, RA, Block> ClientExt<Block> for Client<B, E, Block, RA>
 			post_digests: vec![],
 			body: Some(extrinsics),
 			finalized: false,
+			auxiliary: Vec::new(),
+			fork_choice: ForkChoiceStrategy::Custom(true),
+			allow_missing_state: false,
+		};
+
+		BlockImport::import_block(&mut (&*self), import, HashMap::new()).map(|_| ())
+	}
+
+	fn import_as_final(&self, origin: BlockOrigin, block: Block)
+		-> Result<(), ConsensusError>
+	{
+		let (header, extrinsics) = block.deconstruct();
+		let import = BlockImportParams {
+			origin,
+			header,
+			justification: None,
+			post_digests: vec![],
+			body: Some(extrinsics),
+			finalized: true,
 			auxiliary: Vec::new(),
 			fork_choice: ForkChoiceStrategy::Custom(true),
 			allow_missing_state: false,


### PR DESCRIPTION
* Work around the reorg-to-not-the-best-block by not restarting sync in such cases.
* Small optimization to avoid copying huge `peers` structure needlessly.