### PR TITLE
add hashed_key_for() getter method for StorageDoubleMap

### DIFF
--- a/paint/support/src/storage/generator/double_map.rs
+++ b/paint/support/src/storage/generator/double_map.rs
@@ -89,6 +89,14 @@ where
 {
 	type Query = G::Query;
 
+	fn hashed_key_for<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> Vec<u8>
+	where
+		KArg1: EncodeLike<K1>,
+		KArg2: EncodeLike<K2>,
+	{
+		Self::storage_double_map_final_key(k1, k2)
+	}
+
 	fn exists<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
 	where
 		KArg1: EncodeLike<K1>,

--- a/paint/support/src/storage/mod.rs
+++ b/paint/support/src/storage/mod.rs
@@ -264,6 +264,11 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	/// The type that get/take returns.
 	type Query;
 
+	fn hashed_key_for<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> Vec<u8>
+	where
+		KArg1: EncodeLike<K1>,
+		KArg2: EncodeLike<K2>;
+
 	fn exists<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
 	where
 		KArg1: EncodeLike<K1>,


### PR DESCRIPTION
I noticed that there isn't `hashed_key_for()` getter method for `StorageDoubleMap` whereas one exists in `StorageMap`. This PR adds the method.