### PR TITLE
Support custom runtime interfaces in native executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,6 +5719,7 @@ dependencies = [
  "substrate-runtime-test 2.0.0",
  "substrate-serializer 2.0.0",
  "substrate-state-machine 2.0.0",
+ "substrate-test-runtime 2.0.0",
  "substrate-trie 2.0.0",
  "substrate-wasm-interface 2.0.0",
  "test-case 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -37,13 +37,17 @@ assert_matches = "1.3.0"
 wabt = "0.9.2"
 hex-literal = "0.2.1"
 runtime-test = { package = "substrate-runtime-test", path = "runtime-test" }
+test-runtime = { package = "substrate-test-runtime", path = "../../test/utils/runtime" }
+runtime-interface = { package = "substrate-runtime-interface", path = "../../primitives/runtime-interface" }
 client-api = { package = "substrate-client-api", path = "../api" }
 substrate-offchain = { path = "../offchain/" }
 state_machine = { package = "substrate-state-machine", path = "../../primitives/state-machine"  }
 test-case = "0.3.3"
 
 [features]
-default = []
+default = [ "std" ]
+# This crate does not have `no_std` support, we just require this for tests
+std = []
 wasm-extern-trace = []
 wasmtime = [
 	"cranelift-codegen",


### PR DESCRIPTION
This makes it possible to use custom runtime interfaces within your
runtime by registering them at the native executor.
