### PR TITLE
gossip: replace LRU cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5853,7 +5861,7 @@ dependencies = [
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_hash_set 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -7848,6 +7856,7 @@ dependencies = [
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26b0dca4ac5b5083c5169ab12205e6473df1c7659940e4978b94f363c6b54b22"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,9 +5939,7 @@ version = "2.0.0"
 dependencies = [
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,14 +2478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "mach"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,7 +5792,7 @@ dependencies = [
 name = "substrate-header-metadata"
 version = "2.0.0"
 dependencies = [
- "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-primitives 2.0.0",
 ]
@@ -7857,7 +7849,6 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26b0dca4ac5b5083c5169ab12205e6473df1c7659940e4978b94f363c6b54b22"
-"checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e37c5d4cd9473c5f4c9c111f033f15d4df9bd378fdf615944e360a4f55a05f0b"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"

--- a/client/header-metadata/Cargo.toml
+++ b/client/header-metadata/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-lru-cache = { version = "0.1.2" }
+lru = { version = "0.4.0" }
 parking_lot = { version = "0.9.0" }
 sr-primitives = { path = "../../primitives/sr-primitives" }

--- a/client/header-metadata/src/lib.rs
+++ b/client/header-metadata/src/lib.rs
@@ -19,7 +19,7 @@
 
 use sr_primitives::traits::{Block as BlockT, NumberFor, Header};
 use parking_lot::RwLock;
-use lru_cache::LruCache;
+use lru::LruCache;
 
 /// Set to the expected max difference between `best` and `finalized` blocks at sync.
 const LRU_CACHE_SIZE: usize = 5_000;
@@ -243,16 +243,16 @@ impl<Block: BlockT> HeaderMetadata<Block> for HeaderMetadataCache<Block> {
 	type Error = String;
 
 	fn header_metadata(&self, hash: Block::Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
-		self.cache.write().get_mut(&hash).cloned()
+		self.cache.write().get(&hash).cloned()
 			.ok_or("header metadata not found in cache".to_owned())
 	}
 
 	fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {
-		self.cache.write().insert(hash, metadata);
+		self.cache.write().put(hash, metadata);
 	}
 
 	fn remove_header_metadata(&self, hash: Block::Hash) {
-		self.cache.write().remove(&hash);
+		self.cache.write().pop(&hash);
 	}
 }
 

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -19,7 +19,7 @@ futures03 = { package = "futures-preview", version = "0.3.0-alpha.19", features 
 futures-timer = "0.4.0"
 linked-hash-map = "0.5.2"
 linked_hash_set = "0.1.3"
-lru-cache = "0.1.2"
+lru = "0.4.0"
 rustc-hex = "2.0.1"
 rand = "0.7.2"
 libp2p = { version = "0.13.0", default-features = false, features = ["libp2p-websocket"] }

--- a/primitives/peerset/Cargo.toml
+++ b/primitives/peerset/Cargo.toml
@@ -10,9 +10,7 @@ edition = "2018"
 [dependencies]
 futures-preview = "0.3.0-alpha.19"
 libp2p = { version = "0.13.0", default-features = false }
-linked-hash-map = "0.5.2"
 log = "0.4.8"
-lru-cache = "0.1.2"
 serde_json = "1.0.41"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR replaces the `lru-cache` crate with `lru`. We use this LRU cache in gossip to keep track of what messages we have already seen previously, the issue is that we commonly call `contains_key` on this cache (e.g. when receiving a new message, or when collecting garbage) and this moves the given entry to the front of the LRU list. This made it so that we wouldn't expire messages by insertion order and instead it would depend on how many times we saw the message and when, leading us to sometimes expire recent messages which would then be added as duplicates under `self.messages`.

The `lru-cache` crate is also unmaintained now and therefore it makes sense to replace it with `lru`. The `contains` method in `lru` doesn't update the LRU list and therefore we will always make sure gossip messages are evicted from the cache according to insertion order.

I also updated `header-metadata` to use the same crate, in that case the semantics of the cache should stay the same as calling `get` should update the LRU list.