### PR TITLE
docs: fix CODEOWNERS paths

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -20,8 +20,7 @@
 
 # Wasm execution and the wasm side of Substrate Runtime Interface
 /client/executor/ @pepyakin
-/primitives/sr-io/without_std.rs @pepyakin
-/primitives/sr-std/without_std.rs @pepyakin
+/primitives/sr-io/ @pepyakin
 
 # Sandboxing capability of Substrate Runtime
 /primitives/sr-sandbox/ @pepyakin

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -19,33 +19,33 @@
 # - The latest matching rule, if multiple, takes precedence.
 
 # Wasm execution and the wasm side of Substrate Runtime Interface
-/core/executor/ @pepyakin
-/core/sr-io/without_std.rs @pepyakin
-/core/sr-std/without_std.rs @pepyakin
+/client/executor/ @pepyakin
+/primitives/sr-io/without_std.rs @pepyakin
+/primitives/sr-std/without_std.rs @pepyakin
 
 # Sandboxing capability of Substrate Runtime
-/core/sr-sandbox/ @pepyakin
-/core/primitives/src/sandbox.rs @pepyakin
+/primitives/sr-sandbox/ @pepyakin
+/primitives/core/src/sandbox.rs @pepyakin
 
 # Transaction pool
-/core/transaction-pool/ @tomusdrw
+/client/transaction-pool/ @tomusdrw
 
 # Offchain
-/core/offchain/ @tomusdrw
-/sr-io/src/offchain/ @tomusdrw
+/client/offchain/ @tomusdrw
+/primitives/offchain/ @tomusdrw
 
 # Everything that has RPC in it
-/core/rpc/ @tomusdrw
-/node/rpc/ @tomusdrw
-/node/rpc-client/ @tomusdrw
-/core/rpc-servers/ @tomusdrw
+/bin/node/rpc/ @tomusdrw
+/bin/node/rpc-client/ @tomusdrw
+/client/rpc/ @tomusdrw
+/primitives/rpc/ @tomusdrw
 
 # GRANDPA, BABE, consensus stuff
 /paint/babe/ @andresilva @DemiMarie-parity
 /paint/grandpa/ @andresilva @DemiMarie-parity
-/core/finality-grandpa/ @andresilva @DemiMarie-parity
-/core/consensus/babe/ @andresilva @DemiMarie-parity
-/core/consensus/slots/ @andresilva @DemiMarie-parity
+/client/finality-grandpa/ @andresilva @DemiMarie-parity
+/client/consensus/babe/ @andresilva @DemiMarie-parity
+/client/consensus/slots/ @andresilva @DemiMarie-parity
 
 # Contracts
 /paint/contracts/ @pepyakin @thiolliere @jimpo
@@ -59,10 +59,10 @@
 /paint/election/ @kianenigma
 
 # End to end testing of substrate node
-/node/executor/ @kianenigma
+/bin/node/executor/ @kianenigma
 
 # Transaction weight stuff
-/core/sr-primitives/weights.rs @kianenigma
+/primitives/sr-primitives/src/weights.rs @kianenigma
 
 # Support crates
 /paint/support/ @thiolliere @kianenigma


### PR DESCRIPTION
Folders were moved in #4074 and some paths weren't properly updated in CODEOWNERS file.