### PR TITLE
Transaction pool notification stream

### DIFF
--- a/client/transaction-pool/graph/src/base_pool.rs
+++ b/client/transaction-pool/graph/src/base_pool.rs
@@ -83,8 +83,7 @@ pub struct PruneStatus<Hash, Ex> {
 }
 
 /// Immutable transaction
-#[cfg_attr(test, derive(Clone))]
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Transaction<Hash, Extrinsic> {
 	/// Raw extrinsic representing that transaction.
 	pub data: Extrinsic,

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -556,9 +556,9 @@ mod tests {
 
 		// then
 		let mut it = futures::executor::block_on_stream(stream);
-		assert_eq!(it.next(), Some(()));
-		assert_eq!(it.next(), Some(()));
-		assert_eq!(it.next(), None);
+		assert!(it.next().is_some());
+		assert!(it.next().is_some());
+		assert!(it.next().is_none());
 	}
 
 	#[test]

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -38,7 +38,7 @@ use sr_primitives::{
 use crate::validated_pool::{ValidatedPool, ValidatedTransaction};
 
 /// Modification notification event stream type;
-pub type EventStream = mpsc::UnboundedReceiver<()>;
+pub type EventStream<B> = mpsc::UnboundedReceiver<base::Transaction<ExHash<B>, ExtrinsicFor<B>>>;
 
 /// Extrinsic hash type for a pool.
 pub type ExHash<A> = <A as ChainApi>::Hash;
@@ -280,7 +280,7 @@ impl<B: ChainApi> Pool<B> {
 	}
 
 	/// Return an event stream of transactions imported to the pool.
-	pub fn import_notification_stream(&self) -> EventStream {
+	pub fn import_notification_stream(&self) -> EventStream<B> {
 		self.validated_pool.import_notification_stream()
 	}
 


### PR DESCRIPTION
Previously the function `import_notification_stream` returned `Stream<Item=()>` which isn't very useful.

I'm working on an instant-seal consensus implementation for single node enviroments, and for implementation purposes
I need to get the imported transactions over a stream. This PR implements `Clone` for `transaction_pool::base::Transaction<Hash, Extrinsic>`
which allows the transaction to be cloned for each subscriber of the notification stream.