### PR TITLE
Fix serialization of `transaction_paymentInfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ version = "2.0.0"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-api 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.8"
 primitives = { package = "substrate-primitives", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "14.0.3" }
 runtime_version = { package = "sr-version", path = "../../primitives/sr-version" }
-serde_json = "1.0.41"
+serde_json = { version = "1.0.41", features = ["arbitrary_precision"] }
 session = { package = "substrate-session", path = "../../primitives/session" }
 sr-primitives = { path = "../../primitives/sr-primitives" }
 rpc-primitives = { package = "substrate-rpc-primitives", path = "../../primitives/rpc" }

--- a/paint/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/paint/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -12,7 +12,7 @@ rstd = { package = "sr-std", path = "../../../../primitives/sr-std", default-fea
 sr-primitives = { path = "../../../../primitives/sr-primitives", default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0.41"
+serde_json = { version = "1.0.41", features = ["arbitrary_precision"] }
 
 [features]
 default = ["std"]

--- a/paint/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/paint/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -11,6 +11,9 @@ codec = { package = "parity-scale-codec", version = "1.0.6", default-features = 
 rstd = { package = "sr-std", path = "../../../../primitives/sr-std", default-features = false }
 sr-primitives = { path = "../../../../primitives/sr-primitives", default-features = false }
 
+[dev-dependencies]
+serde_json = "1.0.41"
+
 [features]
 default = ["std"]
 std = [

--- a/paint/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/paint/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -63,5 +63,8 @@ mod tests {
 			serde_json::to_string(&info).unwrap(),
 			r#"{"weight":5,"class":"normal","partialFee":1000000}"#,
 		);
+
+		// should not panic
+		serde_json::to_value(&info).unwrap();
 	}
 }

--- a/paint/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/paint/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -27,6 +27,7 @@ use serde::{Serialize, Deserialize};
 /// Some information related to a dispatchable that can be queried from the runtime.
 #[derive(Eq, PartialEq, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct RuntimeDispatchInfo<Balance> {
 	/// Weight of this dispatch.
 	pub weight: Weight,
@@ -43,5 +44,24 @@ sr_api::decl_runtime_apis! {
 		Extrinsic: Codec,
 	{
 		fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn should_serialize_properly_with_u128() {
+		let info = RuntimeDispatchInfo {
+			weight: 5,
+			class: DispatchClass::Normal,
+			partial_fee: 1_000_000_u128,
+		};
+
+		assert_eq!(
+			serde_json::to_string(&info).unwrap(),
+			r#"{"weight":5,"class":"normal","partialFee":1000000}"#,
+		);
 	}
 }

--- a/primitives/sr-primitives/src/weights.rs
+++ b/primitives/sr-primitives/src/weights.rs
@@ -95,6 +95,7 @@ impl<BlockNumber: Copy> WeighBlock<BlockNumber> for SingleModule {
 /// A generalized group of dispatch types. This is only distinguishing normal, user-triggered transactions
 /// (`Normal`) and anything beyond which serves a higher purpose to the system (`Operational`).
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
 pub enum DispatchClass {
 	/// A normal dispatch.


### PR DESCRIPTION
We serialize to `serde_json::Value` internally in `jsonrpc` and without `arbitrary_precision` feature the `u128` (used as `Balance`) is not support and causes a failure.

Also fixes the format of returned response to be more javascripty.

CC @jacogr 