### PR TITLE
Fix `forks_should_work_correctly` test

### DIFF
--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -10,6 +10,6 @@ impl-trait-for-tuples = "0.1.3"
 network = { package = "substrate-network", path = "../network" }
 primitives = { package = "substrate-primitives", path = "../../primitives/core" }
 serde = { version = "1.0.101", features = ["derive"] }
-serde_json = "1.0.41"
+serde_json = { version = "1.0.41", features = [ "arbitrary_precision" ] }
 sr-primitives = { path = "../../primitives/sr-primitives" }
 tel = { package = "substrate-telemetry", path = "../telemetry" }

--- a/client/chain-spec/src/extension.rs
+++ b/client/chain-spec/src/extension.rs
@@ -289,7 +289,9 @@ mod tests {
 	fn forks_should_work_correctly() {
 		use super::Extension as _ ;
 
-		let ext: Ext2 = serde_json::from_str(r#"
+		// We first need to deserialize into a `Value` because of the following bug:
+		// https://github.com/serde-rs/json/issues/505
+		let ext_val: serde_json::Value = serde_json::from_str(r#"
 {
 	"test": 11,
 	"forkable": {
@@ -313,6 +315,8 @@ mod tests {
 	}
 }
 		"#).unwrap();
+
+		let ext: Ext2 = serde_json::from_value(ext_val).unwrap();
 
 		assert_eq!(ext.get::<Extension1>(), Some(&Extension1 {
 			test: 11


### PR DESCRIPTION
When we enabled arbitary precision for `serde_json`, the feature leaked
through the whole workspace. The given test fails because of some bug in
serde json when the feature is enabled.
