### PR TITLE
Clean up depedencies and cargo tomls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,7 +3407,6 @@ dependencies = [
  "sr-io 2.0.0",
  "sr-primitives 2.0.0",
  "sr-std 2.0.0",
- "substrate-keyring 2.0.0",
  "substrate-primitives 2.0.0",
 ]
 

--- a/palette/balances/Cargo.toml
+++ b/palette/balances/Cargo.toml
@@ -8,26 +8,27 @@ edition = "2018"
 serde = { version = "1.0.101", optional = true }
 safe-mix = { version = "1.0.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-substrate-keyring = { path = "../../primitives/keyring", optional = true }
 rstd = { package = "sr-std", path = "../../primitives/sr-std", default-features = false }
 sr-primitives = { path = "../../primitives/sr-primitives", default-features = false }
 support = { package = "palette-support", path = "../support", default-features = false }
 system = { package = "palette-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-runtime-io = { package = "sr-io", path = "../../primitives/sr-io" }
-primitives = { package = "substrate-primitives",  path = "../../primitives/core" }
-transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment" }
+runtime-io = { package = "sr-io", path = "../../primitives/sr-io", default-features = false }
+primitives = { package = "substrate-primitives", path = "../../primitives/core", default-features = false }
+transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment", default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
 	"safe-mix/std",
-	"substrate-keyring",
 	"codec/std",
 	"rstd/std",
 	"support/std",
 	"sr-primitives/std",
 	"system/std",
+	"runtime-io/std",
+	"primitives/std",
+	"transaction-payment/std",
 ]

--- a/palette/balances/Cargo.toml
+++ b/palette/balances/Cargo.toml
@@ -14,9 +14,9 @@ support = { package = "palette-support", path = "../support", default-features =
 system = { package = "palette-system", path = "../system", default-features = false }
 
 [dev-dependencies]
-runtime-io = { package = "sr-io", path = "../../primitives/sr-io", default-features = false }
-primitives = { package = "substrate-primitives", path = "../../primitives/core", default-features = false }
-transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment", default-features = false }
+runtime-io = { package = "sr-io", path = "../../primitives/sr-io" }
+primitives = { package = "substrate-primitives", path = "../../primitives/core" }
+transaction-payment = { package = "pallet-transaction-payment", path = "../transaction-payment" }
 
 [features]
 default = ["std"]
@@ -28,7 +28,4 @@ std = [
 	"support/std",
 	"sr-primitives/std",
 	"system/std",
-	"runtime-io/std",
-	"primitives/std",
-	"transaction-payment/std",
 ]

--- a/palette/balances/src/lib.rs
+++ b/palette/balances/src/lib.rs
@@ -181,7 +181,9 @@ use sr_primitives::{
 };
 use system::{IsDeadAccount, OnNewAccount, ensure_signed, ensure_root};
 
+#[cfg(test)]
 mod mock;
+#[cfg(test)]
 mod tests;
 
 pub use self::imbalances::{PositiveImbalance, NegativeImbalance};

--- a/palette/balances/src/mock.rs
+++ b/palette/balances/src/mock.rs
@@ -16,8 +16,6 @@
 
 //! Test utilities
 
-#![cfg(test)]
-
 use sr_primitives::{Perbill, traits::{ConvertInto, IdentityLookup}, testing::Header,
 	weights::{DispatchInfo, Weight}};
 use primitives::H256;

--- a/palette/balances/src/tests.rs
+++ b/palette/balances/src/tests.rs
@@ -16,8 +16,6 @@
 
 //! Tests for the module.
 
-#![cfg(test)]
-
 use super::*;
 use mock::{Balances, ExtBuilder, Runtime, System, info_from_weight, CALL};
 use sr_primitives::traits::SignedExtension;

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -17,7 +17,7 @@ impl-serde = { version = "0.2.3", optional = true }
 wasmi = { version = "0.6.2", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
-ed25519-dalek = { version = "0.9.1",  default-features = false, features = ["u64_backend"], optional = true }
+ed25519-dalek = { version = "0.9.1", default-features = false, features = ["u64_backend"], optional = true }
 base58 = { version = "0.1.0", optional = true }
 blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
 schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated"], default-features = false, optional = true }

--- a/primitives/runtime-interface/src/impls.rs
+++ b/primitives/runtime-interface/src/impls.rs
@@ -47,7 +47,7 @@ assert_eq_size!(*const u8, u32);
 /// Converts a pointer and length into an `u64`.
 pub fn pointer_and_len_to_u64(ptr: u32, len: u32) -> u64 {
 	// The static assertions from above are changed into a runtime check.
-	#[cfg(all(feature = "std", not(feature = "disable_target_static_assertions")))]
+	#[cfg(all(not(feature = "std"), feature = "disable_target_static_assertions"))]
 	assert_eq!(4, rstd::mem::size_of::<usize>());
 
 	(u64::from(len) << 32) | u64::from(ptr)
@@ -56,7 +56,7 @@ pub fn pointer_and_len_to_u64(ptr: u32, len: u32) -> u64 {
 /// Splits an `u64` into the pointer and length.
 pub fn pointer_and_len_from_u64(val: u64) -> (u32, u32) {
 	// The static assertions from above are changed into a runtime check.
-	#[cfg(all(feature = "std", not(feature = "disable_target_static_assertions")))]
+	#[cfg(all(not(feature = "std"), feature = "disable_target_static_assertions"))]
 	assert_eq!(4, rstd::mem::size_of::<usize>());
 
 	let ptr = (val & (!0u32 as u64)) as u32;


### PR DESCRIPTION
There is not really anything more we can do at the moment, if we disable the default features for the `dev-dependencies` it at least fixes the problem described in the linked issue.

Fixes: https://github.com/paritytech/substrate/issues/4179