### PR TITLE
Remove `frame/` prefix from `im_online` DB_KEY.

### DIFF
--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -131,7 +131,7 @@ pub mod ed25519 {
 
 /// The local storage database key under which the worker progress status
 /// is tracked.
-const DB_KEY: &[u8] = b"frame/im-online-worker-status";
+const DB_KEY: &[u8] = b"im-online-worker-status";
 
 /// It's important to persist the worker state, since e.g. the
 /// server could be restarted while starting the gossip process, but before

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -131,7 +131,7 @@ pub mod ed25519 {
 
 /// The local storage database key under which the worker progress status
 /// is tracked.
-const DB_KEY: &[u8] = b"im-online-worker-status";
+const DB_KEY: &[u8] = b"parity/im-online-worker-status";
 
 /// It's important to persist the worker state, since e.g. the
 /// server could be restarted while starting the gossip process, but before


### PR DESCRIPTION
Caught in the renaming process. It is not obvious to me why `frame/` or `palette/` or `srml/` was included in the DB key.

If there is rational, would love to know what that is before this is closed.