### PR TITLE
Fixed shared cache race on import

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use consensus::BlockOrigin;
 use hash_db::Hasher;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 /// In memory array of storage values.
 pub type StorageCollection = Vec<(Vec<u8>, Option<Vec<u8>>)>;
@@ -310,7 +310,7 @@ pub trait Backend<Block, H>: AuxStore + Send + Sync where
 	/// the using components should acquire and hold the lock whenever they do
 	/// something that the import of a block would interfere with, e.g. importing
 	/// a new block or calculating the best head.
-	fn get_import_lock(&self) -> &Mutex<()>;
+	fn get_import_lock(&self) -> &RwLock<()>;
 }
 
 /// Changes trie storage that supports pruning.

--- a/client/api/src/blockchain.rs
+++ b/client/api/src/blockchain.rs
@@ -22,7 +22,7 @@ use sr_primitives::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sr_primitives::generic::BlockId;
 use sr_primitives::Justification;
 use log::warn;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 
 use header_metadata::HeaderMetadata;
 
@@ -109,7 +109,7 @@ pub trait Backend<Block: BlockT>: HeaderBackend<Block> + HeaderMetadata<Block, E
 		&self,
 		target_hash: Block::Hash,
 		maybe_max_number: Option<NumberFor<Block>>,
-		import_lock: &Mutex<()>,
+		import_lock: &RwLock<()>,
 	) -> Result<Option<Block::Hash>> {
 		let target_header = {
 			match self.header(BlockId::Hash(target_hash))? {
@@ -130,7 +130,7 @@ pub trait Backend<Block: BlockT>: HeaderBackend<Block> + HeaderMetadata<Block, E
 			// ensure no blocks are imported during this code block.
 			// an import could trigger a reorg which could change the canonical chain.
 			// we depend on the canonical chain staying the same during this code block.
-			let _import_guard = import_lock.lock();
+			let _import_guard = import_lock.read();
 
 			let info = self.info();
 

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -788,7 +788,7 @@ pub struct Backend<Block: BlockT> {
 	blockchain: BlockchainDb<Block>,
 	canonicalization_delay: u64,
 	shared_cache: SharedCache<Block, Blake2Hasher>,
-	import_lock: Mutex<()>,
+	import_lock: RwLock<()>,
 	is_archive: bool,
 }
 
@@ -1251,7 +1251,7 @@ impl<Block: BlockT<Hash=H256>> Backend<Block> {
 				operation.child_storage_updates,
 				Some(hash),
 				Some(number),
-				|| is_best,
+				is_best,
 			);
 		}
 
@@ -1531,13 +1531,14 @@ impl<Block> client_api::backend::Backend<Block, Blake2Hasher> for Backend<Block>
 
 	fn destroy_state(&self, state: Self::State) -> ClientResult<()> {
 		if let Some(hash) = state.cache.parent_hash.clone() {
-			let is_best = || self.blockchain.meta.read().best_hash == hash;
+			let _ = self.import_lock.read();
+			let is_best = self.blockchain.meta.read().best_hash == hash;
 			state.release().sync_cache(&[], &[], vec![], vec![], None, None, is_best);
 		}
 		Ok(())
 	}
 
-	fn get_import_lock(&self) -> &Mutex<()> {
+	fn get_import_lock(&self) -> &RwLock<()> {
 		&self.import_lock
 	}
 }

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1531,7 +1531,6 @@ impl<Block> client_api::backend::Backend<Block, Blake2Hasher> for Backend<Block>
 
 	fn destroy_state(&self, state: Self::State) -> ClientResult<()> {
 		if let Some(hash) = state.cache.parent_hash.clone() {
-			let _ = self.import_lock.read();
 			let is_best = self.blockchain.meta.read().best_hash == hash;
 			state.release().sync_cache(&[], &[], vec![], vec![], None, None, is_best);
 		}

--- a/client/src/call_executor.rs
+++ b/client/src/call_executor.rs
@@ -97,7 +97,7 @@ where
 		)
 		.map(|(result, _, _)| result)?;
 		{
-			let _ = self.backend.get_import_lock().read();
+			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
 		Ok(return_data.into_encoded())
@@ -183,7 +183,7 @@ where
 			.map(|(result, _, _)| result)
 		}?;
 		{
-			let _ = self.backend.get_import_lock().read();
+			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
 		Ok(result)
@@ -201,7 +201,7 @@ where
 		);
 		let version = self.executor.runtime_version(&mut ext);
 		{
-			let _ = self.backend.get_import_lock().read();
+			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
 		version.ok_or(error::Error::VersionInvalid.into())

--- a/client/src/call_executor.rs
+++ b/client/src/call_executor.rs
@@ -96,7 +96,10 @@ where
 			None,
 		)
 		.map(|(result, _, _)| result)?;
-		self.backend.destroy_state(state)?;
+		{
+			let _ = self.backend.get_import_lock().read();
+			self.backend.destroy_state(state)?;
+		}
 		Ok(return_data.into_encoded())
 	}
 
@@ -179,7 +182,10 @@ where
 			)
 			.map(|(result, _, _)| result)
 		}?;
-		self.backend.destroy_state(state)?;
+		{
+			let _ = self.backend.get_import_lock().read();
+			self.backend.destroy_state(state)?;
+		}
 		Ok(result)
 	}
 
@@ -194,7 +200,10 @@ where
 			None,
 		);
 		let version = self.executor.runtime_version(&mut ext);
-		self.backend.destroy_state(state)?;
+		{
+			let _ = self.backend.get_import_lock().read();
+			self.backend.destroy_state(state)?;
+		}
 		version.ok_or(error::Error::VersionInvalid.into())
 	}
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -710,7 +710,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		Err: From<error::Error>,
 	{
 		let inner = || {
-			let _import_lock = self.backend.get_import_lock().lock();
+			let _import_lock = self.backend.get_import_lock().write();
 
 			let mut op = ClientImportOperation {
 				op: self.backend.begin_operation()?,

--- a/client/src/in_mem.rs
+++ b/client/src/in_mem.rs
@@ -18,7 +18,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use parking_lot::{RwLock, Mutex};
+use parking_lot::RwLock;
 use primitives::{ChangesTrieConfiguration, storage::well_known_keys};
 use primitives::offchain::storage::{
 	InMemOffchainStorage as OffchainStorage
@@ -562,7 +562,7 @@ where
 	states: RwLock<HashMap<Block::Hash, InMemory<H>>>,
 	changes_trie_storage: ChangesTrieStorage<Block, H>,
 	blockchain: Blockchain<Block>,
-	import_lock: Mutex<()>,
+	import_lock: RwLock<()>,
 }
 
 impl<Block, H> Backend<Block, H>
@@ -712,7 +712,7 @@ where
 		Ok(Zero::zero())
 	}
 
-	fn get_import_lock(&self) -> &Mutex<()> {
+	fn get_import_lock(&self) -> &RwLock<()> {
 		&self.import_lock
 	}
 }

--- a/client/src/light/backend.rs
+++ b/client/src/light/backend.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use parking_lot::{RwLock, Mutex};
+use parking_lot::RwLock;
 
 use state_machine::{Backend as StateBackend, TrieBackend, backend::InMemory as InMemoryState, ChangesTrieTransaction};
 use primitives::offchain::storage::InMemOffchainStorage;
@@ -49,7 +49,7 @@ const IN_MEMORY_EXPECT_PROOF: &str = "InMemory state backend has Void error type
 pub struct Backend<S, H: Hasher> {
 	blockchain: Arc<Blockchain<S>>,
 	genesis_state: RwLock<Option<InMemoryState<H>>>,
-	import_lock: Mutex<()>,
+	import_lock: RwLock<()>,
 }
 
 /// Light block (header and justification) import operation.
@@ -216,7 +216,7 @@ impl<S, Block, H> ClientBackend<Block, H> for Backend<S, H> where
 		Err(ClientError::NotAvailableOnLightClient)
 	}
 
-	fn get_import_lock(&self) -> &Mutex<()> {
+	fn get_import_lock(&self) -> &RwLock<()> {
 		&self.import_lock
 	}
 }


### PR DESCRIPTION
* Make sure cache is updated under impror lock so that the best block info is always consistent.
* `is_best` functor was checked under cache lock, which was supposed to guarantee consistency. But in reality it does not, because cache is also updated when validating transactions outside of import lock. So this is removed.
* Changed import lock to be `Rwlock` instead of `Mutex` for extra performance.