### PR TITLE
Integrate grafana and tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6577,6 +6577,7 @@ dependencies = [
 name = "substrate-tracing"
 version = "2.0.0"
 dependencies = [
+ "grafana-data-source 2.0.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "substrate-telemetry 2.0.0",

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -265,6 +265,7 @@ arg_enum! {
 	pub enum TracingReceiver {
 		Log,
 		Telemetry,
+		Grafana,
 	}
 }
 
@@ -273,6 +274,7 @@ impl Into<substrate_tracing::TracingReceiver> for TracingReceiver {
 		match self {
 			TracingReceiver::Log => substrate_tracing::TracingReceiver::Log,
 			TracingReceiver::Telemetry => substrate_tracing::TracingReceiver::Telemetry,
+			TracingReceiver::Grafana => substrate_tracing::TracingReceiver::Grafana,
 		}
 	}
 }

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -11,6 +11,7 @@ parking_lot = "0.9.0"
 tracing-core = "0.1.7"
 
 substrate-telemetry = { path = "../telemetry" }
+grafana-data-source = { path = "../grafana-data-source" }
 
 [dev-dependencies]
 tracing = "0.1.10"


### PR DESCRIPTION
This starts the integration between grafana and tracing output:

![Screenshot_2019-11-26 Substrate Dashboard - Grafana](https://user-images.githubusercontent.com/701647/69651896-12bdd100-1071-11ea-85dc-d547319cf964.png)

I opened the PR to get ideas on how to best integrate this two modules and on the usefulness of it.

TODO:
- Make the aggregation more precise (module, function, scopes?).
- Support multiple receivers? (e.g. stdout, grafana, telemetry)
