### PR TITLE
Add sha2-256 hash function

### DIFF
--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -10,7 +10,7 @@ use rstd::{vec::Vec, vec};
 
 #[cfg(not(feature = "std"))]
 use runtime_io::{
-	storage, hashing::{blake2_128, blake2_256, twox_128, twox_256},
+	storage, hashing::{blake2_128, blake2_256, sha2_256, twox_128, twox_256},
 	crypto::{ed25519_verify, sr25519_verify},
 };
 #[cfg(not(feature = "std"))]
@@ -58,6 +58,10 @@ primitives::wasm_export_functions! {
 
 	fn test_blake2_128(input: Vec<u8>) -> Vec<u8> {
 		blake2_128(&input).to_vec()
+	}
+
+	fn test_sha2_256(input: Vec<u8>) -> Vec<u8> {
+		sha2_256(&input).to_vec()
 	}
 
 	fn test_twox_256(input: Vec<u8>) -> Vec<u8> {

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -232,6 +232,42 @@ fn blake2_128_should_work(wasm_method: WasmExecutionMethod) {
 
 #[test_case(WasmExecutionMethod::Interpreted)]
 #[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+fn sha2_256_should_work(wasm_method: WasmExecutionMethod) {
+	let mut ext = TestExternalities::default();
+	let mut ext = ext.ext();
+	let test_code = WASM_BINARY;
+	assert_eq!(
+		call_in_wasm(
+			"test_sha2_256",
+			&[0],
+			wasm_method,
+			&mut ext,
+			&test_code[..],
+			8,
+		)
+		.unwrap(),
+		hex!("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+			.to_vec()
+			.encode(),
+	);
+	assert_eq!(
+		call_in_wasm(
+			"test_sha2_256",
+			&b"Hello world!".to_vec().encode(),
+			wasm_method,
+			&mut ext,
+			&test_code[..],
+			8,
+		)
+		.unwrap(),
+		hex!("c0535e4be2b79ffd93291305436bf889314e4a3faec05ecffcbb7df31ad9e51a")
+			.to_vec()
+			.encode(),
+	);
+}
+
+#[test_case(WasmExecutionMethod::Interpreted)]
+#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
 fn twox_256_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();

--- a/primitives/core/src/hashing.rs
+++ b/primitives/core/src/hashing.rs
@@ -17,6 +17,7 @@
 //! Hashing functions.
 
 use blake2_rfc;
+use sha2::{Digest, Sha256};
 use tiny_keccak::{Hasher, Keccak};
 use twox_hash;
 
@@ -129,5 +130,13 @@ pub fn keccak_256(data: &[u8]) -> [u8; 32] {
 	keccak.update(data);
 	let mut output = [0u8; 32];
 	keccak.finalize(&mut output);
+	output
+}
+
+pub fn sha2_256(data: &[u8]) -> [u8; 32] {
+	let mut hasher = Sha256::new();
+	hasher.input(data);
+	let mut output = [0u8; 32];
+	output.copy_from_slice(&hasher.result());
 	output
 }

--- a/primitives/core/src/hashing.rs
+++ b/primitives/core/src/hashing.rs
@@ -124,7 +124,7 @@ pub fn twox_256(data: &[u8]) -> [u8; 32] {
 	r
 }
 
-/// Do a keccak 256 hash and return result.
+/// Do a keccak 256-bit hash and return result.
 pub fn keccak_256(data: &[u8]) -> [u8; 32] {
 	let mut keccak = Keccak::v256();
 	keccak.update(data);
@@ -133,7 +133,7 @@ pub fn keccak_256(data: &[u8]) -> [u8; 32] {
 	output
 }
 
-/// Do a sha2 256 hash and return result.
+/// Do a sha2 256-bit hash and return result.
 pub fn sha2_256(data: &[u8]) -> [u8; 32] {
 	let mut hasher = Sha256::new();
 	hasher.input(data);

--- a/primitives/core/src/hashing.rs
+++ b/primitives/core/src/hashing.rs
@@ -133,6 +133,7 @@ pub fn keccak_256(data: &[u8]) -> [u8; 32] {
 	output
 }
 
+/// Do a sha2 256 hash and return result.
 pub fn sha2_256(data: &[u8]) -> [u8; 32] {
 	let mut hasher = Sha256::new();
 	hasher.input(data);

--- a/primitives/sr-io/src/lib.rs
+++ b/primitives/sr-io/src/lib.rs
@@ -384,6 +384,11 @@ pub trait Hashing {
 		primitives::hashing::keccak_256(data)
 	}
 
+	/// Conduct a 256-bit Sha2 hash.
+	fn sha2_256(data: &[u8]) -> [u8; 32] {
+		primitives::hashing::sha2_256(data)
+	}
+
 	/// Conduct a 128-bit Blake2 hash.
 	fn blake2_128(data: &[u8]) -> [u8; 16] {
 		primitives::hashing::blake2_128(data)


### PR DESCRIPTION
Widely used hash function, supported by [bitcoin](https://en.bitcoin.it/wiki/Script#Crypto) and [ethereum](https://solidity.readthedocs.io/en/v0.5.13/units-and-global-variables.html#mathematical-and-cryptographic-functions)
