### PR TITLE
The storage runtime interface should not enforce a hash type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,7 +5986,6 @@ name = "substrate-externalities"
 version = "2.0.0"
 dependencies = [
  "environmental 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitive-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sr-std 2.0.0",
  "substrate-primitives-storage 2.0.0",
 ]

--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -913,7 +913,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		assert!(t.ext().storage_changes_root(GENESIS_HASH.into()).unwrap().is_some());
+		assert!(t.ext().storage_changes_root(&GENESIS_HASH.encode()).unwrap().is_some());
 	}
 
 	#[test]
@@ -929,7 +929,7 @@ mod tests {
 			None,
 		).0.unwrap();
 
-		assert!(t.ext().storage_changes_root(GENESIS_HASH.into()).unwrap().is_some());
+		assert!(t.ext().storage_changes_root(&GENESIS_HASH.encode()).unwrap().is_some());
 	}
 
 	#[test]

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -174,7 +174,7 @@ impl<B: BlockT> StateBackend<Blake2Hasher> for RefTrackingState<B> {
 		self.state.storage_root(delta)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H256, bool, Self::Transaction)
 		where
 			I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 	{
@@ -193,7 +193,9 @@ impl<B: BlockT> StateBackend<Blake2Hasher> for RefTrackingState<B> {
 		self.state.child_keys(child_key, prefix)
 	}
 
-	fn as_trie_backend(&mut self) -> Option<&state_machine::TrieBackend<Self::TrieBackendStorage, Blake2Hasher>> {
+	fn as_trie_backend(
+		&mut self,
+	) -> Option<&state_machine::TrieBackend<Self::TrieBackendStorage, Blake2Hasher>> {
 		self.state.as_trie_backend()
 	}
 }

--- a/client/db/src/storage_cache.rs
+++ b/client/db/src/storage_cache.rs
@@ -568,7 +568,7 @@ impl<H: Hasher, S: StateBackend<H>, B: BlockT> StateBackend<H> for CachingState<
 		self.state.storage_root(delta)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 		where
 			I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 			H::Out: Ord

--- a/client/executor/src/deprecated_host_interface.rs
+++ b/client/executor/src/deprecated_host_interface.rs
@@ -425,7 +425,7 @@ impl_wasm_host_interface! {
 			context.read_memory_into(parent_hash_data, &mut parent_hash[..])
 				.map_err(|_| "Invalid attempt to get parent_hash in ext_storage_changes_root")?;
 
-			if let Some(r) = runtime_io::storage::changes_root(parent_hash) {
+			if let Some(r) = runtime_io::storage::changes_root(&parent_hash) {
 				context.write_memory(result, &r[..])
 					.map_err(|_| "Invalid attempt to set memory in ext_storage_changes_root")?;
 				Ok(1)

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -26,7 +26,7 @@ use log::{trace, warn};
 
 use codec::Decode;
 
-use primitives::{storage::well_known_keys, traits::Externalities, H256};
+use primitives::{storage::well_known_keys, traits::Externalities};
 
 use runtime_version::RuntimeVersion;
 use std::{collections::hash_map::{Entry, HashMap}, panic::AssertUnwindSafe};
@@ -82,7 +82,7 @@ pub struct RuntimesCache {
 	/// A cache of runtime instances along with metadata, ready to be reused.
 	///
 	/// Instances are keyed by the Wasm execution method and the hash of their code.
-	instances: HashMap<(WasmExecutionMethod, [u8; 32]), Result<VersionedRuntime, WasmError>>,
+	instances: HashMap<(WasmExecutionMethod, Vec<u8>), Result<VersionedRuntime, WasmError>>,
 }
 
 impl RuntimesCache {
@@ -128,7 +128,7 @@ impl RuntimesCache {
 		wasm_method: WasmExecutionMethod,
 		default_heap_pages: u64,
 		host_functions: &[&'static dyn Function],
-	) -> Result<(&mut (dyn WasmRuntime + 'static), &RuntimeVersion, H256), Error> {
+	) -> Result<(&mut (dyn WasmRuntime + 'static), &RuntimeVersion, Vec<u8>), Error> {
 		let code_hash = ext
 			.original_storage_hash(well_known_keys::CODE)
 			.ok_or(Error::InvalidCode("`CODE` not found in storage.".into()))?;
@@ -138,7 +138,7 @@ impl RuntimesCache {
 			.and_then(|pages| u64::decode(&mut &pages[..]).ok())
 			.unwrap_or(default_heap_pages);
 
-		let result = match self.instances.entry((wasm_method, code_hash.into())) {
+		let result = match self.instances.entry((wasm_method, code_hash.clone())) {
 			Entry::Occupied(o) => {
 				let result = o.into_mut();
 				if let Ok(ref mut cached_runtime) = result {
@@ -198,10 +198,10 @@ impl RuntimesCache {
 	pub fn invalidate_runtime(
 		&mut self,
 		wasm_method: WasmExecutionMethod,
-		code_hash: H256,
+		code_hash: Vec<u8>,
 	) {
 		// Just remove the instance, it will be re-created the next time it is requested.
-		self.instances.remove(&(wasm_method, code_hash.into()));
+		self.instances.remove(&(wasm_method, code_hash));
 	}
 }
 

--- a/client/src/cht.rs
+++ b/client/src/cht.rs
@@ -92,7 +92,7 @@ pub fn build_proof<Header, Hasher, BlocksI, HashesI>(
 	where
 		Header: HeaderT,
 		Hasher: hash_db::Hasher,
-		Hasher::Out: Ord,
+		Hasher::Out: Ord + codec::Codec,
 		BlocksI: IntoIterator<Item=Header::Number>,
 		HashesI: IntoIterator<Item=ClientResult<Option<Header::Hash>>>,
 {
@@ -119,7 +119,7 @@ pub fn check_proof<Header, Hasher>(
 	where
 		Header: HeaderT,
 		Hasher: hash_db::Hasher,
-		Hasher::Out: Ord,
+		Hasher::Out: Ord + codec::Codec,
 {
 	do_check_proof::<Header, Hasher, _>(
 		local_root,
@@ -148,7 +148,7 @@ pub fn check_proof_on_proving_backend<Header, Hasher>(
 	where
 		Header: HeaderT,
 		Hasher: hash_db::Hasher,
-		Hasher::Out: Ord,
+		Hasher::Out: Ord + codec::Codec,
 {
 	do_check_proof::<Header, Hasher, _>(
 		local_root,

--- a/client/src/light/fetcher.rs
+++ b/client/src/light/fetcher.rs
@@ -70,7 +70,7 @@ impl<E, H, B: BlockT, S: BlockchainStorage<B>> LightDataChecker<E, H, B, S> {
 	) -> ClientResult<Vec<(NumberFor<B>, u32)>>
 		where
 			H: Hasher,
-			H::Out: Ord,
+			H::Out: Ord + codec::Codec,
 	{
 		// since we need roots of all changes tries for the range begin..max
 		// => remote node can't use max block greater that one that we have passed
@@ -148,7 +148,7 @@ impl<E, H, B: BlockT, S: BlockchainStorage<B>> LightDataChecker<E, H, B, S> {
 	) -> ClientResult<()>
 		where
 			H: Hasher,
-			H::Out: Ord,
+			H::Out: Ord + codec::Codec,
 	{
 		// all the checks are sharing the same storage
 		let storage = create_proof_check_backend_storage(remote_roots_proof);

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -668,13 +668,17 @@ impl<T: Trait> Module<T> {
 			}
 		}
 
-		let storage_root = T::Hashing::storage_root();
-		let storage_changes_root = T::Hashing::storage_changes_root(parent_hash);
+		let storage_root = T::Hash::decode(&mut &runtime_io::storage::root()[..])
+			.expect("Node is configured to use the same hash; qed");
+		let storage_changes_root = runtime_io::storage::changes_root(&parent_hash.encode());
 
 		// we can't compute changes trie root earlier && put it to the Digest
 		// because it will include all currently existing temporaries.
 		if let Some(storage_changes_root) = storage_changes_root {
-			let item = generic::DigestItem::ChangesTrieRoot(storage_changes_root);
+			let item = generic::DigestItem::ChangesTrieRoot(
+				T::Hash::decode(&mut &storage_changes_root[..])
+					.expect("Node is configured to use the same hash; qed")
+			);
 			digest.push(item);
 		}
 

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-primitive-types = { version = "0.6", features = ["codec"] }
 primitives-storage = { package = "substrate-primitives-storage", path = "../core/storage" }
 rstd = { package = "sr-std", path = "../sr-std" }
 environmental = { version = "1.0.2" }

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -44,7 +44,7 @@ pub trait Externalities: ExtensionStore {
 
 	/// Get child storage value hash. This may be optimized for large values.
 	///
-	/// Returns an `Option` that holds the raw hash.
+	/// Returns an `Option` that holds the SCALE encoded hash.
 	fn child_storage_hash(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Read original runtime storage, ignoring any overlayed changes.

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -22,8 +22,6 @@
 //!
 //! This crate exposes the main [`Externalities`] trait.
 
-use primitive_types::H256;
-
 use std::any::{Any, TypeId};
 
 use primitives_storage::ChildStorageKey;
@@ -42,26 +40,40 @@ pub trait Externalities: ExtensionStore {
 	fn storage(&self, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Get storage value hash. This may be optimized for large values.
-	fn storage_hash(&self, key: &[u8]) -> Option<H256>;
+	fn storage_hash(&self, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Get child storage value hash. This may be optimized for large values.
-	fn child_storage_hash(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<H256>;
+	///
+	/// Returns an `Option` that holds the raw hash.
+	fn child_storage_hash(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Read original runtime storage, ignoring any overlayed changes.
 	fn original_storage(&self, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Read original runtime child storage, ignoring any overlayed changes.
+	///
+	/// Returns an `Option` that holds the SCALE encoded hash.
 	fn original_child_storage(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Get original storage value hash, ignoring any overlayed changes.
 	/// This may be optimized for large values.
-	fn original_storage_hash(&self, key: &[u8]) -> Option<H256>;
+	///
+	/// Returns an `Option` that holds the SCALE encoded hash.
+	fn original_storage_hash(&self, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Get original child storage value hash, ignoring any overlayed changes.
 	/// This may be optimized for large values.
-	fn original_child_storage_hash(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<H256>;
+	///
+	/// Returns an `Option` that holds the SCALE encoded hash.
+	fn original_child_storage_hash(
+		&self,
+		storage_key: ChildStorageKey,
+		key: &[u8],
+	) -> Option<Vec<u8>>;
 
 	/// Read child runtime storage.
+	///
+	/// Returns an `Option` that holds the SCALE encoded hash.
 	fn child_storage(&self, storage_key: ChildStorageKey, key: &[u8]) -> Option<Vec<u8>>;
 
 	/// Set storage entry `key` of current contract being called (effective immediately).
@@ -107,14 +119,23 @@ pub trait Externalities: ExtensionStore {
 	fn place_storage(&mut self, key: Vec<u8>, value: Option<Vec<u8>>);
 
 	/// Set or clear a child storage entry. Return whether the operation succeeds.
-	fn place_child_storage(&mut self, storage_key: ChildStorageKey, key: Vec<u8>, value: Option<Vec<u8>>);
+	fn place_child_storage(
+		&mut self,
+		storage_key: ChildStorageKey,
+		key: Vec<u8>,
+		value: Option<Vec<u8>>,
+	);
 
 	/// Get the identity of the chain.
 	fn chain_id(&self) -> u64;
 
 	/// Get the trie root of the current storage map. This will also update all child storage keys
 	/// in the top-level storage map.
-	fn storage_root(&mut self) -> H256;
+	///
+	/// The hash is defined by the `Block`.
+	///
+	/// Returns the SCALE encoded hash.
+	fn storage_root(&mut self) -> Vec<u8>;
 
 	/// Get the trie root of a child storage map. This will also update the value of the child
 	/// storage keys in the top-level storage map.
@@ -123,7 +144,12 @@ pub trait Externalities: ExtensionStore {
 	fn child_storage_root(&mut self, storage_key: ChildStorageKey) -> Vec<u8>;
 
 	/// Get the change trie root of the current storage overlay at a block with given parent.
-	fn storage_changes_root(&mut self, parent: H256) -> Result<Option<H256>, ()>;
+	/// `parent` is expects a SCALE endcoded hash.
+	///
+	/// The hash is defined by the `Block`.
+	///
+	/// Returns the SCALE encoded hash.
+	fn storage_changes_root(&mut self, parent: &[u8]) -> Result<Option<Vec<u8>>, ()>;
 }
 
 /// Extension for the [`Externalities`] trait.

--- a/primitives/sr-io/src/lib.rs
+++ b/primitives/sr-io/src/lib.rs
@@ -50,7 +50,7 @@ use primitives::{
 };
 
 #[cfg(feature = "std")]
-use trie::{TrieConfiguration, trie_types::Layout};
+use ::trie::{TrieConfiguration, trie_types::Layout};
 
 use runtime_interface::{runtime_interface, Pointer};
 
@@ -186,28 +186,45 @@ pub trait Storage {
 	}
 
 	/// "Commit" all existing operations and compute the resulting storage root.
-	fn root(&mut self) -> H256 {
+	///
+	/// The hashing algorithm is defined by the `Block`.
+	///
+	/// Returns the SCALE encoded hash.
+	fn root(&mut self) -> Vec<u8> {
 		self.storage_root()
 	}
 
 	/// "Commit" all existing operations and compute the resulting child storage root.
+	///
+	/// The hashing algorithm is defined by the `Block`.
+	///
+	/// Returns the SCALE encoded hash.
 	fn child_root(&mut self, child_storage_key: &[u8]) -> Vec<u8> {
 		let storage_key = child_storage_key_or_panic(child_storage_key);
 		self.child_storage_root(storage_key)
 	}
 
 	/// "Commit" all existing operations and get the resulting storage change root.
-	fn changes_root(&mut self, parent_hash: [u8; 32]) -> Option<H256> {
-		self.storage_changes_root(parent_hash.into()).ok().and_then(|h| h)
+	/// `parent_hash` is a SCALE encoded hash.
+	///
+	/// The hashing algorithm is defined by the `Block`.
+	///
+	/// Returns an `Option` that holds the SCALE encoded hash.
+	fn changes_root(&mut self, parent_hash: &[u8]) -> Option<Vec<u8>> {
+		self.storage_changes_root(parent_hash).ok().and_then(|h| h)
 	}
+}
 
+/// Interface that provides trie related functionality.
+#[runtime_interface]
+pub trait Trie {
 	/// A trie root formed from the iterated items.
-	fn blake2_256_trie_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> H256 {
+	fn blake2_256_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> H256 {
 		Layout::<primitives::Blake2Hasher>::trie_root(input)
 	}
 
 	/// A trie root formed from the enumerated items.
-	fn blake2_256_ordered_trie_root(input: Vec<Vec<u8>>) -> H256 {
+	fn blake2_256_ordered_root(input: Vec<Vec<u8>>) -> H256 {
 		Layout::<primitives::Blake2Hasher>::ordered_trie_root(input)
 	}
 }
@@ -774,6 +791,7 @@ pub type SubstrateHostFunctions = (
 	allocator::HostFunctions,
 	logging::HostFunctions,
 	sandbox::HostFunctions,
+	crate::trie::HostFunctions,
 );
 
 #[cfg(test)]

--- a/primitives/sr-primitives/src/traits.rs
+++ b/primitives/sr-primitives/src/traits.rs
@@ -384,12 +384,6 @@ pub trait Hash: 'static + MaybeSerializeDeserialize + Debug + Clone + Eq + Parti
 
 	/// The Patricia tree root of the given mapping.
 	fn trie_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> Self::Output;
-
-	/// Acquire the global storage root.
-	fn storage_root() -> Self::Output;
-
-	/// Acquire the global storage changes root.
-	fn storage_changes_root(parent_hash: Self::Output) -> Option<Self::Output>;
 }
 
 /// Blake2-256 Hash implementation.
@@ -405,19 +399,11 @@ impl Hash for BlakeTwo256 {
 	}
 
 	fn trie_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> Self::Output {
-		runtime_io::storage::blake2_256_trie_root(input)
+		runtime_io::trie::blake2_256_root(input)
 	}
 
 	fn ordered_trie_root(input: Vec<Vec<u8>>) -> Self::Output {
-		runtime_io::storage::blake2_256_ordered_trie_root(input)
-	}
-
-	fn storage_root() -> Self::Output {
-		runtime_io::storage::root().into()
-	}
-
-	fn storage_changes_root(parent_hash: Self::Output) -> Option<Self::Output> {
-		runtime_io::storage::changes_root(parent_hash.into()).map(Into::into)
+		runtime_io::trie::blake2_256_ordered_root(input)
 	}
 }
 

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -25,6 +25,7 @@ use trie::{
 	TrieMut, MemoryDB, child_trie_root, default_child_trie_root, TrieConfiguration,
 	trie_types::{TrieDBMut, Layout},
 };
+use codec::{Encode, Codec};
 
 /// A state backend is used to read state data and can have changes committed
 /// to it.
@@ -95,7 +96,7 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 	/// Calculate the child storage root, with given delta over what is already stored in
 	/// the backend, and produce a "transaction" that can be used to commit. The second argument
 	/// is true if child storage root equals default storage root.
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 	where
 		I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		H::Out: Ord;
@@ -134,7 +135,7 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 		I1: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		I2i: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		I2: IntoIterator<Item=(Vec<u8>, I2i)>,
-		<H as Hasher>::Out: Ord,
+		H::Out: Ord + Encode,
 	{
 		let mut txs: Self::Transaction = Default::default();
 		let mut child_roots: Vec<_> = Default::default();
@@ -146,7 +147,7 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 			if empty {
 				child_roots.push((storage_key, None));
 			} else {
-				child_roots.push((storage_key, Some(child_root)));
+				child_roots.push((storage_key, Some(child_root.encode())));
 			}
 		}
 		let (root, parent_txs) = self.storage_root(
@@ -190,7 +191,7 @@ impl<'a, T: Backend<H>, H: Hasher> Backend<H> for &'a T {
 		(*self).storage_root(delta)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 	where
 		I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		H::Out: Ord,
@@ -287,7 +288,7 @@ impl<H: Hasher> PartialEq for InMemory<H> {
 	}
 }
 
-impl<H: Hasher> InMemory<H> {
+impl<H: Hasher> InMemory<H> where H::Out: Codec {
 	/// Copy the state, with applied updates
 	pub fn update(&self, changes: <Self as Backend<H>>::Transaction) -> Self {
 		let mut inner: HashMap<_, _> = self.inner.clone();
@@ -362,7 +363,7 @@ impl<H: Hasher> InMemory<H> {
 	}
 }
 
-impl<H: Hasher> Backend<H> for InMemory<H> {
+impl<H: Hasher> Backend<H> for InMemory<H> where H::Out: Codec {
 	type Error = Void;
 	type Transaction = Vec<(Option<Vec<u8>>, Vec<u8>, Option<Vec<u8>>)>;
 	type TrieBackendStorage = MemoryDB<H>;
@@ -418,7 +419,7 @@ impl<H: Hasher> Backend<H> for InMemory<H> {
 		(root, full_transaction)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 	where
 		I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		H::Out: Ord

--- a/primitives/state-machine/src/changes_trie/build.rs
+++ b/primitives/state-machine/src/changes_trie/build.rs
@@ -18,7 +18,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::collections::btree_map::Entry;
-use codec::Decode;
+use codec::{Decode, Encode};
 use hash_db::Hasher;
 use num_traits::One;
 use crate::backend::Backend;
@@ -47,6 +47,7 @@ pub(crate) fn prepare_input<'a, B, H, Number>(
 	where
 		B: Backend<H>,
 		H: Hasher + 'a,
+		H::Out: Encode,
 		Number: BlockNumber,
 {
 	let number = parent.number.clone() + One::one();
@@ -200,7 +201,7 @@ fn prepare_digest_input<'a, H, Number>(
 	), String>
 	where
 		H: Hasher,
-		H::Out: 'a,
+		H::Out: 'a + Encode,
 		Number: BlockNumber,
 {
 	let build_skewed_digest = config.end.as_ref() == Some(&block);

--- a/primitives/state-machine/src/changes_trie/changes_iterator.rs
+++ b/primitives/state-machine/src/changes_trie/changes_iterator.rs
@@ -19,7 +19,7 @@
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, Codec};
 use hash_db::Hasher;
 use num_traits::Zero;
 use trie::Recorder;
@@ -81,7 +81,7 @@ pub fn key_changes_proof<'a, H: Hasher, Number: BlockNumber>(
 	max: Number,
 	storage_key: Option<&[u8]>,
 	key: &[u8],
-) -> Result<Vec<Vec<u8>>, String> {
+) -> Result<Vec<Vec<u8>>, String> where H::Out: Codec {
 	// we can't query any roots before root
 	let max = ::std::cmp::min(max.clone(), end.number.clone());
 
@@ -129,7 +129,7 @@ pub fn key_changes_proof_check<'a, H: Hasher, Number: BlockNumber>(
 	max: Number,
 	storage_key: Option<&[u8]>,
 	key: &[u8]
-) -> Result<Vec<(Number, u32)>, String> {
+) -> Result<Vec<(Number, u32)>, String> where H::Out: Encode {
 	key_changes_proof_check_with_db(
 		config,
 		roots_storage,
@@ -152,7 +152,7 @@ pub fn key_changes_proof_check_with_db<'a, H: Hasher, Number: BlockNumber>(
 	max: Number,
 	storage_key: Option<&[u8]>,
 	key: &[u8]
-) -> Result<Vec<(Number, u32)>, String> {
+) -> Result<Vec<(Number, u32)>, String> where H::Out: Encode {
 	// we can't query any roots before root
 	let max = ::std::cmp::min(max.clone(), end.number.clone());
 
@@ -316,8 +316,8 @@ pub struct DrilldownIterator<'a, H, Number>
 	essence: DrilldownIteratorEssence<'a, H, Number>,
 }
 
-impl<'a, H: Hasher, Number: BlockNumber> Iterator
-	for DrilldownIterator<'a, H, Number>
+impl<'a, H: Hasher, Number: BlockNumber> Iterator for DrilldownIterator<'a, H, Number>
+	where H::Out: Encode
 {
 	type Item = Result<(Number, u32), String>;
 
@@ -358,7 +358,7 @@ impl<'a, H, Number> Iterator for ProvingDrilldownIterator<'a, H, Number>
 	where
 		Number: BlockNumber,
 		H: Hasher,
-		H::Out: 'a,
+		H::Out: 'a + Codec,
 {
 	type Item = Result<(Number, u32), String>;
 

--- a/primitives/state-machine/src/changes_trie/mod.rs
+++ b/primitives/state-machine/src/changes_trie/mod.rs
@@ -181,7 +181,7 @@ pub fn build_changes_trie<'a, B: Backend<H>, S: Storage<H, Number>, H: Hasher, N
 	parent_hash: H::Out,
 ) -> Result<Option<(MemoryDB<H>, H::Out, CacheAction<H::Out, Number>)>, ()>
 	where
-		H::Out: Ord + 'static,
+		H::Out: Ord + 'static + Encode,
 {
 	let (storage, config) = match (storage, changes.changes_trie_config.as_ref()) {
 		(Some(storage), Some(config)) => (storage, config),

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -21,7 +21,7 @@
 use std::{fmt, result, collections::HashMap, panic::UnwindSafe, marker::PhantomData};
 use log::{warn, trace};
 use hash_db::Hasher;
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, Codec};
 use primitives::{
 	storage::well_known_keys, NativeOrEncoded, NeverNativeValue,
 	traits::CodeExecutor, hexdisplay::HexDisplay, hash::H256,
@@ -567,7 +567,7 @@ pub fn prove_child_read<B, H, I>(
 where
 	B: Backend<H>,
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 	I: IntoIterator,
 	I::Item: AsRef<[u8]>,
 {
@@ -584,7 +584,7 @@ pub fn prove_read_on_trie_backend<S, H, I>(
 where
 	S: trie_backend_essence::TrieBackendStorage<H>,
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 	I: IntoIterator,
 	I::Item: AsRef<[u8]>,
 {
@@ -606,7 +606,7 @@ pub fn prove_child_read_on_trie_backend<S, H, I>(
 where
 	S: trie_backend_essence::TrieBackendStorage<H>,
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 	I: IntoIterator,
 	I::Item: AsRef<[u8]>,
 {
@@ -627,7 +627,7 @@ pub fn read_proof_check<H, I>(
 ) -> Result<HashMap<Vec<u8>, Option<Vec<u8>>>, Box<dyn Error>>
 where
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 	I: IntoIterator,
 	I::Item: AsRef<[u8]>,
 {
@@ -649,7 +649,7 @@ pub fn read_child_proof_check<H, I>(
 ) -> Result<HashMap<Vec<u8>, Option<Vec<u8>>>, Box<dyn Error>>
 where
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 	I: IntoIterator,
 	I::Item: AsRef<[u8]>,
 {
@@ -673,7 +673,7 @@ pub fn read_proof_check_on_proving_backend<H>(
 ) -> Result<Option<Vec<u8>>, Box<dyn Error>>
 where
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 {
 	proving_backend.storage(key).map_err(|e| Box::new(e) as Box<dyn Error>)
 }
@@ -686,7 +686,7 @@ pub fn read_child_proof_check_on_proving_backend<H>(
 ) -> Result<Option<Vec<u8>>, Box<dyn Error>>
 where
 	H: Hasher,
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 {
 	proving_backend.child_storage(storage_key, key).map_err(|e| Box::new(e) as Box<dyn Error>)
 }

--- a/primitives/state-machine/src/overlayed_changes.rs
+++ b/primitives/state-machine/src/overlayed_changes.rs
@@ -352,7 +352,7 @@ impl From<Option<Vec<u8>>> for OverlayedValue {
 mod tests {
 	use hex_literal::hex;
 	use primitives::{
-		Blake2Hasher, H256, traits::Externalities, storage::well_known_keys::EXTRINSIC_INDEX,
+		Blake2Hasher, traits::Externalities, storage::well_known_keys::EXTRINSIC_INDEX,
 	};
 	use crate::backend::InMemory;
 	use crate::changes_trie::InMemoryStorage as InMemoryChangesTrieStorage;
@@ -426,7 +426,7 @@ mod tests {
 		);
 		const ROOT: [u8; 32] = hex!("39245109cef3758c2eed2ccba8d9b370a917850af3824bc8348d505df2c298fa");
 
-		assert_eq!(ext.storage_root(), H256::from(ROOT));
+		assert_eq!(&ext.storage_root()[..], &ROOT);
 	}
 
 	#[test]

--- a/primitives/state-machine/src/proving_backend.rs
+++ b/primitives/state-machine/src/proving_backend.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 use parking_lot::RwLock;
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, Codec};
 use log::debug;
 use hash_db::{Hasher, HashDB, EMPTY_PREFIX, Prefix};
 use trie::{
@@ -119,6 +119,7 @@ impl<'a, S, H> ProvingBackendRecorder<'a, S, H>
 	where
 		S: TrieBackendStorage<H>,
 		H: Hasher,
+		H::Out: Codec,
 {
 	/// Produce proof for a key query.
 	pub fn storage(&mut self, key: &[u8]) -> Result<Option<Vec<u8>>, String> {
@@ -145,6 +146,7 @@ impl<'a, S, H> ProvingBackendRecorder<'a, S, H>
 		key: &[u8]
 	) -> Result<Option<Vec<u8>>, String> {
 		let root = self.storage(storage_key)?
+			.and_then(|r| Decode::decode(&mut &r[..]).ok())
 			.unwrap_or(default_child_trie_root::<Layout<H>>(storage_key));
 
 		let mut read_overlay = S::Overlay::default();
@@ -158,7 +160,7 @@ impl<'a, S, H> ProvingBackendRecorder<'a, S, H>
 		read_child_trie_value_with::<Layout<H>, _, _>(
 			storage_key,
 			&eph,
-			&root,
+			&root.as_ref(),
 			key,
 			&mut *self.proof_recorder
 		).map_err(map_e)
@@ -199,7 +201,9 @@ pub struct ProofRecorderBackend<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hashe
 	proof_recorder: ProofRecorder<H>,
 }
 
-impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> ProvingBackend<'a, S, H> {
+impl<'a, S: 'a + TrieBackendStorage<H>, H: 'a + Hasher> ProvingBackend<'a, S, H>
+	where H::Out: Codec
+{
 	/// Create new proving backend.
 	pub fn new(backend: &'a TrieBackend<S, H>) -> Self {
 		let proof_recorder = Default::default();
@@ -254,7 +258,7 @@ impl<'a, S, H> Backend<H> for ProvingBackend<'a, S, H>
 	where
 		S: 'a + TrieBackendStorage<H>,
 		H: 'a + Hasher,
-		H::Out: Ord,
+		H::Out: Ord + Codec,
 {
 	type Error = String;
 	type Transaction = S::Overlay;
@@ -302,7 +306,7 @@ impl<'a, S, H> Backend<H> for ProvingBackend<'a, S, H>
 		self.0.storage_root(delta)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 	where
 		I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
 		H::Out: Ord
@@ -318,6 +322,7 @@ pub fn create_proof_check_backend<H>(
 ) -> Result<TrieBackend<MemoryDB<H>, H>, Box<dyn Error>>
 where
 	H: Hasher,
+	H::Out: Codec,
 {
 	let db = create_proof_check_backend_storage(proof);
 

--- a/primitives/state-machine/src/testing.rs
+++ b/primitives/state-machine/src/testing.rs
@@ -178,7 +178,7 @@ mod tests {
 		ext.set_storage(b"dog".to_vec(), b"puppy".to_vec());
 		ext.set_storage(b"dogglesworth".to_vec(), b"cat".to_vec());
 		const ROOT: [u8; 32] = hex!("2a340d3dfd52f5992c6b117e9e45f479e6da5afffafeb26ab619cf137a95aeb8");
-		assert_eq!(ext.storage_root(), H256::from(ROOT));
+		assert_eq!(&ext.storage_root()[..], &ROOT);
 	}
 
 	#[test]

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -22,13 +22,14 @@ use trie::{Trie, delta_trie_root, default_child_trie_root, child_delta_trie_root
 use trie::trie_types::{TrieDB, TrieError, Layout};
 use crate::trie_backend_essence::{TrieBackendEssence, TrieBackendStorage, Ephemeral};
 use crate::Backend;
+use codec::{Codec, Decode};
 
 /// Patricia trie-based backend. Transaction type is an overlay of changes to commit.
 pub struct TrieBackend<S: TrieBackendStorage<H>, H: Hasher> {
 	essence: TrieBackendEssence<S, H>,
 }
 
-impl<S: TrieBackendStorage<H>, H: Hasher> TrieBackend<S, H> {
+impl<S: TrieBackendStorage<H>, H: Hasher> TrieBackend<S, H> where H::Out: Codec {
 	/// Create new trie-based backend.
 	pub fn new(storage: S, root: H::Out) -> Self {
 		TrieBackend {
@@ -64,7 +65,7 @@ impl<S: TrieBackendStorage<H>, H: Hasher> std::fmt::Debug for TrieBackend<S, H> 
 }
 
 impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
-	H::Out: Ord,
+	H::Out: Ord + Codec,
 {
 	type Error = String;
 	type Transaction = S::Overlay;
@@ -159,16 +160,17 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 		(root, write_overlay)
 	}
 
-	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (Vec<u8>, bool, Self::Transaction)
+	fn child_storage_root<I>(&self, storage_key: &[u8], delta: I) -> (H::Out, bool, Self::Transaction)
 	where
 		I: IntoIterator<Item=(Vec<u8>, Option<Vec<u8>>)>,
-		H::Out: Ord
+		H::Out: Ord,
 	{
 		let default_root = default_child_trie_root::<Layout<H>>(storage_key);
 
 		let mut write_overlay = S::Overlay::default();
 		let mut root = match self.storage(storage_key) {
-			Ok(value) => value.unwrap_or(default_root.clone()),
+			Ok(value) =>
+				value.and_then(|r| Decode::decode(&mut &r[..]).ok()).unwrap_or(default_root.clone()),
 			Err(e) => {
 				warn!(target: "trie", "Failed to read child storage root: {}", e);
 				default_root.clone()
@@ -181,10 +183,10 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 				&mut write_overlay,
 			);
 
-			match child_delta_trie_root::<Layout<H>, _, _, _, _>(
+			match child_delta_trie_root::<Layout<H>, _, _, _, _, _>(
 				storage_key,
 				&mut eph,
-				root.clone(),
+				root,
 				delta
 			) {
 				Ok(ret) => root = ret,


### PR DESCRIPTION
Currently the runtime interface enforces `H256` as hash type, but in the
future people could use whatever they want as hash type. The hash type
always needs to match between the runtime and the node, but that is
already required.
