### PR TITLE
Parameter trait for Time::Moment

### DIFF
--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -26,6 +26,8 @@ use sr_primitives::{
 	traits::{MaybeSerializeDeserialize, SimpleArithmetic, Saturating},
 };
 
+use crate::dispatch::Parameter;
+
 /// Anything that can have a `::len()` method.
 pub trait Len {
 	/// Return the length of data type.

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -622,7 +622,7 @@ bitmask! {
 }
 
 pub trait Time {
-	type Moment: SimpleArithmetic + FullCodec + Clone + Default + Copy + Debug;
+	type Moment: SimpleArithmetic + Parameter + Default + Copy;
 
 	fn now() -> Self::Moment;
 }

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -622,7 +622,7 @@ bitmask! {
 }
 
 pub trait Time {
-	type Moment: SimpleArithmetic + FullCodec + Clone + Default + Copy;
+	type Moment: SimpleArithmetic + FullCodec + Clone + Default + Copy + Debug;
 
 	fn now() -> Self::Moment;
 }


### PR DESCRIPTION
Without this we cannot have a Moment parameter in dispatchable functions
