### PR TITLE
Fix reimporting transactions from retracted blocks.

### DIFF
--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -283,7 +283,7 @@ impl<B: ChainApi> Pool<B> {
 		tags: impl IntoIterator<Item=Tag>,
 		known_imported_hashes: impl IntoIterator<Item=ExHash<B>> + Clone,
 	) -> impl Future<Output=Result<(), B::Error>> {
-		log::trace!(target: "txpool", "Pruning at {:?}", at);
+		log::debug!(target: "txpool", "Pruning at {:?}", at);
 		// Prune all transactions that provide given tags
 		let prune_status = match self.validated_pool.prune_tags(tags) {
 			Ok(prune_status) => prune_status,
@@ -317,7 +317,7 @@ impl<B: ChainApi> Pool<B> {
 	}
 
 	/// Return an event stream of notifications for when transactions are imported to the pool.
-	/// 
+	///
 	/// Consumers of this stream should use the `ready` method to actually get the
 	/// pending transactions in the right order.
 	pub fn import_notification_stream(&self) -> EventStream {
@@ -329,7 +329,7 @@ impl<B: ChainApi> Pool<B> {
 		self.validated_pool.on_broadcasted(propagated)
 	}
 
-	/// Remove from the pool.
+	/// Remove invalid transactions from the pool.
 	pub fn remove_invalid(&self, hashes: &[ExHash<B>]) -> Vec<TransactionFor<B>> {
 		self.validated_pool.remove_invalid(hashes)
 	}

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -230,12 +230,12 @@ impl<Hash: hash::Hash + Member + Serialize, Ex> ReadyTransactions<Hash, Ex> {
 		}).collect()
 	}
 
-	/// Removes invalid transactions from the ready pool.
+	/// Removes a subtree of transactions from the ready pool.
 	///
 	/// NOTE removing a transaction will also cause a removal of all transactions that depend on that one
 	/// (i.e. the entire subgraph that this transaction is a start of will be removed).
 	/// All removed transactions are returned.
-	pub fn remove_invalid(&mut self, hashes: &[Hash]) -> Vec<Arc<Transaction<Hash, Ex>>> {
+	pub fn remove_subtree(&mut self, hashes: &[Hash]) -> Vec<Arc<Transaction<Hash, Ex>>> {
 		let mut removed = vec![];
 		let mut to_remove = hashes.iter().cloned().collect::<Vec<_>>();
 


### PR DESCRIPTION
Most of the chains will not really use a runtime-type of `UncheckedExtrinsic` for their in-block extrinsic type, but rather the node will only know about `OpaqueExtrinsic` type.
This type implements `Extrinsic` trait, however `is_signed` always returns `None`.

The fix makes sure we re-import transactions even though `is_signed` is `None`, and we also tone-down the warning level (which seemed to be a reason to add that check in the first place).

Additionally some small changes to add logging and an attempt to clean the naming of methods (`remove_invalid` vs `remove_subtree`). This is an intro to a bigger change which would be periodic revalidation of transactions in the pool.

Should fix #4107