### PR TITLE
Fix db path on normal run.

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -804,9 +804,7 @@ where
 	E: ChainSpecExtension,
 	S: FnOnce(&str) -> Result<Option<ChainSpec<G, E>>, String>,
 {
-	let spec = load_spec(&cli.shared_params, spec_factory)?;
-	let base_path = base_path(&cli.shared_params, &version);
-	let mut config = service::Configuration::default_with_spec_and_base_path(spec.clone(), Some(base_path));
+	let mut config = create_config_with_db_path(spec_factory, &cli.shared_params, &version)?;
 
 	fill_config_keystore_password(&mut config, &cli)?;
 


### PR DESCRIPTION
This fixes the following error.
```
substrate-master git:(master) ✗ ./target/debug/substrate --dev            
2019-11-30 18:02:18 Running in --dev mode, RPC CORS has been disabled.
2019-11-30 18:02:18 Substrate Node
2019-11-30 18:02:18   version 2.0.0-ccd72addd-x86_64-linux-gnu
2019-11-30 18:02:18   by Parity Technologies, 2017-2019
2019-11-30 18:02:18 Chain specification: Development
2019-11-30 18:02:18 Node name: guarded-science-6820
2019-11-30 18:02:18 Roles: AUTHORITY
Error: Service(Client(Backend("IO error: No such file or directoryWhile mkdir if missing: No such file or directory")))
```
The function called contains the replaced ones and adds the path.
