### PR TITLE
Introduce `VestingCurrency` trait

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1212,20 +1212,26 @@ where
 		}
 	}
 
-	/// Insert a vesting schedule for a given account.
-	/// Will overwrite any existing schedule.
-	fn insert_vesting_schedule(
+	/// Adds a vesting schedule to a given account.
+	///
+	/// If there already exists a vesting schedule for the given account, an `Err` is returned
+	/// and nothing is updated.
+	fn add_vesting_schedule(
 		who: &T::AccountId,
 		locked: T::Balance,
 		per_block: T::Balance,
 		starting_block: T::BlockNumber
-	) {
+	) -> Result {
+		if <Vesting<T, I>>::exists(who) {
+			return Err("A vesting schedule already exists for this account.");
+		}
 		let vesting_schedule = VestingSchedule {
 			locked,
 			per_block,
 			starting_block
 		};
 		<Vesting<T, I>>::insert(who, vesting_schedule);
+		Ok(())
 	}
 
 	/// Remove a vesting schedule for a given account.

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -602,6 +602,27 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	);
 }
 
+/// A currency whose accounts can have balances which vest over time.
+pub trait VestingCurrency<AccountId>: Currency<AccountId> {
+	/// The quantity used to denote time; usually just a `BlockNumber`.
+	type Moment;
+
+	/// Get the amount that is currently being vested and cannot be transferred out of this account.
+	fn vesting_balance(who: &AccountId) -> Self::Balance;
+
+	/// Insert a vesting schedule for a given account.
+	/// Will overwrite any existing schedule.
+	fn insert_vesting_schedule(
+		who: &AccountId,
+		locked: Self::Balance,
+		per_block: Self::Balance,
+		starting_block: Self::Moment,
+	);
+
+	/// Remove a vesting schedule for a given account.
+	fn remove_vesting_schedule(who: &AccountId);
+}
+
 bitmask! {
 	/// Reasons for moving funds out of an account.
 	#[derive(Encode, Decode)]

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -610,14 +610,16 @@ pub trait VestingCurrency<AccountId>: Currency<AccountId> {
 	/// Get the amount that is currently being vested and cannot be transferred out of this account.
 	fn vesting_balance(who: &AccountId) -> Self::Balance;
 
-	/// Insert a vesting schedule for a given account.
-	/// Will overwrite any existing schedule.
-	fn insert_vesting_schedule(
+	/// Adds a vesting schedule to a given account.
+	///
+	/// If there already exists a vesting schedule for the given account, an `Err` is returned
+	/// and nothing is updated.
+	fn add_vesting_schedule(
 		who: &AccountId,
 		locked: Self::Balance,
 		per_block: Self::Balance,
 		starting_block: Self::Moment,
-	);
+	) -> result::Result<(), &'static str>;
 
 	/// Remove a vesting schedule for a given account.
 	fn remove_vesting_schedule(who: &AccountId);


### PR DESCRIPTION
This takes the "vesting" part of the Balances module into its own `VestingCurrency` trait.

This will help solve the problem outlined here:
https://github.com/paritytech/polkadot/issues/612

In summary, vesting can only be set directly in the balances module through genesis config. The `claims` module wants to apply some vesting schedule if the user claims their tokens after genesis.

We extract the following functionality into this new trait:

* `vesting_balance`: Returns the vesting balance of a user.
* `add_vesting_schedule`: Allows you to add a new vesting schedule to an account. It will fail if there is any existing schedule.
* `remove_vesting_schedule`: Allows you to remove a vesting schedule from an account.

I believe then this will allow us to use this trait in the Claims module where it will be able to introduce some logic around vesting.