### PR TITLE
Rename OffchainWorker internal method.

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -311,7 +311,7 @@ where
 
 	/// Start an offchain worker and generate extrinsics.
 	pub fn offchain_worker(n: System::BlockNumber) {
-		<AllModules as OffchainWorker<System::BlockNumber>>::generate_extrinsics(n)
+		<AllModules as OffchainWorker<System::BlockNumber>>::offchain_worker(n)
 	}
 }
 

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1001,7 +1001,7 @@ macro_rules! decl_module {
 			$crate::sp_runtime::traits::OffchainWorker<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn generate_extrinsics(_block_number_not_used: $trait_instance::BlockNumber) { $( $impl )* }
+			fn offchain_worker(_block_number_not_used: $trait_instance::BlockNumber) { $( $impl )* }
 		}
 	};
 
@@ -1014,7 +1014,7 @@ macro_rules! decl_module {
 			$crate::sp_runtime::traits::OffchainWorker<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn generate_extrinsics($param: $param_ty) { $( $impl )* }
+			fn offchain_worker($param: $param_ty) { $( $impl )* }
 		}
 	};
 

--- a/primitives/sr-primitives/src/traits.rs
+++ b/primitives/sr-primitives/src/traits.rs
@@ -355,9 +355,9 @@ pub trait OnInitialize<BlockNumber> {
 pub trait OffchainWorker<BlockNumber> {
 	/// This function is being called on every block.
 	///
-	/// Implement this and use special `extern`s to generate transactions or inherents.
+	/// Implement this and use `sp_io` to generate transactions or inherents.
 	/// Any state alterations are lost and are not persisted.
-	fn generate_extrinsics(_n: BlockNumber) {}
+	fn offchain_worker(_n: BlockNumber) {}
 }
 
 /// Abstraction around hashing

--- a/primitives/sr-primitives/src/traits.rs
+++ b/primitives/sr-primitives/src/traits.rs
@@ -346,16 +346,20 @@ pub trait OnInitialize<BlockNumber> {
 /// Off-chain computation trait.
 ///
 /// Implementing this trait on a module allows you to perform long-running tasks
-/// that make validators generate extrinsics (either transactions or inherents)
-/// with the results of those long-running computations.
+/// that make (by default) validators generate transactions that feed results
+/// of those long-running computations back on chain.
 ///
 /// NOTE: This function runs off-chain, so it can access the block state,
-/// but cannot preform any alterations.
+/// but cannot preform any alterations. More specifically alterations are
+/// not forbidden, but they are not persisted in any way after the worker
+/// has finished.
 #[impl_for_tuples(30)]
 pub trait OffchainWorker<BlockNumber> {
-	/// This function is being called on every block.
+	/// This function is being called after every block import (when fully synced).
 	///
-	/// Implement this and use `sp_io` to generate transactions or inherents.
+	/// Implement this and use any of the `Offchain` `sp_io` set of APIs
+	/// to perform offchain computations, calls and submit transactions
+	/// with results to trigger any on-chain changes.
 	/// Any state alterations are lost and are not persisted.
 	fn offchain_worker(_n: BlockNumber) {}
 }

--- a/primitives/sr-version/src/lib.rs
+++ b/primitives/sr-version/src/lib.rs
@@ -173,8 +173,8 @@ impl NativeVersion {
 				self.runtime_version.spec_name,
 				other.spec_name,
 			))
-		} else if (self.runtime_version.authoring_version != other.authoring_version
-			&& !self.can_author_with.contains(&other.authoring_version))
+		} else if self.runtime_version.authoring_version != other.authoring_version
+			&& !self.can_author_with.contains(&other.authoring_version)
 		{
 			Err(format!(
 				"`authoring_version` does not match `{version}` vs `{other_version}` and \


### PR DESCRIPTION
For some obscure historical reason (and most likely my laziness), the method of `OffchainWorker` trait is called `generate_extrinsics`. This PR renames it to just `offchain_worker`.

Note this trait is rarely (rather close to never) implemented manually, it's auto-implemented via `decl_module` macro, so this change should be non-breaking.