### PR TITLE
interruptible test and build jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ stages:
 
 variables:
   GIT_STRATEGY:                    fetch
+  GIT_DEPTH:                       "3"
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
   CARGO_INCREMENTAL:               0
@@ -55,6 +56,8 @@ variables:
       - runner_system_failure
       - unknown_failure
       - api_failure
+  dependencies:                    []
+  interruptible:                   true
   tags:
     - linux-docker
 
@@ -79,6 +82,7 @@ check-runtime:
     GITHUB_API_PROJECT:            "parity%2Finfrastructure%2Fgithub-api"
   script:
     - ./.maintain/gitlab/check_runtime.sh
+  interruptible:                   true
   allow_failure:                   true
 
 
@@ -90,6 +94,7 @@ check-line-width:
     - /^[0-9]+$/
   script:
     - ./.maintain/gitlab/check_line_width.sh
+  interruptible:                   true
   allow_failure:                   true
 
 
@@ -351,8 +356,6 @@ check_polkadot:
   stage:                           build
   <<:                              *docker-env
   allow_failure:                   true
-  dependencies:
-    - test-linux-stable
   script:
     - COMMIT_HASH=$(git rev-parse HEAD)
     - SUBSTRATE_PATH=$(pwd)


### PR DESCRIPTION
- `interruptible`: if more than one pipeline is launched for the branch, the previous pipeline's `interruptible` jobs will be auto-canceled on the fly. And jobs from the next stages won't be executed if previous stage was canceled. I didn't set it for publishing and deploying since it is dangerous to interrupt them.
- `GIT_DEPTH` sets amount of last commits pulled for the job
- `dependencies` is only needed in one job: `check_warnings:` copies artifacts from `test-linux-stable`