### PR TITLE
client/authority-discovery: Fix interval_at to fire on start

### DIFF
--- a/client/authority-discovery/src/lib.rs
+++ b/client/authority-discovery/src/lib.rs
@@ -457,14 +457,11 @@ fn hash_authority_id(id: &[u8]) -> Result<libp2p::kad::record::Key> {
 }
 
 fn interval_at(start: Instant, duration: Duration) -> Interval {
-	let stream = futures::stream::unfold((), move |_| {
-		let wait_time = start.saturating_duration_since(Instant::now());
+	let stream = futures::stream::unfold(start, move |next| {
+		let time_until_next =  next.saturating_duration_since(Instant::now());
 
-		futures::future::join(
-			Delay::new(wait_time),
-			Delay::new(duration)
-		).map(|_| Some(((), ())))
-	}).map(drop);
+		Delay::new(time_until_next).map(move |_| Some(((), next + duration)))
+	});
 
 	Box::new(stream)
 }


### PR DESCRIPTION
The authority discovery module publishes and queries (onto) the DHT on an interval. Given that the `futures-timer` crate removed `Interval` the concept of an `Interval` was introduced into the authority discovery module directly.

In order for the custom implementation to equal the old `futures-timer` implementation, it should support an instant `Interval` as well as *queuing* events when the `Interval` is not polled for a while.

---

Maybe worth discussing after this pull request:

I don't think the authority discovery module should have its own implementation of `Interval`, but rather I would like it to move to its own library, or us depending on an alternative to `futures-timer` with an `Interval` equivalent implementation.

As of now the unit smoke tests depend on timing assumptions that might not hold in all environments (milliseconds scale). With the paragraph above in mind I would like to remove them longterm.

