### PR TITLE
Enumeratable dispatches using unhashed index in key

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -78,7 +78,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 197,
+	spec_version: 198,
 	impl_version: 198,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -283,7 +283,7 @@ decl_storage! {
 			map ReferendumIndex => Option<(ReferendumInfo<T::BlockNumber, T::Hash>)>;
 		/// Queue of successful referenda to be dispatched.
 		pub DispatchQueue get(fn dispatch_queue):
-			map T::BlockNumber => Vec<Option<(T::Hash, ReferendumIndex)>>;
+			map hasher(twox_64_concat) T::BlockNumber => Vec<Option<(T::Hash, ReferendumIndex)>>;
 
 		/// Get the voters for the current proposal.
 		pub VotersFor get(fn voters_for): map ReferendumIndex => Vec<T::AccountId>;

--- a/primitives/sr-version/src/lib.rs
+++ b/primitives/sr-version/src/lib.rs
@@ -173,8 +173,8 @@ impl NativeVersion {
 				self.runtime_version.spec_name,
 				other.spec_name,
 			))
-		} else if (self.runtime_version.authoring_version != other.authoring_version
-			&& !self.can_author_with.contains(&other.authoring_version))
+		} else if self.runtime_version.authoring_version != other.authoring_version
+			&& !self.can_author_with.contains(&other.authoring_version)
 		{
 			Err(format!(
 				"`authoring_version` does not match `{version}` vs `{other_version}` and \


### PR DESCRIPTION
Right now although we can enumerate all *values* of the `democracy::DispatchQueue` mapping, we cannot enumerate all the keys. This is a general failing of `map`, since it will be default use a cryptographic hash (Blake2) to index the item, which is by design not useful for deriving the key itself.

This uses a non-cryptographic hash (the key material is a block number coming from a high-friction governance process and cannot be easily or cheaply gamed) along with the index itself, allowing the index to be derived from the database key.

CC @jacogr 