### PR TITLE
client: Introduce --sentry-nodes flag

### DIFF
--- a/.maintain/sentry-node/docker-compose.yml
+++ b/.maintain/sentry-node/docker-compose.yml
@@ -38,13 +38,12 @@ services:
       - "--base-path"
       - "/tmp/alice"
       - "--chain=local"
-      - "--key"
-      - "//Alice"
       - "--port"
       - "30333"
       - "--validator"
-      - "--name"
-      - "AlicesNode"
+      - "--alice"
+      - "--sentry-nodes"
+      - "/dns4/sentry-a/tcp/30333/p2p/QmV7EhW6J6KgmNdr558RH1mPx2xGGznW7At4BhXzntRFsi"
       - "--reserved-nodes"
       - "/dns4/sentry-a/tcp/30333/p2p/QmV7EhW6J6KgmNdr558RH1mPx2xGGznW7At4BhXzntRFsi"
       # Not only bind to localhost.
@@ -54,6 +53,8 @@ services:
       # - "sub-libp2p=trace"
       # - "--log"
       # - "afg=trace"
+      - "--log"
+      - "sub-authority-discovery=trace"
       - "--no-telemetry"
       - "--rpc-cors"
       - "all"
@@ -74,28 +75,24 @@ services:
       - "--base-path"
       - "/tmp/sentry"
       - "--chain=local"
-      # Don't configure a key, as sentry-a is not a validator.
-      # - "--key"
-      # - "//Charlie"
       - "--port"
       - "30333"
-      # sentry-a is not a validator.
-      # - "--validator"
-      - "--name"
-      - "CharliesNode"
+      - "--charlie"
       - "--bootnodes"
       - "/dns4/validator-a/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR"
       - "--bootnodes"
       - "/dns4/validator-b/tcp/30333/p2p/QmSVnNf9HwVMT1Y4cK1P6aoJcEZjmoTXpjKBmAABLMnZEk"
+      - "--reserved-nodes"
+      - "/dns4/validator-a/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR"
       - "--no-telemetry"
       - "--rpc-cors"
       - "all"
       # Not only bind to localhost.
       - "--ws-external"
       - "--rpc-external"
-      # Make sure sentry-a still participates as a grandpa voter to forward
-      # grandpa finality gossip messages.
-      - "--grandpa-voter"
+      - "--log"
+      - "sub-authority-discovery=trace"
+      - "--sentry"
 
   validator-b:
     image: parity/substrate
@@ -112,13 +109,10 @@ services:
       - "--base-path"
       - "/tmp/bob"
       - "--chain=local"
-      - "--key"
-      - "//Bob"
       - "--port"
       - "30333"
       - "--validator"
-      - "--name"
-      - "BobsNode"
+      - "--bob"
       - "--bootnodes"
       - "/dns4/validator-a/tcp/30333/p2p/QmRpheLN4JWdAnY7HGJfWFNbfkQCb6tFf4vvA6hgjMZKrR"
       - "--bootnodes"
@@ -129,6 +123,8 @@ services:
       # Not only bind to localhost.
       - "--ws-external"
       - "--rpc-external"
+      - "--log"
+      - "sub-authority-discovery=trace"
 
   ui:
     image: polkadot-js/apps

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -125,12 +125,14 @@ macro_rules! new_full {
 			is_authority,
 			force_authoring,
 			name,
-			disable_grandpa
+			disable_grandpa,
+			sentry_nodes,
 		) = (
 			$config.roles.is_authority(),
 			$config.force_authoring,
 			$config.name.clone(),
-			$config.disable_grandpa
+			$config.disable_grandpa,
+			$config.network.sentry_nodes.clone(),
 		);
 
 		// sentry nodes announce themselves as authorities to the network
@@ -194,6 +196,7 @@ macro_rules! new_full {
 			let authority_discovery = authority_discovery::AuthorityDiscovery::new(
 				service.client(),
 				service.network(),
+				sentry_nodes,
 				service.keystore(),
 				future03_dht_event_rx,
 			);

--- a/client/authority-discovery/src/lib.rs
+++ b/client/authority-discovery/src/lib.rs
@@ -457,14 +457,11 @@ fn hash_authority_id(id: &[u8]) -> Result<libp2p::kad::record::Key> {
 }
 
 fn interval_at(start: Instant, duration: Duration) -> Interval {
-	let stream = futures::stream::unfold((), move |_| {
-		let wait_time = start.saturating_duration_since(Instant::now());
+	let stream = futures::stream::unfold(start, move |next| {
+		let time_until_next =  next.saturating_duration_since(Instant::now());
 
-		futures::future::join(
-			Delay::new(wait_time),
-			Delay::new(duration)
-		).map(|_| Some(((), ())))
-	}).map(drop);
+		Delay::new(time_until_next).map(move |_| Some(((), next + duration)))
+	});
 
 	Box::new(stream)
 }

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -674,11 +674,13 @@ fn fill_network_configuration(
 	config.boot_nodes.extend(cli.bootnodes.into_iter());
 	config.config_path = Some(config_path.to_string_lossy().into());
 	config.net_config_path = config.config_path.clone();
-	config.reserved_nodes.extend(cli.reserved_nodes.into_iter());
 
+	config.reserved_nodes.extend(cli.reserved_nodes.into_iter());
 	if cli.reserved_only {
 		config.non_reserved_mode = NonReservedPeerMode::Deny;
 	}
+
+	config.sentry_nodes.extend(cli.sentry_nodes.into_iter());
 
 	for addr in cli.listen_addr.iter() {
 		let addr = addr.parse().ok().ok_or(error::Error::InvalidListenMultiaddress)?;

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -177,6 +177,14 @@ pub struct NetworkConfigurationParams {
 	#[structopt(long = "reserved-only")]
 	pub reserved_only: bool,
 
+	/// Specify a list of sentry node public addresses.
+	#[structopt(
+		long = "sentry-nodes",
+		value_name = "URL",
+		conflicts_with_all = &[ "sentry" ]
+	)]
+	pub sentry_nodes: Vec<String>,
+
 	/// Listen on this multiaddress.
 	#[structopt(long = "listen-addr", value_name = "LISTEN_ADDR")]
 	pub listen_addr: Vec<String>,

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -255,6 +255,8 @@ pub struct NetworkConfiguration {
 	pub reserved_nodes: Vec<String>,
 	/// The non-reserved peer mode.
 	pub non_reserved_mode: NonReservedPeerMode,
+	/// List of sentry node public addresses.
+	pub sentry_nodes: Vec<String>,
 	/// Client identifier. Sent over the wire for debugging purposes.
 	pub client_version: String,
 	/// Name of the node. Sent over the wire for debugging purposes.
@@ -278,6 +280,7 @@ impl Default for NetworkConfiguration {
 			out_peers: 75,
 			reserved_nodes: Vec::new(),
 			non_reserved_mode: NonReservedPeerMode::Accept,
+			sentry_nodes: Vec::new(),
 			client_version: "unknown".into(),
 			node_name: "unknown".into(),
 			transport: TransportConfig::Normal {

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -155,6 +155,7 @@ fn node_config<G, E: Clone> (
 		out_peers: 450,
 		reserved_nodes: vec![],
 		non_reserved_mode: NonReservedPeerMode::Accept,
+		sentry_nodes: vec![],
 		client_version: "network/test/0.1".to_owned(),
 		node_name: "unknown".to_owned(),
 		transport: TransportConfig::Normal {


### PR DESCRIPTION
Enable operators to specify the public addresses of sentry nodes infront of a validator node so that the validator node can announce the sentry node addresses instead of its own public addresses on the DHT via the authority discovery module.

### Commit structure

This pull request is based on https://github.com/paritytech/substrate/pull/4274, thus it should only be merged after https://github.com/paritytech/substrate/pull/4274. One can ignore the first two commits when reviewing this pull request.

Commit 3 (updating `.maintain/sentry-node/docker-compose.yml`) and commit 5 (shortening line length to 100 instead of 120 char) should not need much review.

Commit 4 (https://github.com/paritytech/substrate/commit/a5b5db7f4c1bda0ac906bb04fa67826eabbe9b5b) is the core of this pull request.


### Polkadot

Given that this changes the signature of `AuthorityDiscovery::new`, it will break Polkadot. I will follow up with another pull request on github.com/pairtytech/polkadot.
