### PR TITLE
Revalidate some transactions on every block import.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5574,7 +5574,6 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -16,7 +16,6 @@ txpool-api = { package = "sp-transaction-pool-api", path = "../../../primitives/
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-env_logger = "0.7.0"
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 test_runtime = { package = "substrate-test-runtime", path = "../../../test/utils/runtime" }
 criterion = "0.3"

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -198,11 +198,13 @@ impl<B: ChainApi> Pool<B> {
 					now.elapsed().as_millis()
 				);
 				let now = Instant::now();
-				let res = revalidated_transactions.map(move |revalidated_transactions|
-					validated_pool.resubmit(revalidated_transactions)
+				let res = revalidated_transactions.map(
+					|revalidated_transactions| validated_pool.resubmit(revalidated_transactions)
 				);
 				log::debug!(target: "txpool",
-					"Resubmitted. Took {} ms", now.elapsed().as_millis()
+					"Resubmitted. Took {} ms. Status: {:?}",
+					now.elapsed().as_millis(),
+					validated_pool.status()
 				);
 				res
 			})

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -197,6 +197,7 @@ impl<B: ChainApi> Pool<B> {
 					"Re-verified transactions, took {} ms. Resubmitting.",
 					now.elapsed().as_millis()
 				);
+				let now = Instant::now();
 				let res = revalidated_transactions.map(move |revalidated_transactions|
 					validated_pool.resubmit(revalidated_transactions)
 				);

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -953,7 +953,6 @@ mod tests {
 
 		#[test]
 		fn should_handle_pruning_in_the_middle_of_import() {
-			let _ = env_logger::try_init();
 			// given
 			let (ready, is_ready) = std::sync::mpsc::sync_channel(0);
 			let (tx, rx) = std::sync::mpsc::sync_channel(1);

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use serde::Serialize;
-use log::debug;
+use log::trace;
 use parking_lot::RwLock;
 use sp_runtime::traits::Member;
 use sp_runtime::transaction_validity::{
@@ -267,7 +267,7 @@ impl<Hash: hash::Hash + Member + Serialize, Ex> ReadyTransactions<Hash, Ex> {
 				to_remove.append(&mut tx.unlocks);
 
 				// add to removed
-				debug!(target: "txpool", "[{:?}] Removed as invalid: ", hash);
+				trace!(target: "txpool", "[{:?}] Removed as part of the subtree.", hash);
 				removed.push(tx.transaction.transaction);
 			}
 		}

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -236,6 +236,8 @@ impl<B: ChainApi> ValidatedPool<B> {
 					initial_statuses.insert(removed_hash.clone(), Status::Ready);
 					txs_to_resubmit.push((removed_hash, tx_to_resubmit));
 				}
+				// make sure to remove the hash even if it's not present in the pool any more.
+				updated_transactions.remove(&hash);
 			}
 
 			// if we're rejecting future transactions, then insertion order matters here:

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -478,7 +478,6 @@ impl<B: ChainApi> ValidatedPool<B> {
 
 		let mut listener = self.listener.write();
 		for tx in &invalid {
-			debug!(target: "txpool", "[{:?}] Removed as invalid.", tx.hash);
 			listener.invalid(&tx.hash);
 		}
 

--- a/client/transaction-pool/src/maintainer.rs
+++ b/client/transaction-pool/src/maintainer.rs
@@ -23,7 +23,7 @@ use futures::{
 	Future, FutureExt,
 	future::{Either, join, ready},
 };
-use log::{warn, debug};
+use log::{warn, debug, trace};
 use parking_lot::Mutex;
 
 use client_api::{
@@ -74,6 +74,14 @@ where
 		id: &BlockId<Block>,
 		retracted: &[Block::Hash],
 	) -> Box<dyn Future<Output=()> + Send + Unpin> {
+		let now = std::time::Instant::now();
+		let took = move || {
+			let took = std::time::Instant::now().duration_since(now);
+			format!("Took {} ms", took.as_millis())
+		};
+
+		let id = *id;
+		trace!(target: "txpool", "[{:?}] Starting pool maintainance", id);
 		// Put transactions from retracted blocks back into the pool.
 		let client_copy = self.client.clone();
 		let retracted_transactions = retracted.to_vec().into_iter()
@@ -82,13 +90,14 @@ where
 			// if signed information is not present, attempt to resubmit anyway.
 			.filter(|tx| tx.is_signed().unwrap_or(true));
 		let resubmit_future = self.pool
-			.submit_at(id, retracted_transactions, true)
-			.then(|resubmit_result| ready(match resubmit_result {
-				Ok(_) => (),
-				Err(e) => {
-					debug!(target: "txpool", "Error re-submitting transactions: {:?}", e);
-					()
-				}
+			.submit_at(&id, retracted_transactions, true)
+			.then(move |resubmit_result| ready(match resubmit_result {
+				Ok(_) => trace!(target: "txpool",
+					"[{:?}] Re-submitting retracted done. {}", id, took()
+				),
+				Err(e) => debug!(target: "txpool",
+					"[{:?}] Error re-submitting transactions: {:?}", id, e
+				),
 			}));
 
 		// Avoid calling into runtime if there is nothing to prune from the pool anyway.
@@ -96,28 +105,42 @@ where
 			return Box::new(resubmit_future)
 		}
 
-		let block = (self.client.header(*id), self.client.block_body(id));
-		match block {
+		let block = (self.client.header(id), self.client.block_body(&id));
+		let prune_future = match block {
 			(Ok(Some(header)), Ok(Some(extrinsics))) => {
 				let parent_id = BlockId::hash(*header.parent_hash());
 				let prune_future = self.pool
-					.prune(id, &parent_id, &extrinsics)
-					.then(|prune_result| ready(match prune_result {
-						Ok(_) => (),
-						Err(e) => {
-							warn!("Error pruning transactions: {:?}", e);
-							()
-						}
+					.prune(&id, &parent_id, &extrinsics)
+					.then(move |prune_result| ready(match prune_result {
+						Ok(_) => trace!(target: "txpool",
+							"[{:?}] Pruning done. {}", id, took()
+						),
+						Err(e) => warn!(target: "txpool",
+							"[{:?}] Error pruning transactions: {:?}", id, e
+						),
 					}));
 
-				Box::new(resubmit_future.then(|_| prune_future))
+				Either::Left(resubmit_future.then(|_| prune_future))
 			},
-			(Ok(_), Ok(_)) => Box::new(resubmit_future),
+			(Ok(_), Ok(_)) => Either::Right(resubmit_future),
 			err => {
-				warn!("Error reading block: {:?}", err);
-				Box::new(resubmit_future)
+				warn!(target: "txpool", "[{:?}] Error reading block: {:?}", id, err);
+				Either::Right(resubmit_future)
 			},
-		}
+		};
+
+		let revalidate_future = self.pool
+			.revalidate_ready(&id, Some(16))
+			.map(move |result| match result {
+				Ok(_) => debug!(target: "txpool",
+					"[{:?}] Revalidation done: {}", id, took()
+				),
+				Err(e) => warn!(target: "txpool",
+					"[{:?}] Encountered errors while revalidating transactions: {:?}", id, e
+				),
+			});
+
+		Box::new(prune_future.then(|_| revalidate_future))
 	}
 }
 
@@ -228,7 +251,7 @@ impl<Block, Client, PoolApi, F> LightBasicPoolMaintainer<Block, Client, PoolApi,
 			true => {
 				let revalidation_status = self.revalidation_status.clone();
 				Either::Left(self.pool
-					.revalidate_ready(id)
+					.revalidate_ready(id, None)
 					.map(|r| r.map_err(|e| warn!("Error revalidating known transactions: {}", e)))
 					.map(move |_| revalidation_status.lock().clear()))
 			},


### PR DESCRIPTION
This should fix transactions stalling in the pool for a long time.

I'm still running tests for Kusama to make sure it works correctly.