### PR TITLE
Add linear back-off for aura slot workers

### DIFF
--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -321,8 +321,11 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 		// in normal cases we only attempt to issue blocks up to the end of the slot.
 		// when the chain has been stalled for a few slots, we give more lenience.
 		let slot_lenience = slot_info.number.saturating_sub(parent_slot + 1);
+		println!("{:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience);
 		let slot_lenience = std::cmp::min(slot_lenience, BACKOFF_CAP);
+		println!("{:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience);
 		let slot_lenience = Duration::from_secs(slot_lenience * slot_info.duration);
+		println!("{:?}, {:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience, slot_lenience + slot_remaining);
 		Some(slot_lenience + slot_remaining)
 	}
 }

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -305,14 +305,17 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 
 	fn proposing_remaining_duration(
 		&self,
-		_head: &B::Header,
+		head: &B::Header,
 		slot_info: &SlotInfo
 	) -> Option<std::time::Duration> {
 		// never give more than 20 times more lenience.
 		const BACKOFF_CAP: u64 = 20;
 
 		let slot_remaining = self.slot_remaining_duration(slot_info);
-		let parent_slot = slot_info.last_number;
+		let parent_slot = match find_pre_digest::<B, P>(head) {
+			Err(_) => return Some(slot_remaining),
+			Ok(d) => d,
+		};
 
 		// we allow a lenience of the number of slots since the head of the
 		// chain was produced, minus 1 (since there is always a difference of at least 1)
@@ -321,11 +324,8 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 		// in normal cases we only attempt to issue blocks up to the end of the slot.
 		// when the chain has been stalled for a few slots, we give more lenience.
 		let slot_lenience = slot_info.number.saturating_sub(parent_slot + 1);
-		println!("{:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience);
 		let slot_lenience = std::cmp::min(slot_lenience, BACKOFF_CAP);
-		println!("{:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience);
 		let slot_lenience = Duration::from_secs(slot_lenience * slot_info.duration);
-		println!("{:?}, {:?}, {:?}, {:?}", slot_remaining, parent_slot, slot_lenience, slot_lenience + slot_remaining);
 		Some(slot_lenience + slot_remaining)
 	}
 }
@@ -383,6 +383,10 @@ fn find_pre_digest<B: BlockT, P: Pair>(header: &B::Header) -> Result<u64, Error<
 		P::Signature: Decode,
 		P::Public: Encode + Decode + PartialEq + Clone,
 {
+	if header.number().is_zero() {
+		return Ok(0);
+	}
+
 	let mut pre_digest: Option<u64> = None;
 	for log in header.digest().logs() {
 		trace!(target: "aura", "Checking log {:?}", log);

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -302,6 +302,29 @@ impl<H, B, C, E, I, P, Error, SO> slots::SimpleSlotWorker<B> for AuraWorker<C, E
 			consensus_common::Error::ClientImport(format!("{:?}", e)).into()
 		})
 	}
+
+	fn proposing_remaining_duration(
+		&self,
+		_head: &B::Header,
+		slot_info: &SlotInfo
+	) -> Option<std::time::Duration> {
+		// never give more than 20 times more lenience.
+		const BACKOFF_CAP: u64 = 20;
+
+		let slot_remaining = self.slot_remaining_duration(slot_info);
+		let parent_slot = slot_info.last_number;
+
+		// we allow a lenience of the number of slots since the head of the
+		// chain was produced, minus 1 (since there is always a difference of at least 1)
+		//
+		// linear back-off.
+		// in normal cases we only attempt to issue blocks up to the end of the slot.
+		// when the chain has been stalled for a few slots, we give more lenience.
+		let slot_lenience = slot_info.number.saturating_sub(parent_slot + 1);
+		let slot_lenience = std::cmp::min(slot_lenience, BACKOFF_CAP);
+		let slot_lenience = Duration::from_secs(slot_lenience * slot_info.duration);
+		Some(slot_lenience + slot_remaining)
+	}
 }
 
 impl<H, B: BlockT, C, E, I, P, Error, SO> SlotWorker<B> for AuraWorker<C, E, I, P, SO> where


### PR DESCRIPTION
This implements the linear-back off that exists for babe worker, for the aura worker. It does so by simple piggybacking off the previous slot number.

@rphmeier this still hasn't solved my issue as I just tried running an upgrade where all I did is increment the spec/impl versions. The upgrade still stalled. I'm using the polkadotjs UI, maybe there's something in my process I'm doing incorrectly?