### PR TITLE
Tone down warnings when resubmitting to the pool.

### DIFF
--- a/client/transaction-pool/graph/src/listener.rs
+++ b/client/transaction-pool/graph/src/listener.rs
@@ -91,8 +91,12 @@ impl<H: hash::Hash + traits::Member + Serialize, H2: Clone + fmt::Debug> Listene
 	}
 
 	/// Transaction was removed as invalid.
-	pub fn invalid(&mut self, tx: &H) {
-		warn!(target: "txpool", "Extrinsic invalid: {:?}", tx);
+	pub fn invalid(&mut self, tx: &H, warn: bool) {
+		if warn {
+			warn!(target: "txpool", "Extrinsic invalid: {:?}", tx);
+		} else {
+			debug!(target: "txpool", "Extrinsic invalid: {:?}", tx);
+		}
 		self.fire(tx, |watcher| watcher.invalid());
 	}
 

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -204,6 +204,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 		#[derive(Debug, Clone, Copy, PartialEq)]
 		enum Status { Future, Ready, Failed, Dropped };
 
+		println!("Updated: {:?}", updated_transactions);
 		let (mut initial_statuses, final_statuses) = {
 			let mut pool = self.pool.write();
 
@@ -245,6 +246,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 				updated_transactions.remove(&hash);
 			}
 
+			println!("Updated2: {:?}", updated_transactions);
 			// if we're rejecting future transactions, then insertion order matters here:
 			// if tx1 depends on tx2, then if tx1 is inserted before tx2, then it goes
 			// to the future queue and gets rejected immediately

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -312,7 +312,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 					Status::Future => listener.future(&hash),
 					Status::Ready => listener.ready(&hash, None),
 					Status::Dropped => listener.dropped(&hash, None),
-					Status::Failed if initial_status.is_none() => listener.invalid(&hash),
+					Status::Failed if !initial_status.is_none() => listener.invalid(&hash),
 					_ => {},
 				}
 			}

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -311,8 +311,9 @@ impl<B: ChainApi> ValidatedPool<B> {
 				match final_status {
 					Status::Future => listener.future(&hash),
 					Status::Ready => listener.ready(&hash, None),
-					Status::Failed => listener.invalid(&hash),
 					Status::Dropped => listener.dropped(&hash, None),
+					Status::Failed if initial_status.is_none() => listener.invalid(&hash),
+					_ => {},
 				}
 			}
 		}

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -481,6 +481,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 
 		let mut listener = self.listener.write();
 		for tx in &invalid {
+			println!("Removing invalid");
 			listener.invalid(&tx.hash);
 		}
 
@@ -509,6 +510,7 @@ fn fire_events<H, H2, Ex>(
 		base::Imported::Ready { ref promoted, ref failed, ref removed, ref hash } => {
 			listener.ready(hash, None);
 			for f in failed {
+				println!("Failed");
 				listener.invalid(f);
 			}
 			for r in removed {


### PR DESCRIPTION
Follow up on #4292 

We don't print a warning about invalid transaction if it wasn't known previously. That prevents reporting inherent extrinsics as `invalid` for every block.