### PR TITLE
Change order of events emitted from transfer.

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -934,9 +934,14 @@ where
 			if !<FreeBalance<T, I>>::exists(dest) {
 				Self::new_account(dest, new_to_balance);
 			}
+
+			// Emit transfer event.
+			Self::deposit_event(RawEvent::Transfer(transactor.clone(), dest.clone(), value, fee));
+
+			// Take action on the set_free_balance call.
+			// This will emit events that _resulted_ from the transfer.
 			Self::set_free_balance(dest, new_to_balance);
 			T::TransferPayment::on_unbalanced(NegativeImbalance::new(fee));
-			Self::deposit_event(RawEvent::Transfer(transactor.clone(), dest.clone(), value, fee));
 		}
 
 		Ok(())


### PR DESCRIPTION
This PR is a request from @emielvanderhoek

Right now, the ordering of events from a `transfer` call can be unclear.

For example, when an account is reaped, the order of transactions is:

1. Account Reaped
2. Balance Transferred

But we would expect that the balance `Transfer` event happens first, which then _results_ in an `ReapedAccount` event.

This simply changes the order of actions (in a part of the runtime code which **cannot fail**) to make the order of events more coherent.

> Note: we consciously kept the `NewAccount` event before the transfer. The idea being, first a new account is emitted to the world, and then a transfer is passed to it.

Feedback welcome.