### PR TITLE
client/authority-discovery: Limit the amount of sentries per authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,6 +4814,7 @@ version = "2.0.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-timer 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.41"
 sp-runtime = { path = "../../primitives/sr-primitives" }
 
 [dev-dependencies]
+env_logger = "0.7.0"
 parking_lot = "0.9.0"
 peerset = { package = "sc-peerset", path = "../peerset" }
 test-client = { package = "substrate-test-runtime-client", path = "../../test/utils/runtime/client" }


### PR DESCRIPTION
When receiving more addresses for a given authority than a defined
threshold (5), the authority discovery drops the remaining in order to
prevent a single authority to fill all priority group slots.

