### PR TITLE
Fix Contracts RPC output format.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,6 +3553,7 @@ dependencies = [
  "pallet-contracts-rpc-runtime-api 2.0.0",
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-blockchain 2.0.0",
  "sp-core 2.0.0",
  "sp-rpc 2.0.0",
@@ -3564,7 +3565,6 @@ name = "pallet-contracts-rpc-runtime-api"
 version = "2.0.0"
 dependencies = [
  "parity-scale-codec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-api 2.0.0",
  "sp-runtime 2.0.0",
  "sp-std 2.0.0",

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -15,3 +15,6 @@ rpc-primitives = { package = "sp-rpc", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { path = "../../../primitives/sr-primitives" }
 pallet-contracts-rpc-runtime-api = { path = "./runtime-api" }
+
+[dev-dependencies]
+serde_json = "1.0.41"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 sp-api = { path = "../../../../primitives/sr-api", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 rstd = { package = "sp-std", path = "../../../../primitives/sr-std", default-features = false }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-runtime = { path = "../../../../primitives/sr-primitives", default-features = false }
 
 [features]
@@ -17,6 +16,5 @@ std = [
 	"sp-api/std",
 	"codec/std",
 	"rstd/std",
-	"serde",
 	"sp-runtime/std",
 ]

--- a/frame/contracts/rpc/runtime-api/src/lib.rs
+++ b/frame/contracts/rpc/runtime-api/src/lib.rs
@@ -28,7 +28,6 @@ use sp_runtime::RuntimeDebug;
 
 /// A result of execution of a contract.
 #[derive(Eq, PartialEq, Encode, Decode, RuntimeDebug)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum ContractExecResult {
 	/// The contract returned successfully.
 	///


### PR DESCRIPTION
The Contracts RPC outputs data in a non-common format (i.e. raw bytes, etc).

This PR fixes the format to be more consistent with the rest of the RPCs.
Please take a look at the tests to see how we serialize it now.