### PR TITLE
Perthings: derive PartialOrd and Ord under no_std.

### DIFF
--- a/primitives/sr-arithmetic/src/per_things.rs
+++ b/primitives/sr-arithmetic/src/per_things.rs
@@ -27,8 +27,8 @@ macro_rules! implement_per_thing {
 		/// A fixed point representation of a number between in the range [0, 1].
 		///
 		#[doc = $title]
-		#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Ord, PartialOrd))]
-		#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq, RuntimeDebug, CompactAs)]
+		#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+		#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RuntimeDebug, CompactAs)]
 		pub struct $name($type);
 
 		impl $name {


### PR DESCRIPTION
Perthing types only derive `PartialOrd` and `Ord` under `std`, that makes it not possible to compare by operators like `<` or `<=` etc in runtime modules.

The workaround I could find is using `.deconstruct()` method, but it's verbose. If no particular reasons, it's better to have `PartialOrd` and `Ord` derives under `no_std`.

https://github.com/laminar-protocol/flowchain/blob/52af7fc619c9fd0576b6f924faa8e3727a0fe550/modules/synthetic-protocol/src/lib.rs#L294