### PR TITLE
Disable record_metrics_slice in grafana macro on wasm

### DIFF
--- a/client/grafana-data-source/src/lib.rs
+++ b/client/grafana-data-source/src/lib.rs
@@ -47,9 +47,13 @@ lazy_static! {
 #[macro_export]
 macro_rules! record_metrics(
 	($($key:expr => $value:expr,)*) => {
-		$crate::record_metrics_slice(&[
-			$( ($key, $value as f32), )*
-		]);
+		if cfg!(not(target_os = "unknown")) {
+			$crate::record_metrics_slice(&[
+				$( ($key, $value as f32), )*
+			])
+		} else {
+			Ok(())
+		}
 	}
 );
 

--- a/client/grafana-data-source/src/lib.rs
+++ b/client/grafana-data-source/src/lib.rs
@@ -47,7 +47,7 @@ lazy_static! {
 #[macro_export]
 macro_rules! record_metrics(
 	($($key:expr => $value:expr,)*) => {
-		if cfg!(not(feature = "std")) {
+		if cfg!(not(target_os = "unknown")) {
 			$crate::record_metrics_slice(&[
 				$( ($key, $value as f32), )*
 			])

--- a/client/grafana-data-source/src/lib.rs
+++ b/client/grafana-data-source/src/lib.rs
@@ -47,7 +47,7 @@ lazy_static! {
 #[macro_export]
 macro_rules! record_metrics(
 	($($key:expr => $value:expr,)*) => {
-		if cfg!(not(target_os = "unknown")) {
+		if cfg!(not(feature = "std")) {
 			$crate::record_metrics_slice(&[
 				$( ($key, $value as f32), )*
 			])


### PR DESCRIPTION
This is a lot easier than just disabling the macro entirely.