### PR TITLE
decl_storage: Allow storage value builder to put no value

### DIFF
--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -19,6 +19,7 @@
 #[allow(dead_code)]
 mod tests {
 	use support::metadata::*;
+	use runtime_io::TestExternalities;
 	use std::marker::PhantomData;
 	use codec::{Encode, Decode, EncodeLike};
 
@@ -44,7 +45,7 @@ mod tests {
 			// getters: pub / $default
 			// we need at least one type which uses T, otherwise GenesisConfig will complain.
 			GETU32 get(fn u32_getter): T::Origin;
-			pub PUBGETU32 get(fn pub_u32_getter) build(|config: &GenesisConfig| config.u32_getter_with_config): u32;
+			pub PUBGETU32 get(fn pub_u32_getter): u32;
 			GETU32WITHCONFIG get(fn u32_getter_with_config) config(): u32;
 			pub PUBGETU32WITHCONFIG get(fn pub_u32_getter_with_config) config(): u32;
 			GETU32MYDEF get(fn u32_getter_mydef): Option<u32>;
@@ -52,6 +53,10 @@ mod tests {
 			GETU32WITHCONFIGMYDEF get(fn u32_getter_with_config_mydef) config(): u32 = 2;
 			pub PUBGETU32WITHCONFIGMYDEF get(fn pub_u32_getter_with_config_mydef) config(): u32 = 1;
 			PUBGETU32WITHCONFIGMYDEFOPT get(fn pub_u32_getter_with_config_mydef_opt) config(): Option<u32>;
+
+			GetU32WithBuilder get(fn u32_with_builder) build(|_| 1): u32;
+			GetOptU32WithBuilderSome get(fn opt_u32_with_builder_some) build(|_| Some(1)): Option<u32>;
+			GetOptU32WithBuilderNone get(fn opt_u32_with_builder_none) build(|_| None): Option<u32>;
 
 			// map non-getters: pub / $default
 			MAPU32 : map u32 => Option<String>;
@@ -209,7 +214,33 @@ mod tests {
 					),
 					documentation: DecodeDifferent::Encode(&[]),
 				},
-
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GetU32WithBuilder"),
+					modifier: StorageEntryModifier::Default,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGetU32WithBuilder(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GetOptU32WithBuilderSome"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGetOptU32WithBuilderSome(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
+				StorageEntryMetadata {
+					name: DecodeDifferent::Encode("GetOptU32WithBuilderNone"),
+					modifier: StorageEntryModifier::Optional,
+					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
+					default: DecodeDifferent::Encode(
+						DefaultByteGetter(&__GetByteStructGetOptU32WithBuilderNone(PhantomData::<TraitImpl>))
+					),
+					documentation: DecodeDifferent::Encode(&[]),
+				},
 				StorageEntryMetadata {
 					name: DecodeDifferent::Encode("MAPU32"),
 					modifier: StorageEntryModifier::Optional,
@@ -412,7 +443,7 @@ mod tests {
 	#[test]
 	fn store_metadata() {
 		let metadata = Module::<TraitImpl>::storage_metadata();
-		assert_eq!(EXPECTED_METADATA, metadata);
+		pretty_assertions::assert_eq!(EXPECTED_METADATA, metadata);
 	}
 
 	#[test]
@@ -427,6 +458,16 @@ mod tests {
 		assert_eq!(config.pub_u32_getter_with_config_mydef_opt, 0u32);
 	}
 
+	#[test]
+	fn check_builder_config() {
+		let config = GenesisConfig::default();
+		let storage = config.build_storage().unwrap();
+		TestExternalities::from(storage).execute_with(|| {
+			assert_eq!(Module::<TraitImpl>::u32_with_builder(), 1);
+			assert_eq!(Module::<TraitImpl>::opt_u32_with_builder_some(), Some(1));
+			assert_eq!(Module::<TraitImpl>::opt_u32_with_builder_none(), None);
+		})
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/4315

Allow optional storage value builder to build None such as:
```rust
decl_storage!{
Foo build(|config: &GenesisConfig<T>| None): Option<u64>;
}
```
although regular storage value are not supposed to build nothing thus it still can only insert some value:
```rust
decl_storage!{
Foo build(|config: &GenesisConfig<T>| 1): u64;
}
```