### PR TITLE
New protocol id for flaming fir

### DIFF
--- a/bin/node/cli/res/flaming-fir.json
+++ b/bin/node/cli/res/flaming-fir.json
@@ -18,7 +18,7 @@
 	"telemetryEndpoints": [
 		["wss://telemetry.polkadot.io/submit/", 0]
 	],
-	"protocolId": "fir",
+	"protocolId": "fir2",
 	"consensusEngine": null,
 	"genesis": {
 		"raw": [


### PR DESCRIPTION
Small update to bump protocol id for flaming fir to force a new chain on end nodes.