### PR TITLE
Remove slog-async Github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,14 +769,6 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -5587,9 +5579,9 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-async 2.3.0 (git+https://github.com/paritytech/slog-async)",
  "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5848,17 +5840,6 @@ version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "slog-async"
-version = "2.3.0"
-source = "git+https://github.com/paritytech/slog-async#107848e7ded5e80dc43f6296c2b96039eb92c0a5"
-dependencies = [
- "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8084,7 +8065,6 @@ dependencies = [
 "checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
-"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
@@ -8421,7 +8401,6 @@ dependencies = [
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
-"checksum slog-async 2.3.0 (git+https://github.com/paritytech/slog-async)" = "<none>"
 "checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c44c89dd8b0ae4537d1ae318353eaf7840b4869c536e31c41e963d1ea523ee6"
 "checksum slog_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -16,10 +16,8 @@ log = "0.4.8"
 rand = "0.7.2"
 serde = { version = "1.0.101", features = ["derive"] }
 slog = { version = "2.5.2", features = ["nested-values"] }
-# TODO: we're using slog-async just to be able to clone records; See https://github.com/slog-rs/slog/issues/221,
-# https://github.com/paritytech/substrate/issues/2823 and https://github.com/paritytech/substrate/issues/3260
-slog-async = { git = "https://github.com/paritytech/slog-async", features = ["nested-values"] }
 slog-json = { version = "2.3.0", features = ["nested-values"] }
 slog-scope = "4.1.2"
 tokio-io = "0.1.12"
+take_mut = "0.2.2"
 void = "1.0.2"

--- a/client/telemetry/src/async_record.rs
+++ b/client/telemetry/src/async_record.rs
@@ -1,0 +1,177 @@
+// {{{ Crate docs
+//! # Internal types to ssync drain slog
+//! FIXME: REMOVE THIS ONCE THE PR WAS MERGE
+//! https://github.com/slog-rs/async/pull/14
+
+use slog::{Record, RecordStatic, Level, SingleKV, KV, BorrowedKV};
+use slog::{Serializer, OwnedKVList, Key};
+
+use slog::Drain;
+use std::fmt;
+use take_mut::take;
+
+struct ToSendSerializer {
+    kv: Box<dyn KV + Send>,
+}
+
+impl ToSendSerializer {
+    fn new() -> Self {
+        ToSendSerializer { kv: Box::new(()) }
+    }
+
+    fn finish(self) -> Box<dyn KV + Send> {
+        self.kv
+    }
+}
+
+impl Serializer for ToSendSerializer {
+    fn emit_bool(&mut self, key: Key, val: bool) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_unit(&mut self, key: Key) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, ()))));
+        Ok(())
+    }
+    fn emit_none(&mut self, key: Key) -> slog::Result {
+        let val: Option<()> = None;
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_char(&mut self, key: Key, val: char) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_u8(&mut self, key: Key, val: u8) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_i8(&mut self, key: Key, val: i8) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_u16(&mut self, key: Key, val: u16) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_i16(&mut self, key: Key, val: i16) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_u32(&mut self, key: Key, val: u32) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_i32(&mut self, key: Key, val: i32) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_f32(&mut self, key: Key, val: f32) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_u64(&mut self, key: Key, val: u64) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_i64(&mut self, key: Key, val: i64) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_f64(&mut self, key: Key, val: f64) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_usize(&mut self, key: Key, val: usize) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_isize(&mut self, key: Key, val: isize) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_str(&mut self, key: Key, val: &str) -> slog::Result {
+        let val = val.to_owned();
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    fn emit_arguments(
+        &mut self,
+        key: Key,
+        val: &fmt::Arguments,
+    ) -> slog::Result {
+        let val = fmt::format(*val);
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+
+    #[cfg(feature = "nested-values")]
+    fn emit_serde(&mut self, key: Key, value: &slog::SerdeValue) -> slog::Result {
+        let val = value.to_sendable();
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+}
+
+pub(crate) struct AsyncRecord {
+    msg: String,
+    level: Level,
+    location: Box<slog::RecordLocation>,
+    tag: String,
+    logger_values: OwnedKVList,
+    kv: Box<dyn KV + Send>,
+}
+
+impl AsyncRecord {
+    /// Serializes a `Record` and an `OwnedKVList`.
+    pub fn from(record: &Record, logger_values: &OwnedKVList) -> Self {
+        let mut ser = ToSendSerializer::new();
+        record
+            .kv()
+            .serialize(record, &mut ser)
+            .expect("`ToSendSerializer` can't fail");
+
+        AsyncRecord {
+            msg: fmt::format(*record.msg()),
+            level: record.level(),
+            location: Box::new(*record.location()),
+            tag: String::from(record.tag()),
+            logger_values: logger_values.clone(),
+            kv: ser.finish(),
+        }
+    }
+
+    /// Writes the record to a `Drain`.
+    pub fn to_drain<D: Drain>(self, drain: &D) -> Result<D::Ok, D::Err> {
+        let rs = RecordStatic {
+            location: &*self.location,
+            level: self.level,
+            tag: &self.tag,
+        };
+
+        drain
+            .log(
+                &Record::new(
+                    &rs,
+                    &format_args!("{}", self.msg),
+                    BorrowedKV(&self.kv),
+                ),
+                &self.logger_values,
+            )
+    }
+
+    /// Deconstruct this `AsyncRecord` into a record and `OwnedKVList`.
+    pub fn as_record_values(&self, mut f: impl FnMut(&Record, &OwnedKVList)) {
+        let rs = RecordStatic {
+            location: &*self.location,
+            level: self.level,
+            tag: &self.tag,
+        };
+
+        f(&Record::new(
+            &rs,
+            &format_args!("{}", self.msg),
+            BorrowedKV(&self.kv),
+        ), &self.logger_values)
+    }
+}    

--- a/client/telemetry/src/async_record.rs
+++ b/client/telemetry/src/async_record.rs
@@ -6,7 +6,6 @@
 use slog::{Record, RecordStatic, Level, SingleKV, KV, BorrowedKV};
 use slog::{Serializer, OwnedKVList, Key};
 
-use slog::Drain;
 use std::fmt;
 use take_mut::take;
 
@@ -139,25 +138,6 @@ impl AsyncRecord {
             logger_values: logger_values.clone(),
             kv: ser.finish(),
         }
-    }
-
-    /// Writes the record to a `Drain`.
-    pub fn to_drain<D: Drain>(self, drain: &D) -> Result<D::Ok, D::Err> {
-        let rs = RecordStatic {
-            location: &*self.location,
-            level: self.level,
-            tag: &self.tag,
-        };
-
-        drain
-            .log(
-                &Record::new(
-                    &rs,
-                    &format_args!("{}", self.msg),
-                    BorrowedKV(&self.kv),
-                ),
-                &self.logger_values,
-            )
     }
 
     /// Deconstruct this `AsyncRecord` into a record and `OwnedKVList`.

--- a/client/telemetry/src/async_record.rs
+++ b/client/telemetry/src/async_record.rs
@@ -1,4 +1,3 @@
-// {{{ Crate docs
 //! # Internal types to ssync drain slog
 //! FIXME: REMOVE THIS ONCE THE PR WAS MERGE
 //! https://github.com/slog-rs/async/pull/14
@@ -10,148 +9,148 @@ use std::fmt;
 use take_mut::take;
 
 struct ToSendSerializer {
-    kv: Box<dyn KV + Send>,
+	kv: Box<dyn KV + Send>,
 }
 
 impl ToSendSerializer {
-    fn new() -> Self {
-        ToSendSerializer { kv: Box::new(()) }
-    }
+	fn new() -> Self {
+		ToSendSerializer { kv: Box::new(()) }
+	}
 
-    fn finish(self) -> Box<dyn KV + Send> {
-        self.kv
-    }
+	fn finish(self) -> Box<dyn KV + Send> {
+		self.kv
+	}
 }
 
 impl Serializer for ToSendSerializer {
-    fn emit_bool(&mut self, key: Key, val: bool) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_unit(&mut self, key: Key) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, ()))));
-        Ok(())
-    }
-    fn emit_none(&mut self, key: Key) -> slog::Result {
-        let val: Option<()> = None;
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_char(&mut self, key: Key, val: char) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_u8(&mut self, key: Key, val: u8) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_i8(&mut self, key: Key, val: i8) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_u16(&mut self, key: Key, val: u16) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_i16(&mut self, key: Key, val: i16) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_u32(&mut self, key: Key, val: u32) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_i32(&mut self, key: Key, val: i32) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_f32(&mut self, key: Key, val: f32) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_u64(&mut self, key: Key, val: u64) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_i64(&mut self, key: Key, val: i64) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_f64(&mut self, key: Key, val: f64) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_usize(&mut self, key: Key, val: usize) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_isize(&mut self, key: Key, val: isize) -> slog::Result {
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_str(&mut self, key: Key, val: &str) -> slog::Result {
-        let val = val.to_owned();
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
-    fn emit_arguments(
-        &mut self,
-        key: Key,
-        val: &fmt::Arguments,
-    ) -> slog::Result {
-        let val = fmt::format(*val);
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
+	fn emit_bool(&mut self, key: Key, val: bool) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_unit(&mut self, key: Key) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, ()))));
+		Ok(())
+	}
+	fn emit_none(&mut self, key: Key) -> slog::Result {
+		let val: Option<()> = None;
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_char(&mut self, key: Key, val: char) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_u8(&mut self, key: Key, val: u8) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_i8(&mut self, key: Key, val: i8) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_u16(&mut self, key: Key, val: u16) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_i16(&mut self, key: Key, val: i16) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_u32(&mut self, key: Key, val: u32) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_i32(&mut self, key: Key, val: i32) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_f32(&mut self, key: Key, val: f32) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_u64(&mut self, key: Key, val: u64) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_i64(&mut self, key: Key, val: i64) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_f64(&mut self, key: Key, val: f64) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_usize(&mut self, key: Key, val: usize) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_isize(&mut self, key: Key, val: isize) -> slog::Result {
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_str(&mut self, key: Key, val: &str) -> slog::Result {
+		let val = val.to_owned();
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
+	fn emit_arguments(
+		&mut self,
+		key: Key,
+		val: &fmt::Arguments,
+	) -> slog::Result {
+		let val = fmt::format(*val);
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
 
-    #[cfg(feature = "nested-values")]
-    fn emit_serde(&mut self, key: Key, value: &slog::SerdeValue) -> slog::Result {
-        let val = value.to_sendable();
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
-        Ok(())
-    }
+	#[cfg(feature = "nested-values")]
+	fn emit_serde(&mut self, key: Key, value: &slog::SerdeValue) -> slog::Result {
+		let val = value.to_sendable();
+		take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+		Ok(())
+	}
 }
 
 pub(crate) struct AsyncRecord {
-    msg: String,
-    level: Level,
-    location: Box<slog::RecordLocation>,
-    tag: String,
-    logger_values: OwnedKVList,
-    kv: Box<dyn KV + Send>,
+	msg: String,
+	level: Level,
+	location: Box<slog::RecordLocation>,
+	tag: String,
+	logger_values: OwnedKVList,
+	kv: Box<dyn KV + Send>,
 }
 
 impl AsyncRecord {
-    /// Serializes a `Record` and an `OwnedKVList`.
-    pub fn from(record: &Record, logger_values: &OwnedKVList) -> Self {
-        let mut ser = ToSendSerializer::new();
-        record
-            .kv()
-            .serialize(record, &mut ser)
-            .expect("`ToSendSerializer` can't fail");
+	/// Serializes a `Record` and an `OwnedKVList`.
+	pub fn from(record: &Record, logger_values: &OwnedKVList) -> Self {
+		let mut ser = ToSendSerializer::new();
+		record
+			.kv()
+			.serialize(record, &mut ser)
+			.expect("`ToSendSerializer` can't fail");
 
-        AsyncRecord {
-            msg: fmt::format(*record.msg()),
-            level: record.level(),
-            location: Box::new(*record.location()),
-            tag: String::from(record.tag()),
-            logger_values: logger_values.clone(),
-            kv: ser.finish(),
-        }
-    }
+		AsyncRecord {
+			msg: fmt::format(*record.msg()),
+			level: record.level(),
+			location: Box::new(*record.location()),
+			tag: String::from(record.tag()),
+			logger_values: logger_values.clone(),
+			kv: ser.finish(),
+		}
+	}
 
-    /// Deconstruct this `AsyncRecord` into a record and `OwnedKVList`.
-    pub fn as_record_values(&self, mut f: impl FnMut(&Record, &OwnedKVList)) {
-        let rs = RecordStatic {
-            location: &*self.location,
-            level: self.level,
-            tag: &self.tag,
-        };
+	/// Deconstruct this `AsyncRecord` into a record and `OwnedKVList`.
+	pub fn as_record_values(&self, mut f: impl FnMut(&Record, &OwnedKVList)) {
+		let rs = RecordStatic {
+			location: &*self.location,
+			level: self.level,
+			tag: &self.tag,
+		};
 
-        f(&Record::new(
-            &rs,
-            &format_args!("{}", self.msg),
-            BorrowedKV(&self.kv),
-        ), &self.logger_values)
-    }
+		f(&Record::new(
+			&rs,
+			&format_args!("{}", self.msg),
+			BorrowedKV(&self.kv),
+		), &self.logger_values)
+	}
 }    

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -69,6 +69,7 @@ pub use slog_scope::with_logger;
 pub use slog;
 
 mod worker;
+mod async_record;
 
 /// Configuration for telemetry.
 pub struct TelemetryConfig {
@@ -131,13 +132,13 @@ struct TelemetryInner {
 	/// Worker for the telemetry.
 	worker: worker::TelemetryWorker,
 	/// Receives log entries for them to be dispatched to the worker.
-	receiver: mpsc::Receiver<slog_async::AsyncRecord>,
+	receiver: mpsc::Receiver<async_record::AsyncRecord>,
 }
 
 /// Implements `slog::Drain`.
 struct TelemetryDrain {
 	/// Sends log entries.
-	sender: std::panic::AssertUnwindSafe<mpsc::Sender<slog_async::AsyncRecord>>,
+	sender: std::panic::AssertUnwindSafe<mpsc::Sender<async_record::AsyncRecord>>,
 }
 
 /// Initializes the telemetry. See the crate root documentation for more information.
@@ -241,7 +242,7 @@ impl slog::Drain for TelemetryDrain {
 	fn log(&self, record: &slog::Record, values: &slog::OwnedKVList) -> Result<Self::Ok, Self::Err> {
 		let before = Instant::now();
 
-		let serialized = slog_async::AsyncRecord::from(record, values);
+		let serialized = async_record::AsyncRecord::from(record, values);
 		// Note: interestingly, `try_send` requires a `&mut` because it modifies some internal value, while `clone()`
 		// is lock-free.
 		if let Err(err) = self.sender.clone().try_send(serialized) {

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -68,8 +68,8 @@ use std::{pin::Pin, sync::Arc, task::{Context, Poll}, time::{Duration, Instant}}
 pub use slog_scope::with_logger;
 pub use slog;
 
-mod worker;
 mod async_record;
+mod worker;
 
 /// Configuration for telemetry.
 pub struct TelemetryConfig {


### PR DESCRIPTION
By putting that record we are using directly into the crates–internal use only. Leaving a FIXME comment on the top to remove this once the PR has cleared.

Because this is completely internally an update removing this file and replacing the dependency later would only require a patch-level update.