### PR TITLE
sp-transaction-pool-api: make default std, remove unused sp-core dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6422,7 +6422,6 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-api 2.0.0",
- "sp-core 2.0.0",
  "sp-runtime 2.0.0",
 ]
 

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -20,7 +20,7 @@ std = [
 	"derive_more",
 	"futures",
 	"log",
-	"primitives",
+	"primitives/std",
 	"serde",
 	"sp-api/std",
 	"sp-runtime/std",

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -9,7 +9,7 @@ codec = { package = "parity-scale-codec", version = "1.0.0", optional = true }
 derive_more = { version = "0.99.2", optional = true }
 futures = { version = "0.3.1", optional = true }
 log = { version = "0.4.8", optional = true }
-primitives = { package = "sp-core",  path = "../core", optional = true}
+primitives = { package = "sp-core",  path = "../core", default-features = false }
 serde = { version = "1.0.101", features = ["derive"], optional = true}
 sp-api = { path = "../sr-api", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -15,6 +15,7 @@ sp-api = { path = "../sr-api", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }
 
 [features]
+default = [ "std" ]
 std = [
 	"codec",
 	"derive_more",

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -9,7 +9,6 @@ codec = { package = "parity-scale-codec", version = "1.0.0", optional = true }
 derive_more = { version = "0.99.2", optional = true }
 futures = { version = "0.3.1", optional = true }
 log = { version = "0.4.8", optional = true }
-primitives = { package = "sp-core",  path = "../core", default-features = false }
 serde = { version = "1.0.101", features = ["derive"], optional = true}
 sp-api = { path = "../sr-api", default-features = false }
 sp-runtime = { path = "../runtime", default-features = false }
@@ -21,7 +20,6 @@ std = [
 	"derive_more",
 	"futures",
 	"log",
-	"primitives/std",
 	"serde",
 	"sp-api/std",
 	"sp-runtime/std",


### PR DESCRIPTION
This was causing a compilation error in `subxt` with a dependency on `sp-transaction-pool-api`. 

```
   |
41 | pub use primitives::to_substrate_wasm_fn_return_value;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `to_substrate_wasm_fn_return_value` in the root
```

Looks like it was defaulting to `no_std` and failing to compile. 

Also `sp-core` is not even used here so have removed it.

Rel https://github.com/paritytech/substrate/pull/4320