### PR TITLE
Wrong feature name `disable_allocator` in sr-io

### DIFF
--- a/primitives/sr-io/src/lib.rs
+++ b/primitives/sr-io/src/lib.rs
@@ -750,7 +750,7 @@ pub trait Sandbox {
 #[cfg(not(feature = "std"))]
 struct WasmAllocator;
 
-#[cfg(all(not(feature = "disable_global_allocator"), not(feature = "std")))]
+#[cfg(all(not(feature = "disable_allocator"), not(feature = "std")))]
 #[global_allocator]
 static ALLOCATOR: WasmAllocator = WasmAllocator;
 


### PR DESCRIPTION
This fixes the inconsistency:
- In Cargo.toml: `disable_allocator`
- In lib.rs: `disable_global_allocator`