### PR TITLE
*: Register network event stream for authority discovery

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -113,13 +113,13 @@ macro_rules! new_full_start {
 /// concrete types instead.
 macro_rules! new_full {
 	($config:expr, $with_startup_data: expr) => {{
-		use futures01::sync::mpsc;
-		use sc_network::DhtEvent;
+		use futures01::Stream;
 		use futures::{
 			compat::Stream01CompatExt,
 			stream::StreamExt,
 			future::{FutureExt, TryFutureExt},
 		};
+		use sc_network::Event;
 
 		let (
 			is_authority,
@@ -142,18 +142,10 @@ macro_rules! new_full {
 
 		let (builder, mut import_setup, inherent_data_providers) = new_full_start!($config);
 
-		// Dht event channel from the network to the authority discovery module. Use bounded channel to ensure
-		// back-pressure. Authority discovery is triggering one event per authority within the current authority set.
-		// This estimates the authority set size to be somewhere below 10 000 thereby setting the channel buffer size to
-		// 10 000.
-		let (dht_event_tx, dht_event_rx) =
-			mpsc::channel::<DhtEvent>(10_000);
-
 		let service = builder.with_network_protocol(|_| Ok(crate::service::NodeProtocol::new()))?
 			.with_finality_proof_provider(|client, backend|
 				Ok(Arc::new(grandpa::FinalityProofProvider::new(backend, client)) as _)
 			)?
-			.with_dht_event_tx(dht_event_tx)?
 			.build()?;
 
 		let (block_import, grandpa_link, babe_link) = import_setup.take()
@@ -190,15 +182,20 @@ macro_rules! new_full {
 			let babe = sc_consensus_babe::start_babe(babe_config)?;
 			service.spawn_essential_task(babe);
 
-			let future03_dht_event_rx = dht_event_rx.compat()
+			let network = service.network();
+			let dht_event_stream = network.event_stream().filter_map(|e| match e {
+				Event::Dht(e) => Some(e),
+				_ => None,
+			});
+			let future03_dht_event_stream = dht_event_stream.compat()
 				.map(|x| x.expect("<mpsc::channel::Receiver as Stream> never returns an error; qed"))
 				.boxed();
 			let authority_discovery = sc_authority_discovery::AuthorityDiscovery::new(
 				service.client(),
-				service.network(),
+				network,
 				sentry_nodes,
 				service.keystore(),
-				future03_dht_event_rx,
+				future03_dht_event_stream,
 			);
 			let future01_authority_discovery = authority_discovery.map(|x| Ok(x)).compat();
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -44,7 +44,7 @@ use futures03::{
 };
 use sc_network::{
 	NetworkService, NetworkState, specialization::NetworkSpecialization,
-	Event, DhtEvent, PeerId, ReportHandle,
+	PeerId, ReportHandle,
 };
 use log::{log, warn, debug, error, Level};
 use codec::{Encode, Decode};
@@ -375,7 +375,6 @@ fn build_network_future<
 	status_sinks: Arc<Mutex<status_sinks::StatusSinks<(NetworkStatus<B>, NetworkState)>>>,
 	rpc_rx: futures03::channel::mpsc::UnboundedReceiver<sc_rpc::system::Request<B>>,
 	should_have_peers: bool,
-	dht_event_tx: Option<mpsc::Sender<DhtEvent>>,
 ) -> impl Future<Item = (), Error = ()> {
 	// Compatibility shim while we're transitioning to stable Futures.
 	// See https://github.com/paritytech/substrate/issues/3099
@@ -385,9 +384,6 @@ fn build_network_future<
 		.map(|v| Ok::<_, ()>(v)).compat();
 	let mut finality_notification_stream = client.finality_notification_stream().fuse()
 		.map(|v| Ok::<_, ()>(v)).compat();
-
-	// Initializing a stream in order to obtain DHT events from the network.
-	let mut event_stream = network.service().event_stream();
 
 	futures::future::poll_fn(move || {
 		let before_polling = Instant::now();
@@ -480,26 +476,6 @@ fn build_network_future<
 			let state = network.network_state();
 			(status, state)
 		});
-
-		// Processing DHT events.
-		while let Ok(Async::Ready(Some(event))) = event_stream.poll() {
-			match event {
-				Event::Dht(event) => {
-					// Given that client/authority-discovery is the only upper stack consumer of Dht events at the moment, all Dht
-					// events are being passed on to the authority-discovery module. In the future there might be multiple
-					// consumers of these events. In that case this would need to be refactored to properly dispatch the events,
-					// e.g. via a subscriber model.
-					if let Some(Err(e)) = dht_event_tx.as_ref().map(|c| c.clone().try_send(event)) {
-						if e.is_full() {
-							warn!(target: "service", "Dht event channel to authority discovery is full, dropping event.");
-						} else if e.is_disconnected() {
-							warn!(target: "service", "Dht event channel to authority discovery is disconnected, dropping event.");
-						}
-					}
-				}
-				_ => {}
-			}
-		}
 
 		// Main network polling.
 		if let Ok(Async::Ready(())) = network.poll().map_err(|err| {


### PR DESCRIPTION
Follow up to https://github.com/paritytech/substrate/pull/4284.

Previously one would create a sender and receiver channel pair, pass the
sender to the `build_network_future` through the service builder and
funnel network events returned from polling the network service into the
sender to be consumed by the authority discovery module owning the
receiver.

With recent changes it is now possible to register an `event_stream`
with the network service directly, thus one does not need to make the
detour through the `build_network_future`.