### PR TITLE
Improve is_member and is_runner.

### DIFF
--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -492,14 +492,14 @@ impl<T: Trait> Module<T> {
 	///
 	/// Limited number of members. Binary search. Constant time factor. O(1)
 	fn is_member(who: &T::AccountId) -> bool {
-		Self::members_ids().binary_search(who).is_ok()
+		Self::members().binary_search_by(|(a, _b)| a.cmp(who)).is_ok()
 	}
 
 	/// Check if `who` is currently an active runner.
 	///
 	/// Limited number of runners-up. Binary search. Constant time factor. O(1)
 	fn is_runner(who: &T::AccountId) -> bool {
-		Self::runners_up_ids().binary_search(who).is_ok()
+		Self::runners_up().binary_search_by(|(a, _b)| a.cmp(who)).is_ok()
 	}
 
 	/// Returns number of desired members.


### PR DESCRIPTION
Even if they are bounded, I prefer to fix it. From `O(NlogN)` to `O(logN)`.
Removes the use of `members_id` and `runners_up_id` that are linear. 
