### PR TITLE
Update rustdocs landing page

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -329,7 +329,7 @@ build-rust-doc-release:
     - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
     - BUILD_DUMMY_WASM_BINARY=1 RUSTDOCFLAGS="--html-in-header $(pwd)/.maintain/rustdoc-header.html" time cargo +nightly doc --release --all --verbose
     - cp -R ./target/doc ./crate-docs
-    - echo "<meta http-equiv=refresh content=0;url=substrate_service/index.html>" > ./crate-docs/index.html
+    - echo "<meta http-equiv=refresh content=0;url=sc_service/index.html>" > ./crate-docs/index.html
     - sccache -s
 
 check_warnings:


### PR DESCRIPTION
This will fix the problem currently that https://crates.parity.io/

Redirects to: "substrate_service/index.html", when it has been renamed to `sc_service`.