### PR TITLE
Simplify adding new Ss58AddressFormat variant and add KulupuAccountDirect

### DIFF
--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -165,7 +165,7 @@ fn get_app<'a, 'b>() -> App<'a, 'b> {
 			-k, --secp256k1 'Use SECP256k1/ECDSA/BIP39 cryptography'
 			-s, --sr25519 'Use Schnorr/Ristretto x25519/BIP39 cryptography'
 			[network] -n, --network <network> 'Specify a network. One of substrate \
-									 (default), polkadot, kusama, or dothereum.'
+									 (default), polkadot, kusama, dothereum, or kulupu'
 			[password] -p, --password <password> 'The password for the key'
 		")
 		.subcommands(vec![

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -355,75 +355,83 @@ lazy_static::lazy_static! {
 		= Mutex::new(Ss58AddressFormat::SubstrateAccountDirect);
 }
 
-/// A known address (sub)format/network ID for SS58.
 #[cfg(feature = "full_crypto")]
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum Ss58AddressFormat {
-	/// Any Substrate network, direct checksum, standard account (*25519).
-	SubstrateAccountDirect,
-	/// Polkadot Relay-chain, direct checksum, standard account (*25519).
-	PolkadotAccountDirect,
-	/// Kusama Relay-chain, direct checksum, standard account (*25519).
-	KusamaAccountDirect,
-	/// Dothereum Para-chain, direct checksum, standard account (*25519).
-	DothereumAccountDirect,
-	/// Use a manually provided numeric value.
-	Custom(u8),
+macro_rules! ss58_address_format {
+	( $( $identifier:tt => ($number:expr, $name:expr, $desc:tt) )* ) => (
+		/// A known address (sub)format/network ID for SS58.
+		#[derive(Copy, Clone, PartialEq, Eq)]
+		pub enum Ss58AddressFormat {
+			$(#[doc = $desc] $identifier),*,
+			/// Use a manually provided numeric value.
+			Custom(u8),
+		}
+
+		static ALL_SS58_ADDRESS_FORMATS: [Ss58AddressFormat; 0 $(+ { let _ = $number; 1})*] = [
+			$(Ss58AddressFormat::$identifier),*,
+		];
+
+		impl Ss58AddressFormat {
+			/// All known address formats.
+			pub fn all() -> &'static [Ss58AddressFormat] {
+				&ALL_SS58_ADDRESS_FORMATS
+			}
+		}
+
+		impl From<Ss58AddressFormat> for u8 {
+			fn from(x: Ss58AddressFormat) -> u8 {
+				match x {
+					$(Ss58AddressFormat::$identifier => $number),*,
+					Ss58AddressFormat::Custom(n) => n,
+				}
+			}
+		}
+
+		impl TryFrom<u8> for Ss58AddressFormat {
+			type Error = ();
+
+			fn try_from(x: u8) -> Result<Ss58AddressFormat, ()> {
+				match x {
+					$($number => Ok(Ss58AddressFormat::$identifier)),*,
+					_ => Err(()),
+				}
+			}
+		}
+
+		impl<'a> TryFrom<&'a str> for Ss58AddressFormat {
+			type Error = ();
+
+			fn try_from(x: &'a str) -> Result<Ss58AddressFormat, ()> {
+				match x {
+					$($name => Ok(Ss58AddressFormat::$identifier)),*,
+					a => a.parse::<u8>().map(Ss58AddressFormat::Custom).map_err(|_| ()),
+				}
+			}
+		}
+
+		impl From<Ss58AddressFormat> for String {
+			fn from(x: Ss58AddressFormat) -> String {
+				match x {
+					$(Ss58AddressFormat::$identifier => $name.into()),*,
+					Ss58AddressFormat::Custom(x) => x.to_string(),
+				}
+			}
+		}
+	)
 }
 
 #[cfg(feature = "full_crypto")]
-impl From<Ss58AddressFormat> for u8 {
-	fn from(x: Ss58AddressFormat) -> u8 {
-		match x {
-			Ss58AddressFormat::SubstrateAccountDirect => 42,
-			Ss58AddressFormat::PolkadotAccountDirect => 0,
-			Ss58AddressFormat::KusamaAccountDirect => 2,
-			Ss58AddressFormat::DothereumAccountDirect => 20,
-			Ss58AddressFormat::Custom(n) => n,
-		}
-	}
-}
-
-#[cfg(feature = "full_crypto")]
-impl TryFrom<u8> for Ss58AddressFormat {
-	type Error = ();
-	fn try_from(x: u8) -> Result<Ss58AddressFormat, ()> {
-		match x {
-			42 => Ok(Ss58AddressFormat::SubstrateAccountDirect),
-			0 => Ok(Ss58AddressFormat::PolkadotAccountDirect),
-			2 => Ok(Ss58AddressFormat::KusamaAccountDirect),
-			20 => Ok(Ss58AddressFormat::DothereumAccountDirect),
-			_ => Err(()),
-		}
-	}
-}
-
-#[cfg(feature = "full_crypto")]
-impl<'a> TryFrom<&'a str> for Ss58AddressFormat {
-	type Error = ();
-	fn try_from(x: &'a str) -> Result<Ss58AddressFormat, ()> {
-		match x {
-			"substrate" => Ok(Ss58AddressFormat::SubstrateAccountDirect),
-			"polkadot" => Ok(Ss58AddressFormat::PolkadotAccountDirect),
-			"kusama" => Ok(Ss58AddressFormat::KusamaAccountDirect),
-			"dothereum" => Ok(Ss58AddressFormat::DothereumAccountDirect),
-			a => a.parse::<u8>().map(Ss58AddressFormat::Custom).map_err(|_| ()),
-		}
-	}
-}
-
-#[cfg(feature = "std")]
-impl From<Ss58AddressFormat> for String {
-	fn from(x: Ss58AddressFormat) -> String {
-		match x {
-			Ss58AddressFormat::SubstrateAccountDirect => "substrate".into(),
-			Ss58AddressFormat::PolkadotAccountDirect => "polkadot".into(),
-			Ss58AddressFormat::KusamaAccountDirect => "kusama".into(),
-			Ss58AddressFormat::DothereumAccountDirect => "dothereum".into(),
-			Ss58AddressFormat::Custom(x) => x.to_string(),
-		}
-	}
-}
+ss58_address_format!(
+	SubstrateAccountDirect =>
+		(42, "substrate", "Any Substrate network, direct checksum, standard account (*25519).")
+	PolkadotAccountDirect =>
+		(0, "polkadot", "Polkadot Relay-chain, direct checksum, standard account (*25519).")
+	KusamaAccountDirect =>
+		(2, "kusama", "Kusama Relay-chain, direct checksum, standard account (*25519).")
+	DothereumAccountDirect =>
+		(20, "dothereum", "Dothereum Para-chain, direct checksum, standard account (*25519).")
+	KulupuAccountDirect =>
+		(16, "kulupu", "Kulupu mainnet, direct checksum, standard account (*25519).")
+);
 
 /// Set the default "version" (actually, this is a bit of a misnomer and the version byte is
 /// typically used not just to encode format/version but also network identity) that is used for

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -408,6 +408,7 @@ macro_rules! ss58_address_format {
 			}
 		}
 
+		#[cfg(feature = "std")]
 		impl From<Ss58AddressFormat> for String {
 			fn from(x: Ss58AddressFormat) -> String {
 				match x {


### PR DESCRIPTION
This adds `ss58_address_format` macro, with the following syntax to simplify adding additional variant:

```
[variant] => ([network_id], [description_name], [description_doc])
```

This also adds `KulupuAccountDirect` variant into the list, with id `16`.

