### PR TITLE
Identity module enhancements

### DIFF
--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -527,8 +527,6 @@ decl_module! {
 			}
 		}
 
-		// TODO: revamp any other instances where we modify SubsOf
-
 		/// Clear an account's identity info and all sub-account and return all deposits.
 		///
 		/// Payment: All reserved balances on the account are returned.
@@ -541,7 +539,7 @@ decl_module! {
 		/// # <weight>
 		/// - `O(R + S + X)`.
 		/// - One balance-reserve operation.
-		/// - Two storage mutations.
+		/// - `S + 2` storage deletions.
 		/// - One event.
 		/// # </weight>
 		fn clear_identity(origin) {
@@ -793,7 +791,7 @@ decl_module! {
 		/// # <weight>
 		/// - `O(R + S + X)`.
 		/// - One balance-reserve operation.
-		/// - Two storage mutations.
+		/// - `S + 2` storage mutations.
 		/// - One event.
 		/// # </weight>
 		#[weight = SimpleDispatchInfo::FreeOperational]

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -687,7 +687,7 @@ decl_module! {
 		/// - One storage mutation `O(R)`.
 		/// # </weight>
 		#[weight = SimpleDispatchInfo::FixedNormal(50_000)]
-		fn set_account(origin,
+		fn set_account_id(origin,
 			#[compact] index: RegistrarIndex,
 			new: T::AccountId,
 		) -> Result {
@@ -1131,6 +1131,19 @@ mod tests {
 				], .. Default::default()
 			}));
 			assert_eq!(Balances::free_balance(10), 70);
+		});
+	}
+
+	#[test]
+	fn setting_account_id_should_work() {
+		new_test_ext().execute_with(|| {
+			assert_ok!(Identity::add_registrar(Origin::signed(1), 3));
+			// account 4 cannot change the first registrar's identity since it's owned by 3.
+			assert_noop!(Identity::set_account_id(Origin::signed(4), 0, 3), "invalid index");
+			// account 3 can, because that's the registrar's current account.
+			assert_ok!(Identity::set_account_id(Origin::signed(3), 0, 4));
+			// account 4 can now, because that's their new ID.
+			assert_ok!(Identity::set_account_id(Origin::signed(4), 0, 3));
 		});
 	}
 }


### PR DESCRIPTION
This adds two features:
- `SuperOf` public map item, for looking up the super account of a sub-account. Sub-accounts should be able to be looked up directly since the UI has no way of efficiently enumerating them.
- `fn set_account_id` dispatchable call so that registrars are able to reset their account ID.