### PR TITLE
Fix Fees in Substrate

### DIFF
--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -87,14 +87,14 @@ mod tests {
 
 	/// Default transfer fee
 	fn transfer_fee<E: Encode>(extrinsic: &E, fee_multiplier: Fixed64) -> Balance {
-		let length_fee = TransactionBaseFee::get() +
-			TransactionByteFee::get() *
-			(extrinsic.encode().len() as Balance);
+		let length_fee = TransactionByteFee::get() * (extrinsic.encode().len() as Balance);
 
 		let weight = default_transfer_call().get_dispatch_info().weight;
 		let weight_fee = <Runtime as pallet_transaction_payment::Trait>::WeightToFee::convert(weight);
 
-		fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee) + TransferFee::get()
+		let base_fee = TransactionBaseFee::get();
+
+		 base_fee + fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee) + TransferFee::get()
 	}
 
 	fn default_transfer_call() -> pallet_balances::Call<Runtime> {
@@ -537,7 +537,7 @@ mod tests {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(1),
-					event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(1984780231392)),
+					event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(1984788199392)),
 					topics: vec![],
 				},
 				EventRecord {
@@ -561,7 +561,7 @@ mod tests {
 				},
 				EventRecord {
 					phase: Phase::ApplyExtrinsic(2),
-					event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(1984780231392)),
+					event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(1984788199392)),
 					topics: vec![],
 				},
 				EventRecord {

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -170,6 +170,7 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 			// everything except for tip
 			let basic_fee = base_fee.saturating_add(len_fee).saturating_add(weight_fee);
 			let fee_update = NextFeeMultiplier::get();
+			// basic_fee + (basic_fee * fee_update)
 			let adjusted_fee = fee_update.saturated_multiply_accumulate(basic_fee);
 
 			adjusted_fee.saturating_add(tip)

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -161,7 +161,6 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 	{
 		if info.pays_fee {
 			let len = <BalanceOf<T>>::from(len);
-			let base_fee = T::TransactionBaseFee::get();
 			let per_byte = T::TransactionByteFee::get();
 			let len_fee = per_byte.saturating_mul(len);
 
@@ -177,6 +176,8 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 			let targeted_fee_adjustment = NextFeeMultiplier::get();
 			// adjusted_fee = adjustable_fee + (adjustable_fee * targeted_fee_adjustment)
 			let adjusted_fee = targeted_fee_adjustment.saturated_multiply_accumulate(adjustable_fee);
+			
+			let base_fee = T::TransactionBaseFee::get();
 			let final_fee = base_fee.saturating_add(adjusted_fee).saturating_add(tip);
 
 			final_fee

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -175,7 +175,7 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 			// the adjustable part of the fee
 			let adjustable_fee = len_fee.saturating_add(weight_fee);
 			let targeted_fee_adjustment = NextFeeMultiplier::get();
-			// adjustable_fee + (adjustable_fee * targeted_fee_adjustment)
+			// adjusted_fee = adjustable_fee + (adjustable_fee * targeted_fee_adjustment)
 			let adjusted_fee = targeted_fee_adjustment.saturated_multiply_accumulate(adjustable_fee);
 			let final_fee = base_fee.saturating_add(adjusted_fee).saturating_add(tip);
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -146,7 +146,7 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 	///      size-fee, this is not input dependent and reflects the _complexity_ of the execution
 	///      and the time it consumes.
 	///   - _targeted_fee_adjustment_: This is a multiplier that can tune the final fee based on
-	///     is affected by the congestion of the network.
+	///     the congestion of the network.
 	///   - (optional) _tip_: if included in the transaction, it will be added on top. Only signed
 	///      transactions can have a tip.
 	///


### PR DESCRIPTION
This PR is the result of investigating the fee system in Substrate and possible issues around calculating fees.

When the `TargetedFeeAdjustment` calculation reached `-1`, the fee calculation mechanism would reduce the total fee a user paid to zero.

Instead, we now ensure that the `base_fee` is unaffected by this adjustment multiplier, so even when the network is so un-congested, the user will pay at a minimum some `base_fee`. This adjustment multiplier now only affects the length fee and weight fee of a transaction.

```
final_fee = base_fee + targeted_fee_adjustment(len_fee + weight_fee) + tip;
```

This includes a new test which verifies that the `compute_fee` function behaves as it should in various scenarios with this new formula.