### PR TITLE
Introduce frame::system::Error::InvalidOrigin

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -487,7 +487,6 @@ impl<B, C, E, I, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for BabeWork
 		let slot_lenience = slot_info.number.saturating_sub(parent_slot + 1);
 
 		let slot_lenience = std::cmp::min(slot_lenience, BACKOFF_CAP);
-		let slot_duration = slot_info.duration << (slot_lenience / BACKOFF_STEP);
 
 		if slot_lenience >= 1 {
 			debug!(target: "babe", "No block for {} slots. Applying 2^({}/{}) lenience",

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -26,14 +26,14 @@
 use sp_std::{prelude::*, result};
 use sp_core::u32_trait::Value as U32;
 use sp_runtime::RuntimeDebug;
-use sp_runtime::traits::{Hash, EnsureOrigin};
+use sp_runtime::traits::Hash;
 use frame_support::weights::SimpleDispatchInfo;
 use frame_support::{
 	dispatch::{Dispatchable, Parameter}, codec::{Encode, Decode},
 	traits::{ChangeMembers, InitializeMembers}, decl_module, decl_event,
 	decl_storage, ensure,
 };
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_signed, ensure_root, EnsureOrigin};
 
 /// Simple index type for proposal counting.
 pub type ProposalIndex = u32;

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -22,7 +22,7 @@ use sp_std::prelude::*;
 use sp_std::{result, convert::TryFrom};
 use sp_runtime::{
 	RuntimeDebug,
-	traits::{Zero, Bounded, CheckedMul, CheckedDiv, EnsureOrigin, Hash, Dispatchable, Saturating},
+	traits::{Zero, Bounded, CheckedMul, CheckedDiv, Hash, Dispatchable, Saturating},
 };
 use codec::{Ref, Encode, Decode, Input, Output, Error};
 use frame_support::{
@@ -35,7 +35,7 @@ use frame_support::{
 		OnFreeBalanceZero, OnUnbalanced
 	}
 };
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_signed, ensure_root, EnsureOrigin};
 
 mod vote_threshold;
 pub use vote_threshold::{Approved, VoteThreshold};

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1093,6 +1093,7 @@ mod tests {
 		traits::Contains,
 		weights::Weight,
 	};
+	use frame_system::Error as SystemError;
 	use sp_core::H256;
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup, Bounded}, testing::Header, Perbill};
 	use pallet_balances::BalanceLock;
@@ -1540,7 +1541,7 @@ mod tests {
 			);
 			assert!(Democracy::referendum_info(r).is_some());
 
-			assert_noop!(Democracy::emergency_cancel(Origin::signed(3), r), "Invalid origin");
+			assert_noop!(Democracy::emergency_cancel(Origin::signed(3), r), SystemError::InvalidOrigin.into());
 			assert_ok!(Democracy::emergency_cancel(Origin::signed(4), r));
 			assert!(Democracy::referendum_info(r).is_none());
 
@@ -1624,7 +1625,7 @@ mod tests {
 			assert_noop!(Democracy::external_propose(
 				Origin::signed(1),
 				set_balance_proposal_hash(2),
-			), "Invalid origin");
+			), SystemError::InvalidOrigin.into());
 			assert_ok!(Democracy::external_propose(
 				Origin::signed(2),
 				set_balance_proposal_hash_and_note(2),
@@ -1653,7 +1654,7 @@ mod tests {
 			assert_noop!(Democracy::external_propose_majority(
 				Origin::signed(1),
 				set_balance_proposal_hash(2)
-			), "Invalid origin");
+			), SystemError::InvalidOrigin.into());
 			assert_ok!(Democracy::external_propose_majority(
 				Origin::signed(3),
 				set_balance_proposal_hash_and_note(2)
@@ -1678,7 +1679,7 @@ mod tests {
 			assert_noop!(Democracy::external_propose_default(
 				Origin::signed(3),
 				set_balance_proposal_hash(2)
-			), "Invalid origin");
+			), SystemError::InvalidOrigin.into());
 			assert_ok!(Democracy::external_propose_default(
 				Origin::signed(1),
 				set_balance_proposal_hash_and_note(2)
@@ -1706,7 +1707,7 @@ mod tests {
 				Origin::signed(3),
 				set_balance_proposal_hash_and_note(2)
 			));
-			assert_noop!(Democracy::fast_track(Origin::signed(1), h, 3, 2), "Invalid origin");
+			assert_noop!(Democracy::fast_track(Origin::signed(1), h, 3, 2), SystemError::InvalidOrigin.into());
 			assert_ok!(Democracy::fast_track(Origin::signed(5), h, 0, 0));
 			assert_eq!(
 				Democracy::referendum_info(0),

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -69,13 +69,13 @@ use sp_std::prelude::*;
 use sp_std::{fmt::Debug, ops::Add, iter::once};
 use enumflags2::BitFlags;
 use codec::{Encode, Decode};
-use sp_runtime::{traits::{StaticLookup, EnsureOrigin, Zero}, RuntimeDebug};
+use sp_runtime::{traits::{StaticLookup, Zero}, RuntimeDebug};
 use frame_support::{
 	decl_module, decl_event, decl_storage, ensure, dispatch::Result,
 	traits::{Currency, ReservableCurrency, OnUnbalanced, Get},
 	weights::SimpleDispatchInfo,
 };
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_signed, ensure_root, EnsureOrigin};
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -11,17 +11,16 @@ sp-std = { path = "../../primitives/std", default-features = false }
 sp-io = { path = "../../primitives/io", default-features = false }
 frame-support = { path = "../support", default-features = false }
 frame-system = { path = "../system", default-features = false }
-sp-runtime = { path = "../../primitives/runtime", default-features = false }
 
 [dev-dependencies]
 sp-core = { path = "../../primitives/core" }
+sp-runtime = { path = "../../primitives/runtime" }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
 	"codec/std",
-	"sp-runtime/std",
 	"sp-std/std",
 	"sp-io/std",
 	"frame-support/std",

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -28,8 +28,7 @@ use frame_support::{
 	traits::{ChangeMembers, InitializeMembers},
 	weights::SimpleDispatchInfo,
 };
-use frame_system::{self as system, ensure_root, ensure_signed};
-use sp_runtime::traits::EnsureOrigin;
+use frame_system::{self as system, ensure_root, ensure_signed, EnsureOrigin};
 
 pub trait Trait<I=DefaultInstance>: frame_system::Trait {
 	/// The overarching event type.

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -40,14 +40,14 @@
 
 use sp_std::prelude::*;
 use sp_runtime::{
-	traits::{StaticLookup, EnsureOrigin, Zero}
+	traits::{StaticLookup, Zero}
 };
 use frame_support::{
 	decl_module, decl_event, decl_storage, ensure,
 	traits::{Currency, ReservableCurrency, OnUnbalanced, Get},
 	weights::SimpleDispatchInfo,
 };
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_signed, ensure_root, EnsureOrigin};
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -97,9 +97,9 @@ use frame_support::{
 	decl_module, decl_storage, decl_event, ensure,
 	traits::{ChangeMembers, InitializeMembers, Currency, Get, ReservableCurrency},
 };
-use frame_system::{self as system, ensure_root, ensure_signed};
+use frame_system::{self as system, ensure_root, ensure_signed, EnsureOrigin};
 use sp_runtime::{
-	traits::{EnsureOrigin, SimpleArithmetic, MaybeSerializeDeserialize, Zero, StaticLookup},
+	traits::{SimpleArithmetic, MaybeSerializeDeserialize, Zero, StaticLookup},
 };
 
 type BalanceOf<T, I> = <<T as Trait<I>>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -272,7 +272,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	traits::{
 		Convert, Zero, One, StaticLookup, CheckedSub, Saturating, Bounded, SaturatedConversion,
-		SimpleArithmetic, EnsureOrigin, ModuleDispatchError,
+		SimpleArithmetic, ModuleDispatchError,
 	}
 };
 use sp_staking::{
@@ -281,7 +281,7 @@ use sp_staking::{
 };
 #[cfg(feature = "std")]
 use sp_runtime::{Serialize, Deserialize};
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system, ensure_signed, ensure_root, EnsureOrigin};
 
 use sp_phragmen::{ExtendedBalance, PhragmenStakedAssignment};
 
@@ -794,8 +794,6 @@ decl_error! {
 		AlreadyBonded,
 		/// Controller is already paired.
 		AlreadyPaired,
-		/// Should be the root origin or the `T::SlashCancelOrigin`.
-		BadOrigin,
 		/// Targets cannot be empty.
 		EmptyTargets,
 		/// Duplicate index.
@@ -1191,7 +1189,7 @@ decl_module! {
 			T::SlashCancelOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)
-				.map_err(|_| Error::BadOrigin)?;
+				.map_err(|e| e.as_str())?;
 
 			let mut slash_indices = slash_indices;
 			slash_indices.sort_unstable();

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -93,8 +93,7 @@ use serde::Serialize;
 use sp_std::prelude::*;
 #[cfg(any(feature = "std", test))]
 use sp_std::map;
-use sp_std::marker::PhantomData;
-use sp_std::fmt::Debug;
+use sp_std::{result, marker::PhantomData, fmt::Debug};
 use sp_version::RuntimeVersion;
 use sp_runtime::{
 	RuntimeDebug,
@@ -105,7 +104,7 @@ use sp_runtime::{
 	},
 	traits::{
 		self, CheckEqual, SimpleArithmetic, Zero, SignedExtension, Lookup, LookupError,
-		SimpleBitOps, Hash, Member, MaybeDisplay, EnsureOrigin, SaturatedConversion,
+		SimpleBitOps, Hash, Member, MaybeDisplay, SaturatedConversion,
 		MaybeSerialize, MaybeSerializeDeserialize, StaticLookup, One, Bounded,
 	},
 };
@@ -125,6 +124,20 @@ use sp_io::TestExternalities;
 use sp_core::ChangesTrieConfiguration;
 
 pub mod offchain;
+
+/// Some sort of check on the origin is performed by this object.
+pub trait EnsureOrigin<OuterOrigin> {
+	/// A return type.
+	type Success;
+
+	/// Perform the origin check.
+	fn ensure_origin(o: OuterOrigin) -> result::Result<Self::Success, Error> {
+		Self::try_origin(o).map_err(|_| Error::InvalidOrigin)
+	}
+
+	/// Perform the origin check.
+	fn try_origin(o: OuterOrigin) -> result::Result<Self::Success, OuterOrigin>;
+}
 
 /// Handler for when a new account has been created.
 #[impl_trait_for_tuples::impl_for_tuples(30)]
@@ -323,6 +336,7 @@ decl_error! {
 		RequireSignedOrigin,
 		RequireRootOrigin,
 		RequireNoOrigin,
+		InvalidOrigin,
 	}
 }
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -67,11 +67,11 @@ use frame_support::traits::{
 };
 use sp_runtime::{Permill, ModuleId};
 use sp_runtime::traits::{
-	Zero, EnsureOrigin, StaticLookup, AccountIdConversion, Saturating, ModuleDispatchError,
+	Zero, StaticLookup, AccountIdConversion, Saturating, ModuleDispatchError,
 };
 use frame_support::weights::SimpleDispatchInfo;
 use codec::{Encode, Decode};
-use frame_system::{self as system, ensure_signed};
+use frame_system::{self as system, ensure_signed, EnsureOrigin};
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 type PositiveImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::PositiveImbalance;
@@ -168,7 +168,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = SimpleDispatchInfo::FixedOperational(100_000)]
 		fn reject_proposal(origin, #[compact] proposal_id: ProposalIndex) {
-			T::RejectOrigin::ensure_origin(origin).map_err(|e| Into::<&str>::into(e))?;
+			T::RejectOrigin::ensure_origin(origin).map_err(|e| e.as_str())?;
 			let proposal = <Proposals<T>>::take(proposal_id).ok_or(Error::InvalidProposalIndex)?;
 
 			let value = proposal.bond;
@@ -186,7 +186,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = SimpleDispatchInfo::FixedOperational(100_000)]
 		fn approve_proposal(origin, #[compact] proposal_id: ProposalIndex) {
-			T::ApproveOrigin::ensure_origin(origin).map_err(|e| Into::<&str>::into(e))?;
+			T::ApproveOrigin::ensure_origin(origin).map_err(|e| e.as_str())?;
 
 			ensure!(<Proposals<T>>::exists(proposal_id), Error::InvalidProposalIndex);
 

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -134,28 +134,6 @@ impl<
 	}
 }
 
-/// An error type that indicates that the origin is invalid.
-#[derive(Encode, Decode)]
-pub struct InvalidOrigin;
-
-impl From<InvalidOrigin> for &'static str {
-	fn from(_: InvalidOrigin) -> &'static str {
-		"Invalid origin"
-	}
-}
-
-/// Some sort of check on the origin is performed by this object.
-pub trait EnsureOrigin<OuterOrigin> {
-	/// A return type.
-	type Success;
-	/// Perform the origin check.
-	fn ensure_origin(o: OuterOrigin) -> result::Result<Self::Success, InvalidOrigin> {
-		Self::try_origin(o).map_err(|_| InvalidOrigin)
-	}
-	/// Perform the origin check.
-	fn try_origin(o: OuterOrigin) -> result::Result<Self::Success, OuterOrigin>;
-}
-
 /// An error that indicates that a lookup failed.
 #[derive(Encode, Decode)]
 pub struct LookupError;


### PR DESCRIPTION
Key points:
- `InvalidOrigin` has been added to `frame::system::Error`.
- `EnsureOrigin` trait has been moved from `primitives/runtime/src/traits.rs` to `frame::system`.

Closes #4409.