### PR TITLE
pallet-evm: default implementation for FeeCalculator and ConvertAccountId and separate gas price

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -24,7 +24,7 @@ mod backend;
 pub use crate::backend::{Account, Log, Vicinity, Backend};
 
 use sp_std::{vec::Vec, marker::PhantomData};
-use frame_support::{ensure, dispatch, decl_module, decl_storage, decl_event, decl_error};
+use frame_support::{ensure, decl_module, decl_storage, decl_event, decl_error};
 use frame_support::weights::{Weight, WeighData, ClassifyDispatch, DispatchClass, PaysFee};
 use frame_support::traits::{Currency, WithdrawReason, ExistenceRequirement};
 use frame_system::{self as system, ensure_signed};
@@ -185,6 +185,8 @@ decl_error! {
 		PaymentOverflow,
 		/// Withdraw fee failed
 		WithdrawFailed,
+		/// Gas price is too low.
+		GasPriceTooLow,
 		/// Call failed
 		ExitReasonFailed,
 		/// Call reverted
@@ -252,9 +254,9 @@ decl_module! {
 			value: U256,
 			gas_limit: u32,
 			gas_price: U256,
-		) -> dispatch::Result {
-			let sender = ensure_signed(origin)?.map_err(|e| e.as_str())?;
-			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), "Gas price is too low");
+		) {
+			let sender = ensure_signed(origin).map_err(|e| e.as_str())?;
+			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::GasPriceTooLow);
 
 			let source = T::ConvertAccountId::convert_account_id(&sender);
 
@@ -312,9 +314,9 @@ decl_module! {
 			value: U256,
 			gas_limit: u32,
 			gas_price: U256,
-		) -> dispatch::Result {
-			let sender = ensure_signed(origin)?.map_err(|e| e.as_str())?;
-			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), "Gas price is too low");
+		) {
+			let sender = ensure_signed(origin).map_err(|e| e.as_str())?;
+			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::GasPriceTooLow);
 
 			let source = T::ConvertAccountId::convert_account_id(&sender);
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -172,6 +172,7 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
+		/// Despoit balance from currency/balances module into EVM.
 		#[weight = SimpleDispatchInfo::FixedNormal(10_000)]
 		fn deposit_balance(origin, value: BalanceOf<T>) -> dispatch::Result {
 			let sender = ensure_signed(origin)?;
@@ -193,6 +194,7 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Withdraw balance from EVM into currency/balances module.
 		#[weight = SimpleDispatchInfo::FixedNormal(10_000)]
 		fn withdraw_balance(origin, value: BalanceOf<T>) -> dispatch::Result {
 			let sender = ensure_signed(origin)?;
@@ -217,9 +219,15 @@ decl_module! {
 			Ok(())
 		}
 
+		/// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
 		#[weight = WeightForCallCreate]
 		fn call(
-			origin, target: H160, input: Vec<u8>, value: U256, gas_limit: u32, gas_price: U256,
+			origin,
+			target: H160,
+			input: Vec<u8>,
+			value: U256,
+			gas_limit: u32,
+			gas_price: U256,
 		) -> dispatch::Result {
 			let sender = ensure_signed(origin)?;
 			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), "Gas price is too low");
@@ -271,9 +279,15 @@ decl_module! {
 			ret
 		}
 
+		/// Issue an EVM create operation. This is similar to a contract creation transaction in
+		/// Ethereum.
 		#[weight = WeightForCallCreate]
 		fn create(
-			origin, init: Vec<u8>, value: U256, gas_limit: u32, gas_price: U256,
+			origin,
+			init: Vec<u8>,
+			value: U256,
+			gas_limit: u32,
+			gas_price: U256,
 		) -> dispatch::Result {
 			let sender = ensure_signed(origin)?;
 			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), "Gas price is too low");


### PR DESCRIPTION
* Provide default implementation for `FeeCalculator` and `ConvertAccountId`, so that using the EVM module is easier.
* Move gas price parameter to dispatch parameter, and change `FeeCalculator` to output minimal gas price. This allows `FeeCalculator` to depend on storage values and thus more flexible.