### PR TITLE
grandpa: fix slow gossip test

### DIFF
--- a/client/finality-grandpa/src/communication/tests.rs
+++ b/client/finality-grandpa/src/communication/tests.rs
@@ -272,14 +272,23 @@ fn good_commit_leads_to_relay() {
 			let sender_id = id.clone();
 			let send_message = tester.filter_network_events(move |event| match event {
 				Event::EventStream(sender) => {
+					// Add the sending peer and send the commit
 					let _ = sender.unbounded_send(NetworkEvent::NotificationStreamOpened {
 						remote: sender_id.clone(),
 						engine_id: GRANDPA_ENGINE_ID,
 						roles: Roles::FULL,
 					});
+
 					let _ = sender.unbounded_send(NetworkEvent::NotificationsReceived {
 						remote: sender_id.clone(),
 						messages: vec![(GRANDPA_ENGINE_ID, commit_to_send.clone().into())],
+					});
+
+					// Add a random peer which will be the recipient of this message
+					let _ = sender.unbounded_send(NetworkEvent::NotificationStreamOpened {
+						remote: sc_network::PeerId::random(),
+						engine_id: GRANDPA_ENGINE_ID,
+						roles: Roles::FULL,
 					});
 
 					true


### PR DESCRIPTION
In the GRANDPA test `good_commit_leads_to_relay` we test the gossip layer by sending a valid commit message and then making sure it is propagated after validation. This test was taking a long time to run, the reason was that we were only connected to one peer, so after receiving the commit from it we would refuse to resend the message to it until a periodic forced broadcast was triggered (which took 5 minutes to trigger). An easy fix is to add another peer to the test environment to whom the commit will be immediately propagated.