### PR TITLE
grandpa: log everything under afg target

### DIFF
--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -258,7 +258,7 @@ where
 			// check if the given best block is in the same branch as the block that signaled the change.
 			if is_descendent_of(&change.canon_hash, &best_hash)? {
 				// apply this change: make the set canonical
-				info!(target: "finality", "Applying authority set change forced at block #{:?}",
+				info!(target: "afg", "Applying authority set change forced at block #{:?}",
 					  change.canon_height);
 				telemetry!(CONSENSUS_INFO; "afg.applying_forced_authority_set_change";
 					"block" => ?change.canon_height
@@ -324,7 +324,7 @@ where
 				self.pending_forced_changes.clear();
 
 				if let Some(change) = change {
-					info!(target: "finality", "Applying authority set change scheduled at block #{:?}",
+					info!(target: "afg", "Applying authority set change scheduled at block #{:?}",
 						  change.canon_height);
 					telemetry!(CONSENSUS_INFO; "afg.applying_scheduled_authority_set_change";
 						"block" => ?change.canon_height

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -1007,8 +1007,8 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 			);
 
 			if let Err(e) = write_result {
-				warn!(target: "finality", "Failed to write updated consensus changes to disk. Bailing.");
-				warn!(target: "finality", "Node is in a potentially inconsistent state.");
+				warn!(target: "afg", "Failed to write updated consensus changes to disk. Bailing.");
+				warn!(target: "afg", "Node is in a potentially inconsistent state.");
 
 				return Err(e.into());
 			}
@@ -1060,7 +1060,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 		// ideally some handle to a synchronization oracle would be used
 		// to avoid unconditionally notifying.
 		client.apply_finality(import_op, BlockId::Hash(hash), justification, true).map_err(|e| {
-			warn!(target: "finality", "Error applying finality to block {:?}: {:?}", (hash, number), e);
+			warn!(target: "afg", "Error applying finality to block {:?}: {:?}", (hash, number), e);
 			e
 		})?;
 		telemetry!(CONSENSUS_INFO; "afg.finalized_blocks_up_to";
@@ -1100,8 +1100,8 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 			);
 
 			if let Err(e) = write_result {
-				warn!(target: "finality", "Failed to write updated authority set to disk. Bailing.");
-				warn!(target: "finality", "Node is in a potentially inconsistent state.");
+				warn!(target: "afg", "Failed to write updated authority set to disk. Bailing.");
+				warn!(target: "afg", "Node is in a potentially inconsistent state.");
 
 				return Err(e.into());
 			}

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -167,7 +167,7 @@ impl<B, Block> sc_network::FinalityProofProvider<Block> for FinalityProofProvide
 	) -> Result<Option<Vec<u8>>, ClientError> {
 		let request: FinalityProofRequest<Block::Hash> = Decode::decode(&mut &request[..])
 			.map_err(|e| {
-				warn!(target: "finality", "Unable to decode finality proof request: {}", e.what());
+				warn!(target: "afg", "Unable to decode finality proof request: {}", e.what());
 				ClientError::Backend(format!("Invalid finality proof request"))
 			})?;
 		match request {
@@ -269,7 +269,7 @@ pub(crate) fn prove_finality<Block: BlockT<Hash=H256>, B: BlockchainBackend<Bloc
 	let info = blockchain.info();
 	if info.finalized_number <= begin_number {
 		trace!(
-			target: "finality",
+			target: "afg",
 			"Requested finality proof for descendant of #{} while we only have finalized #{}. Returning empty proof.",
 			begin_number,
 			info.finalized_number,
@@ -344,7 +344,7 @@ pub(crate) fn prove_finality<Block: BlockT<Hash=H256>, B: BlockchainBackend<Bloc
 					);
 					if justification_check_result.is_err() {
 						trace!(
-							target: "finality",
+							target: "afg",
 							"Can not provide finality proof with requested set id #{}\
 							(possible forced change?). Returning empty proof.",
 							authorities_set_id,
@@ -387,7 +387,7 @@ pub(crate) fn prove_finality<Block: BlockT<Hash=H256>, B: BlockchainBackend<Bloc
 
 	if finality_proof.is_empty() {
 		trace!(
-			target: "finality",
+			target: "afg",
 			"No justifications found when making finality proof for {}. Returning empty proof.",
 			end,
 		);
@@ -395,7 +395,7 @@ pub(crate) fn prove_finality<Block: BlockT<Hash=H256>, B: BlockchainBackend<Bloc
 		Ok(None)
 	} else {
 		trace!(
-			target: "finality",
+			target: "afg",
 			"Built finality proof for {} of {} fragments. Last fragment for {}.",
 			end,
 			finality_proof.len(),

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -472,7 +472,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, SC> BlockImport<Block>
 			Some(justification) => {
 				self.import_justification(hash, number, justification, needs_justification).unwrap_or_else(|err| {
 					if needs_justification || enacts_consensus_change {
-						debug!(target: "finality", "Imported block #{} that enacts authority set change with \
+						debug!(target: "afg", "Imported block #{} that enacts authority set change with \
 							invalid justification: {:?}, requesting justification from peers.", number, err);
 						imported_aux.bad_justification = true;
 						imported_aux.needs_justification = true;
@@ -482,7 +482,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, SC> BlockImport<Block>
 			None => {
 				if needs_justification {
 					trace!(
-						target: "finality",
+						target: "afg",
 						"Imported unjustified block #{} that enacts authority set change, waiting for finality for enactment.",
 						number,
 					);
@@ -573,7 +573,7 @@ where
 
 		match result {
 			Err(CommandOrError::VoterCommand(command)) => {
-				info!(target: "finality", "Imported justification for block #{} that triggers \
+				info!(target: "afg", "Imported justification for block #{} that triggers \
 					command {}, signaling voter.", number, command);
 
 				// send the command to the voter

--- a/client/finality-grandpa/src/light_import.rs
+++ b/client/finality-grandpa/src/light_import.rs
@@ -263,7 +263,7 @@ fn do_import_block<B, C, Block: BlockT<Hash=H256>, J>(
 	match justification {
 		Some(justification) => {
 			trace!(
-				target: "finality",
+				target: "afg",
 				"Imported block {}{}. Importing justification.",
 				if enacts_consensus_change { " which enacts consensus changes" } else { "" },
 				hash,
@@ -273,7 +273,7 @@ fn do_import_block<B, C, Block: BlockT<Hash=H256>, J>(
 		},
 		None if enacts_consensus_change => {
 			trace!(
-				target: "finality",
+				target: "afg",
 				"Imported block {} which enacts consensus changes. Requesting finality proof.",
 				hash,
 			);
@@ -393,7 +393,7 @@ fn do_import_justification<B, C, Block: BlockT<Hash=H256>, J>(
 	let justification = match justification {
 		Err(ClientError::BadJustification(_)) => {
 			trace!(
-				target: "finality",
+				target: "afg",
 				"Justification for {} is not valid within current authorities set. Requesting finality proof.",
 				hash,
 			);
@@ -404,7 +404,7 @@ fn do_import_justification<B, C, Block: BlockT<Hash=H256>, J>(
 		},
 		Err(e) => {
 			trace!(
-				target: "finality",
+				target: "afg",
 				"Justification for {} is not valid. Bailing.",
 				hash,
 			);
@@ -413,7 +413,7 @@ fn do_import_justification<B, C, Block: BlockT<Hash=H256>, J>(
 		},
 		Ok(justification) => {
 			trace!(
-				target: "finality",
+				target: "afg",
 				"Justification for {} is valid. Finalizing the block.",
 				hash,
 			);
@@ -444,7 +444,7 @@ fn do_finalize_block<B, C, Block: BlockT<Hash=H256>>(
 {
 	// finalize the block
 	client.finalize_block(BlockId::Hash(hash), Some(justification), true).map_err(|e| {
-		warn!(target: "finality", "Error applying finality to block {:?}: {:?}", (hash, number), e);
+		warn!(target: "afg", "Error applying finality to block {:?}: {:?}", (hash, number), e);
 		ConsensusError::ClientImport(e.to_string())
 	})?;
 
@@ -532,8 +532,8 @@ fn require_insert_aux<T: Encode, A: AuxStore>(
 
 /// Display inconsistency warning.
 fn on_post_finalization_error(error: ClientError, value_type: &str) -> ConsensusError {
-	warn!(target: "finality", "Failed to write updated {} to disk. Bailing.", value_type);
-	warn!(target: "finality", "Node is in a potentially inconsistent state.");
+	warn!(target: "afg", "Failed to write updated {} to disk. Bailing.", value_type);
+	warn!(target: "afg", "Node is in a potentially inconsistent state.");
 	ConsensusError::ClientImport(error.to_string())
 }
 


### PR DESCRIPTION
For some reason we were logging some grandpa messages under the `finality` target rather than `afg`. I don't remember any clear reason for doing this and in practice it's one more logging target that we need to think about adding. I changed it so that all messages are logged under the `afg` target.