### PR TITLE
Add `Clone` bound to the `Origin`.

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -158,7 +158,9 @@ pub fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
 pub trait Trait: 'static + Eq + Clone {
 	/// The aggregated `Origin` type used by dispatchable calls.
 	type Origin:
-		Into<Result<RawOrigin<Self::AccountId>, Self::Origin>> + From<RawOrigin<Self::AccountId>>;
+		Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
+		+ From<RawOrigin<Self::AccountId>>
+		+ Clone;
 
 	/// The aggregated `Call` type.
 	type Call: Debug;


### PR DESCRIPTION
Seems that it might be quite useful (calling two methods that require `ensure_origin` check) and seems implemented for existing `Origin` anyway.
Unfortunately I don't think it's possible to add a bound like this within `decl_module`, so there is no way to only require that for some runtimes.

CC @shawntabrizi