### PR TITLE
ci: increase git cloning depth to 100

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
 
 variables:
   GIT_STRATEGY:                    fetch
-  GIT_DEPTH:                       "3"
+  GIT_DEPTH:                       100
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
   CARGO_INCREMENTAL:               0

--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -27,6 +27,13 @@ github_label () {
 
 
 
+# check if master is part of this checkout
+if ! git log -n 1 origin/master
+then
+	echo "unable to check for runtime changes: checkout does not contain origin/master branch"
+	exit 3
+fi
+
 # check if the wasm sources changed
 if ! git diff --name-only origin/master...${CI_COMMIT_SHA} \
 	| grep -q -e '^bin/node/src/runtime' -e '^frame/' -e '^primitives/sr-' | grep -v -e '^primitives/sr-arithmetic/fuzzer'

--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -27,6 +27,8 @@ github_label () {
 
 
 
+git fetch --depth=${GIT_DEPTH:-100} origin master
+
 # check if master is part of this checkout
 if ! git log -n 1 origin/master
 then


### PR DESCRIPTION
CI jobs are failing due to recently introduced shallow clones for ci checks e.g. https://gitlab.parity.io/parity/substrate/-/jobs/333878

Increasing the cloning depth to 100 should be a safe value :crossed_fingers: 


failing refs in local copy:
```
fatal: ambiguous argument 'origin/master...2003b9d8a08c9b9370a94cb0ee3c0f3e05607ce6': unknown revision or path not in the working tree.
```