### PR TITLE
Update to new kvdb/trie/memdb versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,14 +1012,6 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "elastic-array"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,14 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapsize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,37 +2227,37 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic-array 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-bytes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic-array 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs-swap 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "interleaved-ordered 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2830,13 +2814,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.15.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ahash 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-util-mem 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3006,7 +2990,7 @@ dependencies = [
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-executor 2.0.0",
@@ -4143,7 +4127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-util-mem"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5054,8 +5038,8 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5090,7 +5074,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5118,9 +5102,9 @@ version = "2.0.0"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvdb-rocksdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-memorydb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvdb-rocksdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6544,7 +6528,7 @@ dependencies = [
  "sp-externalities 2.0.0",
  "sp-panic-handler 2.0.0",
  "sp-trie 2.0.0",
- "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6605,12 +6589,12 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-core 2.0.0",
  "sp-std 2.0.0",
- "trie-bench 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-bench 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-standardmap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6828,7 +6812,7 @@ dependencies = [
  "frame-system 2.0.0",
  "frame-system-rpc-runtime-api 2.0.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pallet-babe 2.0.0",
  "pallet-timestamp 2.0.0",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6855,7 +6839,7 @@ dependencies = [
  "sp-version 2.0.0",
  "substrate-test-runtime-client 2.0.0",
  "substrate-wasm-builder-runner 1.0.4",
- "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7404,29 +7388,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "trie-bench"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memory-db 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "trie-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-standardmap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "trie-db"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "elastic-array 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8254,7 +8238,6 @@ dependencies = [
 "checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-"checksum elastic-array 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "580f3768bd6465780d063f5b8213a2ebd506e139b345e4a81eb301ceae3d61e1"
 "checksum enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "33121c8782ba948ba332dab29311b026a8716dc65a1599e5b88f392d38496af8"
 "checksum enumflags2_derive 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ecf634c5213044b8d54a46dd282cf5dd1f86bb5cb53e92c409cb4680a7fb9894"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
@@ -8322,7 +8305,6 @@ dependencies = [
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
-"checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
@@ -8368,9 +8350,9 @@ dependencies = [
 "checksum keccak-hasher 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3468207deea1359a0e921591ae9b4c928733d94eb9d6a2eeda994cfd59f42cf8"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum kv-log-macro 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c54d9f465d530a752e6ebdc217e081a7a614b48cb200f6f0aee21ba6bc9aabb"
-"checksum kvdb 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c1b2f251f01a7224426abdb2563707d856f7de995d821744fd8fa8e2874f69e3"
-"checksum kvdb-memorydb 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "296c12309ed36cb74d59206406adbf1971c3baa56d5410efdb508d8f1c60a351"
-"checksum kvdb-rocksdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f82177237c1ae67d6ab208a6f790cab569a1d81c1ba02348e0736a99510be3"
+"checksum kvdb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cecee8d85a74f6b8284710d52a7d1196f09e31f8217e1f184a475b509d360554"
+"checksum kvdb-memorydb 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0a5d70712b1fe0f02ce7ee36a962fcb0b15d0fe11262ba21a4aa839ef22cf60d"
+"checksum kvdb-rocksdb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54cc6b52f7e511de9f07fd77cda70247adfc6b8192e4b5a1b6dbca416dc425b5"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
@@ -8414,7 +8396,7 @@ dependencies = [
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
-"checksum memory-db 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5dabfe0a8c69954ae3bcfc5fc14260a85fb80e1bf9f86a155f668d10a67e93dd"
+"checksum memory-db 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "828bdf600636e90c56652689f7c3823ae2072104e4b0b5e83ea984f592f12ab9"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum merlin 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
@@ -8456,7 +8438,7 @@ dependencies = [
 "checksum parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f9f9d99dae413590a5f37e43cd99b94d4e62a244160562899126913ea7108673"
 "checksum parity-scale-codec-derive 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34e513ff3e406f3ede6796dcdc83d0b32ffb86668cea1ccf7363118abeb00476"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
-"checksum parity-util-mem 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "570093f39f786beea92dcc09e45d8aae7841516ac19a50431953ac82a0e8f85c"
+"checksum parity-util-mem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8174d85e62c4d615fddd1ef67966bdc5757528891d0742f15b131ad04667b3f9"
 "checksum parity-wasm 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -8638,8 +8620,8 @@ dependencies = [
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-"checksum trie-bench 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "403d8ec7dbc4b46781ef18cd96b371bb9ce6ec394fe83ece75eb3bc755dfa69f"
-"checksum trie-db 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "784a9813d23f18bccab728ab039c39b8a87d0d6956dcdece39e92f5cffe5076e"
+"checksum trie-bench 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d276e600d06806a4ac61e5d6b145a620001e6147151e60a4f1f46a784ec4baa"
+"checksum trie-db 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "191fda5d0106f3ed35a8c6875428b213e15c516e48129cc263dd7ad16e9a665f"
 "checksum trie-root 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
 "checksum trie-standardmap 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3161ba520ab28cd8e6b68e1126f1009f6e335339d1a73b978139011703264c8"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -94,7 +94,7 @@ console_log = { version = "0.1.2", optional = true }
 js-sys = { version = "0.3.22", optional = true }
 wasm-bindgen = { version = "0.2.45", optional = true }
 wasm-bindgen-futures = { version = "0.3.22", optional = true }
-kvdb-memorydb = { version = "0.1.1", optional = true }
+kvdb-memorydb = { version = "0.2.0", optional = true }
 rand6 = { package = "rand", version = "0.6", features = ["wasm-bindgen"], optional = true }	# Imported just for the `wasm-bindgen` feature
 
 [dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ hash-db = { version = "0.15.2" }
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0", path = "../primitives/inherents" }
 sp-keyring = { version = "2.0.0", path = "../primitives/keyring" }
-kvdb = "0.1.1"
+kvdb = "0.2.0"
 log = { version = "0.4.8" }
 parking_lot = { version = "0.9.0" }
 sp-core = { version = "2.0.0", path = "../primitives/core" }
@@ -36,5 +36,5 @@ tracing = "0.1.10"
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 substrate-test-runtime-client = { version = "2.0.0", path = "../test-utils/runtime/client" }
-kvdb-memorydb = "0.1.2"
+kvdb-memorydb = "0.2.0"
 sp-panic-handler = { version = "2.0.0", path = "../primitives/panic-handler" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -17,7 +17,7 @@ sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0", path = "../../primitives/keyring" }
-kvdb = "0.1.1"
+kvdb = "0.2.0"
 log = { version = "0.4.8" }
 parking_lot = { version = "0.9.0" }
 sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 [dependencies]
 parking_lot = "0.9.0"
 log = "0.4.8"
-kvdb = "0.1.1"
-kvdb-rocksdb = { version = "0.2", optional = true }
-kvdb-memorydb = "0.1.2"
+kvdb = "0.2.0"
+kvdb-rocksdb = { version = "0.3", optional = true }
+kvdb-memorydb = "0.2.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
 sc-client-api = { version = "2.0.0", path = "../api" }

--- a/client/db/src/cache/list_storage.rs
+++ b/client/db/src/cache/list_storage.rs
@@ -84,13 +84,13 @@ pub trait StorageTransaction<Block: BlockT, T: CacheItemT> {
 #[derive(Debug)]
 pub struct DbColumns {
 	/// Column holding cache meta.
-	pub meta: Option<u32>,
+	pub meta: u32,
 	/// Column holding the mapping of { block number => block hash } for blocks of the best chain.
-	pub key_lookup: Option<u32>,
+	pub key_lookup: u32,
 	/// Column holding the mapping of { block hash => block header }.
-	pub header: Option<u32>,
+	pub header: u32,
 	/// Column holding cache entries.
-	pub cache: Option<u32>,
+	pub cache: u32,
 }
 
 /// Database-backed list cache storage.

--- a/client/db/src/cache/mod.rs
+++ b/client/db/src/cache/mod.rs
@@ -77,9 +77,9 @@ impl<T> CacheItemT for T where T: Clone + Decode + Encode + PartialEq {}
 pub struct DbCache<Block: BlockT> {
 	cache_at: HashMap<CacheKeyId, ListCache<Block, Vec<u8>, self::list_storage::DbStorage>>,
 	db: Arc<dyn KeyValueDB>,
-	key_lookup_column: Option<u32>,
-	header_column: Option<u32>,
-	authorities_column: Option<u32>,
+	key_lookup_column: u32,
+	header_column: u32,
+	authorities_column: u32,
 	genesis_hash: Block::Hash,
 	best_finalized_block: ComplexBlockId<Block>,
 }
@@ -88,9 +88,9 @@ impl<Block: BlockT> DbCache<Block> {
 	/// Create new cache.
 	pub fn new(
 		db: Arc<dyn KeyValueDB>,
-		key_lookup_column: Option<u32>,
-		header_column: Option<u32>,
-		authorities_column: Option<u32>,
+		key_lookup_column: u32,
+		header_column: u32,
+		authorities_column: u32,
 		genesis_hash: Block::Hash,
 		best_finalized_block: ComplexBlockId<Block>,
 	) -> Self {
@@ -150,9 +150,9 @@ fn get_cache_helper<'a, Block: BlockT>(
 	cache_at: &'a mut HashMap<CacheKeyId, ListCache<Block, Vec<u8>, self::list_storage::DbStorage>>,
 	name: CacheKeyId,
 	db: &Arc<dyn KeyValueDB>,
-	key_lookup: Option<u32>,
-	header: Option<u32>,
-	cache: Option<u32>,
+	key_lookup: u32,
+	header: u32,
+	cache: u32,
 	best_finalized_block: &ComplexBlockId<Block>,
 ) -> &'a mut ListCache<Block, Vec<u8>, self::list_storage::DbStorage> {
 	cache_at.entry(name).or_insert_with(|| {

--- a/client/db/src/children.rs
+++ b/client/db/src/children.rs
@@ -21,12 +21,11 @@ use codec::{Encode, Decode};
 use sp_blockchain;
 use std::hash::Hash;
 
-
 /// Returns the hashes of the children blocks of the block with `parent_hash`.
 pub fn read_children<
 	K: Eq + Hash + Clone + Encode + Decode,
 	V: Eq + Hash + Clone + Encode + Decode,
->(db: &dyn KeyValueDB, column: Option<u32>, prefix: &[u8], parent_hash: K) -> sp_blockchain::Result<Vec<V>> {
+>(db: &dyn KeyValueDB, column: u32, prefix: &[u8], parent_hash: K) -> sp_blockchain::Result<Vec<V>> {
 	let mut buf = prefix.to_vec();
 	parent_hash.using_encoded(|s| buf.extend(s));
 
@@ -55,7 +54,7 @@ pub fn write_children<
 	V: Eq + Hash + Clone + Encode + Decode,
 >(
 	tx: &mut DBTransaction,
-	column: Option<u32>,
+	column: u32,
 	prefix: &[u8],
 	parent_hash: K,
 	children_hashes: V,
@@ -70,7 +69,7 @@ pub fn remove_children<
 	K: Eq + Hash + Clone + Encode + Decode,
 >(
 	tx: &mut DBTransaction,
-	column: Option<u32>,
+	column: u32,
 	prefix: &[u8],
 	parent_hash: K,
 ) {
@@ -87,33 +86,33 @@ mod tests {
 	#[test]
 	fn children_write_read_remove() {
 		const PREFIX: &[u8] = b"children";
-		let db = ::kvdb_memorydb::create(0);
+		let db = ::kvdb_memorydb::create(1);
 
 		let mut tx = DBTransaction::new();
 
 		let mut children1 = Vec::new();
 		children1.push(1_3);
 		children1.push(1_5);
-		write_children(&mut tx, None, PREFIX, 1_1, children1);
+		write_children(&mut tx, 0, PREFIX, 1_1, children1);
 
 		let mut children2 = Vec::new();
 		children2.push(1_4);
 		children2.push(1_6);
-		write_children(&mut tx, None, PREFIX, 1_2, children2);
+		write_children(&mut tx, 0, PREFIX, 1_2, children2);
 
-		db.write(tx.clone()).unwrap();
+		db.write(tx.clone()).expect("(2) Commiting transaction failed");
 
-		let r1: Vec<u32> = read_children(&db, None, PREFIX, 1_1).unwrap();
-		let r2: Vec<u32> = read_children(&db, None, PREFIX, 1_2).unwrap();
+		let r1: Vec<u32> = read_children(&db, 0, PREFIX, 1_1).expect("(1) Getting r1 failed");
+		let r2: Vec<u32> = read_children(&db, 0, PREFIX, 1_2).expect("(1) Getting r2 failed");
 
 		assert_eq!(r1, vec![1_3, 1_5]);
 		assert_eq!(r2, vec![1_4, 1_6]);
 
-		remove_children(&mut tx, None, PREFIX, 1_2);
-		db.write(tx).unwrap();
+		remove_children(&mut tx, 0, PREFIX, 1_2);
+		db.write(tx).expect("(2) Commiting transaction failed");
 
-		let r1: Vec<u32> = read_children(&db, None, PREFIX, 1_1).unwrap();
-		let r2: Vec<u32> = read_children(&db, None, PREFIX, 1_2).unwrap();
+		let r1: Vec<u32> = read_children(&db, 0, PREFIX, 1_1).expect("(2) Getting r1 failed");
+		let r2: Vec<u32> = read_children(&db, 0, PREFIX, 1_2).expect("(2) Getting r2 failed");
 
 		assert_eq!(r1, vec![1_3, 1_5]);
 		assert_eq!(r2.len(), 0);

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -302,18 +302,18 @@ pub fn new_client<E, S, Block, RA>(
 }
 
 pub(crate) mod columns {
-	pub const META: Option<u32> = crate::utils::COLUMN_META;
-	pub const STATE: Option<u32> = Some(1);
-	pub const STATE_META: Option<u32> = Some(2);
+	pub const META: u32 = crate::utils::COLUMN_META;
+	pub const STATE: u32 = 1;
+	pub const STATE_META: u32 = 2;
 	/// maps hashes to lookup keys and numbers to canon hashes.
-	pub const KEY_LOOKUP: Option<u32> = Some(3);
-	pub const HEADER: Option<u32> = Some(4);
-	pub const BODY: Option<u32> = Some(5);
-	pub const JUSTIFICATION: Option<u32> = Some(6);
-	pub const CHANGES_TRIE: Option<u32> = Some(7);
-	pub const AUX: Option<u32> = Some(8);
+	pub const KEY_LOOKUP: u32 = 3;
+	pub const HEADER: u32 = 4;
+	pub const BODY: u32 = 5;
+	pub const JUSTIFICATION: u32 = 6;
+	pub const CHANGES_TRIE: u32 = 7;
+	pub const AUX: u32 = 8;
 	/// Offchain workers local storage
-	pub const OFFCHAIN: Option<u32> = Some(9);
+	pub const OFFCHAIN: u32 = 9;
 }
 
 struct PendingBlock<Block: BlockT> {
@@ -633,7 +633,7 @@ struct StorageDb<Block: BlockT> {
 impl<Block: BlockT> sp_state_machine::Storage<Blake2Hasher> for StorageDb<Block> {
 	fn get(&self, key: &H256, prefix: Prefix) -> Result<Option<DBValue>, String> {
 		let key = prefixed_key::<Blake2Hasher>(key, prefix);
-		self.state_db.get(&key, self).map(|r| r.map(|v| DBValue::from_slice(&v)))
+		self.state_db.get(&key, self)
 			.map_err(|e| format!("Database backend error: {:?}", e))
 	}
 }

--- a/client/db/src/light.rs
+++ b/client/db/src/light.rs
@@ -44,12 +44,12 @@ use crate::DatabaseSettings;
 use log::{trace, warn, debug};
 
 pub(crate) mod columns {
-	pub const META: Option<u32> = crate::utils::COLUMN_META;
-	pub const KEY_LOOKUP: Option<u32> = Some(1);
-	pub const HEADER: Option<u32> = Some(2);
-	pub const CACHE: Option<u32> = Some(3);
-	pub const CHT: Option<u32> = Some(4);
-	pub const AUX: Option<u32> = Some(5);
+	pub const META: u32 = crate::utils::COLUMN_META;
+	pub const KEY_LOOKUP: u32 = 1;
+	pub const HEADER: u32 = 2;
+	pub const CACHE: u32 = 3;
+	pub const CHT: u32 = 4;
+	pub const AUX: u32 = 5;
 }
 
 /// Prefix for headers CHT.

--- a/client/src/leaves.rs
+++ b/client/src/leaves.rs
@@ -77,7 +77,7 @@ impl<H, N> LeafSet<H, N> where
 	}
 
 	/// Read the leaf list from the DB, using given prefix for keys.
-	pub fn read_from_db(db: &dyn KeyValueDB, column: Option<u32>, prefix: &[u8]) -> Result<Self> {
+	pub fn read_from_db(db: &dyn KeyValueDB, column: u32, prefix: &[u8]) -> Result<Self> {
 		let mut storage = BTreeMap::new();
 
 		for (key, value) in db.iter_from_prefix(column, prefix) {
@@ -173,7 +173,7 @@ impl<H, N> LeafSet<H, N> where
 	}
 
 	/// Write the leaf list to the database transaction.
-	pub fn prepare_transaction(&mut self, tx: &mut DBTransaction, column: Option<u32>, prefix: &[u8]) {
+	pub fn prepare_transaction(&mut self, tx: &mut DBTransaction, column: u32, prefix: &[u8]) {
 		let mut buf = prefix.to_vec();
 		for LeafSetItem { hash, number } in self.pending_added.drain(..) {
 			hash.using_encoded(|s| buf.extend(s));
@@ -277,7 +277,7 @@ mod tests {
 	#[test]
 	fn flush_to_disk() {
 		const PREFIX: &[u8] = b"abcdefg";
-		let db = ::kvdb_memorydb::create(0);
+		let db = ::kvdb_memorydb::create(1);
 
 		let mut set = LeafSet::new();
 		set.import(0u32, 0u32, 0u32);
@@ -288,10 +288,10 @@ mod tests {
 
 		let mut tx = DBTransaction::new();
 
-		set.prepare_transaction(&mut tx, None, PREFIX);
+		set.prepare_transaction(&mut tx, 0, PREFIX);
 		db.write(tx).unwrap();
 
-		let set2 = LeafSet::read_from_db(&db, None, PREFIX).unwrap();
+		let set2 = LeafSet::read_from_db(&db, 0, PREFIX).unwrap();
 		assert_eq!(set, set2);
 	}
 
@@ -311,7 +311,7 @@ mod tests {
 	#[test]
 	fn finalization_consistent_with_disk() {
 		const PREFIX: &[u8] = b"prefix";
-		let db = ::kvdb_memorydb::create(0);
+		let db = ::kvdb_memorydb::create(1);
 
 		let mut set = LeafSet::new();
 		set.import(10_1u32, 10u32, 0u32);
@@ -322,12 +322,12 @@ mod tests {
 		assert!(set.contains(10, 10_1));
 
 		let mut tx = DBTransaction::new();
-		set.prepare_transaction(&mut tx, None, PREFIX);
+		set.prepare_transaction(&mut tx, 0, PREFIX);
 		db.write(tx).unwrap();
 
 		let _ = set.finalize_height(11);
 		let mut tx = DBTransaction::new();
-		set.prepare_transaction(&mut tx, None, PREFIX);
+		set.prepare_transaction(&mut tx, 0, PREFIX);
 		db.write(tx).unwrap();
 
 		assert!(set.contains(11, 11_1));
@@ -335,7 +335,7 @@ mod tests {
 		assert!(set.contains(12, 12_1));
 		assert!(!set.contains(10, 10_1));
 
-		let set2 = LeafSet::read_from_db(&db, None, PREFIX).unwrap();
+		let set2 = LeafSet::read_from_db(&db, 0, PREFIX).unwrap();
 		assert_eq!(set, set2);
 	}
 

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 log = "0.4.8"
 parking_lot = "0.9.0"
 hash-db = "0.15.2"
-trie-db = "0.16.0"
+trie-db = "0.18.1"
 trie-root = "0.15.2"
 sp-trie = { version = "2.0.0", path = "../trie" }
 sp-core = { version = "2.0.0", path = "../core" }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -15,13 +15,13 @@ harness = false
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.16.0", default-features = false }
+trie-db = { version = "0.18.1", default-features = false }
 trie-root = { version = "0.15.2", default-features = false }
-memory-db = { version = "0.15.2", default-features = false }
+memory-db = { version = "0.18.0", default-features = false }
 sp-core = { version = "2.0.0", default-features = false, path = "../core" }
 
 [dev-dependencies]
-trie-bench = "0.17.0"
+trie-bench = "0.18.0"
 trie-standardmap = "0.15.2"
 criterion = "0.2.11"
 hex-literal = "0.2.1"

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -16,7 +16,7 @@ frame-executive = { version = "2.0.0", default-features = false, path = "../../f
 sp-inherents = { version = "2.0.0", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0", optional = true, path = "../../primitives/keyring" }
 log = { version = "0.4.8", optional = true }
-memory-db = { version = "0.15.2", default-features = false }
+memory-db = { version = "0.18.0", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false}
 sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
@@ -35,7 +35,7 @@ pallet-timestamp = { version = "2.0.0", default-features = false, path = "../../
 sc-client = { version = "2.0.0", optional = true, path = "../../client" }
 sp-trie = { version = "2.0.0", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "2.0.0", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.16.0", default-features = false }
+trie-db = { version = "0.18.1", default-features = false }
 
 [dev-dependencies]
 sc-executor = { version = "2.0.0", path = "../../client/executor" }


### PR DESCRIPTION
- No more `ElasticArray`
- Columns are now required, and no "default column" notion exists