### PR TITLE
Fix replace_previous of Ready Transaction Queue.

### DIFF
--- a/client/transaction-pool/graph/src/base_pool.rs
+++ b/client/transaction-pool/graph/src/base_pool.rs
@@ -274,7 +274,12 @@ impl<Hash: hash::Hash + Member + Serialize, Ex: std::fmt::Debug> BasePool<Hash, 
 			&self.recently_pruned,
 		);
 		trace!(target: "txpool", "[{:?}] {:?}", tx.transaction.hash, tx);
-		debug!(target: "txpool", "[{:?}] Importing to {}", tx.transaction.hash, if tx.is_ready() { "ready" } else { "future" });
+		debug!(
+			target: "txpool",
+			"[{:?}] Importing to {}",
+			tx.transaction.hash,
+			if tx.is_ready() { "ready" } else { "future" }
+		);
 
 		// If all tags are not satisfied import to future.
 		if !tx.is_ready() {

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -562,7 +562,6 @@ mod tests {
 		ready.import(x)
 	}
 
-
 	#[test]
 	fn should_replace_transaction_that_provides_the_same_tag() {
 		// given

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -478,7 +478,7 @@ pub struct BestIterator<Hash, Ex> {
 }
 
 impl<Hash: hash::Hash + Member, Ex> BestIterator<Hash, Ex> {
-	/// Depending on number of satisfied equirements insert given ref
+	/// Depending on number of satisfied requirements insert given ref
 	/// either to awaiting set or to best set.
 	fn best_or_awaiting(&mut self, satisfied: usize, tx_ref: TransactionRef<Hash, Ex>) {
 		if satisfied >= tx_ref.transaction.requires.len() {


### PR DESCRIPTION
By looking at the code I found a potential issue with `replace_previous`. The clean up procedure that was supposed to remove all traces of replaced transactions was not correct. The bug was not critical, it could only cause a slight incoherence in the internal pool tracking.

The main bug was assuming that newly imported transaction will always have empty `unlock` collection. Which is not necessarily true, if we replace a transaction in the middle of a chain:
`Tx1 -> Tx2 - > Tx3`, then we replace with `Tx2'` and that transaction should still unlock `Tx3`.