### PR TITLE
triggers srml-contracts-waterfall ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,6 +382,9 @@ trigger-contracts-ci:
   trigger:
     project:                       parity/srml-contracts-waterfall
     branch:                        "master"
+  only:
+    - master
+    - schedules
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -373,6 +373,16 @@ check_polkadot:
     - cd -
     - sccache -s
 
+trigger-contracts-ci:
+  stage:                           publish
+  needs:
+    - build-linux-substrate
+  variables:
+    CARGO_TARGET_DIR:              ""
+  trigger:
+    project:                       parity/srml-contracts-waterfall
+    branch:                        "master"
+
 #### stage:                        publish
 
 .publish-docker-release:           &publish-docker-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -377,8 +377,6 @@ trigger-contracts-ci:
   stage:                           publish
   needs:
     - build-linux-substrate
-  variables:
-    CARGO_TARGET_DIR:              ""
   trigger:
     project:                       parity/srml-contracts-waterfall
     branch:                        "master"


### PR DESCRIPTION
Depends on https://github.com/paritytech/srml-contracts-waterfall/pull/28

Won't work until https://github.com/paritytech/srml-contracts-waterfall/issues/27 is solved. [Proof](https://gitlab.parity.io/parity/srml-contracts-waterfall/-/jobs/339252) that CI passes with al older substrate version.

After, it will make sense to add `strategy:                      depend` and to add this job to a stage between `build` and `publish` stages, to fail pipeline by this job.