### PR TITLE
check_polkadot now runs nightly and on master (merges) only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,11 +351,14 @@ check_warnings:
       fi
   allow_failure:                   true
 
-# Check whether Polkadot 'master' branch builds using this Substrate commit.
+# Nightly check whether Polkadot 'master' branch builds.
 check_polkadot:
   stage:                           build
   <<:                              *docker-env
   allow_failure:                   true
+  only:
+    - master
+    - schedules
   script:
     - SUBSTRATE_PATH=$(pwd)
     # Clone the current Polkadot master branch into ./polkadot.


### PR DESCRIPTION
I've been asked to run this job only nightly and on merges, anyways it's always failing.