### PR TITLE
Make `MultiSigner` use compressed ECDSA public key

### DIFF
--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -28,13 +28,13 @@ parking_lot = { version = "0.9.0", optional = true }
 sp-debug-derive = { version = "2.0.0", path = "../debug-derive" }
 sp-externalities = { version = "2.0.0", optional = true, path = "../externalities" }
 sp-storage = { version = "2.0.0", default-features = false, path = "../storage" }
+libsecp256k1 = { version = "0.3.2", default-features = false }
 
 # full crypto
 ed25519-dalek = { version = "1.0.0-pre.3", default-features = false, features = ["u64_backend", "alloc"], optional = true }
 blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
 schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
-libsecp256k1 = { version = "0.3.2", default-features = false, optional = true }
 sha2 = { version = "0.8.0", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }
@@ -90,7 +90,7 @@ std = [
 	"schnorrkel/std",
 	"regex",
 	"num-traits/std",
-	"libsecp256k1",
+	"libsecp256k1/std",
 	"tiny-keccak",
 	"sp-debug-derive/std",
 	"sp-externalities",
@@ -107,7 +107,6 @@ full_crypto = [
 	"blake2-rfc",
 	"tiny-keccak",
 	"schnorrkel",
-	"libsecp256k1",
 	"hex",
 	"sha2",
 	"twox-hash",

--- a/primitives/core/src/hexdisplay.rs
+++ b/primitives/core/src/hexdisplay.rs
@@ -58,7 +58,7 @@ pub trait AsBytesRef {
 	fn as_bytes_ref(&self) -> &[u8];
 }
 
-impl<'a> AsBytesRef for &'a [u8] {
+impl AsBytesRef for &[u8] {
 	fn as_bytes_ref(&self) -> &[u8] { self }
 }
 

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -247,7 +247,7 @@ impl traits::IdentifyAccount for MultiSigner {
 			MultiSigner::Ed25519(who) => <[u8; 32]>::from(who).into(),
 			MultiSigner::Sr25519(who) => <[u8; 32]>::from(who).into(),
 			MultiSigner::Ecdsa(who) => sp_io::hashing::blake2_256(
-				&who.as_compressed().expect("what should we do?")[..],
+				&who.as_compressed().expect("`who` is a valid `ECDSA` public key; qed")[..],
 			).into(),
 		}
 	}

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -310,7 +310,7 @@ impl Verify for MultiSignature {
 			(MultiSignature::Sr25519(ref sig), who) => sig.verify(msg, &sr25519::Public::from_slice(who.as_ref())),
 			(MultiSignature::Ecdsa(ref sig), who) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
-				match sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m) {
+				match sp_io::crypto::secp256k1_ecdsa_recover(sig.as_ref(), &m) {
 					Ok(pubkey) =>
 						&sp_io::hashing::blake2_256(pubkey.as_ref())
 							== <dyn AsRef<[u8; 32]>>::as_ref(who),
@@ -688,8 +688,9 @@ pub fn print(print: impl traits::Printable) {
 
 #[cfg(test)]
 mod tests {
-	use crate::DispatchError;
+	use super::*;
 	use codec::{Encode, Decode};
+	use sp_core::crypto::Pair;
 
 	#[test]
 	fn opaque_extrinsic_serialization() {
@@ -715,5 +716,18 @@ mod tests {
 				message: None,
 			},
 		);
+	}
+
+	#[test]
+	fn multi_signature_ecdsa_verify_works() {
+		let msg = &b"test-message"[..];
+		let (pair, _) = ecdsa::Pair::generate();
+
+		let signature = pair.sign(&msg);
+		assert!(ecdsa::Pair::verify(&signature, msg, &pair.public()));
+
+		let multi_sig = MultiSignature::from(signature);
+		let multi_signer = MultiSigner::from(pair.public());
+		assert!(multi_sig.verify(msg, &multi_signer.into_account()));
 	}
 }

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -98,11 +98,11 @@ impl Verify for sp_core::sr25519::Signature {
 impl Verify for sp_core::ecdsa::Signature {
 	type Signer = sp_core::ecdsa::Public;
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &sp_core::ecdsa::Public) -> bool {
-		match sp_io::crypto::secp256k1_ecdsa_recover(
+		match sp_io::crypto::secp256k1_ecdsa_recover_compressed(
 			self.as_ref(),
 			&sp_io::hashing::blake2_256(msg.get()),
 		) {
-			Ok(pubkey) => <dyn AsRef<[u8]>>::as_ref(signer) == &pubkey[..],
+			Ok(pubkey) => signer.as_compressed().map(|s| &s[..] == &pubkey[..]).unwrap_or(false),
 			_ => false,
 		}
 	}
@@ -1399,5 +1399,6 @@ mod tests {
 		assert!(ecdsa::Pair::verify(&signature, msg, &pair.public()));
 
 		assert!(signature.verify(msg, &pair.public()));
+		assert!(signature.verify(msg, &pair.public().into_compressed().unwrap()));
 	}
 }


### PR DESCRIPTION
`MultiSigner` did not compressed the ECDSA public key before hashing it but `MultiSignature` expected that the public key is compressed when verifying a signature. Thus, the signature verification could never succeed. 

This pr changes the following:
- `MultiSigner` compresses the public key before hashing it with `blake256`.
- `Verify for ecdsa::Signature` compresses given public key before comparing it.
- `ecdsa::Public` is now an enum that distinguishes between the full and compressed format.

Fixes: #4498