### PR TITLE
Increase metadata version to 10

### DIFF
--- a/frame/metadata/src/lib.rs
+++ b/frame/metadata/src/lib.rs
@@ -345,8 +345,10 @@ pub enum RuntimeMetadata {
 	V7(RuntimeMetadataDeprecated),
 	/// Version 8 for runtime metadata. No longer used.
 	V8(RuntimeMetadataDeprecated),
-	/// Version 9 for runtime metadata.
-	V9(RuntimeMetadataV9),
+	/// Version 9 for runtime metadata. No longer used.
+	V9(RuntimeMetadataDeprecated),
+	/// Version 10 for runtime metadata.
+	V10(RuntimeMetadataV10),
 }
 
 /// Enum that should fail.
@@ -370,12 +372,12 @@ impl Decode for RuntimeMetadataDeprecated {
 /// The metadata of a runtime.
 #[derive(Eq, Encode, PartialEq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Decode, Serialize))]
-pub struct RuntimeMetadataV9 {
+pub struct RuntimeMetadataV10 {
 	pub modules: DecodeDifferentArray<ModuleMetadata>,
 }
 
 /// The latest version of the metadata.
-pub type RuntimeMetadataLastVersion = RuntimeMetadataV9;
+pub type RuntimeMetadataLastVersion = RuntimeMetadataV10;
 
 /// All metadata about an runtime module.
 #[derive(Clone, PartialEq, Eq, Encode, RuntimeDebug)]
@@ -400,6 +402,6 @@ impl Into<sp_core::OpaqueMetadata> for RuntimeMetadataPrefixed {
 
 impl Into<RuntimeMetadataPrefixed> for RuntimeMetadataLastVersion {
 	fn into(self) -> RuntimeMetadataPrefixed {
-		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V9(self))
+		RuntimeMetadataPrefixed(META_RESERVED, RuntimeMetadata::V10(self))
 	}
 }


### PR DESCRIPTION
Changes in https://github.com/paritytech/substrate/pull/4462 required a
metadata version increment that was forgotten.
