### PR TITLE
Refactor Client consumers to use only chain info where needed

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -427,7 +427,7 @@ mod tests {
 		let keys: Vec<&ed25519::Pair> = vec![&*alice, &*bob];
 		let dummy_runtime = ::tokio::runtime::Runtime::new().unwrap();
 		let block_factory = |service: &<Factory as service::ServiceFactory>::FullService| {
-			let block_id = BlockId::number(service.client().info().chain.best_number);
+			let block_id = BlockId::number(service.client().chain_info().best_number);
 			let parent_header = service.client().header(&block_id).unwrap().unwrap();
 			let consensus_net = ConsensusNetwork::new(service.network(), service.client().clone());
 			let proposer_factory = consensus::ProposerFactory {
@@ -513,7 +513,7 @@ mod tests {
 					.expect("Creates inherent data.");
 				inherent_data.replace_data(sp_finality_tracker::INHERENT_IDENTIFIER, &1u64);
 
-				let parent_id = BlockId::number(service.client().info().chain.best_number);
+				let parent_id = BlockId::number(service.client().chain_info().best_number);
 				let parent_header = service.client().header(&parent_id).unwrap().unwrap();
 				let mut proposer_factory = sc_basic_authority::ProposerFactory {
 					client: service.client(),
@@ -580,7 +580,7 @@ mod tests {
 				let to: Address = AccountPublic::from(bob.public()).into_account().into();
 				let from: Address = AccountPublic::from(charlie.public()).into_account().into();
 				let genesis_hash = service.client().block_hash(0).unwrap().unwrap();
-				let best_block_id = BlockId::number(service.client().info().chain.best_number);
+				let best_block_id = BlockId::number(service.client().chain_info().best_number);
 				let version = service.client().runtime_version_at(&best_block_id).unwrap().spec_version;
 				let signer = charlie.clone();
 

--- a/client/cli/src/informant.rs
+++ b/client/cli/src/informant.rs
@@ -35,14 +35,14 @@ pub fn build(service: &impl AbstractService) -> impl futures::Future<Output = ()
 		.network_status(Duration::from_millis(5000))
 		.compat()
 		.try_for_each(move |(net_status, _)| {
-			let info = client.info();
+			let info = client.usage_info();
 			display.display(&info, net_status);
 			future::ok(())
 		});
 
 	let client = service.client();
 	let mut last_best = {
-		let info = client.info();
+		let info = client.usage_info();
 		Some((info.chain.best_number, info.chain.best_hash))
 	};
 

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -1012,7 +1012,7 @@ mod tests {
 	fn authorities_call_works() {
 		let client = substrate_test_runtime_client::new();
 
-		assert_eq!(client.info().chain.best_number, 0);
+		assert_eq!(client.chain_info().best_number, 0);
 		assert_eq!(authorities(&client, &BlockId::Number(0)).unwrap(), vec![
 			Keyring::Alice.public().into(),
 			Keyring::Bob.public().into(),

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -989,7 +989,7 @@ impl<B, E, Block, I, RA, PRA> BlockImport<Block> for BabeBlockImport<B, E, Block
 		// this way we can revert it if there's any error
 		let mut old_epoch_changes = None;
 
-		let info = self.client.info().chain;
+		let info = self.client.chain_info();
 
 		if let Some(next_epoch_descriptor) = next_epoch_digest {
 			let next_epoch = epoch.increment(next_epoch_descriptor);
@@ -1104,7 +1104,7 @@ fn prune_finalized<B, E, Block, RA>(
 	B: Backend<Block, Blake2Hasher>,
 	RA: Send + Sync,
 {
-	let info = client.info().chain;
+	let info = client.chain_info();
 
 	let finalized_slot = {
 		let finalized_header = client.header(&BlockId::Hash(info.finalized_hash))

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -707,7 +707,7 @@ fn importing_epoch_change_block_prunes_tree() {
 	// We finalize block #13 from the canon chain, so on the next epoch
 	// change the tree should be pruned, to not contain F (#7).
 	client.finalize_block(BlockId::Hash(canon_hashes[12]), None, false).unwrap();
-	propose_and_import_blocks(BlockId::Hash(client.info().chain.best_hash), 7);
+	propose_and_import_blocks(BlockId::Hash(client.chain_info().best_hash), 7);
 
 	// at this point no hashes from the first fork must exist on the tree
 	assert!(
@@ -725,7 +725,7 @@ fn importing_epoch_change_block_prunes_tree() {
 
 	// finalizing block #25 from the canon chain should prune out the second fork
 	client.finalize_block(BlockId::Hash(canon_hashes[24]), None, false).unwrap();
-	propose_and_import_blocks(BlockId::Hash(client.info().chain.best_hash), 8);
+	propose_and_import_blocks(BlockId::Hash(client.chain_info().best_hash), 8);
 
 	// at this point no hashes from the second fork must exist on the tree
 	assert!(

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -964,7 +964,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 	//       below.
 	let mut authority_set = authority_set.inner().write();
 
-	let status = client.info().chain;
+	let status = client.chain_info();
 	if number <= status.finalized_number && client.hash(number)? == Some(hash) {
 		// This can happen after a forced change (triggered by the finality tracker when finality is stalled), since
 		// the voter will be restarted at the median last finalized block, which can be lower than the local best
@@ -1037,7 +1037,7 @@ pub(crate) fn finalize_block<B, Block: BlockT<Hash=H256>, E, RA>(
 				// finalization to remote nodes
 				if !justification_required {
 					if let Some(justification_period) = justification_period {
-						let last_finalized_number = client.info().chain.finalized_number;
+						let last_finalized_number = client.chain_info().finalized_number;
 						justification_required =
 							(!last_finalized_number.is_zero() || number - last_finalized_number == justification_period) &&
 							(last_finalized_number / justification_period != number / justification_period);

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -87,7 +87,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA, SC> JustificationImport<Block>
 
 	fn on_start(&mut self) -> Vec<(Block::Hash, NumberFor<Block>)> {
 		let mut out = Vec::new();
-		let chain_info = self.inner.info().chain;
+		let chain_info = self.inner.chain_info();
 
 		// request justifications for all pending changes for which change blocks have already been imported
 		let authorities = self.authority_set.inner().read();
@@ -324,7 +324,7 @@ where
 					// for the canon block the new authority set should start
 					// with. we use the minimum between the median and the local
 					// best finalized block.
-					let best_finalized_number = self.inner.info().chain.finalized_number;
+					let best_finalized_number = self.inner.chain_info().finalized_number;
 					let canon_number = best_finalized_number.min(median_last_finalized_number);
 					let canon_hash =
 						self.inner.header(&BlockId::Number(canon_number))

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -411,8 +411,8 @@ where
 	RA: Send + Sync,
 	SC: SelectChain<Block>,
 {
-	let chain_info = client.info();
-	let genesis_hash = chain_info.chain.genesis_hash;
+	let chain_info = client.chain_info();
+	let genesis_hash = chain_info.genesis_hash;
 
 	let persistent_data = aux_schema::load_persistent(
 		&*client,
@@ -507,7 +507,7 @@ fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT<Hash=H25
 			.register_provider(sp_finality_tracker::InherentDataProvider::new(move || {
 				#[allow(deprecated)]
 				{
-					let info = client.info().chain;
+					let info = client.chain_info();
 					telemetry!(CONSENSUS_INFO; "afg.finalized";
 						"finalized_number" => ?info.finalized_number,
 						"finalized_hash" => ?info.finalized_hash,
@@ -710,10 +710,10 @@ where
 			"authority_id" => authority_id.to_string(),
 		);
 
-		let chain_info = self.env.client.info();
+		let chain_info = self.env.client.chain_info();
 		telemetry!(CONSENSUS_INFO; "afg.authority_set";
-			"number" => ?chain_info.chain.finalized_number,
-			"hash" => ?chain_info.chain.finalized_hash,
+			"number" => ?chain_info.finalized_number,
+			"hash" => ?chain_info.finalized_hash,
 			"authority_id" => authority_id.to_string(),
 			"authority_set_id" => ?self.env.set_id,
 			"authorities" => {
@@ -727,8 +727,8 @@ where
 		match &*self.env.voter_set_state.read() {
 			VoterSetState::Live { completed_rounds, .. } => {
 				let last_finalized = (
-					chain_info.chain.finalized_hash,
-					chain_info.chain.finalized_number,
+					chain_info.finalized_hash,
+					chain_info.finalized_number,
 				);
 
 				let global_comms = global_communication(

--- a/client/finality-grandpa/src/light_import.rs
+++ b/client/finality-grandpa/src/light_import.rs
@@ -62,7 +62,7 @@ pub fn light_block_import<B, E, Block: BlockT<Hash=H256>, RA>(
 {
 	let info = client.info();
 	let import_data = load_aux_import_data(
-		info.chain.finalized_hash,
+		info.finalized_hash,
 		&*client,
 		genesis_authorities_provider,
 	)?;
@@ -158,7 +158,7 @@ impl<B, E, Block: BlockT<Hash=H256>, RA> FinalityProofImport<Block>
 
 	fn on_start(&mut self) -> Vec<(Block::Hash, NumberFor<Block>)> {
 		let mut out = Vec::new();
-		let chain_info = self.client.info().chain;
+		let chain_info = self.client.chain_info();
 
 		let data = self.data.read();
 		for (pending_number, pending_hash) in data.consensus_changes.pending_changes() {
@@ -647,7 +647,7 @@ pub mod tests {
 			origin: BlockOrigin::Own,
 			header: Header {
 				number: 1,
-				parent_hash: client.info().chain.best_hash,
+				parent_hash: client.chain_info().best_hash,
 				state_root: Default::default(),
 				digest: Default::default(),
 				extrinsics_root: Default::default(),

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -258,7 +258,7 @@ where
 			&self.keystore,
 		);
 
-		let last_finalized_number = self.client.info().chain.finalized_number;
+		let last_finalized_number = self.client.chain_info().finalized_number;
 
 		// NOTE: since we are not using `round_communication` we have to
 		// manually note the round with the gossip validator, otherwise we won't

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -469,7 +469,7 @@ fn finalize_3_voters_no_observers() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..3 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 20,
+		assert_eq!(net.peer(i).client().info().best_number, 20,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -602,7 +602,7 @@ fn transition_3_voters_twice_1_full_observer() {
 
 	for (i, peer) in net.lock().peers().iter().enumerate() {
 		let full_client = peer.client().as_full().expect("only full clients are used in test");
-		assert_eq!(full_client.info().chain.best_number, 1,
+		assert_eq!(full_client.chain_info().best_number, 1,
 					"Peer #{} failed to sync", i);
 
 		let set: AuthoritySet<Hash, BlockNumber> = crate::aux_schema::load_authorities(&*full_client).unwrap();
@@ -821,7 +821,7 @@ fn sync_justifications_on_change_blocks() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..4 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 25,
+		assert_eq!(net.peer(i).client().info().best_number, 25,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -898,7 +898,7 @@ fn finalizes_multiple_pending_changes_in_order() {
 
 	// all peers imported both change blocks
 	for i in 0..6 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 30,
+		assert_eq!(net.peer(i).client().info().best_number, 30,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -948,7 +948,7 @@ fn force_change_to_new_set() {
 	net.lock().block_until_sync(&mut runtime);
 
 	for (i, peer) in net.lock().peers().iter().enumerate() {
-		assert_eq!(peer.client().info().chain.best_number, 26,
+		assert_eq!(peer.client().info().best_number, 26,
 				"Peer #{} failed to sync", i);
 
 		let full_client = peer.client().as_full().expect("only full clients are used in test");
@@ -1091,7 +1091,7 @@ fn voter_persists_its_votes() {
 	net.peer(0).push_blocks(20, false);
 	net.block_until_sync(&mut runtime);
 
-	assert_eq!(net.peer(0).client().info().chain.best_number, 20,
+	assert_eq!(net.peer(0).client().info().best_number, 20,
 			   "Peer #{} failed to sync", 0);
 
 
@@ -1265,7 +1265,7 @@ fn voter_persists_its_votes() {
 
 				future::Either::A(interval
 					.take_while(move |_| {
-						Ok(net2.lock().peer(1).client().info().chain.best_number != 40)
+						Ok(net2.lock().peer(1).client().info().best_number != 40)
 					})
 					.for_each(|_| Ok(()))
 					.and_then(move |_| {
@@ -1342,7 +1342,7 @@ fn finalize_3_voters_1_light_observer() {
 	net.block_until_sync(&mut runtime);
 
 	for i in 0..4 {
-		assert_eq!(net.peer(i).client().info().chain.best_number, 20,
+		assert_eq!(net.peer(i).client().info().best_number, 20,
 			"Peer #{} failed to sync", i);
 	}
 
@@ -1395,7 +1395,7 @@ fn finality_proof_is_fetched_by_light_client_when_consensus_data_changes() {
 
 	// check that the block#1 is finalized on light client
 	runtime.block_on(futures::future::poll_fn(move || -> std::result::Result<_, ()> {
-		if net.lock().peer(1).client().info().chain.finalized_number == 1 {
+		if net.lock().peer(1).client().info().finalized_number == 1 {
 			Ok(Async::Ready(()))
 		} else {
 			net.lock().poll();
@@ -1467,7 +1467,7 @@ fn empty_finality_proof_is_returned_to_light_client_when_authority_set_is_differ
 
 	// check block, finalized on light client
 	assert_eq!(
-		net.lock().peer(3).client().info().chain.finalized_number,
+		net.lock().peer(3).client().info().finalized_number,
 		if FORCE_CHANGE { 0 } else { 10 },
 	);
 }
@@ -1662,7 +1662,7 @@ fn grandpa_environment_respects_voting_rules() {
 	// the unrestricted environment should just return the best block
 	assert_eq!(
 		unrestricted_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		20,
 	);
@@ -1671,14 +1671,14 @@ fn grandpa_environment_respects_voting_rules() {
 	// way in the unfinalized chain
 	assert_eq!(
 		three_quarters_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		15,
 	);
 
 	assert_eq!(
 		default_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		15,
 	);
@@ -1689,7 +1689,7 @@ fn grandpa_environment_respects_voting_rules() {
 	// the 3/4 environment should propose block 20 for voting
 	assert_eq!(
 		three_quarters_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		20,
 	);
@@ -1698,7 +1698,7 @@ fn grandpa_environment_respects_voting_rules() {
 	// on the best block
 	assert_eq!(
 		default_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		19,
 	);
@@ -1711,7 +1711,7 @@ fn grandpa_environment_respects_voting_rules() {
 	// the given base (#20).
 	assert_eq!(
 		default_env.best_chain_containing(
-			peer.client().info().chain.finalized_hash
+			peer.client().info().finalized_hash
 		).unwrap().1,
 		20,
 	);

--- a/client/network/src/chain.rs
+++ b/client/network/src/chain.rs
@@ -17,8 +17,8 @@
 //! Blockchain access trait
 
 use sc_client::Client as SubstrateClient;
-use sp_blockchain::Error;
-use sc_client_api::{ChangesProof, StorageProof, ClientInfo, CallExecutor};
+use sp_blockchain::{Error, Info as BlockchainInfo};
+use sc_client_api::{ChangesProof, StorageProof, CallExecutor};
 use sp_consensus::{BlockImport, BlockStatus, Error as ConsensusError};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use sp_runtime::generic::{BlockId};
@@ -29,7 +29,7 @@ use sp_core::storage::{StorageKey, ChildInfo};
 /// Local client abstraction for the network.
 pub trait Client<Block: BlockT>: Send + Sync {
 	/// Get blockchain info.
-	fn info(&self) -> ClientInfo<Block>;
+	fn info(&self) -> BlockchainInfo<Block>;
 
 	/// Get block status.
 	fn block_status(&self, id: &BlockId<Block>) -> Result<BlockStatus, Error>;
@@ -99,8 +99,8 @@ impl<B, E, Block, RA> Client<Block> for SubstrateClient<B, E, Block, RA> where
 	Block: BlockT<Hash=H256>,
 	RA: Send + Sync
 {
-	fn info(&self) -> ClientInfo<Block> {
-		(self as &SubstrateClient<B, E, Block, RA>).info()
+	fn info(&self) -> BlockchainInfo<Block> {
+		(self as &SubstrateClient<B, E, Block, RA>).chain_info()
 	}
 
 	fn block_status(&self, id: &BlockId<Block>) -> Result<BlockStatus, Error> {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -473,7 +473,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				chain,
 			},
 			light_dispatch: LightDispatch::new(checker),
-			genesis_hash: info.chain.genesis_hash,
+			genesis_hash: info.genesis_hash,
 			sync,
 			specialization,
 			handshaking_peers: HashMap::new(),
@@ -1010,7 +1010,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 					.context_data
 					.chain
 					.info()
-					.chain.best_number;
+					.best_number;
 				let blocks_difference = self_best_block
 					.checked_sub(&status.best_number)
 					.unwrap_or_else(Zero::zero)
@@ -1232,7 +1232,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			return;
 		}
 
-		let is_best = self.context_data.chain.info().chain.best_hash == hash;
+		let is_best = self.context_data.chain.info().best_hash == hash;
 		debug!(target: "sync", "Reannouncing block {:?}", hash);
 		self.send_announcement(&header, data, is_best, true)
 	}
@@ -1278,10 +1278,10 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		let status = message::generic::Status {
 			version: CURRENT_VERSION,
 			min_supported_version: MIN_VERSION,
-			genesis_hash: info.chain.genesis_hash,
+			genesis_hash: info.genesis_hash,
 			roles: self.config.roles.into(),
-			best_number: info.chain.best_number,
-			best_hash: info.chain.best_hash,
+			best_number: info.best_number,
+			best_hash: info.best_hash,
 			chain_status: self.specialization.status(),
 		};
 

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -28,8 +28,7 @@
 //!
 
 use blocks::BlockCollection;
-use sc_client_api::ClientInfo;
-use sp_blockchain::Error as ClientError;
+use sp_blockchain::{Error as ClientError, Info as BlockchainInfo};
 use sp_consensus::{BlockOrigin, BlockStatus,
 	block_validation::{BlockAnnounceValidator, Validation},
 	import_queue::{IncomingBlock, BlockImportResult, BlockImportError}
@@ -291,7 +290,7 @@ impl<B: BlockT> ChainSync<B> {
 	pub fn new(
 		role: Roles,
 		client: Arc<dyn crate::chain::Client<B>>,
-		info: &ClientInfo<B>,
+		info: &BlockchainInfo<B>,
 		request_builder: Option<BoxFinalityProofRequestBuilder<B>>,
 		block_announce_validator: Box<dyn BlockAnnounceValidator<B> + Send>,
 		max_parallel_downloads: u32,
@@ -306,9 +305,9 @@ impl<B: BlockT> ChainSync<B> {
 			client,
 			peers: HashMap::new(),
 			blocks: BlockCollection::new(),
-			best_queued_hash: info.chain.best_hash,
-			best_queued_number: info.chain.best_number,
-			best_imported_number: info.chain.best_number,
+			best_queued_hash: info.best_hash,
+			best_queued_number: info.best_number,
+			best_imported_number: info.best_number,
 			extra_finality_proofs: ExtraRequests::new(),
 			extra_justifications: ExtraRequests::new(),
 			role,
@@ -579,7 +578,7 @@ impl<B: BlockT> ChainSync<B> {
 		let attrs = &self.required_block_attributes;
 		let fork_targets = &mut self.fork_targets;
 		let mut have_requests = false;
-		let last_finalized = self.client.info().chain.finalized_number;
+		let last_finalized = self.client.info().finalized_number;
 		let best_queued = self.best_queued_number;
 		let client = &self.client;
 		let queue = &self.queue_blocks;
@@ -1142,8 +1141,8 @@ impl<B: BlockT> ChainSync<B> {
 		self.queue_blocks.clear();
 		self.blocks.clear();
 		let info = self.client.info();
-		self.best_queued_hash = info.chain.best_hash;
-		self.best_queued_number = std::cmp::max(info.chain.best_number, self.best_imported_number);
+		self.best_queued_hash = info.best_hash;
+		self.best_queued_number = std::cmp::max(info.best_number, self.best_imported_number);
 		self.is_idle = false;
 		debug!(target:"sync", "Restarted with {} ({})", self.best_queued_number, self.best_queued_hash);
 		let old_peers = std::mem::replace(&mut self.peers, HashMap::new());

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -374,8 +374,8 @@ fn own_blocks_are_announced() {
 
 	net.block_until_sync(&mut runtime);
 
-	assert_eq!(net.peer(0).client.info().chain.best_number, 1);
-	assert_eq!(net.peer(1).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(0).client.info().best_number, 1);
+	assert_eq!(net.peer(1).client.info().best_number, 1);
 	let peer0 = &net.peers()[0];
 	assert!(net.peers()[1].blockchain_canon_equals(peer0));
 	(net.peers()[2].blockchain_canon_equals(peer0));
@@ -396,9 +396,9 @@ fn blocks_are_not_announced_by_light_nodes() {
 
 	// Sync between 0 and 1.
 	net.peer(0).push_blocks(1, false);
-	assert_eq!(net.peer(0).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(0).client.info().best_number, 1);
 	net.block_until_sync(&mut runtime);
-	assert_eq!(net.peer(1).client.info().chain.best_number, 1);
+	assert_eq!(net.peer(1).client.info().best_number, 1);
 
 	// Add another node and remove node 0.
 	net.add_full_peer(&ProtocolConfig::default());
@@ -410,7 +410,7 @@ fn blocks_are_not_announced_by_light_nodes() {
 		net.poll();
 		delay.poll().map_err(|_| ())
 	})).unwrap();
-	assert_eq!(net.peer(1).client.info().chain.best_number, 0);
+	assert_eq!(net.peer(1).client.info().best_number, 0);
 }
 
 #[test]
@@ -423,13 +423,13 @@ fn can_sync_small_non_best_forks() {
 
 	// small fork + reorg on peer 1.
 	net.peer(0).push_blocks_at(BlockId::Number(30), 2, true);
-	let small_hash = net.peer(0).client().info().chain.best_hash;
+	let small_hash = net.peer(0).client().info().best_hash;
 	net.peer(0).push_blocks_at(BlockId::Number(30), 10, false);
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	// peer 1 only ever had the long fork.
 	net.peer(1).push_blocks(10, false);
-	assert_eq!(net.peer(1).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(1).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_none());
@@ -446,7 +446,7 @@ fn can_sync_small_non_best_forks() {
 
 	// synchronization: 0 synced to longer chain and 1 didn't sync to small chain.
 
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(!net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
@@ -493,8 +493,8 @@ fn can_not_sync_from_light_peer() {
 	net.block_until_sync(&mut runtime);
 
 	// ensure #0 && #1 have the same best block
-	let full0_info = net.peer(0).client.info().chain;
-	let light_info = net.peer(1).client.info().chain;
+	let full0_info = net.peer(0).client.info();
+	let light_info = net.peer(1).client.info();
 	assert_eq!(full0_info.best_number, 1);
 	assert_eq!(light_info.best_number, 1);
 	assert_eq!(light_info.best_hash, full0_info.best_hash);
@@ -555,14 +555,14 @@ fn can_sync_explicit_forks() {
 
 	// small fork + reorg on peer 1.
 	net.peer(0).push_blocks_at(BlockId::Number(30), 2, true);
-	let small_hash = net.peer(0).client().info().chain.best_hash;
-	let small_number = net.peer(0).client().info().chain.best_number;
+	let small_hash = net.peer(0).client().info().best_hash;
+	let small_number = net.peer(0).client().info().best_number;
 	net.peer(0).push_blocks_at(BlockId::Number(30), 10, false);
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	// peer 1 only ever had the long fork.
 	net.peer(1).push_blocks(10, false);
-	assert_eq!(net.peer(1).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(1).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_none());
@@ -579,7 +579,7 @@ fn can_sync_explicit_forks() {
 
 	// synchronization: 0 synced to longer chain and 1 didn't sync to small chain.
 
-	assert_eq!(net.peer(0).client().info().chain.best_number, 40);
+	assert_eq!(net.peer(0).client().info().best_number, 40);
 
 	assert!(net.peer(0).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
 	assert!(!net.peer(1).client().header(&BlockId::Hash(small_hash)).unwrap().is_some());
@@ -612,8 +612,8 @@ fn syncs_header_only_forks() {
 	net.peer(1).push_blocks(2, false);
 
 	net.peer(0).push_blocks(2, true);
-	let small_hash = net.peer(0).client().info().chain.best_hash;
-	let small_number = net.peer(0).client().info().chain.best_number;
+	let small_hash = net.peer(0).client().info().best_hash;
+	let small_number = net.peer(0).client().info().best_number;
 	net.peer(1).push_blocks(4, false);
 
 	net.block_until_sync(&mut runtime);

--- a/client/rpc/src/author/mod.rs
+++ b/client/rpc/src/author/mod.rs
@@ -102,7 +102,7 @@ impl<B, E, P, Block, RA> AuthorApi<Block::Hash, Block::Hash> for Author<B, E, P,
 	}
 
 	fn rotate_keys(&self) -> Result<Bytes> {
-		let best_block_hash = self.client.info().chain.best_hash;
+		let best_block_hash = self.client.chain_info().best_hash;
 		self.client.runtime_api().generate_session_keys(
 			&generic::BlockId::Hash(best_block_hash),
 			None,
@@ -114,7 +114,7 @@ impl<B, E, P, Block, RA> AuthorApi<Block::Hash, Block::Hash> for Author<B, E, P,
 			Ok(xt) => xt,
 			Err(err) => return Box::new(result(Err(err.into()))),
 		};
-		let best_block_hash = self.client.info().chain.best_hash;
+		let best_block_hash = self.client.chain_info().best_hash;
 		Box::new(self.pool
 			.submit_one(&generic::BlockId::hash(best_block_hash), xt)
 			.compat()
@@ -157,7 +157,7 @@ impl<B, E, P, Block, RA> AuthorApi<Block::Hash, Block::Hash> for Author<B, E, P,
 		xt: Bytes,
 	) {
 		let submit = || -> Result<_> {
-			let best_block_hash = self.client.info().chain.best_hash;
+			let best_block_hash = self.client.chain_info().best_hash;
 			let dxt = TransactionFor::<P>::decode(&mut &xt[..])
 				.map_err(error::Error::from)?;
 			Ok(

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -63,7 +63,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 	/// Tries to unwrap passed block hash, or uses best block hash otherwise.
 	fn unwrap_or_best(&self, hash: Option<Block::Hash>) -> Block::Hash {
 		match hash.into() {
-			None => self.client().info().chain.best_hash,
+			None => self.client().chain_info().best_hash,
 			Some(hash) => hash,
 		}
 	}
@@ -82,7 +82,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 		number: Option<NumberOrHex<NumberFor<Block>>>,
 	) -> Result<Option<Block::Hash>> {
 		Ok(match number {
-			None => Some(self.client().info().chain.best_hash),
+			None => Some(self.client().chain_info().best_hash),
 			Some(num_or_hex) => self.client()
 				.header(&BlockId::number(num_or_hex.to_number()?))
 				.map_err(client_err)?
@@ -92,7 +92,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 
 	/// Get hash of the last finalized block in the canon chain.
 	fn finalized_head(&self) -> Result<Block::Hash> {
-		Ok(self.client().info().chain.finalized_hash)
+		Ok(self.client().chain_info().finalized_hash)
 	}
 
 	/// New head subscription
@@ -105,7 +105,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 			self.client(),
 			self.subscriptions(),
 			subscriber,
-			|| self.client().info().chain.best_hash,
+			|| self.client().chain_info().best_hash,
 			|| self.client().import_notification_stream()
 				.filter(|notification| future::ready(notification.is_new_best))
 				.map(|notification| Ok::<_, ()>(notification.header))
@@ -132,7 +132,7 @@ trait ChainBackend<B, E, Block: BlockT, RA>: Send + Sync + 'static
 			self.client(),
 			self.subscriptions(),
 			subscriber,
-			|| self.client().info().chain.finalized_hash,
+			|| self.client().chain_info().finalized_hash,
 			|| self.client().finality_notification_stream()
 				.map(|notification| Ok::<_, ()>(notification.header))
 				.compat(),

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -83,7 +83,7 @@ impl<B, E, Block: BlockT, RA> FullState<B, E, Block, RA>
 
 	/// Returns given block hash or best block hash if None is passed.
 	fn block_or_best(&self, hash: Option<Block::Hash>) -> ClientResult<Block::Hash> {
-		Ok(hash.unwrap_or_else(|| self.client.info().chain.best_hash))
+		Ok(hash.unwrap_or_else(|| self.client.chain_info().best_hash))
 	}
 
 	/// Splits the `query_storage` block range into 'filtered' and 'unfiltered' subranges.
@@ -403,9 +403,9 @@ impl<B, E, Block, RA> StateBackend<B, E, Block, RA> for FullState<B, E, Block, R
 
 			let stream = stream
 				.filter_map(move |_| {
-					let info = client.info();
+					let info = client.chain_info();
 					let version = client
-						.runtime_version_at(&BlockId::hash(info.chain.best_hash))
+						.runtime_version_at(&BlockId::hash(info.best_hash))
 						.map_err(client_err)
 						.map_err(Into::into);
 					if previous_version != version {
@@ -457,7 +457,7 @@ impl<B, E, Block, RA> StateBackend<B, E, Block, RA> for FullState<B, E, Block, R
 		// initial values
 		let initial = stream::iter_result(keys
 			.map(|keys| {
-				let block = self.client.info().chain.best_hash;
+				let block = self.client.chain_info().best_hash;
 				let changes = keys
 					.into_iter()
 					.map(|key| self.storage(Some(block.clone()).into(), key.clone())

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -168,7 +168,7 @@ impl<Block: BlockT, F: Fetcher<Block> + 'static, B, E, RA> LightState<Block, F, 
 
 	/// Returns given block hash or best block hash if None is passed.
 	fn block_or_best(&self, hash: Option<Block::Hash>) -> Block::Hash {
-		hash.unwrap_or_else(|| self.client.info().chain.best_hash)
+		hash.unwrap_or_else(|| self.client.chain_info().best_hash)
 	}
 }
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -766,7 +766,7 @@ ServiceBuilder<
 
 		sp_session::generate_initial_session_keys(
 			client.clone(),
-			&BlockId::Hash(client.info().chain.best_hash),
+			&BlockId::Hash(client.chain_info().best_hash),
 			config.dev_key_seed.clone().map(|s| vec![s]).unwrap_or_default(),
 		)?;
 
@@ -780,7 +780,7 @@ ServiceBuilder<
 		let (essential_failed_tx, essential_failed_rx) = mpsc::unbounded();
 
 		let import_queue = Box::new(import_queue);
-		let chain_info = client.info().chain;
+		let chain_info = client.chain_info();
 
 		let version = config.full_version();
 		info!("Highest known block at #{}", chain_info.best_number);
@@ -916,7 +916,7 @@ ServiceBuilder<
 		let (state_tx, state_rx) = mpsc::unbounded::<(NetworkStatus<_>, NetworkState)>();
 		network_status_sinks.lock().push(std::time::Duration::from_millis(5000), state_tx);
 		let tel_task = state_rx.for_each(move |(net_status, _)| {
-			let info = client_.info();
+			let info = client_.usage_info();
 			let best_number = info.chain.best_number.saturated_into::<u64>();
 			let best_hash = info.chain.best_hash;
 			let num_peers = net_status.num_connected_peers;

--- a/client/service/src/chain_ops.rs
+++ b/client/service/src/chain_ops.rs
@@ -198,7 +198,7 @@ impl<
 			}
 
 			if link.imported_blocks >= count {
-				info!("Imported {} blocks. Best: #{}", read_block_count, client.info().chain.best_number);
+				info!("Imported {} blocks. Best: #{}", read_block_count, client.chain_info().best_number);
 				return std::task::Poll::Ready(Ok(()));
 
 			} else {
@@ -222,7 +222,7 @@ impl<
 		let last = match to {
 			Some(v) if v.is_zero() => One::one(),
 			Some(v) => v,
-			None => client.info().chain.best_number,
+			None => client.chain_info().best_number,
 		};
 
 		let mut wrote_header = false;
@@ -283,7 +283,7 @@ impl<
 		blocks: NumberFor<TBl>
 	) -> Result<(), Error> {
 		let reverted = self.client.revert(blocks)?;
-		let info = self.client.info().chain;
+		let info = self.client.chain_info();
 
 		if reverted.is_zero() {
 			info!("There aren't any non-finalized blocks to revert.");

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -684,7 +684,7 @@ where
 		let encoded = transaction.encode();
 		match Decode::decode(&mut &encoded[..]) {
 			Ok(uxt) => {
-				let best_block_id = BlockId::hash(self.client.info().chain.best_hash);
+				let best_block_id = BlockId::hash(self.client.info().best_hash);
 				let import_future = self.pool.submit_one(&best_block_id, uxt);
 				let import_future = import_future
 					.then(move |import_result| {

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -446,15 +446,15 @@ pub fn sync<G, E, Fb, F, Lb, L, B, ExF, U>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.best_number == (NUM_BLOCKS as u32).into(),
+			service.get().client().chain_info().best_number == (NUM_BLOCKS as u32).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number == (NUM_BLOCKS as u32).into(),
+			service.get().client().chain_info().best_number == (NUM_BLOCKS as u32).into(),
 	);
 
 	info!("Checking extrinsic propagation");
 	let first_service = network.full_nodes[0].1.clone();
 	let first_user_data = &network.full_nodes[0].2;
-	let best_block = BlockId::number(first_service.get().client().info().chain.best_number);
+	let best_block = BlockId::number(first_service.get().client().chain_info().best_number);
 	let extrinsic = extrinsic_factory(&first_service.get(), first_user_data);
 	futures03::executor::block_on(first_service.get().transaction_pool().submit_one(&best_block, extrinsic)).unwrap();
 	network.run_until_all_full(
@@ -501,9 +501,9 @@ pub fn consensus<G, E, Fb, F, Lb, L>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.finalized_number >= (NUM_BLOCKS as u32 / 2).into(),
+			service.get().client().chain_info().finalized_number >= (NUM_BLOCKS as u32 / 2).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number >= (NUM_BLOCKS as u32 / 2).into(),
+			service.get().client().chain_info().best_number >= (NUM_BLOCKS as u32 / 2).into(),
 	);
 
 	info!("Adding more peers");
@@ -523,8 +523,8 @@ pub fn consensus<G, E, Fb, F, Lb, L>(
 	}
 	network.run_until_all_full(
 		|_index, service|
-			service.get().client().info().chain.finalized_number >= (NUM_BLOCKS as u32).into(),
+			service.get().client().chain_info().finalized_number >= (NUM_BLOCKS as u32).into(),
 		|_index, service|
-			service.get().client().info().chain.best_number >= (NUM_BLOCKS as u32).into(),
+			service.get().client().chain_info().best_number >= (NUM_BLOCKS as u32).into(),
 	);
 }

--- a/client/src/light/fetcher.rs
+++ b/client/src/light/fetcher.rs
@@ -550,8 +550,8 @@ pub mod tests {
 			local_executor(),
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
-		let max = remote_client.info().chain.best_number;
-		let max_hash = remote_client.info().chain.best_hash;
+		let max = remote_client.chain_info().best_number;
+		let max_hash = remote_client.chain_info().best_hash;
 
 		for (index, (begin, end, key, expected_result)) in test_cases.into_iter().enumerate() {
 			let begin_hash = remote_client.block_hash(begin).unwrap().unwrap();
@@ -648,8 +648,8 @@ pub mod tests {
 			local_executor(),
 		);
 		let local_checker = &local_checker as &dyn FetchChecker<Block>;
-		let max = remote_client.info().chain.best_number;
-		let max_hash = remote_client.info().chain.best_hash;
+		let max = remote_client.chain_info().best_number;
+		let max_hash = remote_client.chain_info().best_hash;
 
 		let (begin, end, key, _) = test_cases[0].clone();
 		let begin_hash = remote_client.block_hash(begin).unwrap().unwrap();

--- a/primitives/api/test/benches/bench.rs
+++ b/primitives/api/test/benches/bench.rs
@@ -26,14 +26,14 @@ fn sp_api_benchmark(c: &mut Criterion) {
 	c.bench_function("add one with same runtime api", |b| {
 		let client = substrate_test_runtime_client::new();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		b.iter(|| runtime_api.benchmark_add_one(&block_id, &1))
 	});
 
 	c.bench_function("add one with recreating runtime api", |b| {
 		let client = substrate_test_runtime_client::new();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		b.iter(|| client.runtime_api().benchmark_add_one(&block_id, &1))
 	});
@@ -41,7 +41,7 @@ fn sp_api_benchmark(c: &mut Criterion) {
 	c.bench_function("vector add one with same runtime api", |b| {
 		let client = substrate_test_runtime_client::new();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 		let data = vec![0; 1000];
 
 		b.iter_with_large_drop(|| runtime_api.benchmark_vector_add_one(&block_id, &data))
@@ -49,7 +49,7 @@ fn sp_api_benchmark(c: &mut Criterion) {
 
 	c.bench_function("vector add one with recreating runtime api", |b| {
 		let client = substrate_test_runtime_client::new();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 		let data = vec![0; 1000];
 
 		b.iter_with_large_drop(|| client.runtime_api().benchmark_vector_add_one(&block_id, &data))
@@ -57,13 +57,13 @@ fn sp_api_benchmark(c: &mut Criterion) {
 
 	c.bench_function("calling function by function pointer in wasm", |b| {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 		b.iter(|| client.runtime_api().benchmark_indirect_call(&block_id).unwrap())
 	});
 
 	c.bench_function("calling function in wasm", |b| {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 		b.iter(|| client.runtime_api().benchmark_direct_call(&block_id).unwrap())
 	});
 }

--- a/primitives/api/test/tests/runtime_calls.rs
+++ b/primitives/api/test/tests/runtime_calls.rs
@@ -34,7 +34,7 @@ use codec::Encode;
 fn calling_function_with_strat(strat: ExecutionStrategy) {
 	let client = TestClientBuilder::new().set_execution_strategy(strat).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 
 	assert_eq!(runtime_api.benchmark_add_one(&block_id, &1).unwrap(), 2);
 }
@@ -57,7 +57,7 @@ fn calling_wasm_runtime_function() {
 fn calling_native_runtime_function_with_non_decodable_parameter() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	runtime_api.fail_convert_parameter(&block_id, DecodeFails::new()).unwrap();
 }
 
@@ -66,7 +66,7 @@ fn calling_native_runtime_function_with_non_decodable_parameter() {
 fn calling_native_runtime_function_with_non_decodable_return_value() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	runtime_api.fail_convert_return_value(&block_id).unwrap();
 }
 
@@ -74,7 +74,7 @@ fn calling_native_runtime_function_with_non_decodable_return_value() {
 fn calling_native_runtime_signature_changed_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeWhenPossible).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 
 	assert_eq!(runtime_api.function_signature_changed(&block_id).unwrap(), 1);
 }
@@ -83,7 +83,7 @@ fn calling_native_runtime_signature_changed_function() {
 fn calling_wasm_runtime_signature_changed_old_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 
 	#[allow(deprecated)]
 	let res = runtime_api.function_signature_changed_before_version_2(&block_id).unwrap();
@@ -94,7 +94,7 @@ fn calling_wasm_runtime_signature_changed_old_function() {
 fn calling_with_both_strategy_and_fail_on_wasm_should_return_error() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert!(runtime_api.fail_on_wasm(&block_id).is_err());
 }
 
@@ -102,7 +102,7 @@ fn calling_with_both_strategy_and_fail_on_wasm_should_return_error() {
 fn calling_with_both_strategy_and_fail_on_native_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.fail_on_native(&block_id).unwrap(), 1);
 }
 
@@ -111,7 +111,7 @@ fn calling_with_both_strategy_and_fail_on_native_should_work() {
 fn calling_with_native_else_wasm_and_fail_on_wasm_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeElseWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.fail_on_wasm(&block_id).unwrap(), 1);
 }
 
@@ -119,7 +119,7 @@ fn calling_with_native_else_wasm_and_fail_on_wasm_should_work() {
 fn calling_with_native_else_wasm_and_fail_on_native_should_work() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::NativeElseWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.fail_on_native(&block_id).unwrap(), 1);
 }
 
@@ -127,7 +127,7 @@ fn calling_with_native_else_wasm_and_fail_on_native_should_work() {
 fn use_trie_function() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.use_trie(&block_id).unwrap(), 2);
 }
 
@@ -135,7 +135,7 @@ fn use_trie_function() {
 fn initialize_block_works() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.get_block_number(&block_id).unwrap(), 1);
 }
 
@@ -143,7 +143,7 @@ fn initialize_block_works() {
 fn initialize_block_is_called_only_once() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert_eq!(runtime_api.take_block_number(&block_id).unwrap(), Some(1));
 	assert_eq!(runtime_api.take_block_number(&block_id).unwrap(), None);
 }
@@ -152,7 +152,7 @@ fn initialize_block_is_called_only_once() {
 fn initialize_block_is_skipped() {
 	let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::Both).build();
 	let runtime_api = client.runtime_api();
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	assert!(runtime_api.without_initialize_block(&block_id).unwrap());
 }
 
@@ -162,7 +162,7 @@ fn record_proof_works() {
 		.set_execution_strategy(ExecutionStrategy::Both)
 		.build_with_longest_chain();
 
-	let block_id = BlockId::Number(client.info().chain.best_number);
+	let block_id = BlockId::Number(client.chain_info().best_number);
 	let storage_root = longest_chain.best_chain().unwrap().state_root().clone();
 
 	let transaction = Transfer {

--- a/test-utils/runtime/client/src/trait_tests.rs
+++ b/test-utils/runtime/client/src/trait_tests.rs
@@ -44,7 +44,7 @@ pub fn test_leaves_for_backend<B: 'static>(backend: Arc<B>) where
 	let client = TestClientBuilder::with_backend(backend.clone()).build();
 	let blockchain = backend.blockchain();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.chain_info().genesis_hash;
 
 	assert_eq!(
 		blockchain.leaves().unwrap(),
@@ -224,7 +224,7 @@ pub fn test_children_for_backend<B: 'static>(backend: Arc<B>) where
 	let d2 = builder.bake().unwrap();
 	client.import(BlockOrigin::Own, d2.clone()).unwrap();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.chain_info().genesis_hash;
 
 	let children1 = blockchain.children(a4.hash()).unwrap();
 	assert_eq!(vec![a5.hash()], children1);
@@ -314,7 +314,7 @@ pub fn test_blockchain_query_by_number_gets_canonical<B: 'static>(backend: Arc<B
 	let d2 = builder.bake().unwrap();
 	client.import(BlockOrigin::Own, d2.clone()).unwrap();
 
-	let genesis_hash = client.info().chain.genesis_hash;
+	let genesis_hash = client.chain_info().genesis_hash;
 
 	assert_eq!(blockchain.header(BlockId::Number(0)).unwrap().unwrap().hash(), genesis_hash);
 	assert_eq!(blockchain.hash(0).unwrap().unwrap(), genesis_hash);

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -966,7 +966,7 @@ mod tests {
 	fn returns_mutable_static() {
 		let client = TestClientBuilder::new().set_execution_strategy(ExecutionStrategy::AlwaysWasm).build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		let ret = runtime_api.returns_mutable_static(&block_id).unwrap();
 		assert_eq!(ret, 33);
@@ -997,7 +997,7 @@ mod tests {
 			.set_heap_pages(REQUIRED_MEMORY_PAGES)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		// On the first invocation we allocate approx. 768KB (75%) of stack and then trap.
 		let ret = runtime_api.allocates_huge_stack_array(&block_id, true);
@@ -1018,7 +1018,7 @@ mod tests {
 			.set_heap_pages(8)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		// Try to allocate 1024k of memory on heap. This is going to fail since it is twice larger
 		// than the heap.
@@ -1047,7 +1047,7 @@ mod tests {
 			.set_execution_strategy(ExecutionStrategy::Both)
 			.build();
 		let runtime_api = client.runtime_api();
-		let block_id = BlockId::Number(client.info().chain.best_number);
+		let block_id = BlockId::Number(client.chain_info().best_number);
 
 		runtime_api.test_storage(&block_id).unwrap();
 	}


### PR DESCRIPTION
Right now Client api consumers request full `ClientInfo` when they only need `sp_blockchain::Info`, this addresses this.

While now it is rather cheap to construct ClientInfo (though it requires shared cache locking and cache structure traversing already), this is expected to be not that cheap (more memory stats, along with I/o stats)