### PR TITLE
Fix light node sync problem

### DIFF
--- a/core/client/src/light/call_executor.rs
+++ b/core/client/src/light/call_executor.rs
@@ -133,7 +133,7 @@ where
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> ClientResult<RuntimeVersion> {
-		let call_result = self.call(id, "version", &[], ExecutionStrategy::NativeElseWasm, NeverOffchainExt::new())?;
+		let call_result = self.call(id, "Core_version", &[], ExecutionStrategy::NativeElseWasm, NeverOffchainExt::new())?;
 		RuntimeVersion::decode(&mut call_result.as_slice())
 			.ok_or_else(|| ClientErrorKind::VersionInvalid.into())
 	}

--- a/core/consensus/common/src/import_queue.rs
+++ b/core/consensus/common/src/import_queue.rs
@@ -417,7 +417,7 @@ impl<B: BlockT, V: 'static + Verifier<B>> BlockImportWorker<B, V> {
 		verifier: Arc<V>,
 		block_import: SharedBlockImport<B>,
 	) -> Sender<BlockImportWorkerMsg<B>> {
-		let (sender, port) = channel::bounded(4);
+		let (sender, port) = channel::unbounded();
 		let _ = thread::Builder::new()
 			.name("ImportQueueWorker".into())
 			.spawn(move || {


### PR DESCRIPTION
Fixes #4523

v1.0 light node cannot sync to the newest block.
There are 2 problems:

* light node call a wrong method name `version`
`version` is a method of Core mudule, so  the method name should be `Core_version`

* the  import blocks channel of light node has a limited capacity
light node makes remote calls when importing and verifying new blocks and costs more time than full node does.  
When a light node has a lot of new blocks to sync, a limited capacity channel will be a problem. 

