### PR TITLE
client: helper to create standalone client without service

### DIFF
--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -54,6 +54,7 @@ use sp_runtime::traits::{NumberFor, Block as BlockT};
 
 pub use self::error::Error;
 pub use self::builder::{
+	new_full_client,
 	ServiceBuilder, ServiceBuilderCommand, TFullClient, TLightClient, TFullBackend, TLightBackend,
 	TFullCallExecutor, TLightCallExecutor,
 };


### PR DESCRIPTION
An helper for creating a client given a config without going through creating the whole service. In particular, we only need a borrow to the config (unlike full service creation), this is helpful in some scenarios since the config isn't cloneable.