### PR TITLE
client: hack around fork blocks deserialization issue

### DIFF
--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -16,12 +16,11 @@
 
 //! A set of APIs supported by the client along with their primitives.
 
-use std::collections::HashMap;
 use futures::channel::mpsc;
 use sp_core::storage::StorageKey;
 use sp_runtime::{
-    traits::{Block as BlockT, NumberFor},
-    generic::BlockId
+	traits::{Block as BlockT, NumberFor},
+	generic::BlockId
 };
 use sp_consensus::BlockOrigin;
 
@@ -38,7 +37,7 @@ pub type FinalityNotifications<Block> = mpsc::UnboundedReceiver<FinalityNotifica
 /// Expected hashes of blocks at given heights.
 ///
 /// This may be used as chain spec extension to filter out known, unwanted forks.
-pub type ForkBlocks<Block> = Option<HashMap<NumberFor<Block>, <Block as BlockT>::Hash>>;
+pub type ForkBlocks<Block> = Option<Vec<(NumberFor<Block>, <Block as BlockT>::Hash)>>;
 
 /// Figure out the block type for a given type (for now, just a `Client`).
 pub trait BlockOf {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1472,7 +1472,10 @@ impl<'a, B, E, Block, RA> sp_consensus::BlockImport<Block> for &'a Client<B, E, 
 	) -> Result<ImportResult, Self::Error> {
 		let BlockCheckParams { hash, number, parent_hash, allow_missing_state, import_existing } = block;
 
-		if let Some(h) = self.fork_blocks.as_ref().and_then(|x| x.get(&number)) {
+		let fork_block = self.fork_blocks.as_ref()
+			.and_then(|fs| fs.iter().find(|(n, _)| *n == number));
+
+		if let Some((_, h)) = fork_block {
 			if &hash != h  {
 				trace!(
 					"Rejecting block from known invalid fork. Got {:?}, expected: {:?} at height {}",


### PR DESCRIPTION
With the current definition of the `ForkBlocks` type the correct json definition should be like:

```
"forkBlocks": {
  "516510": "0x15b1b925b0..."
}
```

Unfortunately, Serde fails to deserialize this with an error:

`Error: Input("Error parsing spec file: invalid type: string \"516510\", expected u32 at line 3457 column 1")`

Changing the type to a vector of tuples instead makes it work properly:

```
"forkBlocks": [
  [516510, "0x15b1b925b0..."]
]
```

This is just a temporary work around as we need this feature for the upcoming Kusama fix and this feature is currently unused (so changing format is a non-issue). I didn't spend too much time to try and figure out why deserialization failed.

Created #4540 so that we find a proper fix for this aftewards and revert to `HashMap`.
