### PR TITLE
client: add a block blacklist extension

### DIFF
--- a/bin/node/cli/res/flaming-fir.json
+++ b/bin/node/cli/res/flaming-fir.json
@@ -22,7 +22,8 @@
     "tokenDecimals": 15,
     "tokenSymbol": "FIR"
   },
-  "fork_blocks": null,
+  "forkBlocks": null,
+  "badBlocks": null,
   "consensusEngine": null,
   "genesis": {
     "raw": {

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -47,9 +47,12 @@ const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 /// Additional parameters for some Substrate core modules,
 /// customizable from the chain spec.
 #[derive(Default, Clone, Serialize, Deserialize, ChainSpecExtension)]
+#[serde(rename_all = "camelCase")]
 pub struct Extensions {
 	/// Block numbers with known hashes.
 	pub fork_blocks: sc_client::ForkBlocks<Block>,
+	/// Known bad block hashes.
+	pub bad_blocks: sc_client::BadBlocks<Block>,
 }
 
 /// Specialized `ChainSpec`.

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -16,6 +16,7 @@
 
 //! A set of APIs supported by the client along with their primitives.
 
+use std::collections::HashSet;
 use futures::channel::mpsc;
 use sp_core::storage::StorageKey;
 use sp_runtime::{
@@ -36,8 +37,15 @@ pub type FinalityNotifications<Block> = mpsc::UnboundedReceiver<FinalityNotifica
 
 /// Expected hashes of blocks at given heights.
 ///
-/// This may be used as chain spec extension to filter out known, unwanted forks.
+/// This may be used as chain spec extension to set trusted checkpoints, i.e.
+/// the client will refuse to import a block with a different hash at the given
+/// height.
 pub type ForkBlocks<Block> = Option<Vec<(NumberFor<Block>, <Block as BlockT>::Hash)>>;
+
+/// Known bad block hashes.
+///
+/// This may be used as chain spec extension to filter out known, unwanted forks.
+pub type BadBlocks<Block> = Option<HashSet<<Block as BlockT>::Hash>>;
 
 /// Figure out the block type for a given type (for now, just a `Client`).
 pub trait BlockOf {

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -39,7 +39,7 @@ use std::path::PathBuf;
 use std::io;
 use std::collections::{HashMap, HashSet};
 
-use sc_client_api::{execution_extensions::ExecutionExtensions, ForkBlocks};
+use sc_client_api::{execution_extensions::ExecutionExtensions, BadBlocks, ForkBlocks};
 use sc_client_api::backend::NewBlockState;
 use sc_client_api::backend::{StorageCollection, ChildStorageCollection};
 use sp_blockchain::{
@@ -276,6 +276,7 @@ pub fn new_client<E, S, Block, RA>(
 	executor: E,
 	genesis_storage: S,
 	fork_blocks: ForkBlocks<Block>,
+	bad_blocks: BadBlocks<Block>,
 	execution_extensions: ExecutionExtensions<Block>,
 ) -> Result<(
 		sc_client::Client<
@@ -296,7 +297,14 @@ pub fn new_client<E, S, Block, RA>(
 	let backend = Arc::new(Backend::new(settings, CANONICALIZATION_DELAY)?);
 	let executor = sc_client::LocalCallExecutor::new(backend.clone(), executor);
 	Ok((
-		sc_client::Client::new(backend.clone(), executor, genesis_storage, fork_blocks, execution_extensions)?,
+		sc_client::Client::new(
+			backend.clone(),
+			executor,
+			genesis_storage,
+			fork_blocks,
+			bad_blocks,
+			execution_extensions,
+		)?,
 		backend,
 	))
 }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -181,6 +181,12 @@ fn new_full_parts<TBl, TRtApi, TExecDisp, TCfg, TGen, TCSExt>(
 		.cloned()
 		.unwrap_or_default();
 
+	let bad_blocks = config.chain_spec
+		.extensions()
+		.get::<sc_client::BadBlocks<TBl>>()
+		.cloned()
+		.unwrap_or_default();
+
 	let (client, backend) = {
 		let db_config = sc_client_db::DatabaseSettings {
 			state_cache_size: config.state_cache_size,
@@ -208,6 +214,7 @@ fn new_full_parts<TBl, TRtApi, TExecDisp, TCfg, TGen, TCSExt>(
 			executor,
 			&config.chain_spec,
 			fork_blocks,
+			bad_blocks,
 			extensions,
 		)?
 	};

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -68,6 +68,7 @@
 //! 	<Storage>::default(),
 //! 	Default::default(),
 //! 	Default::default(),
+//! 	Default::default(),
 //! );
 //! ```
 //!

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -98,7 +98,7 @@ pub use crate::{
 		new_in_mem,
 		BlockBody, ImportNotifications, FinalityNotifications, BlockchainEvents,
 		BlockImportNotification, Client, ClientInfo, ExecutionStrategies, FinalityNotification,
-		LongestChain, BlockOf, ProvideUncles, ForkBlocks, apply_aux,
+		LongestChain, BlockOf, ProvideUncles, BadBlocks, ForkBlocks, apply_aux,
 	},
 	leaves::LeafSet,
 };

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -70,7 +70,14 @@ pub fn new_light<B, S, GS, RA, E>(
 {
 	let local_executor = LocalCallExecutor::new(backend.clone(), code_executor);
 	let executor = GenesisCallExecutor::new(backend.clone(), local_executor);
-	Client::new(backend, executor, genesis_storage, Default::default(), Default::default())
+	Client::new(
+		backend,
+		executor,
+		genesis_storage,
+		Default::default(),
+		Default::default(),
+		Default::default(),
+	)
 }
 
 /// Create an instance of fetch data checker.

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -204,6 +204,7 @@ impl<Executor, Backend, G: GenesisInit> TestClientBuilder<Executor, Backend, G> 
 			executor,
 			storage,
 			Default::default(),
+			Default::default(),
 			ExecutionExtensions::new(
 				self.execution_strategies,
 				self.keystore.clone(),


### PR DESCRIPTION
We already have a "whitelist" feature through `ForkBlocks` which allows defining the canonical block at a given height in the chainspec. This PR adds a `BadBlocks` extension that allows defining bad block hashes, the client will refuse to import these blocks.