### PR TITLE
client/network-gossip: Remove `GossipEngine::abort` method

### DIFF
--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -143,11 +143,6 @@ impl<B: BlockT> GossipEngine<B> {
 		gossip_engine
 	}
 
-	/// Closes all notification streams.
-	pub fn abort(&self) {
-		self.inner.lock().state_machine.abort();
-	}
-
 	pub fn report(&self, who: PeerId, reputation: ReputationChange) {
 		self.inner.lock().context.report_peer(who, reputation);
 	}

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -253,11 +253,6 @@ impl<B: BlockT> ConsensusGossip<B> {
 		}
 	}
 
-	/// Closes all notification streams.
-	pub fn abort(&mut self) {
-		self.live_message_sinks.clear();
-	}
-
 	/// Register message validator for a message type.
 	pub fn register_validator(
 		&mut self,


### PR DESCRIPTION
`GossipEngine::abort` and thus `ConsensusGossip::abort` are never
called. This patch removes both.

As far as I can tell, Polkadot is not using it. Are there any other
consumers of the functions that I am not aware of?
