### PR TITLE
do not chill indirectly-slashed nominators

### DIFF
--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -392,9 +392,9 @@ fn slash_nominators<T: Trait>(
 			);
 
 			if target_span == Some(spans.span_index()) {
-				// Chill the nominator outright, ending the slashing span.
+				// End the span, but don't chill the nominator. its nomination
+				// on this validator will be ignored in the future.
 				spans.end_span(now);
-				<Module<T>>::chill_stash(stash);
 			}
 		}
 


### PR DESCRIPTION
cc @burdges, @jacogr 

When a validator is slashed, its nominators are currently kicked until explicit re-nomination. This PR causes that not to happen. The phragmén election already pre-filters for votes cast _after_ a validator's most recent slash, so the nominators' votes on the slashed validator will be ignored until next explicit nomination.

The UX here is not ideal, since those votes on slashed validators will be silently ignored. User apps will be able to perform the same check as the staking code - I've spoken with @jacogr about this before, but pinging again here.