### PR TITLE
Add translate function for storage prefixed map.

### DIFF
--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -526,20 +526,25 @@ mod test {
 			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![]);
 
 			// test migration
-			unhashed::put(&[&k[..], &vec![1][..]].concat(), &1u128);
-			unhashed::put(&[&k[..], &vec![8][..]].concat(), &2u128);
+			unhashed::put(&[&k[..], &vec![1][..]].concat(), &1u32);
+			unhashed::put(&[&k[..], &vec![8][..]].concat(), &2u32);
 
+			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![]);
 			MyStorage::translate_values(|v: u32| v as u64).unwrap();
 			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![1, 2]);
+			MyStorage::remove_all();
 
 			// test migration 2
 			unhashed::put(&[&k[..], &vec![1][..]].concat(), &1u128);
-			unhashed::put(&[&k[..], &vec![1, 1][..]].concat(), &3u64);
-			unhashed::put(&[&k[..], &vec![8][..]].concat(), &2u128);
+			unhashed::put(&[&k[..], &vec![1, 1][..]].concat(), &2u64);
+			unhashed::put(&[&k[..], &vec![8][..]].concat(), &3u128);
+			unhashed::put(&[&k[..], &vec![10][..]].concat(), &4u32);
 
-			assert_eq!(MyStorage::translate_values(|v: u128| v as u64), Err(1));
-			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![1, 2]);
-
+			// (contains some value that successfully decoded to u64)
+			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+			assert_eq!(MyStorage::translate_values(|v: u128| v as u64), Err(2));
+			assert_eq!(MyStorage::iter().collect::<Vec<_>>(), vec![1, 3]);
+			MyStorage::remove_all();
 
 			// test that other values are not modified.
 			assert_eq!(unhashed::get(&key_before[..]), Some(32u64));

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -431,8 +431,7 @@ pub trait StoragePrefixedMap<Value: FullCodec> {
 	/// `TV` translates values.
 	///
 	/// Returns `Err` if the map could not be interpreted as the old type, and Ok if it could.
-	/// The `Err` contains the first hashed key which could not be migrated, or `None` if the
-	/// head of the list could not be read.
+	/// The `Err` contains the first hashed key which could not be migrated.
 	///
 	/// # Warning
 	///
@@ -453,8 +452,7 @@ pub trait StoragePrefixedMap<Value: FullCodec> {
 			.filter(|n| n.starts_with(&prefix[..]))
 		{
 			let value: OldValue = unhashed::get(&next_key)
-				// We failed to read the value.
-				// TODO TODO: should we remove all value after this ?
+				// We failed to read the value. Stop the translation and return an error.
 				.ok_or_else(|| next_key.clone())?;
 
 			unhashed::put(&next_key[..], &translate_val(value));


### PR DESCRIPTION
Add a function to migrate values from one type to one another.

In case we fail to migrate one element we return an error with the key that has failed to decoded.
We could also remove values that fail to decode and finish the migration and at the end returning an error saying there is some value that has been removed.