### PR TITLE
Build wasmtime support by default

### DIFF
--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -105,7 +105,7 @@ structopt = "=0.3.7"
 vergen = "3.0.4"
 
 [features]
-default = ["cli"]
+default = ["cli", "wasmtime"]
 browser = [
 	"browser-utils",
 	"wasm-bindgen",


### PR DESCRIPTION
Polkadot builds wasmtime support by default. Substrate node could do as well. 