### PR TITLE
Update `per_thing` docs

### DIFF
--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -69,7 +69,7 @@ macro_rules! implement_per_thing {
 				Self::from_rational_approximation(p, q)
 			}
 
-			/// Converts from a fraction.
+			/// Converts a fraction into `Self`.
 			#[cfg(feature = "std")]
 			pub fn from_fraction(x: f64) -> Self { Self((x * ($max as f64)) as $type) }
 

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -69,7 +69,7 @@ macro_rules! implement_per_thing {
 				Self::from_rational_approximation(p, q)
 			}
 
-			/// Converts a fraction into `Permill`.
+			/// Converts from a fraction.
 			#[cfg(feature = "std")]
 			pub fn from_fraction(x: f64) -> Self { Self((x * ($max as f64)) as $type) }
 

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -54,7 +54,7 @@ macro_rules! implement_per_thing {
 				Self([parts, $max][(parts > $max) as usize])
 			}
 
-			/// Converts from a percent. Equal to `x / 100`.
+			/// Converts a percent into `Self`. Equal to `x / 100`.
 			///
 			/// This can be created at compile time.
 			pub const fn from_percent(x: $type) -> Self {


### PR DESCRIPTION
The macro which generates "generic" per-things had hard written comment about `permill`.

Updated.