### PR TITLE
Add missing weights for Identity module.

### DIFF
--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -540,6 +540,7 @@ decl_module! {
 		/// - At most O(2 * S + 1) storage mutations; codec complexity `O(1 * S + S * 1)`);
 		///   one storage-exists.
 		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedNormal(50_000)]
 		fn set_subs(origin, subs: Vec<(T::AccountId, Data)>) {
 			let sender = ensure_signed(origin)?;
 			ensure!(<IdentityOf<T>>::exists(&sender), Error::<T>::NotFound);
@@ -586,6 +587,7 @@ decl_module! {
 		/// - `S + 2` storage deletions.
 		/// - One event.
 		/// # </weight>
+		#[weight = SimpleDispatchInfo::FixedNormal(50_000)]
 		fn clear_identity(origin) {
 			let sender = ensure_signed(origin)?;
 


### PR DESCRIPTION
Afaik all dispatchable functions need a weight annotation.

Even though weights are gonna be updated later, I prefer to fix it now so we don't forget.

The weight is copy pasted from others functions in the module.