### PR TITLE
Fix race on light client when header is read during import

### DIFF
--- a/client/api/src/light.rs
+++ b/client/api/src/light.rs
@@ -259,19 +259,19 @@ pub trait Storage<Block: BlockT>: AuxStore + HeaderBackend<Block> + HeaderMetada
 	/// Get last finalized header.
 	fn last_finalized(&self) -> ClientResult<Block::Hash>;
 
-	/// Get headers CHT root for given block. Fails if the block is not pruned (not a part of any CHT).
+	/// Get headers CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
 	fn header_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
-	) -> ClientResult<Block::Hash>;
+	) -> ClientResult<Option<Block::Hash>>;
 
-	/// Get changes trie CHT root for given block. Fails if the block is not pruned (not a part of any CHT).
+	/// Get changes trie CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
 	fn changes_trie_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
-	) -> ClientResult<Block::Hash>;
+	) -> ClientResult<Option<Block::Hash>>;
 
 	/// Get storage cache.
 	fn cache(&self) -> Option<Arc<dyn BlockchainCache<Block>>>;

--- a/client/src/cht.rs
+++ b/client/src/cht.rs
@@ -62,6 +62,19 @@ pub fn is_build_required<N>(cht_size: N, block_num: N) -> Option<N>
 	Some(block_cht_num - two)
 }
 
+/// Returns Some(max_cht_number) if CHT has ever been built given maximal canonical block number.
+pub fn max_cht_number<N>(cht_size: N, max_canonical_block: N) -> Option<N>
+	where
+		N: Clone + SimpleArithmetic,
+{
+	let max_cht_number = block_to_cht_number(cht_size, max_canonical_block)?;
+	let two = N::one() + N::one();
+	if max_cht_number < two {
+		return None;
+	}
+	Some(max_cht_number - two)
+}
+
 /// Compute a CHT root from an iterator of block hashes. Fails if shorter than
 /// SIZE items. The items are assumed to proceed sequentially from `start_number(cht_num)`.
 /// Discards the trie's nodes.
@@ -329,8 +342,24 @@ mod tests {
 		assert_eq!(is_build_required(SIZE, SIZE + 1), None);
 		assert_eq!(is_build_required(SIZE, 2 * SIZE), None);
 		assert_eq!(is_build_required(SIZE, 2 * SIZE + 1), Some(0));
+		assert_eq!(is_build_required(SIZE, 2 * SIZE + 2), None);
 		assert_eq!(is_build_required(SIZE, 3 * SIZE), None);
 		assert_eq!(is_build_required(SIZE, 3 * SIZE + 1), Some(1));
+		assert_eq!(is_build_required(SIZE, 3 * SIZE + 2), None);
+	}
+
+	#[test]
+	fn max_cht_number_works() {
+		assert_eq!(max_cht_number(SIZE, 0u32.into()), None);
+		assert_eq!(max_cht_number(SIZE, 1u32.into()), None);
+		assert_eq!(max_cht_number(SIZE, SIZE), None);
+		assert_eq!(max_cht_number(SIZE, SIZE + 1), None);
+		assert_eq!(max_cht_number(SIZE, 2 * SIZE), None);
+		assert_eq!(max_cht_number(SIZE, 2 * SIZE + 1), Some(0));
+		assert_eq!(max_cht_number(SIZE, 2 * SIZE + 2), Some(0));
+		assert_eq!(max_cht_number(SIZE, 3 * SIZE), Some(0));
+		assert_eq!(max_cht_number(SIZE, 3 * SIZE + 1), Some(1));
+		assert_eq!(max_cht_number(SIZE, 3 * SIZE + 2), Some(1));
 	}
 
 	#[test]

--- a/client/src/in_mem.rs
+++ b/client/src/in_mem.rs
@@ -433,18 +433,20 @@ impl<Block: BlockT> sc_client_api::light::Storage<Block> for Blockchain<Block>
 		&self,
 		_cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
-	) -> sp_blockchain::Result<Block::Hash> {
+	) -> sp_blockchain::Result<Option<Block::Hash>> {
 		self.storage.read().header_cht_roots.get(&block).cloned()
 			.ok_or_else(|| sp_blockchain::Error::Backend(format!("Header CHT for block {} not exists", block)))
+			.map(Some)
 	}
 
 	fn changes_trie_cht_root(
 		&self,
 		_cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
-	) -> sp_blockchain::Result<Block::Hash> {
+	) -> sp_blockchain::Result<Option<Block::Hash>> {
 		self.storage.read().changes_trie_cht_roots.get(&block).cloned()
 			.ok_or_else(|| sp_blockchain::Error::Backend(format!("Changes trie CHT for block {} not exists", block)))
+			.map(Some)
 	}
 
 	fn cache(&self) -> Option<Arc<dyn blockchain::Cache<Block>>> {

--- a/client/src/light/fetcher.rs
+++ b/client/src/light/fetcher.rs
@@ -153,7 +153,7 @@ impl<E, H, B: BlockT, S: BlockchainStorage<B>> LightDataChecker<E, H, B, S> {
 		// all the checks are sharing the same storage
 		let storage = create_proof_check_backend_storage(remote_roots_proof);
 
-		// we remote_roots.keys() are sorted => we can use this to group changes tries roots
+		// remote_roots.keys() are sorted => we can use this to group changes tries roots
 		// that are belongs to the same CHT
 		let blocks = remote_roots.keys().cloned();
 		cht::for_each_cht_group::<B::Header, _, _, _>(cht_size, blocks, |mut storage, _, cht_blocks| {
@@ -162,7 +162,8 @@ impl<E, H, B: BlockT, S: BlockchainStorage<B>> LightDataChecker<E, H, B, S> {
 			// when required header has been pruned (=> replaced with CHT)
 			let first_block = cht_blocks.first().cloned()
 				.expect("for_each_cht_group never calls callback with empty groups");
-			let local_cht_root = self.blockchain.storage().changes_trie_cht_root(cht_size, first_block)?;
+			let local_cht_root = self.blockchain.storage().changes_trie_cht_root(cht_size, first_block)?
+				.ok_or(ClientError::InvalidCHTProof)?;
 
 			// check changes trie root for every block within CHT range
 			for block in cht_blocks {


### PR DESCRIPTION
closes #4507 

There was a light-specific code that has been assuming that IF `local_storage.header()` returns `None`, AND the `local_storage.status() != Unknown` THEN the header is a part of CHT. If that code has been called during block import, it may have returned `None` from `local_storage.header()` and then, after insertion, may have also passed the `local_storage.status() != Unknown` condition. So the light node was assuming that it is part of CHT, even though it was not.

This PR makes `*_cht_root()` functions return `Ok(None)` if there's no yet CHT for given block => we assume that the header is unknown in the above ^^^ case. Previously these functions were failing, which leading to occasional test failures.