### PR TITLE
Fix runners-up candidacy submission check in council

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 201,
-	impl_version: 201,
+	spec_version: 202,
+	impl_version: 202,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -2080,4 +2080,23 @@ mod tests {
 			);
 		})
 	}
+
+	#[test]
+	fn behavior_with_dupe_candidate() {
+		ExtBuilder::default().desired_runners_up(2).build().execute_with(|| {
+			<Candidates<Test>>::put(vec![1, 1, 2, 3, 4]);
+
+			assert_ok!(Elections::vote(Origin::signed(5), vec![1], 50));
+			assert_ok!(Elections::vote(Origin::signed(4), vec![4], 40));
+			assert_ok!(Elections::vote(Origin::signed(3), vec![3], 30));
+			assert_ok!(Elections::vote(Origin::signed(2), vec![2], 20));
+
+			System::set_block_number(5);
+			assert_ok!(Elections::end_block(System::block_number()));
+
+			assert_eq!(Elections::members_ids(), vec![1, 1]);
+			assert_eq!(Elections::runners_up_ids(), vec![4, 3]);
+			assert_eq!(Elections::candidates(), vec![]);
+		})
+	}
 }

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -161,8 +161,8 @@ decl_storage! {
 		/// Locked stake of a voter.
 		pub StakeOf get(fn stake_of): map T::AccountId => BalanceOf<T>;
 
-		/// The present candidate list. Sorted based on account id. A current member can never enter
-		/// this vector and is always implicitly assumed to be a candidate.
+		/// The present candidate list. Sorted based on account-id. A current member or a runner can
+		/// never enter this vector and is always implicitly assumed to be a candidate.
 		pub Candidates get(fn candidates): Vec<T::AccountId>;
 	}
 }
@@ -535,7 +535,7 @@ impl<T: Trait> Module<T> {
 	///
 	/// Limited number of runners-up. Binary search. Constant time factor. O(1)
 	fn is_runner(who: &T::AccountId) -> bool {
-		Self::runners_up().binary_search_by(|(a, _b)| a.cmp(who)).is_ok()
+		Self::runners_up().iter().position(|(a, _b)| a == who).is_some()
 	}
 
 	/// Returns number of desired members.


### PR DESCRIPTION
same issue as: https://github.com/paritytech/substrate/pull/4429/files

- Tests already existed; yet they also worked with the wrong binary search since the container to search was just one element. I reviewed all leftover of the `binary_seach_xxx` in that file and they only apply to members and candidates who _are_ actually sorted by account id; This should close this whole issue. 
- With or without this update, in the next Kusama term change the candidate list should be cleaned. Luckily the phragmen implementation also ignores (kinda by luck; needs issue to be cleaned) dupe candidates so we should be fine.