### PR TITLE
Fix master

### DIFF
--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -439,7 +439,7 @@ decl_storage! {
 		/// Double map from Candidate -> Voter -> (Maybe) Vote.
 		Votes: double_map
 			hasher(twox_64_concat) T::AccountId,
-			twox_64_concat(T::AccountId)
+			hasher(twox_64_concat) T::AccountId
 		=> Option<Vote>;
 
 		/// The defending member currently being challenged.


### PR DESCRIPTION
society merge has conflicted with new syntax of doublemap https://github.com/paritytech/substrate/pull/4576

Here is the fix.