### PR TITLE
Remove now unused `lang_items` feature in IO primitives

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -19,7 +19,6 @@
 #![warn(missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(lang_items))]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 #![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 


### PR DESCRIPTION
This is a drive-by fix as I'm slowly digging into the code.

We don't use any explicit `#[lang = ...]` items anymore (`panic_fmt` is replaced with now-stable `#[panic_implementation]`, OOM is handled via `alloc_error_handler` feature directly etc.), so I thought it'd be good to remove it for clarity to limit used nightly features.