### PR TITLE
Additional zero bid logic for Society pallet

### DIFF
--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -1306,7 +1306,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 				// select one as primary, randomly chosen from the accepted, weighted by approvals. 
 				// Choose a random number between 0 and `total_approvals`
 				let primary_point = pick_usize(&mut rng, total_approvals - 1);
-				// Find the user who falls on that point
+				// Find the zero bid or the user who falls on that point
 				let primary = accepted.iter().find(|e| e.2.is_zero() || e.1 > primary_point)
 					.expect("e.1 of final item == total_approvals; \
 						worst case find will always return that item; qed")

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -1271,7 +1271,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 					// We track here the total_approvals so that every candidate has a unique range
 					// of numbers from 0 to `total_approvals` with length `approval_count` so each
 					// candidate is proportionally represented when selecting a "primary" below.
-					Some((candidate, total_approvals))
+					Some((candidate, total_approvals, value))
 				} else {
 					// Suspend Candidate
 					<SuspendedCandidates<T, I>>::insert(&candidate, (value, kind));
@@ -1307,7 +1307,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 				// Choose a random number between 0 and `total_approvals`
 				let primary_point = pick_usize(&mut rng, total_approvals - 1);
 				// Find the user who falls on that point
-				let primary = accepted.iter().find(|e| e.1 > primary_point)
+				let primary = accepted.iter().find(|e| e.2.is_zero() || e.1 > primary_point)
 					.expect("e.1 of final item == total_approvals; \
 						worst case find will always return that item; qed")
 					.0.clone();


### PR DESCRIPTION
This introduces some additional logic around users trying to join society with zero value bids.

1. We will only select one zero value bid to be a candidate per rotation period. The rest of the selected candidates will comprise of users whose bids have some non-zero value.
2. If the accepted candidate pool contains a user with bid value of zero, that user automatically becomes the Head no matter the number of approvals they recieved. Otherwise, a random candidate is selected as head, weighted by approvals (as it was before).