### PR TITLE
Take `genesis_storage` by ref

### DIFF
--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -70,7 +70,7 @@ impl<G: RuntimeGenesis> GenesisSource<G> {
 	}
 }
 
-impl<'a, G: RuntimeGenesis, E> BuildStorage for &'a ChainSpec<G, E> {
+impl<G: RuntimeGenesis, E> BuildStorage for ChainSpec<G, E> {
 	fn build_storage(&self) -> Result<Storage, String> {
 		match self.genesis.resolve()? {
 			Genesis::Runtime(gc) => gc.build_storage(),

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -274,7 +274,7 @@ pub enum DatabaseSettingsSrc {
 pub fn new_client<E, S, Block, RA>(
 	settings: DatabaseSettings,
 	executor: E,
-	genesis_storage: S,
+	genesis_storage: &S,
 	fork_blocks: ForkBlocks<Block>,
 	bad_blocks: BadBlocks<Block>,
 	execution_extensions: ExecutionExtensions<Block>,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -129,7 +129,7 @@ impl<H> PrePostHeader<H> {
 /// Create an instance of in-memory client.
 pub fn new_in_mem<E, Block, S, RA>(
 	executor: E,
-	genesis_storage: S,
+	genesis_storage: &S,
 	keystore: Option<sp_core::traits::BareCryptoStorePtr>,
 ) -> sp_blockchain::Result<Client<
 	in_mem::Backend<Block>,
@@ -149,7 +149,7 @@ pub fn new_in_mem<E, Block, S, RA>(
 pub fn new_with_backend<B, E, Block, S, RA>(
 	backend: Arc<B>,
 	executor: E,
-	build_genesis_storage: S,
+	build_genesis_storage: &S,
 	keystore: Option<sp_core::traits::BareCryptoStorePtr>,
 ) -> sp_blockchain::Result<Client<B, LocalCallExecutor<B, E>, Block, RA>>
 	where
@@ -187,7 +187,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	pub fn new<S: BuildStorage>(
 		backend: Arc<B>,
 		executor: E,
-		build_genesis_storage: S,
+		build_genesis_storage: &S,
 		fork_blocks: ForkBlocks<Block>,
 		bad_blocks: BadBlocks<Block>,
 		execution_extensions: ExecutionExtensions<Block>,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -65,7 +65,7 @@
 //! 		NativeExecutor::<LocalExecutor>::new(WasmExecutionMethod::Interpreted, None),
 //!		),
 //! 	// This parameter provides the storage for the chain genesis.
-//! 	<Storage>::default(),
+//! 	&<Storage>::default(),
 //! 	Default::default(),
 //! 	Default::default(),
 //! 	Default::default(),

--- a/client/src/light/mod.rs
+++ b/client/src/light/mod.rs
@@ -56,7 +56,7 @@ pub fn new_light_backend<B, S>(blockchain: Arc<Blockchain<S>>) -> Arc<Backend<S,
 /// Create an instance of light client.
 pub fn new_light<B, S, GS, RA, E>(
 	backend: Arc<Backend<S, HasherFor<B>>>,
-	genesis_storage: GS,
+	genesis_storage: &GS,
 	code_executor: E,
 ) -> ClientResult<
 		Client<

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -283,7 +283,7 @@ use sp_staking::{
 use sp_runtime::{Serialize, Deserialize};
 use frame_system::{self as system, ensure_signed, ensure_root};
 
-use sp_phragmen::{ExtendedBalance, PhragmenStakedAssignment};
+use sp_phragmen::ExtendedBalance;
 
 const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
 const MAX_NOMINATIONS: usize = 16;
@@ -1508,12 +1508,10 @@ impl<T: Trait> Module<T> {
 				.collect::<Vec<T::AccountId>>();
 			let assignments = phragmen_result.assignments;
 
-			let to_votes = |b: BalanceOf<T>|
-				<T::CurrencyToVote as Convert<BalanceOf<T>, u64>>::convert(b) as ExtendedBalance;
 			let to_balance = |e: ExtendedBalance|
 				<T::CurrencyToVote as Convert<ExtendedBalance, BalanceOf<T>>>::convert(e);
 
-			let mut supports = sp_phragmen::build_support_map::<_, _, _, T::CurrencyToVote>(
+			let supports = sp_phragmen::build_support_map::<_, _, _, T::CurrencyToVote>(
 				&elected_stashes,
 				&assignments,
 				Self::slashable_balance_of,

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -190,7 +190,7 @@ impl<Executor, Backend, G: GenesisInit> TestClientBuilder<Executor, Backend, G> 
 		let client = sc_client::Client::new(
 			self.backend.clone(),
 			executor,
-			storage,
+			&storage,
 			Default::default(),
 			Default::default(),
 			ExecutionExtensions::new(


### PR DESCRIPTION
Instead of having these weird implementation of `BuildStorage for
&ChainSpec` we should just take the `genesis_storage` by ref. The
`BuildStorage` trait changed some time ago to take a self ref anyway,
instead of a self value.

Also fixes warnings in frame-staking
