### PR TITLE
Make offchain worker calls more future proof.

### DIFF
--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -101,13 +101,14 @@ impl<Client, Storage, Block> OffchainWorkers<
 		let has_api_v1 = runtime.has_api_with::<dyn OffchainWorkerApi<Block, Error = ()>, _>(
 			&at, |v| v == 1
 		);
-		let has_api_v2 = runtime.has_api::<dyn OffchainWorkerApi<Block, Error = ()>>(&at);
+		let has_api_v2 = runtime.has_api_with::<dyn OffchainWorkerApi<Block, Error = ()>, _>(
+			&at, |v| v == 2
+		);
 		let version = match (has_api_v1, has_api_v2) {
 			(_, Ok(true)) => 2,
 			(Ok(true), _) => 1,
 			_ => 0,
 		};
-
 		debug!("Checking offchain workers at {:?}: version:{}", at, version);
 		if version > 0 {
 			let (api, runner) = api::AsyncApi::new(

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -139,6 +139,8 @@ impl<Client, Storage, Block> OffchainWorkers<
 			});
 			futures::future::Either::Left(runner.process())
 		} else {
+			let help = "Consider turning off offchain workers if they are not part of your runtime.";
+			warn!("Unsupported Offchain Worker API version: {}. {}", version, help);
 			futures::future::Either::Right(futures::future::ready(()))
 		}
 	}

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -141,7 +141,7 @@ impl<Client, Storage, Block> OffchainWorkers<
 			futures::future::Either::Left(runner.process())
 		} else {
 			let help = "Consider turning off offchain workers if they are not part of your runtime.";
-			warn!("Unsupported Offchain Worker API version: {}. {}", version, help);
+			log::error!("Unsupported Offchain Worker API version: {}. {}", version, help);
 			futures::future::Either::Right(futures::future::ready(()))
 		}
 	}


### PR DESCRIPTION
This will help debugging possible issues when we migrate to future versions.

1. Display an error if version is not supported.
2. Support only version 1 and 2. Will error out when we ever switch to `v3`.
