### PR TITLE
Do not issue empty remote read request + fix rr-related trace on full node

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1472,6 +1472,13 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		who: PeerId,
 		request: message::RemoteReadRequest<B::Hash>,
 	) {
+		if request.keys.is_empty() {
+			debug!(target: "sync", "Invalid remote read request sent by {}", who);
+			self.behaviour.disconnect_peer(&who);
+			self.peerset_handle.report_peer(who, rep::BAD_MESSAGE);
+			return;
+		}
+
 		let keys_str = || match request.keys.len() {
 			1 => request.keys[0].to_hex::<String>(),
 			_ => format!(
@@ -1510,6 +1517,13 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 		who: PeerId,
 		request: message::RemoteReadChildRequest<B::Hash>,
 	) {
+		if request.keys.is_empty() {
+			debug!(target: "sync", "Invalid remote child read request sent by {}", who);
+			self.behaviour.disconnect_peer(&who);
+			self.peerset_handle.report_peer(who, rep::BAD_MESSAGE);
+			return;
+		}
+
 		let keys_str = || match request.keys.len() {
 			1 => request.keys[0].to_hex::<String>(),
 			_ => format!(

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -325,8 +325,8 @@ impl<Block, F, B, E, RA> StateBackend<B, E, Block, RA> for LightState<Block, F, 
 		keys: Option<Vec<StorageKey>>
 	) {
 		let keys = match keys {
-			Some(keys) => keys,
-			None => {
+			Some(keys) if !keys.is_empty() => keys,
+			_ => {
 				warn!("Cannot subscribe to all keys on light client. Subscription rejected.");
 				return;
 			}


### PR DESCRIPTION
Fixes two related issues:
1) there's no need to issue empty `RemoteRead` && `RemoteReadChild` requests from light node and it turns current UI (at https://polkadot.js.org/apps/#/) does this;
2) I've recently introduced invalid `trace!()` call in network (when we moved to single-key-in-remote-request to multiple-keys-in-single-remote-request) which leads to panic when invalid request is received  over network :(