### PR TITLE
Make Proposer instantiation potentially async.

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -404,6 +404,7 @@ mod tests {
 	use sc_service::AbstractService;
 	use crate::service::{new_full, new_light};
 	use sp_runtime::traits::IdentifyAccount;
+	use futures::prelude::*;
 
 	type AccountPublic = <Signature as Verify>::Signer;
 
@@ -535,15 +536,16 @@ mod tests {
 
 				digest.push(<DigestItem as CompatibleDigestItem>::babe_pre_digest(babe_pre_digest));
 
-				let mut proposer = futures::executor::block_on(
-					proposer_factory.init(&parent_header)
-				).unwrap();
-				let new_block = futures::executor::block_on(proposer.propose(
-					inherent_data,
-					digest,
-					std::time::Duration::from_secs(1),
-					RecordProof::Yes,
-				)).expect("Error making test block").block;
+				let proposing = proposer_factory.init(&parent_header)
+					.and_then(|mut proposer| proposer.propose(
+						inherent_data,
+						digest,
+						std::time::Duration::from_secs(1),
+						RecordProof::Yes,
+					));
+
+				let new_block = futures::executor::block_on(proposing)
+					.expect("Error making test block").block;
 
 				let (new_header, new_body) = new_block.deconstruct();
 				let pre_hash = new_header.hash();

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -535,7 +535,9 @@ mod tests {
 
 				digest.push(<DigestItem as CompatibleDigestItem>::babe_pre_digest(babe_pre_digest));
 
-				let mut proposer = proposer_factory.init(&parent_header).unwrap();
+				let mut proposer = futures::executor::block_on(
+					proposer_factory.init(&parent_header)
+				).unwrap();
 				let new_block = futures::executor::block_on(proposer.propose(
 					inherent_data,
 					digest,

--- a/client/basic-authorship/src/lib.rs
+++ b/client/basic-authorship/src/lib.rs
@@ -34,9 +34,12 @@
 //! };
 //!
 //! // From this factory, we create a `Proposer`.
-//! let mut proposer = proposer_factory.init(
+//! let proposer = proposer_factory.init(
 //! 	&client.header(&BlockId::number(0)).unwrap().unwrap(),
-//! ).unwrap();
+//! );
+//!
+//! // The proposer is created asynchronously.
+//! let mut proposer = futures::executor::block_on(proposer).unwrap();
 //!
 //! // This `Proposer` allows us to create a block proposition.
 //! // The proposer will grab transactions from the transaction pool, and put them into the block.

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -217,6 +217,9 @@ impl<B, C, E, I, P, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for AuraW
 {
 	type BlockImport = I;
 	type SyncOracle = SO;
+	type CreateProposer = Pin<Box<
+		dyn Future<Output = Result<E::Proposer, sp_consensus::Error>> + Send + 'static
+	>>;
 	type Proposer = E::Proposer;
 	type Claim = P;
 	type EpochData = Vec<AuthorityId<P>>;
@@ -302,10 +305,10 @@ impl<B, C, E, I, P, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for AuraW
 		&mut self.sync_oracle
 	}
 
-	fn proposer(&mut self, block: &B::Header) -> Result<Self::Proposer, sp_consensus::Error> {
-		self.env.init(block).map_err(|e| {
+	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
+		Box::pin(self.env.init(block).map_err(|e| {
 			sp_consensus::Error::ClientImport(format!("{:?}", e)).into()
-		})
+		}))
 	}
 
 	fn proposing_remaining_duration(
@@ -874,12 +877,13 @@ mod tests {
 
 	impl Environment<TestBlock> for DummyFactory {
 		type Proposer = DummyProposer;
+		type CreateProposer = futures::future::Ready<Result<DummyProposer, Error>>;
 		type Error = Error;
 
 		fn init(&mut self, parent_header: &<TestBlock as BlockT>::Header)
-			-> Result<DummyProposer, Error>
+			-> Self::CreateProposer
 		{
-			Ok(DummyProposer(parent_header.number + 1, self.0.clone()))
+			futures::future::ready(Ok(DummyProposer(parent_header.number + 1, self.0.clone())))
 		}
 	}
 

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -486,7 +486,7 @@ fn mine_loop<B: BlockT, C, Algorithm, E, SO, S, CAW>(
 		}
 
 		let mut aux = PowAux::read(client, &best_hash)?;
-		let mut proposer = env.init(&best_header)
+		let mut proposer = futures::executor::block_on(env.init(&best_header))
 			.map_err(|e| Error::Environment(format!("{:?}", e)))?;
 
 		let inherent_data = inherent_data_providers

--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -74,13 +74,16 @@ pub enum BlockStatus {
 /// Environment producer for a Consensus instance. Creates proposer instance and communication streams.
 pub trait Environment<B: BlockT> {
 	/// The proposer type this creates.
-	type Proposer: Proposer<B> + 'static;
+	type Proposer: Proposer<B> + Send + 'static;
+	/// A future that resolves to the proposer.
+	type CreateProposer: Future<Output = Result<Self::Proposer, Self::Error>>
+		+ Send + Unpin + 'static;
 	/// Error which can occur upon creation.
 	type Error: From<Error> + std::fmt::Debug + 'static;
 
 	/// Initialize the proposal logic on top of a specific header. Provide
 	/// the authorities at that header.
-	fn init(&mut self, parent_header: &B::Header) -> Result<Self::Proposer, Self::Error>;
+	fn init(&mut self, parent_header: &B::Header) -> Self::CreateProposer;
 }
 
 /// A proposal that is created by a [`Proposer`].


### PR DESCRIPTION
Needed for an upcoming Polkadot refactor and is strictly more general. This API was always intended to be used in an async context, so it doesn't break any underlying assumptions.