### PR TITLE
Use default in-memory keystore for commands that don't use keystore

### DIFF
--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -139,7 +139,6 @@ pub fn run<I, T, E>(args: I, exit: E, version: sc_cli::VersionInfo) -> error::Re
 				&cli_args.shared_params,
 				&version,
 			)?;
-
 			sc_cli::fill_import_params(&mut config, &cli_args.import_params, ServiceRoles::FULL)?;
 
 			match ChainSpec::from(config.chain_spec.id()) {


### PR DESCRIPTION
Probably as a workaround until better refactoring

Fixes #4623