### PR TITLE
Make the sync_cycle_from_offline_to_syncing_to_offline test non flaky

### DIFF
--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -80,7 +80,7 @@ fn sync_cycle_from_offline_to_syncing_to_offline() {
 			}
 			if peer < 2 {
 				// Major syncing.
-				if !net.peer(peer).is_major_syncing() {
+				if net.peer(peer).blocks_count() < 100 && !net.peer(peer).is_major_syncing() {
 					return Ok(Async::NotReady)
 				}
 			}


### PR DESCRIPTION
This test starts by waiting for nodes 0 and 1 to be major-syncing.

However what I think sometimes happens is that the background task fully syncs these nodes and that therefore `is_major_syncing` returns false. The test then freezes because it's still waiting for the major syncing to happen even though it's already finished.

Since this test is entirely single-threaded, it's still unclear to Arkadiy and me why this happens only from time to time. EDIT: probably because libp2p 0.14 spawns connection tasks on a thread pool no matter what