### PR TITLE
CODEOWNERS: Add myself to pow and EVM module

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -46,10 +46,15 @@
 /client/finality-grandpa/ @andresilva @DemiMarie-parity
 /client/consensus/babe/ @andresilva @DemiMarie-parity
 /client/consensus/slots/ @andresilva @DemiMarie-parity
+/client/consensus/pow/ @sorpaas
+/primitives/consensus/pow/ @sorpaas
 
 # Contracts
 /frame/contracts/ @pepyakin @thiolliere
 /frame/contracts/src/wasm/runtime.rs @Robbepop
+
+# EVM
+/frame/evm/ @sorpaas
 
 # Inflation points
 /frame/staking/src/inflation.rs @thiolliere


### PR DESCRIPTION
This adds myself to CODEOWNERS file for pow and EVM module, so that I can receive specific notifications.