### PR TITLE
`sp-runtime-interface` add table about FFI types

### DIFF
--- a/primitives/runtime-interface/src/impls.rs
+++ b/primitives/runtime-interface/src/impls.rs
@@ -150,7 +150,7 @@ impl IntoFFIValue for bool {
 ///
 /// The `u64` value is build by `length 32bit << 32 | pointer 32bit`
 ///
-/// If `T == u8` the length and the pointer are taken directly from the `Self`.
+/// If `T == u8` the length and the pointer are taken directly from `Self`.
 /// Otherwise `Self` is encoded and the length and the pointer are taken from the encoded vector.
 impl<T> RIType for Vec<T> {
 	type FFIType = u64;
@@ -209,7 +209,7 @@ impl<T: 'static + Decode> FromFFIValue for Vec<T> {
 ///
 /// The `u64` value is build by `length 32bit << 32 | pointer 32bit`
 ///
-/// If `T == u8` the length and the pointer are taken directly from the `Self`.
+/// If `T == u8` the length and the pointer are taken directly from `Self`.
 /// Otherwise `Self` is encoded and the length and the pointer are taken from the encoded vector.
 impl<T> RIType for [T] {
 	type FFIType = u64;
@@ -400,7 +400,7 @@ for_primitive_types! {
 ///
 /// The `u64` value is build by `length 32bit << 32 | pointer 32bit`
 ///
-/// The length and the pointer are taken directly from the `Self`.
+/// The length and the pointer are taken directly from `Self`.
 impl RIType for str {
 	type FFIType = u64;
 }

--- a/primitives/runtime-interface/src/pass_by.rs
+++ b/primitives/runtime-interface/src/pass_by.rs
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Provides the [`PassBy`](pass_by::PassBy) trait to simplify the implementation of the
+//! Provides the [`PassBy`](PassBy) trait to simplify the implementation of the
 //! runtime interface traits for custom types.
 //!
-//! [`Codec`](pass_by::Codec), [`Inner`](pass_by::Inner) and [`Enum`](pass_by::Enum) are the
-//! provided strategy implementations.
+//! [`Codec`], [`Inner`] and [`Enum`] are the provided strategy implementations.
 
 use crate::{RIType, util::{unpack_ptr_and_len, pack_ptr_and_len}};
 


### PR DESCRIPTION
Adds a table to the rustdoc that shows how each individual type is
passed between the wasm and the host side.

