### PR TITLE
make compute_fee public

### DIFF
--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -151,7 +151,7 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> {
 	///      transactions can have a tip.
 	///
 	/// final_fee = base_fee + targeted_fee_adjustment(len_fee + weight_fee) + tip;
-	fn compute_fee(
+	pub fn compute_fee(
 		len: u32,
 		info: <Self as SignedExtension>::DispatchInfo,
 		tip: BalanceOf<T>,


### PR DESCRIPTION
We want some additional custom logic on tx fee but don't want to copy & paste the whole transaction payment module. This will allow us to reuse some logic.

The module we are implementing: https://github.com/AcalaNetwork/Acala/issues/58 https://github.com/AcalaNetwork/Acala/pull/70