### PR TITLE
Update bridge pallet to work with the (almost) lastest master

### DIFF
--- a/frame/bridge/Cargo.toml
+++ b/frame/bridge/Cargo.toml
@@ -16,11 +16,11 @@ primitives = { package = "sp-core",  path = "../../primitives/core", default-fea
 session = { package = "pallet-session", path = "../session", default-features = false }
 serde = { version = "1.0", optional = true }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
-sp-state-machine = { version = "2.0.0", path = "../../primitives/state-machine" } # TODO: Move to Dev Dependencies
 sp-trie = { version = "2.0.0", path = "../../primitives/trie", default-features = false }
 
 [dev-dependencies]
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-state-machine = { version = "2.0.0", path = "../../primitives/state-machine" }
 
 [features]
 default = ["std"]

--- a/frame/bridge/Cargo.toml
+++ b/frame/bridge/Cargo.toml
@@ -9,28 +9,28 @@ edition = "2018"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
 fg_primitives = { package = "sp-finality-grandpa", path = "../../primitives/finality-grandpa" }
+frame-support = { version = "2.0.0", default-features = false, path = "../support" }
+frame-system = { package = "frame-system", path = "../system", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
 primitives = { package = "sp-core",  path = "../../primitives/core", default-features = false }
 session = { package = "pallet-session", path = "../session", default-features = false }
 serde = { version = "1.0", optional = true }
-sp-runtime = { path = "../../primitives/runtime", default-features = false }
+sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 state-machine = { package = "sp-state-machine", path = "../../primitives/state-machine" }
-support = { package = "frame-support", path = "../support", default-features = false }
-system = { package = "frame-system", path = "../system", default-features = false }
-sp-trie = { path = "../../primitives/trie", default-features = false }
+sp-trie = { version = "2.0.0", path = "../../primitives/trie", default-features = false }
 
 [dev-dependencies]
-sp-io = { path = "../../primitives/io", default-features = false }
+sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
 	"codec/std",
-	"session/std",
+	"frame-support/std",
+	"frame-system/std",
 	"primitives/std",
-	"support/std",
-	"system/std",
+	"session/std",
 	"sp-runtime/std",
 	"sp-trie/std",
 	"sp-io/std",

--- a/frame/bridge/Cargo.toml
+++ b/frame/bridge/Cargo.toml
@@ -16,7 +16,7 @@ primitives = { package = "sp-core",  path = "../../primitives/core", default-fea
 session = { package = "pallet-session", path = "../session", default-features = false }
 serde = { version = "1.0", optional = true }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
-state-machine = { package = "sp-state-machine", path = "../../primitives/state-machine" }
+sp-state-machine = { version = "2.0.0", path = "../../primitives/state-machine" } # TODO: Move to Dev Dependencies
 sp-trie = { version = "2.0.0", path = "../../primitives/trie", default-features = false }
 
 [dev-dependencies]

--- a/frame/bridge/Cargo.toml
+++ b/frame/bridge/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
-fg_primitives = { package = "sp-finality-grandpa", path = "../../primitives/finality-grandpa" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
-frame-system = { package = "frame-system", path = "../system", default-features = false }
+frame-system = { version = "2.0.0", default-features = false, path = "../system" }
 hash-db = { version = "0.15.2", default-features = false }
-primitives = { package = "sp-core",  path = "../../primitives/core", default-features = false }
-session = { package = "pallet-session", path = "../session", default-features = false }
+pallet-session = { version = "2.0.0", default-features = false, path = "../session" }
 serde = { version = "1.0", optional = true }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
+sp-finality-grandpa = { version = "2.0.0", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
-sp-trie = { version = "2.0.0", path = "../../primitives/trie", default-features = false }
+sp-trie = { version = "2.0.0", default-features = false, path = "../../primitives/trie" }
 
 [dev-dependencies]
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
@@ -29,8 +29,9 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
-	"primitives/std",
-	"session/std",
+	"pallet-session/std",
+	"sp-core/std",
+	"sp-finality-grandpa/std",
 	"sp-runtime/std",
 	"sp-trie/std",
 	"sp-io/std",

--- a/frame/bridge/src/lib.rs
+++ b/frame/bridge/src/lib.rs
@@ -38,7 +38,7 @@ mod storage_proof;
 
 use crate::storage_proof::{StorageProof, StorageProofChecker};
 use codec::{Encode, Decode};
-use fg_primitives::{AuthorityId, AuthorityWeight};
+use sp_finality_grandpa::{AuthorityId, AuthorityWeight};
 use sp_runtime::traits::Header;
 use frame_support::{
 	dispatch::{DispatchResult, DispatchError},
@@ -209,7 +209,7 @@ impl<T: Trait> Module<T> {
 mod tests {
 	use super::*;
 
-	use primitives::{Blake2Hasher, H256, Public};
+	use sp_core::{Blake2Hasher, H256, Public};
 	use sp_runtime::{
 		Perbill, traits::{Header as HeaderT, IdentityLookup}, testing::Header, generic::Digest,
 	};

--- a/frame/bridge/src/lib.rs
+++ b/frame/bridge/src/lib.rs
@@ -40,7 +40,7 @@ use crate::storage_proof::StorageProofChecker;
 use codec::{Encode, Decode};
 use fg_primitives::{AuthorityId, AuthorityWeight};
 use sp_runtime::traits::Header;
-use state_machine::StorageProof;
+use sp_state_machine::StorageProof;
 use frame_support::{
 	dispatch::{DispatchResult, DispatchError},
 	decl_error, decl_module, decl_storage,
@@ -282,13 +282,13 @@ mod tests {
 	}
 
 	fn create_dummy_validator_proof(validator_set: Vec<(AuthorityId, AuthorityWeight)>) -> (H256, StorageProof) {
-		use state_machine::{prove_read, backend::{Backend, InMemory}};
+		use sp_state_machine::{prove_read, backend::Backend, InMemoryBackend};
 
 		let encoded_set = validator_set.encode();
 
 		// construct storage proof
-		let backend = <InMemory<Blake2Hasher>>::from(vec![
-			(None, b":grandpa_authorities".to_vec(), Some(encoded_set)),
+		let backend = <InMemoryBackend<Blake2Hasher>>::from(vec![
+			(None, vec![(b":grandpa_authorities".to_vec(), Some(encoded_set))]),
 		]);
 		let root = backend.storage_root(std::iter::empty()).0;
 
@@ -423,7 +423,7 @@ mod tests {
 
 		assert_err!(
 			MockBridge::verify_ancestry(proof, fake_ancestor.hash(), child),
-			Error::InvalidAncestryProof
+			Error::<Test>::InvalidAncestryProof
 		);
 	}
 
@@ -453,7 +453,7 @@ mod tests {
 
 		assert_err!(
 			MockBridge::verify_ancestry(invalid_proof, ancestor.hash(), child),
-			Error::InvalidAncestryProof
+			Error::<Test>::InvalidAncestryProof
 		);
 	}
 }

--- a/frame/bridge/src/lib.rs
+++ b/frame/bridge/src/lib.rs
@@ -36,11 +36,10 @@
 
 mod storage_proof;
 
-use crate::storage_proof::StorageProofChecker;
+use crate::storage_proof::{StorageProof, StorageProofChecker};
 use codec::{Encode, Decode};
 use fg_primitives::{AuthorityId, AuthorityWeight};
 use sp_runtime::traits::Header;
-use sp_state_machine::StorageProof;
 use frame_support::{
 	dispatch::{DispatchResult, DispatchError},
 	decl_error, decl_module, decl_storage,
@@ -293,7 +292,10 @@ mod tests {
 		let root = backend.storage_root(std::iter::empty()).0;
 
 		// Generates a storage read proof
-		let proof = prove_read(backend, &[&b":grandpa_authorities"[..]]).unwrap();
+		let proof: StorageProof = prove_read(backend, &[&b":grandpa_authorities"[..]])
+			.unwrap()
+			.iter_nodes()
+			.collect();
 
 		(root, proof)
 	}

--- a/frame/bridge/src/storage_proof.rs
+++ b/frame/bridge/src/storage_proof.rs
@@ -20,7 +20,7 @@ use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
 use state_machine::StorageProof;
 use sp_trie::{MemoryDB, Trie, trie_types::TrieDB};
 
-use crate::Error;
+// use crate::Error;
 
 /// This struct is used to read storage values from a subset of a Merklized database. The "proof"
 /// is a subset of the nodes in the Merkle structure of the database, so that it provides
@@ -57,7 +57,7 @@ impl<H> StorageProofChecker<H>
 	pub fn read_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
 		self.trie()?
 			.get(key)
-			.map(|value| value.map(|value| value.into_vec()))
+			.map(|value| value.map(|value| value.to_vec()))
 			.map_err(|_| Error::StorageValueUnavailable)
 	}
 
@@ -65,6 +65,11 @@ impl<H> StorageProofChecker<H>
 		TrieDB::new(&self.db, &self.root)
 			.map_err(|_| Error::StorageRootMismatch)
 	}
+}
+
+pub enum Error {
+	StorageRootMismatch,
+	StorageValueUnavailable,
 }
 
 #[cfg(test)]

--- a/frame/bridge/src/storage_proof.rs
+++ b/frame/bridge/src/storage_proof.rs
@@ -17,7 +17,7 @@
 //! Logic for checking Substrate storage proofs.
 
 use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
-use state_machine::StorageProof;
+use sp_state_machine::StorageProof;
 use sp_trie::{MemoryDB, Trie, trie_types::TrieDB};
 use sp_runtime::RuntimeDebug;
 
@@ -79,18 +79,18 @@ mod tests {
 	use super::*;
 
 	use primitives::{Blake2Hasher, H256};
-	use state_machine::{prove_read, backend::{Backend, InMemory}};
+	use sp_state_machine::{prove_read, backend::Backend, InMemoryBackend};
 	// use trie::{PrefixedMemoryDB, TrieDBMut};
 
 	#[test]
 	fn storage_proof_check() {
 		// construct storage proof
-		let backend = <InMemory<Blake2Hasher>>::from(vec![
-			(None, b"key1".to_vec(), Some(b"value1".to_vec())),
-			(None, b"key2".to_vec(), Some(b"value2".to_vec())),
-			(None, b"key3".to_vec(), Some(b"value3".to_vec())),
+		let backend = <InMemoryBackend<Blake2Hasher>>::from(vec![
+			(None, vec![(b"key1".to_vec(), Some(b"value1".to_vec()))]),
+			(None, vec![(b"key2".to_vec(), Some(b"value2".to_vec()))]),
+			(None, vec![(b"key3".to_vec(), Some(b"value3".to_vec()))]),
 			// Value is too big to fit in a branch node
-			(None, b"key11".to_vec(), Some(vec![0u8; 32])),
+			(None, vec![(b"key11".to_vec(), Some(vec![0u8; 32]))]),
 		]);
 		let root = backend.storage_root(std::iter::empty()).0;
 		let proof = prove_read(backend, &[&b"key1"[..], &b"key2"[..], &b"key22"[..]]).unwrap();

--- a/frame/bridge/src/storage_proof.rs
+++ b/frame/bridge/src/storage_proof.rs
@@ -79,7 +79,7 @@ pub enum Error {
 mod tests {
 	use super::*;
 
-	use primitives::{Blake2Hasher, H256};
+	use sp_core::{Blake2Hasher, H256};
 	use sp_state_machine::{prove_read, backend::Backend, InMemoryBackend};
 	// use trie::{PrefixedMemoryDB, TrieDBMut};
 

--- a/frame/bridge/src/storage_proof.rs
+++ b/frame/bridge/src/storage_proof.rs
@@ -20,8 +20,6 @@ use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
 use sp_trie::{MemoryDB, Trie, trie_types::TrieDB};
 use sp_runtime::RuntimeDebug;
 
-// use crate::Error;
-
 pub(crate) type StorageProof = Vec<Vec<u8>>;
 
 /// This struct is used to read storage values from a subset of a Merklized database. The "proof"
@@ -81,7 +79,6 @@ mod tests {
 
 	use sp_core::{Blake2Hasher, H256};
 	use sp_state_machine::{prove_read, backend::Backend, InMemoryBackend};
-	// use trie::{PrefixedMemoryDB, TrieDBMut};
 
 	#[test]
 	fn storage_proof_check() {

--- a/frame/bridge/src/storage_proof.rs
+++ b/frame/bridge/src/storage_proof.rs
@@ -19,6 +19,7 @@
 use hash_db::{Hasher, HashDB, EMPTY_PREFIX};
 use state_machine::StorageProof;
 use sp_trie::{MemoryDB, Trie, trie_types::TrieDB};
+use sp_runtime::RuntimeDebug;
 
 // use crate::Error;
 
@@ -67,6 +68,7 @@ impl<H> StorageProofChecker<H>
 	}
 }
 
+#[derive(RuntimeDebug, PartialEq)]
 pub enum Error {
 	StorageRootMismatch,
 	StorageValueUnavailable,


### PR DESCRIPTION
I've rebased the `hc-jp-bridge-module` branch onto `master` from last week-ish, and now in this PR I've make some changes to make the pallet compile. The two main things are using the new `decl_error!` changes introduced by Basti, and updating dependencies to use their 2.0.0 versions.
