### PR TITLE
ci: increase retention for logs of tests to 144 hours

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,7 @@ test-linux-stable:                 &test-linux
     - awk '/^warning:/,/^$/ { print }' output.log > ${CI_COMMIT_SHORT_SHA}_warnings.log
   artifacts:
     name:                          $CI_COMMIT_SHORT_SHA
-    expire_in:                     24 hrs
+    expire_in:                     144 hrs
     paths:
       - ${CI_COMMIT_SHORT_SHA}_warnings.log
 
@@ -210,7 +210,7 @@ test-linux-stable-int:
   artifacts:
     name:                          $CI_COMMIT_SHORT_SHA
     when:                          on_failure
-    expire_in:                     24 hrs
+    expire_in:                     144 hrs
     paths:
       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,7 @@ test-linux-stable:                 &test-linux
     - awk '/^warning:/,/^$/ { print }' output.log > ${CI_COMMIT_SHORT_SHA}_warnings.log
   artifacts:
     name:                          $CI_COMMIT_SHORT_SHA
-    expire_in:                     144 hrs
+    expire_in:                     3 days
     paths:
       - ${CI_COMMIT_SHORT_SHA}_warnings.log
 
@@ -210,7 +210,7 @@ test-linux-stable-int:
   artifacts:
     name:                          $CI_COMMIT_SHORT_SHA
     when:                          on_failure
-    expire_in:                     144 hrs
+    expire_in:                     3 days
     paths:
       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 


### PR DESCRIPTION
increase test log file retention to 144h

cannot debug https://gitlab.parity.io/parity/substrate/-/jobs/356316/artifacts/file/cc589213_int_failure.log anymore