### PR TITLE
Move DummySpecialization to sc-network

### DIFF
--- a/client/network/src/protocol/specialization.rs
+++ b/client/network/src/protocol/specialization.rs
@@ -57,6 +57,32 @@ pub trait NetworkSpecialization<B: BlockT>: Send + Sync + 'static {
 	fn on_block_imported(&mut self, _ctx: &mut dyn Context<B>, _hash: B::Hash, _header: &B::Header) { }
 }
 
+/// A specialization that does nothing.
+#[derive(Clone)]
+pub struct DummySpecialization;
+
+impl<B: BlockT> NetworkSpecialization<B> for DummySpecialization {
+	fn status(&self) -> Vec<u8> {
+		vec![]
+	}
+
+	fn on_connect(
+		&mut self,
+		_ctx: &mut dyn Context<B>,
+		_peer_id: PeerId,
+		_status: crate::message::Status<B>
+	) {}
+
+	fn on_disconnect(&mut self, _ctx: &mut dyn Context<B>, _peer_id: PeerId) {}
+
+	fn on_message(
+		&mut self,
+		_ctx: &mut dyn Context<B>,
+		_peer_id: PeerId,
+		_message: Vec<u8>,
+	) {}
+}
+
 /// Construct a simple protocol that is composed of several sub protocols.
 /// Each "sub protocol" needs to implement `Specialization` and needs to provide a `new()` function.
 /// For more fine grained implementations, this macro is not usable.

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -62,6 +62,7 @@ use substrate_test_runtime_client::{self, AccountKeyring};
 
 pub use substrate_test_runtime_client::runtime::{Block, Extrinsic, Hash, Transfer};
 pub use substrate_test_runtime_client::{TestClient, TestClientBuilder, TestClientBuilderExt};
+pub use sc_network::specialization::DummySpecialization;
 
 type AuthorityId = sp_consensus_babe::AuthorityId;
 
@@ -99,32 +100,6 @@ impl<B: BlockT> Verifier<B> for PassThroughVerifier {
 			import_existing: false,
 		}, maybe_keys))
 	}
-}
-
-/// The test specialization.
-#[derive(Clone)]
-pub struct DummySpecialization;
-
-impl NetworkSpecialization<Block> for DummySpecialization {
-	fn status(&self) -> Vec<u8> {
-		vec![]
-	}
-
-	fn on_connect(
-		&mut self,
-		_ctx: &mut dyn Context<Block>,
-		_peer_id: PeerId,
-		_status: sc_network::message::Status<Block>
-	) {}
-
-	fn on_disconnect(&mut self, _ctx: &mut dyn Context<Block>, _peer_id: PeerId) {}
-
-	fn on_message(
-		&mut self,
-		_ctx: &mut dyn Context<Block>,
-		_peer_id: PeerId,
-		_message: Vec<u8>,
-	) {}
 }
 
 pub type PeersFullClient =


### PR DESCRIPTION
Right now it is defined in `sc-network-test`, but I need to use it for tests within `sc-network`. We can avoid a dependency loop by moving it to `sc-network`.

cc'ing @rphmeier because there might be a conflict with #4665 