### PR TITLE
Make debug builds more usable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6973,7 +6973,7 @@ version = "2.0.0"
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "build-helper 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bin/node-template/runtime/build.rs
+++ b/bin/node-template/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::{build_current_project_with_rustflags, WasmBuilderSourc
 fn main() {
 	build_current_project_with_rustflags(
 		"wasm_binary.rs",
-		WasmBuilderSource::Crates("1.0.8"),
+		WasmBuilderSource::Crates("1.0.9"),
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.
 		"-Clink-arg=--export=__heap_base",

--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -140,7 +140,12 @@ pub fn run<I, T, E>(args: I, exit: E, version: sc_cli::VersionInfo) -> error::Re
 				&version,
 				None,
 			)?;
-			sc_cli::fill_import_params(&mut config, &cli_args.import_params, ServiceRoles::FULL)?;
+			sc_cli::fill_import_params(
+				&mut config,
+				&cli_args.import_params,
+				ServiceRoles::FULL,
+				cli_args.shared_params.dev,
+			)?;
 
 			match ChainSpec::from(config.chain_spec.id()) {
 				Some(ref c) if c == &ChainSpec::Development || c == &ChainSpec::LocalTestnet => {},

--- a/bin/node/runtime/build.rs
+++ b/bin/node/runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../../utils/wasm-builder",
-			version: "1.0.8",
+			version: "1.0.9",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/client/cli/src/execution_strategy.rs
+++ b/client/cli/src/execution_strategy.rs
@@ -33,6 +33,18 @@ arg_enum! {
 	}
 }
 
+impl ExecutionStrategy {
+	/// Returns the variant as `'&static str`.
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::Native => "Native",
+			Self::Wasm => "Wasm",
+			Self::Both => "Both",
+			Self::NativeElseWasm => "NativeElseWasm",
+		}
+	}
+}
+
 /// Default value for the `--execution-syncing` parameter.
 pub const DEFAULT_EXECUTION_SYNCING: ExecutionStrategy = ExecutionStrategy::NativeElseWasm;
 /// Default value for the `--execution-import-block` parameter.

--- a/client/cli/src/execution_strategy.rs
+++ b/client/cli/src/execution_strategy.rs
@@ -20,7 +20,7 @@ use structopt::clap::arg_enum;
 
 arg_enum! {
 	/// How to execute blocks
-	#[derive(Debug, Clone, Copy)]
+	#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 	pub enum ExecutionStrategy {
 		// Execute with native build (if available, WebAssembly otherwise).
 		Native,
@@ -33,3 +33,13 @@ arg_enum! {
 	}
 }
 
+/// Default value for the `--execution-syncing` parameter.
+pub const DEFAULT_EXECUTION_SYNCING: ExecutionStrategy = ExecutionStrategy::NativeElseWasm;
+/// Default value for the `--execution-import-block` parameter.
+pub const DEFAULT_EXECUTION_IMPORT_BLOCK: ExecutionStrategy = ExecutionStrategy::NativeElseWasm;
+/// Default value for the `--execution-block-construction` parameter.
+pub const DEFAULT_EXECUTION_BLOCK_CONSTRUCTION: ExecutionStrategy = ExecutionStrategy::Wasm;
+/// Default value for the `--execution-offchain-worker` parameter.
+pub const DEFAULT_EXECUTION_OFFCHAIN_WORKER: ExecutionStrategy = ExecutionStrategy::Native;
+/// Default value for the `--execution-other` parameter.
+pub const DEFAULT_EXECUTION_OTHER: ExecutionStrategy = ExecutionStrategy::Native;

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -956,11 +956,11 @@ pub fn fill_import_params<C, G, E>(
 
 	let exec = &cli.execution_strategies;
 	let exec_all_or = |strat: ExecutionStrategy, default: ExecutionStrategy| {
-		if strat == default && is_dev {
-			exec.execution.unwrap_or(ExecutionStrategy::Native)
+		exec.execution.unwrap_or(if strat == default && is_dev {
+			ExecutionStrategy::Native
 		} else {
-			exec.execution.unwrap_or(strat)
-		}.into()
+			strat
+		}).into()
 	};
 
 	config.execution_strategies = ExecutionStrategies {

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -18,6 +18,7 @@ use crate::traits::GetSharedParams;
 
 use std::{str::FromStr, path::PathBuf};
 use structopt::{StructOpt, StructOptInternal, clap::{arg_enum, App, AppSettings, SubCommand, Arg}};
+use crate::execution_strategy::*;
 
 pub use crate::execution_strategy::ExecutionStrategy;
 
@@ -321,7 +322,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "NativeElseWasm"
+		default_value = "DEFAULT_EXECUTION_SYNCING"
 	)]
 	pub execution_syncing: ExecutionStrategy,
 
@@ -331,7 +332,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "NativeElseWasm"
+		default_value = "DEFAULT_EXECUTION_IMPORT_BLOCK"
 	)]
 	pub execution_import_block: ExecutionStrategy,
 
@@ -341,7 +342,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "Wasm"
+		default_value = "DEFAULT_EXECUTION_BLOCK_CONSTRUCTION"
 	)]
 	pub execution_block_construction: ExecutionStrategy,
 
@@ -351,7 +352,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "Native"
+		default_value = "DEFAULT_EXECUTION_OFFCHAIN_WORKER"
 	)]
 	pub execution_offchain_worker: ExecutionStrategy,
 
@@ -361,7 +362,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "Native"
+		default_value = "DEFAULT_EXECUTION_OTHER"
 	)]
 	pub execution_other: ExecutionStrategy,
 

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -322,7 +322,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "DEFAULT_EXECUTION_SYNCING"
+		default_value = DEFAULT_EXECUTION_SYNCING.as_str(),
 	)]
 	pub execution_syncing: ExecutionStrategy,
 
@@ -332,7 +332,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "DEFAULT_EXECUTION_IMPORT_BLOCK"
+		default_value = DEFAULT_EXECUTION_IMPORT_BLOCK.as_str(),
 	)]
 	pub execution_import_block: ExecutionStrategy,
 
@@ -342,7 +342,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "DEFAULT_EXECUTION_BLOCK_CONSTRUCTION"
+		default_value = DEFAULT_EXECUTION_BLOCK_CONSTRUCTION.as_str(),
 	)]
 	pub execution_block_construction: ExecutionStrategy,
 
@@ -352,7 +352,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "DEFAULT_EXECUTION_OFFCHAIN_WORKER"
+		default_value = DEFAULT_EXECUTION_OFFCHAIN_WORKER.as_str(),
 	)]
 	pub execution_offchain_worker: ExecutionStrategy,
 
@@ -362,7 +362,7 @@ pub struct ExecutionStrategies {
 		value_name = "STRATEGY",
 		possible_values = &ExecutionStrategy::variants(),
 		case_insensitive = true,
-		default_value = "DEFAULT_EXECUTION_OTHER"
+		default_value = DEFAULT_EXECUTION_OTHER.as_str(),
 	)]
 	pub execution_other: ExecutionStrategy,
 

--- a/client/executor/runtime-test/build.rs
+++ b/client/executor/runtime-test/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../../utils/wasm-builder",
-			version: "1.0.8",
+			version: "1.0.9",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/primitives/runtime-interface/test-wasm/build.rs
+++ b/primitives/runtime-interface/test-wasm/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../../utils/wasm-builder",
-			version: "1.0.6",
+			version: "1.0.9",
 		},
 		// This instructs LLD to export __heap_base as a global variable, which is used by the
 		// external memory allocator.

--- a/test-utils/runtime/build.rs
+++ b/test-utils/runtime/build.rs
@@ -21,7 +21,7 @@ fn main() {
 		"wasm_binary.rs",
 		WasmBuilderSource::CratesOrPath {
 			path: "../../utils/wasm-builder",
-			version: "1.0.8",
+			version: "1.0.9",
 		},
 		// Note that we set the stack-size to 1MB explicitly even though it is set
 		// to this value by default. This is because some of our tests (`restoration_of_globals`)

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -357,7 +357,7 @@ fn is_release_build() -> bool {
 			),
 		}
 	} else {
-		!build_helper::debug()
+		true
 	}
 }
 


### PR DESCRIPTION
This pr makes debug builds more usable in terms of `cargo run -- --dev`.

1. `--dev` activates `--execution native`, iff `--execution` is not
given or no sub `--execution-*` is given.
2. It was probably a mistake to compile WASM in debug for a debug build.
So, we now build the WASM binary always as `release` (if not requested
differently by the user). So, we trade compilation time for a better
debug experience.

