### PR TITLE
client/finality-grandpa/communication: Add doc comment for PeerReport

### DIFF
--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -1445,6 +1445,7 @@ impl<Block: BlockT> sc_network_gossip::Validator<Block> for GossipValidator<Bloc
 	}
 }
 
+/// Report specifying a reputation change for a given peer.
 pub(super) struct PeerReport {
 	pub who: PeerId,
 	pub cost_benefit: ReputationChange,


### PR DESCRIPTION
Applying review suggestion from https://github.com/paritytech/substrate/pull/4661/files#r368046058.

@rphmeier I think the members of the struct are self-explanatory. Let me know if you still want them documented.