### PR TITLE
contracts: New contract events + unconfusions

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -782,7 +782,7 @@ where
 	fn deposit_event(&mut self, topics: Vec<T::Hash>, data: Vec<u8>) {
 		self.ctx.deferred.push(DeferredAction::DepositEvent {
 			topics,
-			event: RawEvent::Contract(self.ctx.self_account.clone(), data),
+			event: RawEvent::ContractExecution(self.ctx.self_account.clone(), data),
 		});
 	}
 

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -356,15 +356,7 @@ where
 		// Assumption: pay_rent doesn't collide with overlay because
 		// pay_rent will be done on first call and dest contract and balance
 		// cannot be changed before the first call
-		let (rent_outcome, contract_info) = rent::pay_rent::<T>(&dest);
-
-		// Deposit an event to indicate contract eviction.
-		if rent_outcome == rent::RentOutcome::Evicted {
-			self.deferred.push(DeferredAction::DepositEvent {
-				event: RawEvent::Evicted(dest.clone()),
-				topics: Vec::new(),
-			});
-		}
+		let contract_info = rent::pay_rent::<T>(&dest);
 
 		// Calls to dead contracts always fail.
 		if let Some(ContractInfo::Tombstone(_)) = contract_info {

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -906,8 +906,8 @@ decl_event! {
 		/// successful execution or not.
 		Dispatched(AccountId, bool),
 
-		/// An event from contract of account.
-		Contract(AccountId, Vec<u8>),
+		/// An event deposited upon execution of a contract from the account.
+		ContractExecution(AccountId, Vec<u8>),
 	}
 }
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -905,9 +905,7 @@ decl_event! {
 		/// Contract has been evicted and is now in tombstone state.
 		Evicted(AccountId),
 
-		/// Contract has successfully been restored from tombstone state to a
-		/// ctive.
-		///
+		/// Restoration for a contract has been initiated.
 		///
 		/// # Params
 		///

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -671,7 +671,6 @@ decl_module! {
 			// If poking the contract has lead to eviction of the contract, give out the rewards.
 			if rent::try_evict::<T>(&dest, handicap) == rent::RentOutcome::Evicted {
 				T::Currency::deposit_into_existing(&rewarded, T::SurchargeReward::get())?;
-				Self::deposit_event(RawEvent::Evicted(dest));
 			}
 		}
 
@@ -903,7 +902,12 @@ decl_event! {
 		Instantiated(AccountId, AccountId),
 
 		/// Contract has been evicted and is now in tombstone state.
-		Evicted(AccountId),
+		///
+		/// # Params
+		///
+		/// - `contract`: `AccountId`: The account ID of the evicted contract.
+		/// - `tombstone`: `bool`: True if the evicted contract left behind a tombstone.
+		Evicted(AccountId, bool),
 
 		/// Restoration for a contract has been initiated.
 		///

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{BalanceOf, ContractInfo, ContractInfoOf, TombstoneContractInfo, Trait, AliveContractInfo};
+use crate::{Module, RawEvent, BalanceOf, ContractInfo, ContractInfoOf, TombstoneContractInfo,
+	Trait, AliveContractInfo};
 use sp_runtime::traits::{Bounded, CheckedDiv, CheckedMul, Saturating, Zero,
 	SaturatedConversion};
 use frame_support::traits::{Currency, ExistenceRequirement, Get, WithdrawReason, OnUnbalanced};
@@ -101,6 +102,7 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 		// The contract cannot afford to leave a tombstone, so remove the contract info altogether.
 		<ContractInfoOf<T>>::remove(account);
 		child::kill_storage(&contract.trie_id, contract.child_trie_unique_id());
+		<Module<T>>::deposit_event(RawEvent::Evicted(account.clone(), false));
 		return (RentOutcome::Evicted, None);
 	}
 
@@ -160,6 +162,8 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 
 		child::kill_storage(&contract.trie_id, contract.child_trie_unique_id());
 
+		<Module<T>>::deposit_event(RawEvent::Evicted(account.clone(), true));
+
 		return (RentOutcome::Evicted, Some(tombstone_info));
 	}
 
@@ -181,8 +185,8 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 /// Make account paying the rent for the current block number
 ///
 /// NOTE: This function acts eagerly.
-pub fn pay_rent<T: Trait>(account: &T::AccountId) -> (RentOutcome, Option<ContractInfo<T>>) {
-	try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true)
+pub fn pay_rent<T: Trait>(account: &T::AccountId) -> Option<ContractInfo<T>> {
+	try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true).1
 }
 
 /// Evict the account if it should be evicted at the given block number.

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -181,8 +181,8 @@ fn try_evict_or_and_pay_rent<T: Trait>(
 /// Make account paying the rent for the current block number
 ///
 /// NOTE: This function acts eagerly.
-pub fn pay_rent<T: Trait>(account: &T::AccountId) -> Option<ContractInfo<T>> {
-	try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true).1
+pub fn pay_rent<T: Trait>(account: &T::AccountId) -> (RentOutcome, Option<ContractInfo<T>>) {
+	try_evict_or_and_pay_rent::<T>(account, Zero::zero(), true)
 }
 
 /// Evict the account if it should be evicted at the given block number.

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1143,7 +1143,7 @@ fn call_removed_contract() {
 		assert_eq!(System::events(), vec![
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
-				event: MetaEvent::contract(RawEvent::Evicted(BOB)),
+				event: MetaEvent::contract(RawEvent::Evicted(BOB, true)),
 				topics: vec![],
 			},
 		]);
@@ -1389,7 +1389,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
 				event: MetaEvent::contract(
-					RawEvent::Evicted(BOB.clone())
+					RawEvent::Evicted(BOB.clone(), true)
 				),
 				topics: vec![],
 			},
@@ -1452,7 +1452,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 					assert_eq!(System::events(), vec![
 						EventRecord {
 							phase: Phase::ApplyExtrinsic(0),
-							event: MetaEvent::contract(RawEvent::Evicted(BOB)),
+							event: MetaEvent::contract(RawEvent::Evicted(BOB, true)),
 							topics: vec![],
 						},
 						EventRecord {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1139,8 +1139,16 @@ fn call_removed_contract() {
 			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
 			"contract has been evicted"
 		);
+		// Calling a contract that is about to evict shall emit an event.
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(RawEvent::Evicted(BOB)),
+				topics: vec![],
+			},
+		]);
 
- 		// Subsequent contract calls should also fail.
+		// Subsequent contract calls should also fail.
 		assert_err!(
 			Contract::call(Origin::signed(ALICE), BOB, 0, 100_000, call::null()),
 			"contract has been evicted"
@@ -1367,6 +1375,9 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 		// Advance 4 blocks, to the 5th.
 		initialize_block(5);
 
+		/// Preserve `BOB`'s code hash for later introspection.
+		let bob_code_hash = ContractInfoOf::<Test>::get(BOB).unwrap()
+			.get_alive().unwrap().code_hash;
 		// Call `BOB`, which makes it pay rent. Since the rent allowance is set to 0
 		// we expect that it will get removed leaving tombstone.
 		assert_err!(
@@ -1374,6 +1385,15 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			"contract has been evicted"
 		);
 		assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
+		assert_eq!(System::events(), vec![
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: MetaEvent::contract(
+					RawEvent::Evicted(BOB.clone())
+				),
+				topics: vec![],
+			},
+		]);
 
 		/// Create another account with the address `DJANGO` with `CODE_RESTORATION`.
 		///
@@ -1416,6 +1436,60 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			assert_eq!(django_contract.storage_size, 16);
 			assert_eq!(django_contract.trie_id, django_trie_id);
 			assert_eq!(django_contract.deduct_block, System::block_number());
+			match (test_different_storage, test_restore_to_with_dirty_storage) {
+				(true, false) => {
+					assert_eq!(System::events(), vec![
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::contract(
+								RawEvent::Restored(DJANGO, BOB, bob_code_hash, 50, false)
+							),
+							topics: vec![],
+						},
+					]);
+				}
+				(_, true) => {
+					assert_eq!(System::events(), vec![
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::contract(RawEvent::Evicted(BOB)),
+							topics: vec![],
+						},
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::balances(pallet_balances::RawEvent::NewAccount(CHARLIE, 1_000_000)),
+							topics: vec![],
+						},
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::balances(pallet_balances::RawEvent::NewAccount(DJANGO, 30_000)),
+							topics: vec![],
+						},
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::contract(RawEvent::Transfer(CHARLIE, DJANGO, 30_000)),
+							topics: vec![],
+						},
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::contract(RawEvent::Instantiated(CHARLIE, DJANGO)),
+							topics: vec![],
+						},
+						EventRecord {
+							phase: Phase::ApplyExtrinsic(0),
+							event: MetaEvent::contract(RawEvent::Restored(
+								DJANGO,
+								BOB,
+								bob_code_hash,
+								50,
+								false,
+							)),
+							topics: vec![],
+						},
+					]);
+				}
+				_ => unreachable!(),
+			}
 		} else {
 			// Here we expect that the restoration is succeeded. Check that the restoration
 			// contract `DJANGO` ceased to exist and that `BOB` returned back.
@@ -1427,6 +1501,20 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			assert_eq!(bob_contract.trie_id, django_trie_id);
 			assert_eq!(bob_contract.deduct_block, System::block_number());
 			assert!(ContractInfoOf::<Test>::get(DJANGO).is_none());
+			assert_eq!(System::events(), vec![
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: MetaEvent::balances(balances::RawEvent::ReapedAccount(DJANGO, 0)),
+					topics: vec![],
+				},
+				EventRecord {
+					phase: Phase::ApplyExtrinsic(0),
+					event: MetaEvent::contract(
+						RawEvent::Restored(DJANGO, BOB, bob_contract.code_hash, 50, true)
+					),
+					topics: vec![],
+				},
+			]);
 		}
 	});
 }

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -453,7 +453,7 @@ fn instantiate_and_call_and_deposit_event() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
-				event: MetaEvent::contract(RawEvent::Contract(BOB, vec![1, 2, 3, 4])),
+				event: MetaEvent::contract(RawEvent::ContractExecution(BOB, vec![1, 2, 3, 4])),
 				topics: vec![],
 			},
 			EventRecord {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -650,7 +650,7 @@ fn dispatch_call_not_dispatched_after_top_level_transaction_failure() {
 				100_000,
 				vec![],
 			),
-			"during execution"
+			"contract trapped during execution"
 		);
 		assert_eq!(System::events(), vec![
 			EventRecord {
@@ -1533,7 +1533,7 @@ fn storage_max_value_limit() {
 				100_000,
 				Encode::encode(&(self::MaxValueSize::get() + 1)),
 			),
-			"during execution"
+			"contract trapped during execution"
 		);
 	});
 }
@@ -2056,7 +2056,7 @@ fn cannot_self_destruct_while_live() {
 				100_000,
 				vec![0],
 			),
-			"during execution"
+			"contract trapped during execution"
 		);
 
 		// Check that BOB is still alive.

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1430,7 +1430,9 @@ mod tests {
 				MockExt::default(),
 				&mut gas_meter
 			),
-			Err(ExecError { reason: DispatchError::Other("contract trapped during execution"), buffer: _ })
+			Err(ExecError {
+				reason: DispatchError::Other("contract trapped during execution"), buffer: _
+			})
 		);
 	}
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1430,7 +1430,7 @@ mod tests {
 				MockExt::default(),
 				&mut gas_meter
 			),
-			Err(ExecError { reason: DispatchError::Other("during execution"), buffer: _ })
+			Err(ExecError { reason: DispatchError::Other("contract trapped during execution"), buffer: _ })
 		);
 	}
 
@@ -1472,7 +1472,7 @@ mod tests {
 				MockExt::default(),
 				&mut gas_meter
 			),
-			Err(ExecError { reason: DispatchError::Other("during execution"), buffer: _ })
+			Err(ExecError { reason: DispatchError::Other("contract trapped during execution"), buffer: _ })
 		);
 	}
 

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -109,7 +109,7 @@ pub(crate) fn to_execution_result<E: Ext>(
 			Err(ExecError { reason: "validation error".into(), buffer: runtime.scratch_buf }),
 		// Any other kind of a trap should result in a failure.
 		Err(sp_sandbox::Error::Execution) | Err(sp_sandbox::Error::OutOfBounds) =>
-			Err(ExecError { reason: "during execution".into(), buffer: runtime.scratch_buf }),
+			Err(ExecError { reason: "contract trapped during execution".into(), buffer: runtime.scratch_buf }),
 	}
 }
 


### PR DESCRIPTION
Improves contracts PALLET by

- adds two new events: `Restored` and `Evicted`
    - `Event::Evicted(AccountId, bool)`
        1. `contract: AccountID`: The account ID of the evicted contract.
        1. `tombstone: bool`: True if the evicted contract left behind a tombstone.
    - `Event::Restored(AccountId, AccountId, Hash, Balance, bool)`
        1. `donor: AccountId`: The Account ID of the restoring contract
        1. `dest: AccountId`: The account ID of the restored contract
        1. `code_hash: Hash`: The code hash of the restored contract
        1. `rent_allowance: Balance`: The initial rent allowance of the restored contract
        1. `success: bool`: If restoration was successful
- rename `Event::Contract` to `Event::ContractExecution` so that it is clear that the event was triggered by a contract execution
- improving error message that have previously be shown to confuse users (`"during execution"`)