### PR TITLE
Make dummy crypto app-crypto-wrappable.

### DIFF
--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -37,6 +37,24 @@ pub use sp_std::{ops::Deref, vec::Vec};
 
 pub mod ed25519;
 pub mod sr25519;
+
+#[cfg(feature = "std")]
+/// A dummy cryptography, useful at most for tests
+/// that don't care about any particular crypto or even
+/// having multiple different public keys.
+/// The `Dummy` type is opaque, and the same non-parametrizable
+/// type represents public key, signature and the entire pair.
+/// All operations always succeed (i.e. sign, verify, etc).
+pub mod dummy {
+	use sp_core::crypto::Dummy;
+	/// Dummy opaque public key.
+	pub type Public = Dummy;
+	/// Dummy opaque signature.
+	pub type Signature = Dummy;
+	/// Dummy opaque key pair.
+	pub type Pair = Dummy;
+}
+
 mod traits;
 
 pub use traits::*;
@@ -431,4 +449,15 @@ macro_rules! wrap {
 			}
 		}
 	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{app_crypto, dummy, key_types};
+
+	#[test]
+	fn should_be_possible_to_wrap_dummy_crypto() {
+		app_crypto!(dummy, key_types::DUMMY);
+	}
+
 }

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -143,3 +143,27 @@ pub trait BoundToRuntimeAppPublic {
 	/// The `RuntimeAppPublic` this type is bound to.
 	type Public: RuntimeAppPublic;
 }
+
+#[cfg(feature = "full_crypto")]
+use sp_core::crypto::Dummy;
+
+#[cfg(feature = "full_crypto")]
+impl RuntimePublic for Dummy {
+	type Signature = Self;
+
+	fn all(_key_type: KeyTypeId) -> Vec<Self> {
+		vec![Dummy]
+	}
+
+	fn generate_pair(_key_type: KeyTypeId, _seed: Option<Vec<u8>>) -> Self {
+		Dummy
+	}
+
+	fn sign<M: AsRef<[u8]>>(&self, _key_type: KeyTypeId, msg: &M) -> Option<Self::Signature> {
+		Some(Pair::sign(self, msg.as_ref()))
+	}
+
+	fn verify<M: AsRef<[u8]>>(&self, msg: &M, signature: &Self::Signature) -> bool {
+		<Dummy as Pair>::verify(signature, msg, self)
+	}
+}

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -144,10 +144,10 @@ pub trait BoundToRuntimeAppPublic {
 	type Public: RuntimeAppPublic;
 }
 
-#[cfg(feature = "full_crypto")]
+#[cfg(feature = "std")]
 use sp_core::crypto::Dummy;
 
-#[cfg(feature = "full_crypto")]
+#[cfg(feature = "std")]
 impl RuntimePublic for Dummy {
 	type Signature = Self;
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -632,8 +632,14 @@ mod dummy {
 	use super::*;
 
 	/// Dummy cryptography. Doesn't do anything.
-	#[derive(Clone, Hash, Default, Eq, PartialEq)]
+	#[derive(Clone, Hash, Default, Eq, PartialEq, Encode, Decode, Debug, Ord, PartialOrd)]
 	pub struct Dummy;
+
+	impl std::fmt::Display for Dummy {
+		fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+			write!(fmt, "{:?}", self)
+		}
+	}
 
 	impl AsRef<[u8]> for Dummy {
 		fn as_ref(&self) -> &[u8] { &b""[..] }

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -73,6 +73,12 @@ impl IdentifyAccount for sp_core::ecdsa::Public {
 	fn into_account(self) -> Self { self }
 }
 
+#[cfg(feature = "std")]
+impl IdentifyAccount for sp_core::crypto::Dummy {
+	type AccountId = Self;
+	fn into_account(self) -> Self { self }
+}
+
 /// Means of signature verification.
 pub trait Verify {
 	/// Type of the signer.


### PR DESCRIPTION
Expose `dummy` crypto for runtime use as well, and allow it to be wrapped by `app_crypto!` macro.
This makes it possible to use it for tests where we pass mocks.

Mostly useful in cases where we don't really care about particular accounts, and only want some kind of crypto to instantiate properly `system::offchain` extensions (like `CreateTransaction` test).

Marking as a draft, until we figure out if it solves all the issues when writing tests for offchain workers that submit signed transactions.