### PR TITLE
Pass an executor through the Configuration

### DIFF
--- a/bin/node-template/src/cli.rs
+++ b/bin/node-template/src/cli.rs
@@ -18,7 +18,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 	type Config<T> = Configuration<(), T>;
 	match parse_and_prepare::<NoCustom, NoCustom, _>(&version, "substrate-node", args) {
 		ParseAndPrepare::Run(cmd) => cmd.run(load_spec, exit,
-		|exit, _cli_args, _custom_args, config: Config<_>| {
+		|exit, _cli_args, _custom_args, mut config: Config<_>| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by {}, 2017, 2018", version.author);
@@ -26,6 +26,10 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 			info!("Node name: {}", config.name);
 			info!("Roles: {}", display_role(&config));
 			let runtime = Runtime::new().map_err(|e| format!("{:?}", e))?;
+			config.tasks_executor = {
+				let runtime_handle = runtime.handle().clone();
+				Some(Box::new(move |fut| { runtime_handle.spawn(fut); }))
+			};
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,

--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -98,7 +98,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: sc_cli::VersionInfo) -> error::Re
 
 	match parse_and_prepare::<CustomSubcommands, NoCustom, _>(&version, "substrate-node", args) {
 		ParseAndPrepare::Run(cmd) => cmd.run(load_spec, exit,
-		|exit, _cli_args, _custom_args, config: Config<_, _>| {
+		|exit, _cli_args, _custom_args, mut config: Config<_, _>| {
 			info!("{}", version.name);
 			info!("  version {}", config.full_version());
 			info!("  by Parity Technologies, 2017-2019");
@@ -110,6 +110,10 @@ pub fn run<I, T, E>(args: I, exit: E, version: sc_cli::VersionInfo) -> error::Re
 				.threaded_scheduler()
 				.build()
 				.map_err(|e| format!("{:?}", e))?;
+			config.tasks_executor = {
+				let runtime_handle = runtime.handle().clone();
+				Some(Box::new(move |fut| { runtime_handle.spawn(fut); }))
+			};
 			match config.roles {
 				ServiceRoles::LIGHT => run_until_exit(
 					runtime,

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -30,7 +30,6 @@ use sp_consensus::import_queue::ImportQueue;
 use futures::{
 	Future, FutureExt, StreamExt,
 	channel::mpsc,
-	executor::ThreadPoolBuilder,
 	future::{select, ready}
 };
 use sc_keystore::{Store as Keystore};
@@ -1149,15 +1148,10 @@ ServiceBuilder<
 			to_spawn_tx,
 			to_spawn_rx,
 			tasks_executor: if let Some(exec) = config.tasks_executor {
-				Some(exec)
+				exec
 			} else {
-				ThreadPoolBuilder::new()
-					.name_prefix("main-task-")
-					.create()
-					.ok()
-					.map(|tp| Box::new(move |fut| tp.spawn_ok(fut)) as Box<_>)
+				return Err(Error::TasksExecutorRequired);
 			},
-			to_poll: Vec::new(),
 			rpc_handlers,
 			_rpc: rpc,
 			_telemetry: telemetry,

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -38,8 +38,7 @@ pub struct Configuration<C, G, E = NoExtension> {
 	pub impl_commit: &'static str,
 	/// Node roles.
 	pub roles: Roles,
-	/// How to spawn background tasks.
-	/// If `None`, will try to use a threads pool.
+	/// How to spawn background tasks. Mandatory, otherwise creating a `Service` will error.
 	pub tasks_executor: Option<Box<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>>,
 	/// Extrinsic pool configuration.
 	pub transaction_pool: TransactionPoolOptions,

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -21,7 +21,7 @@ pub use sc_client_db::{kvdb::KeyValueDB, PruningMode};
 pub use sc_network::config::{ExtTransport, NetworkConfiguration, Roles};
 pub use sc_executor::WasmExecutionMethod;
 
-use std::{path::{PathBuf, Path}, net::SocketAddr, sync::Arc};
+use std::{future::Future, path::{PathBuf, Path}, pin::Pin, net::SocketAddr, sync::Arc};
 pub use sc_transaction_pool::txpool::Options as TransactionPoolOptions;
 use sc_chain_spec::{ChainSpec, RuntimeGenesis, Extension, NoExtension};
 use sp_core::crypto::Protected;
@@ -29,7 +29,6 @@ use target_info::Target;
 use sc_telemetry::TelemetryEndpoints;
 
 /// Service configuration.
-#[derive(Clone)]
 pub struct Configuration<C, G, E = NoExtension> {
 	/// Implementation name
 	pub impl_name: &'static str,
@@ -39,6 +38,9 @@ pub struct Configuration<C, G, E = NoExtension> {
 	pub impl_commit: &'static str,
 	/// Node roles.
 	pub roles: Roles,
+	/// How to spawn background tasks.
+	/// If `None`, will try to use a threads pool.
+	pub tasks_executor: Option<Box<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>>,
 	/// Extrinsic pool configuration.
 	pub transaction_pool: TransactionPoolOptions,
 	/// Network configuration.
@@ -160,6 +162,7 @@ impl<C, G, E> Configuration<C, G, E> where
 			config_dir: config_dir.clone(),
 			name: Default::default(),
 			roles: Roles::FULL,
+			tasks_executor: None,
 			transaction_pool: Default::default(),
 			network: Default::default(),
 			keystore: KeystoreConfig::None,

--- a/client/service/src/error.rs
+++ b/client/service/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
 	/// Best chain selection strategy is missing.
 	#[display(fmt="Best chain selection strategy (SelectChain) is not provided.")]
 	SelectChainRequired,
+	/// Tasks executor is missing.
+	#[display(fmt="Tasks executor hasn't been provided.")]
+	TasksExecutorRequired,
 	/// Other error.
 	Other(String),
 }

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -38,7 +38,7 @@ use parking_lot::Mutex;
 use sc_client::Client;
 use exit_future::Signal;
 use futures::{
-	Future, FutureExt, Stream, StreamExt, TryFutureExt,
+	Future, FutureExt, Stream, StreamExt,
 	future::select, channel::mpsc,
 	compat::*,
 	sink::SinkExt,
@@ -96,11 +96,7 @@ pub struct Service<TBl, TCl, TSc, TNetStatus, TNet, TTxPool, TOc> {
 	/// Receiver for futures that must be spawned as background tasks.
 	to_spawn_rx: mpsc::UnboundedReceiver<Pin<Box<dyn Future<Output = ()> + Send>>>,
 	/// How to spawn background tasks.
-	tasks_executor: Option<Box<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>>,
-	/// List of futures to poll from `poll`.
-	/// If spawning a background task is not possible, we instead push the task into this `Vec`.
-	/// The elements must then be polled manually.
-	to_poll: Vec<Pin<Box<dyn Future<Output = ()> + Send>>>,
+	tasks_executor: Box<dyn Fn(Pin<Box<dyn Future<Output = ()> + Send>>) + Send>,
 	rpc_handlers: sc_rpc_server::RpcHandler<sc_rpc::Metadata>,
 	_rpc: Box<dyn std::any::Any + Send + Sync>,
 	_telemetry: Option<sc_telemetry::Telemetry>,
@@ -324,16 +320,7 @@ impl<TBl: Unpin, TCl, TSc: Unpin, TNetStatus, TNet, TTxPool, TOc> Future for
 		}
 
 		while let Poll::Ready(Some(task_to_spawn)) = Pin::new(&mut this.to_spawn_rx).poll_next(cx) {
-			if let Some(tasks_executor) = this.tasks_executor.as_ref() {
-				tasks_executor(task_to_spawn);
-			} else {
-				this.to_poll.push(Box::pin(task_to_spawn.map(drop)));
-			}
-		}
-
-		// Polling all the `to_poll` futures.
-		while let Some(pos) = this.to_poll.iter_mut().position(|t| Pin::new(t).poll(cx).is_ready()) {
-			let _ = this.to_poll.remove(pos);
+			(this.tasks_executor)(task_to_spawn);
 		}
 
 		// The service future never ends.

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -19,9 +19,11 @@
 use std::iter;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::net::Ipv4Addr;
+use std::pin::Pin;
 use std::time::Duration;
 use log::info;
 use futures01::{Future, Stream, Poll};
+use futures::{FutureExt as _, TryFutureExt as _};
 use tempfile::TempDir;
 use tokio::{runtime::Runtime, prelude::FutureExt};
 use tokio::timer::Interval;
@@ -131,6 +133,7 @@ fn node_config<G, E: Clone> (
 	index: usize,
 	spec: &ChainSpec<G, E>,
 	role: Roles,
+	tasks_executor: Box<dyn Fn(Pin<Box<dyn futures::Future<Output = ()> + Send>>) + Send>,
 	key_seed: Option<String>,
 	base_port: u16,
 	root: &TempDir,
@@ -172,7 +175,7 @@ fn node_config<G, E: Clone> (
 		impl_version: "0.1",
 		impl_commit: "",
 		roles: role,
-		tasks_executor: None,
+		tasks_executor: Some(tasks_executor),
 		transaction_pool: Default::default(),
 		network: network_config,
 		keystore: KeystoreConfig::Path {
@@ -252,10 +255,15 @@ impl<G, E, F, L, U> TestNet<G, E, F, L, U> where
 		let executor = self.runtime.executor();
 
 		for (key, authority) in authorities {
+			let tasks_executor = {
+				let executor = executor.clone();
+				Box::new(move |fut: Pin<Box<dyn futures::Future<Output = ()> + Send>>| executor.spawn(fut.unit_error().compat()))
+			};
 			let node_config = node_config(
 				self.nodes,
 				&self.chain_spec,
 				Roles::AUTHORITY,
+				tasks_executor,
 				Some(key),
 				self.base_port,
 				&temp,
@@ -271,7 +279,11 @@ impl<G, E, F, L, U> TestNet<G, E, F, L, U> where
 		}
 
 		for full in full {
-			let node_config = node_config(self.nodes, &self.chain_spec, Roles::FULL, None, self.base_port, &temp);
+			let tasks_executor = {
+				let executor = executor.clone();
+				Box::new(move |fut: Pin<Box<dyn futures::Future<Output = ()> + Send>>| executor.spawn(fut.unit_error().compat()))
+			};
+			let node_config = node_config(self.nodes, &self.chain_spec, Roles::FULL, tasks_executor, None, self.base_port, &temp);
 			let addr = node_config.network.listen_addresses.iter().next().unwrap().clone();
 			let (service, user_data) = full(node_config).expect("Error creating test node service");
 			let service = SyncService::from(service);
@@ -283,7 +295,11 @@ impl<G, E, F, L, U> TestNet<G, E, F, L, U> where
 		}
 
 		for light in light {
-			let node_config = node_config(self.nodes, &self.chain_spec, Roles::LIGHT, None, self.base_port, &temp);
+			let tasks_executor = {
+				let executor = executor.clone();
+				Box::new(move |fut: Pin<Box<dyn futures::Future<Output = ()> + Send>>| executor.spawn(fut.unit_error().compat()))
+			};
+			let node_config = node_config(self.nodes, &self.chain_spec, Roles::LIGHT, tasks_executor, None, self.base_port, &temp);
 			let addr = node_config.network.listen_addresses.iter().next().unwrap().clone();
 			let service = SyncService::from(light(node_config).expect("Error creating test node service"));
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -172,6 +172,7 @@ fn node_config<G, E: Clone> (
 		impl_version: "0.1",
 		impl_commit: "",
 		roles: role,
+		tasks_executor: None,
 		transaction_pool: Default::default(),
 		network: network_config,
 		keystore: KeystoreConfig::Path {

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -52,6 +52,9 @@ where
 		allow_private_ipv4: true,
 		enable_mdns: false,
 	};
+	config.tasks_executor = Some(Box::new(move |fut| {
+		wasm_bindgen_futures::spawn_local(fut)
+	}));
 	config.telemetry_external_transport = Some(transport);
 	config.roles = Roles::LIGHT;
 	config.name = format!("{} (Browser)", name);


### PR DESCRIPTION
Hopefully fixes the performance issues that Polkadot was having.

One issue that we have in master right now is that all the tasks go through this path:

- https://github.com/paritytech/substrate/blob/a90c72e6d7088d0473670bf74253c65791411589/client/service/src/lib.rs#L334
- https://github.com/paritytech/substrate/blob/a90c72e6d7088d0473670bf74253c65791411589/client/service/src/lib.rs#L339-L341

In other words, everything is single-threaded (except the networking).

In this PR, we now pass a "tasks executor" through the `Configuration` struct.
It is set up to be a tokio runtime, or the `spawn_local` function of `wasm_bindgen_futures`, ~~or a threads pool by default, or local polling if all else fails~~ EDIT: removed fallbacks after review.

**Important**: this executor is stored within the `Service`, and all the components of Substrate should then use the `Service` (through `spawn_task` or `spawn_task_handle` or `spawn_essential_task`) to create tasks.