### PR TITLE
Call enable_all() when building tokio runtime

### DIFF
--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -108,6 +108,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: sc_cli::VersionInfo) -> error::Re
 			let runtime = RuntimeBuilder::new()
 				.thread_name("main-tokio-")
 				.threaded_scheduler()
+				.enable_all()
 				.build()
 				.map_err(|e| format!("{:?}", e))?;
 			match config.roles {


### PR DESCRIPTION
Otherwise using tokio sockets or timers will panic.
Note that this doesn't affect Polkadot of `node-template` because they do `Runtime::new` instead of using a `RuntimeBuilder`.