### PR TITLE
grandpa: reduce allocations when verifying multiple messages

### DIFF
--- a/client/finality-grandpa/src/justification.rs
+++ b/client/finality-grandpa/src/justification.rs
@@ -132,14 +132,16 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 			}
 		}
 
+		let mut buf = Vec::new();
 		let mut visited_hashes = HashSet::new();
 		for signed in self.commit.precommits.iter() {
-			if let Err(_) = communication::check_message_sig::<Block>(
+			if let Err(_) = communication::check_message_sig_with_buffer::<Block>(
 				&finality_grandpa::Message::Precommit(signed.precommit.clone()),
 				&signed.id,
 				&signed.signature,
 				self.round,
 				set_id,
+				&mut buf,
 			) {
 				return Err(ClientError::BadJustification(
 					"invalid signature for precommit in grandpa justification".to_string()).into());


### PR DESCRIPTION
GRANDPA messages are localized when encoded, to include the round and set id they refer to. This means that given a message and a signature there's an extra step of intermediary encoding needed to do the verification. This PR re-uses the buffer used for encoding when verifying multiple messages at once (i.e. commits, catch-up requests and justifications).

@arkpar reported that checking of compact commits was showing up on the profiler as performing a lot of allocations.