### PR TITLE
fixes trigger-contracts-ci job to actually depend on build-linux-subs…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,23 +108,23 @@ cargo-audit:
   allow_failure:                   true
 
 
-cargo-check-benches:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
-    - sccache -s
+# cargo-check-benches:
+#   stage:                           test
+#   <<:                              *docker-env
+#   script:
+#     - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
+#     - sccache -s
 
 
-cargo-check-subkey:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-  script:
-    - cd ./bin/utils/subkey
-    - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
-    - sccache -s
+# cargo-check-subkey:
+#   stage:                           test
+#   <<:                              *docker-env
+#   except:
+#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+#   script:
+#     - cd ./bin/utils/subkey
+#     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
+#     - sccache -s
 
 
 test-linux-stable:                 &test-linux
@@ -150,117 +150,117 @@ test-linux-stable:                 &test-linux
     paths:
       - ${CI_COMMIT_SHORT_SHA}_warnings.log
 
-test-dependency-rules:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - .maintain/ensure-deps.sh
+# test-dependency-rules:
+#   stage:                           test
+#   <<:                              *docker-env
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - .maintain/ensure-deps.sh
 
-test-frame-staking:
-  stage:                           test
-  <<:                              *docker-env
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: -Cdebug-assertions=y
-    RUST_BACKTRACE: 1
-  except:
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - cd frame/staking/
-    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features std
-    - sccache -s
+# test-frame-staking:
+#   stage:                           test
+#   <<:                              *docker-env
+#   variables:
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: -Cdebug-assertions=y
+#     RUST_BACKTRACE: 1
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - cd frame/staking/
+#     - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features std
+#     - sccache -s
 
-test-wasmtime:
-  stage:                           test
-  <<:                              *docker-env
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: -Cdebug-assertions=y
-    RUST_BACKTRACE: 1
-  except:
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - cd client/executor
-    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features wasmtime
-    - sccache -s
+# test-wasmtime:
+#   stage:                           test
+#   <<:                              *docker-env
+#   variables:
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: -Cdebug-assertions=y
+#     RUST_BACKTRACE: 1
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - cd client/executor
+#     - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features wasmtime
+#     - sccache -s
 
-test-linux-stable-int:
-  <<:                              *test-linux
-  except:
-    refs:
-      - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - echo "___Logs will be partly shown at the end in case of failure.___"
-    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
-    - WASM_BUILD_NO_COLOR=1 RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-        time cargo test -p node-cli --release --verbose --locked -- --ignored
-        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-    - sccache -s
-  after_script:
-    - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
-  artifacts:
-    name:                          $CI_COMMIT_SHORT_SHA
-    when:                          on_failure
-    expire_in:                     3 days
-    paths:
-      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
-
-
-check-web-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-  script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/substrate/issues/2416
-    - time cargo build --target=wasm32-unknown-unknown -p sp-io
-    - time cargo build --target=wasm32-unknown-unknown -p sp-runtime
-    - time cargo build --target=wasm32-unknown-unknown -p sp-std
-    - time cargo build --target=wasm32-unknown-unknown -p sc-client
-    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-aura
-    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-babe
-    - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
-    - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
-    # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
-    - time cargo build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features "browser" --target=wasm32-unknown-unknown
-    - sccache -s
-
-node-exits:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-  script:
-    - ./.maintain/check_for_exit.sh
+# test-linux-stable-int:
+#   <<:                              *test-linux
+#   except:
+#     refs:
+#       - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - echo "___Logs will be partly shown at the end in case of failure.___"
+#     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
+#     - WASM_BUILD_NO_COLOR=1 RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+#         time cargo test -p node-cli --release --verbose --locked -- --ignored
+#         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+#     - sccache -s
+#   after_script:
+#     - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
+#   artifacts:
+#     name:                          $CI_COMMIT_SHORT_SHA
+#     when:                          on_failure
+#     expire_in:                     3 days
+#     paths:
+#       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 
 
-test-full-crypto-feature:
-  stage:                           test
-  <<:                              *docker-env
-  variables:
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS: -Cdebug-assertions=y
-    RUST_BACKTRACE: 1
-  except:
-    variables:
-      - $DEPLOY_TAG
-  script:
-    - cd primitives/core/
-    - time cargo +nightly build --verbose --no-default-features --features full_crypto
-    - cd ../application-crypto
-    - time cargo +nightly build --verbose --no-default-features --features full_crypto
-    - sccache -s
+# check-web-wasm:
+#   stage:                           test
+#   <<:                              *docker-env
+#   except:
+#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+#   script:
+#     # WASM support is in progress. As more and more crates support WASM, we
+#     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
+#     - time cargo build --target=wasm32-unknown-unknown -p sp-io
+#     - time cargo build --target=wasm32-unknown-unknown -p sp-runtime
+#     - time cargo build --target=wasm32-unknown-unknown -p sp-std
+#     - time cargo build --target=wasm32-unknown-unknown -p sc-client
+#     - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-aura
+#     - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-babe
+#     - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
+#     - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
+#     # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
+#     - time cargo build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features "browser" --target=wasm32-unknown-unknown
+#     - sccache -s
+
+# node-exits:
+#   stage:                           test
+#   <<:                              *docker-env
+#   except:
+#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+#   script:
+#     - ./.maintain/check_for_exit.sh
+
+
+# test-full-crypto-feature:
+#   stage:                           test
+#   <<:                              *docker-env
+#   variables:
+#     # Enable debug assertions since we are running optimized builds for testing
+#     # but still want to have debug assertions.
+#     RUSTFLAGS: -Cdebug-assertions=y
+#     RUST_BACKTRACE: 1
+#   except:
+#     variables:
+#       - $DEPLOY_TAG
+#   script:
+#     - cd primitives/core/
+#     - time cargo +nightly build --verbose --no-default-features --features full_crypto
+#     - cd ../application-crypto
+#     - time cargo +nightly build --verbose --no-default-features --features full_crypto
+#     - sccache -s
 
 
 #### stage:                        build
@@ -269,7 +269,7 @@ build-linux-substrate:             &build-binary
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-only
+  # <<:                              *build-only
   before_script:
     - mkdir -p ./artifacts/substrate/
   except:
@@ -373,14 +373,16 @@ check_polkadot:
 
 trigger-contracts-ci:
   stage:                           publish
+  dependencies:
+    - build-linux-substrate
   needs:
     - build-linux-substrate
   trigger:
     project:                       parity/srml-contracts-waterfall
     branch:                        "master"
-  only:
-    - master
-    - schedules
+  # only:
+    # - master
+    # - schedules
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,23 +108,23 @@ cargo-audit:
   allow_failure:                   true
 
 
-# cargo-check-benches:
-#   stage:                           test
-#   <<:                              *docker-env
-#   script:
-#     - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
-#     - sccache -s
+cargo-check-benches:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
+    - sccache -s
 
 
-# cargo-check-subkey:
-#   stage:                           test
-#   <<:                              *docker-env
-#   except:
-#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-#   script:
-#     - cd ./bin/utils/subkey
-#     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
-#     - sccache -s
+cargo-check-subkey:
+  stage:                           test
+  <<:                              *docker-env
+  except:
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+  script:
+    - cd ./bin/utils/subkey
+    - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
+    - sccache -s
 
 
 test-linux-stable:                 &test-linux
@@ -138,7 +138,6 @@ test-linux-stable:                 &test-linux
     variables:
       - $DEPLOY_TAG
   script:
-    - fail here
     - WASM_BUILD_NO_COLOR=1 time cargo test --all --release --verbose --locked |
         tee output.log
     - sccache -s
@@ -151,117 +150,117 @@ test-linux-stable:                 &test-linux
     paths:
       - ${CI_COMMIT_SHORT_SHA}_warnings.log
 
-# test-dependency-rules:
-#   stage:                           test
-#   <<:                              *docker-env
-#   except:
-#     variables:
-#       - $DEPLOY_TAG
-#   script:
-#     - .maintain/ensure-deps.sh
+test-dependency-rules:
+  stage:                           test
+  <<:                              *docker-env
+  except:
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - .maintain/ensure-deps.sh
 
-# test-frame-staking:
-#   stage:                           test
-#   <<:                              *docker-env
-#   variables:
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: -Cdebug-assertions=y
-#     RUST_BACKTRACE: 1
-#   except:
-#     variables:
-#       - $DEPLOY_TAG
-#   script:
-#     - cd frame/staking/
-#     - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features std
-#     - sccache -s
+test-frame-staking:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: -Cdebug-assertions=y
+    RUST_BACKTRACE: 1
+  except:
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - cd frame/staking/
+    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features std
+    - sccache -s
 
-# test-wasmtime:
-#   stage:                           test
-#   <<:                              *docker-env
-#   variables:
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: -Cdebug-assertions=y
-#     RUST_BACKTRACE: 1
-#   except:
-#     variables:
-#       - $DEPLOY_TAG
-#   script:
-#     - cd client/executor
-#     - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features wasmtime
-#     - sccache -s
+test-wasmtime:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: -Cdebug-assertions=y
+    RUST_BACKTRACE: 1
+  except:
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - cd client/executor
+    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features wasmtime
+    - sccache -s
 
-# test-linux-stable-int:
-#   <<:                              *test-linux
-#   except:
-#     refs:
-#       - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
-#     variables:
-#       - $DEPLOY_TAG
-#   script:
-#     - echo "___Logs will be partly shown at the end in case of failure.___"
-#     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
-#     - WASM_BUILD_NO_COLOR=1 RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-#         time cargo test -p node-cli --release --verbose --locked -- --ignored
-#         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-#     - sccache -s
-#   after_script:
-#     - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
-#   artifacts:
-#     name:                          $CI_COMMIT_SHORT_SHA
-#     when:                          on_failure
-#     expire_in:                     3 days
-#     paths:
-#       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
-
-
-# check-web-wasm:
-#   stage:                           test
-#   <<:                              *docker-env
-#   except:
-#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-#   script:
-#     # WASM support is in progress. As more and more crates support WASM, we
-#     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
-#     - time cargo build --target=wasm32-unknown-unknown -p sp-io
-#     - time cargo build --target=wasm32-unknown-unknown -p sp-runtime
-#     - time cargo build --target=wasm32-unknown-unknown -p sp-std
-#     - time cargo build --target=wasm32-unknown-unknown -p sc-client
-#     - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-aura
-#     - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-babe
-#     - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
-#     - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
-#     # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
-#     - time cargo build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features "browser" --target=wasm32-unknown-unknown
-#     - sccache -s
-
-# node-exits:
-#   stage:                           test
-#   <<:                              *docker-env
-#   except:
-#     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-#   script:
-#     - ./.maintain/check_for_exit.sh
+test-linux-stable-int:
+  <<:                              *test-linux
+  except:
+    refs:
+      - /^v[0-9]+\.[0-9]+.*$/      # i.e. v1.0, v2.1rc1
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - echo "___Logs will be partly shown at the end in case of failure.___"
+    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
+    - WASM_BUILD_NO_COLOR=1 RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+        time cargo test -p node-cli --release --verbose --locked -- --ignored
+        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+    - sccache -s
+  after_script:
+    - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
+  artifacts:
+    name:                          $CI_COMMIT_SHORT_SHA
+    when:                          on_failure
+    expire_in:                     3 days
+    paths:
+      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
 
 
-# test-full-crypto-feature:
-#   stage:                           test
-#   <<:                              *docker-env
-#   variables:
-#     # Enable debug assertions since we are running optimized builds for testing
-#     # but still want to have debug assertions.
-#     RUSTFLAGS: -Cdebug-assertions=y
-#     RUST_BACKTRACE: 1
-#   except:
-#     variables:
-#       - $DEPLOY_TAG
-#   script:
-#     - cd primitives/core/
-#     - time cargo +nightly build --verbose --no-default-features --features full_crypto
-#     - cd ../application-crypto
-#     - time cargo +nightly build --verbose --no-default-features --features full_crypto
-#     - sccache -s
+check-web-wasm:
+  stage:                           test
+  <<:                              *docker-env
+  except:
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+  script:
+    # WASM support is in progress. As more and more crates support WASM, we
+    # should add entries here. See https://github.com/paritytech/substrate/issues/2416
+    - time cargo build --target=wasm32-unknown-unknown -p sp-io
+    - time cargo build --target=wasm32-unknown-unknown -p sp-runtime
+    - time cargo build --target=wasm32-unknown-unknown -p sp-std
+    - time cargo build --target=wasm32-unknown-unknown -p sc-client
+    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-aura
+    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-babe
+    - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
+    - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
+    # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
+    - time cargo build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features "browser" --target=wasm32-unknown-unknown
+    - sccache -s
+
+node-exits:
+  stage:                           test
+  <<:                              *docker-env
+  except:
+    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+  script:
+    - ./.maintain/check_for_exit.sh
+
+
+test-full-crypto-feature:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: -Cdebug-assertions=y
+    RUST_BACKTRACE: 1
+  except:
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - cd primitives/core/
+    - time cargo +nightly build --verbose --no-default-features --features full_crypto
+    - cd ../application-crypto
+    - time cargo +nightly build --verbose --no-default-features --features full_crypto
+    - sccache -s
 
 
 #### stage:                        build
@@ -270,7 +269,7 @@ build-linux-substrate:             &build-binary
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  # <<:                              *build-only
+  <<:                              *build-only
   before_script:
     - mkdir -p ./artifacts/substrate/
   except:
@@ -383,9 +382,9 @@ trigger-contracts-ci:
     project:                       parity/srml-contracts-waterfall
     branch:                        master
     strategy:                      depend
-  # only:
-    # - master
-    # - schedules
+  only:
+    - master
+    - schedules
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,7 +376,9 @@ trigger-contracts-ci:
   stage:                           publish
   needs:
     - job:                         build-linux-substrate
-      artifacts:                   true
+      artifacts:                   false
+    - job:                         test-linux-stable
+      artifacts:                   false
   trigger:
     project:                       parity/srml-contracts-waterfall
     branch:                        master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -373,13 +373,13 @@ check_polkadot:
 
 trigger-contracts-ci:
   stage:                           publish
-  dependencies:
-    - build-linux-substrate
   needs:
-    - build-linux-substrate
+    - job:                         build-linux-substrate
+      artifacts:                   false
   trigger:
     project:                       parity/srml-contracts-waterfall
-    branch:                        "master"
+    branch:                        master
+    strategy:                      depend
   # only:
     # - master
     # - schedules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,6 +138,7 @@ test-linux-stable:                 &test-linux
     variables:
       - $DEPLOY_TAG
   script:
+    - fail here
     - WASM_BUILD_NO_COLOR=1 time cargo test --all --release --verbose --locked |
         tee output.log
     - sccache -s

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,7 +376,7 @@ trigger-contracts-ci:
   stage:                           publish
   needs:
     - job:                         build-linux-substrate
-      artifacts:                   false
+      artifacts:                   true
   trigger:
     project:                       parity/srml-contracts-waterfall
     branch:                        master


### PR DESCRIPTION
Fixes this kind of behavior https://gitlab.parity.io/parity/substrate/pipelines/75386
when substrate pipeline regardless `needs` depending on the `build` job was started even if `test` job in the previous stage was failed and `build` wasn't even triggered.