### PR TITLE
Support `u128`/`i128` in runtime interface

### DIFF
--- a/primitives/runtime-interface/src/lib.rs
+++ b/primitives/runtime-interface/src/lib.rs
@@ -81,10 +81,12 @@
 //! | `u16` | `u16` | `Identity` |
 //! | `u32` | `u32` | `Identity` |
 //! | `u64` | `u64` | `Identity` |
+//! | `i128` | `u32` | `v.as_ptr()` (pointer to a 16 byte array) |
 //! | `i8` | `i8` | `Identity` |
 //! | `i16` | `i16` | `Identity` |
 //! | `i32` | `i32` | `Identity` |
 //! | `i64` | `i64` | `Identity` |
+//! | `u128` | `u32` | `v.as_ptr()` (pointer to a 16 byte array) |
 //! | `bool` | `u8` | `if v { 1 } else { 0 }` |
 //! | `&str` | `u64` | <code>v.len() 32bit << 32 &#124; v.as_ptr() 32bit</code> |
 //! | `&[u8]` | `u64` | <code>v.len() 32bit << 32 &#124; v.as_ptr() 32bit</code> |
@@ -93,6 +95,7 @@
 //! | `&[T] where T: Encode` | `u64` | `let e = v.encode();`<br><br><code>e.len() 32bit << 32 &#124; e.as_ptr() 32bit</code> |
 //! | `[u8; N]` | `u32` | `v.as_ptr()` |
 //! | `*const T` | `u32` | `Identity` |
+//! | `Option<T>` | `u64` | `let e = v.encode();`<br><br><code>e.len() 32bit << 32 &#124; e.as_ptr() 32bit</code> |
 //! | [`T where T: PassBy<PassBy=Inner>`](pass_by::Inner) | Depends on inner | Depends on inner |
 //! | [`T where T: PassBy<PassBy=Codec>`](pass_by::Codec) | `u64`| <code>v.len() 32bit << 32 &#124; v.as_ptr() 32bit</code> |
 //!

--- a/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -82,6 +82,16 @@ pub trait TestApi {
 	fn overwrite_native_function_implementation() -> bool {
 		false
 	}
+
+	/// Gets an `u128` and returns this value
+	fn get_and_return_u128(val: u128) -> u128 {
+		val
+	}
+
+	/// Gets an `i128` and returns this value
+	fn get_and_return_i128(val: i128) -> i128 {
+		val
+	}
 }
 
 /// Two random external functions from the old runtime interface.
@@ -190,5 +200,15 @@ wasm_export_functions! {
 			.replace_implementation(new_implementation);
 
 		assert!(test_api::overwrite_native_function_implementation());
+	}
+
+	fn test_u128_i128_as_parameter_and_return_value() {
+		for val in &[u128::max_value(), 1u128, 5000u128, u64::max_value() as u128] {
+			assert_eq!(*val, test_api::get_and_return_u128(*val));
+		}
+
+		for val in &[i128::max_value(), i128::min_value(), 1i128, 5000i128, u64::max_value() as i128] {
+			assert_eq!(*val, test_api::get_and_return_i128(*val));
+		}
 	}
 }

--- a/primitives/runtime-interface/test/src/lib.rs
+++ b/primitives/runtime-interface/test/src/lib.rs
@@ -108,3 +108,8 @@ fn test_invalid_utf8_data_should_return_an_error() {
 fn test_overwrite_native_function_implementation() {
 	call_wasm_method::<HostFunctions>("test_overwrite_native_function_implementation");
 }
+
+#[test]
+fn test_u128_i128_as_parameter_and_return_value() {
+	call_wasm_method::<HostFunctions>("test_u128_i128_as_parameter_and_return_value");
+}


### PR DESCRIPTION
This implements support for `u128`/`i128` as parameters/return value in
runtime interfaces. As we can not pass them as identity, as for the
other primitives types, we pass them as an pointer to an `[u8; 16]` array.

<!---
Thank you for your Pull Request!

Before you submitting, please check that:

- [ ] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR with appropriate labels if you have permissions to do so.
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres [the style guide](https://github.com/paritytech/polkadot/wiki/Style-Guide)
  - In particular, mind the maximal line length.
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
-->
