### PR TITLE
Move "wasm" allocator into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5407,6 +5407,7 @@ dependencies = [
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-allocator 2.0.0",
  "sp-core 2.0.0",
  "sp-runtime-interface 2.0.0",
  "sp-serializer 2.0.0",
@@ -5422,6 +5423,7 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sc-executor-common 0.8.0",
+ "sp-allocator 2.0.0",
  "sp-core 2.0.0",
  "sp-runtime-interface 2.0.0",
  "sp-wasm-interface 2.0.0",
@@ -5442,6 +5444,7 @@ dependencies = [
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sc-executor-common 0.8.0",
+ "sp-allocator 2.0.0",
  "sp-core 2.0.0",
  "sp-runtime-interface 2.0.0",
  "sp-wasm-interface 2.0.0",
@@ -5715,6 +5718,7 @@ dependencies = [
 name = "sc-runtime-test"
 version = "2.0.0"
 dependencies = [
+ "sp-allocator 2.0.0",
  "sp-core 2.0.0",
  "sp-io 2.0.0",
  "sp-runtime 2.0.0",
@@ -6166,6 +6170,17 @@ dependencies = [
 name = "sourcefile"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sp-allocator"
+version = "2.0.0"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 2.0.0",
+ "sp-std 2.0.0",
+ "sp-wasm-interface 2.0.0",
+]
 
 [[package]]
 name = "sp-api"
@@ -6722,6 +6737,7 @@ name = "sp-wasm-interface"
 version = "2.0.0"
 dependencies = [
  "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std 2.0.0",
  "wasmi 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ members = [
 	"frame/transaction-payment/rpc/runtime-api",
 	"frame/treasury",
 	"frame/utility",
+	"primitives/allocator",
 	"primitives/application-crypto",
 	"primitives/application-crypto/test",
 	"primitives/authority-discovery",

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -10,6 +10,7 @@ derive_more = "0.99.2"
 codec = { package = "parity-scale-codec", version = "1.0.0" }
 wasmi = "0.6.2"
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0", path = "../../../primitives/allocator" }
 sp-wasm-interface = { version = "2.0.0", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0", path = "../../../primitives/runtime-interface" }
 sp-serializer = { version = "2.0.0", path = "../../../primitives/serializer" }

--- a/client/executor/common/src/error.rs
+++ b/client/executor/common/src/error.rs
@@ -72,17 +72,10 @@ pub enum Error {
 	#[display(fmt="The runtime has the `start` function")]
 	RuntimeHasStartFn,
 	/// Some other error occurred
-	#[from(ignore)]
 	Other(String),
 	/// Some error occurred in the allocator
 	#[display(fmt="Error in allocator: {}", _0)]
-	Allocator(&'static str),
-	/// The allocator ran out of space.
-	#[display(fmt="Allocator ran out of space")]
-	AllocatorOutOfSpace,
-	/// Someone tried to allocate more memory than the allowed maximum per allocation.
-	#[display(fmt="Requested allocation size is too large")]
-	RequestedAllocationTooLarge,
+	Allocator(sp_allocator::Error),
 	/// Execution of a host function failed.
 	#[display(fmt="Host function {} execution failed with: {}", _0, _1)]
 	FunctionExecution(String, String),
@@ -101,9 +94,9 @@ impl std::error::Error for Error {
 
 impl wasmi::HostError for Error {}
 
-impl From<String> for Error {
-	fn from(err: String) -> Error {
-		Error::Other(err)
+impl From<&'static str> for Error {
+	fn from(err: &'static str) -> Error {
+		Error::Other(err.into())
 	}
 }
 

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -11,10 +11,16 @@ sp-io = { version = "2.0.0", default-features = false, path = "../../../primitiv
 sp-sandbox = { version = "0.8.0", default-features = false, path = "../../../primitives/sandbox" }
 sp-core = { version = "2.0.0", default-features = false, path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../../primitives/runtime" }
+sp-allocator = { version = "2.0.0", default-features = false, path = "../../../primitives/allocator" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.4", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
 
 [features]
 default = [ "std" ]
-std = ["sp-io/std", "sp-sandbox/std", "sp-std/std"]
+std = [
+	"sp-io/std",
+	"sp-sandbox/std",
+	"sp-std/std",
+	"sp-allocator/std",
+]

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -212,6 +212,11 @@ sp_core::wasm_export_functions! {
 
 		run().is_some()
 	}
+
+	// Just some test to make sure that `sp-allocator` compiles on `no_std`.
+	fn test_sp_allocator_compiles() {
+		sp_allocator::FreeingBumpHeapAllocator::new(0);
+	}
  }
 
 #[cfg(not(feature = "std"))]

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -48,7 +48,7 @@ pub use sp_core::traits::Externalities;
 pub use sp_wasm_interface;
 pub use wasm_runtime::WasmExecutionMethod;
 
-pub use sc_executor_common::{error, allocator, sandbox};
+pub use sc_executor_common::{error, sandbox};
 
 /// Call the given `function` in the given wasm `code`.
 ///

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -13,3 +13,4 @@ sc-executor-common = { version = "0.8", path = "../common" }
 sp-wasm-interface = { version = "2.0.0", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0", path = "../../../primitives/allocator" }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -13,6 +13,7 @@ sc-executor-common = { version = "0.8", path = "../common" }
 sp-wasm-interface = { version = "2.0.0", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0", path = "../../../primitives/allocator" }
 
 cranelift-codegen = "0.50"
 cranelift-entity = "0.50"

--- a/client/executor/wasmtime/src/function_executor.rs
+++ b/client/executor/wasmtime/src/function_executor.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use sc_executor_common::allocator::FreeingBumpHeapAllocator;
+use sp_allocator::FreeingBumpHeapAllocator;
 use sc_executor_common::error::{Error, Result};
 use sc_executor_common::sandbox::{self, SandboxCapabilities, SupervisorFuncIndex};
 use crate::util::{
@@ -127,11 +127,11 @@ impl<'a> SandboxCapabilities for FunctionExecutor<'a> {
 	}
 
 	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>> {
-		self.heap.allocate(self.memory, len)
+		self.heap.allocate(self.memory, len).map_err(Into::into)
 	}
 
 	fn deallocate(&mut self, ptr: Pointer<u8>) -> Result<()> {
-		self.heap.deallocate(self.memory, ptr)
+		self.heap.deallocate(self.memory, ptr).map_err(Into::into)
 	}
 
 	fn write_memory(&mut self, ptr: Pointer<u8>, data: &[u8]) -> Result<()> {

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sp-allocator"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+sp-std = { version = "2.0.0", path = "../std", default-features = false }
+sp-core = { version = "2.0.0", path = "../core", default-features = false }
+sp-wasm-interface = { version = "2.0.0", path = "../wasm-interface", default-features = false }
+log = { version = "0.4.8", optional = true }
+derive_more = { version = "0.99.2", optional = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"sp-std/std",
+	"sp-core/std",
+	"sp-wasm-interface/std",
+	"log",
+	"derive_more",
+]

--- a/primitives/allocator/src/error.rs
+++ b/primitives/allocator/src/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+/// The error type used by the allocators.
+#[derive(sp_core::RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(derive_more::Display))]
+pub enum Error {
+	/// Someone tried to allocate more memory than the allowed maximum per allocation.
+	#[cfg_attr(feature = "std", display(fmt="Requested allocation size is too large"))]
+	RequestedAllocationTooLarge,
+	/// Allocator run out of space.
+	#[cfg_attr(feature = "std", display(fmt="Allocator ran out of space"))]
+	AllocatorOutOfSpace,
+	/// Some other error occurred.
+	Other(&'static str)
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
+	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+		match self {
+			_ => None,
+		}
+	}
+}

--- a/primitives/allocator/src/lib.rs
+++ b/primitives/allocator/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// Copyright 2020 Parity Technologies (UK) Ltd.
 // This file is part of Substrate.
 
 // Substrate is free software: you can redistribute it and/or modify
@@ -14,10 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! A set of common definitions that are needed for defining execution engines.
+//! Collection of allocator implementations.
+//!
+//! This crate provides the following allocator implementations:
+//! - A freeing-bump allocator: [`FreeingBumpHeapAllocator`](freeing_bump::FreeingBumpHeapAllocator)
 
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 
-pub mod sandbox;
-pub mod error;
-pub mod wasm_runtime;
+mod error;
+mod freeing_bump;
+
+pub use freeing_bump::FreeingBumpHeapAllocator;
+pub use error::Error;

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -309,3 +309,43 @@ pub fn to_substrate_wasm_fn_return_value(value: &impl Encode) -> u64 {
 
 	res
 }
+
+/// Macro for creating `Maybe*` marker traits.
+///
+/// Such a maybe-marker trait requires the given bound when `feature = std` and doesn't require
+/// the bound on `no_std`. This is useful for situations where you require that a type implements
+/// a certain trait with `feature = std`, but not on `no_std`.
+///
+/// # Example
+///
+/// ```
+/// sp_core::impl_maybe_marker! {
+///     /// A marker for a type that implements `Debug` when `feature = std`.
+///     trait MaybeDebug: std::fmt::Debug;
+///     /// A marker for a type that implements `Debug + Display` when `feature = std`.
+///     trait MaybeDebugDisplay: std::fmt::Debug, std::fmt::Display;
+/// }
+/// ```
+#[macro_export]
+macro_rules! impl_maybe_marker {
+	(
+		$(
+			$(#[$doc:meta] )+
+			trait $trait_name:ident: $( $trait_bound:path ),+;
+		)+
+	) => {
+		$(
+			$(#[$doc])+
+			#[cfg(feature = "std")]
+			pub trait $trait_name: $( $trait_bound + )+ {}
+			#[cfg(feature = "std")]
+			impl<T: $( $trait_bound + )+> $trait_name for T {}
+
+			$(#[$doc])+
+			#[cfg(not(feature = "std"))]
+			pub trait $trait_name {}
+			#[cfg(not(feature = "std"))]
+			impl<T> $trait_name for T {}
+		)+
+	}
+}

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -458,36 +458,18 @@ impl<H: PartialEq + Eq + Debug> CheckEqual for super::generic::DigestItem<H> whe
 	}
 }
 
-macro_rules! impl_maybe_marker {
-	( $( $(#[$doc:meta])+ $trait_name:ident: $($trait_bound:path),+ );+ ) => {
-		$(
-			$(#[$doc])+
-			#[cfg(feature = "std")]
-			pub trait $trait_name: $($trait_bound +)+ {}
-			#[cfg(feature = "std")]
-			impl<T: $($trait_bound +)+> $trait_name for T {}
-
-			$(#[$doc])+
-			#[cfg(not(feature = "std"))]
-			pub trait $trait_name {}
-			#[cfg(not(feature = "std"))]
-			impl<T> $trait_name for T {}
-		)+
-	}
-}
-
-impl_maybe_marker!(
+sp_core::impl_maybe_marker!(
 	/// A type that implements Display when in std environment.
-	MaybeDisplay: Display;
+	trait MaybeDisplay: Display;
 
 	/// A type that implements Hash when in std environment.
-	MaybeHash: sp_std::hash::Hash;
+	trait MaybeHash: sp_std::hash::Hash;
 
 	/// A type that implements Serialize when in std environment.
-	MaybeSerialize: Serialize;
+	trait MaybeSerialize: Serialize;
 
 	/// A type that implements Serialize, DeserializeOwned and Debug when in std environment.
-	MaybeSerializeDeserialize: DeserializeOwned, Serialize
+	trait MaybeSerializeDeserialize: DeserializeOwned, Serialize;
 );
 
 /// A type that provides a randomness beacon.

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -81,10 +81,7 @@ pub type HostFuncType<T> = fn(&mut T, &[TypedValue]) -> Result<ReturnValue, Host
 /// will be used by the guest module.
 ///
 /// The memory can't be directly accessed by supervisor, but only
-/// through designated functions [`get`] and [`set`].
-///
-/// [`get`]: #method.get
-/// [`set`]: #method.set
+/// through designated functions [`get`](Memory::get) and [`set`](Memory::set).
 #[derive(Clone)]
 pub struct Memory {
 	inner: imp::Memory,

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -5,5 +5,10 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-wasmi = "0.6.2"
+wasmi = { version = "0.6.2", optional = true }
 impl-trait-for-tuples = "0.1.2"
+sp-std = { version = "2.0.0", path = "../std", default-features = false }
+
+[features]
+default = [ "std" ]
+std = [ "wasmi", "sp-std/std" ]

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -16,12 +16,20 @@
 
 //! Types and traits for interfacing between the host and the wasm runtime.
 
-use std::{borrow::Cow, marker::PhantomData, mem, iter::Iterator, result};
+#![cfg_attr(not(feature = "std"), no_std)]
 
+use sp_std::{
+	borrow::Cow, marker::PhantomData, mem, iter::Iterator, result, vec::Vec,
+};
+
+#[cfg(feature = "std")]
 mod wasmi_impl;
 
 /// Result type used by traits in this crate.
+#[cfg(feature = "std")]
 pub type Result<T> = result::Result<T, String>;
+#[cfg(not(feature = "std"))]
+pub type Result<T> = result::Result<T, &'static str>;
 
 /// Value types supported by Substrate on the boundary between host/Wasm.
 #[derive(Copy, Clone, PartialEq, Debug, Eq)]
@@ -189,11 +197,22 @@ impl Signature {
 			return_value: None,
 		}
 	}
-
 }
 
+/// A trait that requires `RefUnwindSafe` when `feature = std`.
+#[cfg(feature = "std")]
+pub trait MaybeRefUnwindSafe: std::panic::RefUnwindSafe {}
+#[cfg(feature = "std")]
+impl<T: std::panic::RefUnwindSafe> MaybeRefUnwindSafe for T {}
+
+/// A trait that requires `RefUnwindSafe` when `feature = std`.
+#[cfg(not(feature = "std"))]
+pub trait MaybeRefUnwindSafe {}
+#[cfg(not(feature = "std"))]
+impl<T> MaybeRefUnwindSafe for T {}
+
 /// Something that provides a function implementation on the host for a wasm function.
-pub trait Function: std::panic::RefUnwindSafe + Send + Sync {
+pub trait Function: MaybeRefUnwindSafe + Send + Sync {
 	/// Returns the name of this function.
 	fn name(&self) -> &str;
 	/// Returns the signature of this function.


### PR DESCRIPTION
This moves the wasm-allocator (`FreeingBumpHeapAllocator`) into its own
crate `sp-allocator`. This new crate can theoretically provide multiple
different allocators. Besides moving the allocator, this pr also makes
`FreeingBumpHeapAllocator` compile on `no_std`.
