### PR TITLE
Add `system_time` host function

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -33,7 +33,6 @@ use sp_std::vec::Vec;
 use sp_std::ops::Deref;
 
 #[cfg(feature = "std")]
-#[cfg(feature = "std")]
 use sp_core::{
 	crypto::Pair,
 	traits::{KeystoreExt, CallInWasmExt},

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -775,9 +775,9 @@ pub trait Logging {
 /// Interface that provides functions for benchmarking the runtime.
 #[runtime_interface]
 pub trait Benchmarking {
-		/// Get the current system time in nanoseconds.
+		/// Get the number of nanoseconds passed since the UNIX epoch
 		///
-		/// WARNING! This is a non-determinisic call. Do not use this within
+		/// WARNING! This is a non-deterministic call. Do not use this within
 		/// consensus critical logic.
 		fn current_time() -> u128 {
 			std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -930,7 +930,6 @@ pub type SubstrateHostFunctions = (
 	logging::HostFunctions,
 	sandbox::HostFunctions,
 	crate::trie::HostFunctions,
-	benchmarking::HostFunctions,
 );
 
 #[cfg(test)]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -33,7 +33,6 @@ use sp_std::vec::Vec;
 use sp_std::ops::Deref;
 
 #[cfg(feature = "std")]
-use std::time;
 #[cfg(feature = "std")]
 use sp_core::{
 	crypto::Pair,

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -930,6 +930,7 @@ pub type SubstrateHostFunctions = (
 	logging::HostFunctions,
 	sandbox::HostFunctions,
 	crate::trie::HostFunctions,
+	benchmarking::HostFunctions,
 );
 
 #[cfg(test)]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -34,7 +34,6 @@ use sp_std::ops::Deref;
 
 #[cfg(feature = "std")]
 use std::time;
-
 #[cfg(feature = "std")]
 use sp_core::{
 	crypto::Pair,

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -33,6 +33,9 @@ use sp_std::vec::Vec;
 use sp_std::ops::Deref;
 
 #[cfg(feature = "std")]
+use std::time;
+
+#[cfg(feature = "std")]
 use sp_core::{
 	crypto::Pair,
 	traits::{KeystoreExt, CallInWasmExt},
@@ -369,6 +372,13 @@ pub trait Misc {
 			.expect("No `CallInWasmExt` associated for the current context!")
 			.call_in_wasm(wasm, "Core_version", &[], &mut ext)
 			.ok()
+	}
+
+	/// Get the current system time in nanoseconds.
+	fn system_time() -> u128 {
+		time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH)
+		.expect("Unix time doesn't go backwards; qed")
+		.as_nanos()
 	}
 }
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -370,13 +370,6 @@ pub trait Misc {
 			.call_in_wasm(wasm, "Core_version", &[], &mut ext)
 			.ok()
 	}
-
-	/// Get the current system time in nanoseconds.
-	fn current_time() -> u128 {
-		std::time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH)
-		.expect("Unix time doesn't go backwards; qed")
-		.as_nanos()
-	}
 }
 
 /// Interfaces for working with crypto related types from within the runtime.
@@ -777,6 +770,20 @@ pub trait Logging {
 			)
 		}
 	}
+}
+
+/// Interface that provides functions for benchmarking the runtime.
+#[runtime_interface]
+pub trait Benchmarking {
+		/// Get the current system time in nanoseconds.
+		///
+		/// WARNING! This is a non-determinisic call. Do not use this within
+		/// consensus critical logic.
+		fn current_time() -> u128 {
+			std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+				.expect("Unix time doesn't go backwards; qed")
+				.as_nanos()
+		}
 }
 
 /// Wasm-only interface that provides functions for interacting with the sandbox.

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -373,7 +373,7 @@ pub trait Misc {
 
 	/// Get the current system time in nanoseconds.
 	fn current_time() -> u128 {
-		time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH)
+		std::time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH)
 		.expect("Unix time doesn't go backwards; qed")
 		.as_nanos()
 	}

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -375,7 +375,7 @@ pub trait Misc {
 	}
 
 	/// Get the current system time in nanoseconds.
-	fn system_time() -> u128 {
+	fn current_time() -> u128 {
 		time::SystemTime::now().duration_since(time::SystemTime::UNIX_EPOCH)
 		.expect("Unix time doesn't go backwards; qed")
 		.as_nanos()


### PR DESCRIPTION
This PR introduces a new host function which allows the runtime to get the `SystemTime` from the node.

The intention is to use this to create benchmarking timers within the runtime.

I have placed this in the `misc` host functions, so it is accessible as:

```
sp_io::misc::system_time()
````

And returns the current time in nanoseconds using `u128`.