### PR TITLE
Cursed implementation of allowing missing imports on wasmtime

### DIFF
--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -31,48 +31,6 @@ use sp_trie::{TrieConfiguration, trie_types::Layout};
 use crate::WasmExecutionMethod;
 
 pub type TestExternalities = CoreTestExternalities<Blake2Hasher, u64>;
-
-#[cfg(feature = "wasmtime")]
-mod wasmtime_missing_externals {
-	use sp_wasm_interface::{Function, FunctionContext, HostFunctions, Result, Signature, Value};
-
-	pub struct WasmtimeHostFunctions;
-
-	impl HostFunctions for WasmtimeHostFunctions {
-		fn host_functions() -> Vec<&'static dyn Function> {
-			vec![MISSING_EXTERNAL_FUNCTION, YET_ANOTHER_MISSING_EXTERNAL_FUNCTION]
-		}
-	}
-
-	struct MissingExternalFunction(&'static str);
-
-	impl Function for MissingExternalFunction {
-		fn name(&self) -> &str { self.0 }
-
-		fn signature(&self) -> Signature {
-			Signature::new(vec![], None)
-		}
-
-		fn execute(
-			&self,
-			_context: &mut dyn FunctionContext,
-			_args: &mut dyn Iterator<Item = Value>,
-		) -> Result<Option<Value>> {
-			panic!("should not be called");
-		}
-	}
-
-	static MISSING_EXTERNAL_FUNCTION: &'static MissingExternalFunction =
-		&MissingExternalFunction("missing_external");
-	static YET_ANOTHER_MISSING_EXTERNAL_FUNCTION: &'static MissingExternalFunction =
-		&MissingExternalFunction("yet_another_missing_external");
-}
-
-#[cfg(feature = "wasmtime")]
-type HostFunctions =
-	(sp_io::SubstrateHostFunctions);
-
-#[cfg(not(feature = "wasmtime"))]
 type HostFunctions = sp_io::SubstrateHostFunctions;
 
 fn call_in_wasm<E: Externalities>(

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -70,7 +70,7 @@ mod wasmtime_missing_externals {
 
 #[cfg(feature = "wasmtime")]
 type HostFunctions =
-	(wasmtime_missing_externals::WasmtimeHostFunctions, sp_io::SubstrateHostFunctions);
+	(sp_io::SubstrateHostFunctions);
 
 #[cfg(not(feature = "wasmtime"))]
 type HostFunctions = sp_io::SubstrateHostFunctions;
@@ -114,8 +114,14 @@ fn returning_should_work(wasm_method: WasmExecutionMethod) {
 
 #[test_case(WasmExecutionMethod::Interpreted)]
 #[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
-#[should_panic(expected = "Function `missing_external` is only a stub. Calling a stub is not allowed.")]
-#[cfg(not(feature = "wasmtime"))]
+#[cfg_attr(
+	feature = "wasmtime",
+	should_panic(expected = "call to undefined external function with index 67")
+)]
+#[cfg_attr(
+	not(feature = "wasmtime"),
+	should_panic(expected = "Function `missing_external` is only a stub. Calling a stub is not allowed.")
+)]
 fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -133,8 +139,14 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 
 #[test_case(WasmExecutionMethod::Interpreted)]
 #[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
-#[should_panic(expected = "Function `yet_another_missing_external` is only a stub. Calling a stub is not allowed.")]
-#[cfg(not(feature = "wasmtime"))]
+#[cfg_attr(
+	feature = "wasmtime",
+	should_panic(expected = "call to undefined external function with index 68")
+)]
+#[cfg_attr(
+	not(feature = "wasmtime"),
+	should_panic(expected = "Function `yet_another_missing_external` is only a stub. Calling a stub is not allowed.")
+)]
 fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -68,7 +68,7 @@ pub fn call_in_wasm<HF: sp_wasm_interface::HostFunctions>(
 	ext: &mut dyn Externalities,
 	code: &[u8],
 	heap_pages: u64,
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 ) -> error::Result<Vec<u8>> {
 	call_in_wasm_with_host_functions(
 		function,
@@ -78,7 +78,7 @@ pub fn call_in_wasm<HF: sp_wasm_interface::HostFunctions>(
 		code,
 		heap_pages,
 		HF::host_functions(),
-		allow_missing_imports,
+		allow_missing_func_imports,
 	)
 }
 
@@ -92,14 +92,14 @@ pub fn call_in_wasm_with_host_functions(
 	code: &[u8],
 	heap_pages: u64,
 	host_functions: Vec<&'static dyn sp_wasm_interface::Function>,
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 ) -> error::Result<Vec<u8>> {
 	let instance = wasm_runtime::create_wasm_runtime_with_code(
 		execution_method,
 		heap_pages,
 		code,
 		host_functions,
-		allow_missing_imports,
+		allow_missing_func_imports,
 	)?;
 
 	// It is safe, as we delete the instance afterwards.

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -191,15 +191,15 @@ pub fn create_wasm_runtime_with_code(
 	heap_pages: u64,
 	code: &[u8],
 	host_functions: Vec<&'static dyn Function>,
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 ) -> Result<Box<dyn WasmRuntime>, WasmError> {
 	match wasm_method {
 		WasmExecutionMethod::Interpreted =>
-			sc_executor_wasmi::create_instance(code, heap_pages, host_functions, allow_missing_imports)
+			sc_executor_wasmi::create_instance(code, heap_pages, host_functions, allow_missing_func_imports)
 				.map(|runtime| -> Box<dyn WasmRuntime> { Box::new(runtime) }),
 		#[cfg(feature = "wasmtime")]
 		WasmExecutionMethod::Compiled =>
-			sc_executor_wasmtime::create_instance(code, heap_pages, host_functions)
+			sc_executor_wasmtime::create_instance(code, heap_pages, host_functions, allow_missing_func_imports)
 				.map(|runtime| -> Box<dyn WasmRuntime> { Box::new(runtime) }),
 	}
 }

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -38,7 +38,7 @@ struct FunctionExecutor<'a> {
 	memory: MemoryRef,
 	table: Option<TableRef>,
 	host_functions: &'a [&'static dyn Function],
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 	missing_functions: &'a [String],
 }
 
@@ -48,7 +48,7 @@ impl<'a> FunctionExecutor<'a> {
 		heap_base: u32,
 		t: Option<TableRef>,
 		host_functions: &'a [&'static dyn Function],
-		allow_missing_imports: bool,
+		allow_missing_func_imports: bool,
 		missing_functions: &'a [String],
 	) -> Result<Self, Error> {
 		Ok(FunctionExecutor {
@@ -57,7 +57,7 @@ impl<'a> FunctionExecutor<'a> {
 			memory: m,
 			table: t,
 			host_functions,
-			allow_missing_imports,
+			allow_missing_func_imports,
 			missing_functions,
 		})
 	}
@@ -273,15 +273,15 @@ impl<'a> Sandbox for FunctionExecutor<'a> {
 
 struct Resolver<'a> {
 	host_functions: &'a[&'static dyn Function],
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 	missing_functions: RefCell<Vec<String>>,
 }
 
 impl<'a> Resolver<'a> {
-	fn new(host_functions: &'a[&'static dyn Function], allow_missing_imports: bool) -> Resolver<'a> {
+	fn new(host_functions: &'a[&'static dyn Function], allow_missing_func_imports: bool) -> Resolver<'a> {
 		Resolver {
 			host_functions,
-			allow_missing_imports,
+			allow_missing_func_imports,
 			missing_functions: RefCell::new(Vec::new()),
 		}
 	}
@@ -311,7 +311,7 @@ impl<'a> wasmi::ModuleImportResolver for Resolver<'a> {
 			}
 		}
 
-		if self.allow_missing_imports {
+		if self.allow_missing_func_imports {
 			trace!(target: "wasm-executor", "Could not find function `{}`, a stub will be provided instead.", name);
 			let id = self.missing_functions.borrow().len() + self.host_functions.len();
 			self.missing_functions.borrow_mut().push(name.to_string());
@@ -336,7 +336,7 @@ impl<'a> wasmi::Externals for FunctionExecutor<'a> {
 				.map_err(|msg| Error::FunctionExecution(function.name().to_string(), msg))
 				.map_err(wasmi::Trap::from)
 				.map(|v| v.map(Into::into))
-		} else if self.allow_missing_imports
+		} else if self.allow_missing_func_imports
 			&& index >= self.host_functions.len()
 			&& index < self.host_functions.len() + self.missing_functions.len()
 		{
@@ -381,7 +381,7 @@ fn call_in_wasm_module(
 	method: &str,
 	data: &[u8],
 	host_functions: &[&'static dyn Function],
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 	missing_functions: &Vec<String>,
 ) -> Result<Vec<u8>, Error> {
 	// extract a reference to a linear memory, optional reference to a table
@@ -397,7 +397,7 @@ fn call_in_wasm_module(
 		heap_base,
 		table,
 		host_functions,
-		allow_missing_imports,
+		allow_missing_func_imports,
 		missing_functions,
 	)?;
 
@@ -433,9 +433,9 @@ fn instantiate_module(
 	heap_pages: usize,
 	module: &Module,
 	host_functions: &[&'static dyn Function],
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 ) -> Result<(ModuleRef, Vec<String>), Error> {
-	let resolver = Resolver::new(host_functions, allow_missing_imports);
+	let resolver = Resolver::new(host_functions, allow_missing_func_imports);
 	// start module instantiation. Don't run 'start' function yet.
 	let intermediate_instance = ModuleInstance::new(
 		module,
@@ -575,7 +575,7 @@ pub struct WasmiRuntime {
 	host_functions: Vec<&'static dyn Function>,
 	/// Enable stub generation for functions that are not available in `host_functions`.
 	/// These stubs will error when the wasm blob tries to call them.
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 	/// List of missing functions detected during function resolution
 	missing_functions: Vec<String>,
 }
@@ -607,7 +607,7 @@ impl WasmRuntime for WasmiRuntime {
 			method,
 			data,
 			&self.host_functions,
-			self.allow_missing_imports,
+			self.allow_missing_func_imports,
 			&self.missing_functions,
 		)
 	}
@@ -617,7 +617,7 @@ pub fn create_instance(
 	code: &[u8],
 	heap_pages: u64,
 	host_functions: Vec<&'static dyn Function>,
-	allow_missing_imports: bool,
+	allow_missing_func_imports: bool,
 ) -> Result<WasmiRuntime, WasmError> {
 	let module = Module::from_buffer(&code).map_err(|_| WasmError::InvalidModule)?;
 
@@ -632,7 +632,7 @@ pub fn create_instance(
 		heap_pages as usize,
 		&module,
 		&host_functions,
-		allow_missing_imports,
+		allow_missing_func_imports,
 	).map_err(|e| WasmError::Instantiation(e.to_string()))?;
 
 	// Take state snapshot before executing anything.
@@ -648,7 +648,7 @@ pub fn create_instance(
 		instance,
 		state_snapshot,
 		host_functions,
-		allow_missing_imports,
+		allow_missing_func_imports,
 		missing_functions,
 	})
 }

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -174,12 +174,9 @@ fn scan_missing_functions(
 				func_ty
 			}
 			_ => {
-				// The executor doesn't provide any non function imports!
-				return Err(WasmError::Other(format!(
-					"{}:{} is not a function",
-					import_entry.module(),
-					import_entry.field()
-				)));
+				// We are looking only for missing **functions** here. Any other items, be they
+				// missing or not, will be handled at the resolution stage later.
+				continue;
 			}
 		};
 		let signature = convert_parity_wasm_signature(func_ty);
@@ -195,8 +192,8 @@ fn scan_missing_functions(
 			}
 		}
 
-		// This import is a function, not from env module, or doesn't have a corresponding host
-		// function, or the signature is not matching.
+		// This function is either not from the env module, or doesn't have a corresponding host
+		// function, or the signature is not matching. Add it to the list.
 		let sig = cranelift_ir_signature(signature, &call_conv);
 
 		missing_functions.insert(

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -195,14 +195,14 @@ fn scan_missing_functions(
 			}
 		}
 
-		// This import is not a function, not from env module, or doesn't have a corresponding host
+		// This import is a function, not from env module, or doesn't have a corresponding host
 		// function, or the signature is not matching.
 		let sig = cranelift_ir_signature(signature, &call_conv);
 
 		missing_functions.insert(
 			import_entry.module().to_string(),
 			import_entry.field().to_string(),
-			sig
+			sig,
 		);
 	}
 
@@ -237,7 +237,7 @@ fn create_compiled_unit(
 	let env_missing_functions = missing_functions_stubs.stubs.remove("env").unwrap_or_else(|| Vec::new());
 	context.name_instance(
 		"env".to_owned(),
-		instantiate_env_module(global_exports, compiler, host_functions, env_missing_functions)?
+		instantiate_env_module(global_exports, compiler, host_functions, env_missing_functions)?,
 	);
 
 	for (module, missing_functions_stubs) in missing_functions_stubs.stubs {
@@ -349,7 +349,7 @@ fn instantiate_env_module(
 	for MissingFunction { name, sig } in missing_functions_stubs {
 		let sig = translate_signature(
 			sig,
-			pointer_type
+			pointer_type,
 		);
 		let sig_id = module.signatures.push(sig.clone());
 		let func_id = module.functions.push(sig_id);

--- a/client/executor/wasmtime/src/util.rs
+++ b/client/executor/wasmtime/src/util.rs
@@ -51,6 +51,24 @@ pub fn checked_range(offset: usize, len: usize, max: usize) -> Option<Range<usiz
 	}
 }
 
+/// Convert from a parity wasm FunctionType to wasm interface's Signature.
+pub fn convert_parity_wasm_signature(func_ty: &parity_wasm::elements::FunctionType) -> Signature {
+	fn convert_value_type(val_ty: parity_wasm::elements::ValueType) -> ValueType {
+		use parity_wasm::elements::ValueType::*;
+		match val_ty {
+			I32 => ValueType::I32,
+			I64 => ValueType::I64,
+			F32 => ValueType::F32,
+			F64 => ValueType::F64,
+		}
+	}
+
+	Signature::new(
+		func_ty.params().iter().cloned().map(convert_value_type).collect::<Vec<_>>(),
+		func_ty.return_type().map(convert_value_type),
+	)
+}
+
 /// Convert a wasm_interface Signature into a cranelift_codegen Signature.
 pub fn cranelift_ir_signature(signature: Signature, call_conv: &isa::CallConv) -> ir::Signature {
 	ir::Signature {


### PR DESCRIPTION
This is a quick and dirty implementation of the wasmtime counterpart of https://github.com/paritytech/substrate/pull/4550. This is aimed to unblock polkadot progress while we are waiting #4686.

The idea is that we employ parity-wasm to extract all the imports and do the resolving ourselves, then we collect all the missing function imports and create modules and stubs for them.
