### PR TITLE
Remove default hasher

### DIFF
--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -228,11 +228,11 @@ decl_error! {
 decl_storage! {
 	trait Store for Module<T: Trait> as Assets {
 		/// The number of units of assets held by any given account.
-		Balances: map (T::AssetId, T::AccountId) => T::Balance;
+		Balances: map hasher(blake2_256) (T::AssetId, T::AccountId) => T::Balance;
 		/// The next asset identifier up for grabs.
 		NextAssetId get(fn next_asset_id): T::AssetId;
 		/// The total unit supply of an asset.
-		TotalSupply: map T::AssetId => T::Balance;
+		TotalSupply: map hasher(blake2_256) T::AssetId => T::Balance;
 	}
 }
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -145,7 +145,7 @@ decl_storage! {
 		/// We reset all segments and return to `0` at the beginning of every
 		/// epoch.
 		SegmentIndex build(|_| 0): u32;
-		UnderConstruction: map u32 => Vec<[u8; 32 /* VRF_OUTPUT_LENGTH */]>;
+		UnderConstruction: map hasher(blake2_256) u32 => Vec<[u8; 32 /* VRF_OUTPUT_LENGTH */]>;
 
 		/// Temporary value (cleared at block finalization) which is `Some`
 		/// if per-block initialization has already been called for current block.

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -374,7 +374,9 @@ decl_storage! {
 						})
 					})
 			}).collect::<Vec<_>>()
-		}): map T::AccountId => Option<VestingSchedule<T::Balance, T::BlockNumber>>;
+		}):
+			map hasher(blake2_256) T::AccountId
+			=> Option<VestingSchedule<T::Balance, T::BlockNumber>>;
 
 		/// The 'free' balance of a given account.
 		///
@@ -389,7 +391,7 @@ decl_storage! {
 		/// collapsed to zero if it ever becomes less than `ExistentialDeposit`.
 		pub FreeBalance get(fn free_balance)
 			build(|config: &GenesisConfig<T, I>| config.balances.clone()):
-			map T::AccountId => T::Balance;
+			map hasher(blake2_256) T::AccountId => T::Balance;
 
 		/// The amount of the balance of a given account that is externally reserved; this can still get
 		/// slashed, but gets slashed last of all.
@@ -402,10 +404,12 @@ decl_storage! {
 		///
 		/// `frame_system::AccountNonce` is also deleted if `FreeBalance` is also zero (it also gets
 		/// collapsed to zero if it ever becomes less than `ExistentialDeposit`.)
-		pub ReservedBalance get(fn reserved_balance): map T::AccountId => T::Balance;
+		pub ReservedBalance get(fn reserved_balance):
+			map hasher(blake2_256) T::AccountId => T::Balance;
 
 		/// Any liquidity locks on some account balances.
-		pub Locks get(fn locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
+		pub Locks get(fn locks):
+			map hasher(blake2_256) T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
 	}
 	add_extra_genesis {
 		config(balances): Vec<(T::AccountId, T::Balance)>;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -87,9 +87,11 @@ decl_storage! {
 		/// The hashes of the active proposals.
 		pub Proposals get(fn proposals): Vec<T::Hash>;
 		/// Actual proposal for a given hash, if it's current.
-		pub ProposalOf get(fn proposal_of): map T::Hash => Option<<T as Trait<I>>::Proposal>;
+		pub ProposalOf get(fn proposal_of):
+			map hasher(blake2_256) T::Hash => Option<<T as Trait<I>>::Proposal>;
 		/// Votes on a given proposal, if it is ongoing.
-		pub Voting get(fn voting): map T::Hash => Option<Votes<T::AccountId>>;
+		pub Voting get(fn voting):
+			map hasher(blake2_256) T::Hash => Option<Votes<T::AccountId>>;
 		/// Proposals so far.
 		pub ProposalCount get(fn proposal_count): u32;
 		/// The current members of the collective. This is stored sorted (just by value).

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -942,13 +942,13 @@ decl_storage! {
 		/// Current cost schedule for contracts.
 		CurrentSchedule get(fn current_schedule) config(): Schedule = Schedule::default();
 		/// A mapping from an original code hash to the original code, untouched by instrumentation.
-		pub PristineCode: map CodeHash<T> => Option<Vec<u8>>;
+		pub PristineCode: map hasher(blake2_256) CodeHash<T> => Option<Vec<u8>>;
 		/// A mapping between an original code hash and instrumented wasm code, ready for execution.
-		pub CodeStorage: map CodeHash<T> => Option<wasm::PrefabWasmModule>;
+		pub CodeStorage: map hasher(blake2_256) CodeHash<T> => Option<wasm::PrefabWasmModule>;
 		/// The subtrie counter.
 		pub AccountCounter: u64 = 0;
 		/// The code associated with a given account.
-		pub ContractInfoOf: map T::AccountId => Option<ContractInfo<T>>;
+		pub ContractInfoOf: map hasher(blake2_256) T::AccountId => Option<ContractInfo<T>>;
 		/// The price of one unit of gas.
 		GasPrice get(fn gas_price) config(): BalanceOf<T> = 1.into();
 	}

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -268,9 +268,12 @@ decl_storage! {
 		pub PublicProps get(fn public_props): Vec<(PropIndex, T::Hash, T::AccountId)>;
 		/// Map of hashes to the proposal preimage, along with who registered it and their deposit.
 		/// The block number is the block at which it was deposited.
-		pub Preimages: map T::Hash => Option<(Vec<u8>, T::AccountId, BalanceOf<T>, T::BlockNumber)>;
+		pub Preimages:
+			map hasher(blake2_256) T::Hash
+			=> Option<(Vec<u8>, T::AccountId, BalanceOf<T>, T::BlockNumber)>;
 		/// Those who have locked a deposit.
-		pub DepositOf get(fn deposit_of): map PropIndex => Option<(BalanceOf<T>, Vec<T::AccountId>)>;
+		pub DepositOf get(fn deposit_of):
+			map hasher(blake2_256) PropIndex => Option<(BalanceOf<T>, Vec<T::AccountId>)>;
 
 		/// The next free referendum index, aka the number of referenda started so far.
 		pub ReferendumCount get(fn referendum_count) build(|_| 0 as ReferendumIndex): ReferendumIndex;
@@ -279,25 +282,28 @@ decl_storage! {
 		pub LowestUnbaked get(fn lowest_unbaked) build(|_| 0 as ReferendumIndex): ReferendumIndex;
 		/// Information concerning any given referendum.
 		pub ReferendumInfoOf get(fn referendum_info):
-			map ReferendumIndex => Option<ReferendumInfo<T::BlockNumber, T::Hash>>;
+			map hasher(blake2_256) ReferendumIndex
+			=> Option<ReferendumInfo<T::BlockNumber, T::Hash>>;
 		/// Queue of successful referenda to be dispatched. Stored ordered by block number.
 		pub DispatchQueue get(fn dispatch_queue): Vec<(T::BlockNumber, T::Hash, ReferendumIndex)>;
 
 		/// Get the voters for the current proposal.
-		pub VotersFor get(fn voters_for): map ReferendumIndex => Vec<T::AccountId>;
+		pub VotersFor get(fn voters_for):
+			map hasher(blake2_256) ReferendumIndex => Vec<T::AccountId>;
 
 		/// Get the vote in a given referendum of a particular voter. The result is meaningful only
 		/// if `voters_for` includes the voter when called with the referendum (you'll get the
 		/// default `Vote` value otherwise). If you don't want to check `voters_for`, then you can
 		/// also check for simple existence with `VoteOf::exists` first.
-		pub VoteOf get(fn vote_of): map (ReferendumIndex, T::AccountId) => Vote;
+		pub VoteOf get(fn vote_of): map hasher(blake2_256) (ReferendumIndex, T::AccountId) => Vote;
 
 		/// Who is able to vote for whom. Value is the fund-holding account, key is the
 		/// vote-transaction-sending account.
-		pub Proxy get(fn proxy): map T::AccountId => Option<T::AccountId>;
+		pub Proxy get(fn proxy): map hasher(blake2_256) T::AccountId => Option<T::AccountId>;
 
 		/// Get the account (and lock periods) to which another account is delegating vote.
-		pub Delegations get(fn delegations): linked_map T::AccountId => (T::AccountId, Conviction);
+		pub Delegations get(fn delegations):
+			linked_map hasher(blake2_256) T::AccountId => (T::AccountId, Conviction);
 
 		/// True if the last referendum tabled was submitted externally. False if it was a public
 		/// proposal.
@@ -311,10 +317,11 @@ decl_storage! {
 
 		/// A record of who vetoed what. Maps proposal hash to a possible existent block number
 		/// (until when it may not be resubmitted) and who vetoed it.
-		pub Blacklist get(fn blacklist): map T::Hash => Option<(T::BlockNumber, Vec<T::AccountId>)>;
+		pub Blacklist get(fn blacklist):
+			map hasher(blake2_256) T::Hash => Option<(T::BlockNumber, Vec<T::AccountId>)>;
 
 		/// Record of all proposals that have been subject to emergency cancellation.
-		pub Cancellations: map T::Hash => bool;
+		pub Cancellations: map hasher(blake2_256) T::Hash => bool;
 	}
 }
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -157,9 +157,9 @@ decl_storage! {
 		pub ElectionRounds get(fn election_rounds): u32 = Zero::zero();
 
 		/// Votes of a particular voter, with the round index of the votes.
-		pub VotesOf get(fn votes_of): linked_map T::AccountId => Vec<T::AccountId>;
+		pub VotesOf get(fn votes_of): linked_map hasher(blake2_256) T::AccountId => Vec<T::AccountId>;
 		/// Locked stake of a voter.
-		pub StakeOf get(fn stake_of): map T::AccountId => BalanceOf<T>;
+		pub StakeOf get(fn stake_of): map hasher(blake2_256) T::AccountId => BalanceOf<T>;
 
 		/// The present candidate list. Sorted based on account-id. A current member or a runner can
 		/// never enter this vector and is always implicitly assumed to be a candidate.

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -235,14 +235,17 @@ decl_storage! {
 		// bit-wise manner. In order to get a human-readable representation (`Vec<bool>`), use
 		// [`all_approvals_of`]. Furthermore, each vector of scalars is chunked with the cap of
 		// `APPROVAL_SET_SIZE`.
-		pub ApprovalsOf get(fn approvals_of): map (T::AccountId, SetIndex) => Vec<ApprovalFlag>;
+		pub ApprovalsOf get(fn approvals_of):
+			map hasher(blake2_256) (T::AccountId, SetIndex) => Vec<ApprovalFlag>;
 		/// The vote index and list slot that the candidate `who` was registered or `None` if they
 		/// are not currently registered.
-		pub RegisterInfoOf get(fn candidate_reg_info): map T::AccountId => Option<(VoteIndex, u32)>;
+		pub RegisterInfoOf get(fn candidate_reg_info):
+			map hasher(blake2_256) T::AccountId => Option<(VoteIndex, u32)>;
 		/// Basic information about a voter.
-		pub VoterInfoOf get(fn voter_info): map T::AccountId => Option<VoterInfo<BalanceOf<T>>>;
+		pub VoterInfoOf get(fn voter_info):
+			map hasher(blake2_256) T::AccountId => Option<VoterInfo<BalanceOf<T>>>;
 		/// The present voter list (chunked and capped at [`VOTER_SET_SIZE`]).
-		pub Voters get(fn voters): map SetIndex => Vec<Option<T::AccountId>>;
+		pub Voters get(fn voters): map hasher(blake2_256) SetIndex => Vec<Option<T::AccountId>>;
 		/// the next free set to store a voter in. This will keep growing.
 		pub NextVoterSet get(fn next_nonfull_voter_set): SetIndex = 0;
 		/// Current number of Voters.
@@ -263,7 +266,7 @@ decl_storage! {
 
 		/// Who is able to vote for whom. Value is the fund-holding account, key is the
 		/// vote-transaction-sending account.
-		pub Proxy get(fn proxy): map T::AccountId => Option<T::AccountId>;
+		pub Proxy get(fn proxy): map hasher(blake2_256) T::AccountId => Option<T::AccountId>;
 	}
 }
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -163,9 +163,9 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
-		Accounts get(fn accounts) config(): map H160 => Account;
-		AccountCodes: map H160 => Vec<u8>;
-		AccountStorages: double_map H160, H256 => H256;
+		Accounts get(fn accounts) config(): map hasher(blake2_256) H160 => Account;
+		AccountCodes: map hasher(blake2_256) H160 => Vec<u8>;
+		AccountStorages: double_map hasher(blake2_256) H160, hasher(blake2_256) H256 => H256;
 	}
 }
 

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -329,7 +329,7 @@ decl_storage! {
 		//   `pub? Name get(fn getter_name)? [config()|config(myname)] [build(|_| {...})] : <type> (= <new_default_value>)?;`
 		// where `<type>` is either:
 		//   - `Type` (a basic value item); or
-		//   - `map KeyType => ValueType` (a map item).
+		//   - `map hasher(HasherKind) KeyType => ValueType` (a map item).
 		//
 		// Note that there are two optional modifiers for the storage type declaration.
 		// - `Foo: Option<u32>`:
@@ -339,7 +339,7 @@ decl_storage! {
 		//   - `Foo::put(1); Foo::get()` returns `1`;
 		//   - `Foo::kill(); Foo::get()` returns `0` (u32::default()).
 		// e.g. Foo: u32;
-		// e.g. pub Bar get(fn bar): map T::AccountId => Vec<(T::Balance, u64)>;
+		// e.g. pub Bar get(fn bar): map hasher(blake2_256) T::AccountId => Vec<(T::Balance, u64)>;
 		//
 		// For basic value items, you'll get a type which implements
 		// `frame_support::StorageValue`. For map items, you'll get a type which
@@ -351,7 +351,7 @@ decl_storage! {
 		Dummy get(fn dummy) config(): Option<T::Balance>;
 
 		// A map that has enumerable entries.
-		Bar get(fn bar) config(): linked_map T::AccountId => T::Balance;
+		Bar get(fn bar) config(): linked_map hasher(blake2_256) T::AccountId => T::Balance;
 
 		// this one uses the default, we'll demonstrate the usage of 'mutate' API.
 		Foo get(fn foo) config(): T::Balance;

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -454,22 +454,26 @@ decl_storage! {
 		pub TotalIssuance get(fn total_issuance) build(|config: &GenesisConfig<T>| {
 			let issuance = config.initial_balance * (config.endowed_accounts.len() as u32).into();
 			config.assets.iter().map(|id| (id.clone(), issuance)).collect::<Vec<_>>()
-		}): map T::AssetId => T::Balance;
+		}): map hasher(blake2_256) T::AssetId => T::Balance;
 
 		/// The free balance of a given asset under an account.
-		pub FreeBalance: double_map T::AssetId, hasher(twox_128) T::AccountId => T::Balance;
+		pub FreeBalance:
+			double_map hasher(blake2_256) T::AssetId, hasher(twox_128) T::AccountId => T::Balance;
 
 		/// The reserved balance of a given asset under an account.
-		pub ReservedBalance: double_map T::AssetId, hasher(twox_128) T::AccountId => T::Balance;
+		pub ReservedBalance:
+			double_map hasher(blake2_256) T::AssetId, hasher(twox_128) T::AccountId => T::Balance;
 
 		/// Next available ID for user-created asset.
 		pub NextAssetId get(fn next_asset_id) config(): T::AssetId;
 
 		/// Permission options for a given asset.
-		pub Permissions get(fn get_permission): map T::AssetId => PermissionVersions<T::AccountId>;
+		pub Permissions get(fn get_permission):
+			map hasher(blake2_256) T::AssetId => PermissionVersions<T::AccountId>;
 
 		/// Any liquidity locks on some account balances.
-		pub Locks get(fn locks): map T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
+		pub Locks get(fn locks):
+			map hasher(blake2_256) T::AccountId => Vec<BalanceLock<T::Balance, T::BlockNumber>>;
 
 		/// The identity of the asset which is the one that is designated for the chain's staking system.
 		pub StakingAssetId get(fn staking_asset_id) config(): T::AssetId;

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -175,7 +175,7 @@ decl_storage! {
 		CurrentSetId get(fn current_set_id) build(|_| fg_primitives::SetId::default()): SetId;
 
 		/// A mapping from grandpa set ID to the index of the *most recent* session for which its members were responsible.
-		SetIdSession get(fn session_for_set): map SetId => Option<SessionIndex>;
+		SetIdSession get(fn session_for_set): map hasher(blake2_256) SetId => Option<SessionIndex>;
 	}
 	add_extra_genesis {
 		config(authorities): AuthorityList;

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -377,16 +377,19 @@ pub struct RegistrarInfo<
 decl_storage! {
 	trait Store for Module<T: Trait> as Sudo {
 		/// Information that is pertinent to identify the entity behind an account.
-		pub IdentityOf get(fn identity): map T::AccountId => Option<Registration<BalanceOf<T>>>;
+		pub IdentityOf get(fn identity):
+			map hasher(blake2_256) T::AccountId => Option<Registration<BalanceOf<T>>>;
 
 		/// The super-identity of an alternative "sub" identity together with its name, within that
 		/// context. If the account is not some other account's sub-identity, then just `None`.
-		pub SuperOf get(fn super_of): map T::AccountId => Option<(T::AccountId, Data)>;
+		pub SuperOf get(fn super_of):
+			map hasher(blake2_256) T::AccountId => Option<(T::AccountId, Data)>;
 
 		/// Alternative "sub" identities of this account.
 		///
 		/// The first item is the deposit, the second is a vector of the accounts.
-		pub SubsOf get(fn subs): map T::AccountId => (BalanceOf<T>, Vec<T::AccountId>);
+		pub SubsOf get(fn subs):
+			map hasher(blake2_256) T::AccountId => (BalanceOf<T>, Vec<T::AccountId>);
 
 		/// The set of registrars. Not expected to get very big as can only be added through a
 		/// special origin (likely a council motion).

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -233,12 +233,14 @@ decl_storage! {
 
 		/// For each session index, we keep a mapping of `AuthIndex`
 		/// to `offchain::OpaqueNetworkState`.
-		ReceivedHeartbeats get(fn received_heartbeats): double_map SessionIndex, AuthIndex
+		ReceivedHeartbeats get(fn received_heartbeats):
+			double_map hasher(blake2_256) SessionIndex, hasher(blake2_256) AuthIndex
 			=> Option<Vec<u8>>;
 
 		/// For each session index, we keep a mapping of `T::ValidatorId` to the
 		/// number of blocks authored by the given authority.
-		AuthoredBlocks get(fn authored_blocks): double_map SessionIndex, T::ValidatorId => u32;
+		AuthoredBlocks get(fn authored_blocks):
+			double_map hasher(blake2_256) SessionIndex, hasher(blake2_256) T::ValidatorId => u32;
 	}
 	add_extra_genesis {
 		config(keys): Vec<T::AuthorityId>;

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -108,7 +108,7 @@ decl_storage! {
 					].to_owned(),
 				))
 				.collect::<Vec<_>>()
-		}): map T::AccountIndex => Vec<T::AccountId>;
+		}): map hasher(blake2_256) T::AccountIndex => Vec<T::AccountId>;
 	}
 	add_extra_genesis {
 		config(ids): Vec<T::AccountId>;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Trait: frame_system::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Sudo {
 		/// The lookup table for names.
-		NameOf: map T::AccountId => Option<(Vec<u8>, BalanceOf<T>)>;
+		NameOf: map hasher(blake2_256) T::AccountId => Option<(Vec<u8>, BalanceOf<T>)>;
 	}
 }
 

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -54,10 +54,12 @@ pub trait Trait: frame_system::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Offences {
 		/// The primary structure that holds all offence records keyed by report identifiers.
-		Reports get(fn reports): map ReportIdOf<T> => Option<OffenceDetails<T::AccountId, T::IdentificationTuple>>;
+		Reports get(fn reports): map hasher(blake2_256) ReportIdOf<T> => Option<OffenceDetails<T::AccountId, T::IdentificationTuple>>;
 
 		/// A vector of reports of the same kind that happened at the same time slot.
-		ConcurrentReportsIndex: double_map Kind, OpaqueTimeSlot => Vec<ReportIdOf<T>>;
+		ConcurrentReportsIndex:
+			double_map hasher(blake2_256) Kind, hasher(blake2_256) OpaqueTimeSlot
+			=> Vec<ReportIdOf<T>>;
 
 		/// Enumerates all reports of a kind along with the time they happened.
 		///
@@ -65,7 +67,7 @@ decl_storage! {
 		///
 		/// Note that the actual type of this mapping is `Vec<u8>`, this is because values of
 		/// different types are not supported at the moment so we are doing the manual serialization.
-		ReportsByKindIndex: map Kind => Vec<u8>; // (O::TimeSlot, ReportIdOf<T>)
+		ReportsByKindIndex: map hasher(blake2_256) Kind => Vec<u8>; // (O::TimeSlot, ReportIdOf<T>)
 	}
 }
 

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -242,7 +242,8 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Recovery {
 		/// The set of recoverable accounts and their recovery configuration.
 		pub Recoverable get(fn recovery_config):
-			map T::AccountId => Option<RecoveryConfig<T::BlockNumber, BalanceOf<T>, T::AccountId>>;
+			map hasher(blake2_256) T::AccountId
+			=> Option<RecoveryConfig<T::BlockNumber, BalanceOf<T>, T::AccountId>>;
 		/// Active recovery attempts.
 		///
 		/// First account is the account to be recovered, and the second account
@@ -253,7 +254,8 @@ decl_storage! {
 		/// The final list of recovered accounts.
 		///
 		/// Map from the recovered account to the user who can access it.
-		pub Recovered get(fn recovered_account): map T::AccountId => Option<T::AccountId>;
+		pub Recovered get(fn recovered_account):
+			map hasher(blake2_256) T::AccountId => Option<T::AccountId>;
 	}
 }
 

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -165,7 +165,7 @@ decl_storage! {
 		/// check if a candidate is already in the pool, without having to
 		/// iterate over the entire pool (the `Pool` is not sorted by
 		/// `T::AccountId`, but by `T::Score` instead).
-		CandidateExists get(fn candidate_exists): map T::AccountId => bool;
+		CandidateExists get(fn candidate_exists): map hasher(blake2_256) T::AccountId => bool;
 
 		/// The current membership, stored as an ordered Vec.
 		Members get(fn members): Vec<T::AccountId>;

--- a/frame/session/src/historical.rs
+++ b/frame/session/src/historical.rs
@@ -55,11 +55,14 @@ pub trait Trait: super::Trait {
 decl_storage! {
 	trait Store for Module<T: Trait> as Session {
 		/// Mapping from historical session indices to session-data root hash and validator count.
-		HistoricalSessions get(fn historical_root): map SessionIndex => Option<(T::Hash, ValidatorCount)>;
+		HistoricalSessions get(fn historical_root):
+			map hasher(blake2_256) SessionIndex => Option<(T::Hash, ValidatorCount)>;
 		/// The range of historical sessions we store. [first, last)
 		StoredRange: Option<(SessionIndex, SessionIndex)>;
 		/// Deprecated.
-		CachedObsolete: map SessionIndex => Option<Vec<(T::ValidatorId, T::FullIdentification)>>;
+		CachedObsolete:
+			map hasher(blake2_256) SessionIndex
+			=> Option<Vec<(T::ValidatorId, T::FullIdentification)>>;
 	}
 }
 

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -414,7 +414,8 @@ decl_storage! {
 
 		/// The set of suspended candidates.
 		pub SuspendedCandidates get(suspended_candidate):
-			map T::AccountId => Option<(BalanceOf<T, I>, BidKind<T::AccountId, BalanceOf<T, I>>)>;
+			map hasher(blake2_256) T::AccountId
+			=> Option<(BalanceOf<T, I>, BidKind<T::AccountId, BalanceOf<T, I>>)>;
 
 		/// Amount of our account balance that is specifically for the next round's bid(s).
 		pub Pot get(fn pot) config(): BalanceOf<T, I>;
@@ -431,19 +432,19 @@ decl_storage! {
 		}): Vec<T::AccountId>;
 
 		/// The set of suspended members.
-		pub SuspendedMembers get(fn suspended_member): map T::AccountId => bool;
+		pub SuspendedMembers get(fn suspended_member): map hasher(blake2_256) T::AccountId => bool;
 
 		/// The current bids, stored ordered by the value of the bid.
 		Bids: Vec<Bid<T::AccountId, BalanceOf<T, I>>>;
 
 		/// Members currently vouching or banned from vouching again
-		Vouching get(fn vouching): map T::AccountId => Option<VouchingStatus>;
+		Vouching get(fn vouching): map hasher(blake2_256) T::AccountId => Option<VouchingStatus>;
 
 		/// Pending payouts; ordered by block number, with the amount that should be paid out.
-		Payouts: map T::AccountId => Vec<(T::BlockNumber, BalanceOf<T, I>)>;
+		Payouts: map hasher(blake2_256) T::AccountId => Vec<(T::BlockNumber, BalanceOf<T, I>)>;
 
 		/// The ongoing number of losing votes cast by the member.
-		Strikes: map T::AccountId => StrikeCount;
+		Strikes: map hasher(blake2_256) T::AccountId => StrikeCount;
 
 		/// Double map from Candidate -> Voter -> (Maybe) Vote.
 		Votes: double_map

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -671,28 +671,32 @@ decl_storage! {
 		pub Invulnerables get(fn invulnerables) config(): Vec<T::AccountId>;
 
 		/// Map from all locked "stash" accounts to the controller account.
-		pub Bonded get(fn bonded): map T::AccountId => Option<T::AccountId>;
+		pub Bonded get(fn bonded): map hasher(blake2_256) T::AccountId => Option<T::AccountId>;
 		/// Map from all (unlocked) "controller" accounts to the info regarding the staking.
 		pub Ledger get(fn ledger):
-			map T::AccountId => Option<StakingLedger<T::AccountId, BalanceOf<T>>>;
+			map hasher(blake2_256) T::AccountId
+			=> Option<StakingLedger<T::AccountId, BalanceOf<T>>>;
 
 		/// Where the reward payment should be made. Keyed by stash.
-		pub Payee get(fn payee): map T::AccountId => RewardDestination;
+		pub Payee get(fn payee): map hasher(blake2_256) T::AccountId => RewardDestination;
 
 		/// The map from (wannabe) validator stash key to the preferences of that validator.
-		pub Validators get(fn validators): linked_map T::AccountId => ValidatorPrefs;
+		pub Validators get(fn validators):
+			linked_map hasher(blake2_256) T::AccountId => ValidatorPrefs;
 
 		/// The map from nominator stash key to the set of stash keys of all validators to nominate.
 		///
 		/// NOTE: is private so that we can ensure upgraded before all typical accesses.
 		/// Direct storage APIs can still bypass this protection.
-		Nominators get(fn nominators): linked_map T::AccountId => Option<Nominations<T::AccountId>>;
+		Nominators get(fn nominators):
+			linked_map hasher(blake2_256) T::AccountId => Option<Nominations<T::AccountId>>;
 
 		/// Nominators for a particular account that is in action right now. You can't iterate
 		/// through validators here, but you can find them in the Session module.
 		///
 		/// This is keyed by the stash account.
-		pub Stakers get(fn stakers): map T::AccountId => Exposure<T::AccountId, BalanceOf<T>>;
+		pub Stakers get(fn stakers):
+			map hasher(blake2_256) T::AccountId => Exposure<T::AccountId, BalanceOf<T>>;
 
 		/// The currently elected validator set keyed by stash account ID.
 		pub CurrentElected get(fn current_elected): Vec<T::AccountId>;
@@ -729,7 +733,8 @@ decl_storage! {
 		pub CanceledSlashPayout get(fn canceled_payout) config(): BalanceOf<T>;
 
 		/// All unapplied slashes that are queued for later.
-		pub UnappliedSlashes: map EraIndex => Vec<UnappliedSlash<T::AccountId, BalanceOf<T>>>;
+		pub UnappliedSlashes:
+			map hasher(blake2_256) EraIndex => Vec<UnappliedSlash<T::AccountId, BalanceOf<T>>>;
 
 		/// A mapping from still-bonded eras to the first session index of that era.
 		BondedEras: Vec<(EraIndex, SessionIndex)>;
@@ -737,19 +742,22 @@ decl_storage! {
 		/// All slashing events on validators, mapped by era to the highest slash proportion
 		/// and slash value of the era.
 		ValidatorSlashInEra:
-			double_map EraIndex, hasher(twox_128) T::AccountId => Option<(Perbill, BalanceOf<T>)>;
+			double_map hasher(blake2_256) EraIndex, hasher(twox_128) T::AccountId
+			=> Option<(Perbill, BalanceOf<T>)>;
 
 		/// All slashing events on nominators, mapped by era to the highest slash value of the era.
 		NominatorSlashInEra:
-			double_map EraIndex, hasher(twox_128) T::AccountId => Option<BalanceOf<T>>;
+			double_map hasher(blake2_256) EraIndex, hasher(twox_128) T::AccountId
+			=> Option<BalanceOf<T>>;
 
 		/// Slashing spans for stash accounts.
-		SlashingSpans: map T::AccountId => Option<slashing::SlashingSpans>;
+		SlashingSpans: map hasher(blake2_256) T::AccountId => Option<slashing::SlashingSpans>;
 
 		/// Records information about the maximum slash of a stash within a slashing span,
 		/// as well as how much reward has been paid out.
 		SpanSlash:
-			map (T::AccountId, slashing::SpanIndex) => slashing::SpanRecord<BalanceOf<T>>;
+			map hasher(blake2_256) (T::AccountId, slashing::SpanIndex)
+			=> slashing::SpanRecord<BalanceOf<T>>;
 
 		/// The earliest era for which we have a pending, unapplied slash.
 		EarliestUnappliedSlash: Option<EraIndex>;

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -35,8 +35,8 @@ use proc_macro::TokenStream;
 /// decl_storage! {
 /// 	trait Store for Module<T: Trait> as Example {
 /// 		Foo get(fn foo) config(): u32=12;
-/// 		Bar: map u32 => u32;
-/// 		pub Zed build(|config| vec![(0, 0)]): linked_map u32 => u32;
+/// 		Bar: map hasher(blake2_256) u32 => u32;
+/// 		pub Zed build(|config| vec![(0, 0)]): linked_map hasher(blake2_256) u32 => u32;
 /// 	}
 /// }
 /// ```
@@ -74,7 +74,7 @@ use proc_macro::TokenStream;
 ///   `$hash` representing a choice of hashing algorithms available in the
 ///   [`Hashable`](../frame_support/trait.Hashable.html) trait.
 ///
-///   `hasher($hash)` is optional and its default is `blake2_256`. One should use another hasher
+///   `blake2_256` and `blake2_128_concat` are strong hasher. One should use another hasher
 ///   with care, see generator documentation.
 ///
 ///   The generator is implemented with:
@@ -95,7 +95,7 @@ use proc_macro::TokenStream;
 ///   `$hash` representing a choice of hashing algorithms available in the
 ///   [`Hashable`](../frame_support/trait.Hashable.html) trait.
 ///
-///   `hasher($hash)` is optional and its default is `blake2_256`. One should use another hasher
+///   `blake2_256` and `blake2_128_concat` are strong hasher. One should use another hasher
 ///   with care, see generator documentation.
 ///
 ///   All key formatting logic can be accessed in a type-agnostic format via the
@@ -126,13 +126,12 @@ use proc_macro::TokenStream;
 ///   [`Hashable`](../frame_support/trait.Hashable.html) trait. They must be choosen with care, see
 ///   generator documentation.
 ///
-///   `hasher($hash1)` and `hasher($hash2) are optional and default to `blake2_256`.
-///   One should use another hasher with care, see generator documentation.
-///
-///   If the first key is untrusted, a cryptographic `hasher` such as `blake2_256` must be used.
+///   If the first key is untrusted, a cryptographic `hasher` such as `blake2_256` or
+///   `blake2_128_concat`  must be used.
 ///   Otherwise, other values of all storage items can be compromised.
 ///
-///   If the second key is untrusted, a cryptographic `hasher` such as `blake2_256` must be used.
+///   If the second key is untrusted, a cryptographic `hasher` such as `blake2_256` or
+///   `blake2_128_concat` must be used.
 ///   Otherwise, other items in storage with the same first key can be compromised.
 ///
 ///   The generator is implemented with:

--- a/frame/support/procedural/src/storage/parse.rs
+++ b/frame/support/procedural/src/storage/parse.rs
@@ -461,29 +461,31 @@ fn parse_storage_line_defs(
 			})?;
 		}
 
+		let span = line.storage_type.span();
+		let no_hasher_error = || syn::Error::new(
+			span,
+			"Default hasher has been removed, use explicit hasher(blake2_256) instead."
+		);
+
 		let storage_type = match line.storage_type {
 			DeclStorageType::Map(map) => super::StorageLineTypeDef::Map(
 				super::MapDef {
-					hasher: map.hasher.inner.map(Into::into)
-						.unwrap_or(super::HasherKind::Blake2_256),
+					hasher: map.hasher.inner.ok_or_else(no_hasher_error)?.into(),
 					key: map.key,
 					value: map.value,
 				}
 			),
 			DeclStorageType::LinkedMap(map) => super::StorageLineTypeDef::LinkedMap(
 				super::MapDef {
-					hasher: map.hasher.inner.map(Into::into)
-						.unwrap_or(super::HasherKind::Blake2_256),
+					hasher: map.hasher.inner.ok_or_else(no_hasher_error)?.into(),
 					key: map.key,
 					value: map.value,
 				}
 			),
 			DeclStorageType::DoubleMap(map) => super::StorageLineTypeDef::DoubleMap(
 				super::DoubleMapDef {
-					hasher1: map.hasher1.inner.map(Into::into)
-						.unwrap_or(super::HasherKind::Blake2_256),
-					hasher2: map.hasher2.inner.map(Into::into)
-						.unwrap_or(super::HasherKind::Blake2_256),
+					hasher1: map.hasher1.inner.ok_or_else(no_hasher_error)?.into(),
+					hasher2: map.hasher2.inner.ok_or_else(no_hasher_error)?.into(),
 					key1: map.key1,
 					key2: map.key2,
 					value: map.value,

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -253,20 +253,23 @@ mod tests {
 		trait Store for Module<T: Trait> as Example {
 			pub Data get(fn data) build(|_| vec![(15u32, 42u64)]):
 				linked_map hasher(twox_64_concat) u32 => u64;
-			pub OptionLinkedMap: linked_map u32 => Option<u32>;
+			pub OptionLinkedMap: linked_map hasher(blake2_256) u32 => Option<u32>;
 			pub GenericData get(fn generic_data):
 				linked_map hasher(twox_128) T::BlockNumber => T::BlockNumber;
 			pub GenericData2 get(fn generic_data2):
-				linked_map T::BlockNumber => Option<T::BlockNumber>;
+				linked_map hasher(blake2_256) T::BlockNumber => Option<T::BlockNumber>;
 			pub GetterNoFnKeyword get(no_fn): Option<u32>;
 
 			pub DataDM config(test_config) build(|_| vec![(15u32, 16u32, 42u64)]):
 				double_map hasher(twox_64_concat) u32, hasher(blake2_256) u32 => u64;
 			pub GenericDataDM:
-				double_map T::BlockNumber, hasher(twox_128) T::BlockNumber => T::BlockNumber;
+				double_map hasher(blake2_256) T::BlockNumber, hasher(twox_128) T::BlockNumber
+				=> T::BlockNumber;
 			pub GenericData2DM:
-				double_map T::BlockNumber, hasher(twox_256) T::BlockNumber => Option<T::BlockNumber>;
-			pub AppendableDM: double_map u32, T::BlockNumber => Vec<u32>;
+				double_map hasher(blake2_256) T::BlockNumber, hasher(twox_256) T::BlockNumber
+				=> Option<T::BlockNumber>;
+			pub AppendableDM:
+				double_map hasher(blake2_256) u32, hasher(blake2_256) T::BlockNumber => Vec<u32>;
 		}
 	}
 

--- a/frame/support/src/storage/generator/mod.rs
+++ b/frame/support/src/storage/generator/mod.rs
@@ -65,7 +65,7 @@ mod tests {
 	crate::decl_storage! {
 		trait Store for Module<T: Trait> as Runtime {
 			Value get(fn value) config(): (u64, u64);
-			NumberMap: linked_map NumberNumber => u64;
+			NumberMap: linked_map hasher(blake2_256) NumberNumber => u64;
 		}
 	}
 

--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -59,23 +59,27 @@ mod tests {
 			GetOptU32WithBuilderNone get(fn opt_u32_with_builder_none) build(|_| None): Option<u32>;
 
 			// map non-getters: pub / $default
-			MAPU32 : map u32 => Option<String>;
-			pub PUBMAPU32 : map u32 => Option<String>;
-			MAPU32MYDEF : map u32 => Option<String>;
-			pub PUBMAPU32MYDEF : map u32 => Option<String>;
+			MAPU32 : map hasher(blake2_256) u32 => Option<String>;
+			pub PUBMAPU32 : map hasher(blake2_256) u32 => Option<String>;
+			MAPU32MYDEF : map hasher(blake2_256) u32 => Option<String>;
+			pub PUBMAPU32MYDEF : map hasher(blake2_256) u32 => Option<String>;
 
 			// map getters: pub / $default
-			GETMAPU32 get(fn map_u32_getter): map u32 => String;
-			pub PUBGETMAPU32 get(fn pub_map_u32_getter): map u32 => String;
+			GETMAPU32 get(fn map_u32_getter): map hasher(blake2_256) u32 => String;
+			pub PUBGETMAPU32 get(fn pub_map_u32_getter): map hasher(blake2_256) u32 => String;
 
-			GETMAPU32MYDEF get(fn map_u32_getter_mydef): map u32 => String = "map".into();
-			pub PUBGETMAPU32MYDEF get(fn pub_map_u32_getter_mydef): map u32 => String = "pubmap".into();
+			GETMAPU32MYDEF get(fn map_u32_getter_mydef):
+				map hasher(blake2_256) u32 => String = "map".into();
+			pub PUBGETMAPU32MYDEF get(fn pub_map_u32_getter_mydef):
+				map hasher(blake2_256) u32 => String = "pubmap".into();
 
 			// linked map
-			LINKEDMAPU32 : linked_map u32 => Option<String>;
-			pub PUBLINKEDMAPU32MYDEF : linked_map u32 => Option<String>;
-			GETLINKEDMAPU32 get(fn linked_map_u32_getter): linked_map u32 => String;
-			pub PUBGETLINKEDMAPU32MYDEF get(fn pub_linked_map_u32_getter_mydef): linked_map u32 => String = "pubmap".into();
+			LINKEDMAPU32 : linked_map hasher(blake2_256) u32 => Option<String>;
+			pub PUBLINKEDMAPU32MYDEF : linked_map hasher(blake2_256) u32 => Option<String>;
+			GETLINKEDMAPU32 get(fn linked_map_u32_getter):
+				linked_map hasher(blake2_256) u32 => String;
+			pub PUBGETLINKEDMAPU32MYDEF get(fn pub_linked_map_u32_getter_mydef):
+				linked_map hasher(blake2_256) u32 => String = "pubmap".into();
 
 			COMPLEXTYPE1: ::std::vec::Vec<<T as Trait>::Origin>;
 			COMPLEXTYPE2: (Vec<Vec<(u16,Box<(  )>)>>, u32);
@@ -558,17 +562,17 @@ mod test_append_and_len {
 			JustVecWithDefault: Vec<u32> = vec![6, 9];
 			OptionVec: Option<Vec<u32>>;
 
-			MapVec: map u32 => Vec<u32>;
-			MapVecWithDefault: map u32 => Vec<u32> = vec![6, 9];
-			OptionMapVec: map u32 => Option<Vec<u32>>;
+			MapVec: map hasher(blake2_256) u32 => Vec<u32>;
+			MapVecWithDefault: map hasher(blake2_256) u32 => Vec<u32> = vec![6, 9];
+			OptionMapVec: map hasher(blake2_256) u32 => Option<Vec<u32>>;
 
-			DoubleMapVec: double_map u32, u32 => Vec<u32>;
-			DoubleMapVecWithDefault: double_map u32, u32 => Vec<u32> = vec![6, 9];
-			OptionDoubleMapVec: double_map u32, u32 => Option<Vec<u32>>;
+			DoubleMapVec: double_map hasher(blake2_256) u32, hasher(blake2_256) u32 => Vec<u32>;
+			DoubleMapVecWithDefault: double_map hasher(blake2_256) u32, hasher(blake2_256) u32 => Vec<u32> = vec![6, 9];
+			OptionDoubleMapVec: double_map hasher(blake2_256) u32, hasher(blake2_256) u32 => Option<Vec<u32>>;
 
-			LinkedMapVec: linked_map u32 => Vec<u32>;
-			LinkedMapVecWithDefault: linked_map u32 => Vec<u32> = vec![6, 9];
-			OptionLinkedMapVec: linked_map u32 => Option<Vec<u32>>;
+			LinkedMapVec: linked_map hasher(blake2_256) u32 => Vec<u32>;
+			LinkedMapVecWithDefault: linked_map hasher(blake2_256) u32 => Vec<u32> = vec![6, 9];
+			OptionLinkedMapVec: linked_map hasher(blake2_256) u32 => Option<Vec<u32>>;
 		}
 	}
 

--- a/frame/support/test/tests/final_keys.rs
+++ b/frame/support/test/tests/final_keys.rs
@@ -35,18 +35,18 @@ mod no_instance {
 		trait Store for Module<T: Trait> as FinalKeysNone {
 			pub Value config(value): u32;
 
-			pub Map: map u32 => u32;
+			pub Map: map hasher(blake2_256) u32 => u32;
 			pub Map2: map hasher(twox_128) u32 => u32;
 
-			pub LinkedMap: linked_map u32 => u32;
+			pub LinkedMap: linked_map hasher(blake2_256) u32 => u32;
 			pub LinkedMap2: linked_map hasher(twox_128) u32 => u32;
 
-			pub DoubleMap: double_map u32, u32 => u32;
+			pub DoubleMap: double_map hasher(blake2_256) u32, hasher(blake2_256) u32 => u32;
 			pub DoubleMap2: double_map hasher(twox_128) u32, hasher(blake2_128) u32 => u32;
 
 			pub TestGenericValue get(fn test_generic_value) config(): Option<T::BlockNumber>;
 			pub TestGenericDoubleMap get(fn foo2) config(test_generic_double_map):
-				double_map u32, T::BlockNumber => Option<u32>;
+				double_map hasher(blake2_256) u32, hasher(blake2_256) T::BlockNumber => Option<u32>;
 		}
 	}
 }
@@ -65,18 +65,18 @@ mod instance {
 		{
 			pub Value config(value): u32;
 
-			pub Map: map u32 => u32;
+			pub Map: map hasher(blake2_256) u32 => u32;
 			pub Map2: map hasher(twox_128) u32 => u32;
 
-			pub LinkedMap: linked_map u32 => u32;
+			pub LinkedMap: linked_map hasher(blake2_256) u32 => u32;
 			pub LinkedMap2: linked_map hasher(twox_128) u32 => u32;
 
-			pub DoubleMap: double_map u32, u32 => u32;
+			pub DoubleMap: double_map hasher(blake2_256) u32, hasher(blake2_256) u32 => u32;
 			pub DoubleMap2: double_map hasher(twox_128) u32, hasher(blake2_128) u32 => u32;
 
 			pub TestGenericValue get(fn test_generic_value) config(): Option<T::BlockNumber>;
 			pub TestGenericDoubleMap get(fn foo2) config(test_generic_double_map):
-				double_map u32, T::BlockNumber => Option<u32>;
+				double_map hasher(blake2_256) u32, hasher(blake2_256) T::BlockNumber => Option<u32>;
 		}
 		add_extra_genesis {
 			// See `decl_storage` limitation.

--- a/frame/support/test/tests/genesisconfig.rs
+++ b/frame/support/test/tests/genesisconfig.rs
@@ -25,7 +25,7 @@ frame_support::decl_module! {
 
 frame_support::decl_storage! {
 	trait Store for Module<T: Trait> as Example {
-		pub AppendableDM config(t): double_map u32, T::BlockNumber => Vec<u32>;
+		pub AppendableDM config(t): double_map hasher(blake2_256) u32, hasher(blake2_256) T::BlockNumber => Vec<u32>;
 	}
 }
 

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -67,8 +67,8 @@ mod module1 {
 			T::BlockNumber: From<u32> + std::fmt::Display
 		{
 			pub Value config(value): T::GenericType;
-			pub Map: map u32 => u64;
-			pub LinkedMap: linked_map u32 => u64;
+			pub Map: map hasher(blake2_256) u32 => u64;
+			pub LinkedMap: linked_map hasher(blake2_256) u32 => u64;
 		}
 
 		add_extra_genesis {
@@ -136,9 +136,9 @@ mod module2 {
 	frame_support::decl_storage! {
 		trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Module2 {
 			pub Value config(value): T::Amount;
-			pub Map config(map): map u64 => u64;
-			pub LinkedMap config(linked_map): linked_map u64 => Vec<u8>;
-			pub DoubleMap config(double_map): double_map u64, u64 => u64;
+			pub Map config(map): map hasher(blake2_256) u64 => u64;
+			pub LinkedMap config(linked_map): linked_map hasher(blake2_256) u64 => Vec<u8>;
+			pub DoubleMap config(double_map): double_map hasher(blake2_256) u64, hasher(blake2_256) u64 => u64;
 		}
 	}
 

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -109,7 +109,7 @@ mod module {
 				} else {
 					vec![]
 				}
-			}): map Role => Option<RoleParameters<T>>;
+			}): map hasher(blake2_256) Role => Option<RoleParameters<T>>;
 
 			/// the roles members can enter into
 			pub AvailableRoles get(fn available_roles) build(|config: &GenesisConfig| {
@@ -124,10 +124,12 @@ mod module {
 			pub ActorAccountIds get(fn actor_account_ids) : Vec<T::AccountId>;
 
 			/// actor accounts associated with a role
-			pub AccountIdsByRole get(fn account_ids_by_role) : map Role => Vec<T::AccountId>;
+			pub AccountIdsByRole get(fn account_ids_by_role):
+				map hasher(blake2_256) Role => Vec<T::AccountId>;
 
 			/// tokens locked until given block number
-			pub Bondage get(fn bondage) : map T::AccountId => T::BlockNumber;
+			pub Bondage get(fn bondage):
+				map hasher(blake2_256) T::AccountId => T::BlockNumber;
 
 			/// First step before enter a role is registering intent with a new account/key.
 			/// This is done by sending a role_entry_request() from the new account.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -436,7 +436,7 @@ type EventIndex = u32;
 decl_storage! {
 	trait Store for Module<T: Trait> as System {
 		/// Extrinsics nonce for accounts.
-		pub AccountNonce get(fn account_nonce): map T::AccountId => T::Index;
+		pub AccountNonce get(fn account_nonce): map hasher(blake2_256) T::AccountId => T::Index;
 		/// Total extrinsics count for the current block.
 		ExtrinsicCount: Option<u32>;
 		/// Total weight for all extrinsics put together, for the current block.
@@ -444,9 +444,10 @@ decl_storage! {
 		/// Total length (in bytes) for all extrinsics put together, for the current block.
 		AllExtrinsicsLen: Option<u32>;
 		/// Map of block numbers to block hashes.
-		pub BlockHash get(fn block_hash) build(|_| vec![(T::BlockNumber::zero(), hash69())]): map T::BlockNumber => T::Hash;
+		pub BlockHash get(fn block_hash) build(|_| vec![(T::BlockNumber::zero(), hash69())]):
+			map hasher(blake2_256) T::BlockNumber => T::Hash;
 		/// Extrinsics data for the current block (maps an extrinsic's index to its data).
-		ExtrinsicData get(fn extrinsic_data): map u32 => Vec<u8>;
+		ExtrinsicData get(fn extrinsic_data): map hasher(blake2_256) u32 => Vec<u8>;
 		/// The current block number being processed. Set by `execute_block`.
 		Number get(fn block_number) build(|_| 1.into()): T::BlockNumber;
 		/// Hash of the previous block.
@@ -475,7 +476,7 @@ decl_storage! {
 		/// The value has the type `(T::BlockNumber, EventIndex)` because if we used only just
 		/// the `EventIndex` then in case if the topic has the same contents on the next block
 		/// no notification will be triggered thus the event might be lost.
-		EventTopics get(fn event_topics): map T::Hash => Vec<(T::BlockNumber, EventIndex)>;
+		EventTopics get(fn event_topics): map hasher(blake2_256) T::Hash => Vec<(T::BlockNumber, EventIndex)>;
 	}
 	add_extra_genesis {
 		config(changes_trie_config): Option<ChangesTrieConfiguration>;

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -200,7 +200,7 @@ decl_storage! {
 		ProposalCount get(fn proposal_count): ProposalIndex;
 
 		/// Proposals that have been made.
-		Proposals get(fn proposals): map ProposalIndex => Option<Proposal<T::AccountId, BalanceOf<T>>>;
+		Proposals get(fn proposals): map hasher(blake2_256) ProposalIndex => Option<Proposal<T::AccountId, BalanceOf<T>>>;
 
 		/// Proposal indices that have been approved but not yet awarded.
 		Approvals get(fn approvals): Vec<ProposalIndex>;

--- a/test-utils/runtime/src/system.rs
+++ b/test-utils/runtime/src/system.rs
@@ -46,7 +46,7 @@ decl_module! {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as TestRuntime {
-		ExtrinsicData: map u32 => Vec<u8>;
+		ExtrinsicData: map hasher(blake2_256) u32 => Vec<u8>;
 		// The current block number being processed. Set by `execute_block`.
 		Number get(fn number): Option<BlockNumber>;
 		ParentHash get(fn parent_hash): Hash;

--- a/utils/frame/rpc/support/src/lib.rs
+++ b/utils/frame/rpc/support/src/lib.rs
@@ -65,9 +65,9 @@ use sc_rpc_api::state::StateClient;
 /// decl_storage! {
 ///     trait Store for Module<T: Trait> as TestRuntime {
 ///         pub LastActionId: u64;
-///         pub Voxels: map Loc => Block;
-///         pub Actions: linked_map u64 => Loc;
-///         pub Prefab: double_map u128, (i8, i8, i8) => Block;
+///         pub Voxels: map hasher(blake2_256) Loc => Block;
+///         pub Actions: linked_map hasher(blake2_256) u64 => Loc;
+///         pub Prefab: double_map hasher(blake2_256) u128, hasher(blake2_256) (i8, i8, i8) => Block;
 ///     }
 /// }
 ///


### PR DESCRIPTION
This is the first step to achieve https://github.com/paritytech/substrate/issues/4610

First we remove default hasher, later when all conflict has been upgraded, we can introduce a new default.

You can review by commit here, first commit is the change of decl_storage macro, second commit is the fix of all decl_storage calls in substrate.

Note that if the hasher is missing the message printed is:
```
error: Default hasher has been removed, use explicit hasher(blake2_256) instead.
   --> frame/system/src/lib.rs:479:37
    |
479 |         EventTopics get(fn event_topics): map T::Hash => Vec<(T::BlockNumber, EventIndex)>;
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

Companion PR for polkadot https://github.com/paritytech/polkadot/pull/804