### PR TITLE
Remove unnecessary duplication in generic asset create

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 205,
-	impl_version: 206,
+	impl_version: 208,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -362,21 +362,7 @@ decl_module! {
 		/// Create a new kind of asset.
 		fn create(origin, options: AssetOptions<T::Balance, T::AccountId>) -> DispatchResult {
 			let origin = ensure_signed(origin)?;
-			let id = Self::next_asset_id();
-
-			let permissions: PermissionVersions<T::AccountId> = options.permissions.clone().into();
-
-			// The last available id serves as the overflow mark and won't be used.
-			let next_id = id.checked_add(&One::one()).ok_or_else(|| Error::<T>::NoIdAvailable)?;
-
-			<NextAssetId<T>>::put(next_id);
-			<TotalIssuance<T>>::insert(id, &options.initial_issuance);
-			<FreeBalance<T>>::insert(&id, &origin, &options.initial_issuance);
-			<Permissions<T>>::insert(&id, permissions);
-
-			Self::deposit_event(RawEvent::Created(id, origin, options));
-
-			Ok(())
+			Self::create_asset(None, Some(origin), options)
 		}
 
 		/// Transfer some liquid free balance to another account.


### PR DESCRIPTION
The generic asset create extrinsic duplicated code that was already in `create_asset`.
This is a simple refactoring to make generic asset a tiny bit DRY-er.
No functional changes made.