### PR TITLE
Make sure destroy_state is called in case of errors.

### DIFF
--- a/client/src/call_executor.rs
+++ b/client/src/call_executor.rs
@@ -181,7 +181,7 @@ where
 			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
-		result
+		result.map_err(Into::into)
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> sp_blockchain::Result<RuntimeVersion> {

--- a/client/src/call_executor.rs
+++ b/client/src/call_executor.rs
@@ -89,12 +89,12 @@ where
 		).execute_using_consensus_failure_handler::<_, NeverNativeValue, fn() -> _>(
 			strategy.get_manager(),
 			None,
-		)?;
+		);
 		{
 			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
-		Ok(return_data.into_encoded())
+		Ok(return_data?.into_encoded())
 	}
 
 	fn contextual_call<
@@ -173,12 +173,12 @@ where
 			)
 			.with_storage_transaction_cache(storage_transaction_cache.as_mut().map(|c| &mut **c))
 			.execute_using_consensus_failure_handler(execution_manager, native_call)
-		}?;
+		};
 		{
 			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
-		Ok(result)
+		Ok(result?)
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> sp_blockchain::Result<RuntimeVersion> {

--- a/client/src/call_executor.rs
+++ b/client/src/call_executor.rs
@@ -181,7 +181,7 @@ where
 			let _lock = self.backend.get_import_lock().read();
 			self.backend.destroy_state(state)?;
 		}
-		Ok(result?)
+		result
 	}
 
 	fn runtime_version(&self, id: &BlockId<Block>) -> sp_blockchain::Result<RuntimeVersion> {


### PR DESCRIPTION
This PR makes sure that `backend.destroy_state` is being called even if the call returns an error.
Seems that the consequences could be unsynchronized cache or incorrect usage reporting (so nothing super bad afaiu).

Long term solution would rather be to have a guard that does that on `Drop`, but I've heard that @arkpar might be investigating this already.
