### PR TITLE
Print extrinsic failed error always, not just on import

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 205,
-	impl_version: 206,
+	impl_version: 207,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -262,8 +262,7 @@ where
 	fn apply_extrinsic_no_note(uxt: Block::Extrinsic) {
 		let l = uxt.encode().len();
 		match Self::apply_extrinsic_with_len(uxt, l, None) {
-			Ok(Ok(())) => (),
-			Ok(Err(e)) => sp_runtime::print(e),
+			Ok(_) => (),
 			Err(e) => { let err: &'static str = e.into(); panic!(err) },
 		}
 	}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -852,7 +852,10 @@ impl<T: Trait> Module<T> {
 		Self::deposit_event(
 			match r {
 				Ok(()) => Event::ExtrinsicSuccess(info),
-				Err(err) => Event::ExtrinsicFailed(err.clone(), info),
+				Err(err) => {
+					sp_runtime::print(err);
+					Event::ExtrinsicFailed(err.clone(), info)
+				},
 			}
 		);
 

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -1216,6 +1216,12 @@ pub trait Printable {
 	fn print(&self);
 }
 
+impl<T: Printable> Printable for &T {
+	fn print(&self) {
+		(*self).print()
+	}
+}
+
 impl Printable for u8 {
 	fn print(&self) {
 		(*self as u64).print()


### PR DESCRIPTION
Before we printed the error of a transaction only when importing a
block, this pr changes it to print the error also at building the block.
