### PR TITLE
Add SS58 network identifier for Centrifuge

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -80,8 +80,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to equal spec_version. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 205,
-	impl_version: 206,
+	spec_version: 207,
+	impl_version: 207,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -442,6 +442,8 @@ ss58_address_format!(
 		(16, "kulupu", "Kulupu mainnet, direct checksum, standard account (*25519).")
 	EdgewareAccountDirect =>
 		(7, "edgeware", "Edgeware mainnet, direct checksum, standard account (*25519).")
+	CentrifugeAccountDirect =>
+		(36, "centrifuge", "Centrifuge Chain mainnet, direct checksum, standard account (*25519).")
 );
 
 /// Set the default "version" (actually, this is a bit of a misnomer and the version byte is


### PR DESCRIPTION
Thank you for your work on substrate!

As discussed in the Substrate Builder's Program call, we would love to use our own network identifier for Centrifuge Chain. 

There are multiple reasons for that, the main one is to prevent reusage across networks, decreasing the value at risk if a private key is lost. Also it allows us to easily identify Centrifuge addresses, which will start with `4b` to `4h`. 

Looking forward to hear your feedback!