### PR TITLE
clarify licensing

### DIFF
--- a/.maintain/node-template-release/Cargo.toml
+++ b/.maintain/node-template-release/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-template-release"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 toml = "0.4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5293,7 +5293,7 @@ dependencies = [
  "sp-state-machine 0.8.0",
  "sp-trie 2.0.0",
  "substrate-test-runtime-client 2.0.0",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7185,15 +7185,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8841,7 +8832,6 @@ dependencies = [
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
 "checksum target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c63f48baada5c52e65a29eef93ab4f8982681b67f9e8d29c7b05abcfec2b9ffe"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum test-case 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a605baa797821796a751f4a959e1206079b24a4b7e1ed302b7d785d81a9276c9"

--- a/bin/node-template/Cargo.toml
+++ b/bin/node-template/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Anonymous"]
 build = "build.rs"
 edition = "2018"
+license = "Unlicense"
 
 [[bin]]
 name = "node-template"

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-template-runtime"
 version = "2.0.0"
 authors = ["Anonymous"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 aura = { version = "2.0.0", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -3,7 +3,7 @@ name = "node-template-runtime"
 version = "2.0.0"
 authors = ["Anonymous"]
 edition = "2018"
-license = "GPL-3.0"
+license = "Unlicense"
 
 [dependencies]
 aura = { version = "2.0.0", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 build = "build.rs"
 edition = "2018"
+license = "GPL-3.0"
 default-run = "substrate"
 
 [badges]

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-primitives"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-core = { version = "2.0.0", default-features = false, path = "../../../primitives/core" }

--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-rpc-client"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 env_logger = "0.7.0"

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-rpc"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-client = { version = "0.8", path = "../../../client/" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -4,8 +4,10 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
+
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
 integer-sqrt = { version = "0.1.2" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Test utilities for Substrate node."
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 pallet-balances = { version = "2.0.0", path = "../../../frame/balances" }

--- a/bin/node/transaction-factory/Cargo.toml
+++ b/bin/node/transaction-factory/Cargo.toml
@@ -3,6 +3,7 @@ name = "node-transaction-factory"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-block-builder = { version = "2.0.0", path = "../../../primitives/block-builder" }

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 license = "GPL-3.0"
 
 [dependencies]
-
 ansi_term = "0.12.1"
 sc-keystore = { version = "2.0.0", path = "../../../client/keystore" }
 node-cli = { version = "2.0.0", path = "../../node/cli" }

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -4,8 +4,10 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
+
 ansi_term = "0.12.1"
 sc-keystore = { version = "2.0.0", path = "../../../client/keystore" }
 node-cli = { version = "2.0.0", path = "../../node/cli" }

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -3,6 +3,7 @@ name = "subkey"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 futures = "0.1.29"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-client"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-block-builder = { version = "0.8", path = "block-builder" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-client-api"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-basic-authorship"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-block-builder"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-state-machine = { version = "0.8", path = "../../primitives/state-machine" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-chain-spec"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-chain-spec-derive = { version = "2.0.0", path = "./derive" }

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-chain-spec-derive"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate CLI interface."
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 clap = "2.33.0"

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Aura consensus algorithm for substrate"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", path = "../../../primitives/application-crypto" }

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "BABE consensus algorithm for substrate"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Manual sealing engine for Substrate"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "PoW consensus algorithm for substrate"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic slots-based utilities for consensus"
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/client/consensus/uncles/Cargo.toml
+++ b/client/consensus/uncles/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic uncle inclusion utilities for consensus"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-client-api = { version = "2.0.0", path = "../../api" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-client-db"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 parking_lot = "0.9.0"
@@ -32,7 +33,7 @@ substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/ru
 env_logger = "0.7.0"
 quickcheck = "0.9"
 kvdb-rocksdb = "0.4"
-tempdir = "0.3"
+tempfile = "3"
 
 [features]
 default = []

--- a/client/db/src/upgrade.rs
+++ b/client/db/src/upgrade.rs
@@ -172,14 +172,14 @@ mod tests {
 
 	#[test]
 	fn downgrade_never_happens() {
-		let db_dir = tempdir::TempDir::new("").unwrap();
+		let db_dir = tempfile::TempDir::new().unwrap();
 		create_db(db_dir.path(), Some(CURRENT_VERSION + 1));
 		assert!(open_database(db_dir.path()).is_err());
 	}
 
 	#[test]
 	fn open_empty_database_works() {
-		let db_dir = tempdir::TempDir::new("").unwrap();
+		let db_dir = tempfile::TempDir::new().unwrap();
 		open_database(db_dir.path()).unwrap();
 		open_database(db_dir.path()).unwrap();
 		assert_eq!(current_version(db_dir.path()).unwrap(), CURRENT_VERSION);
@@ -188,7 +188,7 @@ mod tests {
 	#[test]
 	fn upgrade_from_0_to_1_works() {
 		for version_from_file in &[None, Some(0)] {
-			let db_dir = tempdir::TempDir::new("").unwrap();
+			let db_dir = tempfile::TempDir::new().unwrap();
 			let db_path = db_dir.path();
 			create_db(db_path, *version_from_file);
 			open_database(db_path).unwrap();

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-executor"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-executor-common"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -4,8 +4,10 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
+
 sp-std = { version = "2.0.0", default-features = false, path = "../../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../../primitives/io" }
 sp-sandbox = { version = "0.8.0", default-features = false, path = "../../../primitives/sandbox" }

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 license = "GPL-3.0"
 
 [dependencies]
-
 sp-std = { version = "2.0.0", default-features = false, path = "../../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../../primitives/io" }
 sp-sandbox = { version = "0.8.0", default-features = false, path = "../../../primitives/sandbox" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-executor-wasmi"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-executor-wasmtime"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-finality-grandpa"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 fork-tree = { version = "2.0.0", path = "../../utils/fork-tree" }

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-keystore"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-rpc-api"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-rpc-server"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 jsonrpc-core = "14.0.3"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-rpc"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-rpc-api = { version = "0.8", path = "../rpc-api" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-service"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [features]
 default = ["rocksdb"]

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-service-test"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 tempfile = "3.1.0"

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-state-db"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 parking_lot = "0.9.0"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Telemetry utils"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 bytes = "0.5"

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-transaction-pool"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-transaction-graph"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-assets"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-aura"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../primitives/application-crypto" }

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-authority-discovery"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-authority-discovery = { version = "2.0.0", default-features = false, path = "../../primitives/authority-discovery" }

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 description = "Block and Uncle Author tracking for the SRML"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-babe"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 hex-literal = "0.2.1"

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-balances"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-collective"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-contracts"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-contracts-rpc"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-contracts-rpc-runtime-api"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", default-features = false, path = "../../../../primitives/api" }

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-democracy"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-elections-phragmen"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-elections"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-evm"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-example"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-executive"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/frame/finality-tracker/Cargo.toml
+++ b/frame/finality-tracker/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-finality-tracker"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }

--- a/frame/generic-asset/Cargo.toml
+++ b/frame/generic-asset/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-generic-asset"
 version = "2.0.0"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-grandpa"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-identity"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-im-online"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../primitives/application-crypto" }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-indices"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-membership"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/metadata/Cargo.toml
+++ b/frame/metadata/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-metadata"
 version = "10.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-nicks"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-offences"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-randomness-collective-flip"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 safe-mix = { version = "1.0", default-features = false }

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-recovery"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-scored-pool"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -2,7 +2,8 @@
 name = "pallet-session"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition =  "2018"
+edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-society"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-staking"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-staking-reward-curve"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-sudo"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-support"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4"

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-support-procedural"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-support-procedural-tools"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 frame-support-procedural-tools-derive = { version = "2.0.0", path = "./derive" }

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-support-test"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-system"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", default-features = false, path = "../../../../primitives/api" }

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-timestamp"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-transaction-payment"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0" }

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-treasury"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-utility"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-allocator"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-std = { version = "2.0.0", path = "../std", default-features = false }

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-api"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-api-proc-macro"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-api-test"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", path = "../" }

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Provides facilities for generating application specific crypto wrapper types."
+license = "GPL-3.0"
 
 [dependencies]
 sp-core = { version = "2.0.0", default-features = false, path = "../core" }

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Integration tests for application-crypto"
+license = "GPL-3.0"
 publish = false
 
 [dependencies]

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-arithmetic"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-arithmetic-fuzzer"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-arithmetic = { version = "2.0.0", path = ".." }

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Authority discovery primitives"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../application-crypto" }

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Authorship primitives"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-inherents = { version = "2.0.0", default-features = false, path = "../inherents" }

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-block-builder"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" }

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-blockchain"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../application-crypto" }

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for BABE consensus"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../application-crypto" }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Common utilities for substrate consensus"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", default-features = false, path = "../../api" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-core"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-debug-derive"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-finality-grandpa"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 app-crypto = { version = "2.0.0", default-features = false, package = "sp-application-crypto", path = "../application-crypto" }

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-finality-tracker"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-inherents"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 parking_lot = { version = "0.9.0", optional = true }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-io"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false }

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-keyring"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-core = { version = "2.0.0", path = "../core" }

--- a/primitives/panic-handler/Cargo.toml
+++ b/primitives/panic-handler/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate panic handler."
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 backtrace = "0.3.38"

--- a/primitives/phragmen/Cargo.toml
+++ b/primitives/phragmen/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-phragmen"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-rpc"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", features = ["derive"] }

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-runtime-interface"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-wasm-interface = { version = "2.0.0", optional = true, path = "../wasm-interface" }

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [lib]
 proc-macro = true

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -4,8 +4,10 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
+
 sp-runtime-interface = { version = "2.0.0", default-features = false, path = "../" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../io" }

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 license = "GPL-3.0"
 
 [dependencies]
-
 sp-runtime-interface = { version = "2.0.0", default-features = false, path = "../" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../io" }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-runtime-interface-test"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 publish = false
 
 [dependencies]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-runtime"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-sandbox"
 version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 wasmi = { version = "0.6.2", optional = true }

--- a/primitives/serializer/Cargo.toml
+++ b/primitives/serializer/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-serializer"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 serde = "1.0.101"

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-session"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", default-features = false, path = "../api" }

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-staking"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate State Machine"
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-std"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [features]
 default = ["std"]

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Storage related primitives"
+license = "GPL-3.0"
 
 [dependencies]
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-test-primitives"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../application-crypto" }

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-timestamp"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sp-api = { version = "2.0.0", default-features = false, path = "../api" }

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-transaction-pool"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", optional = true }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-version"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 impl-serde = { version = "0.2.3", optional = true }

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -3,6 +3,7 @@ name = "sp-wasm-interface"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 wasmi = { version = "0.6.2", optional = true }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -3,3 +3,4 @@ name = "substrate-test-utils"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-test-client"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-client-api = { version = "2.0.0", path = "../../client/api" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -4,8 +4,10 @@ version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
+license = "GPL-3.0"
 
 [dependencies]
+
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../primitives/application-crypto" }
 sp-consensus-aura = { version = "0.8", default-features = false, path = "../../primitives/consensus/aura" }
 sp-consensus-babe = { version = "0.8", default-features = false, path = "../../primitives/consensus/babe" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 license = "GPL-3.0"
 
 [dependencies]
-
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../primitives/application-crypto" }
 sp-consensus-aura = { version = "0.8", default-features = false, path = "../../primitives/consensus/aura" }
 sp-consensus-babe = { version = "0.8", default-features = false, path = "../../primitives/consensus/babe" }

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-test-runtime-client"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-block-builder = { version = "0.8", path = "../../../client/block-builder" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utilities for creating a browser light-client."
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 futures = "0.3"

--- a/utils/build-script-utils/Cargo.toml
+++ b/utils/build-script-utils/Cargo.toml
@@ -3,5 +3,6 @@ name = "substrate-build-script-utils"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -3,6 +3,7 @@ name = "fork-tree"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-frame-rpc-support"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Andrew Dirksen <andrew@dirksen.com>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 futures = { version = "0.3.0", features = ["compat"] }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -3,6 +3,7 @@ name = "substrate-frame-rpc-system"
 version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
+license = "GPL-3.0"
 
 [dependencies]
 sc-client = { version = "0.8", path = "../../../../client/" }


### PR DESCRIPTION
refs #4753 .

This removes an old deprecated dependency, fixing an unknown license leaking in; and sets the `license`-field in our local `Cargo.toml` files (to `GPL-3.0` as our code already states). Except for `node-template`, which is set to be the `Unlicense`-License.