### PR TITLE
LinkedMap doesn't implement StoragePrefixedMap

### DIFF
--- a/frame/support/procedural/src/storage/storage_struct.rs
+++ b/frame/support/procedural/src/storage/storage_struct.rs
@@ -167,18 +167,6 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 				);
 
 				quote!(
-					impl<#impl_trait> #scrate::storage::StoragePrefixedMap<#value_type>
-						for #storage_struct #optional_storage_where_clause
-					{
-						fn module_prefix() -> &'static [u8] {
-							#instance_or_inherent::PREFIX.as_bytes()
-						}
-
-						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
-						}
-					}
-
 					impl<#impl_trait> #scrate::#storage_generator_trait for #storage_struct
 					#optional_storage_where_clause
 					{

--- a/frame/support/test/tests/final_keys.rs
+++ b/frame/support/test/tests/final_keys.rs
@@ -112,13 +112,11 @@ fn final_keys_no_instance() {
 		k.extend(1u32.using_encoded(blake2_256).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
 		assert_eq!(unhashed::get::<u32>(&head), Some(1u32));
-		assert_eq!(&k[..32], &<no_instance::LinkedMap>::final_prefix());
 
 		no_instance::LinkedMap2::insert(1, 2);
 		let mut k = [twox_128(b"FinalKeysNone"), twox_128(b"LinkedMap2")].concat();
 		k.extend(1u32.using_encoded(twox_128).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
-		assert_eq!(&k[..32], &<no_instance::LinkedMap2>::final_prefix());
 
 		no_instance::DoubleMap::insert(&1, &2, &3);
 		let mut k = [twox_128(b"FinalKeysNone"), twox_128(b"DoubleMap")].concat();
@@ -163,13 +161,11 @@ fn final_keys_default_instance() {
 		k.extend(1u32.using_encoded(blake2_256).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
 		assert_eq!(unhashed::get::<u32>(&head), Some(1u32));
-		assert_eq!(&k[..32], &<instance::LinkedMap<instance::DefaultInstance>>::final_prefix());
 
 		<instance::LinkedMap2<instance::DefaultInstance>>::insert(1, 2);
 		let mut k = [twox_128(b"FinalKeysSome"), twox_128(b"LinkedMap2")].concat();
 		k.extend(1u32.using_encoded(twox_128).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
-		assert_eq!(&k[..32], &<instance::LinkedMap2<instance::DefaultInstance>>::final_prefix());
 
 		<instance::DoubleMap<instance::DefaultInstance>>::insert(&1, &2, &3);
 		let mut k = [twox_128(b"FinalKeysSome"), twox_128(b"DoubleMap")].concat();
@@ -214,13 +210,11 @@ fn final_keys_instance_2() {
 		k.extend(1u32.using_encoded(blake2_256).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
 		assert_eq!(unhashed::get::<u32>(&head), Some(1u32));
-		assert_eq!(&k[..32], &<instance::LinkedMap<instance::Instance2>>::final_prefix());
 
 		<instance::LinkedMap2<instance::Instance2>>::insert(1, 2);
 		let mut k = [twox_128(b"Instance2FinalKeysSome"), twox_128(b"LinkedMap2")].concat();
 		k.extend(1u32.using_encoded(twox_128).to_vec());
 		assert_eq!(unhashed::get::<u32>(&k), Some(2u32));
-		assert_eq!(&k[..32], &<instance::LinkedMap2<instance::Instance2>>::final_prefix());
 
 		<instance::DoubleMap<instance::Instance2>>::insert(&1, &2, &3);
 		let mut k = [twox_128(b"Instance2FinalKeysSome"), twox_128(b"DoubleMap")].concat();


### PR DESCRIPTION
StoragePrefixedMap means a storage has all its value after a prefix
.
But for the linkedmap the value is different from `#value_type` as the actual value stored is `#values_type++Option<previous_key>++Option<next_key>`
and also there is a head key which is after another prefix.

This creates 2 bugs:
* remove_all doesn't remove the head.
* translate actually removes all `Option<previous_key>++Option<next_key>`, breaking the linkedmap.

We should implement those functions in storagelinkedmap directly.