### PR TITLE
Order network dependencies alphabetically

### DIFF
--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-futures01 = { package = "futures", version = "0.1.29" }
 futures = { version = "0.3.1", features = ["compat"] }
+futures01 = { package = "futures", version = "0.1.29" }
 futures-timer = "0.4.0"
-lru = "0.1.2"
 libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
-sc-network = { version = "0.8", path = "../network" }
+lru = "0.1.2"
 parking_lot = "0.9.0"
+sc-network = { version = "0.8", path = "../network" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -7,53 +7,53 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
+bitflags = "1.2.0"
 bytes = "0.5.0"
+codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
 derive_more = "0.99.2"
 either = "1.5.3"
-log = "0.4.8"
-parking_lot = "0.9.0"
-bitflags = "1.2.0"
+erased-serde = "0.3.9"
 fnv = "1.0.6"
+fork-tree = { version = "2.0.0", path = "../../utils/fork-tree" }
 futures = "0.3.1"
 futures_codec = "0.3.3"
 futures-timer = "0.4.0"
+libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
 linked-hash-map = "0.5.2"
 linked_hash_set = "0.1.3"
+log = "0.4.8"
 lru = "0.4.0"
-rustc-hex = "2.0.1"
+parking_lot = "0.9.0"
 rand = "0.7.2"
-libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
-fork-tree = { version = "2.0.0", path = "../../utils/fork-tree" }
-sp-consensus = { version = "0.8", path = "../../primitives/consensus/common" }
+rustc-hex = "2.0.1"
+sc-block-builder = { version = "0.8", path = "../block-builder" }
 sc-client = { version = "0.8", path = "../" }
 sc-client-api = { version = "2.0.0", path = "../api" }
-sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
-sp-arithmetic = { version = "2.0.0", path = "../../primitives/arithmetic" }
-sp-core = { version = "2.0.0", path = "../../primitives/core" }
-sc-block-builder = { version = "0.8", path = "../block-builder" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
 sc-peerset = { version = "2.0.0", path = "../peerset" }
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 slog = { version = "2.5.2", features = ["nested-values"] }
 slog_derive = "0.2.0"
 smallvec = "0.6.10"
-unsigned-varint = { version = "0.3.0", features = ["codec"] }
+sp-arithmetic = { version = "2.0.0", path = "../../primitives/arithmetic" }
+sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
+sp-consensus = { version = "0.8", path = "../../primitives/consensus/common" }
+sp-consensus-babe = { version = "0.8", path = "../../primitives/consensus/babe" }
+sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-keyring = { version = "2.0.0", optional = true, path = "../../primitives/keyring" }
+sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 substrate-test-client = { version = "2.0.0", optional = true, path = "../../test-utils/client" }
 substrate-test-runtime-client = { version = "2.0.0", optional = true, path = "../../test-utils/runtime/client" }
-erased-serde = "0.3.9"
+unsigned-varint = { version = "0.3.0", features = ["codec"] }
 void = "1.0.2"
 zeroize = "1.0.0"
-sp-consensus-babe = { version = "0.8", path = "../../primitives/consensus/babe" }
 
 [dev-dependencies]
-sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }
 env_logger = "0.7.0"
-sp-keyring = { version = "2.0.0", path = "../../primitives/keyring" }
 quickcheck = "0.9.0"
 rand = "0.7.2"
+sp-keyring = { version = "2.0.0", path = "../../primitives/keyring" }
+sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }
 tempfile = "3.1.0"
 
 [features]


### PR DESCRIPTION
This is a very stupid pull request, but every time I have to touch this Cargo.toml I find it messy and hate that it's not ordered alphabetically.