### PR TITLE
adding a ss58 format for SubstraTEE

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -444,6 +444,8 @@ ss58_address_format!(
 		(7, "edgeware", "Edgeware mainnet, direct checksum, standard account (*25519).")
 	CentrifugeAccountDirect =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, direct checksum, standard account (*25519).")
+	SubstraTeeAccountDirect =>
+		(44, "substratee", "Any SubstraTEE off-chain network private account, direct checksum, standard account (*25519).")
 );
 
 /// Set the default "version" (actually, this is a bit of a misnomer and the version byte is


### PR DESCRIPTION
We'd like to add a special SS58 format identifier for [SubstraTEE](https://github.com/scs/substraTEE) because addresses for chain-isolated SubstraTEE accounts should never be published. We think it is better to clearly distinguish between accounts to be used on-chain and those only to be used within enclaves (what we called "incognito" accounts in our [private-tx example](https://github.com/scs/substraTEE/blob/master/M5_DEMO.md))
