### PR TITLE
Fix warnings.

### DIFF
--- a/bin/node-template/src/cli.rs
+++ b/bin/node-template/src/cli.rs
@@ -90,7 +90,9 @@ where
 
 	let _ = exit_send.send(());
 
-	runtime.block_on(handle);
+	if let Err(e) = runtime.block_on(handle) {
+		log::error!("Error running node: {:?}", e);
+	}
 
 	match service_res {
 		Either::Left((res, _)) => res.map_err(error::Error::Service),

--- a/bin/node-template/src/service.rs
+++ b/bin/node-template/src/service.rs
@@ -11,7 +11,6 @@ use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sp_consensus_aura::sr25519::{AuthorityPair as AuraPair};
 use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider};
-use futures::{FutureExt, compat::Future01CompatExt};
 
 // Our native executor instance.
 native_executor_instance!(

--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -200,7 +200,9 @@ where
 
 	let _ = exit_send.send(());
 
-	runtime.block_on(handle);
+	if let Err(e) = runtime.block_on(handle) {
+		log::error!("Error running node: {:?}", e);
+	}
 
 	match service_res {
 		Either::Left((res, _)) => res.map_err(error::Error::Service),

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -171,15 +171,6 @@ type CommunicationInH<Block, H> = finality_grandpa::voter::CommunicationIn<
 	AuthorityId,
 >;
 
-/// A global communication sink for commits. Not exposed publicly, used
-/// internally to simplify types in the communication layer.
-type CommunicationOut<Block> = finality_grandpa::voter::CommunicationOut<
-	<Block as BlockT>::Hash,
-	NumberFor<Block>,
-	AuthoritySignature,
-	AuthorityId,
->;
-
 /// Global communication sink for commits with the hash type not being derived
 /// from the block, useful for forcing the hash to some type (e.g. `H256`) when
 /// the compiler can't do the inference.

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -392,7 +392,7 @@ impl TransactionPool<Hash, Block> for EmptyTransactionPool {
 
 	fn on_broadcasted(&self, _: HashMap<Hash, Vec<String>>) {}
 
-	fn transaction(&self, h: &Hash) -> Option<Extrinsic> { None }
+	fn transaction(&self, _h: &Hash) -> Option<Extrinsic> { None }
 }
 
 pub trait SpecializationFactory {


### PR DESCRIPTION
There is one left that I don't really know where it's coming from. My suspicion is that it's the `codec` derive code that generates a code with this unused variable. That should probably be fixed in upstream `codec` crate.

```rust
warning: unused variable: `message`
   --> primitives/runtime/src/lib.rs:376:3
    |
367 |       /// A custom error in a module
    |  _____-
368 | |     Module {
369 | |         /// Module index, matching the metadata module index
370 | |         index: u8,
...   |
375 | |         #[allow(unused_variables)] // most likely caused by codec(skip)?
376 | |         message: Option<&'static str>,
    | |         ^^^^^^-
    | |_______________|
    |                 help: try ignoring the field: `message: _`
    |
    = note: `#[warn(unused_variables)]` on by default

```