### PR TITLE
Remove --release from check_for_exit.sh

### DIFF
--- a/.maintain/check_for_exit.sh
+++ b/.maintain/check_for_exit.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-cargo build --release
-./target/release/substrate --dev &
+cargo build
+./target/debug/substrate --dev &
 PID=$!
 
 # Let the chain running for 60 seconds


### PR DESCRIPTION
I don't see any good reason to build with --release to test this but this step takes 8-8:30 min on the CI and I suspect we would save some time by using the debug build instead.
