### PR TITLE
Update to the latest crate names

### DIFF
--- a/.maintain/rename-crates-for-2.0.sh
+++ b/.maintain/rename-crates-for-2.0.sh
@@ -87,7 +87,7 @@ TO_RENAME=(
 
     # # CLIENT
     "substrate-client sc-client"
-    "substrate-client-api sc-api"
+    "substrate-client-api sc-client-api"
     "substrate-authority-discovery sc-authority-discovery"
     "substrate-basic-authorship sc-basic-authorship"
     "substrate-block-builder sc-block-builder"
@@ -99,7 +99,7 @@ TO_RENAME=(
     "substrate-consensus-pow sc-consensus-pow"
     "substrate-consensus-slots sc-consensus-slots"
     "substrate-consensus-uncles sc-consensus-uncles"
-    "substrate-client-db sc-database"
+    "substrate-client-db sc-client-db"
     "substrate-executor sc-executor"
     "substrate-runtime-test sc-runtime-test"
     "substrate-finality-grandpa sc-finality-grandpa"

--- a/.maintain/rename-crates-for-2.0.sh
+++ b/.maintain/rename-crates-for-2.0.sh
@@ -44,6 +44,8 @@ TO_RENAME=(
     "sp-sesssion sp-session"
     "sp-tracing-pool sp-transaction-pool"
     "sc-basic-authority sc-basic-authorship"
+    "sc-api sc-client-api"
+    "sc-database sc-client-db"
 
     # PRIMITIVES
     "substrate-application-crypto sp-application-crypto"


### PR DESCRIPTION
I was using this [script](https://github.com/paritytech/substrate/blob/master/.maintain/rename-crates-for-2.0.sh) as a reference of the crate name changes, and found a couple of outdated names:
```
sc-api       =>  sc-client-api (./client/api)
sc-database  =>  sc-client-db  (.client/db`)
```