### PR TITLE
Adding Serde Deserialisation to UncheckExtrinsics

### DIFF
--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -276,7 +276,8 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 
 #[cfg(feature = "std")]
 impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension> serde::Deserialize<'a>
-	for UncheckedExtrinsic<Address, Call, Signature, Extra> {
+	for UncheckedExtrinsic<Address, Call, Signature, Extra>
+{
 	fn deserialize<D>(de: D) -> Result<Self, D::Error> where
 		D: serde::Deserializer<'a>,
 	{

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -274,6 +274,18 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 	}
 }
 
+#[cfg(feature = "std")]
+impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension> serde::Deserialize<'a>
+	for UncheckedExtrinsic<Address, Call, Signature, Extra> {
+	fn deserialize<D>(de: D) -> Result<Self, D::Error> where
+		D: serde::Deserializer<'a>,
+	{
+		let r = sp_core::bytes::deserialize(de)?;
+		Decode::decode(&mut &r[..])
+			.map_err(|e| serde::de::Error::custom(format!("Decode error: {}", e)))
+	}
+}
+
 impl<Address, Call, Signature, Extra> fmt::Debug
 	for UncheckedExtrinsic<Address, Call, Signature, Extra>
 where


### PR DESCRIPTION
to be able to use the ChainApi RPC from the client side. Of course guarded behind `std`.