### PR TITLE
Remove ambiguous into_iter

### DIFF
--- a/client/api/src/notifications.rs
+++ b/client/api/src/notifications.rs
@@ -323,7 +323,7 @@ mod tests {
 			let child_filters = Some([
 				(StorageKey(vec![4]), None),
 				(StorageKey(vec![5]), None),
-			].into_iter().cloned().collect());
+			].iter().cloned().collect());
 			StorageChangeSet {
 				changes: Arc::new(changes.0),
 				child_changes: Arc::new(changes.1),

--- a/client/cli/src/node_key.rs
+++ b/client/cli/src/node_key.rs
@@ -113,7 +113,7 @@ mod tests {
 	#[test]
 	fn test_node_key_config_input() {
 		fn secret_input(net_config_dir: Option<String>) -> error::Result<()> {
-			NodeKeyType::variants().into_iter().try_for_each(|t| {
+			NodeKeyType::variants().iter().try_for_each(|t| {
 				let node_key_type = NodeKeyType::from_str(t).unwrap();
 				let sk = match node_key_type {
 					NodeKeyType::Ed25519 => ed25519::SecretKey::generate().as_ref().to_vec()
@@ -139,7 +139,7 @@ mod tests {
 	#[test]
 	fn test_node_key_config_file() {
 		fn secret_file(net_config_dir: Option<String>) -> error::Result<()> {
-			NodeKeyType::variants().into_iter().try_for_each(|t| {
+			NodeKeyType::variants().iter().try_for_each(|t| {
 				let node_key_type = NodeKeyType::from_str(t).unwrap();
 				let tmp = tempfile::Builder::new().prefix("alice").tempdir()?;
 				let file = tmp.path().join(format!("{}_mysecret", t)).to_path_buf();
@@ -166,7 +166,7 @@ mod tests {
 		where
 			F: Fn(NodeKeyParams) -> error::Result<()>
 		{
-			NodeKeyType::variants().into_iter().try_for_each(|t| {
+			NodeKeyType::variants().iter().try_for_each(|t| {
 				let node_key_type = NodeKeyType::from_str(t).unwrap();
 				f(NodeKeyParams {
 					node_key_type,

--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -386,7 +386,7 @@ fn generate_test_module(input: &INposInput) -> TokenStream2 {
 
 			#[test]
 			fn reward_curve_precision() {
-				for &base in [MILLION, u32::max_value()].into_iter() {
+				for &base in [MILLION, u32::max_value()].iter() {
 					let number_of_check = 100_000.min(base);
 					for check_index in 0..=number_of_check {
 						let i = (check_index as u64 * base as u64 / number_of_check as u64) as u32;


### PR DESCRIPTION
Fix the compiler warning:
```
warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> client/cli/src/node_key.rs:169:28
    |
169 |             NodeKeyType::variants().into_iter().try_for_each(|t| {
    |                                     ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>

```

Note that all instance of this code are in test so that doesn't even matter to right that this could be improved in the future once into_iter for array is implemented.