### PR TITLE
block_import: switch to Box<dyn Any> for intermediates representation

### DIFF
--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -65,8 +65,6 @@ pub enum Error<B: BlockT> {
 	InvalidSeal,
 	#[display(fmt = "PoW validation error: invalid difficulty")]
 	InvalidDifficulty,
-	#[display(fmt = "PoW block import expects an intermediate, but not found one")]
-	NoIntermediate,
 	#[display(fmt = "Rejecting block too far in future")]
 	TooFarInFuture,
 	#[display(fmt = "Fetching best header failed using select chain: {:?}", _0)]

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -31,6 +31,7 @@
 
 use std::sync::Arc;
 use std::any::Any;
+use std::borrow::Cow;
 use std::thread;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -316,7 +317,7 @@ impl<B, I, C, S, Algorithm> BlockImport<B> for PowBlockImport<B, I, C, S, Algori
 
 		let intermediate = block.take_intermediate::<PowIntermediate::<B, Algorithm::Difficulty>>(
 			INTERMEDIATE_KEY
-		).ok_or(Error::<B>::NoIntermediate)?;
+		)?;
 
 		let difficulty = match intermediate.difficulty {
 			Some(difficulty) => difficulty,
@@ -420,7 +421,7 @@ impl<B: BlockT, Algorithm> Verifier<B> for PowVerifier<B, Algorithm> where
 			justification,
 			intermediates: {
 				let mut ret = HashMap::new();
-				ret.insert(INTERMEDIATE_KEY, Box::new(intermediate) as Box<dyn Any>);
+				ret.insert(Cow::from(INTERMEDIATE_KEY), Box::new(intermediate) as Box<dyn Any>);
 				ret
 			},
 			auxiliary: vec![],
@@ -662,7 +663,7 @@ fn mine_loop<B: BlockT, C, Algorithm, E, SO, S, CAW>(
 			storage_changes: Some(proposal.storage_changes),
 			intermediates: {
 				let mut ret = HashMap::new();
-				ret.insert(INTERMEDIATE_KEY, Box::new(intermediate) as Box<dyn Any>);
+				ret.insert(Cow::from(INTERMEDIATE_KEY), Box::new(intermediate) as Box<dyn Any>);
 				ret
 			},
 			finalized: false,

--- a/primitives/consensus/common/src/block_import.rs
+++ b/primitives/consensus/common/src/block_import.rs
@@ -233,7 +233,7 @@ impl<Block: BlockT, Transaction> BlockImportParams<Block, Transaction> {
 				.ok_or(Error::NoIntermediate)
 				.and_then(|value| {
 					value.downcast::<T>()
-						.map_err(|_| Error::NoIntermediate)
+						.map_err(|_| Error::InvalidIntermediate)
 				})
 		} else {
 			Err(Error::NoIntermediate)
@@ -243,15 +243,17 @@ impl<Block: BlockT, Transaction> BlockImportParams<Block, Transaction> {
 	/// Get a reference to a given intermediate.
 	pub fn intermediate<T: 'static>(&self, key: &[u8]) -> Result<&T, Error> {
 		self.intermediates.get(key)
-			.and_then(|value| value.downcast_ref::<T>())
-			.ok_or(Error::NoIntermediate)
+			.ok_or(Error::NoIntermediate)?
+			.downcast_ref::<T>()
+			.ok_or(Error::InvalidIntermediate)
 	}
 
 	/// Get a mutable reference to a given intermediate.
 	pub fn intermediate_mut<T: 'static>(&mut self, key: &[u8]) -> Result<&mut T, Error> {
 		self.intermediates.get_mut(key)
-			.and_then(|value| value.downcast_mut::<T>())
-			.ok_or(Error::NoIntermediate)
+			.ok_or(Error::NoIntermediate)?
+			.downcast_mut::<T>()
+			.ok_or(Error::InvalidIntermediate)
 	}
 }
 

--- a/primitives/consensus/common/src/error.rs
+++ b/primitives/consensus/common/src/error.rs
@@ -32,8 +32,11 @@ pub enum Error {
 	#[display(fmt="I/O terminated unexpectedly.")]
 	IoTerminated,
 	/// Intermediate missing.
-	#[display(fmt="Missing or invalid intermediate.")]
+	#[display(fmt="Missing intermediate.")]
 	NoIntermediate,
+	/// Intermediate is of wrong type.
+	#[display(fmt="Invalid intermediate.")]
+	InvalidIntermediate,
 	/// Unable to schedule wakeup.
 	#[display(fmt="Timer error: {}", _0)]
 	FaultyTimer(std::io::Error),

--- a/primitives/consensus/common/src/error.rs
+++ b/primitives/consensus/common/src/error.rs
@@ -31,6 +31,9 @@ pub enum Error {
 	/// I/O terminated unexpectedly
 	#[display(fmt="I/O terminated unexpectedly.")]
 	IoTerminated,
+	/// Intermediate missing.
+	#[display(fmt="Missing or invalid intermediate.")]
+	NoIntermediate,
 	/// Unable to schedule wakeup.
 	#[display(fmt="Timer error: {}", _0)]
 	FaultyTimer(std::io::Error),


### PR DESCRIPTION
Use built-in rust dynamic types `Box<dyn Any>`. This avoids the extra step of encoding/decoding.