### PR TITLE
Fix set of earliest unapplied slashes on offence

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 212,
+	spec_version: 213,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1765,9 +1765,7 @@ impl <T: Trait> OnOffenceHandler<T::AccountId, pallet_session::historical::Ident
 		};
 
 		<Self as Store>::EarliestUnappliedSlash::mutate(|earliest| {
-			if earliest.is_none() {
-				*earliest = Some(era_now)
-			}
+			*earliest = Some(earliest.unwrap_or(era_now).min(era_now));
 		});
 
 		let slash_defer_duration = T::SlashDeferDuration::get();


### PR DESCRIPTION
When a new offence is created is update the earliest unapplied storage only if none exist.

But this is used by apply_unapplied_slashed
https://github.com/paritytech/substrate/blob/9195fac755df57e18ed59fbd358ee528d2a52d0e/frame/staking/src/lib.rs#L1460-L1474

Thus an offence previous to `current_era - slash_defer_duration` will never be applied.