### PR TITLE
Fix flaky messed signature test

### DIFF
--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -735,7 +735,8 @@ mod test {
 		let public = pair.public();
 		let message = b"Signed payload";
 		let Signature(mut bytes) = pair.sign(&message[..]);
-		bytes[0] = bytes[2];
+		bytes[0] = !bytes[0];
+		bytes[2] = !bytes[2];
 		let signature = Signature(bytes);
 		assert!(!Pair::verify(&signature, &message[..], &public));
 	}


### PR DESCRIPTION
When messing with the signature, we need to make sure that we acutally
mess-up the signature. As the generated private/public key is random,
the signature is random as well. It can happen that `bytes[0] ==
bytes[2]` which makes the test fail. We fix this problem by just
inverting the bytes at `0` and `2`.
