### PR TITLE
pallet-evm: log created address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2c6961fdc9952371fc5f0416f03a9d90378a9dfb6862f6a7a9a3b8986b8dd"
+checksum = "73f887b371f9999682ccc5b1cb771e7d4408ae61e93fc0343ceaeb761fca42d1"
 dependencies = [
  "evm-core",
  "evm-gasometer",
@@ -8190,7 +8190,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.3.23",
 ]
 
 [[package]]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 212,
+	spec_version: 213,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -174,6 +174,8 @@ decl_event! {
 	pub enum Event {
 		/// Ethereum events from contracts.
 		Log(Log),
+		/// A contract has been created at given address.
+		Created(H160),
 	}
 }
 
@@ -343,6 +345,7 @@ decl_module! {
 			}
 			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
 
+			let create_address = executor.create_address(source, evm::CreateScheme::Dynamic);
 			let reason = executor.transact_create(
 				source,
 				value,
@@ -361,6 +364,7 @@ decl_module! {
 
 			let (values, logs) = executor.deconstruct();
 			backend.apply(values, logs, true);
+			Module::<T>::deposit_event(Event::Created(create_address));
 
 			ret.map_err(Into::into)
 		}

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -354,7 +354,10 @@ decl_module! {
 			);
 
 			let ret = match reason {
-				ExitReason::Succeed(_) => Ok(()),
+				ExitReason::Succeed(_) => {
+					Module::<T>::deposit_event(Event::Created(create_address));
+					Ok(())
+				},
 				ExitReason::Error(_) => Err(Error::<T>::ExitReasonFailed),
 				ExitReason::Revert(_) => Err(Error::<T>::ExitReasonRevert),
 				ExitReason::Fatal(_) => Err(Error::<T>::ExitReasonFatal),
@@ -364,7 +367,6 @@ decl_module! {
 
 			let (values, logs) = executor.deconstruct();
 			backend.apply(values, logs, true);
-			Module::<T>::deposit_event(Event::Created(create_address));
 
 			ret.map_err(Into::into)
 		}


### PR DESCRIPTION
cc @danforbes

Currently it's not trivial to fetch the created address after contract creation. This PR adds `Event::Created(H160)` so that the address is apparent.