### PR TITLE
Get rid of in-substrate usages of `core_intrinsics` feature

### DIFF
--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -21,5 +21,9 @@ std = [ "full_crypto", "sp-core/std", "codec/std", "serde", "sp-std/std", "sp-io
 # or Intel SGX.
 # For the regular wasm runtime builds this should not be used.
 full_crypto = [
-    "sp-core/full_crypto"
+    "sp-core/full_crypto",
+	# Don't add `panic_handler` and `alloc_error_handler` since they are expected to be provided
+	# by the user anyway.
+	"sp-io/disable_panic_handler",
+	"sp-io/disable_oom",
 ]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -20,7 +20,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
 #![cfg_attr(feature = "std",
    doc = "Substrate runtime standard library as compiled when linked with Rust's standard library.")]
@@ -892,7 +891,7 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
 	unsafe {
 		let message = sp_std::alloc::format!("{}", info);
 		logging::log(LogLevel::Error, "runtime", message.as_bytes());
-		core::intrinsics::abort()
+		core::arch::wasm32::unreachable();
 	}
 }
 
@@ -902,7 +901,7 @@ pub fn panic(info: &core::panic::PanicInfo) -> ! {
 pub fn oom(_: core::alloc::Layout) -> ! {
 	unsafe {
 		logging::log(LogLevel::Error, "runtime", b"Runtime memory exhausted. Aborting");
-		core::intrinsics::abort();
+		core::arch::wasm32::unreachable();
 	}
 }
 

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -36,7 +36,6 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
 use sp_std::prelude::*;
 

--- a/primitives/std/src/lib.rs
+++ b/primitives/std/src/lib.rs
@@ -18,7 +18,7 @@
 //! or client/alloc to be used with any code that depends on the runtime.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
+
 
 #![cfg_attr(feature = "std",
    doc = "Substrate runtime standard library as compiled when linked with Rust's standard library.")]

--- a/primitives/std/without_std.rs
+++ b/primitives/std/without_std.rs
@@ -27,7 +27,6 @@ pub use core::convert;
 pub use core::default;
 pub use core::fmt;
 pub use core::hash;
-pub use core::intrinsics;
 pub use core::iter;
 pub use core::marker;
 pub use core::mem;


### PR DESCRIPTION
Removes all instances of usage `core_intrinsics`. In two cases they were really useless. In the third case, we could substitute it with a call to `core::arch::wasm32::unreachable` which is stable.

One little step towards https://github.com/paritytech/substrate/issues/1252

The behavior hasn't changed, thus no bumping of runtime is required.