### PR TITLE
executor: Simplify the SandboxCapabilities interface

### DIFF
--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -27,7 +27,7 @@ use wasmi::{
 	Externals, ImportResolver, MemoryInstance, MemoryRef, Module, ModuleInstance,
 	ModuleRef, RuntimeArgs, RuntimeValue, Trap, TrapKind, memory_units::Pages,
 };
-use sp_wasm_interface::{Pointer, WordSize};
+use sp_wasm_interface::{FunctionContext, Pointer, WordSize};
 
 /// Index of a function inside the supervisor.
 ///
@@ -144,41 +144,9 @@ impl ImportResolver for Imports {
 /// This trait encapsulates sandboxing capabilities.
 ///
 /// Note that this functions are only called in the `supervisor` context.
-pub trait SandboxCapabilities {
+pub trait SandboxCapabilities: FunctionContext {
 	/// Represents a function reference into the supervisor environment.
 	type SupervisorFuncRef;
-
-	/// Allocate space of the specified length in the supervisor memory.
-	///
-	/// # Errors
-	///
-	/// Returns `Err` if allocation not possible or errors during heap management.
-	///
-	/// Returns pointer to the allocated block.
-	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>>;
-
-	/// Deallocate space specified by the pointer that was previously returned by [`allocate`].
-	///
-	/// # Errors
-	///
-	/// Returns `Err` if deallocation not possible or because of errors in heap management.
-	///
-	/// [`allocate`]: #tymethod.allocate
-	fn deallocate(&mut self, ptr: Pointer<u8>) -> Result<()>;
-
-	/// Write `data` into the supervisor memory at offset specified by `ptr`.
-	///
-	/// # Errors
-	///
-	/// Returns `Err` if `ptr + data.len()` is out of bounds.
-	fn write_memory(&mut self, ptr: Pointer<u8>, data: &[u8]) -> Result<()>;
-
-	/// Read `len` bytes from the supervisor memory.
-	///
-	/// # Errors
-	///
-	/// Returns `Err` if `ptr + len` is out of bounds.
-	fn read_memory(&self, ptr: Pointer<u8>, len: WordSize) -> Result<Vec<u8>>;
 
 	/// Invoke a function in the supervisor environment.
 	///
@@ -264,8 +232,14 @@ impl<'a, FE: SandboxCapabilities + 'a> Externals for GuestExternals<'a, FE> {
 		// Move serialized arguments inside the memory and invoke dispatch thunk and
 		// then free allocated memory.
 		let invoke_args_len = invoke_args_data.len() as WordSize;
-		let invoke_args_ptr = self.supervisor_externals.allocate(invoke_args_len)?;
-		self.supervisor_externals.write_memory(invoke_args_ptr, &invoke_args_data)?;
+		let invoke_args_ptr = self
+			.supervisor_externals
+			.allocate_memory(invoke_args_len)
+			.map_err(|_| trap("Can't allocate memory in supervisor for the arguments"))?;
+		self
+			.supervisor_externals
+			.write_memory(invoke_args_ptr, &invoke_args_data)
+			.map_err(|_| trap("Can't write invoke args into memory"))?;
 		let result = self.supervisor_externals.invoke(
 			&self.sandbox_instance.dispatch_thunk,
 			invoke_args_ptr,
@@ -273,7 +247,10 @@ impl<'a, FE: SandboxCapabilities + 'a> Externals for GuestExternals<'a, FE> {
 			state,
 			func_idx,
 		)?;
-		self.supervisor_externals.deallocate(invoke_args_ptr)?;
+		self
+			.supervisor_externals
+			.deallocate_memory(invoke_args_ptr)
+			.map_err(|_| trap("Can't deallocate memory for dispatch thunk's invoke arguments"))?;
 
 		// dispatch_thunk returns pointer to serialized arguments.
 		// Unpack pointer and len of the serialized result data.
@@ -286,9 +263,11 @@ impl<'a, FE: SandboxCapabilities + 'a> Externals for GuestExternals<'a, FE> {
 		};
 
 		let serialized_result_val = self.supervisor_externals
-			.read_memory(serialized_result_val_ptr, serialized_result_val_len)?;
+			.read_memory(serialized_result_val_ptr, serialized_result_val_len)
+			.map_err(|_| trap("Can't read the serialized result from dispatch thunk"))?;
 		self.supervisor_externals
-			.deallocate(serialized_result_val_ptr)?;
+			.deallocate_memory(serialized_result_val_ptr)
+			.map_err(|_| trap("Can't deallocate memory for dispatch thunk's result"))?;
 
 		deserialize_result(&serialized_result_val)
 	}

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -66,25 +66,6 @@ impl<'a> FunctionExecutor<'a> {
 impl<'a> sandbox::SandboxCapabilities for FunctionExecutor<'a> {
 	type SupervisorFuncRef = wasmi::FuncRef;
 
-	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>, Error> {
-		let heap = &mut self.heap;
-		self.memory.with_direct_access_mut(|mem| {
-			heap.allocate(mem, len).map_err(Into::into)
-		})
-	}
-	fn deallocate(&mut self, ptr: Pointer<u8>) -> Result<(), Error> {
-		let heap = &mut self.heap;
-		self.memory.with_direct_access_mut(|mem| {
-			heap.deallocate(mem, ptr).map_err(Into::into)
-		})
-	}
-	fn write_memory(&mut self, ptr: Pointer<u8>, data: &[u8]) -> Result<(), Error> {
-		self.memory.set(ptr.into(), data).map_err(Into::into)
-	}
-	fn read_memory(&self, ptr: Pointer<u8>, len: WordSize) -> Result<Vec<u8>, Error> {
-		self.memory.get(ptr.into(), len as usize).map_err(Into::into)
-	}
-
 	fn invoke(
 		&mut self,
 		dispatch_thunk: &Self::SupervisorFuncRef,

--- a/client/executor/wasmi/src/lib.rs
+++ b/client/executor/wasmi/src/lib.rs
@@ -66,12 +66,6 @@ impl<'a> FunctionExecutor<'a> {
 impl<'a> sandbox::SandboxCapabilities for FunctionExecutor<'a> {
 	type SupervisorFuncRef = wasmi::FuncRef;
 
-	fn store(&self) -> &sandbox::Store<Self::SupervisorFuncRef> {
-		&self.sandbox_store
-	}
-	fn store_mut(&mut self) -> &mut sandbox::Store<Self::SupervisorFuncRef> {
-		&mut self.sandbox_store
-	}
 	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>, Error> {
 		let heap = &mut self.heap;
 		self.memory.with_direct_access_mut(|mem| {
@@ -259,8 +253,15 @@ impl<'a> Sandbox for FunctionExecutor<'a> {
 				.clone()
 		};
 
+		let guest_env = match sandbox::GuestEnvironment::decode(&self.sandbox_store, raw_env_def) {
+			Ok(guest_env) => guest_env,
+			Err(_) => return Ok(sandbox_primitives::ERR_MODULE as u32),
+		};
+
 		let instance_idx_or_err_code =
-			match sandbox::instantiate(self, dispatch_thunk, wasm, raw_env_def, state) {
+			match sandbox::instantiate(self, dispatch_thunk, wasm, guest_env, state)
+				.map(|i| i.register(&mut self.sandbox_store))
+			{
 				Ok(instance_idx) => instance_idx,
 				Err(sandbox::InstantiationError::StartTrapped) =>
 					sandbox_primitives::ERR_EXECUTION,

--- a/client/executor/wasmtime/src/function_executor.rs
+++ b/client/executor/wasmtime/src/function_executor.rs
@@ -118,14 +118,6 @@ impl<'a> FunctionExecutor<'a> {
 impl<'a> SandboxCapabilities for FunctionExecutor<'a> {
 	type SupervisorFuncRef = SupervisorFuncRef;
 
-	fn store(&self) -> &sandbox::Store<Self::SupervisorFuncRef> {
-		&self.sandbox_store
-	}
-
-	fn store_mut(&mut self) -> &mut sandbox::Store<Self::SupervisorFuncRef> {
-		&mut self.sandbox_store
-	}
-
 	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>> {
 		self.heap.allocate(self.memory, len).map_err(Into::into)
 	}
@@ -327,8 +319,15 @@ impl<'a> Sandbox for FunctionExecutor<'a> {
 			SupervisorFuncRef(func_ref)
 		};
 
+		let guest_env = match sandbox::GuestEnvironment::decode(&self.sandbox_store, raw_env_def) {
+			Ok(guest_env) => guest_env,
+			Err(_) => return Ok(sandbox_primitives::ERR_MODULE as u32),
+		};
+
 		let instance_idx_or_err_code =
-			match sandbox::instantiate(self, dispatch_thunk, wasm, raw_env_def, state) {
+			match sandbox::instantiate(self, dispatch_thunk, wasm, guest_env, state)
+				.map(|i| i.register(&mut self.sandbox_store))
+			{
 				Ok(instance_idx) => instance_idx,
 				Err(sandbox::InstantiationError::StartTrapped) =>
 					sandbox_primitives::ERR_EXECUTION,

--- a/client/executor/wasmtime/src/function_executor.rs
+++ b/client/executor/wasmtime/src/function_executor.rs
@@ -118,24 +118,6 @@ impl<'a> FunctionExecutor<'a> {
 impl<'a> SandboxCapabilities for FunctionExecutor<'a> {
 	type SupervisorFuncRef = SupervisorFuncRef;
 
-	fn allocate(&mut self, len: WordSize) -> Result<Pointer<u8>> {
-		self.heap.allocate(self.memory, len).map_err(Into::into)
-	}
-
-	fn deallocate(&mut self, ptr: Pointer<u8>) -> Result<()> {
-		self.heap.deallocate(self.memory, ptr).map_err(Into::into)
-	}
-
-	fn write_memory(&mut self, ptr: Pointer<u8>, data: &[u8]) -> Result<()> {
-		write_memory_from(self.memory, ptr, data)
-	}
-
-	fn read_memory(&self, ptr: Pointer<u8>, len: WordSize) -> Result<Vec<u8>> {
-		let mut output = vec![0; len as usize];
-		read_memory_into(self.memory, ptr, output.as_mut())?;
-		Ok(output)
-	}
-
 	fn invoke(
 		&mut self,
 		dispatch_thunk: &Self::SupervisorFuncRef,


### PR DESCRIPTION
Two changes basically which can be reviewed commit-by-commit. 

1. Don't require `store` and `store_mut` impl by `SandboxCapabilities`. This is achieved by doing some borrowck gymnastics introducing separate structures.
2. Don't require `allocate`, `deallocate`, `read_memory` and `write_memory` since those are already provided by the `FunctionContext` and practically `SandboxCapabilities` implements it. So I just have added an explicit requirement for that.

I think we could do better by abstracting more common logic, but I will save that for another day.
