### PR TITLE
Fix missing overrides of NetworkBehaviour

### DIFF
--- a/client/network/src/debug_info.rs
+++ b/client/network/src/debug_info.rs
@@ -17,12 +17,14 @@
 use fnv::FnvHashMap;
 use futures::prelude::*;
 use libp2p::Multiaddr;
+use libp2p::core::nodes::listeners::ListenerId;
 use libp2p::core::{ConnectedPoint, either::EitherOutput, PeerId, PublicKey};
 use libp2p::swarm::{IntoProtocolsHandler, IntoProtocolsHandlerSelect, ProtocolsHandler};
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p::identify::{Identify, IdentifyEvent, IdentifyInfo};
 use libp2p::ping::{Ping, PingConfig, PingEvent, PingSuccess};
 use log::{debug, trace, error};
+use std::error;
 use std::collections::hash_map::Entry;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -249,6 +251,16 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static {
 	fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
 		self.ping.inject_new_external_addr(addr);
 		self.identify.inject_new_external_addr(addr);
+	}
+
+	fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn error::Error + 'static)) {
+		self.ping.inject_listener_error(id, err);
+		self.identify.inject_listener_error(id, err);
+	}
+
+	fn inject_listener_closed(&mut self, id: ListenerId) {
+		self.ping.inject_listener_closed(id);
+		self.identify.inject_listener_closed(id);
 	}
 
 	fn poll(

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -47,7 +47,7 @@
 
 use futures::prelude::*;
 use futures_timer::Delay;
-use libp2p::core::{ConnectedPoint, Multiaddr, PeerId, PublicKey};
+use libp2p::core::{nodes::listeners::ListenerId, ConnectedPoint, Multiaddr, PeerId, PublicKey};
 use libp2p::swarm::{ProtocolsHandler, NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use libp2p::kad::{Kademlia, KademliaEvent, Quorum, Record};
 use libp2p::kad::GetClosestPeersError;
@@ -266,6 +266,15 @@ where
 		NetworkBehaviour::inject_replaced(&mut self.kademlia, peer_id, closed, opened)
 	}
 
+	fn inject_addr_reach_failure(
+		&mut self,
+		peer_id: Option<&PeerId>,
+		addr: &Multiaddr,
+		error: &dyn std::error::Error
+	) {
+		NetworkBehaviour::inject_addr_reach_failure(&mut self.kademlia, peer_id, addr, error)
+	}
+
 	fn inject_node_event(
 		&mut self,
 		peer_id: PeerId,
@@ -278,10 +287,28 @@ where
 		let new_addr = addr.clone()
 			.with(Protocol::P2p(self.local_peer_id.clone().into()));
 		info!(target: "sub-libp2p", "Discovered new external address for our node: {}", new_addr);
+		NetworkBehaviour::inject_new_external_addr(&mut self.kademlia, addr)
 	}
 
 	fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
 		info!(target: "sub-libp2p", "No longer listening on {}", addr);
+		NetworkBehaviour::inject_expired_listen_addr(&mut self.kademlia, addr)
+	}
+
+	fn inject_dial_failure(&mut self, peer_id: &PeerId) {
+		NetworkBehaviour::inject_dial_failure(&mut self.kademlia, peer_id)
+	}
+
+	fn inject_new_listen_addr(&mut self, addr: &Multiaddr) {
+		NetworkBehaviour::inject_new_listen_addr(&mut self.kademlia, addr)
+	}
+
+	fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn std::error::Error + 'static)) {
+		NetworkBehaviour::inject_listener_error(&mut self.kademlia, id, err);
+	}
+
+	fn inject_listener_closed(&mut self, id: ListenerId) {
+		NetworkBehaviour::inject_listener_closed(&mut self.kademlia, id);
 	}
 
 	fn poll(

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -20,7 +20,7 @@ use crate::utils::interval;
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
 use libp2p::{Multiaddr, PeerId};
-use libp2p::core::{ConnectedPoint, nodes::Substream, muxing::StreamMuxerBox};
+use libp2p::core::{ConnectedPoint, nodes::{listeners::ListenerId, Substream}, muxing::StreamMuxerBox};
 use libp2p::swarm::{ProtocolsHandler, IntoProtocolsHandler};
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use sp_core::storage::{StorageKey, ChildInfo};
@@ -2003,6 +2003,14 @@ Protocol<B, S, H> {
 
 	fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
 		self.behaviour.inject_new_external_addr(addr)
+	}
+
+	fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn std::error::Error + 'static)) {
+		self.behaviour.inject_listener_error(id, err);
+	}
+
+	fn inject_listener_closed(&mut self, id: ListenerId) {
+		self.behaviour.inject_listener_closed(id);
 	}
 }
 

--- a/client/network/src/protocol/legacy_proto/tests.rs
+++ b/client/network/src/protocol/legacy_proto/tests.rs
@@ -18,13 +18,13 @@
 
 use futures::{prelude::*, ready};
 use codec::{Encode, Decode};
-use libp2p::core::nodes::Substream;
+use libp2p::core::nodes::{Substream, listeners::ListenerId};
 use libp2p::core::{ConnectedPoint, transport::boxed::Boxed, muxing::StreamMuxerBox};
 use libp2p::swarm::{Swarm, ProtocolsHandler, IntoProtocolsHandler};
 use libp2p::swarm::{PollParameters, NetworkBehaviour, NetworkBehaviourAction};
 use libp2p::{PeerId, Multiaddr, Transport};
 use rand::seq::SliceRandom;
-use std::{io, task::Context, task::Poll, time::Duration};
+use std::{error, io, task::Context, task::Poll, time::Duration};
 use crate::message::Message;
 use crate::protocol::legacy_proto::{LegacyProto, LegacyProtoOut};
 use sp_test_primitives::Block;
@@ -203,6 +203,14 @@ impl NetworkBehaviour for CustomProtoWithAddr {
 
 	fn inject_new_external_addr(&mut self, addr: &Multiaddr) {
 		self.inner.inject_new_external_addr(addr)
+	}
+
+	fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn error::Error + 'static)) {
+		self.inner.inject_listener_error(id, err);
+	}
+
+	fn inject_listener_closed(&mut self, id: ListenerId) {
+		self.inner.inject_listener_closed(id);
 	}
 }
 


### PR DESCRIPTION
I realized this right after opening #4828 

Fixes an overlook: at several places we have manual implementations of `NetworkBehaviour` that wouldn't redirect events to their underlying codes.
In particular, this means that we wouldn't notify Kademlia when we fail to reach a node.
