### PR TITLE
Remove support for secio

### DIFF
--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -17,12 +17,10 @@
 use futures::prelude::*;
 use libp2p::{
 	InboundUpgradeExt, OutboundUpgradeExt, PeerId, Transport,
-	mplex, identity, secio, yamux, bandwidth, wasm_ext
+	mplex, identity, yamux, bandwidth, wasm_ext
 };
 #[cfg(not(target_os = "unknown"))]
 use libp2p::{tcp, dns, websocket, noise};
-#[cfg(not(target_os = "unknown"))]
-use libp2p::core::{either::EitherError, either::EitherOutput};
 use libp2p::core::{self, upgrade, transport::boxed::Boxed, transport::OptionalTransport, muxing::StreamMuxerBox};
 use std::{io, sync::Arc, time::Duration, usize};
 
@@ -52,7 +50,6 @@ pub fn build_transport(
 				rare panic here is basically zero");
 		noise::NoiseConfig::ix(noise_keypair)
 	};
-	let secio_config = secio::SecioConfig::new(keypair);
 
 	// Build configuration objects for multiplexing mechanisms.
 	let mut mplex_config = mplex::MplexConfig::new();
@@ -93,28 +90,23 @@ pub fn build_transport(
 	// For non-WASM, we support both secio and noise.
 	#[cfg(not(target_os = "unknown"))]
 	let transport = transport.and_then(move |stream, endpoint| {
-		let upgrade = core::upgrade::SelectUpgrade::new(noise_config, secio_config);
-		core::upgrade::apply(stream, upgrade, endpoint, upgrade::Version::V1)
-			.map(|out| match out? {
-				// We negotiated noise
-				EitherOutput::First((remote_id, out)) => {
-					let remote_key = match remote_id {
-						noise::RemoteIdentity::IdentityKey(key) => key,
-						_ => return Err(upgrade::UpgradeError::Apply(EitherError::A(noise::NoiseError::InvalidKey)))
-					};
-					Ok((EitherOutput::First(out), remote_key.into_peer_id()))
-				}
-				// We negotiated secio
-				EitherOutput::Second((remote_id, out)) =>
-					Ok((EitherOutput::Second(out), remote_id))
+		core::upgrade::apply(stream, noise_config, endpoint, upgrade::Version::V1)
+			.and_then(|(remote_id, out)| async move {
+				let remote_key = match remote_id {
+					noise::RemoteIdentity::IdentityKey(key) => key,
+					_ => return Err(upgrade::UpgradeError::Apply(noise::NoiseError::InvalidKey))
+				};
+				Ok((out, remote_key.into_peer_id()))
 			})
 	});
 
-	// For WASM, we only support secio for now.
+	// We refuse all WASM connections for now. It is intended that we negotiate noise in the
+	// future. See https://github.com/libp2p/rust-libp2p/issues/1414
 	#[cfg(target_os = "unknown")]
-	let transport = transport.and_then(move |stream, endpoint| {
-		core::upgrade::apply(stream, secio_config, endpoint, upgrade::Version::V1)
-			.map_ok(|(id, stream)| ((stream, id)))
+	let transport = transport.and_then(move |_, _| async move {
+		let r: Result<(wasm_ext::Connection, PeerId), _> =
+			Err(io::Error::new(io::ErrorKind::Other, format!("No encryption protocol supported")));
+		r
 	});
 
 	// Multiplexing


### PR DESCRIPTION
It's always been intended that we deprecate secio in favour of noise. Noise has been working in production for the past six months to a year, without causing any issue. We can say it's working.

Let's remove secio before we ship Substrate 2.0, in order to avoid having to make a networking breaking change afterwards.

This unfortunately breaks the browser stuff (cc @expenses). The intent is to restore it as soon as possible by doing https://github.com/libp2p/rust-libp2p/issues/1414.
