### PR TITLE
node: disable grandpa automatic finality fallback

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -476,7 +476,7 @@ parameter_types! {
 }
 
 impl pallet_finality_tracker::Trait for Runtime {
-	type OnFinalizationStalled = Grandpa;
+	type OnFinalizationStalled = ();
 	type WindowSize = WindowSize;
 	type ReportLatency = ReportLatency;
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 213,
+	spec_version: 214,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };


### PR DESCRIPTION
The current implementation of the finality tracker can only track finality using a window of the last 100 blocks, with 3s block times this means that any GRANDPA stall longer than 5 minutes triggers a forced authority set change. This feature is currently unused in Polkadot and we don't have plans to use the automatic fallback anytime soon (it would require changing the finality tracker implementation to efficiently allow tracking longer windows), and instead we plan on implementing a way to manually trigger a forced change (which on Kusama/Polkadot would happen through democracy). Having this enabled makes it harder to diagnose any finality issues introduced by recent changes / test builds on Flaming Fir since the authority set will be forcefully changed after any temporary stall.

I think we should reset flaming fir and redeploy it after this is merged. The reason being that in the current state it already went through some forced authority set changes (which kills light clients right now). Alternatively we can just do a runtime upgrade.