### PR TITLE
ci: enable build for pre-tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -525,7 +525,7 @@ publish-gh-doc:
       insteadOf = "https://github.com/"
       EOC
     - unset GITHUB_TOKEN
-    - git clone https://github.com/substrate-developer-hub/rustdocs.git
+    - git clone --depth 1 https://github.com/substrate-developer-hub/rustdocs.git
     - rsync -ax --delete ./crate-docs/ ./rustdocs/${CI_COMMIT_REF_NAME}/
     - cd ./rustdocs; git add .
     - git commit -m "update rustdoc ${CI_COMMIT_REF_NAME}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,7 @@ variables:
   only:
     - master
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+    - /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/
     - web
 
 


### PR DESCRIPTION
https://github.com/paritytech/devops/issues/419

building and publishing rustdocs is requested to happen for pre-tags as the distance to official tagged releases is too long.