### PR TITLE
Fix broken factory by adding keystore back.

### DIFF
--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -50,6 +50,8 @@ where
 				cli_args.shared_params.dev,
 			)?;
 
+			sc_cli::fill_config_keystore_in_memory(&mut config)?;
+
 			match ChainSpec::from(config.expect_chain_spec().id()) {
 				Some(ref c) if c == &ChainSpec::Development || c == &ChainSpec::LocalTestnet => {},
 				_ => panic!("Factory is only supported for development and local testnet."),

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -445,7 +445,7 @@ fn input_keystore_password() -> Result<String, String> {
 }
 
 /// Use in memory keystore config when it is not required at all.
-fn fill_config_keystore_in_memory<G, E>(config: &mut sc_service::Configuration<G, E>)
+pub fn fill_config_keystore_in_memory<G, E>(config: &mut sc_service::Configuration<G, E>)
 	-> Result<(), String>
 {
 	match &mut config.keystore {


### PR DESCRIPTION
Fixes:
```
➜  substrate-3 git:(master) ./target/debug/substrate factory --dev
Error: Service(Other("No keystore config provided!"))
```