### PR TITLE
pow: re-add support for algorithms where only linear verification is possible

### DIFF
--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -454,20 +454,17 @@ pub fn register_pow_inherent_data_provider(
 pub type PowImportQueue<B, Transaction> = BasicQueue<B, Transaction>;
 
 /// Import queue for PoW engine.
-pub fn import_queue<B, C, S, Algorithm>(
-	block_import: BoxBlockImport<B, sp_api::TransactionFor<C, B>>,
+pub fn import_queue<B, Transaction, Algorithm>(
+	block_import: BoxBlockImport<B, Transaction>,
 	algorithm: Algorithm,
 	inherent_data_providers: InherentDataProviders,
 ) -> Result<
-	PowImportQueue<B, sp_api::TransactionFor<C, B>>,
+	PowImportQueue<B, Transaction>,
 	sp_consensus::Error
 > where
 	B: BlockT,
-	C: ProvideRuntimeApi<B> + HeaderBackend<B> + BlockOf + ProvideCache<B> + AuxStore,
-	C: Send + Sync + AuxStore + 'static,
-	C::Api: BlockBuilderApi<B, Error = sp_blockchain::Error>,
+	Transaction: Send + Sync + 'static,
 	Algorithm: PowAlgorithm<B> + Clone + Send + Sync + 'static,
-	S: SelectChain<B> + 'static,
 {
 	register_pow_inherent_data_provider(&inherent_data_providers)?;
 

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -192,6 +192,19 @@ pub struct PowBlockImport<B: BlockT, I, C, S, Algorithm> {
 	check_inherents_after: <<B as BlockT>::Header as HeaderT>::Number,
 }
 
+impl<B: BlockT, I: Clone, C, S: Clone, Algorithm: Clone> Clone for PowBlockImport<B, I, C, S, Algorithm> {
+	fn clone(&self) -> Self {
+		Self {
+			algorithm: self.algorithm.clone(),
+			inner: self.inner.clone(),
+			select_chain: self.select_chain.clone(),
+			client: self.client.clone(),
+			inherent_data_providers: self.inherent_data_providers.clone(),
+			check_inherents_after: self.check_inherents_after.clone(),
+		}
+	}
+}
+
 impl<B, I, C, S, Algorithm> PowBlockImport<B, I, C, S, Algorithm> where
 	B: BlockT,
 	I: BlockImport<B, Transaction = sp_api::TransactionFor<C, B>> + Send + Sync,


### PR DESCRIPTION
This restores the API of PoW engine after https://github.com/paritytech/substrate/pull/4652. No-parent verification now again becomes optional (called `preliminary_verify`). This is needed because for some algorithms only linear verification is possible (for PoW algorithms that just relies on parent block information). Also fixed some unused generic parameters.