### PR TITLE
Rename StorageMap::exists to ::contains_key (Resolves #4839)

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 214,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1381,6 +1381,6 @@ where
 {
 	fn is_dead_account(who: &T::AccountId) -> bool {
 		// this should always be exactly equivalent to `Self::account(who).total().is_zero()`
-		!Account::<T, I>::exists(who)
+		!Account::<T, I>::contains_key(who)
 	}
 }

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -191,7 +191,7 @@ decl_module! {
 
 			let proposal_hash = T::Hashing::hash_of(&proposal);
 
-			ensure!(!<ProposalOf<T, I>>::exists(proposal_hash), Error::<T, I>::DuplicateProposal);
+			ensure!(!<ProposalOf<T, I>>::contains_key(proposal_hash), Error::<T, I>::DuplicateProposal);
 
 			if threshold < 2 {
 				let seats = Self::members().len() as MemberCount;

--- a/frame/contracts/src/account_db.rs
+++ b/frame/contracts/src/account_db.rs
@@ -137,7 +137,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 		<ContractInfoOf<T>>::get(account).and_then(|i| i.as_alive().map(|i| i.rent_allowance))
 	}
 	fn contract_exists(&self, account: &T::AccountId) -> bool {
-		<ContractInfoOf<T>>::exists(account)
+		<ContractInfoOf<T>>::contains_key(account)
 	}
 	fn get_balance(&self, account: &T::AccountId) -> BalanceOf<T> {
 		T::Currency::free_balance(account)

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -460,7 +460,7 @@ fn instantiate_and_call_and_deposit_event() {
 		]);
 
 		assert_ok!(creation);
-		assert!(ContractInfoOf::<Test>::exists(BOB));
+		assert!(ContractInfoOf::<Test>::contains_key(BOB));
 	});
 }
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -520,7 +520,7 @@ impl<T: Trait> Module<T> {
 	///
 	/// State: O(1).
 	fn is_voter(who: &T::AccountId) -> bool {
-		<StakeOf<T>>::exists(who)
+		<StakeOf<T>>::contains_key(who)
 	}
 
 	/// Check if `who` is currently an active member.

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -525,7 +525,7 @@ decl_module! {
 			let who = ensure_signed(origin)?;
 
 			ensure!(!Self::presentation_active(), Error::<T>::CannotRetractPresenting);
-			ensure!(<VoterInfoOf<T>>::exists(&who), Error::<T>::RetractNonVoter);
+			ensure!(<VoterInfoOf<T>>::contains_key(&who), Error::<T>::RetractNonVoter);
 			let index = index as usize;
 			let voter = Self::voter_at(index).ok_or(Error::<T>::InvalidRetractionIndex)?;
 			ensure!(voter == who, Error::<T>::InvalidRetractionIndex);
@@ -730,7 +730,7 @@ impl<T: Trait> Module<T> {
 
 	/// If `who` a candidate at the moment?
 	pub fn is_a_candidate(who: &T::AccountId) -> bool {
-		<RegisterInfoOf<T>>::exists(who)
+		<RegisterInfoOf<T>>::contains_key(who)
 	}
 
 	/// Iff the member `who` still has a seat at blocknumber `n` returns `true`.

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -580,7 +580,7 @@ impl<T: Trait> Module<T> {
 		options: AssetOptions<T::Balance, T::AccountId>,
 	) -> DispatchResult {
 		let asset_id = if let Some(asset_id) = asset_id {
-			ensure!(!<TotalIssuance<T>>::exists(&asset_id), Error::<T>::IdAlreadyTaken);
+			ensure!(!<TotalIssuance<T>>::contains_key(&asset_id), Error::<T>::IdAlreadyTaken);
 			ensure!(asset_id < Self::next_asset_id(), Error::<T>::IdUnavailable);
 			asset_id
 		} else {

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -553,7 +553,7 @@ decl_module! {
 		#[weight = SimpleDispatchInfo::FixedNormal(50_000)]
 		fn set_subs(origin, subs: Vec<(T::AccountId, Data)>) {
 			let sender = ensure_signed(origin)?;
-			ensure!(<IdentityOf<T>>::exists(&sender), Error::<T>::NotFound);
+			ensure!(<IdentityOf<T>>::contains_key(&sender), Error::<T>::NotFound);
 			ensure!(subs.len() <= T::MaxSubAccounts::get() as usize, Error::<T>::TooManySubAccounts);
 
 			let (old_deposit, old_ids) = <SubsOf<T>>::get(&sender);

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -315,7 +315,7 @@ decl_module! {
 			ensure_none(origin)?;
 
 			let current_session = <pallet_session::Module<T>>::current_index();
-			let exists = <ReceivedHeartbeats>::exists(
+			let exists = <ReceivedHeartbeats>::contains_key(
 				&current_session,
 				&heartbeat.authority_index
 			);
@@ -398,7 +398,7 @@ impl<T: Trait> Module<T> {
 	fn is_online_aux(authority_index: AuthIndex, authority: &T::ValidatorId) -> bool {
 		let current_session = <pallet_session::Module<T>>::current_index();
 
-		<ReceivedHeartbeats>::exists(&current_session, &authority_index) ||
+		<ReceivedHeartbeats>::contains_key(&current_session, &authority_index) ||
 			<AuthoredBlocks<T>>::get(
 				&current_session,
 				authority,
@@ -409,7 +409,7 @@ impl<T: Trait> Module<T> {
 	/// the authorities series, during the current session. Otherwise `false`.
 	pub fn received_heartbeat_in_current_session(authority_index: AuthIndex) -> bool {
 		let current_session = <pallet_session::Module<T>>::current_index();
-		<ReceivedHeartbeats>::exists(&current_session, &authority_index)
+		<ReceivedHeartbeats>::contains_key(&current_session, &authority_index)
 	}
 
 	/// Note that the given authority has authored a block in the current session.

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -150,7 +150,7 @@ impl<T: Trait> Module<T> {
 		for offender in offenders {
 			let report_id = Self::report_id::<O>(time_slot, &offender);
 
-			if !<Reports<T>>::exists(&report_id) {
+			if !<Reports<T>>::contains_key(&report_id) {
 				any_new = true;
 				<Reports<T>>::insert(
 					&report_id,

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -401,7 +401,7 @@ decl_module! {
 		) {
 			let who = ensure_signed(origin)?;
 			// Check account is not already set up for recovery
-			ensure!(!<Recoverable<T>>::exists(&who), Error::<T>::AlreadyRecoverable);
+			ensure!(!<Recoverable<T>>::contains_key(&who), Error::<T>::AlreadyRecoverable);
 			// Check user input is valid
 			ensure!(threshold >= 1, Error::<T>::ZeroThreshold);
 			ensure!(!friends.is_empty(), Error::<T>::NotEnoughFriends);
@@ -456,9 +456,9 @@ decl_module! {
 		fn initiate_recovery(origin, account: T::AccountId) {
 			let who = ensure_signed(origin)?;
 			// Check that the account is recoverable
-			ensure!(<Recoverable<T>>::exists(&account), Error::<T>::NotRecoverable);
+			ensure!(<Recoverable<T>>::contains_key(&account), Error::<T>::NotRecoverable);
 			// Check that the recovery process has not already been started
-			ensure!(!<ActiveRecoveries<T>>::exists(&account, &who), Error::<T>::AlreadyStarted);
+			ensure!(!<ActiveRecoveries<T>>::contains_key(&account, &who), Error::<T>::AlreadyStarted);
 			// Take recovery deposit
 			let recovery_deposit = T::RecoveryDeposit::get();
 			T::Currency::reserve(&who, recovery_deposit)?;

--- a/frame/recovery/src/tests.rs
+++ b/frame/recovery/src/tests.rs
@@ -92,9 +92,9 @@ fn recovery_lifecycle_works() {
 		assert_eq!(Balances::free_balance(1), 200);
 		assert_eq!(Balances::free_balance(5), 0);
 		// All storage items are removed from the module
-		assert!(!<ActiveRecoveries<Test>>::exists(&5, &1));
-		assert!(!<Recoverable<Test>>::exists(&5));
-		assert!(!<Recovered<Test>>::exists(&5));
+		assert!(!<ActiveRecoveries<Test>>::contains_key(&5, &1));
+		assert!(!<Recoverable<Test>>::contains_key(&5));
+		assert!(!<Recovered<Test>>::contains_key(&5));
 	});
 }
 

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -265,7 +265,7 @@ decl_module! {
 		/// the index of the transactor in the `Pool`.
 		pub fn submit_candidacy(origin) {
 			let who = ensure_signed(origin)?;
-			ensure!(!<CandidateExists<T, I>>::exists(&who), Error::<T, I>::AlreadyInPool);
+			ensure!(!<CandidateExists<T, I>>::contains_key(&who), Error::<T, I>::AlreadyInPool);
 
 			let deposit = T::CandidateDeposit::get();
 			T::Currency::reserve(&who, deposit)?;

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -530,8 +530,8 @@ decl_module! {
 		#[weight = SimpleDispatchInfo::FixedNormal(50_000)]
 		pub fn bid(origin, value: BalanceOf<T, I>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-			ensure!(!<SuspendedCandidates<T, I>>::exists(&who), Error::<T, I>::Suspended);
-			ensure!(!<SuspendedMembers<T, I>>::exists(&who), Error::<T, I>::Suspended);
+			ensure!(!<SuspendedCandidates<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
+			ensure!(!<SuspendedMembers<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
 			let bids = <Bids<T, I>>::get();
 			ensure!(!Self::is_bid(&bids, &who), Error::<T, I>::AlreadyBid);
 			let candidates = <Candidates<T, I>>::get();
@@ -640,8 +640,8 @@ decl_module! {
 		pub fn vouch(origin, who: T::AccountId, value: BalanceOf<T, I>, tip: BalanceOf<T, I>) -> DispatchResult {
 			let voucher = ensure_signed(origin)?;
 			// Check user is not suspended.
-			ensure!(!<SuspendedCandidates<T, I>>::exists(&who), Error::<T, I>::Suspended);
-			ensure!(!<SuspendedMembers<T, I>>::exists(&who), Error::<T, I>::Suspended);
+			ensure!(!<SuspendedCandidates<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
+			ensure!(!<SuspendedMembers<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
 			// Check user is not a bid or candidate.
 			let bids = <Bids<T, I>>::get();
 			ensure!(!Self::is_bid(&bids, &who), Error::<T, I>::AlreadyBid);
@@ -652,7 +652,7 @@ decl_module! {
 			ensure!(!Self::is_member(&members, &who), Error::<T, I>::AlreadyMember);
 			// Check sender can vouch.
 			ensure!(Self::is_member(&members, &voucher), Error::<T, I>::NotMember);
-			ensure!(!<Vouching<T, I>>::exists(&voucher), Error::<T, I>::AlreadyVouching);
+			ensure!(!<Vouching<T, I>>::contains_key(&voucher), Error::<T, I>::AlreadyVouching);
 
 			<Vouching<T, I>>::insert(&voucher, VouchingStatus::Vouching);
 			Self::put_bid(bids, &who, value.clone(), BidKind::Vouch(voucher.clone(), tip));
@@ -892,7 +892,7 @@ decl_module! {
 		#[weight = SimpleDispatchInfo::FixedNormal(30_000)]
 		fn judge_suspended_member(origin, who: T::AccountId, forgive: bool) {
 			T::SuspensionJudgementOrigin::ensure_origin(origin)?;
-			ensure!(<SuspendedMembers<T, I>>::exists(&who), Error::<T, I>::NotSuspended);
+			ensure!(<SuspendedMembers<T, I>>::contains_key(&who), Error::<T, I>::NotSuspended);
 
 			if forgive {
 				// Try to add member back to society. Can fail with `MaxMembers` limit.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -887,13 +887,13 @@ decl_module! {
 		) {
 			let stash = ensure_signed(origin)?;
 
-			if <Bonded<T>>::exists(&stash) {
+			if <Bonded<T>>::contains_key(&stash) {
 				Err(Error::<T>::AlreadyBonded)?
 			}
 
 			let controller = T::Lookup::lookup(controller)?;
 
-			if <Ledger<T>>::exists(&controller) {
+			if <Ledger<T>>::contains_key(&controller) {
 				Err(Error::<T>::AlreadyPaired)?
 			}
 
@@ -1139,7 +1139,7 @@ decl_module! {
 			let stash = ensure_signed(origin)?;
 			let old_controller = Self::bonded(&stash).ok_or(Error::<T>::NotStash)?;
 			let controller = T::Lookup::lookup(controller)?;
-			if <Ledger<T>>::exists(&controller) {
+			if <Ledger<T>>::contains_key(&controller) {
 				Err(Error::<T>::AlreadyPaired)?
 			}
 			if controller != old_controller {

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -977,7 +977,7 @@ fn bond_extra_works() {
 	// See `bond_extra_and_withdraw_unbonded_works` for more details and updates on `Exposure`.
 	ExtBuilder::default().build().execute_with(|| {
 		// Check that account 10 is a validator
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 		// Check that account 10 is bonded to account 11
 		assert_eq!(Staking::bonded(&11), Some(10));
 		// Check how much is at stake
@@ -1375,7 +1375,7 @@ fn slot_stake_is_least_staked_validator_and_exposure_defines_maximum_punishment(
 		// Confirm validator count is 2
 		assert_eq!(Staking::validator_count(), 2);
 		// Confirm account 10 and 20 are validators
-		assert!(<Validators<Test>>::exists(&11) && <Validators<Test>>::exists(&21));
+		assert!(<Validators<Test>>::contains_key(&11) && <Validators<Test>>::contains_key(&21));
 
 		assert_eq!(Staking::stakers(&11).total, 1000);
 		assert_eq!(Staking::stakers(&21).total, 2000);
@@ -1433,10 +1433,10 @@ fn on_free_balance_zero_stash_removes_validator() {
 		assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Stash));
 
 		// Check storage items that should be cleaned up
-		assert!(<Ledger<Test>>::exists(&10));
-		assert!(<Bonded<Test>>::exists(&11));
-		assert!(<Validators<Test>>::exists(&11));
-		assert!(<Payee<Test>>::exists(&11));
+		assert!(<Ledger<Test>>::contains_key(&10));
+		assert!(<Bonded<Test>>::contains_key(&11));
+		assert!(<Validators<Test>>::contains_key(&11));
+		assert!(<Payee<Test>>::contains_key(&11));
 
 		// Reduce free_balance of controller to 0
 		let _ = Balances::slash(&10, u64::max_value());
@@ -1447,10 +1447,10 @@ fn on_free_balance_zero_stash_removes_validator() {
 		assert_eq!(Staking::bonded(&11), Some(10));
 
 		// Check storage items have not changed
-		assert!(<Ledger<Test>>::exists(&10));
-		assert!(<Bonded<Test>>::exists(&11));
-		assert!(<Validators<Test>>::exists(&11));
-		assert!(<Payee<Test>>::exists(&11));
+		assert!(<Ledger<Test>>::contains_key(&10));
+		assert!(<Bonded<Test>>::contains_key(&11));
+		assert!(<Validators<Test>>::contains_key(&11));
+		assert!(<Payee<Test>>::contains_key(&11));
 
 		// Reduce free_balance of stash to 0
 		let _ = Balances::slash(&11, u64::max_value());
@@ -1458,11 +1458,11 @@ fn on_free_balance_zero_stash_removes_validator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Check storage items do not exist
-		assert!(!<Ledger<Test>>::exists(&10));
-		assert!(!<Bonded<Test>>::exists(&11));
-		assert!(!<Validators<Test>>::exists(&11));
-		assert!(!<Nominators<Test>>::exists(&11));
-		assert!(!<Payee<Test>>::exists(&11));
+		assert!(!<Ledger<Test>>::contains_key(&10));
+		assert!(!<Bonded<Test>>::contains_key(&11));
+		assert!(!<Validators<Test>>::contains_key(&11));
+		assert!(!<Nominators<Test>>::contains_key(&11));
+		assert!(!<Payee<Test>>::contains_key(&11));
 	});
 }
 
@@ -1474,7 +1474,7 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		// Make 10 a nominator
 		assert_ok!(Staking::nominate(Origin::signed(10), vec![20]));
 		// Check that account 10 is a nominator
-		assert!(<Nominators<Test>>::exists(11));
+		assert!(<Nominators<Test>>::contains_key(11));
 		// Check the balance of the nominator account
 		assert_eq!(Balances::free_balance(10), 256);
 		// Check the balance of the stash account
@@ -1484,10 +1484,10 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		assert_ok!(Staking::set_payee(Origin::signed(10), RewardDestination::Stash));
 
 		// Check storage items that should be cleaned up
-		assert!(<Ledger<Test>>::exists(&10));
-		assert!(<Bonded<Test>>::exists(&11));
-		assert!(<Nominators<Test>>::exists(&11));
-		assert!(<Payee<Test>>::exists(&11));
+		assert!(<Ledger<Test>>::contains_key(&10));
+		assert!(<Bonded<Test>>::contains_key(&11));
+		assert!(<Nominators<Test>>::contains_key(&11));
+		assert!(<Payee<Test>>::contains_key(&11));
 
 		// Reduce free_balance of controller to 0
 		let _ = Balances::slash(&10, u64::max_value());
@@ -1500,10 +1500,10 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		assert_eq!(Staking::bonded(&11), Some(10));
 
 		// Check storage items have not changed
-		assert!(<Ledger<Test>>::exists(&10));
-		assert!(<Bonded<Test>>::exists(&11));
-		assert!(<Nominators<Test>>::exists(&11));
-		assert!(<Payee<Test>>::exists(&11));
+		assert!(<Ledger<Test>>::contains_key(&10));
+		assert!(<Bonded<Test>>::contains_key(&11));
+		assert!(<Nominators<Test>>::contains_key(&11));
+		assert!(<Payee<Test>>::contains_key(&11));
 
 		// Reduce free_balance of stash to 0
 		let _ = Balances::slash(&11, u64::max_value());
@@ -1511,11 +1511,11 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Check storage items do not exist
-		assert!(!<Ledger<Test>>::exists(&10));
-		assert!(!<Bonded<Test>>::exists(&11));
-		assert!(!<Validators<Test>>::exists(&11));
-		assert!(!<Nominators<Test>>::exists(&11));
-		assert!(!<Payee<Test>>::exists(&11));
+		assert!(!<Ledger<Test>>::contains_key(&10));
+		assert!(!<Bonded<Test>>::contains_key(&11));
+		assert!(!<Validators<Test>>::contains_key(&11));
+		assert!(!<Nominators<Test>>::contains_key(&11));
+		assert!(!<Payee<Test>>::contains_key(&11));
 	});
 }
 
@@ -1968,7 +1968,7 @@ fn offence_ensures_new_era_without_clobbering() {
 #[test]
 fn offence_deselects_validator_when_slash_is_zero() {
 	ExtBuilder::default().build().execute_with(|| {
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 		on_offence_now(
 			&[OffenceDetails {
 				offender: (
@@ -1980,7 +1980,7 @@ fn offence_deselects_validator_when_slash_is_zero() {
 			&[Perbill::from_percent(0)],
 		);
 		assert_eq!(Staking::force_era(), Forcing::ForceNew);
-		assert!(!<Validators<Test>>::exists(11));
+		assert!(!<Validators<Test>>::contains_key(11));
 	});
 }
 
@@ -2017,7 +2017,7 @@ fn slash_in_old_span_does_not_deselect() {
 	ExtBuilder::default().build().execute_with(|| {
 		start_era(1);
 
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 		on_offence_now(
 			&[OffenceDetails {
 				offender: (
@@ -2029,13 +2029,13 @@ fn slash_in_old_span_does_not_deselect() {
 			&[Perbill::from_percent(0)],
 		);
 		assert_eq!(Staking::force_era(), Forcing::ForceNew);
-		assert!(!<Validators<Test>>::exists(11));
+		assert!(!<Validators<Test>>::contains_key(11));
 
 		start_era(2);
 
 		Staking::validate(Origin::signed(10), Default::default()).unwrap();
 		assert_eq!(Staking::force_era(), Forcing::NotForcing);
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 
 		start_era(3);
 
@@ -2056,7 +2056,7 @@ fn slash_in_old_span_does_not_deselect() {
 
 		// not for zero-slash.
 		assert_eq!(Staking::force_era(), Forcing::NotForcing);
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 
 		on_offence_in_era(
 			&[OffenceDetails {
@@ -2072,7 +2072,7 @@ fn slash_in_old_span_does_not_deselect() {
 
 		// or non-zero.
 		assert_eq!(Staking::force_era(), Forcing::NotForcing);
-		assert!(<Validators<Test>>::exists(11));
+		assert!(<Validators<Test>>::contains_key(11));
 		assert_ledger_consistent(11);
 	});
 }

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -110,7 +110,7 @@ where
 		Self::storage_double_map_final_key(k1, k2)
 	}
 
-	fn exists<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
+	fn contains_key<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
 	where
 		KArg1: EncodeLike<K1>,
 		KArg2: EncodeLike<K2>,

--- a/frame/support/src/storage/generator/linked_map.rs
+++ b/frame/support/src/storage/generator/linked_map.rs
@@ -326,7 +326,7 @@ where
 
 	type Enumerator = Enumerator<K, V, G::KeyFormat>;
 
-	fn exists<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool {
+	fn contains_key<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool {
 		unhashed::exists(Self::storage_linked_map_final_key(key).as_ref())
 	}
 

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -95,7 +95,7 @@ impl<K: FullEncode, V: FullCodec, G: StorageMap<K, V>> storage::StorageMap<K, V>
 		}
 	}
 
-	fn exists<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool {
+	fn contains_key<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool {
 		unhashed::exists(Self::storage_map_final_key(key).as_ref())
 	}
 

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -126,7 +126,7 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	fn hashed_key_for<KeyArg: EncodeLike<K>>(key: KeyArg) -> Vec<u8>;
 
 	/// Does the value (explicitly) exist in storage?
-	fn exists<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool;
+	fn contains_key<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool;
 
 	/// Load the value associated with the given key from the map.
 	fn get<KeyArg: EncodeLike<K>>(key: KeyArg) -> Self::Query;
@@ -176,7 +176,7 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 	/// `T` is required to implement `Codec::DecodeLength`.
 	///
 	/// Note that `0` is returned as the default value if no encoded value exists at the given key.
-	/// Therefore, this function cannot be used as a sign of _existence_. use the `::exists()`
+	/// Therefore, this function cannot be used as a sign of _existence_. use the `::contains_key()`
 	/// function for this purpose.
 	fn decode_len<KeyArg: EncodeLike<K>>(key: KeyArg) -> Result<usize, &'static str>
 		where V: codec::DecodeLength + Len;
@@ -196,7 +196,7 @@ pub trait StorageLinkedMap<K: FullCodec, V: FullCodec> {
 	type Enumerator: Iterator<Item = (K, V)>;
 
 	/// Does the value (explicitly) exist in storage?
-	fn exists<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool;
+	fn contains_key<KeyArg: EncodeLike<K>>(key: KeyArg) -> bool;
 
 	/// Load the value associated with the given key from the map.
 	fn get<KeyArg: EncodeLike<K>>(key: KeyArg) -> Self::Query;
@@ -227,7 +227,7 @@ pub trait StorageLinkedMap<K: FullCodec, V: FullCodec> {
 	/// `T` is required to implement `Codec::DecodeLength`.
 	///
 	/// Note that `0` is returned as the default value if no encoded value exists at the given key.
-	/// Therefore, this function cannot be used as a sign of _existence_. use the `::exists()`
+	/// Therefore, this function cannot be used as a sign of _existence_. use the `::contains_key()`
 	/// function for this purpose.
 	fn decode_len<KeyArg: EncodeLike<K>>(key: KeyArg) -> Result<usize, &'static str>
 		where V: codec::DecodeLength + Len;
@@ -270,7 +270,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 		KArg1: EncodeLike<K1>,
 		KArg2: EncodeLike<K2>;
 
-	fn exists<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
+	fn contains_key<KArg1, KArg2>(k1: KArg1, k2: KArg2) -> bool
 	where
 		KArg1: EncodeLike<K1>,
 		KArg2: EncodeLike<K2>;
@@ -348,7 +348,7 @@ pub trait StorageDoubleMap<K1: FullEncode, K2: FullEncode, V: FullCodec> {
 	/// `V` is required to implement `Codec::DecodeLength`.
 	///
 	/// Note that `0` is returned as the default value if no encoded value exists at the given key.
-	/// Therefore, this function cannot be used as a sign of _existence_. use the `::exists()`
+	/// Therefore, this function cannot be used as a sign of _existence_. use the `::contains_key()`
 	/// function for this purpose.
 	fn decode_len<KArg1, KArg2>(key1: KArg1, key2: KArg2) -> Result<usize, &'static str>
 		where

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -348,8 +348,8 @@ fn storage_with_instance_basic_operation() {
 		assert_eq!(Value::get(), 0);
 
 		let key = 1;
-		assert_eq!(Map::exists(0), true);
-		assert_eq!(Map::exists(key), false);
+		assert_eq!(Map::contains_key(0), true);
+		assert_eq!(Map::contains_key(key), false);
 		Map::insert(key, 1);
 		assert_eq!(Map::get(key), 1);
 		assert_eq!(Map::take(key), 1);
@@ -357,11 +357,11 @@ fn storage_with_instance_basic_operation() {
 		Map::mutate(key, |a| *a=2);
 		assert_eq!(Map::get(key), 2);
 		Map::remove(key);
-		assert_eq!(Map::exists(key), false);
+		assert_eq!(Map::contains_key(key), false);
 		assert_eq!(Map::get(key), 0);
 
-		assert_eq!(LinkedMap::exists(0), true);
-		assert_eq!(LinkedMap::exists(key), false);
+		assert_eq!(LinkedMap::contains_key(0), true);
+		assert_eq!(LinkedMap::contains_key(key), false);
 		LinkedMap::insert(key, vec![1]);
 		assert_eq!(LinkedMap::enumerate().count(), 2);
 		assert_eq!(LinkedMap::get(key), vec![1]);
@@ -373,17 +373,17 @@ fn storage_with_instance_basic_operation() {
 		assert_eq!(LinkedMap::get(key), vec![2]);
 		LinkedMap::remove(key);
 		assert_eq!(LinkedMap::enumerate().count(), 1);
-		assert_eq!(LinkedMap::exists(key), false);
+		assert_eq!(LinkedMap::contains_key(key), false);
 		assert_eq!(LinkedMap::get(key), vec![]);
-		assert_eq!(LinkedMap::exists(key), false);
+		assert_eq!(LinkedMap::contains_key(key), false);
 		assert_eq!(LinkedMap::enumerate().count(), 1);
 		LinkedMap::insert(key, &vec![1]);
 		assert_eq!(LinkedMap::enumerate().count(), 2);
 
 		let key1 = 1;
 		let key2 = 1;
-		assert_eq!(DoubleMap::exists(&0, &0), true);
-		assert_eq!(DoubleMap::exists(&key1, &key2), false);
+		assert_eq!(DoubleMap::contains_key(&0, &0), true);
+		assert_eq!(DoubleMap::contains_key(&key1, &key2), false);
 		DoubleMap::insert(&key1, &key2, &1);
 		assert_eq!(DoubleMap::get(&key1, &key2), 1);
 		assert_eq!(DoubleMap::take(&key1, &key2), 1);

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1146,7 +1146,7 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckEra<T> {
 	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
 		let current_u64 = <Module<T>>::block_number().saturated_into::<u64>();
 		let n = (self.0).0.birth(current_u64).saturated_into::<T::BlockNumber>();
-		if !<BlockHash<T>>::exists(n) {
+		if !<BlockHash<T>>::contains_key(n) {
 			Err(InvalidTransaction::AncientBirthBlock.into())
 		} else {
 			Ok(<Module<T>>::block_hash(n))

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -371,7 +371,7 @@ decl_module! {
 		fn approve_proposal(origin, #[compact] proposal_id: ProposalIndex) {
 			T::ApproveOrigin::ensure_origin(origin)?;
 
-			ensure!(<Proposals<T>>::exists(proposal_id), Error::<T>::InvalidProposalIndex);
+			ensure!(<Proposals<T>>::contains_key(proposal_id), Error::<T>::InvalidProposalIndex);
 
 			Approvals::mutate(|v| v.push(proposal_id));
 		}
@@ -403,9 +403,9 @@ decl_module! {
 			ensure!(reason.len() <= MAX_SENSIBLE_REASON_LENGTH, Error::<T>::ReasonTooBig);
 
 			let reason_hash = T::Hashing::hash(&reason[..]);
-			ensure!(!Reasons::<T>::exists(&reason_hash), Error::<T>::AlreadyKnown);
+			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
 			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
-			ensure!(!Tips::<T>::exists(&hash), Error::<T>::AlreadyKnown);
+			ensure!(!Tips::<T>::contains_key(&hash), Error::<T>::AlreadyKnown);
 
 			let deposit = T::TipReportDepositBase::get()
 				+ T::TipReportDepositPerByte::get() * (reason.len() as u32).into();
@@ -474,7 +474,7 @@ decl_module! {
 			let tipper = ensure_signed(origin)?;
 			ensure!(T::Tippers::contains(&tipper), BadOrigin);
 			let reason_hash = T::Hashing::hash(&reason[..]);
-			ensure!(!Reasons::<T>::exists(&reason_hash), Error::<T>::AlreadyKnown);
+			ensure!(!Reasons::<T>::contains_key(&reason_hash), Error::<T>::AlreadyKnown);
 			let hash = T::Hashing::hash_of(&(&reason_hash, &who));
 
 			Reasons::<T>::insert(&reason_hash, &reason);

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -212,7 +212,7 @@ impl<T: Trait> Module<T> {
 	/// (Re)set or remove the module's currency lock on `who`'s account in accordance with their
 	/// current unvested amount.
 	fn update_lock(who: T::AccountId) -> DispatchResult {
-		ensure!(Vesting::<T>::exists(&who), Error::<T>::NotVesting);
+		ensure!(Vesting::<T>::contains_key(&who), Error::<T>::NotVesting);
 		let unvested = Self::vesting_balance(&who);
 		if unvested.is_zero() {
 			T::Currency::remove_lock(VESTING_ID, &who);
@@ -257,7 +257,7 @@ impl<T: Trait> VestingSchedule<T::AccountId> for Module<T> where
 		starting_block: T::BlockNumber
 	) -> DispatchResult {
 		if locked.is_zero() { return Ok(()) }
-		if Vesting::<T>::exists(who) {
+		if Vesting::<T>::contains_key(who) {
 			Err(Error::<T>::ExistingVestingSchedule)?
 		}
 		let vesting_schedule = VestingInfo {


### PR DESCRIPTION
As mentioned in #4839 it would be nice to align the `StorageMap` interface with the ones provided by Rusts `HashMap` and `BTreeMap`.

This PR renames `StorageMap::exists(key)` to `StorageMap::contains_key(key)` (and adjusts usage in pallets).

As I don't have a good overview of substrate, yet, please let me know which documentation needs to change.

See paritytech/polkadot#827 and substrate-developer-hub/substrate-developer-hub.github.io#445 for the companion PRs.
