### PR TITLE
Fix CLI setup again

### DIFF
--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -40,8 +40,7 @@ where
 			&version,
 		),
 		Some(Subcommand::Factory(cli_args)) => {
-			sc_cli::init(&cli_args.shared_params, &version)?;
-			sc_cli::load_spec(&mut config, &cli_args.shared_params, load_spec)?;
+			sc_cli::init(&mut config, &cli_args.shared_params, &version, load_spec)?;
 			sc_cli::fill_import_params(
 				&mut config,
 				&cli_args.import_params,

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -40,7 +40,8 @@ where
 			&version,
 		),
 		Some(Subcommand::Factory(cli_args)) => {
-			sc_cli::init(&mut config, &cli_args.shared_params, &version, load_spec)?;
+			sc_cli::init(&cli_args.shared_params, &version)?;
+			sc_cli::init_config(&mut config, &cli_args.shared_params, &version, load_spec)?;
 			sc_cli::fill_import_params(
 				&mut config,
 				&cli_args.import_params,

--- a/bin/node/cli/tests/common.rs
+++ b/bin/node/cli/tests/common.rs
@@ -1,0 +1,34 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{process::{Child, ExitStatus}, thread, time::Duration};
+
+/// Wait for the given `child` the given ammount of `secs`.
+///
+/// Returns the `Some(exit status)` or `None` if the process did not finish in the given time.
+pub fn wait_for(child: &mut Child, secs: usize) -> Option<ExitStatus> {
+	for _ in 0..secs {
+		match child.try_wait().unwrap() {
+			Some(status) => return Some(status),
+			None => thread::sleep(Duration::from_secs(1)),
+		}
+	}
+	eprintln!("Took to long to exit. Killing...");
+	let _ = child.kill();
+	child.wait().unwrap();
+
+	None
+}

--- a/bin/node/cli/tests/purge_chain_works.rs
+++ b/bin/node/cli/tests/purge_chain_works.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use assert_cmd::cargo::cargo_bin;
+use std::{convert::TryInto, process::Command, thread, time::Duration, fs, path::PathBuf};
+
+mod common;
+
+#[test]
+#[cfg(unix)]
+fn purge_chain_works() {
+	use nix::sys::signal::{kill, Signal::SIGINT};
+	use nix::unistd::Pid;
+
+	let base_path = "purge_chain_test";
+
+	let _ = fs::remove_dir_all(base_path);
+	let mut cmd = Command::new(cargo_bin("substrate"))
+		.args(&["--dev", "-d", base_path])
+		.spawn()
+		.unwrap();
+
+	// Let it produce some blocks.
+	thread::sleep(Duration::from_secs(30));
+	assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
+
+	// Stop the process
+	kill(Pid::from_raw(cmd.id().try_into().unwrap()), SIGINT).unwrap();
+	assert!(common::wait_for(&mut cmd, 30).map(|x| x.success()).unwrap_or_default());
+
+	let status = Command::new(cargo_bin("substrate"))
+		.args(&["purge-chain", "--dev", "-d", base_path, "-y"])
+		.status()
+		.unwrap();
+	assert!(status.success());
+
+	// Make sure that the `dev` chain folder exists, but the `db` is deleted.
+	assert!(PathBuf::from(base_path).join("chains/dev/").exists());
+	assert!(!PathBuf::from(base_path).join("chains/dev/db").exists());
+}

--- a/client/cli/src/params.rs
+++ b/client/cli/src/params.rs
@@ -933,11 +933,7 @@ impl RunCmd {
 	{
 		assert!(config.chain_spec.is_some(), "chain_spec must be present before continuing");
 
-		crate::update_config_for_running_node(
-			&mut config,
-			self,
-			&version,
-		)?;
+		crate::update_config_for_running_node(&mut config, self)?;
 
 		crate::run_node(config, new_light, new_full, &version)
 	}


### PR DESCRIPTION
We need to set `config_dir` and `database_path` for almost every
command.
This fixes `purge-chain` and also adds a test to make sure we don't
break it again.

Closes: https://github.com/paritytech/substrate/issues/4849