### PR TITLE
Update parity-multiaddr dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,12 +445,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
-
-[[package]]
-name = "bs58"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
@@ -2646,8 +2640,8 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr 0.7.1",
- "parity-multihash 0.2.1",
+ "parity-multiaddr",
+ "parity-multihash",
  "parking_lot 0.10.0",
  "pin-project",
  "smallvec 1.2.0",
@@ -2661,7 +2655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbafb2706b8082233f66dc13e196f9cf9b4c229f2cd7c96b2b16617ad6ee330b"
 dependencies = [
  "asn1_der",
- "bs58 0.3.0",
+ "bs58",
  "ed25519-dalek",
  "fnv",
  "futures 0.3.1",
@@ -2670,8 +2664,8 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.8",
  "multistream-select",
- "parity-multiaddr 0.7.1",
- "parity-multihash 0.2.1",
+ "parity-multiaddr",
+ "parity-multihash",
  "parking_lot 0.10.0",
  "pin-project",
  "prost",
@@ -2682,7 +2676,7 @@ dependencies = [
  "sha2",
  "smallvec 1.2.0",
  "thiserror",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "untrusted",
  "void",
  "zeroize 1.1.0",
@@ -2726,7 +2720,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bdf6fba9272ad47dde94bade89540fdb16e24ae9ff7fb714c1c80a035165f28"
 dependencies = [
- "bs58 0.3.0",
+ "bs58",
  "cuckoofilter",
  "fnv",
  "futures 0.3.1",
@@ -2745,7 +2739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e6ecd058bf769d27ebec530544b081e08b0a1088e3186da8cc58d59915784d0"
 dependencies = [
  "base64 0.11.0",
- "bs58 0.3.0",
+ "bs58",
  "byteorder 1.3.2",
  "bytes 0.5.4",
  "fnv",
@@ -2760,7 +2754,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2",
  "smallvec 1.2.0",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
@@ -2795,14 +2789,14 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log 0.4.8",
- "parity-multihash 0.2.1",
+ "parity-multihash",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "sha2",
  "smallvec 1.2.0",
  "uint",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -2842,7 +2836,7 @@ dependencies = [
  "libp2p-core",
  "log 0.4.8",
  "parking_lot 0.10.0",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2894,7 +2888,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rw-stream-sink",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "void",
 ]
 
@@ -3302,7 +3296,7 @@ dependencies = [
  "log 0.4.8",
  "smallvec 1.2.0",
  "tokio-io",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -4509,53 +4503,20 @@ checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045b3c7af871285146300da35b1932bb6e4639b66c7c98e85d06a32cbc4e8fa7"
-dependencies = [
- "arrayref",
- "bs58 0.2.5",
- "byteorder 1.3.2",
- "bytes 0.4.12",
- "data-encoding",
- "parity-multihash 0.1.3",
- "percent-encoding 1.0.1",
- "serde",
- "unsigned-varint 0.2.3",
- "url 1.7.2",
-]
-
-[[package]]
-name = "parity-multiaddr"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
 dependencies = [
  "arrayref",
- "bs58 0.3.0",
+ "bs58",
  "byteorder 1.3.2",
  "data-encoding",
- "parity-multihash 0.2.1",
+ "parity-multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "url 2.1.1",
-]
-
-[[package]]
-name = "parity-multihash"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3a17dc27848fd99e4f87eb0f8c9baba6ede0a6d555400c850ca45254ef4ce3"
-dependencies = [
- "blake2",
- "bytes 0.4.12",
- "rand 0.6.5",
- "sha-1",
- "sha2",
- "sha3",
- "unsigned-varint 0.2.3",
 ]
 
 [[package]]
@@ -4570,7 +4531,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "sha3",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -6102,7 +6063,7 @@ dependencies = [
  "substrate-test-client",
  "substrate-test-runtime-client",
  "tempfile",
- "unsigned-varint 0.3.0",
+ "unsigned-varint",
  "void",
  "zeroize 1.1.0",
 ]
@@ -6290,7 +6251,7 @@ dependencies = [
  "grafana-data-source",
  "lazy_static",
  "log 0.4.8",
- "parity-multiaddr 0.5.0",
+ "parity-multiaddr",
  "parity-scale-codec",
  "parking_lot 0.10.0",
  "sc-chain-spec",
@@ -8362,12 +8323,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 
 [[package]]
 name = "unsigned-varint"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -52,7 +52,7 @@ sc-rpc-server = { version = "2.0.0", path = "../rpc-servers" }
 sc-rpc = { version = "2.0.0", path = "../rpc" }
 sc-telemetry = { version = "2.0.0", path = "../telemetry" }
 sc-offchain = { version = "2.0.0", path = "../offchain" }
-parity-multiaddr = { package = "parity-multiaddr", version = "0.5.0" }
+parity-multiaddr = { package = "parity-multiaddr", version = "0.7.1" }
 grafana-data-source = { version = "0.8", path = "../../utils/grafana-data-source" }
 sc-tracing = { version = "2.0.0", path = "../tracing" }
 tracing = "0.1.10"


### PR DESCRIPTION
This will remove on extra dependency in substrate:

```
[0] [11:12:31] ~/r/substrate cecton-cargo-update > cargo update -p parity-multihash
error: There are multiple `parity-multihash` packages in your project, and the specification `parity-multihash` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  parity-multihash:0.1.3
  parity-multihash:0.2.1
```