### PR TITLE
Refactor and document allocator

### DIFF
--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -310,7 +310,7 @@ impl FreeingBumpHeapAllocator {
 			header_ptr
 		} else {
 			// Corresponding free list is empty. Allocate a new item.
-			self.bump(order.size(), mem.size())?
+			self.bump(order.size() + HEADER_SIZE, mem.size())?
 		};
 
 		// Write the order in the occupied header.
@@ -353,18 +353,18 @@ impl FreeingBumpHeapAllocator {
 		Ok(())
 	}
 
-	/// Increases the `bumper` by `item_size + HEADER_SIZE`.
+	/// Increases the `bumper` by `size`.
 	///
 	/// Returns the `bumper` from before the increase.
 	/// Returns an `Error::AllocatorOutOfSpace` if the operation
 	/// would exhaust the heap.
-	fn bump(&mut self, item_size: u32, heap_end: u32) -> Result<u32, Error> {
-		if self.bumper + HEADER_SIZE + item_size > heap_end {
+	fn bump(&mut self, size: u32, heap_end: u32) -> Result<u32, Error> {
+		if self.bumper + size > heap_end {
 			return Err(Error::AllocatorOutOfSpace);
 		}
 
 		let res = self.bumper;
-		self.bumper += item_size + HEADER_SIZE;
+		self.bumper += size;
 		Ok(res)
 	}
 }

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -316,7 +316,7 @@ impl FreeingBumpHeapAllocator {
 		// Write the order in the occupied header.
 		Header::Occupied(order).write_into(&mut mem, header_ptr)?;
 
-		self.total_size = self.total_size + order.size() + HEADER_SIZE;
+		self.total_size += order.size() + HEADER_SIZE;
 		trace!("Heap size is {} bytes after allocation", self.total_size);
 
 		Ok(Pointer::new(header_ptr + HEADER_SIZE))
@@ -343,10 +343,9 @@ impl FreeingBumpHeapAllocator {
 		self.heads[order.0 as usize] = Link::Ptr(header_ptr);
 
 		// Do the total_size book keeping.
-		let item_size = order.size();
 		self.total_size = self
 			.total_size
-			.checked_sub(item_size as u32 + HEADER_SIZE)
+			.checked_sub(order.size() + HEADER_SIZE)
 			.ok_or_else(|| error("Unable to subtract from total heap size without overflow"))?;
 		trace!("Heap size is {} bytes after deallocation", self.total_size);
 

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -83,7 +83,7 @@ macro_rules! trace {
 
 /// The exponent for the power of two sized block adjusted to the minimum size.
 ///
-/// This way, if MIN_POSSIBLE_ALLOCATION == 8, we would get:
+/// This way, if `MIN_POSSIBLE_ALLOCATION == 8`, we would get:
 ///
 /// power_of_two_size | order
 /// 8                 | 0
@@ -111,7 +111,7 @@ impl Order {
 	///
 	/// The size is clamped, so that the following holds:
 	///
-	/// MIN_POSSIBLE_ALLOCATION <= size <= MAX_POSSIBLE_ALLOCATION
+	/// `MIN_POSSIBLE_ALLOCATION <= size <= MAX_POSSIBLE_ALLOCATION`
 	fn from_size(size: u32) -> Result<Self, Error> {
 		let clamped_size = if size > MAX_POSSIBLE_ALLOCATION {
 			return Err(Error::RequestedAllocationTooLarge);
@@ -137,7 +137,7 @@ impl Order {
 	///
 	/// Note that it is always a power of two.
 	fn size(&self) -> u32 {
-		1 << MIN_POSSIBLE_ALLOCATION.trailing_zeros() << self.0
+		MIN_POSSIBLE_ALLOCATION << self.0
 	}
 
 	/// Extract the order as `u32`.
@@ -162,7 +162,7 @@ impl Link {
 	/// Creates a link from raw value.
 	fn from_raw(raw: u32) -> Self {
 		if raw != EMPTY_MARKER {
-			Self::Ptr(raw as u32)
+			Self::Ptr(raw)
 		} else {
 			Self::Null
 		}
@@ -363,7 +363,7 @@ impl FreeingBumpHeapAllocator {
 	///
 	/// # Arguments
 	///
-	/// - `mem` - a slice representing the linear memory on which this allocator oper®®ates.
+	/// - `mem` - a slice representing the linear memory on which this allocator operates.
 	/// - `ptr` - pointer to the allocated chunk
 	pub fn deallocate<M: Memory + ?Sized>(&mut self, mem: &mut M, ptr: Pointer<u8>) -> Result<(), Error> {
 		let header_ptr = u32::from(ptr)

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -67,16 +67,6 @@ const MIN_POSSIBLE_ALLOCATION: u32 = 8;
 // to which it belongs.
 const PREFIX_SIZE: u32 = 8;
 
-/// An implementation of freeing bump allocator.
-///
-/// Refer to the module-level documentation for further details.
-pub struct FreeingBumpHeapAllocator {
-	bumper: u32,
-	heads: [u32; N],
-	ptr_offset: u32,
-	total_size: u32,
-}
-
 /// Create an allocator error.
 fn error(msg: &'static str) -> Error {
 	Error::Other(msg)
@@ -91,6 +81,16 @@ macro_rules! trace {
 			log::trace!(target: "wasm-heap", $( $args ),+);
 		}
 	}
+}
+
+/// An implementation of freeing bump allocator.
+///
+/// Refer to the module-level documentation for further details.
+pub struct FreeingBumpHeapAllocator {
+	bumper: u32,
+	heads: [u32; N],
+	ptr_offset: u32,
+	total_size: u32,
 }
 
 impl FreeingBumpHeapAllocator {

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -110,8 +110,8 @@ impl Order {
 	/// Compute the order by the given size
 	///
 	/// The size is clamped, so that the following holds:
-	//
-	// MIN_POSSIBLE_ALLOCATION <= size <= MAX_POSSIBLE_ALLOCATION
+	///
+	/// MIN_POSSIBLE_ALLOCATION <= size <= MAX_POSSIBLE_ALLOCATION
 	fn from_size(size: u32) -> Result<Self, Error> {
 		let clamped_size = if size > MAX_POSSIBLE_ALLOCATION {
 			return Err(Error::RequestedAllocationTooLarge);


### PR DESCRIPTION
A little bit belated refactoring of the allocator crate.

Overview of changes:

- A concept of `Order` and a separate type is introduced for it. The term Order was inspired by [this](https://www.kernel.org/doc/gorman/html/understand/understand009.html).
- Instead of juglling around with u32 for specifying the pointer to the next item, a separate enum `Link = Ptr(u32) | Null` is introduced. The end of linked list is still ultimately encoded as a `u32::max_value`.
- Prefix is now referred as a Header. A separate enum is introduced as a `Header = Free(Link) | Occupied(Order)`. Apart from that, the in-memory encoding is changed so that it is now it is possible to tell if the header encodes a free or occupied variant, which should aid in detecting memory corruptions.
- Introduced the `Memory` trait to abstract different ways of accessing memory. Might come in handy for the case if we wanted to reuse the allocator code for implementing the substrate runtime interface for a sandboxed module.

This PR (at the moment of writing) is reviewable on commit by commit basis. The changes to API should be backwards compatible.