### PR TITLE
epoch_changes: functions to fetch by reference and mutable reference

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -515,7 +515,7 @@ mod tests {
 					parent_number,
 					slot_num,
 					|slot| babe_link.config().genesis_epoch(slot)
-				).unwrap().unwrap();
+				).unwrap().unwrap().into_cloned();
 
 				let mut digest = Digest::<H256>::default();
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1325,7 +1325,7 @@ pub mod test_helpers {
 			parent.number().clone(),
 			slot_number,
 			|slot| link.config.genesis_epoch(slot),
-		).unwrap().unwrap();
+		).unwrap().unwrap().into_cloned();
 
 		authorship::claim_slot(
 			slot_number,

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -435,6 +435,7 @@ impl<B, C, E, I, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for BabeWork
 			|slot| self.config.genesis_epoch(slot)
 		)
 			.map_err(|e| ConsensusError::ChainLookup(format!("{:?}", e)))?
+			.map(|v| v.into_cloned())
 			.ok_or(sp_consensus::Error::InvalidAuthoritiesSet)
 	}
 
@@ -798,6 +799,7 @@ impl<B, E, Block, RA, PRA> Verifier<Block> for BabeVerifier<B, E, Block, RA, PRA
 				|slot| self.config.genesis_epoch(slot),
 			)
 				.map_err(|e| Error::<Block>::ForkTree(Box::new(e)))?
+				.map(|v| v.into_cloned())
 				.ok_or_else(|| Error::<Block>::FetchEpoch(parent_hash))?
 		};
 

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -132,7 +132,7 @@ impl DummyProposer {
 		)
 			.expect("client has data to find epoch")
 			.expect("can compute epoch for baked block")
-			.into_inner();
+			.into_cloned_inner();
 
 		let first_in_epoch = self.parent_slot < epoch.start_slot;
 		if first_in_epoch {
@@ -575,7 +575,7 @@ fn propose_and_import_block<Transaction>(
 		*parent.number(),
 		slot_number,
 		|slot| proposer_factory.config.genesis_epoch(slot)
-	).unwrap().unwrap();
+	).unwrap().unwrap().into_cloned();
 
 	let seal = {
 		// sign the pre-sealed hash of the block and then
@@ -661,7 +661,7 @@ fn importing_block_one_sets_genesis_epoch() {
 		1,
 		1000,
 		|slot| data.link.config.genesis_epoch(slot),
-	).unwrap().unwrap().into_inner();
+	).unwrap().unwrap().into_cloned_inner();
 
 	assert_eq!(epoch_for_second_block, genesis_epoch);
 }

--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Generic utilities for epoch-based consensus engines.
 
-use std::{sync::Arc, ops::Add, borrow::Borrow};
+use std::{sync::Arc, ops::Add, borrow::{Borrow, BorrowMut}};
 use parking_lot::Mutex;
 use codec::{Encode, Decode};
 use fork_tree::ForkTree;
@@ -110,6 +110,17 @@ impl<Epoch, EpochRef> AsRef<Epoch> for ViableEpoch<Epoch, EpochRef> where
 		match *self {
 			ViableEpoch::Genesis(UnimportedGenesisEpoch(ref e)) => e,
 			ViableEpoch::Regular(ref e) => e.borrow(),
+		}
+	}
+}
+
+impl<Epoch, EpochRef> AsMut<Epoch> for ViableEpoch<Epoch, EpochRef> where
+	EpochRef: BorrowMut<Epoch>,
+{
+	fn as_mut(&mut self) -> &mut Epoch {
+		match *self {
+			ViableEpoch::Genesis(UnimportedGenesisEpoch(ref mut e)) => e,
+			ViableEpoch::Regular(ref mut e) => e.borrow_mut(),
 		}
 	}
 }

--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -90,7 +90,7 @@ pub struct UnimportedGenesisEpoch<Epoch>(Epoch);
 ///
 /// If this is the first non-genesis block in the chain, then it will
 /// hold an `UnimportedGenesis` epoch.
-pub enum ViableEpoch<Epoch, EpochRef> {
+pub enum ViableEpoch<Epoch, EpochRef = Epoch> {
 	/// Genesis viable epoch data.
 	Genesis(UnimportedGenesisEpoch<Epoch>),
 	/// Regular viable epoch data.

--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -127,6 +127,15 @@ impl<Epoch, EpochRef> ViableEpoch<Epoch, EpochRef> where
 		}
 	}
 
+	/// Get cloned value for the viable epoch.
+	pub fn into_cloned(self) -> ViableEpoch<Epoch, Epoch> {
+		match self {
+			ViableEpoch::Genesis(UnimportedGenesisEpoch(e)) =>
+				ViableEpoch::Genesis(UnimportedGenesisEpoch(e)),
+			ViableEpoch::Regular(e) => ViableEpoch::Regular(e.borrow().clone()),
+		}
+	}
+
 	/// Increment the epoch, yielding an `IncrementedEpoch` to be imported
 	/// into the fork-tree.
 	pub fn increment(


### PR DESCRIPTION
Add function `epoch_for_child_of_ref` and `epoch_for_child_of_mut` to allow fetching values by reference and mutable reference, avoiding copying, and enabling writing data back to fork tree.