### PR TITLE
Wrap runtime_print! macro in its own scope

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -80,7 +80,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 214,
-	impl_version: 2,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/support/src/debug.rs
+++ b/frame/support/src/debug.rs
@@ -129,10 +129,12 @@ pub mod native {
 #[macro_export]
 macro_rules! runtime_print {
 	($($arg:tt)+) => {
-		use core::fmt::Write;
-		let mut w = $crate::debug::Writer::default();
-		let _ = core::write!(&mut w, $($arg)+);
-		w.print();
+		{
+			use core::fmt::Write;
+			let mut w = $crate::debug::Writer::default();
+			let _ = core::write!(&mut w, $($arg)+);
+			w.print();
+		}
 	}
 }
 


### PR DESCRIPTION
Before this fix runtime_print! can be used only once in a scope because of the name pollution.