### PR TITLE
Remove the unnecessary std dependency from 'blake2-rfc'

### DIFF
--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 quote = "1.0.2"
 syn = { version = "1.0.8", features = ["full", "fold", "extra-traits", "visit"] }
 proc-macro2 = "1.0.6"
-blake2-rfc = "0.2.18"
+blake2-rfc = { version = "0.2.18", default-features = false }
 proc-macro-crate = "0.1.4"
 
 # Required for the doc tests


### PR DESCRIPTION
A trivial change. Tested by `cargo test`.