### PR TITLE
Export crypto_full feature in primitives/finality-grandpa

### DIFF
--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -23,3 +23,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std",
 ]
+full_crypto = [
+	"app-crypto/full_crypto"
+]


### PR DESCRIPTION
Trivial change. Exporting `crypto_full` can make it easier to build a light client in Intel SGX (`no_std`) environment.