### PR TITLE
Add timing trace for import block.

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1599,6 +1599,9 @@ impl<B, E, Block, RA> sp_consensus::BlockImport<Block> for &Client<B, E, Block, 
 		mut import_block: BlockImportParams<Block, backend::TransactionFor<B, Block>>,
 		new_cache: HashMap<CacheKeyId, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
+		let span = tracing::span!(tracing::Level::DEBUG, "import_block");
+		let _enter = span.enter();
+
 		if let Some(res) = self.prepare_block_storage_changes(&mut import_block).map_err(|e| {
 			warn!("Block prepare storage changes error:\n{:?}", e);
 			ConsensusError::ClientImport(e.to_string())


### PR DESCRIPTION
I think we should trace the timing for import block.
I'm not sure this is the best place though (another option may be to log in `import_batch_of_blocks`?).