### PR TITLE
Export GRANDPA AuthorityPair when full_crypto is enabled

### DIFF
--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -23,3 +23,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std",
 ]
+full_crypto = [
+	"app-crypto/full_crypto"
+]

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -34,7 +34,7 @@ mod app {
 }
 
 /// The grandpa crypto scheme defined via the keypair type.
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "full_crypto"))]
 pub type AuthorityPair = app::Pair;
 
 /// Identity of a Grandpa authority.


### PR DESCRIPTION
Exporting GRANDPA `AuthorityPair` can make it easier to build a light client in Intel SGX (no_std) environment.

This PR is a re-open of #4869. In the previous PR I forgot to add the AuthorityPair change.