### PR TITLE
Don't expose `Benchmarking` host functions by default

### DIFF
--- a/bin/node/executor/src/lib.rs
+++ b/bin/node/executor/src/lib.rs
@@ -25,5 +25,6 @@ use sc_executor::native_executor_instance;
 native_executor_instance!(
 	pub Executor,
 	node_runtime::api::dispatch,
-	node_runtime::native_version
+	node_runtime::native_version,
+	sp_io::benchmarking::HostFunctions,
 );

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -88,7 +88,7 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled => assert_eq!(
 					&format!("{:?}", e),
-					"Other(\"call to undefined external function with index 71\")"
+					"Other(\"call to undefined external function with index 68\")"
 				),
 			}
 		}
@@ -117,7 +117,7 @@ fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled => assert_eq!(
 					&format!("{:?}", e),
-					"Other(\"call to undefined external function with index 72\")"
+					"Other(\"call to undefined external function with index 69\")"
 				),
 			}
 		}

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -774,25 +774,25 @@ pub trait Logging {
 /// Interface that provides functions for benchmarking the runtime.
 #[runtime_interface]
 pub trait Benchmarking {
-		/// Get the number of nanoseconds passed since the UNIX epoch
-		///
-		/// WARNING! This is a non-deterministic call. Do not use this within
-		/// consensus critical logic.
-		fn current_time() -> u128 {
-			std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
-				.expect("Unix time doesn't go backwards; qed")
-				.as_nanos()
-		}
+	/// Get the number of nanoseconds passed since the UNIX epoch
+	///
+	/// WARNING! This is a non-deterministic call. Do not use this within
+	/// consensus critical logic.
+	fn current_time() -> u128 {
+		std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+			.expect("Unix time doesn't go backwards; qed")
+			.as_nanos()
+	}
 
-		/// Reset the trie database to the genesis state.
-		fn wipe_db(&mut self) {
-			self.wipe()
-		}
+	/// Reset the trie database to the genesis state.
+	fn wipe_db(&mut self) {
+		self.wipe()
+	}
 
-		/// Commit pending storage changes to the trie database and clear the database cache.
-		fn commit_db(&mut self) {
-			self.commit()
-		}
+	/// Commit pending storage changes to the trie database and clear the database cache.
+	fn commit_db(&mut self) {
+		self.commit()
+	}
 }
 
 /// Wasm-only interface that provides functions for interacting with the sandbox.
@@ -947,7 +947,6 @@ pub type SubstrateHostFunctions = (
 	logging::HostFunctions,
 	sandbox::HostFunctions,
 	crate::trie::HostFunctions,
-	benchmarking::HostFunctions,
 );
 
 #[cfg(test)]


### PR DESCRIPTION
Instead of exposing the benchmarking functions to each Substrate runtime by default, it must be explicitly enabled in the  `native_executor_instance!` macro call.

If the functions are not exported, but requested by the runtime, the instantiation will fail.