### PR TITLE
Run offchain workers at hash, not number.

### DIFF
--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -320,7 +320,9 @@ pub fn require_header<Block: BlockT>(
 	id: BlockId<Block>,
 ) -> sp_blockchain::Result<Block::Header> {
 	read_header(db, col_index, col, id)
-		.and_then(|header| header.ok_or_else(|| sp_blockchain::Error::UnknownBlock(format!("{}", id))))
+		.and_then(|header| header.ok_or_else(||
+			sp_blockchain::Error::UnknownBlock(format!("Require header: {}", id))
+		))
 }
 
 /// Read meta from the database.

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -169,7 +169,6 @@ mod tests {
 	use substrate_test_runtime_client::runtime::Block;
 	use sc_transaction_pool::{BasicPool, FullChainApi};
 	use sp_transaction_pool::{TransactionPool, InPoolTransaction};
-	use sp_runtime::{generic::Header, traits::Header as _};
 
 	struct MockNetworkStateInfo();
 
@@ -210,13 +209,7 @@ mod tests {
 			.register_transaction_pool(Arc::downgrade(&pool.clone()) as _);
 		let db = sc_client_db::offchain::LocalStorage::new_test();
 		let network_state = Arc::new(MockNetworkStateInfo());
-		let header = Header::new(
-			0u64,
-			Default::default(),
-			Default::default(),
-			Default::default(),
-			Default::default(),
-		);
+		let header = client.header(&BlockId::number(0)).unwrap().unwrap();
 
 		// when
 		let offchain = OffchainWorkers::new(client, db);

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -97,7 +97,7 @@ impl<Client, Storage, Block> OffchainWorkers<
 		is_validator: bool,
 	) -> impl Future<Output = ()> {
 		let runtime = self.client.runtime_api();
-		let at = BlockId::number(*header.number());
+		let at = BlockId::hash(header.hash());
 		let has_api_v1 = runtime.has_api_with::<dyn OffchainWorkerApi<Block, Error = ()>, _>(
 			&at, |v| v == 1
 		);

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -913,7 +913,7 @@ ServiceBuilder<
 						Some(_) => log::debug!(
 							target: "sc_offchain",
 							"Skipping offchain workers for non-canon block: {:?}",
-							notification.header
+							notification.header,
 						),
 						_ => {},
 					}

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -907,7 +907,7 @@ ServiceBuilder<
 							);
 							let _ = to_spawn_tx_.unbounded_send((
 									Box::pin(future),
-									From::from("offchain-on-block")
+									From::from("offchain-on-block"),
 							));
 						},
 						Some(_) => log::debug!(

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -903,7 +903,7 @@ ServiceBuilder<
 							let future = offchain.on_block_imported(
 								&notification.header,
 								network_state_info.clone(),
-								is_validator
+								is_validator,
 							);
 							let _ = to_spawn_tx_.unbounded_send((
 									Box::pin(future),

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -898,16 +898,24 @@ ServiceBuilder<
 					}
 
 					let offchain = offchain.as_ref().and_then(|o| o.upgrade());
-					if let Some(offchain) = offchain {
-						let future = offchain.on_block_imported(
-							&notification.header,
-							network_state_info.clone(),
-							is_validator
-						);
-						let _ = to_spawn_tx_.unbounded_send((
-							Box::pin(future),
-							From::from("offchain-on-block")
-						));
+					match offchain {
+						Some(offchain) if notification.is_new_best => {
+							let future = offchain.on_block_imported(
+								&notification.header,
+								network_state_info.clone(),
+								is_validator
+							);
+							let _ = to_spawn_tx_.unbounded_send((
+									Box::pin(future),
+									From::from("offchain-on-block")
+							));
+						},
+						Some(_) => log::debug!(
+							target: "sc_offchain",
+							"Skipping offchain workers for non-canon block: {:?}",
+							notification.header
+						),
+						_ => {},
 					}
 
 					ready(())

--- a/primitives/blockchain/src/backend.rs
+++ b/primitives/blockchain/src/backend.rs
@@ -59,19 +59,23 @@ pub trait HeaderBackend<Block: BlockT>: Send + Sync {
 
 	/// Get block header. Returns `UnknownBlock` error if block is not found.
 	fn expect_header(&self, id: BlockId<Block>) -> Result<Block::Header> {
-		self.header(id)?.ok_or_else(|| Error::UnknownBlock(format!("{}", id)))
+		self.header(id)?.ok_or_else(|| Error::UnknownBlock(format!("Expect header: {}", id)))
 	}
 
 	/// Convert an arbitrary block ID into a block number. Returns `UnknownBlock` error if block is not found.
 	fn expect_block_number_from_id(&self, id: &BlockId<Block>) -> Result<NumberFor<Block>> {
 		self.block_number_from_id(id)
-			.and_then(|n| n.ok_or_else(|| Error::UnknownBlock(format!("{}", id))))
+			.and_then(|n| n.ok_or_else(||
+				Error::UnknownBlock(format!("Expect block number from id: {}", id))
+			))
 	}
 
 	/// Convert an arbitrary block ID into a block hash. Returns `UnknownBlock` error if block is not found.
 	fn expect_block_hash_from_id(&self, id: &BlockId<Block>) -> Result<Block::Hash> {
 		self.block_hash_from_id(id)
-			.and_then(|n| n.ok_or_else(|| Error::UnknownBlock(format!("{}", id))))
+			.and_then(|n| n.ok_or_else(||
+				Error::UnknownBlock(format!("Expect block hash from id: {}", id))
+			))
 	}
 }
 


### PR DESCRIPTION
Current execution of offchain workers is potentially racey with block (fork) imports. We run the workers at specific block NUMBER, while we should be running at specific block HASH.

This PR changes the execution to be bound to a specific hash and adds a bunch of more detailed logging to `UnknownBlock` errors that are observed in the wild.

```
2020-02-10 03:14:37.295 import-queue-worker-0 TRACE babe  Ignoring digest not meant for us
2020-02-10 03:14:37.297 import-queue-worker-0 TRACE db  Canonicalize block #979162 (0x1fe9739db9a2f21edc075394a166e631d20296dad1d8757e01ab98f79f1506da)
2020-02-10 03:14:37.297 import-queue-worker-0 DEBUG db  DB Commit 0x41222a919b0d1fdc868f6566d8093f5e84f671b49d9bfe8dfbf9d88647087518 (983258), best = false
2020-02-10 03:14:37.297 import-queue-worker-0 TRACE forks  First available: None (0), Last canon: None (0), Best forks: []
2020-02-10 03:14:37.297 import-queue-worker-0 TRACE sync  Block imported successfully Some(983258) (0x4122…7518)
2020-02-10 03:14:37.297 main-tokio- ERROR sc_offchain  Unsupported Offchain Worker API version: (Err(UnknownBlock("BlockId::Number(983258)")), Err(UnknownBlock("BlockId::Number(983258)"))). Consider turning off offchain workers if they
are not part of your runtime..
```
The error gets triggered when we import a block that is not a new best block. The state is not available for such blocks, and the offchain worker is failing.

Because of that in this PR I've added additional check to only run OW when the block is new best.