### PR TITLE
Add a sub command to generate a node key file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7445,6 +7445,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
+ "libp2p",
  "node-primitives",
  "node-runtime",
  "pallet-balances",

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -28,6 +28,8 @@ derive_more = { version = "0.99.2" }
 sc-rpc = { version = "2.0.0", path = "../../../client/rpc" }
 jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
+libp2p = "0.15.0"
+
 
 [features]
 bench = []

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -30,6 +30,5 @@ jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
 libp2p = "0.15.0"
 
-
 [features]
 bench = []

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -32,7 +32,7 @@ use sp_core::{
 };
 use sp_runtime::{traits::{IdentifyAccount, Verify}, generic::Era};
 use std::{
-	convert::{TryInto, TryFrom}, io::{stdin, Read, Write}, str::FromStr, path::PathBuf, fs, fmt,
+	convert::{TryInto, TryFrom}, io::{stdin, Read}, str::FromStr, path::PathBuf, fs, fmt,
 };
 
 mod rpc;
@@ -345,12 +345,7 @@ where
 			let secret = keypair.secret();
 			let peer_id = PublicKey::Ed25519(keypair.public()).into_peer_id();
 
-			let mut file = fs::OpenOptions::new()
-												.create_new(true)
-												.write(true)
-												.open(file)?;
-												
-			file.write_all(secret.as_ref())?;
+			fs::write(file, secret.as_ref())?;
 
 			println!("{}", peer_id);
 		}

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -23,6 +23,7 @@ use clap::{App, ArgMatches, SubCommand};
 use codec::{Decode, Encode};
 use hex_literal::hex;
 use itertools::Itertools;
+use libp2p::identity::{ed25519 as libp2p_ed25519, PublicKey};
 use node_primitives::{Balance, Hash, Index, AccountId, Signature};
 use node_runtime::{BalancesCall, Call, Runtime, SignedPayload, UncheckedExtrinsic, VERSION};
 use sp_core::{
@@ -31,7 +32,7 @@ use sp_core::{
 };
 use sp_runtime::{traits::{IdentifyAccount, Verify}, generic::Era};
 use std::{
-	convert::{TryInto, TryFrom}, io::{stdin, Read}, str::FromStr, path::PathBuf, fs, fmt,
+	convert::{TryInto, TryFrom}, io::{stdin, Read, Write}, str::FromStr, path::PathBuf, fs, fmt,
 };
 
 mod rpc;
@@ -181,6 +182,9 @@ fn get_app<'a, 'b>(usage: &'a str) -> App<'a, 'b> {
 						'The number of words in the phrase to generate. One of 12 \
 						(default), 15, 18, 21 and 24.'
 				"),
+			SubCommand::with_name("generate-node-key")
+				.about("Generate a random node libp2p key, save it to file and print its peer ID")
+				.args_from_usage("[file] 'Name of file to save secret key to'"),
 			SubCommand::with_name("inspect")
 				.about("Gets a public key and a SS58 address from the provided Secret URI")
 				.args_from_usage("[uri] 'A Key URI to be inspected. May be a secret seed, \
@@ -333,6 +337,22 @@ where
 		("generate", Some(matches)) => {
 			let mnemonic = generate_mnemonic(matches)?;
 			C::print_from_uri(mnemonic.phrase(), password, maybe_network);
+		}
+		("generate-node-key", Some(matches)) => {
+			let file = matches.value_of("file").ok_or(Error::Static("Output file name is required"))?;
+
+			let keypair = libp2p_ed25519::Keypair::generate();
+			let secret = keypair.secret();
+			let peer_id = PublicKey::Ed25519(keypair.public()).into_peer_id();
+
+			let mut file = fs::OpenOptions::new()
+												.create_new(true)
+												.write(true)
+												.open(file)?;
+												
+			file.write_all(secret.as_ref())?;
+
+			println!("{}", peer_id);
 		}
 		("inspect", Some(matches)) => {
 			C::print_from_uri(&get_uri("uri", &matches)?, password, maybe_network);


### PR DESCRIPTION
This PR adds a new subcommand to subkey, 'generate-node-key' which can be used to generate a new libp2p secret key, save it to file in the format required by a substrate node and also print its peer ID.