### PR TITLE
Adds `with_pair!` macro to application-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8269,7 +8269,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -102,9 +102,10 @@ pub mod sr25519 {
 		app_crypto!(sr25519, IM_ONLINE);
 	}
 
-	/// An i'm online keypair using sr25519 as its crypto.
-	#[cfg(feature = "std")]
-	pub type AuthorityPair = app_sr25519::Pair;
+	sp_application_crypto::with_pair! {
+		/// An i'm online keypair using sr25519 as its crypto.
+		pub type AuthorityPair = app_sr25519::Pair;
+	}
 
 	/// An i'm online signature using sr25519 as its crypto.
 	pub type AuthoritySignature = app_sr25519::Signature;
@@ -119,9 +120,10 @@ pub mod ed25519 {
 		app_crypto!(ed25519, IM_ONLINE);
 	}
 
-	/// An i'm online keypair using ed25519 as its crypto.
-	#[cfg(feature = "std")]
-	pub type AuthorityPair = app_ed25519::Pair;
+	sp_application_crypto::with_pair! {
+		/// An i'm online keypair using ed25519 as its crypto.
+		pub type AuthorityPair = app_ed25519::Pair;
+	}
 
 	/// An i'm online signature using ed25519 as its crypto.
 	pub type AuthoritySignature = app_ed25519::Signature;

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -444,7 +444,9 @@ macro_rules! wrap {
 /// # Example
 ///
 /// ```
-/// application_crypto::with_pair!(pub type Pair = ();)
+/// sp_application_crypto::with_pair! {
+///     pub type Pair = ();
+/// }
 /// ```
 #[macro_export]
 #[cfg(any(feature = "std", feature = "full_crypto"))]

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -436,3 +436,28 @@ macro_rules! wrap {
 		}
 	}
 }
+
+/// Generate the given code if the pair type is available.
+///
+/// The pair type is available when `feature = "std"` || `feature = "full_crypto"`.
+///
+/// # Example
+///
+/// ```
+/// application_crypto::with_pair!(pub type Pair = ();)
+/// ```
+#[macro_export]
+#[cfg(any(feature = "std", feature = "full_crypto"))]
+macro_rules! with_pair {
+	( $( $def:tt )* ) => {
+		$( $def )*
+	}
+}
+
+
+#[doc(hidden)]
+#[macro_export]
+#[cfg(all(not(feature = "std"), not(feature = "full_crypto")))]
+macro_rules! with_pair {
+	( $( $def:tt )* ) => {}
+}

--- a/primitives/authority-discovery/src/lib.rs
+++ b/primitives/authority-discovery/src/lib.rs
@@ -25,9 +25,10 @@ mod app {
 	app_crypto!(sr25519, AUTHORITY_DISCOVERY);
 }
 
-/// An authority discovery authority keypair.
-#[cfg(feature = "std")]
-pub type AuthorityPair = app::Pair;
+sp_application_crypto::with_pair! {
+	/// An authority discovery authority keypair.
+	pub type AuthorityPair = app::Pair;
+}
 
 /// An authority discovery authority identifier.
 pub type AuthorityId = app::Public;

--- a/primitives/consensus/aura/src/lib.rs
+++ b/primitives/consensus/aura/src/lib.rs
@@ -30,9 +30,10 @@ pub mod sr25519 {
 		app_crypto!(sr25519, AURA);
 	}
 
-	/// An Aura authority keypair using S/R 25519 as its crypto.
-	#[cfg(feature = "std")]
-	pub type AuthorityPair = app_sr25519::Pair;
+	sp_application_crypto::with_pair! {
+		/// An Aura authority keypair using S/R 25519 as its crypto.
+		pub type AuthorityPair = app_sr25519::Pair;
+	}
 
 	/// An Aura authority signature using S/R 25519 as its crypto.
 	pub type AuthoritySignature = app_sr25519::Signature;
@@ -47,9 +48,10 @@ pub mod ed25519 {
 		app_crypto!(ed25519, AURA);
 	}
 
-	/// An Aura authority keypair using Ed25519 as its crypto.
-	#[cfg(feature = "std")]
-	pub type AuthorityPair = app_ed25519::Pair;
+	sp_application_crypto::with_pair! {
+		/// An Aura authority keypair using Ed25519 as its crypto.
+		pub type AuthorityPair = app_ed25519::Pair;
+	}
 
 	/// An Aura authority signature using Ed25519 as its crypto.
 	pub type AuthoritySignature = app_ed25519::Signature;

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-app-crypto = { version = "2.0.0", default-features = false, package = "sp-application-crypto", path = "../application-crypto" }
+sp-application-crypto = { version = "2.0.0", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
@@ -16,13 +16,10 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" 
 [features]
 default = ["std"]
 std = [
-	"app-crypto/std",
+	"sp-application-crypto/std",
 	"codec/std",
 	"sp-std/std",
 	"serde",
 	"sp-api/std",
 	"sp-runtime/std",
-]
-full_crypto = [
-	"app-crypto/full_crypto"
 ]

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -29,13 +29,14 @@ use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
 
 mod app {
-	use app_crypto::{app_crypto, key_types::GRANDPA, ed25519};
+	use sp_application_crypto::{app_crypto, key_types::GRANDPA, ed25519};
 	app_crypto!(ed25519, GRANDPA);
 }
 
-/// The grandpa crypto scheme defined via the keypair type.
-#[cfg(any(feature = "std", feature = "full_crypto"))]
-pub type AuthorityPair = app::Pair;
+sp_application_crypto::with_pair! {
+	/// The grandpa crypto scheme defined via the keypair type.
+	pub type AuthorityPair = app::Pair;
+}
 
 /// Identity of a Grandpa authority.
 pub type AuthorityId = app::Public;


### PR DESCRIPTION
This macro will "generate" the given code only when the crypto pair is
available. So, when either the `std` or the `full_crypto` feature is
enabled.

CC @h4x3rotab