### PR TITLE
impl Randomness trait for Babe and remove unused RandomBeacon trait

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 215,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -23,10 +23,10 @@
 pub use pallet_timestamp;
 
 use sp_std::{result, prelude::*};
-use frame_support::{decl_storage, decl_module, traits::FindAuthor, traits::Get};
+use frame_support::{decl_storage, decl_module, traits::{FindAuthor, Get, Randomness as RandomnessT}};
 use sp_timestamp::OnTimestampSet;
 use sp_runtime::{generic::DigestItem, ConsensusEngineId, Perbill};
-use sp_runtime::traits::{IsMember, SaturatedConversion, Saturating, RandomnessBeacon};
+use sp_runtime::traits::{IsMember, SaturatedConversion, Saturating, Hash};
 use sp_staking::{
 	SessionIndex,
 	offence::{Offence, Kind},
@@ -191,9 +191,13 @@ decl_module! {
 	}
 }
 
-impl<T: Trait> RandomnessBeacon for Module<T> {
-	fn random() -> [u8; VRF_OUTPUT_LENGTH] {
-		Self::randomness()
+impl<T: Trait> RandomnessT<<T as frame_system::Trait>::Hash> for Module<T> {
+	fn random(subject: &[u8]) -> T::Hash {
+		let mut subject = subject.to_vec();
+		subject.reserve(VRF_OUTPUT_LENGTH);
+		subject.extend_from_slice(&Self::randomness()[..]);
+
+		<T as frame_system::Trait>::Hashing::hash(&subject[..])
 	}
 }
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -767,7 +767,10 @@ pub trait Randomness<Output> {
 	/// Get a "random" value
 	///
 	/// Being a deterministic blockchain, real randomness is difficult to come by. This gives you
-	/// something that approximates it. `subject` is a context identifier and allows you to get a
+	/// something that approximates it. At best, this will be randomness which was
+	/// hard to predict a long time ago, but that has become easy to predict recently.
+	///
+	/// `subject` is a context identifier and allows you to get a
 	/// different result to other callers of this function; use it like
 	/// `random(&b"my context"[..])`.
 	fn random(subject: &[u8]) -> Output;

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -476,22 +476,6 @@ sp_core::impl_maybe_marker!(
 	trait MaybeMallocSizeOf: parity_util_mem::MallocSizeOf;
 );
 
-/// A type that provides a randomness beacon.
-pub trait RandomnessBeacon {
-	/// Returns 32 bytes of random data. The output will change eventually, but
-	/// is not guaranteed to be different between any two calls.
-	///
-	/// # Security
-	///
-	/// This MUST NOT be used for gambling, as it can be influenced by a
-	/// malicious validator in the short term. It MAY be used in many
-	/// cryptographic protocols, however, so long as one remembers that this
-	/// (like everything else on-chain) is public. For example, it can be
-	/// used where a number is needed that cannot have been chosen by an
-	/// adversary, for purposes such as public-coin zero-knowledge proofs.
-	fn random() -> [u8; 32];
-}
-
 /// A type that can be used in runtime structures.
 pub trait Member: Send + Sync + Sized + Debug + Eq + PartialEq + Clone + 'static {}
 impl<T: Send + Sync + Sized + Debug + Eq + PartialEq + Clone + 'static> Member for T {}


### PR DESCRIPTION
This will allow BABE to be slotted in places that were previously using `RandomnessCollectiveFlip`.