### PR TITLE
Increase the reputation penality for being offline

### DIFF
--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -29,7 +29,7 @@ use std::{pin::Pin, task::Context, task::Poll};
 /// We don't accept nodes whose reputation is under this value.
 const BANNED_THRESHOLD: i32 = 82 * (i32::min_value() / 100);
 /// Reputation change for a node when we get disconnected from it.
-const DISCONNECT_REPUTATION_CHANGE: i32 = -10;
+const DISCONNECT_REPUTATION_CHANGE: i32 = -256;
 /// Reserved peers group ID
 const RESERVED_NODES: &'static str = "reserved";
 


### PR DESCRIPTION
This is a random attempt at improving the number of active TCP connections (#4679) by increasing the reputation penalty for nodes being offline.
Right now it is only `-10`, which actually immediately vanishes because reputations regress towards 0 at each tick.

This reduces the chances that we try to connect to the the exact same node again in the near future.

I noticed locally that doing this change seems to improve the ratio of active per inactive connection.
Even if this doesn't improve anything, it's still a change in the right direction considering that right now that penalty might as well be 0.