### PR TITLE
pallet-evm: optional nonce parameter

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -81,8 +81,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 215,
-	impl_version: 2,
+	spec_version: 216,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -284,11 +284,11 @@ decl_module! {
 			let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
 			let source_account = Accounts::get(&source);
 			ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
+			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
+
 			if let Some(nonce) = nonce {
 				ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
 			}
-
-			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
 
 			let reason = executor.transact_call(
 				source,
@@ -347,11 +347,11 @@ decl_module! {
 			let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
 			let source_account = Accounts::get(&source);
 			ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
+			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
+
 			if let Some(nonce) = nonce {
 				ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
 			}
-
-			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
 
 			let create_address = executor.create_address(source, evm::CreateScheme::Dynamic);
 			let reason = executor.transact_create(

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -117,19 +117,19 @@ impl Precompiles for () {
 
 struct WeightForCallCreate;
 
-impl WeighData<(&H160, &Vec<u8>, &U256, &u32, &U256)> for WeightForCallCreate {
+impl WeighData<(&H160, &Vec<u8>, &U256, &u32, &U256, &Option<U256>)> for WeightForCallCreate {
 	fn weigh_data(
 		&self,
-		(_, _, _, gas_provided, gas_price): (&H160, &Vec<u8>, &U256, &u32, &U256)
+		(_, _, _, gas_provided, gas_price, _): (&H160, &Vec<u8>, &U256, &u32, &U256, &Option<U256>)
 	) -> Weight {
 		(*gas_price).saturated_into::<Weight>().saturating_mul(*gas_provided)
 	}
 }
 
-impl WeighData<(&Vec<u8>, &U256, &u32, &U256)> for WeightForCallCreate {
+impl WeighData<(&Vec<u8>, &U256, &u32, &U256, &Option<U256>)> for WeightForCallCreate {
 	fn weigh_data(
 		&self,
-		(_, _, gas_provided, gas_price): (&Vec<u8>, &U256, &u32, &U256)
+		(_, _, gas_provided, gas_price, _): (&Vec<u8>, &U256, &u32, &U256, &Option<U256>)
 	) -> Weight {
 		(*gas_price).saturated_into::<Weight>().saturating_mul(*gas_provided)
 	}
@@ -197,6 +197,8 @@ decl_error! {
 		ExitReasonRevert,
 		/// Call returned VM fatal error
 		ExitReasonFatal,
+		/// Nonce is invalid
+		InvalidNonce,
 	}
 }
 
@@ -258,6 +260,7 @@ decl_module! {
 			value: U256,
 			gas_limit: u32,
 			gas_price: U256,
+			nonce: Option<U256>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
@@ -278,11 +281,13 @@ decl_module! {
 
 			let total_fee = gas_price.checked_mul(U256::from(gas_limit))
 				.ok_or(Error::<T>::FeeOverflow)?;
-			if Accounts::get(&source).balance <
-				value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?
-			{
-				Err(Error::<T>::BalanceLow)?
+			let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
+			let source_account = Accounts::get(&source);
+			ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
+			if let Some(nonce) = nonce {
+				ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
 			}
+
 			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
 
 			let reason = executor.transact_call(
@@ -317,6 +322,7 @@ decl_module! {
 			value: U256,
 			gas_limit: u32,
 			gas_price: U256,
+			nonce: Option<U256>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
@@ -338,11 +344,13 @@ decl_module! {
 
 			let total_fee = gas_price.checked_mul(U256::from(gas_limit))
 				.ok_or(Error::<T>::FeeOverflow)?;
-			if Accounts::get(&source).balance <
-				value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?
-			{
-				Err(Error::<T>::BalanceLow)?
+			let total_payment = value.checked_add(total_fee).ok_or(Error::<T>::PaymentOverflow)?;
+			let source_account = Accounts::get(&source);
+			ensure!(source_account.balance >= total_payment, Error::<T>::BalanceLow);
+			if let Some(nonce) = nonce {
+				ensure!(source_account.nonce == nonce, Error::<T>::InvalidNonce);
 			}
+
 			executor.withdraw(source, total_fee).map_err(|_| Error::<T>::WithdrawFailed)?;
 
 			let create_address = executor.create_address(source, evm::CreateScheme::Dynamic);


### PR DESCRIPTION
Some operations in EVM needs precise values of nonce. This PR adds an optional parameter `nonce`. If set, it requires that the source account nonce equals to that value. If not, it consumes all gases but does not do any other state changes.