### PR TITLE
serialize partial_fee into string

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 216,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/frame/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/frame/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -22,12 +22,13 @@ use sp_std::prelude::*;
 use frame_support::weights::{Weight, DispatchClass};
 use codec::{Encode, Codec, Decode};
 #[cfg(feature = "std")]
-use serde::{Serialize, Deserialize};
-use sp_runtime::traits::{UniqueSaturatedInto, SaturatedConversion};
+use serde::{Serialize, Deserialize, Serializer};
+use sp_runtime::traits::MaybeDisplay;
 
 /// Some information related to a dispatchable that can be queried from the runtime.
 #[derive(Eq, PartialEq, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct RuntimeDispatchInfo<Balance> {
 	/// Weight of this dispatch.
 	pub weight: Weight,
@@ -35,47 +36,19 @@ pub struct RuntimeDispatchInfo<Balance> {
 	pub class: DispatchClass,
 	/// The partial inclusion fee of this dispatch. This does not include tip or anything else which
 	/// is dependent on the signature (aka. depends on a `SignedExtension`).
+	#[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
+	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
 	pub partial_fee: Balance,
 }
 
-/// A capped version of `RuntimeDispatchInfo`.
-///
-/// The `Balance` is capped (or expanded) to `u64` to avoid serde issues with `u128`.
-#[derive(Eq, PartialEq, Encode, Decode, Default)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
-pub struct CappedDispatchInfo {
-	/// Weight of this dispatch.
-	pub weight: Weight,
-	/// Class of this dispatch.
-	pub class: DispatchClass,
-	/// The partial inclusion fee of this dispatch. This does not include tip or anything else which
-	/// is dependent on the signature (aka. depends on a `SignedExtension`).
-	pub partial_fee: u64,
-}
-
-impl CappedDispatchInfo {
-	/// Create a new `CappedDispatchInfo` from `RuntimeDispatchInfo`.
-	pub fn new<Balance: UniqueSaturatedInto<u64>>(
-		dispatch: RuntimeDispatchInfo<Balance>,
-	) -> Self {
-		let RuntimeDispatchInfo {
-			weight,
-			class,
-			partial_fee,
-		} = dispatch;
-
-		Self {
-			weight,
-			class,
-			partial_fee: partial_fee.saturated_into(),
-		}
-	}
+#[cfg(feature = "std")]
+fn serialize_as_string<S: Serializer, T: std::fmt::Display>(t: &T, serializer: S) -> Result<S::Ok, S::Error> {
+	serializer.serialize_str(&t.to_string())
 }
 
 sp_api::decl_runtime_apis! {
 	pub trait TransactionPaymentApi<Balance, Extrinsic> where
-		Balance: Codec,
+		Balance: Codec + MaybeDisplay,
 		Extrinsic: Codec,
 	{
 		fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
@@ -87,17 +60,33 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn should_serialize_properly_with_u64() {
+	fn should_serialize_properly_with_string() {
 		let info = RuntimeDispatchInfo {
 			weight: 5,
 			class: DispatchClass::Normal,
 			partial_fee: 1_000_000_u64,
 		};
 
-		let info = CappedDispatchInfo::new(info);
 		assert_eq!(
 			serde_json::to_string(&info).unwrap(),
-			r#"{"weight":5,"class":"normal","partialFee":1000000}"#,
+			r#"{"weight":5,"class":"normal","partialFee":"1000000"}"#,
+		);
+
+		// should not panic
+		serde_json::to_value(&info).unwrap();
+	}
+
+	#[test]
+	fn should_serialize_properly_large_value() {
+		let info = RuntimeDispatchInfo {
+			weight: 5,
+			class: DispatchClass::Normal,
+			partial_fee: u128::max_value(),
+		};
+
+		assert_eq!(
+			serde_json::to_string(&info).unwrap(),
+			r#"{"weight":5,"class":"normal","partialFee":"340282366920938463463374607431768211455"}"#,
 		);
 
 		// should not panic

--- a/frame/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/frame/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -22,8 +22,8 @@ use sp_std::prelude::*;
 use frame_support::weights::{Weight, DispatchClass};
 use codec::{Encode, Codec, Decode};
 #[cfg(feature = "std")]
-use serde::{Serialize, Deserialize, Serializer};
-use sp_runtime::traits::MaybeDisplay;
+use serde::{Serialize, Deserialize, Serializer, Deserializer};
+use sp_runtime::traits::{MaybeDisplay, MaybeFromStr};
 
 /// Some information related to a dispatchable that can be queried from the runtime.
 #[derive(Eq, PartialEq, Encode, Decode, Default)]
@@ -38,6 +38,8 @@ pub struct RuntimeDispatchInfo<Balance> {
 	/// is dependent on the signature (aka. depends on a `SignedExtension`).
 	#[cfg_attr(feature = "std", serde(bound(serialize = "Balance: std::fmt::Display")))]
 	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+	#[cfg_attr(feature = "std", serde(bound(deserialize = "Balance: std::str::FromStr")))]
+	#[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
 	pub partial_fee: Balance,
 }
 
@@ -46,9 +48,15 @@ fn serialize_as_string<S: Serializer, T: std::fmt::Display>(t: &T, serializer: S
 	serializer.serialize_str(&t.to_string())
 }
 
+#[cfg(feature = "std")]
+fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(deserializer: D) -> Result<T, D::Error> {
+	let s = String::deserialize(deserializer)?;
+	s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
+}
+
 sp_api::decl_runtime_apis! {
 	pub trait TransactionPaymentApi<Balance, Extrinsic> where
-		Balance: Codec + MaybeDisplay,
+		Balance: Codec + MaybeDisplay + MaybeFromStr,
 		Extrinsic: Codec,
 	{
 		fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
@@ -60,34 +68,34 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn should_serialize_properly_with_string() {
+	fn should_serialize_and_deserialize_properly_with_string() {
 		let info = RuntimeDispatchInfo {
 			weight: 5,
 			class: DispatchClass::Normal,
 			partial_fee: 1_000_000_u64,
 		};
 
-		assert_eq!(
-			serde_json::to_string(&info).unwrap(),
-			r#"{"weight":5,"class":"normal","partialFee":"1000000"}"#,
-		);
+		let json_str = r#"{"weight":5,"class":"normal","partialFee":"1000000"}"#;
+
+		assert_eq!(serde_json::to_string(&info).unwrap(), json_str);
+		assert_eq!(serde_json::from_str::<RuntimeDispatchInfo<u64>>(json_str).unwrap(), info);
 
 		// should not panic
 		serde_json::to_value(&info).unwrap();
 	}
 
 	#[test]
-	fn should_serialize_properly_large_value() {
+	fn should_serialize_and_deserialize_properly_large_value() {
 		let info = RuntimeDispatchInfo {
 			weight: 5,
 			class: DispatchClass::Normal,
 			partial_fee: u128::max_value(),
 		};
 
-		assert_eq!(
-			serde_json::to_string(&info).unwrap(),
-			r#"{"weight":5,"class":"normal","partialFee":"340282366920938463463374607431768211455"}"#,
-		);
+		let json_str = r#"{"weight":5,"class":"normal","partialFee":"340282366920938463463374607431768211455"}"#;
+
+		assert_eq!(serde_json::to_string(&info).unwrap(), json_str);
+		assert_eq!(serde_json::from_str::<RuntimeDispatchInfo<u128>>(json_str).unwrap(), info);
 
 		// should not panic
 		serde_json::to_value(&info).unwrap();

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -21,21 +21,21 @@ use codec::{Codec, Decode};
 use sp_blockchain::HeaderBackend;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
-use sp_runtime::{generic::BlockId, traits::{Block as BlockT, UniqueSaturatedInto}};
+use sp_runtime::{generic::BlockId, traits::{Block as BlockT, MaybeDisplay}};
 use sp_api::ProvideRuntimeApi;
 use sp_core::Bytes;
-use pallet_transaction_payment_rpc_runtime_api::CappedDispatchInfo;
+use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 pub use pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi as TransactionPaymentRuntimeApi;
 pub use self::gen_client::Client as TransactionPaymentClient;
 
 #[rpc]
-pub trait TransactionPaymentApi<BlockHash, Balance> {
+pub trait TransactionPaymentApi<BlockHash, ResponseType> {
 	#[rpc(name = "payment_queryInfo")]
 	fn query_info(
 		&self,
 		encoded_xt: Bytes,
 		at: Option<BlockHash>
-	) -> Result<CappedDispatchInfo>;
+	) -> Result<ResponseType>;
 }
 
 /// A struct that implements the [`TransactionPaymentApi`].
@@ -68,20 +68,20 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, Balance, Extrinsic> TransactionPaymentApi<<Block as BlockT>::Hash, Balance>
+impl<C, Block, Balance, Extrinsic> TransactionPaymentApi<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
 	for TransactionPayment<C, (Block, Extrinsic)>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: TransactionPaymentRuntimeApi<Block, Balance, Extrinsic>,
-	Balance: Codec + UniqueSaturatedInto<u64>,
+	Balance: Codec + MaybeDisplay,
 	Extrinsic: Codec + Send + Sync + 'static,
 {
 	fn query_info(
 		&self,
 		encoded_xt: Bytes,
 		at: Option<<Block as BlockT>::Hash>
-	) -> Result<CappedDispatchInfo> {
+	) -> Result<RuntimeDispatchInfo<Balance>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(||
 			// If the block hash is not supplied assume the best block.
@@ -99,6 +99,6 @@ where
 			code: ErrorCode::ServerError(Error::RuntimeError.into()),
 			message: "Unable to query dispatch info.".into(),
 			data: Some(format!("{:?}", e).into()),
-		}).map(CappedDispatchInfo::new)
+		})
 	}
 }

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -21,7 +21,7 @@ use codec::{Codec, Decode};
 use sp_blockchain::HeaderBackend;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
 use jsonrpc_derive::rpc;
-use sp_runtime::{generic::BlockId, traits::{Block as BlockT, MaybeDisplay}};
+use sp_runtime::{generic::BlockId, traits::{Block as BlockT, MaybeDisplay, MaybeFromStr}};
 use sp_api::ProvideRuntimeApi;
 use sp_core::Bytes;
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
@@ -74,7 +74,7 @@ where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: TransactionPaymentRuntimeApi<Block, Balance, Extrinsic>,
-	Balance: Codec + MaybeDisplay,
+	Balance: Codec + MaybeDisplay + MaybeFromStr,
 	Extrinsic: Codec + Send + Sync + 'static,
 {
 	fn query_info(

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -44,7 +44,7 @@ use sp_runtime::{
 		TransactionPriority, ValidTransaction, InvalidTransaction, TransactionValidityError,
 		TransactionValidity,
 	},
-	traits::{Zero, Saturating, SignedExtension, SaturatedConversion, Convert},
+	traits::{Zero, Saturating, SignedExtension, SaturatedConversion, Convert, MaybeDisplay},
 };
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 
@@ -115,7 +115,7 @@ impl<T: Trait> Module<T> {
 	) -> RuntimeDispatchInfo<BalanceOf<T>>
 	where
 		T: Send + Sync,
-		BalanceOf<T>: Send + Sync,
+		BalanceOf<T>: Send + Sync + MaybeDisplay,
 	{
 		let dispatch_info = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -44,7 +44,7 @@ use sp_runtime::{
 		TransactionPriority, ValidTransaction, InvalidTransaction, TransactionValidityError,
 		TransactionValidity,
 	},
-	traits::{Zero, Saturating, SignedExtension, SaturatedConversion, Convert, MaybeDisplay},
+	traits::{Zero, Saturating, SignedExtension, SaturatedConversion, Convert},
 };
 use pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo;
 
@@ -115,7 +115,7 @@ impl<T: Trait> Module<T> {
 	) -> RuntimeDispatchInfo<BalanceOf<T>>
 	where
 		T: Send + Sync,
-		BalanceOf<T>: Send + Sync + MaybeDisplay,
+		BalanceOf<T>: Send + Sync,
 	{
 		let dispatch_info = <Extrinsic as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
 

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -22,6 +22,8 @@ use sp_io;
 #[cfg(feature = "std")]
 use std::fmt::Display;
 #[cfg(feature = "std")]
+use std::str::FromStr;
+#[cfg(feature = "std")]
 use serde::{Serialize, Deserialize, de::DeserializeOwned};
 use sp_core::{self, Hasher, Blake2Hasher, TypeId, RuntimeDebug};
 use crate::BenchmarkParameter;
@@ -462,6 +464,9 @@ impl<H: PartialEq + Eq + Debug> CheckEqual for super::generic::DigestItem<H> whe
 sp_core::impl_maybe_marker!(
 	/// A type that implements Display when in std environment.
 	trait MaybeDisplay: Display;
+
+	/// A type that implements FromStr when in std environment.
+	trait MaybeFromStr: FromStr;
 
 	/// A type that implements Hash when in std environment.
 	trait MaybeHash: sp_std::hash::Hash;


### PR DESCRIPTION
Fixes #4897 

Not sure if I need to an implementation with `deserialize_with`

This is kind of a breaking change but polkadot.js should automatically handle string to number conversion.