### PR TITLE
Cache CARGO_TARGET_DIR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,8 +17,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
-  SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
-  CARGO_INCREMENTAL:               0
+  CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CI_SERVER_NAME:                  "GitLab CI"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
@@ -44,6 +43,8 @@ variables:
     - rustup show
     - cargo --version
     - sccache -s
+    - mkdir -p ${CARGO_HOME}; touch ${CARGO_HOME}/config
+    - mkdir -p ${CARGO_TARGET_DIR}
   only:
     - master
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
@@ -269,7 +270,7 @@ build-linux-substrate:             &build-binary
       - $DEPLOY_TAG
   script:
     - WASM_BUILD_NO_COLOR=1 time cargo build --release --verbose
-    - mv ./target/release/substrate ./artifacts/substrate/.
+    - mv ${CARGO_TARGET_DIR}/release/substrate ./artifacts/substrate/.
     - echo -n "Substrate version = "
     - if [ "${CI_COMMIT_TAG}" ]; then
         echo "${CI_COMMIT_TAG}" | tee ./artifacts/substrate/VERSION;
@@ -292,7 +293,7 @@ build-linux-subkey:
     - cd ./bin/utils/subkey
     - BUILD_DUMMY_WASM_BINARY=1 time cargo build --release --verbose
     - cd -
-    - mv ./target/release/subkey ./artifacts/subkey/.
+    - mv ${CARGO_TARGET_DIR}/release/subkey ./artifacts/subkey/.
     - echo -n "Subkey version = "
     - ./artifacts/subkey/subkey --version |
         sed -n -r 's/^subkey ([0-9.]+.*)/\1/p' |
@@ -315,7 +316,7 @@ build-rust-doc-release:
   script:
     - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
     - BUILD_DUMMY_WASM_BINARY=1 RUSTDOCFLAGS="--html-in-header $(pwd)/.maintain/rustdoc-header.html" time cargo +nightly doc --release --all --verbose
-    - cp -R ./target/doc ./crate-docs
+    - cp -R ${CARGO_TARGET_DIR}/doc ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=sc_service/index.html>" > ./crate-docs/index.html
     - sccache -s
 
@@ -354,8 +355,8 @@ check_polkadot:
     # Make sure we override the crates in native and wasm build
     - mkdir .cargo
     - echo "paths = [ \"$SUBSTRATE_PATH\" ]" > .cargo/config
-    - mkdir -p target/debug/wbuild/.cargo
-    - echo "paths = [ \"$SUBSTRATE_PATH\" ]" > target/debug/wbuild/.cargo/config
+    - mkdir -p ${CARGO_TARGET_DIR}/debug/wbuild/.cargo
+    - echo "paths = [ \"$SUBSTRATE_PATH\" ]" > ${CARGO_TARGET_DIR}/debug/wbuild/.cargo/config
     # package, others are updated along the way.
     - cargo update
     # Check whether Polkadot 'master' branch builds with this Substrate commit.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,15 @@ variables:
     - cargo --version
     - sccache -s
     - mkdir -p ${CARGO_HOME}; touch ${CARGO_HOME}/config
-    - mkdir -p ${CARGO_TARGET_DIR}
+    # if there is no directory for this $CI_COMMIT_REF_NAME/$CI_JOB_NAME
+    # create such directory and
+    # create hardlinks recursively of all the files from the master/$CI_JOB_NAME if it exists
+    - if [[ ! -d $CARGO_TARGET_DIR ]]; then
+        mkdir -p /ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME};
+        cp -al /ci-cache/${CI_PROJECT_NAME}/targets/master/${CI_JOB_NAME}
+          /ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME} ||
+          echo "_____No such target dir, proceeding from scratch_____";
+      fi
   only:
     - master
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1


### PR DESCRIPTION
`CARGO_TARGET_DIR` dir is now shared and available for the same job on the same branch.
This drastically speeds up the CI enabling to reuse build artifacts from a previous job run. As on your local machine.
`CARGO_INCREMENTAL=0` is not needed any more since now we are able to benefit from incremental compilations. Previously it was turned to 0 to get advantage caching those files with `sccache`.
- scheme is `/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}` is a compulsory measure because of both security (to not allow someone to spoil your cache) and to avoid data-race conditions which are very much a thing there if you try accessing the same cache from multiple sides.
- first CI_JOB_NAME of the new branch on a runner will hardlink to the same CI_JOB_NAME on the `master` branch and reuse a big chunk of cache from it. This does not compromise the security of the cache, saving more than 60% of disk space and time for the first build. The only downside is that the data race with `master` can happen, but this is unlikely and quite easily fixable. 
- CI servers periodically clean up old files, FIFO.