### PR TITLE
Fix benchmarks on master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-executor",
+ "sc-service",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -48,6 +48,7 @@ tempdir = "0.3"
 fs_extra = "1"
 hex-literal = "0.2.1"
 sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-service = { version = "0.8.0", path = "../../../client/service", features = ["rocksdb"] }
 
 [[bench]]
 name = "import"


### PR DESCRIPTION
@shawntabrizi 

FYI it is impossible to reference `sc-cli` now without similar fix, you will get error

```
error[E0425]: cannot find function `benchmark_runtime` in module `sc_service::chain_ops`
    --> client/cli/src/params.rs:1265:26
     |
1265 |         sc_service::chain_ops::benchmark_runtime::<BB, BC::NativeDispatch, _, _>(spec, execution_strategy, wasm_method, pallet, extrinsic, steps, repeat)?;

```