### PR TITLE
Update libp2p to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
  "futures-timer 3.0.1",
  "js-sys",
  "kvdb-web",
- "libp2p 0.15.0",
+ "libp2p",
  "log 0.4.8",
  "rand 0.6.5",
  "rand 0.7.3",
@@ -2643,43 +2643,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84847789ab24b3fc5971a68656ac85886df640986d9ce3264c0327694eae471"
-dependencies = [
- "bytes 0.5.4",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.15.0",
- "libp2p-core-derive 0.15.0",
- "libp2p-deflate 0.7.0",
- "libp2p-dns 0.15.0",
- "libp2p-floodsub 0.15.0",
- "libp2p-gossipsub 0.15.0",
- "libp2p-identify 0.15.0",
- "libp2p-kad 0.15.0",
- "libp2p-mdns 0.15.0",
- "libp2p-mplex 0.15.0",
- "libp2p-noise 0.13.0",
- "libp2p-ping 0.15.0",
- "libp2p-plaintext 0.15.0",
- "libp2p-secio 0.15.0",
- "libp2p-swarm 0.5.0",
- "libp2p-tcp 0.15.0",
- "libp2p-uds 0.15.0",
- "libp2p-wasm-ext 0.8.0",
- "libp2p-websocket 0.15.0",
- "libp2p-yamux 0.15.0",
- "parity-multiaddr",
- "parity-multihash",
- "parking_lot 0.10.0",
- "pin-project",
- "smallvec 1.2.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58becf0b9585fcfbb8215bbe6e6ac187fcc180fd1026925ca180c845aa5a6e8"
@@ -2687,67 +2650,33 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.16.0",
- "libp2p-core-derive 0.16.0",
- "libp2p-deflate 0.16.0",
- "libp2p-dns 0.16.0",
- "libp2p-floodsub 0.16.0",
- "libp2p-gossipsub 0.16.0",
- "libp2p-identify 0.16.0",
- "libp2p-kad 0.16.0",
- "libp2p-mdns 0.16.0",
- "libp2p-mplex 0.16.0",
- "libp2p-noise 0.16.0",
- "libp2p-ping 0.16.0",
- "libp2p-plaintext 0.16.0",
+ "libp2p-core",
+ "libp2p-core-derive",
+ "libp2p-deflate",
+ "libp2p-dns",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-mplex",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-plaintext",
  "libp2p-pnet",
- "libp2p-secio 0.16.0",
- "libp2p-swarm 0.16.0",
- "libp2p-tcp 0.16.0",
- "libp2p-uds 0.16.0",
- "libp2p-wasm-ext 0.16.0",
- "libp2p-websocket 0.16.0",
- "libp2p-yamux 0.16.0",
+ "libp2p-secio",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-uds",
+ "libp2p-wasm-ext",
+ "libp2p-websocket",
+ "libp2p-yamux",
  "parity-multiaddr",
  "parity-multihash",
  "parking_lot 0.10.0",
  "pin-project",
  "smallvec 1.2.0",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbafb2706b8082233f66dc13e196f9cf9b4c229f2cd7c96b2b16617ad6ee330b"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "fnv",
- "futures 0.3.4",
- "futures-timer 2.0.2",
- "lazy_static",
- "libsecp256k1",
- "log 0.4.8",
- "multistream-select",
- "parity-multiaddr",
- "parity-multihash",
- "parking_lot 0.10.0",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "smallvec 1.2.0",
- "thiserror",
- "unsigned-varint",
- "untrusted",
- "void",
- "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -2785,16 +2714,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c320266be0a7760e23484d635acdb83844b2d74d3612d93b41c393c9bcf004e"
-dependencies = [
- "quote 1.0.2",
- "syn",
-]
-
-[[package]]
-name = "libp2p-core-derive"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
@@ -2805,35 +2724,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be32697b42d040b325c3737f827ea04ede569ec956b7807700dd8d89d8210f9"
-dependencies = [
- "flate2",
- "futures 0.3.4",
- "libp2p-core 0.15.0",
-]
-
-[[package]]
-name = "libp2p-deflate"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e25004d4d9837b44b22c5f1a69be1724a5168fef6cff1716b5176a972c3aa62"
 dependencies = [
  "flate2",
  "futures 0.3.4",
- "libp2p-core 0.16.0",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c979b882f25d85726b15637d5bbc722dfa1be576605c54e99b8cf56906be3"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "log 0.4.8",
+ "libp2p-core",
 ]
 
 [[package]]
@@ -2843,26 +2740,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99e552f9939b606eb4b59f7f64d9b01e3f96752f47e350fc3c5fc646ed3f649"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
-]
-
-[[package]]
-name = "libp2p-floodsub"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bdf6fba9272ad47dde94bade89540fdb16e24ae9ff7fb714c1c80a035165f28"
-dependencies = [
- "bs58",
- "cuckoofilter",
- "fnv",
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "smallvec 1.2.0",
 ]
 
 [[package]]
@@ -2874,38 +2753,12 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.4",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "smallvec 1.2.0",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6ecd058bf769d27ebec530544b081e08b0a1088e3186da8cc58d59915784d0"
-dependencies = [
- "base64 0.11.0",
- "bs58",
- "byteorder 1.3.4",
- "bytes 0.5.4",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "log 0.4.8",
- "lru 0.4.3",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "smallvec 1.2.0",
- "unsigned-varint",
- "wasm-timer",
 ]
 
 [[package]]
@@ -2920,8 +2773,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.8",
  "lru 0.4.3",
  "prost",
@@ -2935,60 +2788,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1a6261b804111c2dbf53f8ca03f66edc5ad1c29b78a61cf0cc5354052e28e9"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "log 0.4.8",
- "prost",
- "prost-build",
- "smallvec 1.2.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-identify"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfeb935a9bd41263e4f3a24b988e9f4a044f3ae89ac284e83c17fe2f84e0d66b"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.8",
  "prost",
  "prost-build",
  "smallvec 1.2.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6ea6fece0d99599afb1b2082ca8937944cdd6b0946a88d54cb3ae7a38d1253"
-dependencies = [
- "arrayvec 0.5.1",
- "bytes 0.5.4",
- "either",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "log 0.4.8",
- "parity-multihash",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "smallvec 1.2.0",
- "uint",
- "unsigned-varint",
- "void",
  "wasm-timer",
 ]
 
@@ -3004,8 +2814,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.8",
  "parity-multihash",
  "prost",
@@ -3015,28 +2825,6 @@ dependencies = [
  "smallvec 1.2.0",
  "uint",
  "unsigned-varint",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074312353355df310affa105ec71b16fd7e52f5c6ae61d3dcbb3e79e8fdc9e5f"
-dependencies = [
- "async-std",
- "data-encoding",
- "dns-parser",
- "either",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "log 0.4.8",
- "net2",
- "rand 0.7.3",
- "smallvec 1.2.0",
  "void",
  "wasm-timer",
 ]
@@ -3053,30 +2841,14 @@ dependencies = [
  "either",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.8",
  "net2",
  "rand 0.7.3",
  "smallvec 1.2.0",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-mplex"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d0b44dfdef80cc2be4b42d127de1c793905eca2459415a5c57d6b4fbd8ec30"
-dependencies = [
- "bytes 0.5.4",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "parking_lot 0.10.0",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -3089,30 +2861,10 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0845e8208d814cd41c26c90a6a2f2b720c31b588209cecc49a44c881a09f417f"
-dependencies = [
- "curve25519-dalek 1.2.3",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "ring",
- "snow",
- "x25519-dalek 0.5.2",
- "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -3124,7 +2876,7 @@ dependencies = [
  "curve25519-dalek 1.2.3",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "prost",
  "prost-build",
@@ -3138,50 +2890,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ecced2949ae93b6ff29565303ecd1bef15c4e4efb689033ee744922561a36b"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "libp2p-swarm 0.5.0",
- "log 0.4.8",
- "rand 0.7.3",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-ping"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d22f2f228b3a828dca1cb8aa9fa331e0bc9c36510cb2c1916956e20dc85e8c"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.16.0",
- "libp2p-swarm 0.16.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log 0.4.8",
  "rand 0.7.3",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-plaintext"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195fda6b6a948a242fd30570e0e3418ae8e0a20055ea75d45458e1079a8efb05"
-dependencies = [
- "bytes 0.5.4",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "prost",
- "prost-build",
- "rw-stream-sink",
- "unsigned-varint",
- "void",
 ]
 
 [[package]]
@@ -3193,7 +2912,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "prost",
  "prost-build",
@@ -3218,36 +2937,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-secio"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceef68ca377b264f84d64c88739a8fa118b5db1e8f18297351dff75314504a5f"
-dependencies = [
- "aes-ctr",
- "ctr",
- "futures 0.3.4",
- "hmac",
- "js-sys",
- "lazy_static",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "libp2p-secio"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec00eb9a3404ed76a0e14f637edcaa7f2b4a27a16884da4a56f2f21e166c2843"
@@ -3258,7 +2947,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "parity-send-wrapper",
  "pin-project",
@@ -3278,45 +2967,16 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ea00be81bc3985e36abad263ce2ad1b6aeb862aa743563eb70ad42880c05ae"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "smallvec 1.2.0",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e9f4fb84a4bfe3d3a361c1fbcd4af017ba68f0a46a77bfbcc48bf8a456d6ef"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "smallvec 1.2.0",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e65ef381570df31cb047dfbc11483ab0fe7e6abbdcf2bdc2c60b5d11133d241"
-dependencies = [
- "async-std",
- "futures 0.3.4",
- "futures-timer 2.0.2",
- "get_if_addrs",
- "ipnet",
- "libp2p-core 0.15.0",
- "log 0.4.8",
 ]
 
 [[package]]
@@ -3330,19 +2990,7 @@ dependencies = [
  "futures-timer 3.0.1",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.16.0",
- "log 0.4.8",
-]
-
-[[package]]
-name = "libp2p-uds"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4f4f7989b35f33d4b9738aab2f031310eb20fec513cab44d12b1bc985a8074"
-dependencies = [
- "async-std",
- "futures 0.3.4",
- "libp2p-core 0.15.0",
+ "libp2p-core",
  "log 0.4.8",
 ]
 
@@ -3354,22 +3002,8 @@ checksum = "76d329564a43da9d0e055a5b938633c4a8ceab1f59cec133fbc4647917c07341"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
-]
-
-[[package]]
-name = "libp2p-wasm-ext"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4d457adb91a5e2212343218a554394cd8ced64a79fb8e36e7aed2a16d49495"
-dependencies = [
- "futures 0.3.4",
- "js-sys",
- "libp2p-core 0.15.0",
- "parity-send-wrapper",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3380,31 +3014,10 @@ checksum = "39703653caa36f4afd0def39cc49a3ac0fa1d4289ca1802e417af03e4f5ef950"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libp2p-websocket"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba425f2af1fdb7dece88b9ae05ca9430dfb0b72b2c078e73ded6f1556084509"
-dependencies = [
- "async-tls",
- "bytes 0.5.4",
- "either",
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "quicksink",
- "rustls",
- "rw-stream-sink",
- "soketto",
- "url 2.1.1",
- "webpki",
- "webpki-roots 0.18.0",
 ]
 
 [[package]]
@@ -3417,7 +3030,7 @@ dependencies = [
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "log 0.4.8",
  "quicksink",
  "rustls",
@@ -3430,26 +3043,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca25b3aac78a3c93c2a567622abd3cfc16f96f26ae1bf6134f0056203d62d86"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.15.0",
- "log 0.4.8",
- "parking_lot 0.10.0",
- "thiserror",
- "yamux",
-]
-
-[[package]]
-name = "libp2p-yamux"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f72aa5a7273c29c6eaea09108a49feaefc7456164863f64f86a193f9e78a4b7f"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.16.0",
+ "libp2p-core",
  "parking_lot 0.10.0",
  "thiserror",
  "yamux",
@@ -5950,7 +5549,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "parity-scale-codec",
  "prost",
@@ -6522,7 +6121,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.1",
  "futures_codec",
- "libp2p 0.16.0",
+ "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log 0.4.8",
@@ -6571,7 +6170,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "lru 0.1.17",
  "parking_lot 0.10.0",
@@ -6588,7 +6187,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "rand 0.7.3",
@@ -6644,7 +6243,7 @@ name = "sc-peerset"
 version = "2.0.0"
 dependencies = [
  "futures 0.3.4",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "rand 0.7.3",
  "serde_json",
@@ -6828,7 +6427,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "pin-project",
@@ -7390,7 +6989,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-diagnose",
  "futures-timer 3.0.1",
- "libp2p 0.16.0",
+ "libp2p",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",
@@ -7933,7 +7532,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
- "libp2p 0.15.0",
+ "libp2p",
  "node-primitives",
  "node-runtime",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
  "futures-timer 3.0.1",
  "js-sys",
  "kvdb-web",
- "libp2p",
+ "libp2p 0.15.0",
  "log 0.4.8",
  "rand 0.6.5",
  "rand 0.7.3",
@@ -579,6 +579,15 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chacha20-poly1305-aead"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d2058ba29594f69c75e8a9018e0485e3914ca5084e3613cd64529042f5423b"
+dependencies = [
+ "constant_time_eq",
+]
 
 [[package]]
 name = "chain-spec-builder"
@@ -2641,26 +2650,64 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
- "libp2p-core-derive",
- "libp2p-deflate",
- "libp2p-dns",
- "libp2p-floodsub",
- "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-mplex",
- "libp2p-noise",
- "libp2p-ping",
- "libp2p-plaintext",
- "libp2p-secio",
- "libp2p-swarm",
- "libp2p-tcp",
- "libp2p-uds",
- "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux",
+ "libp2p-core 0.15.0",
+ "libp2p-core-derive 0.15.0",
+ "libp2p-deflate 0.7.0",
+ "libp2p-dns 0.15.0",
+ "libp2p-floodsub 0.15.0",
+ "libp2p-gossipsub 0.15.0",
+ "libp2p-identify 0.15.0",
+ "libp2p-kad 0.15.0",
+ "libp2p-mdns 0.15.0",
+ "libp2p-mplex 0.15.0",
+ "libp2p-noise 0.13.0",
+ "libp2p-ping 0.15.0",
+ "libp2p-plaintext 0.15.0",
+ "libp2p-secio 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "libp2p-tcp 0.15.0",
+ "libp2p-uds 0.15.0",
+ "libp2p-wasm-ext 0.8.0",
+ "libp2p-websocket 0.15.0",
+ "libp2p-yamux 0.15.0",
+ "parity-multiaddr",
+ "parity-multihash",
+ "parking_lot 0.10.0",
+ "pin-project",
+ "smallvec 1.2.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a58becf0b9585fcfbb8215bbe6e6ac187fcc180fd1026925ca180c845aa5a6e8"
+dependencies = [
+ "bytes 0.5.4",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.16.0",
+ "libp2p-core-derive 0.16.0",
+ "libp2p-deflate 0.16.0",
+ "libp2p-dns 0.16.0",
+ "libp2p-floodsub 0.16.0",
+ "libp2p-gossipsub 0.16.0",
+ "libp2p-identify 0.16.0",
+ "libp2p-kad 0.16.0",
+ "libp2p-mdns 0.16.0",
+ "libp2p-mplex 0.16.0",
+ "libp2p-noise 0.16.0",
+ "libp2p-ping 0.16.0",
+ "libp2p-plaintext 0.16.0",
+ "libp2p-pnet",
+ "libp2p-secio 0.16.0",
+ "libp2p-swarm 0.16.0",
+ "libp2p-tcp 0.16.0",
+ "libp2p-uds 0.16.0",
+ "libp2p-wasm-ext 0.16.0",
+ "libp2p-websocket 0.16.0",
+ "libp2p-yamux 0.16.0",
  "parity-multiaddr",
  "parity-multihash",
  "parking_lot 0.10.0",
@@ -2704,10 +2751,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b874594c4b29de1a29f27871feba8e6cd13aa54a8a1e8f8c7cf3dfac5ca287c"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "fnv",
+ "futures 0.3.4",
+ "futures-timer 3.0.1",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.8",
+ "multistream-select",
+ "parity-multiaddr",
+ "parity-multihash",
+ "parking_lot 0.10.0",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "smallvec 1.2.0",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize 1.1.0",
+]
+
+[[package]]
 name = "libp2p-core-derive"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c320266be0a7760e23484d635acdb83844b2d74d3612d93b41c393c9bcf004e"
+dependencies = [
+ "quote 1.0.2",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-core-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d472e9d522f588805c77801de10b957be84e10f019ca5f869fa1825b15ea9b"
 dependencies = [
  "quote 1.0.2",
  "syn",
@@ -2721,7 +2811,18 @@ checksum = "3be32697b42d040b325c3737f827ea04ede569ec956b7807700dd8d89d8210f9"
 dependencies = [
  "flate2",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+]
+
+[[package]]
+name = "libp2p-deflate"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e25004d4d9837b44b22c5f1a69be1724a5168fef6cff1716b5176a972c3aa62"
+dependencies = [
+ "flate2",
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
 ]
 
 [[package]]
@@ -2731,7 +2832,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f11c979b882f25d85726b15637d5bbc722dfa1be576605c54e99b8cf56906be3"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99e552f9939b606eb4b59f7f64d9b01e3f96752f47e350fc3c5fc646ed3f649"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
 ]
 
@@ -2745,8 +2857,25 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "smallvec 1.2.0",
+]
+
+[[package]]
+name = "libp2p-floodsub"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3234f12e44f9a50351a9807b97fe7de11eb9ae4482370392ba10da6dc90722"
+dependencies = [
+ "cuckoofilter",
+ "fnv",
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2766,8 +2895,33 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "log 0.4.8",
+ "lru 0.4.3",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "smallvec 1.2.0",
+ "unsigned-varint",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cb3e0841bd951cbf4feae56cdc081e6347836a644fb260c3ec554149b4006"
+dependencies = [
+ "base64 0.11.0",
+ "byteorder 1.3.4",
+ "bytes 0.5.4",
+ "fnv",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "log 0.4.8",
  "lru 0.4.3",
  "prost",
@@ -2786,8 +2940,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1a6261b804111c2dbf53f8ca03f66edc5ad1c29b78a61cf0cc5354052e28e9"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "log 0.4.8",
+ "prost",
+ "prost-build",
+ "smallvec 1.2.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfeb935a9bd41263e4f3a24b988e9f4a044f3ae89ac284e83c17fe2f84e0d66b"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "log 0.4.8",
  "prost",
  "prost-build",
@@ -2807,8 +2977,35 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "log 0.4.8",
+ "parity-multihash",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "smallvec 1.2.0",
+ "uint",
+ "unsigned-varint",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2efcff2af085e8181c421f68fe9c2b0a067379d146731925b3ac8f8e605c458"
+dependencies = [
+ "arrayvec 0.5.1",
+ "bytes 0.5.4",
+ "either",
+ "fnv",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "log 0.4.8",
  "parity-multihash",
  "prost",
@@ -2834,8 +3031,30 @@ dependencies = [
  "either",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "log 0.4.8",
+ "net2",
+ "rand 0.7.3",
+ "smallvec 1.2.0",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881fcfb360c2822db9f0e6bb6f89529621556ed9a8b038313414eda5107334de"
+dependencies = [
+ "async-std",
+ "data-encoding",
+ "dns-parser",
+ "either",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "log 0.4.8",
  "net2",
  "rand 0.7.3",
@@ -2854,7 +3073,23 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+ "parking_lot 0.10.0",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8507b37ad0eed275efcde67a023c3d85af6c80768b193845b9288e848e1af95"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "unsigned-varint",
@@ -2869,14 +3104,35 @@ dependencies = [
  "curve25519-dalek 1.2.3",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.15.0",
  "log 0.4.8",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "ring",
  "snow",
- "x25519-dalek",
+ "x25519-dalek 0.5.2",
+ "zeroize 1.1.0",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7d33809afdf6794f09fdb2f9f94e1550ae230be5bae6430a078eb96fc9e5a6"
+dependencies = [
+ "curve25519-dalek 1.2.3",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.16.0",
+ "log 0.4.8",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek 0.5.2",
  "zeroize 1.1.0",
 ]
 
@@ -2887,8 +3143,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ecced2949ae93b6ff29565303ecd1bef15c4e4efb689033ee744922561a36b"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.15.0",
+ "libp2p-swarm 0.5.0",
+ "log 0.4.8",
+ "rand 0.7.3",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d22f2f228b3a828dca1cb8aa9fa331e0bc9c36510cb2c1916956e20dc85e8c"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
+ "libp2p-swarm 0.16.0",
  "log 0.4.8",
  "rand 0.7.3",
  "void",
@@ -2904,13 +3175,45 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
+ "libp2p-core 0.15.0",
  "log 0.4.8",
  "prost",
  "prost-build",
  "rw-stream-sink",
  "unsigned-varint",
  "void",
+]
+
+[[package]]
+name = "libp2p-plaintext"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56126a204d7b3382bac163143ff4125a14570b3ba76ba979103d1ae1abed1923"
+dependencies = [
+ "bytes 0.5.4",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.16.0",
+ "log 0.4.8",
+ "prost",
+ "prost-build",
+ "rw-stream-sink",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
+name = "libp2p-pnet"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b916938a8868f75180aeeffcc6a516a922d165e8fa2a90b57bad989d1ccbb57a"
+dependencies = [
+ "futures 0.3.4",
+ "log 0.4.8",
+ "pin-project",
+ "rand 0.7.3",
+ "salsa20",
+ "sha3",
 ]
 
 [[package]]
@@ -2925,7 +3228,37 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+ "parity-send-wrapper",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "quicksink",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "static_assertions",
+ "twofish",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "libp2p-secio"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec00eb9a3404ed76a0e14f637edcaa7f2b4a27a16884da4a56f2f21e166c2843"
+dependencies = [
+ "aes-ctr",
+ "ctr",
+ "futures 0.3.4",
+ "hmac",
+ "js-sys",
+ "lazy_static",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
  "parity-send-wrapper",
  "pin-project",
@@ -2950,7 +3283,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ea00be81bc3985e36abad263ce2ad1b6aeb862aa743563eb70ad42880c05ae"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+ "smallvec 1.2.0",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e9f4fb84a4bfe3d3a361c1fbcd4af017ba68f0a46a77bfbcc48bf8a456d6ef"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
  "smallvec 1.2.0",
  "void",
@@ -2968,7 +3315,22 @@ dependencies = [
  "futures-timer 2.0.2",
  "get_if_addrs",
  "ipnet",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e80ad4e3535345f3d666554ce347d3100453775611c05c60786bf9a1747a10"
+dependencies = [
+ "async-std",
+ "futures 0.3.4",
+ "futures-timer 3.0.1",
+ "get_if_addrs",
+ "ipnet",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
 ]
 
@@ -2980,7 +3342,19 @@ checksum = "1e4f4f7989b35f33d4b9738aab2f031310eb20fec513cab44d12b1bc985a8074"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+]
+
+[[package]]
+name = "libp2p-uds"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d329564a43da9d0e055a5b938633c4a8ceab1f59cec133fbc4647917c07341"
+dependencies = [
+ "async-std",
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
 ]
 
@@ -2992,7 +3366,21 @@ checksum = "0b4d457adb91a5e2212343218a554394cd8ced64a79fb8e36e7aed2a16d49495"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "parity-send-wrapper",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39703653caa36f4afd0def39cc49a3ac0fa1d4289ca1802e417af03e4f5ef950"
+dependencies = [
+ "futures 0.3.4",
+ "js-sys",
+ "libp2p-core 0.16.0",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3008,7 +3396,28 @@ dependencies = [
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
+ "log 0.4.8",
+ "quicksink",
+ "rustls",
+ "rw-stream-sink",
+ "soketto",
+ "url 2.1.1",
+ "webpki",
+ "webpki-roots 0.18.0",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351ca9eea122081c1c0f9323164d2918cac29b5a6bfe5054d4ba8ec9447cf42"
+dependencies = [
+ "async-tls",
+ "bytes 0.5.4",
+ "either",
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
  "log 0.4.8",
  "quicksink",
  "rustls",
@@ -3026,8 +3435,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca25b3aac78a3c93c2a567622abd3cfc16f96f26ae1bf6134f0056203d62d86"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.15.0",
  "log 0.4.8",
+ "parking_lot 0.10.0",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72aa5a7273c29c6eaea09108a49feaefc7456164863f64f86a193f9e78a4b7f"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.16.0",
  "parking_lot 0.10.0",
  "thiserror",
  "yamux",
@@ -4533,9 +4955,9 @@ checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80878c27f90dd162d3143333d672e80b194d6b080f05c83440e3dfda42e409f2"
+checksum = "26df883298bc3f4e92528b4c5cc9f806b791955b136da3e5e939ed9de0fd958b"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4551,9 +4973,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multihash"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11f42bbd3a021c5061b77154bd3334d5a57e1a03eb162de0b962681cc25800d"
+checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
 dependencies = [
  "blake2",
  "bytes 0.5.4",
@@ -5491,6 +5913,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "salsa20"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2324b0e8c3bb9a586a571fdb3136f70e7e2c748de00a78043f86e0cff91f91fe"
+dependencies = [
+ "byteorder 1.3.4",
+ "salsa20-core",
+ "stream-cipher",
+]
+
+[[package]]
+name = "salsa20-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
+dependencies = [
+ "stream-cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5508,7 +5950,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "parity-scale-codec",
  "prost",
@@ -6080,7 +6522,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.1",
  "futures_codec",
- "libp2p",
+ "libp2p 0.16.0",
  "linked-hash-map",
  "linked_hash_set",
  "log 0.4.8",
@@ -6129,7 +6571,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "lru 0.1.17",
  "parking_lot 0.10.0",
@@ -6146,7 +6588,7 @@ dependencies = [
  "futures 0.1.29",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "rand 0.7.3",
@@ -6202,7 +6644,7 @@ name = "sc-peerset"
 version = "2.0.0"
 dependencies = [
  "futures 0.3.4",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "rand 0.7.3",
  "serde_json",
@@ -6386,7 +6828,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures-timer 3.0.1",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "parking_lot 0.10.0",
  "pin-project",
@@ -6765,10 +7207,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb767eee7d257ba202f0b9b08673bc13b22281632ef45267b19f13100accd2f"
 dependencies = [
  "arrayref",
+ "blake2-rfc",
+ "chacha20-poly1305-aead",
+ "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
+ "sha2",
  "subtle 2.2.2",
+ "x25519-dalek 0.6.0",
 ]
 
 [[package]]
@@ -6943,7 +7390,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-diagnose",
  "futures-timer 3.0.1",
- "libp2p",
+ "libp2p 0.16.0",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",
@@ -7486,7 +7933,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
- "libp2p",
+ "libp2p 0.15.0",
  "node-primitives",
  "node-runtime",
  "pallet-balances",
@@ -9013,6 +9460,17 @@ dependencies = [
  "clear_on_drop",
  "curve25519-dalek 1.2.3",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
+dependencies = [
+ "curve25519-dalek 2.0.0",
+ "rand_core 0.5.1",
+ "zeroize 1.1.0",
 ]
 
 [[package]]

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -28,7 +28,7 @@ derive_more = { version = "0.99.2" }
 sc-rpc = { version = "2.0.0", path = "../../../client/rpc" }
 jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
-libp2p = "0.15.0"
+libp2p = "0.16.0"
 serde_json = "1.0"
 
 [features]

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -15,7 +15,7 @@ codec = { package = "parity-scale-codec", default-features = false, version = "1
 derive_more = "0.99.2"
 futures = "0.3.1"
 futures-timer = "3.0.1"
-libp2p = { version = "0.15.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
+libp2p = { version = "0.16.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
 log = "0.4.8"
 prost = "0.6.1"
 rand = "0.7.2"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -12,7 +12,7 @@ futures = { version = "0.3.1", features = ["compat"] }
 wasm-timer = "0.2"
 futures-timer = "3.0.1"
 futures01 = { package = "futures", version = "0.1.29" }
-libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
 lru = "0.1.2"
 parking_lot = "0.10.0"
 sc-network = { version = "0.8", path = "../network" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.1"
 futures_codec = "0.3.3"
 futures-timer = "3.0.1"
 wasm-timer = "0.2"
-libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
 linked-hash-map = "0.5.2"
 linked_hash_set = "0.1.3"
 log = "0.4.8"

--- a/client/network/src/debug_info.rs
+++ b/client/network/src/debug_info.rs
@@ -39,11 +39,11 @@ const GARBAGE_COLLECT_INTERVAL: Duration = Duration::from_secs(2 * 60);
 
 /// Implementation of `NetworkBehaviour` that holds information about nodes in cache for diagnostic
 /// purposes.
-pub struct DebugInfoBehaviour<TSubstream> {
+pub struct DebugInfoBehaviour {
 	/// Periodically ping nodes, and close the connection if it's unresponsive.
-	ping: Ping<TSubstream>,
+	ping: Ping,
 	/// Periodically identifies the remote and responds to incoming requests.
-	identify: Identify<TSubstream>,
+	identify: Identify,
 	/// Information that we know about all nodes.
 	nodes_info: FnvHashMap<PeerId, NodeInfo>,
 	/// Interval at which we perform garbage collection in `nodes_info`.
@@ -64,7 +64,7 @@ struct NodeInfo {
 	latest_ping: Option<Duration>,
 }
 
-impl<TSubstream> DebugInfoBehaviour<TSubstream> {
+impl DebugInfoBehaviour {
 	/// Builds a new `DebugInfoBehaviour`.
 	pub fn new(
 		user_agent: String,
@@ -151,11 +151,10 @@ pub enum DebugInfoEvent {
 	},
 }
 
-impl<TSubstream> NetworkBehaviour for DebugInfoBehaviour<TSubstream>
-where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static {
+impl NetworkBehaviour for DebugInfoBehaviour {
 	type ProtocolsHandler = IntoProtocolsHandlerSelect<
-		<Ping<TSubstream> as NetworkBehaviour>::ProtocolsHandler,
-		<Identify<TSubstream> as NetworkBehaviour>::ProtocolsHandler
+		<Ping as NetworkBehaviour>::ProtocolsHandler,
+		<Identify as NetworkBehaviour>::ProtocolsHandler
 	>;
 	type OutEvent = DebugInfoEvent;
 

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -55,8 +55,6 @@ use libp2p::kad::record::{self, store::MemoryStore};
 #[cfg(not(target_os = "unknown"))]
 use libp2p::{swarm::toggle::Toggle};
 #[cfg(not(target_os = "unknown"))]
-use libp2p::core::{nodes::Substream, muxing::StreamMuxerBox};
-#[cfg(not(target_os = "unknown"))]
 use libp2p::mdns::{Mdns, MdnsEvent};
 use libp2p::multiaddr::Protocol;
 use log::{debug, info, trace, warn, error};
@@ -65,15 +63,15 @@ use std::task::{Context, Poll};
 use sp_core::hexdisplay::HexDisplay;
 
 /// Implementation of `NetworkBehaviour` that discovers the nodes on the network.
-pub struct DiscoveryBehaviour<TSubstream> {
+pub struct DiscoveryBehaviour {
 	/// User-defined list of nodes and their addresses. Typically includes bootstrap nodes and
 	/// reserved nodes.
 	user_defined: Vec<(PeerId, Multiaddr)>,
 	/// Kademlia requests and answers.
-	kademlia: Kademlia<TSubstream, MemoryStore>,
+	kademlia: Kademlia<MemoryStore>,
 	/// Discovers nodes on the local network.
 	#[cfg(not(target_os = "unknown"))]
-	mdns: Toggle<Mdns<Substream<StreamMuxerBox>>>,
+	mdns: Toggle<Mdns>,
 	/// Stream that fires when we need to perform the next random Kademlia query.
 	next_kad_random_query: Delay,
 	/// After `next_kad_random_query` triggers, the next one triggers after this duration.
@@ -91,7 +89,7 @@ pub struct DiscoveryBehaviour<TSubstream> {
 	discovery_only_if_under_num: u64,
 }
 
-impl<TSubstream> DiscoveryBehaviour<TSubstream> {
+impl DiscoveryBehaviour {
 	/// Builds a new `DiscoveryBehaviour`.
 	///
 	/// `user_defined` is a list of known address for nodes that never expire.
@@ -207,11 +205,8 @@ pub enum DiscoveryOut {
 	ValuePutFailed(record::Key),
 }
 
-impl<TSubstream> NetworkBehaviour for DiscoveryBehaviour<TSubstream>
-where
-	TSubstream: AsyncRead + AsyncWrite + Unpin,
-{
-	type ProtocolsHandler = <Kademlia<TSubstream, MemoryStore> as NetworkBehaviour>::ProtocolsHandler;
+impl NetworkBehaviour for DiscoveryBehaviour {
+	type ProtocolsHandler = <Kademlia<MemoryStore> as NetworkBehaviour>::ProtocolsHandler;
 	type OutEvent = DiscoveryOut;
 
 	fn new_handler(&mut self) -> Self::ProtocolsHandler {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -20,7 +20,7 @@ use crate::utils::interval;
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
 use libp2p::{Multiaddr, PeerId};
-use libp2p::core::{ConnectedPoint, nodes::{listeners::ListenerId, Substream}, muxing::StreamMuxerBox};
+use libp2p::core::{ConnectedPoint, nodes::listeners::ListenerId};
 use libp2p::swarm::{ProtocolsHandler, IntoProtocolsHandler};
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
 use sp_core::storage::{StorageKey, ChildInfo};
@@ -158,7 +158,7 @@ pub struct Protocol<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> {
 	/// When asked for a proof of finality, we use this struct to build one.
 	finality_proof_provider: Option<Arc<dyn FinalityProofProvider<B>>>,
 	/// Handles opening the unique substream and sending and receiving raw messages.
-	behaviour: LegacyProto<Substream<StreamMuxerBox>>,
+	behaviour: LegacyProto,
 	/// List of notification protocols that have been registered.
 	registered_notif_protocols: HashSet<ConsensusEngineId>,
 }
@@ -207,7 +207,7 @@ pub struct PeerInfo<B: BlockT> {
 }
 
 struct LightDispatchIn<'a> {
-	behaviour: &'a mut LegacyProto<Substream<StreamMuxerBox>>,
+	behaviour: &'a mut LegacyProto,
 	peerset: sc_peerset::PeersetHandle,
 }
 
@@ -347,7 +347,7 @@ pub trait Context<B: BlockT> {
 
 /// Protocol context.
 struct ProtocolContext<'a, B: 'a + BlockT, H: 'a + ExHashT> {
-	behaviour: &'a mut LegacyProto<Substream<StreamMuxerBox>>,
+	behaviour: &'a mut LegacyProto,
 	context_data: &'a mut ContextData<B, H>,
 	peerset_handle: &'a sc_peerset::PeersetHandle,
 }
@@ -355,7 +355,7 @@ struct ProtocolContext<'a, B: 'a + BlockT, H: 'a + ExHashT> {
 impl<'a, B: BlockT + 'a, H: 'a + ExHashT> ProtocolContext<'a, B, H> {
 	fn new(
 		context_data: &'a mut ContextData<B, H>,
-		behaviour: &'a mut LegacyProto<Substream<StreamMuxerBox>>,
+		behaviour: &'a mut LegacyProto,
 		peerset_handle: &'a sc_peerset::PeersetHandle,
 	) -> Self {
 		ProtocolContext { context_data, peerset_handle, behaviour }
@@ -913,14 +913,14 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 				if peer.block_request.as_ref().map_or(false, |(t, _)| (tick - *t).as_secs() > REQUEST_TIMEOUT_SEC) {
 					log!(
 						target: "sync",
-						if self.important_peers.contains(&who) { Level::Warn } else { Level::Trace },
+						if self.important_peers.contains(who) { Level::Warn } else { Level::Trace },
 						"Request timeout {}", who
 					);
 					aborting.push(who.clone());
 				} else if peer.obsolete_requests.values().any(|t| (tick - *t).as_secs() > REQUEST_TIMEOUT_SEC) {
 					log!(
 						target: "sync",
-						if self.important_peers.contains(&who) { Level::Warn } else { Level::Trace },
+						if self.important_peers.contains(who) { Level::Warn } else { Level::Trace },
 						"Obsolete timeout {}", who
 					);
 					aborting.push(who.clone());
@@ -931,7 +931,7 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			{
 				log!(
 					target: "sync",
-					if self.important_peers.contains(&who) { Level::Warn } else { Level::Trace },
+					if self.important_peers.contains(who) { Level::Warn } else { Level::Trace },
 					"Handshake timeout {}", who
 				);
 				aborting.push(who.clone());
@@ -1835,7 +1835,7 @@ pub enum CustomMessageOutcome<B: BlockT> {
 }
 
 fn send_request<B: BlockT, H: ExHashT>(
-	behaviour: &mut LegacyProto<Substream<StreamMuxerBox>>,
+	behaviour: &mut LegacyProto,
 	stats: &mut HashMap<&'static str, PacketStats>,
 	peers: &mut HashMap<PeerId, Peer<B, H>>,
 	who: &PeerId,
@@ -1856,7 +1856,7 @@ fn send_request<B: BlockT, H: ExHashT>(
 }
 
 fn send_message<B: BlockT>(
-	behaviour: &mut LegacyProto<Substream<StreamMuxerBox>>,
+	behaviour: &mut LegacyProto,
 	stats: &mut HashMap<&'static str, PacketStats>,
 	who: &PeerId,
 	message: Message<B>,
@@ -1870,7 +1870,7 @@ fn send_message<B: BlockT>(
 
 impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> NetworkBehaviour for
 Protocol<B, S, H> {
-	type ProtocolsHandler = <LegacyProto<Substream<StreamMuxerBox>> as NetworkBehaviour>::ProtocolsHandler;
+	type ProtocolsHandler = <LegacyProto as NetworkBehaviour>::ProtocolsHandler;
 	type OutEvent = CustomMessageOutcome<B>;
 
 	fn new_handler(&mut self) -> Self::ProtocolsHandler {

--- a/client/network/src/protocol/light_dispatch.rs
+++ b/client/network/src/protocol/light_dispatch.rs
@@ -504,7 +504,7 @@ impl<B: BlockT> LightDispatch<B> where
 	}
 
 	pub fn is_light_response(&self, peer: &PeerId, request_id: message::RequestId) -> bool {
-		self.active_peers.get(&peer).map_or(false, |r| r.id == request_id)
+		self.active_peers.get(peer).map_or(false, |r| r.id == request_id)
 	}
 
 	fn remove(&mut self, peer: PeerId, id: u64) -> Option<Request<B>> {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -35,7 +35,6 @@ use sp_consensus::import_queue::{BlockImportResult, BlockImportError};
 use futures::{prelude::*, channel::mpsc};
 use log::{warn, error, info, trace};
 use libp2p::{PeerId, Multiaddr, kad::record};
-use libp2p::core::{transport::boxed::Boxed, muxing::StreamMuxerBox};
 use libp2p::swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use parking_lot::Mutex;
 use sc_peerset::PeersetHandle;
@@ -854,7 +853,6 @@ impl<B: BlockT + 'static, S: NetworkSpecialization<B>, H: ExHashT> Unpin for Net
 
 /// The libp2p swarm, customized for our needs.
 type Swarm<B, S, H> = libp2p::swarm::Swarm<
-	Boxed<(PeerId, StreamMuxerBox), io::Error>,
 	Behaviour<B, S, H>
 >;
 

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.1.29"
 futures03 = { package = "futures", version = "0.3.1", features = ["compat"] }
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
 sp-consensus = { version = "0.8", path = "../../../primitives/consensus/common" }
 sc-client = { version = "0.8", path = "../../" }
 sc-client-api = { version = "2.0.0", path = "../../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-libp2p = { version = "0.15.0", default-features = false }
+libp2p = { version = "0.16.0", default-features = false }
 log = "0.4.8"
 serde_json = "1.0.41"
 wasm-timer = "0.2"

--- a/client/peerset/src/peersstate.rs
+++ b/client/peerset/src/peersstate.rs
@@ -156,7 +156,7 @@ impl PeersState {
 	pub fn priority_not_connected_peer(&mut self) -> Option<NotConnectedPeer> {
 		let id = self.priority_nodes.values()
 			.flatten()
-			.find(|id| self.nodes.get(id).map_or(false, |node| !node.connection_state.is_connected()))
+			.find(|&id| self.nodes.get(id).map_or(false, |node| !node.connection_state.is_connected()))
 			.cloned();
 		id.map(move |id| NotConnectedPeer {
 			state: self,
@@ -170,7 +170,7 @@ impl PeersState {
 	pub fn priority_not_connected_peer_from_group(&mut self, group_id: &str) -> Option<NotConnectedPeer> {
 		let id = self.priority_nodes.get(group_id)
 			.and_then(|group| group.iter()
-				.find(|id| self.nodes.get(id).map_or(false, |node| !node.connection_state.is_connected()))
+				.find(|&id| self.nodes.get(id).map_or(false, |node| !node.connection_state.is_connected()))
 				.cloned());
 		id.map(move |id| NotConnectedPeer {
 			state: self,
@@ -300,7 +300,7 @@ impl PeersState {
 
 		for id in &peers {
 			// update slots for nodes that become priority
-			if !all_other_groups.contains(&id) {
+			if !all_other_groups.contains(id) {
 				let peer = self.nodes.entry(id.clone()).or_default();
 				match peer.connection_state {
 					ConnectionState::In => self.num_in -= 1,
@@ -322,7 +322,7 @@ impl PeersState {
 	/// Remove a peer from a priority group.
 	pub fn remove_from_priority_group(&mut self, group_id: &str, peer_id: &PeerId) {
 		let mut peers = self.priority_nodes.get(group_id).cloned().unwrap_or_default();
-		peers.remove(&peer_id);
+		peers.remove(peer_id);
 		self.set_priority_group(group_id, peers);
 	}
 

--- a/client/peerset/tests/fuzz.rs
+++ b/client/peerset/tests/fuzz.rs
@@ -108,7 +108,7 @@ fn test_once() {
 
 				// If we generate 4, connect to a random node.
 				4 => if let Some(id) = known_nodes.iter()
-					.filter(|n| incoming_nodes.values().all(|m| m != *n) && !connected_nodes.contains(n))
+					.filter(|n| incoming_nodes.values().all(|m| m != *n) && !connected_nodes.contains(*n))
 					.choose(&mut rng) {
 					peerset.incoming(id.clone(), next_incoming_id.clone());
 					incoming_nodes.insert(next_incoming_id.clone(), id.clone());
@@ -120,7 +120,7 @@ fn test_once() {
 				6 => peerset_handle.set_reserved_only(false),
 
 				// 7 and 8 are about switching a random node in or out of reserved mode.
-				7 => if let Some(id) = known_nodes.iter().filter(|n| !reserved_nodes.contains(n)).choose(&mut rng) {
+				7 => if let Some(id) = known_nodes.iter().filter(|n| !reserved_nodes.contains(*n)).choose(&mut rng) {
 					peerset_handle.add_reserved_peer(id.clone());
 					reserved_nodes.insert(id.clone());
 				}

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -12,7 +12,7 @@ parking_lot = "0.10.0"
 futures = "0.3.1"
 futures-timer = "3.0.1"
 wasm-timer = "0.2.0"
-libp2p = { version = "0.15.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
 log = "0.4.8"
 pin-project = "0.4.6"
 rand = "0.7.2"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"
-libp2p = { version = "0.15.0", default-features = false }
+libp2p = { version = "0.16.0", default-features = false }
 log = "0.4.8"
 sp-core = { path= "../../core" }
 sp-inherents = { version = "2.0.0", path = "../../inherents" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 futures = "0.3"
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
-libp2p = { version = "0.15.0", default-features = false }
+libp2p = { version = "0.16.0", default-features = false }
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 js-sys = "0.3.34"


### PR DESCRIPTION
Unlocks a few cool things, notably #4880 and #4887. cc'ing @expenses
Should also reduce the memory usage of connections, cc #4679 

Changes should be straight-forward.