### PR TITLE
Refactor BlockImportParams to be non_exhaustive

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -369,7 +369,7 @@ pub fn new_light(config: NodeConfiguration)
 
 #[cfg(test)]
 mod tests {
-	use std::{sync::Arc, collections::HashMap, borrow::Cow, any::Any};
+	use std::{sync::Arc, borrow::Cow, any::Any};
 	use sc_consensus_babe::{
 		CompatibleDigestItem, BabeIntermediate, INTERMEDIATE_KEY
 	};
@@ -557,27 +557,14 @@ mod tests {
 				);
 				slot_num += 1;
 
-				let params = BlockImportParams {
-					origin: BlockOrigin::File,
-					header: new_header,
-					justification: None,
-					post_digests: vec![item],
-					body: Some(new_body),
-					storage_changes: None,
-					finalized: false,
-					auxiliary: Vec::new(),
-					intermediates: {
-						let mut intermediates = HashMap::new();
-						intermediates.insert(
-							Cow::from(INTERMEDIATE_KEY),
-							Box::new(BabeIntermediate { epoch }) as Box<dyn Any>,
-						);
-						intermediates
-					},
-					fork_choice: Some(ForkChoiceStrategy::LongestChain),
-					allow_missing_state: false,
-					import_existing: false,
-				};
+				let mut params = BlockImportParams::new(BlockOrigin::File, new_header);
+				params.post_digests.push(item);
+				params.body = Some(new_body);
+				params.intermediates.insert(
+					Cow::from(INTERMEDIATE_KEY),
+					Box::new(BabeIntermediate { epoch }) as Box<dyn Any>,
+				);
+				params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 				block_import.import_block(params, Default::default())
 					.expect("error importing test block");

--- a/bin/node/testing/benches/import.rs
+++ b/bin/node/testing/benches/import.rs
@@ -358,20 +358,9 @@ fn generate_block_import(client: &Client, keyring: &BenchKeyring) -> Block {
 
 // Import generated block.
 fn import_block(client: &mut Client, block: Block) {
-	let import_params = BlockImportParams {
-		origin: BlockOrigin::NetworkBroadcast,
-		header: block.header().clone(),
-		post_digests: Default::default(),
-		body: Some(block.extrinsics().to_vec()),
-		storage_changes: Default::default(),
-		finalized: false,
-		justification: Default::default(),
-		auxiliary: Default::default(),
-		intermediates: Default::default(),
-		fork_choice: Some(ForkChoiceStrategy::LongestChain),
-		allow_missing_state: false,
-		import_existing: false,
-	};
+	let mut import_params = BlockImportParams::new(BlockOrigin::NetworkBroadcast, block.header.clone());
+	import_params.body = Some(block.extrinsics().to_vec());
+	import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 	assert_eq!(client.chain_info().best_number, 0);
 

--- a/bin/node/transaction-factory/src/lib.rs
+++ b/bin/node/transaction-factory/src/lib.rs
@@ -156,20 +156,9 @@ where
 		best_hash = block.header().hash();
 		best_block_id = BlockId::<Block>::hash(best_hash);
 
-		let import = BlockImportParams {
-			origin: BlockOrigin::File,
-			header: block.header().clone(),
-			post_digests: Vec::new(),
-			body: Some(block.extrinsics().to_vec()),
-			storage_changes: None,
-			finalized: false,
-			justification: None,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(BlockOrigin::File, block.header().clone());
+		import.body = Some(block.extrinsics().to_vec());
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 		client.clone().import_block(import, HashMap::new()).expect("Failed to import block");
 
 		info!("Imported block at {}", factory_state.block_number());

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -593,30 +593,15 @@ fn propose_and_import_block<Transaction>(
 		h
 	};
 
-	let import_result = block_import.import_block(
-		BlockImportParams {
-			origin: BlockOrigin::Own,
-			header: block.header,
-			justification: None,
-			post_digests: vec![seal],
-			body: Some(block.extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: {
-				let mut intermediates = HashMap::new();
-				intermediates.insert(
-					Cow::from(INTERMEDIATE_KEY),
-					Box::new(BabeIntermediate { epoch }) as Box<dyn Any>,
-				);
-				intermediates
-			},
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		},
-		Default::default(),
-	).unwrap();
+	let mut import = BlockImportParams::new(BlockOrigin::Own, block.header);
+	import.post_digests.push(seal);
+	import.body = Some(block.extrinsics);
+	import.intermediates.insert(
+		Cow::from(INTERMEDIATE_KEY),
+		Box::new(BabeIntermediate { epoch }) as Box<dyn Any>,
+	);
+	import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+	let import_result = block_import.import_block(import, Default::default()).unwrap();
 
 	match import_result {
 		ImportResult::Imported(_) => {},

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -89,20 +89,11 @@ impl<B: BlockT> Verifier<B> for ManualSealVerifier {
 		justification: Option<Justification>,
 		body: Option<Vec<B::Extrinsic>>,
 	) -> Result<(BlockImportParams<B, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
-		let import_params = BlockImportParams {
-			origin,
-			header,
-			justification,
-			post_digests: Vec::new(),
-			body,
-			storage_changes: None,
-			finalized: true,
-			auxiliary: Vec::new(),
-			intermediates: HashMap::new(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import_params = BlockImportParams::new(origin, header);
+		import_params.justification = justification;
+		import_params.body = body;
+		import_params.finalized = true;
+		import_params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		Ok((import_params, None))
 	}

--- a/client/consensus/manual-seal/src/seal_new_block.rs
+++ b/client/consensus/manual-seal/src/seal_new_block.rs
@@ -121,20 +121,10 @@ pub async fn seal_new_block<B, SC, CB, E, T, P>(
 		}
 
 		let (header, body) = proposal.block.deconstruct();
-		let params = BlockImportParams {
-			origin: BlockOrigin::Own,
-			header: header.clone(),
-			justification: None,
-			post_digests: Vec::new(),
-			body: Some(body),
-			finalized: finalize,
-			storage_changes: None,
-			auxiliary: Vec::new(),
-			intermediates: HashMap::new(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut params = BlockImportParams::new(BlockOrigin::Own, header.clone());
+		params.body = Some(body);
+		params.finalized = finalize;
+		params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		match block_import.import_block(params, HashMap::new())? {
 			ImportResult::Imported(aux) => {

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -287,13 +287,13 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			info!(
 				"Pre-sealed block for proposal at {}. Hash now {:?}, previously {:?}.",
 				header_num,
-				block_import_params.post_header().hash(),
+				block_import_params.post_hash(),
 				header_hash,
 			);
 
 			telemetry!(CONSENSUS_INFO; "slots.pre_sealed_block";
 				"header_num" => ?header_num,
-				"hash_now" => ?block_import_params.post_header().hash(),
+				"hash_now" => ?block_import_params.post_hash(),
 				"hash_previously" => ?header_hash,
 			);
 

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -398,7 +398,7 @@ impl<B, E, Block: BlockT, RA, SC> BlockImport<Block>
 		mut block: BlockImportParams<Block, Self::Transaction>,
 		new_cache: HashMap<well_known_cache_keys::Id, Vec<u8>>,
 	) -> Result<ImportResult, Self::Error> {
-		let hash = block.post_header().hash();
+		let hash = block.post_hash();
 		let number = block.header.number().clone();
 
 		// early exit if block already in chain, otherwise the check for

--- a/client/finality-grandpa/src/light_import.rs
+++ b/client/finality-grandpa/src/light_import.rs
@@ -257,7 +257,7 @@ fn do_import_block<B, C, Block: BlockT, J>(
 		DigestFor<Block>: Encode,
 		J: ProvableJustification<Block::Header>,
 {
-	let hash = block.post_header().hash();
+	let hash = block.post_hash();
 	let number = block.header.number().clone();
 
 	// we don't want to finalize on `inner.import_block`
@@ -682,26 +682,19 @@ pub mod tests {
 			authority_set: LightAuthoritySet::genesis(vec![(AuthorityId::from_slice(&[1; 32]), 1)]),
 			consensus_changes: ConsensusChanges::empty(),
 		};
-		let block = BlockImportParams {
-			origin: BlockOrigin::Own,
-			header: Header {
+		let mut block = BlockImportParams::new(
+			BlockOrigin::Own,
+			Header {
 				number: 1,
 				parent_hash: client.chain_info().best_hash,
 				state_root: Default::default(),
 				digest: Default::default(),
 				extrinsics_root: Default::default(),
 			},
-			justification,
-			post_digests: Vec::new(),
-			body: None,
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: true,
-			import_existing: false,
-		};
+		);
+		block.justification = justification;
+		block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
 		do_import_block::<_, _, _, TestJustification>(
 			&client,
 			&mut import_data,

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -1011,20 +1011,11 @@ fn allows_reimporting_change_blocks() {
 
 	let block = || {
 		let block = block.clone();
-		BlockImportParams {
-			origin: BlockOrigin::File,
-			header: block.header,
-			justification: None,
-			post_digests: Vec::new(),
-			body: Some(block.extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		}
+		let mut import = BlockImportParams::new(BlockOrigin::File, block.header);
+		import.body = Some(block.extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
+		import
 	};
 
 	assert_eq!(
@@ -1071,20 +1062,12 @@ fn test_bad_justification() {
 
 	let block = || {
 		let block = block.clone();
-		BlockImportParams {
-			origin: BlockOrigin::File,
-			header: block.header,
-			justification: Some(Vec::new()),
-			post_digests: Vec::new(),
-			body: Some(block.extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		}
+		let mut import = BlockImportParams::new(BlockOrigin::File, block.header);
+		import.justification = Some(Vec::new());
+		import.body = Some(block.extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
+		import
 	};
 
 	assert_eq!(
@@ -1805,23 +1788,13 @@ fn imports_justification_for_regular_blocks_on_import() {
 	};
 
 	// we import the block with justification attached
-	let block = BlockImportParams {
-		origin: BlockOrigin::File,
-		header: block.header,
-		justification: Some(justification.encode()),
-		post_digests: Vec::new(),
-		body: Some(block.extrinsics),
-		storage_changes: None,
-		finalized: false,
-		auxiliary: Vec::new(),
-		intermediates: Default::default(),
-		fork_choice: Some(ForkChoiceStrategy::LongestChain),
-		allow_missing_state: false,
-		import_existing: false,
-	};
+	let mut import = BlockImportParams::new(BlockOrigin::File, block.header);
+	import.justification = Some(justification.encode());
+	import.body = Some(block.extrinsics);
+	import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 	assert_eq!(
-		block_import.import_block(block, HashMap::new()).unwrap(),
+		block_import.import_block(import, HashMap::new()).unwrap(),
 		ImportResult::Imported(ImportedAux {
 			needs_justification: false,
 			clear_justification_requests: false,

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -85,21 +85,13 @@ impl<B: BlockT> Verifier<B> for PassThroughVerifier {
 				.or_else(|| l.try_as_raw(OpaqueDigestItemId::Consensus(b"babe")))
 			)
 			.map(|blob| vec![(well_known_cache_keys::AUTHORITIES, blob.to_vec())]);
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = body;
+		import.finalized = self.0;
+		import.justification = justification;
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
-		Ok((BlockImportParams {
-			origin,
-			header,
-			body,
-			storage_changes: None,
-			finalized: self.0,
-			justification,
-			post_digests: vec![],
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		}, maybe_keys))
+		Ok((import, maybe_keys))
 	}
 }
 

--- a/test-utils/client/src/client_ext.rs
+++ b/test-utils/client/src/client_ext.rs
@@ -87,60 +87,28 @@ impl<Block: BlockT, T, Transaction> ClientBlockImportExt<Block> for std::sync::A
 {
 	fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
 
 	fn import_as_best(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::Custom(true)),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
 
 	fn import_as_final(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: true,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::Custom(true)),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.finalized = true;
+		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
@@ -152,20 +120,11 @@ impl<Block: BlockT, T, Transaction> ClientBlockImportExt<Block> for std::sync::A
 		justification: Justification,
 	) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: Some(justification),
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: true,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.justification = Some(justification);
+		import.body = Some(extrinsics);
+		import.finalized = true;
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
@@ -177,60 +136,28 @@ impl<B, E, RA, Block: BlockT> ClientBlockImportExt<Block> for Client<B, E, Block
 {
 	fn import(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
 
 	fn import_as_best(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: false,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::Custom(true)),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
 
 	fn import_as_final(&mut self, origin: BlockOrigin, block: Block) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: None,
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: true,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::Custom(true)),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.body = Some(extrinsics);
+		import.finalized = true;
+		import.fork_choice = Some(ForkChoiceStrategy::Custom(true));
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}
@@ -242,20 +169,11 @@ impl<B, E, RA, Block: BlockT> ClientBlockImportExt<Block> for Client<B, E, Block
 		justification: Justification,
 	) -> Result<(), ConsensusError> {
 		let (header, extrinsics) = block.deconstruct();
-		let import = BlockImportParams {
-			origin,
-			header,
-			justification: Some(justification),
-			post_digests: vec![],
-			body: Some(extrinsics),
-			storage_changes: None,
-			finalized: true,
-			auxiliary: Vec::new(),
-			intermediates: Default::default(),
-			fork_choice: Some(ForkChoiceStrategy::LongestChain),
-			allow_missing_state: false,
-			import_existing: false,
-		};
+		let mut import = BlockImportParams::new(origin, header);
+		import.justification = Some(justification);
+		import.body = Some(extrinsics);
+		import.finalized = true;
+		import.fork_choice = Some(ForkChoiceStrategy::LongestChain);
 
 		BlockImport::import_block(self, import, HashMap::new()).map(|_| ())
 	}


### PR DESCRIPTION
This marks `BlockImportParams` as `non_exhaustive`. From time to time we add new field into the struct. By making sure users use initialization function we avoid too much breakage.