### PR TITLE
sync: process empty response for justification requests

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -864,8 +864,6 @@ impl<B: BlockT, S: NetworkSpecialization<B>, H: ExHashT> Protocol<B, S, H> {
 			blocks_range
 		);
 
-		// TODO [andre]: move this logic to the import queue so that
-		// justifications are imported asynchronously (#1482)
 		if request.fields == message::BlockAttributes::JUSTIFICATION {
 			match self.sync.on_block_justification(peer, response) {
 				Ok(sync::OnBlockJustification::Nothing) => CustomMessageOutcome::None,

--- a/client/network/src/protocol/sync/extra_requests.rs
+++ b/client/network/src/protocol/sync/extra_requests.rs
@@ -228,6 +228,18 @@ impl<B: BlockT> ExtraRequests<B> {
 
 		true
 	}
+
+	/// Returns an iterator over all active (in-flight) requests and associated peer id.
+	#[cfg(test)]
+	pub(crate) fn active_requests(&self) -> impl Iterator<Item = (&PeerId, &ExtraRequest<B>)> {
+		self.active_requests.iter()
+	}
+
+	/// Returns an iterator over all scheduled pending requests.
+	#[cfg(test)]
+	pub(crate) fn pending_requests(&self) -> impl Iterator<Item = &ExtraRequest<B>> {
+		self.pending_requests.iter()
+	}
 }
 
 /// Matches peers with pending extra requests.


### PR DESCRIPTION
If we ask for a justification for a given block to a peer that doesn't know that block (different from not having a justification), the peer will reply with an empty response. Currently, we would ignore the empty response and not notify the `ExtraRequests` scheduler, this caused the request to always be considered in active state preventing it from ever being rescheduled to another peer (unless the peer disconnected from us). This should fix the issue with some nodes getting stuck on finalized blocks that are around authority set changes and never making any progress until restart (since the request would be properly rescheduled on startup).