### PR TITLE
Benchmark trait for input types

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::{
 	weights::Weight,
 	traits::{SplitTwoWays, Currency, Randomness},
 };
-use sp_core::u32_trait::{_1, _2, _3, _4};
+use sp_core::{u32_trait::{_1, _2, _3, _4}, Benchmark as BenchType};
 pub use node_primitives::{AccountId, Signature};
 use node_primitives::{AccountIndex, Balance, BlockNumber, Hash, Index, Moment};
 use sp_api::impl_runtime_apis;
@@ -232,6 +232,8 @@ impl_opaque_keys! {
 		pub authority_discovery: AuthorityDiscovery,
 	}
 }
+
+impl BenchType for SessionKeys {}
 
 parameter_types! {
 	pub const DisabledValidatorsThreshold: Perbill = Perbill::from_percent(17);

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -8,11 +8,9 @@ license = "GPL-3.0"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
-# Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
-# Needed for type-safe access to storage DB.
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
-# `system` module provides us with all sorts of useful stuff and macros depend on it being around.
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
 
 [dev-dependencies]
@@ -26,6 +24,7 @@ std = [
 	"serde",
 	"codec/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -134,6 +134,7 @@
 
 use frame_support::{Parameter, decl_module, decl_event, decl_storage, decl_error, ensure};
 use sp_runtime::traits::{Member, AtLeast32Bit, Zero, StaticLookup};
+use sp_core::Benchmark;
 use frame_system::{self as system, ensure_signed};
 use sp_runtime::traits::One;
 
@@ -143,10 +144,10 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// The units in which we record balances.
-	type Balance: Member + Parameter + AtLeast32Bit + Default + Copy;
+	type Balance: Member + Parameter + AtLeast32Bit + Default + Copy + Benchmark;
 
 	/// The arithmetic type of asset identifier.
-	type AssetId: Parameter + AtLeast32Bit + Default + Copy;
+	type AssetId: Parameter + AtLeast32Bit + Default + Copy + Benchmark;
 }
 
 decl_module! {

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -11,6 +11,7 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
 
@@ -27,6 +28,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -20,6 +20,7 @@ use super::*;
 
 use frame_system::RawOrigin;
 use sp_io::hashing::blake2_256;
+use sp_core::Benchmark;
 use sp_runtime::{BenchmarkResults, BenchmarkParameter};
 use sp_runtime::traits::{Bounded, Benchmarking, BenchmarkingSetup, Dispatchable};
 
@@ -53,7 +54,7 @@ impl<T: Trait> BenchmarkingSetup<T, crate::Call<T>, RawOrigin<T::AccountId>> for
 
 		// Select an account
 		let u = components.iter().find(|&c| c.0 == BenchmarkParameter::U).unwrap().1;
-		let user = account::<T>("user", u);
+		let user = <T::AccountId as Benchmark>::value(b"user", u);
 		let user_origin = RawOrigin::Signed(user.clone());
 
 		// Give some multiple of the existential deposit + creation fee + transfer fee

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -169,11 +169,12 @@ use frame_support::{
 		ExistenceRequirement::AllowDeath, IsDeadAccount, BalanceStatus as Status
 	}
 };
+use sp_core::Benchmark;
 use sp_runtime::{
 	RuntimeDebug, DispatchResult, DispatchError,
 	traits::{
 		Zero, AtLeast32Bit, StaticLookup, Member, CheckedAdd, CheckedSub,
-		MaybeSerializeDeserialize, Saturating, Bounded,
+		MaybeSerializeDeserialize, Saturating, Bounded
 	},
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
@@ -186,7 +187,7 @@ pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 pub trait Subtrait<I: Instance = DefaultInstance>: frame_system::Trait {
 	/// The balance of an account.
 	type Balance: Parameter + Member + AtLeast32Bit + Codec + Default + Copy +
-		MaybeSerializeDeserialize + Debug;
+		MaybeSerializeDeserialize + Debug + Benchmark;
 
 	/// The minimum amount required to keep an account open.
 	type ExistentialDeposit: Get<Self::Balance>;
@@ -198,7 +199,7 @@ pub trait Subtrait<I: Instance = DefaultInstance>: frame_system::Trait {
 pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait {
 	/// The balance of an account.
 	type Balance: Parameter + Member + AtLeast32Bit + Codec + Default + Copy +
-		MaybeSerializeDeserialize + Debug;
+		MaybeSerializeDeserialize + Debug + Benchmark;
 
 	/// Handler for the unbalanced reduction when removing a dust account.
 	type DustRemoval: OnUnbalanced<NegativeImbalance<Self, I>>;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -24,7 +24,7 @@
 #![recursion_limit="128"]
 
 use sp_std::{prelude::*, result};
-use sp_core::u32_trait::Value as U32;
+use sp_core::{u32_trait::Value as U32, Benchmark};
 use sp_runtime::RuntimeDebug;
 use sp_runtime::traits::{Hash, EnsureOrigin};
 use frame_support::weights::SimpleDispatchInfo;
@@ -49,7 +49,7 @@ pub trait Trait<I=DefaultInstance>: frame_system::Trait {
 	type Origin: From<RawOrigin<Self::AccountId, I>>;
 
 	/// The outer call dispatch type.
-	type Proposal: Parameter + Dispatchable<Origin=<Self as Trait<I>>::Origin>;
+	type Proposal: Parameter + Dispatchable<Origin=<Self as Trait<I>>::Origin> + Benchmark;
 
 	/// The outer event type.
 	type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -108,7 +108,7 @@ pub use crate::exec::{ExecResult, ExecReturnValue, ExecError, StatusCode};
 
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
-use sp_core::crypto::UncheckedFrom;
+use sp_core::{crypto::UncheckedFrom, Benchmark};
 use sp_std::{prelude::*, marker::PhantomData, fmt::Debug};
 use codec::{Codec, Encode, Decode};
 use sp_io::hashing::blake2_256;
@@ -122,7 +122,7 @@ use sp_runtime::{
 use frame_support::dispatch::{DispatchResult, Dispatchable};
 use frame_support::{
 	Parameter, decl_module, decl_event, decl_storage, decl_error, storage::child,
-	parameter_types, IsSubType,
+	parameter_types, IsSubType, Benchmark,
 	weights::DispatchInfo,
 };
 use frame_support::traits::{OnReapAccount, OnUnbalanced, Currency, Get, Time, Randomness};
@@ -977,7 +977,7 @@ impl<T: Trait> Config<T> {
 
 /// Definition of the cost schedule and other parameterizations for wasm vm.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug)]
+#[derive(Clone, Encode, Decode, PartialEq, Eq, RuntimeDebug, Benchmark)]
 pub struct Schedule {
 	/// Version of the schedule.
 	pub version: u32,

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
@@ -29,5 +30,6 @@ std = [
 	"sp-io/std",
 	"frame-support/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-system/std",
 ]

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -24,10 +24,11 @@ use sp_runtime::{
 	RuntimeDebug, DispatchResult,
 	traits::{Zero, Bounded, CheckedMul, CheckedDiv, EnsureOrigin, Hash, Dispatchable, Saturating},
 };
+use sp_core::Benchmark;
 use codec::{Ref, Encode, Decode, Input, Output};
 use frame_support::{
 	decl_module, decl_storage, decl_event, decl_error, ensure, Parameter,
-	weights::SimpleDispatchInfo,
+	weights::SimpleDispatchInfo, Benchmark,
 	traits::{
 		Currency, ReservableCurrency, LockableCurrency, WithdrawReason, LockIdentifier, Get,
 		OnReapAccount, OnUnbalanced, BalanceStatus
@@ -47,7 +48,7 @@ pub type PropIndex = u32;
 pub type ReferendumIndex = u32;
 
 /// A value denoting the strength of conviction of a vote.
-#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, RuntimeDebug, Benchmark)]
 pub enum Conviction {
 	/// 0.1x votes, unlocked.
 	None,
@@ -146,7 +147,7 @@ impl Bounded for Conviction {
 const MAX_RECURSION_LIMIT: u32 = 16;
 
 /// A number of lock periods, plus a vote, one way or the other.
-#[derive(Copy, Clone, Eq, PartialEq, Default, RuntimeDebug)]
+#[derive(Copy, Clone, Eq, PartialEq, Default, RuntimeDebug, Benchmark)]
 pub struct Vote {
 	pub aye: bool,
 	pub conviction: Conviction,

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-phragmen = { version = "2.0.0", default-features = false, path = "../../primitives/phragmen" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
@@ -27,6 +28,7 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"sp-phragmen/std",
 	"frame-system/std",
 	"sp-std/std",

--- a/frame/generic-asset/Cargo.toml
+++ b/frame/generic-asset/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
@@ -24,6 +25,7 @@ std =[
     "codec/std",
     "sp-std/std",
     "sp-runtime/std",
+    "sp-core/std",
     "frame-support/std",
     "frame-system/std",
 ]

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -11,6 +11,7 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 enumflags2 = { version = "0.6.2" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
@@ -27,6 +28,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -69,10 +69,11 @@ use sp_std::prelude::*;
 use sp_std::{fmt::Debug, ops::Add, iter::once};
 use enumflags2::BitFlags;
 use codec::{Encode, Decode};
+use sp_core::Benchmark;
 use sp_runtime::{DispatchResult, RuntimeDebug};
 use sp_runtime::traits::{StaticLookup, EnsureOrigin, Zero, AppendZerosInput};
 use frame_support::{
-	decl_module, decl_event, decl_storage, ensure, decl_error,
+	decl_module, decl_event, decl_storage, ensure, decl_error, Benchmark,
 	traits::{Currency, ReservableCurrency, OnUnbalanced, Get, BalanceStatus},
 	weights::SimpleDispatchInfo,
 };
@@ -122,7 +123,7 @@ pub trait Trait: frame_system::Trait {
 /// than 32-bytes then it will be truncated when encoding.
 ///
 /// Can also be `None`.
-#[derive(Clone, Eq, PartialEq, RuntimeDebug)]
+#[derive(Clone, Eq, PartialEq, RuntimeDebug, Benchmark)]
 pub enum Data {
 	/// No data here.
 	None,
@@ -220,6 +221,18 @@ pub enum Judgement<
 
 impl<
 	Balance: Encode + Decode + Copy + Clone + Debug + Eq + PartialEq
+> Default for Judgement<Balance> {
+	fn default() -> Self {
+		Self::Unknown
+	}
+}
+
+impl<
+	Balance: Encode + Decode + Copy + Clone + Debug + Eq + PartialEq
+> Benchmark for Judgement<Balance> {}
+
+impl<
+	Balance: Encode + Decode + Copy + Clone + Debug + Eq + PartialEq
 > Judgement<Balance> {
 	/// Returns `true` if this judgement is indicative of a deposit being currently held. This means
 	/// it should not be cleared or replaced except by an operation which utilizes the deposit.
@@ -260,6 +273,7 @@ pub enum IdentityField {
 #[derive(Clone, Copy, PartialEq, Default, RuntimeDebug)]
 pub struct IdentityFields(BitFlags<IdentityField>);
 
+impl Benchmark for IdentityFields {}
 impl Eq for IdentityFields {}
 impl Encode for IdentityFields {
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
@@ -277,7 +291,7 @@ impl Decode for IdentityFields {
 ///
 /// NOTE: This should be stored at the end of the storage item to facilitate the addition of extra
 /// fields in a backwards compatible way through a specialized `Decode` impl.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug)]
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, Benchmark)]
 #[cfg_attr(test, derive(Default))]
 pub struct IdentityInfo {
 	/// Additional fields of the identity that are not catered for with the struct's explicit
@@ -364,10 +378,10 @@ impl<
 }
 
 /// Information concerning a registrar.
-#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug)]
+#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, Default, Benchmark)]
 pub struct RegistrarInfo<
-	Balance: Encode + Decode + Clone + Debug + Eq + PartialEq,
-	AccountId: Encode + Decode + Clone + Debug + Eq + PartialEq
+	Balance: Encode + Decode + Clone + Debug + Eq + PartialEq + Default,
+	AccountId: Encode + Decode + Clone + Debug + Eq + PartialEq + Default
 > {
 	/// The account of the registrar.
 	pub account: AccountId,

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -72,7 +72,7 @@ mod tests;
 
 use sp_application_crypto::RuntimeAppPublic;
 use codec::{Encode, Decode};
-use sp_core::offchain::OpaqueNetworkState;
+use sp_core::{offchain::OpaqueNetworkState, Benchmark};
 use sp_std::prelude::*;
 use sp_std::convert::TryInto;
 use pallet_session::historical::IdentificationTuple;
@@ -203,7 +203,7 @@ impl<BlockNumber: sp_std::fmt::Debug> sp_std::fmt::Debug for OffchainErr<BlockNu
 pub type AuthIndex = u32;
 
 /// Heartbeat which is sent/received.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug, Default)]
 pub struct Heartbeat<BlockNumber>
 	where BlockNumber: PartialEq + Eq + Decode + Encode,
 {
@@ -216,6 +216,8 @@ pub struct Heartbeat<BlockNumber>
 	/// An index of the authority on the list of validators.
 	pub authority_index: AuthIndex,
 }
+
+impl<BlockNumber: Default + PartialEq + Eq + Decode + Encode> Benchmark for Heartbeat<BlockNumber> {}
 
 pub trait Trait: frame_system::Trait + pallet_session::historical::Trait {
 	/// The identifier type for an authority.

--- a/frame/indices/src/address.rs
+++ b/frame/indices/src/address.rs
@@ -19,6 +19,7 @@
 #[cfg(feature = "std")]
 use std::fmt;
 use sp_std::convert::TryInto;
+use sp_core::Benchmark;
 use crate::Member;
 use codec::{Encode, Decode, Input, Output, Error};
 
@@ -34,6 +35,15 @@ pub enum Address<AccountId, AccountIndex> where
 	Id(AccountId),
 	/// It's an account index.
 	Index(AccountIndex),
+}
+
+impl<AccountId, AccountIndex> Benchmark for Address<AccountId, AccountIndex> where
+	AccountId: Member + Benchmark,
+	AccountIndex: Member + Benchmark,
+{
+	fn value(name: &[u8], index: u32) -> Self {
+		Address::Id(AccountId::value(name, index))
+	}
 }
 
 #[cfg(feature = "std")]

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -21,8 +21,9 @@
 
 use sp_std::prelude::*;
 use codec::Codec;
+use sp_core::Benchmark;
 use sp_runtime::traits::{
-	StaticLookup, Member, LookupError, Zero, One, BlakeTwo256, Hash, Saturating, AtLeast32Bit
+	StaticLookup, Member, LookupError, Zero, One, BlakeTwo256, Hash, Saturating, AtLeast32Bit,
 };
 use frame_support::{Parameter, decl_module, decl_error, decl_event, decl_storage, ensure};
 use frame_support::dispatch::DispatchResult;
@@ -42,7 +43,7 @@ type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trai
 pub trait Trait: frame_system::Trait {
 	/// Type used for storing an account's index; implies the maximum number of accounts the system
 	/// can hold.
-	type AccountIndex: Parameter + Member + Codec + Default + AtLeast32Bit + Copy;
+	type AccountIndex: Parameter + Member + Codec + Default + AtLeast32Bit + Copy + Benchmark;
 
 	/// The currency trait.
 	type Currency: ReservableCurrency<Self::AccountId>;

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -11,6 +11,7 @@ codec = { package = "parity-scale-codec", version = "1.0.0", default-features = 
 enumflags2 = { version = "0.6.2" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
@@ -27,6 +28,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -155,6 +155,7 @@ use sp_runtime::{
 	traits::{Dispatchable, SaturatedConversion, CheckedAdd, CheckedMul},
 	DispatchResult
 };
+use sp_core::Benchmark;
 use codec::{Encode, Decode};
 
 use frame_support::{
@@ -182,7 +183,7 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// The overarching call type.
-	type Call: Parameter + Dispatchable<Origin=Self::Origin> + GetDispatchInfo;
+	type Call: Parameter + Dispatchable<Origin=Self::Origin> + GetDispatchInfo + Benchmark;
 
 	/// The currency mechanism.
 	type Currency: ReservableCurrency<Self::AccountId>;

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
@@ -25,6 +26,7 @@ std = [
 	"serde",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"sp-std/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -101,6 +101,7 @@ use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
 	traits::{EnsureOrigin, AtLeast32Bit, MaybeSerializeDeserialize, Zero, StaticLookup},
 };
+use sp_core::Benchmark;
 
 type BalanceOf<T, I> = <<T as Trait<I>>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 type PoolT<T, I> = Vec<(<T as frame_system::Trait>::AccountId, Option<<T as Trait<I>>::Score>)>;
@@ -121,7 +122,7 @@ pub trait Trait<I=DefaultInstance>: frame_system::Trait {
 
 	/// The score attributed to a member or candidate.
 	type Score:
-		AtLeast32Bit + Clone + Copy + Default + FullCodec + MaybeSerializeDeserialize + Debug;
+		AtLeast32Bit + Clone + Copy + Default + FullCodec + MaybeSerializeDeserialize + Debug + Benchmark;
 
 	/// The overarching event type.
 	type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "2.0.0", default-features = false, path = "../../primitives/staking" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -104,9 +104,13 @@ use codec::Decode;
 use sp_runtime::{KeyTypeId, Perbill, RuntimeAppPublic, BoundToRuntimeAppPublic};
 use frame_support::weights::SimpleDispatchInfo;
 use sp_runtime::traits::{Convert, Zero, Member, OpaqueKeys};
+use sp_core::Benchmark;
 use sp_staking::SessionIndex;
 use frame_support::{dispatch, ConsensusEngineId, decl_module, decl_event, decl_storage, decl_error};
-use frame_support::{ensure, traits::{OnReapAccount, Get, FindAuthor, ValidatorRegistration}, Parameter};
+use frame_support::{
+	ensure, Parameter,
+	traits::{OnReapAccount, Get, FindAuthor, ValidatorRegistration},
+};
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
@@ -325,7 +329,7 @@ pub trait Trait: frame_system::Trait {
 	type SessionHandler: SessionHandler<Self::ValidatorId>;
 
 	/// The keys.
-	type Keys: OpaqueKeys + Member + Parameter + Default;
+	type Keys: OpaqueKeys + Member + Parameter + Default + Benchmark;
 
 	/// The fraction of validators set that is safe to be disabled.
 	///

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0"
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-io ={ path = "../../primitives/io", default-features = false }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
@@ -26,6 +27,7 @@ std = [
 	"serde",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"rand_chacha/std",
 	"sp-std/std",
 	"frame-support/std",

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -259,7 +259,8 @@ use sp_runtime::{Percent, ModuleId, RuntimeDebug,
 		TrailingZeroInput, CheckedSub, EnsureOrigin
 	}
 };
-use frame_support::{decl_error, decl_module, decl_storage, decl_event, ensure, dispatch::DispatchResult};
+use sp_core::Benchmark;
+use frame_support::{decl_error, decl_module, decl_storage, decl_event, ensure, dispatch::DispatchResult, Benchmark};
 use frame_support::weights::SimpleDispatchInfo;
 use frame_support::traits::{
 	Currency, ReservableCurrency, Randomness, Get, ChangeMembers, BalanceStatus,
@@ -327,7 +328,7 @@ pub enum Vote {
 }
 
 /// A judgement by the suspension judgement origin on a suspended candidate.
-#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug)]
+#[derive(Encode, Decode, Copy, Clone, PartialEq, Eq, RuntimeDebug, Benchmark)]
 pub enum Judgement {
 	/// The suspension judgement origin takes no direct judgment
 	/// and places the candidate back into the bid pool.
@@ -336,6 +337,12 @@ pub enum Judgement {
 	Reject,
 	/// The suspension judgement origin approves of the candidate's application.
 	Approve,
+}
+
+impl Default for Judgement {
+	fn default() -> Self {
+		Self::Approve
+	}
 }
 
 /// Details of a payout given as a per-block linear "trickle".

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -12,6 +12,7 @@ sp-keyring = { version = "2.0.0", optional = true, path = "../../primitives/keyr
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-phragmen = { version = "2.0.0", default-features = false, path = "../../primitives/phragmen" }
 sp-io ={ path = "../../primitives/io", default-features = false }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "2.0.0", default-features = false, path = "../../primitives/staking" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
@@ -37,6 +38,7 @@ std = [
 	"sp-phragmen/std",
 	"sp-io/std",
 	"frame-support/std",
+	"sp-core/std",
 	"sp-runtime/std",
 	"sp-staking/std",
 	"pallet-session/std",

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -282,7 +282,8 @@ use sp_runtime::{Serialize, Deserialize};
 use frame_system::{self as system, ensure_signed, ensure_root};
 
 use sp_phragmen::ExtendedBalance;
-use frame_support::traits::OnReapAccount;
+use sp_core::Benchmark;
+use frame_support::{traits::OnReapAccount, Benchmark};
 
 const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
 const MAX_NOMINATIONS: usize = 16;
@@ -330,7 +331,7 @@ pub enum StakerStatus<AccountId> {
 }
 
 /// A destination account for payment.
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug)]
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, RuntimeDebug, Benchmark)]
 pub enum RewardDestination {
 	/// Pay into the stash account, increasing the amount at stake accordingly.
 	Staked,
@@ -347,7 +348,7 @@ impl Default for RewardDestination {
 }
 
 /// Preference of what happens regarding validation.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, Benchmark)]
 pub struct ValidatorPrefs {
 	/// Reward that validator takes up-front; only the rest is split between themselves and
 	/// nominators.

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
@@ -25,6 +26,7 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"frame-system/std",
 ]

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -87,7 +87,7 @@
 
 use sp_std::prelude::*;
 use sp_runtime::{traits::{StaticLookup, Dispatchable}, DispatchError};
-
+use sp_core::Benchmark;
 use frame_support::{
 	Parameter, decl_module, decl_event, decl_storage, decl_error, ensure,
 	weights::SimpleDispatchInfo,
@@ -99,7 +99,7 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// A sudo-able call.
-	type Proposal: Parameter + Dispatchable<Origin=Self::Origin>;
+	type Proposal: Parameter + Dispatchable<Origin=Self::Origin> + Benchmark;
 }
 
 decl_module! {

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -306,3 +306,29 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 pub fn construct_runtime(input: TokenStream) -> TokenStream {
 	construct_runtime::construct_runtime(input)
 }
+
+
+use quote::quote;
+use syn;
+
+#[proc_macro_derive(Benchmark)]
+pub fn benchmark_derive(input: TokenStream) -> TokenStream {
+    // Construct syntax tree.
+    let ast = syn::parse(input).expect("failed to parse input in benchmark derive");
+
+    // Build the trait implementation.
+    impl_benchmark_macro(&ast)
+}
+
+fn impl_benchmark_macro(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let gen = quote! {
+        impl #impl_generics Benchmark for #name #ty_generics #where_clause {
+            fn value(name: &[u8], index: u32) -> Self {
+                Default::default()
+            }
+        }
+    };
+    gen.into()
+}

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -144,7 +144,7 @@ macro_rules! ord_parameter_types {
 }
 
 #[doc(inline)]
-pub use frame_support_procedural::{decl_storage, construct_runtime};
+pub use frame_support_procedural::{decl_storage, construct_runtime, Benchmark};
 
 /// Return Err of the expression: `return Err($expression);`.
 ///

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -20,7 +20,7 @@
 
 use sp_std::{prelude::*, result, marker::PhantomData, ops::Div, fmt::Debug};
 use codec::{FullCodec, Codec, Encode, Decode};
-use sp_core::u32_trait::Value as U32;
+use sp_core::{u32_trait::Value as U32, Benchmark};
 use sp_runtime::{
 	RuntimeDebug,
 	ConsensusEngineId, DispatchResult, DispatchError,
@@ -444,7 +444,7 @@ impl<
 /// Abstraction over a fungible assets system.
 pub trait Currency<AccountId> {
 	/// The balance of an account.
-	type Balance: AtLeast32Bit + FullCodec + Copy + MaybeSerializeDeserialize + Debug + Default;
+	type Balance: AtLeast32Bit + FullCodec + Copy + MaybeSerializeDeserialize + Debug + Default + Benchmark;
 
 	/// The opaque token type for an imbalance. This is returned by unbalanced operations
 	/// and must be dealt with. It may be dropped but cannot be cloned.
@@ -942,6 +942,8 @@ pub struct CallMetadata {
 
 /// Gets the function name of the Call.
 pub trait GetCallName {
+	/// Return a call in this module.
+	fn get_call(function: &str, inputs: Vec<u32>) -> Self;
 	/// Return all function names.
 	fn get_call_names() -> &'static [&'static str];
 	/// Return the function name of the Call.
@@ -950,6 +952,8 @@ pub trait GetCallName {
 
 /// Gets the metadata for the Call - function name and pallet name.
 pub trait GetCallMetadata {
+	/// Return a call.
+	fn get_call(module: &str, function: &str, inputs: Vec<u32>) -> Self;
 	/// Return all module names.
 	fn get_module_names() -> &'static [&'static str];
 	/// Return all function names for the given `module`.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -110,7 +110,7 @@ use sp_runtime::{
 	},
 };
 
-use sp_core::{ChangesTrieConfiguration, storage::well_known_keys};
+use sp_core::{ChangesTrieConfiguration, storage::well_known_keys, Benchmark};
 use frame_support::{
 	decl_module, decl_event, decl_storage, decl_error, storage, Parameter,
 	traits::{
@@ -154,12 +154,12 @@ pub trait Trait: 'static + Eq + Clone {
 
 	/// The block number type used by the runtime.
 	type BlockNumber:
-		Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + AtLeast32Bit
+		Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + AtLeast32Bit + Benchmark
 		+ Default + Bounded + Copy + sp_std::hash::Hash + sp_std::str::FromStr + MaybeMallocSizeOf;
 
 	/// The output of the `Hashing` function.
 	type Hash:
-		Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + SimpleBitOps + Ord
+		Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + SimpleBitOps + Ord + Benchmark
 		+ Default + Copy + CheckEqual + sp_std::hash::Hash + AsRef<[u8]> + AsMut<[u8]> + MaybeMallocSizeOf;
 
 	/// The hashing system (algorithm) being used in the runtime (e.g. Blake2).
@@ -167,7 +167,7 @@ pub trait Trait: 'static + Eq + Clone {
 
 	/// The user account identifier type for the runtime.
 	type AccountId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord
-		+ Default;
+		+ Default + Benchmark;
 
 	/// Converting trait to take a source type and convert to `AccountId`.
 	///
@@ -178,7 +178,7 @@ pub trait Trait: 'static + Eq + Clone {
 	type Lookup: StaticLookup<Target = Self::AccountId>;
 
 	/// The block header.
-	type Header: Parameter + traits::Header<
+	type Header: Parameter + Benchmark + traits::Header<
 		Number = Self::BlockNumber,
 		Hash = Self::Hash,
 	>;

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
@@ -28,6 +29,7 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
+	"sp-core/std",
 	"frame-support/std",
 	"serde",
 	"frame-system/std",

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -98,10 +98,9 @@ use frame_support::{Parameter, decl_storage, decl_module};
 use frame_support::traits::{Time, Get};
 use sp_runtime::{
 	RuntimeString,
-	traits::{
-		AtLeast32Bit, Zero, SaturatedConversion, Scale
-	}
+	traits::{AtLeast32Bit, Zero, SaturatedConversion, Scale}
 };
+use sp_core::Benchmark;
 use frame_support::weights::SimpleDispatchInfo;
 use frame_system::ensure_none;
 use sp_timestamp::{
@@ -112,7 +111,7 @@ use sp_timestamp::{
 /// The module configuration trait
 pub trait Trait: frame_system::Trait {
 	/// Type used for expressing timestamp.
-	type Moment: Parameter + Default + AtLeast32Bit
+	type Moment: Parameter + Default + AtLeast32Bit + Benchmark
 		+ Scale<Self::BlockNumber, Output = Self::Moment> + Copy;
 
 	/// Something which can be notified when the timestamp is set. Set this to `()` if not needed.

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -63,14 +63,15 @@
 
 use sp_std::prelude::*;
 use codec::{Encode, Decode};
-use sp_core::TypeId;
+use sp_core::{TypeId, Benchmark};
 use sp_io::hashing::blake2_256;
 use frame_support::{decl_module, decl_event, decl_error, decl_storage, Parameter, ensure, RuntimeDebug};
-use frame_support::{traits::{Get, ReservableCurrency, Currency}, weights::{
-	GetDispatchInfo, ClassifyDispatch, WeighData, Weight, DispatchClass, PaysFee
-}};
+use frame_support::{
+	traits::{Get, ReservableCurrency, Currency},
+	weights::{GetDispatchInfo, ClassifyDispatch, WeighData, Weight, DispatchClass, PaysFee},
+};
 use frame_system::{self as system, ensure_signed};
-use sp_runtime::{DispatchError, DispatchResult, traits::Dispatchable};
+use sp_runtime::{DispatchError, DispatchResult, traits::{Dispatchable}};
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 
@@ -80,7 +81,7 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// The overarching call type.
-	type Call: Parameter + Dispatchable<Origin=Self::Origin> + GetDispatchInfo;
+	type Call: Parameter + Dispatchable<Origin=Self::Origin> + GetDispatchInfo + Benchmark;
 
 	/// The currency mechanism.
 	type Currency: ReservableCurrency<Self::AccountId>;
@@ -110,6 +111,8 @@ pub struct Timepoint<BlockNumber> {
 	/// The index of the extrinsic at the point in time.
 	index: u32,
 }
+
+impl<BlockNumber: Default> Benchmark for Timepoint<BlockNumber> {}
 
 /// An open multisig operation.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default, RuntimeDebug)]
@@ -166,7 +169,7 @@ decl_event! {
 	/// Events type.
 	pub enum Event<T> where
 		AccountId = <T as system::Trait>::AccountId,
-		BlockNumber = <T as system::Trait>::BlockNumber
+		BlockNumber = <T as system::Trait>::BlockNumber,
 	{
 		/// Batch of dispatches did not complete fully. Index of first failing dispatch given, as
 		/// well as the error.

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -25,7 +25,7 @@ pub use sp_core::{self, crypto::{CryptoType, Public, Derive, IsWrappedBy, Wraps}
 #[doc(hidden)]
 #[cfg(feature = "full_crypto")]
 pub use sp_core::crypto::{SecretStringError, DeriveJunction, Ss58Codec, Pair};
-pub use sp_core::{crypto::{KeyTypeId, key_types}};
+pub use sp_core::{crypto::{KeyTypeId, key_types}, Benchmark};
 
 #[doc(hidden)]
 pub use codec;
@@ -331,6 +331,8 @@ macro_rules! app_crypto_signature_full_crypto {
 			type Pair = Pair;
 		}
 
+		impl $crate::Benchmark for Signature {}
+
 		impl $crate::AppKey for Signature {
 			type UntypedGeneric = $sig;
 			type Public = Public;
@@ -359,6 +361,8 @@ macro_rules! app_crypto_signature_not_full_crypto {
 		}
 
 		impl $crate::CryptoType for Signature {}
+
+		impl $crate::Benchmark for Signature {}
 
 		impl $crate::AppKey for Signature {
 			type UntypedGeneric = $sig;

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -18,6 +18,7 @@
 use sp_core::crypto::Pair;
 
 use codec::Codec;
+use sp_core::Benchmark;
 use sp_core::crypto::{KeyTypeId, CryptoType, IsWrappedBy, Public};
 use sp_std::{fmt::Debug, vec::Vec};
 
@@ -117,7 +118,7 @@ pub trait RuntimeAppPublic: Sized {
 	const ID: KeyTypeId;
 
 	/// The signature that will be generated when signing with the corresponding private key.
-	type Signature: Codec + Debug + MaybeHash + Eq + PartialEq + Clone;
+	type Signature: Codec + Debug + MaybeHash + Eq + PartialEq + Clone + Benchmark;
 
 	/// Returns all public keys for this application in the keystore.
 	fn all() -> crate::Vec<Self>;

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -51,6 +51,7 @@ pub use impl_serde::serialize as bytes;
 pub mod hashing;
 #[cfg(feature = "full_crypto")]
 pub use hashing::{blake2_128, blake2_256, twox_64, twox_128, twox_256, keccak_256};
+
 #[cfg(feature = "std")]
 pub mod hexdisplay;
 pub mod crypto;
@@ -75,6 +76,7 @@ pub use self::uint::U256;
 pub use changes_trie::{ChangesTrieConfiguration, ChangesTrieConfigurationRange};
 #[cfg(feature = "full_crypto")]
 pub use crypto::{DeriveJunction, Pair, Public};
+use crypto::AccountId32;
 
 pub use hash_db::Hasher;
 // Switch back to Blake after PoC-3 is out
@@ -346,3 +348,36 @@ macro_rules! impl_maybe_marker {
 		)+
 	}
 }
+
+/// Abtract types for benchmarking purposes.
+pub trait Benchmark: Default {
+	/// Get a simple value for benchmarking.
+	fn value(_name: &[u8], _index: u32) -> Self {
+		Default::default()
+	}
+}
+
+impl Benchmark for bool {}
+impl Benchmark for u8 {}
+impl Benchmark for [u8; 32] {}
+impl Benchmark for u16 {}
+impl Benchmark for u32 {}
+impl Benchmark for u64 {}
+impl Benchmark for u128 {}
+impl Benchmark for i32 {}
+impl Benchmark for () {}
+impl Benchmark for H160 {}
+impl Benchmark for H256 {}
+impl Benchmark for U256 {}
+impl Benchmark for ChangesTrieConfiguration {}
+impl Benchmark for AccountId32 {
+	#[cfg(feature = "full_crypto")]
+	fn value(name: &[u8], index: u32) -> Self {
+		let entropy = (name, index).using_encoded(blake2_256);
+		Self::decode(&mut &entropy[..]).unwrap_or_default()
+	}
+}
+impl<A: Benchmark, B: Benchmark> Benchmark for (A, B) {}
+impl<T: Benchmark> Benchmark for Vec<T> {}
+impl<T: Benchmark> Benchmark for Option<T> {}
+impl<T: Benchmark> Benchmark for Box<T> {}

--- a/primitives/core/src/offchain/mod.rs
+++ b/primitives/core/src/offchain/mod.rs
@@ -174,8 +174,7 @@ impl TryFrom<u32> for HttpRequestStatus {
 
 /// A blob to hold information about the local node's network state
 /// without committing to its format.
-#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, PassByCodec)]
-#[cfg_attr(feature = "std", derive(Default))]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, PassByCodec, Default)]
 pub struct OpaqueNetworkState {
 	/// PeerId of the local node.
 	pub peer_id: OpaquePeerId,

--- a/primitives/runtime/src/generic/header.rs
+++ b/primitives/runtime/src/generic/header.rs
@@ -25,14 +25,14 @@ use crate::traits::{
 	MaybeMallocSizeOf,
 };
 use crate::generic::Digest;
-use sp_core::U256;
+use sp_core::{U256, Benchmark};
 use sp_std::{
 	convert::TryFrom,
 	fmt::Debug,
 };
 
 /// Abstraction over a block header for a substrate chain.
-#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug)]
+#[derive(PartialEq, Eq, Clone, sp_core::RuntimeDebug, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "std", serde(deny_unknown_fields))]
@@ -51,6 +51,8 @@ pub struct Header<Number: Copy + Into<U256> + TryFrom<U256>, Hash: HashT> {
 	/// A chain-specific digest of data useful for light clients or referencing auxiliary data.
 	pub digest: Digest<Hash::Output>,
 }
+
+impl<Number: Copy + Default + Into<U256> + TryFrom<U256>, Hash: HashT + Default> Benchmark for Header<Number, Hash> {}
 
 #[cfg(feature = "std")]
 impl<Number, Hash> parity_util_mem::MallocSizeOf for Header<Number, Hash>

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -25,7 +25,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize, de::DeserializeOwned};
-use sp_core::{self, Hasher, Blake2Hasher, TypeId, RuntimeDebug};
+use sp_core::{self, Hasher, Blake2Hasher, TypeId, RuntimeDebug, Benchmark};
 use crate::BenchmarkParameter;
 use crate::codec::{Codec, Encode, Decode};
 use crate::transaction_validity::{
@@ -190,7 +190,7 @@ pub trait Lookup {
 /// context.
 pub trait StaticLookup {
 	/// Type to lookup from.
-	type Source: Codec + Clone + PartialEq + Debug;
+	type Source: Codec + Clone + PartialEq + Debug + Benchmark;
 	/// Type to lookup into.
 	type Target;
 	/// Attempt a lookup.
@@ -202,7 +202,7 @@ pub trait StaticLookup {
 /// A lookup implementation returning the input value.
 #[derive(Default)]
 pub struct IdentityLookup<T>(PhantomData<T>);
-impl<T: Codec + Clone + PartialEq + Debug> StaticLookup for IdentityLookup<T> {
+impl<T: Codec + Clone + PartialEq + Debug + Benchmark> StaticLookup for IdentityLookup<T> {
 	type Source = T;
 	type Target = T;
 	fn lookup(x: T) -> Result<T, LookupError> { Ok(x) }
@@ -394,7 +394,7 @@ pub trait Hash: 'static + MaybeSerializeDeserialize + Debug + Clone + Eq + Parti
 }
 
 /// Blake2-256 Hash implementation.
-#[derive(PartialEq, Eq, Clone, RuntimeDebug)]
+#[derive(PartialEq, Eq, Clone, RuntimeDebug, Default)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct BlakeTwo256;
 
@@ -1386,6 +1386,8 @@ macro_rules! selected_benchmark {
 		}
 	};
 }
+
+impl Benchmark for BlakeTwo256 {}
 
 #[cfg(test)]
 mod tests {

--- a/primitives/std/src/lib.rs
+++ b/primitives/std/src/lib.rs
@@ -72,6 +72,7 @@ pub mod prelude {
 	pub use crate::boxed::Box;
 	pub use crate::cmp::{Eq, PartialEq, Reverse};
 	pub use crate::clone::Clone;
+	pub use crate::default::Default;
 
 	// Re-export `vec!` macro here, but not in `std` mode, since
 	// std's prelude already brings `vec!` into the scope.


### PR DESCRIPTION
**Summary**
There are many testing/benchmarking efforts, in order to reuse code for these purposes, I would like to abstract away each type used for extrinsic inputs with a trait `Benchmark` (or `BenchType`) . This also can facilitate in the near future to create blocks with mixed transactions.

This trait has a method: 
- `value(mode: &[u8], index: u32)`:  get a value using behavior `mode` of difficulty `index`. This one seems to match the way we are iterating over values in pallets benchmarks. 

**Example**
Instead of defining a function `account()` everywhere and use:
`let user = account("user", index);`
we can do:
`let user = <T::AccountId as Benchmark>::value(b"user", index);`

And for generating blocks with mixed transactions we can use:
`let extrinsic = Call::get_call(b"Balances", b"transfer", &[user]);`

**Done:**
- Implement `Default` for all extrinsic inputs.
- Implemented `Benchmark` trait to all extrinsic inputs, for now it's just using `Default`.
- Implemented custom `Benchmark::value()` for `AccountId`.
- Implemented `get_call(module, transaction, params)` (need to fix it a bit).

**Todo:**
- Custom implementation for other types?
- Improve custom derive?
- Feature gate it?

**Question**
I put this PR to discuss possible approaches or if it even makes sense such an effort.
