### PR TITLE
Remove direct yamux dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3721,9 +3721,9 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nohash-hasher"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a2bf1c26159ebf17e0a980bc4ce61f4b2fec5ec3b42d42fddd7a84a9e538f"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -6204,7 +6204,6 @@ dependencies = [
  "unsigned-varint",
  "void",
  "wasm-timer",
- "yamux",
  "zeroize 1.1.0",
 ]
 
@@ -9127,9 +9126,9 @@ checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 
 [[package]]
 name = "yamux"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902f4cee32c401c211b6b69f4a3f6f4cf3515644db5bd822cf685a7dbd6201f9"
+checksum = "d73295bc9d9acf89dd9336b3b5f5b57731ee72b587857dd4312721a0196b48e5"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -27,7 +27,7 @@ linked-hash-map = "0.5.2"
 linked_hash_set = "0.1.3"
 log = "0.4.8"
 lru = "0.4.0"
-nohash-hasher = "0.1.3"
+nohash-hasher = "0.2.0"
 parking_lot = "0.10.0"
 prost = "0.6.1"
 rand = "0.7.2"
@@ -54,7 +54,6 @@ thiserror = "1"
 unsigned-varint = { version = "0.3.0", features = ["futures-codec"] }
 void = "1.0.2"
 zeroize = "1.0.0"
-yamux = "0.4.2"
 
 [dev-dependencies]
 async-std = "1.5"

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -57,17 +57,14 @@ pub fn build_transport(
 	mplex_config.max_buffer_len_behaviour(mplex::MaxBufferBehaviour::Block);
 	mplex_config.max_buffer_len(usize::MAX);
 
-	let yamux_config = {
-		let mut c = yamux::Config::default();
-		// Only set SYN flag on first data frame sent to the remote.
-		c.set_lazy_open(true);
-		if use_yamux_flow_control {
-			// Enable proper flow-control: window updates are only sent when
-			// buffered data has been consumed.
-			c.set_window_update_mode(yamux::WindowUpdateMode::OnRead);
-		}
-		libp2p::yamux::Config::new(c)
-	};
+	let mut yamux_config = libp2p::yamux::Config::default();
+	yamux_config.set_lazy_open(true); // Only set SYN flag on first data frame sent to the remote.
+
+	if use_yamux_flow_control {
+		// Enable proper flow-control: window updates are only sent when
+		// buffered data has been consumed.
+		yamux_config.set_window_update_mode(libp2p::yamux::WindowUpdateMode::OnRead);
+	}
 
 	// Build the base layer of the transport.
 	let transport = if let Some(t) = wasm_external_transport {


### PR DESCRIPTION
libp2p-0.16 allows configuring yamux through libp2p-yamux, so the direct dependency is no longer needed.

While at it we also update to the latest versions of yamux and nohash-hasher, though the code changes do not depend on it.