### PR TITLE
fixes sc_transaction_pool::testing::fork_aware_finalization

### DIFF
--- a/client/transaction-pool/src/testing/pool.rs
+++ b/client/transaction-pool/src/testing/pool.rs
@@ -384,7 +384,7 @@ fn fork_aware_finalization() {
 	let mut canon_watchers = vec![];
 
 	let from_alice = uxt(Alice, 1);
-	let from_dave = uxt(Dave, 1);
+	let from_dave = uxt(Dave, 2);
 	let from_bob = uxt(Bob, 1);
 	let from_charlie = uxt(Charlie, 1);
 	pool.api.increment_nonce(Alice.into());
@@ -488,7 +488,7 @@ fn fork_aware_finalization() {
 
 	// block e1
 	{
-		let header = pool.api.push_block(5, vec![from_dave]);
+		let header = pool.api.push_block(5, vec![from_dave, from_bob]);
 		e1 = header.hash();
 		let event = ChainEvent::NewBlock {
 			id: BlockId::Hash(header.hash()),
@@ -515,15 +515,8 @@ fn fork_aware_finalization() {
 		assert_eq!(stream.next(), Some(TransactionStatus::Ready));
 		assert_eq!(stream.next(), Some(TransactionStatus::InBlock(c2.clone())));
 		assert_eq!(stream.next(), Some(TransactionStatus::Retracted(c2)));
-
-		// can be either Ready, or InBlock, depending on which event comes first
-		assert_eq!(
-			match stream.next() {
-				Some(TransactionStatus::Ready) => stream.next(),
-				val @ _ => val,
-			}, 
-			Some(TransactionStatus::InBlock(e1)),
-		);
+		assert_eq!(stream.next(), Some(TransactionStatus::Ready));
+		assert_eq!(stream.next(), Some(TransactionStatus::InBlock(e1)));
 		assert_eq!(stream.next(), Some(TransactionStatus::Finalized(e1.clone())));
 		assert_eq!(stream.next(), None);
 	}
@@ -533,6 +526,10 @@ fn fork_aware_finalization() {
 		assert_eq!(stream.next(), Some(TransactionStatus::Ready));
 		assert_eq!(stream.next(), Some(TransactionStatus::InBlock(d2.clone())));
 		assert_eq!(stream.next(), Some(TransactionStatus::Retracted(d2)));
+		assert_eq!(stream.next(), Some(TransactionStatus::Ready));
+		assert_eq!(stream.next(), Some(TransactionStatus::InBlock(e1)));
+		assert_eq!(stream.next(), Some(TransactionStatus::Finalized(e1.clone())));
+		assert_eq!(stream.next(), None);
 	}
 
 }

--- a/client/transaction-pool/src/testing/pool.rs
+++ b/client/transaction-pool/src/testing/pool.rs
@@ -405,6 +405,7 @@ fn fork_aware_finalization() {
 		let watcher = block_on(pool.submit_and_watch(&BlockId::number(1), from_alice.clone())).expect("1. Imported");
 		let header = pool.api.push_block(2, vec![from_alice.clone()]);
 		canon_watchers.push((watcher, header.hash()));
+		assert_eq!(pool.status().ready, 1);
 
 		let event = ChainEvent::NewBlock {
 			id: BlockId::Number(2),
@@ -414,6 +415,7 @@ fn fork_aware_finalization() {
 		};
 		b1 = header.hash();
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 0);
 		let event = ChainEvent::Finalized { hash: b1 };
 		block_on(pool.maintain(event));
 	}
@@ -423,6 +425,7 @@ fn fork_aware_finalization() {
 		let header = pool.api.push_fork_block_with_parent(b1, vec![from_dave.clone()]);
 		from_dave_watcher = block_on(pool.submit_and_watch(&BlockId::number(1), from_dave.clone()))
 			.expect("1. Imported");
+		assert_eq!(pool.status().ready, 1);
 		let event = ChainEvent::NewBlock {
 			id: BlockId::Hash(header.hash()),
 			is_new_best: true,
@@ -431,11 +434,13 @@ fn fork_aware_finalization() {
 		};
 		c2 = header.hash();
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 0);
 	}
 
 	// block D2
 	{
 		from_bob_watcher = block_on(pool.submit_and_watch(&BlockId::number(1), from_bob.clone())).expect("1. Imported");
+		assert_eq!(pool.status().ready, 1);
 		let header = pool.api.push_fork_block_with_parent(c2, vec![from_bob.clone()]);
 
 		let event = ChainEvent::NewBlock {
@@ -446,11 +451,13 @@ fn fork_aware_finalization() {
 		};
 		d2 = header.hash();
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 0);
 	}
 
 	// block C1
 	{
 		let watcher = block_on(pool.submit_and_watch(&BlockId::number(1), from_charlie.clone())).expect("1.Imported");
+		assert_eq!(pool.status().ready, 1);
 		let header = pool.api.push_block(3, vec![from_charlie.clone()]);
 
 		canon_watchers.push((watcher, header.hash()));
@@ -461,6 +468,7 @@ fn fork_aware_finalization() {
 			retracted: vec![c2, d2],
 		};
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 2);
 		let event = ChainEvent::Finalized { hash: header.hash() };
 		block_on(pool.maintain(event));
 	}
@@ -469,6 +477,7 @@ fn fork_aware_finalization() {
 	{
 		let xt = uxt(Eve, 0);
 		let w = block_on(pool.submit_and_watch(&BlockId::number(1), xt.clone())).expect("1. Imported");
+		assert_eq!(pool.status().ready, 3);
 		let header = pool.api.push_block(4, vec![xt.clone()]);
 		canon_watchers.push((w, header.hash()));
 
@@ -480,6 +489,7 @@ fn fork_aware_finalization() {
 		};
 		d1 = header.hash();
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 2);
 		let event = ChainEvent::Finalized { hash: d1 };
 		block_on(pool.maintain(event));
 	}
@@ -497,6 +507,7 @@ fn fork_aware_finalization() {
 			retracted: vec![]
 		};
 		block_on(pool.maintain(event));
+		assert_eq!(pool.status().ready, 0);
 		block_on(pool.maintain(ChainEvent::Finalized { hash: e1 }));
 	}
 


### PR DESCRIPTION
I discovered the tx `from_dave` sometimes never re-enters the pool, erroring with `PriorityTooLow`. Simply increasing the nonce got rid of the flakiness. :ok: