### PR TITLE
Added subscribe_all_heads RPC function

### DIFF
--- a/client/rpc-api/src/chain/mod.rs
+++ b/client/rpc-api/src/chain/mod.rs
@@ -54,6 +54,18 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 	#[rpc(name = "chain_getFinalizedHead", alias("chain_getFinalisedHead"))]
 	fn finalized_head(&self) -> Result<Hash>;
 
+	/// All head subscription
+	#[pubsub(subscription = "chain_allHead", subscribe, name = "chain_subscribeAllHeads")]
+	fn subscribe_all_heads(&self, metadata: Self::Metadata, subscriber: Subscriber<Header>);
+
+	/// Unsubscribe from all head subscription.
+	#[pubsub(subscription = "chain_allHead", unsubscribe, name = "chain_unsubscribeAllHeads")]
+	fn unsubscribe_all_heads(
+		&self,
+		metadata: Option<Self::Metadata>,
+		id: SubscriptionId,
+	) -> RpcResult<bool>;
+
 	/// New head subscription
 	#[pubsub(
 		subscription = "chain_newHead",
@@ -76,7 +88,7 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 		id: SubscriptionId,
 	) -> RpcResult<bool>;
 
-	/// New head subscription
+	/// Finalized head subscription
 	#[pubsub(
 		subscription = "chain_finalizedHead",
 		subscribe,
@@ -85,7 +97,7 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 	)]
 	fn subscribe_finalized_heads(&self, metadata: Self::Metadata, subscriber: Subscriber<Header>);
 
-	/// Unsubscribe from new head subscription.
+	/// Unsubscribe from finalized head subscription.
 	#[pubsub(
 		subscription = "chain_finalizedHead",
 		unsubscribe,

--- a/client/rpc/src/chain/tests.rs
+++ b/client/rpc/src/chain/tests.rs
@@ -217,6 +217,7 @@ fn should_notify_about_latest_block() {
 	// no more notifications on this channel
 	assert_eq!(core.block_on(next.into_future()).unwrap().0, None);
 }
+
 #[test]
 fn should_notify_about_best_block() {
 	let mut core = ::tokio::runtime::Runtime::new().unwrap();

--- a/client/rpc/src/chain/tests.rs
+++ b/client/rpc/src/chain/tests.rs
@@ -199,6 +199,34 @@ fn should_notify_about_latest_block() {
 		let mut client = Arc::new(substrate_test_runtime_client::new());
 		let api = new_full(client.clone(), Subscriptions::new(Arc::new(remote)));
 
+		api.subscribe_all_heads(Default::default(), subscriber);
+
+		// assert id assigned
+		assert_eq!(core.block_on(id), Ok(Ok(SubscriptionId::Number(1))));
+
+		let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
+		client.import(BlockOrigin::Own, block).unwrap();
+	}
+
+	// assert initial head sent.
+	let (notification, next) = core.block_on(transport.into_future()).unwrap();
+	assert!(notification.is_some());
+	// assert notification sent to transport
+	let (notification, next) = core.block_on(next.into_future()).unwrap();
+	assert!(notification.is_some());
+	// no more notifications on this channel
+	assert_eq!(core.block_on(next.into_future()).unwrap().0, None);
+}
+#[test]
+fn should_notify_about_best_block() {
+	let mut core = ::tokio::runtime::Runtime::new().unwrap();
+	let remote = core.executor();
+	let (subscriber, id, transport) = Subscriber::new_test("test");
+
+	{
+		let mut client = Arc::new(substrate_test_runtime_client::new());
+		let api = new_full(client.clone(), Subscriptions::new(Arc::new(remote)));
+
 		api.subscribe_new_heads(Default::default(), subscriber);
 
 		// assert id assigned


### PR DESCRIPTION
Added subscribe_all_heads RPC call, there was no way to get all blocks received by the node through RPC. This will help apps that analyze blockchain. I.E. Equivocation detection can now be done by apps connected to RPC. 

Also fixed updated comments and added test.

fixes #4738 