### PR TITLE
Re-export PeerId from the peerset API

### DIFF
--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -21,11 +21,12 @@ mod peersstate;
 
 use std::{collections::{HashSet, HashMap}, collections::VecDeque};
 use futures::{prelude::*, channel::mpsc};
-use libp2p::PeerId;
 use log::{debug, error, trace};
 use serde_json::json;
 use std::{pin::Pin, task::Context, task::Poll};
 use wasm_timer::Instant;
+
+pub use libp2p::PeerId;
 
 /// We don't accept nodes whose reputation is under this value.
 const BANNED_THRESHOLD: i32 = 82 * (i32::min_value() / 100);


### PR DESCRIPTION
Nothing important, but makes it so that one doesn't need to import `libp2p` in order to use `sc-peerset`.