### PR TITLE
`vesting_balance` returns `Option`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -81,7 +81,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 222,
+	spec_version: 223,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -734,7 +734,8 @@ pub trait VestingSchedule<AccountId> {
 	type Currency: Currency<AccountId>;
 
 	/// Get the amount that is currently being vested and cannot be transferred out of this account.
-	fn vesting_balance(who: &AccountId) -> <Self::Currency as Currency<AccountId>>::Balance;
+	/// Returns `None` if the account has no vesting schedule.
+	fn vesting_balance(who: &AccountId) -> Option<<Self::Currency as Currency<AccountId>>::Balance>;
 
 	/// Adds a vesting schedule to a given account.
 	///


### PR DESCRIPTION
This is a small improvement to the `vesting_balance` API, which now returns an `Option<Balance>` rather than just a balance.

The old api:

```rust
/// Get the amount that is currently being vested and cannot be transferred out of this account.
fn vesting_balance(who: &T::AccountId) -> BalanceOf<T> {
	if let Some(v) = Self::vesting(who) {
		let now = <frame_system::Module<T>>::block_number();
		let locked_now = v.locked_at::<T::BlockNumberToBalance>(now);
		T::Currency::free_balance(who).min(locked_now)
	} else {
		Zero::zero()
	}
}
```

If we observe the previous behavior, when a user did not have a vesting schedule, we would return `vesting_balance` of zero. We could _also_ return zero if the balance of the account is zero **even though** they may actually have some vesting schedule!

Then let us observe the logic in `add_vesting_schedule`:

```rust
/// Adds a vesting schedule to a given account.
///
/// If there already exists a vesting schedule for the given account, an `Err` is returned
/// and nothing is updated.
///
/// On success, a linearly reducing amount of funds will be locked. In order to realise any
/// reduction of the lock over time as it diminishes, the account owner must use `vest` or
/// `vest_other`.
///
/// Is a no-op if the amount to be vested is zero.
fn add_vesting_schedule(
	who: &T::AccountId,
	locked: BalanceOf<T>,
	per_block: BalanceOf<T>,
	starting_block: T::BlockNumber
) -> DispatchResult {
	if locked.is_zero() { return Ok(()) }
	if Vesting::<T>::contains_key(who) {
		Err(Error::<T>::ExistingVestingSchedule)?
	}
	let vesting_schedule = VestingInfo {
		locked,
		per_block,
		starting_block
	};
	Vesting::<T>::insert(who, vesting_schedule);
	// it can't fail, but even if somehow it did, we don't really care.
	let _ = Self::update_lock(who.clone());
	Ok(())
}
```

Here, this function will fail if `Vesting::<T>::contains_key(...)`.

Given the old API, there would be no way for an external caller to know whether an existing vesting schedule exists for a user. They could _assume_ that when the `vesting_balance` was zero, that there is no vesting schedule... but as we can see there is a condition where a vesting schedule exists and it would return 0.

The better solution here is just to return an Option, then the called would always be able to know for certain if a vesting schedule exists or not, and whether `add_vesting_schedule` will succeed or not.