### PR TITLE
Log kademlia errors when get/put record fails.

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -391,7 +391,14 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 
 								DiscoveryOut::ValueFound(results)
 							}
+							Err(e@libp2p::kad::GetRecordError::NotFound{..}) => {
+								trace!(target: "sub-libp2p",
+									"Libp2p => Failed to get record: {:?}", e);
+								DiscoveryOut::ValueNotFound(e.into_key())
+							}
 							Err(e) => {
+								warn!(target: "sub-libp2p",
+									"Libp2p => Failed to get record: {:?}", e);
 								DiscoveryOut::ValueNotFound(e.into_key())
 							}
 						};
@@ -401,6 +408,8 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 						let ev = match res {
 							Ok(ok) => DiscoveryOut::ValuePut(ok.key),
 							Err(e) => {
+								warn!(target: "sub-libp2p",
+									"Libp2p => Failed to put record: {:?}", e);
 								DiscoveryOut::ValuePutFailed(e.into_key())
 							}
 						};

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -391,7 +391,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 
 								DiscoveryOut::ValueFound(results)
 							}
-							Err(e@libp2p::kad::GetRecordError::NotFound{..}) => {
+							Err(e @ libp2p::kad::GetRecordError::NotFound { .. }) => {
 								trace!(target: "sub-libp2p",
 									"Libp2p => Failed to get record: {:?}", e);
 								DiscoveryOut::ValueNotFound(e.into_key())


### PR DESCRIPTION
The current approach makes it difficult to figure out what the underlying error was, that made the operation fail.
