### PR TITLE
utils/proemtheus/src/lib: Log info that Grafana is removed

### DIFF
--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -120,7 +120,8 @@ mod known_os {
 			.await
 			.map_err(|_| Error::PortInUse(prometheus_addr))?;
 
-		log::info!("Prometheus server started at {}", prometheus_addr);
+		log::info!("Prometheus server started at {}.", prometheus_addr);
+		log::info!("The Grafana endpoint has been removed in favor of the Prometheus endpoint.");
 
 		let service = make_service_fn(move |_| {
 			let registry = registry.clone();


### PR DESCRIPTION
Log an info line to the console that the Grafana metric endpoint has been
removed in favor of the Prometheus endpoint.

@gautamdhameja suggested to add this log line on startup for people that either
didn't read the changelog or that are running on newest `master`.

What do people think? Let me know if this is to verbose. Once the Prometheus
endpoint is reasonably well known within the community we can remove the log
line.
