### PR TITLE
Un-deprecate ValidateUnsigned

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 223,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 223,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -86,16 +86,15 @@ pub(super) fn secondary_slot_author(
 	Some(&expected_author.0)
 }
 
-#[allow(deprecated)]
 pub(super) fn make_transcript(
 	randomness: &[u8],
 	slot_number: u64,
 	epoch: u64,
 ) -> Transcript {
 	let mut transcript = Transcript::new(&BABE_ENGINE_ID);
-	transcript.commit_bytes(b"slot number", &slot_number.to_le_bytes());
-	transcript.commit_bytes(b"current epoch", &epoch.to_le_bytes());
-	transcript.commit_bytes(b"chain randomness", randomness);
+	transcript.append_message(b"slot number", &slot_number.to_le_bytes());
+	transcript.append_message(b"current epoch", &epoch.to_le_bytes());
+	transcript.append_message(b"chain randomness", randomness);
 	transcript
 }
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -60,9 +60,7 @@
 //! # pub type AllModules = u64;
 //! # pub enum Runtime {};
 //! # use sp_runtime::transaction_validity::{TransactionValidity, UnknownTransaction};
-//!	# #[allow(deprecated)]
 //! # use sp_runtime::traits::ValidateUnsigned;
-//!	# #[allow(deprecated)]
 //! # impl ValidateUnsigned for Runtime {
 //! # 	type Call = ();
 //! #
@@ -88,7 +86,6 @@ use sp_runtime::{
 	transaction_validity::TransactionValidity,
 };
 use sp_runtime::generic::CheckSignature;
-#[allow(deprecated)]
 use sp_runtime::traits::ValidateUnsigned;
 use codec::{Codec, Encode};
 use frame_system::{extrinsics_root, DigestOf};
@@ -107,7 +104,6 @@ pub struct Executive<System, Block, Context, UnsignedValidator, AllModules>(
 	PhantomData<(System, Block, Context, UnsignedValidator, AllModules)>
 );
 
-#[allow(deprecated)] // Allow ValidateUnsigned, remove the attribute when the trait is removed.
 impl<
 	System: frame_system::Trait,
 	Block: traits::Block<Header=System::Header, Hash=System::Hash>,
@@ -133,7 +129,6 @@ where
 	}
 }
 
-#[allow(deprecated)] // Allow ValidateUnsigned, remove the attribute when the trait is removed.
 impl<
 	System: frame_system::Trait,
 	Block: traits::Block<Header=System::Header, Hash=System::Hash>,
@@ -496,7 +491,6 @@ mod tests {
 	}
 	impl custom::Trait for Runtime {}
 
-	#[allow(deprecated)]
 	impl ValidateUnsigned for Runtime {
 		type Call = Call;
 

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -619,7 +619,6 @@ impl<T: Trait> pallet_session::OneSessionHandler<T::AccountId> for Module<T> {
 	}
 }
 
-#[allow(deprecated)]
 impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 	type Call = Call<T>;
 

--- a/frame/im-online/src/tests.rs
+++ b/frame/im-online/src/tests.rs
@@ -112,7 +112,6 @@ fn heartbeat(
 	authority_index: u32,
 	id: UintAuthorityId,
 ) -> dispatch::DispatchResult {
-	#[allow(deprecated)]
 	use frame_support::unsigned::ValidateUnsigned;
 
 	let heartbeat = Heartbeat {
@@ -126,7 +125,6 @@ fn heartbeat(
 	};
 	let signature = id.sign(&heartbeat.encode()).unwrap();
 
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	ImOnline::pre_dispatch(&crate::Call::heartbeat(heartbeat.clone(), signature.clone()))
 		.map_err(|e| <&'static str>::from(e))?;
 	ImOnline::heartbeat(

--- a/frame/support/src/unsigned.rs
+++ b/frame/support/src/unsigned.rs
@@ -15,7 +15,6 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 #[doc(hidden)]
-#[allow(deprecated)]
 pub use crate::sp_runtime::traits::ValidateUnsigned;
 #[doc(hidden)]
 pub use crate::sp_runtime::transaction_validity::{
@@ -66,7 +65,6 @@ macro_rules! impl_outer_validate_unsigned {
 			$( $module:ident )*
 		}
 	) => {
-		#[allow(deprecated)] // Allow ValidateUnsigned
 		impl $crate::unsigned::ValidateUnsigned for $runtime {
 			type Call = Call;
 
@@ -109,7 +107,6 @@ mod test_partial_and_full_call {
 	pub mod timestamp {
 		pub struct Module;
 
-		#[allow(deprecated)] // Allow ValidateUnsigned
 		impl super::super::ValidateUnsigned for Module {
 			type Call = Call;
 

--- a/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -20,7 +20,6 @@
 use crate::traits::{
 	self, Member, MaybeDisplay, SignedExtension, Dispatchable,
 };
-#[allow(deprecated)]
 use crate::traits::ValidateUnsigned;
 use crate::transaction_validity::TransactionValidity;
 
@@ -54,7 +53,6 @@ where
 		self.signed.as_ref().map(|x| &x.0)
 	}
 
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn validate<U: ValidateUnsigned<Call = Self::Call>>(
 		&self,
 		info: Self::DispatchInfo,
@@ -69,7 +67,6 @@ where
 		}
 	}
 
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn apply<U: ValidateUnsigned<Call=Self::Call>>(
 		self,
 		info: Self::DispatchInfo,

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -23,7 +23,6 @@ use crate::traits::{
 	self, Checkable, Applyable, BlakeTwo256, OpaqueKeys,
 	SignedExtension, Dispatchable,
 };
-#[allow(deprecated)]
 use crate::traits::ValidateUnsigned;
 use crate::{generic::{self, CheckSignature}, KeyTypeId, ApplyExtrinsicResult};
 pub use sp_core::{H256, sr25519};
@@ -418,7 +417,6 @@ impl<Origin, Call, Extra, Info> Applyable for TestXt<Call, Extra> where
 	fn sender(&self) -> Option<&Self::AccountId> { self.signature.as_ref().map(|x| &x.0) }
 
 	/// Checks to see if this is a valid *transaction*. It returns information on it if so.
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn validate<U: ValidateUnsigned<Call=Self::Call>>(
 		&self,
 		_info: Self::DispatchInfo,
@@ -429,7 +427,6 @@ impl<Origin, Call, Extra, Info> Applyable for TestXt<Call, Extra> where
 
 	/// Executes all necessary logic needed prior to dispatch and deconstructs into function call,
 	/// index and sender.
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn apply<U: ValidateUnsigned<Call=Self::Call>>(
 		self,
 		info: Self::DispatchInfo,

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -889,7 +889,6 @@ pub trait Applyable: Sized + Send + Sync {
 	fn sender(&self) -> Option<&Self::AccountId>;
 
 	/// Checks to see if this is a valid *transaction*. It returns information on it if so.
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn validate<V: ValidateUnsigned<Call=Self::Call>>(
 		&self,
 		info: Self::DispatchInfo,
@@ -898,7 +897,6 @@ pub trait Applyable: Sized + Send + Sync {
 
 	/// Executes all necessary logic needed prior to dispatch and deconstructs into function call,
 	/// index and sender.
-	#[allow(deprecated)] // Allow ValidateUnsigned
 	fn apply<V: ValidateUnsigned<Call=Self::Call>>(
 		self,
 		info: Self::DispatchInfo,
@@ -924,7 +922,6 @@ pub trait GetNodeBlockType {
 /// the transaction for the transaction pool.
 /// During block execution phase one need to perform the same checks anyway,
 /// since this function is not being called.
-#[deprecated(note = "Use SignedExtensions instead.")]
 pub trait ValidateUnsigned {
 	/// The call to validate
 	type Call;


### PR DESCRIPTION
Related #4419 and #3419 

Implementing unsigned validation via `SignedExtension` for a single pallet is a bit cumbersome currently. We're lacking some extra glue code to make it as easy as for `ValidateUnsigned`.

Because of this I'd like to propose to un-deprecate `ValidateUnsigned` for 2.0 release and possibly deprecating it only after (but as I said in #4419 I think it may end up useful anyway; I'm currently evaluating that).

Submitting this as a minimal PR so that it can later be reverted easily if needed.