### PR TITLE
Add gitlab job for publishing draft releases

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -524,7 +524,16 @@ publish-gh-doc:
   after_script:
     - rm -vrf ${HOME}/.gitconfig
 
-
+publish-draft-release:
+  stage:                           publish
+  image:                           parity/tools:latest
+  only:
+    - tags
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+  script:
+    - ./scripts/gitlab/publish_draft_release.sh
+  interruptible:                   true
+  allow_failure:                   true
 
 .deploy-template:                  &deploy
   stage:                           kubernetes

--- a/scripts/gitlab/lib.sh
+++ b/scripts/gitlab/lib.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+api_base="https://api.github.com/repos"
+
+# Function to take 2 git tags/commits and get any lines from commit messages
+# that contain something that looks like a PR reference: e.g., (#1234)
+sanitised_git_logs(){
+  git --no-pager log --pretty=format:"%s" "$1..$2" |
+  # Only find messages referencing a PR
+  grep -E '\(#[0-9]+\)' |
+  # Strip any asterisks
+  sed 's/^* //g' |
+  # And add them all back
+  sed 's/^/* /g'
+}
+
+# Checks whether a tag on github has been verified
+# repo: 'organization/repo'
+# tagver: 'v1.2.3'
+# Usage: check_tag $repo $tagver
+check_tag () {
+  repo=$1
+  tagver=$2
+  tag_out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/git/refs/tags/$tagver")
+  tag_sha=$(echo "$tag_out" | jq -r .object.sha)
+  object_url=$(echo "$tag_out" | jq -r .object.url)
+  if [ "$tag_sha" = "null" ]; then
+    return 2
+  fi
+  verified_str=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$object_url" | jq -r .verification.verified)
+  if [ "$verified_str" = "true" ]; then
+    # Verified, everything is good
+    return 0
+  else
+    # Not verified. Bad juju.
+    return 1
+  fi
+}
+
+# Checks whether a given PR has a given label.
+# repo: 'organization/repo'
+# pr_id: 12345
+# label: B1-silent
+# Usage: has_label $repo $pr_id $label
+has_label(){
+  repo="$1"
+  pr_id="$2"
+  label="$3"
+  out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/pulls/$pr_id")
+  [ -n "$(echo "$out" | jq ".labels | .[] | select(.name==\"$label\")")" ]
+}
+
+# Formats a message into a JSON string for posting to Matrix
+# message: 'any plaintext message'
+# formatted_message: '<strong>optional message formatted in <em>html</em></strong>' 
+# Usage: structure_message $content $formatted_content (optional)
+structure_message() {
+  if [ -z "$2" ]; then
+    body=$(jq -Rs --arg body "$1" '{"msgtype": "m.text", $body}' < /dev/null)
+  else
+    body=$(jq -Rs --arg body "$1" --arg formatted_body "$2" '{"msgtype": "m.text", $body, "format": "org.matrix.custom.html", $formatted_body}' < /dev/null)
+  fi
+  echo "$body"
+}
+
+# Post a message to a matrix room
+# body: '{body: "JSON string produced by structure_message"}'
+# room_id: !fsfSRjgjBWEWffws:matrix.parity.io
+# access_token: see https://matrix.org/docs/guides/client-server-api/
+# Usage: send_message $body (json formatted) $room_id $access_token
+send_message() {
+curl -XPOST -d "$1" "https://matrix.parity.io/_matrix/client/r0/rooms/$2/send/m.room.message?access_token=$3"
+}

--- a/scripts/gitlab/publish_draft_release.sh
+++ b/scripts/gitlab/publish_draft_release.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# shellcheck source=lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+
+# Substrate labels for PRs we want to include in the release notes
+labels=(
+  'B1-runtimenoteworthy'
+  'B1-clientnoteworthy'
+  'B1-apinoteworthy'
+)
+
+version="$CI_COMMIT_TAG"
+last_version=$(git tag -l | sort -V | grep -B 1 -x "$version" | head -n 1)
+echo "[+] Version: $version; Previous version: $last_version"
+
+# Check that a signed tag exists on github for this version
+echo '[+] Checking tag has been signed'
+#check_tag "paritytech/substrate" "$version"
+case $? in
+  0) echo '[+] Tag found and has been signed'
+    ;;
+  1) echo '[!] Tag found but has not been signed. Aborting release.'; exit 1
+    ;;
+  2) echo '[!] Tag not found. Aborting release.'; exit
+esac
+
+all_changes="$(sanitised_git_logs "$last_version" "$version")"
+labelled_changes=""
+echo "[+] Iterating through $(wc -l <<< "$all_changes") changes to find labelled PRs"
+while IFS= read -r line; do
+  pr_id=$(echo "$line" | sed -E 's/.*#([0-9]+)\)$/\1/')
+
+  # Skip if the PR has the silent label - this allows us to skip a few requests
+  if has_label 'paritytech/substrate' "$pr_id" 'B0-silent'; then
+    continue
+  fi
+  for label in "${labels[@]}"; do
+    if has_label 'paritytech/substrate' "$pr_id" "$label"; then
+      labelled_changes="$labelled_changes
+$line"
+    fi
+  done
+done <<< "$all_changes"
+
+
+release_text="Substrate $version
+-----------------
+$labelled_changes"
+
+echo "[+] Release text generated: "
+echo "$release_text"
+exit
+echo "[+] Pushing release to github"
+# Create release on github
+release_name="Substrate $version"
+data=$(jq -Rs --arg version "$version" \
+  --arg release_name "$release_name" \
+  --arg release_text "$release_text" \
+'{
+  "tag_name": $version,
+  "target_commitish": "master",
+  "name": $release_name,
+  "body": $release_text,
+  "draft": true,
+  "prerelease": false
+}' < /dev/null)
+
+out=$(curl -s -X POST --data "$data" -H "Authorization: token $GITHUB_RELEASE_TOKEN" "$api_base/paritytech/substrate/releases")
+
+html_url=$(echo "$out" | jq -r .html_url)
+
+if [ "$html_url" == "null" ]
+then
+  echo "[!] Something went wrong posting:"
+  echo "$out"
+else
+  echo "[+] Release draft created: $html_url"
+fi
+
+echo '[+] Sending draft release URL to Matrix'
+
+msg_body=$(cat <<EOF
+**Release pipeline for Substrate $version complete.**
+Draft release created: $html_url
+EOF
+)
+formatted_msg_body=$(cat <<EOF
+<strong>Release pipeline for Substrate $version complete.</strong><br />
+Draft release created: $html_url
+EOF
+)
+send_message "$(structure_message "$msg_body" "$formatted_msg_body")" "$MATRIX_ACCESS_TOKEN"
+
+echo "[+] Done! Maybe the release worked..."


### PR DESCRIPTION
Idea is much the same as we currently do on polkadot - When a new tag is pushed (that fits our pattern for tags, e.g. `v1.2.3`), find a list of labelled changes and generate a changelog based on that. Create a draft release on Github and post about it on Matrix.