### PR TITLE
CI: Add example CI job template to .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,21 @@
 # pipelines can be triggered manually in the web
 # setting DEPLOY_TAG will only deploy the tagged image
 
+# SAMPLE JOB TEMPLATE - This is not a complete example but is enough to build a
+# simple CI job. For full documentation, visit https://docs.gitlab.com/ee/ci/yaml/
+#
+# my-example-job:
+#   stage:                           test # One of the stages listed below this job (required)
+#   image:                           parity/tools:latest # Any docker image (required)
+#   allow_failure:                   true # Allow the pipeline to continue if this job fails (default: false)
+#   dependencies:
+#     - build-rust-doc-release # Any jobs that are required to run before this job (optional)
+#   variables:
+#     MY_ENVIRONMENT_VARIABLE:       "some useful value" # Environment variables passed to the job (optional)
+#   script:
+#     - echo "List of shell commands to run in your job"
+#     - echo "You can also just specify a script here, like so:"
+#     - ./scripts/gitlab/my_amazing_script.sh
 
 stages:
   - test


### PR DESCRIPTION
Simple job template added to .gitlab-ci.yml. At the very least, copying and using this template will create a job that won't error and includes required fields.