### PR TITLE
Make sure we use libp2p 0.16.1

### DIFF
--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -28,7 +28,7 @@ derive_more = { version = "0.99.2" }
 sc-rpc = { version = "2.0.0", path = "../../../client/rpc" }
 jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
-libp2p = "0.16.0"
+libp2p = "0.16.1"
 serde_json = "1.0"
 
 [features]

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -15,7 +15,7 @@ codec = { package = "parity-scale-codec", default-features = false, version = "1
 derive_more = "0.99.2"
 futures = "0.3.1"
 futures-timer = "3.0.1"
-libp2p = { version = "0.16.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
+libp2p = { version = "0.16.1", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
 log = "0.4.8"
 prost = "0.6.1"
 rand = "0.7.2"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.1"
 futures-timer = "3.0.1"
-libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.1", default-features = false, features = ["libp2p-websocket"] }
 log = "0.4.8"
 lru = "0.1.2"
 parking_lot = "0.10.0"

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.1"
 futures_codec = "0.3.3"
 futures-timer = "3.0.1"
 wasm-timer = "0.2"
-libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.1", default-features = false, features = ["libp2p-websocket"] }
 linked-hash-map = "0.5.2"
 linked_hash_set = "0.1.3"
 log = "0.4.8"

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.1.29"
 futures03 = { package = "futures", version = "0.3.1", features = ["compat"] }
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.1", default-features = false, features = ["libp2p-websocket"] }
 sp-consensus = { version = "0.8", path = "../../../primitives/consensus/common" }
 sc-client = { version = "0.8", path = "../../" }
 sc-client-api = { version = "2.0.0", path = "../../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-libp2p = { version = "0.16.0", default-features = false }
+libp2p = { version = "0.16.1", default-features = false }
 log = "0.4.8"
 serde_json = "1.0.41"
 wasm-timer = "0.2"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -12,7 +12,7 @@ parking_lot = "0.10.0"
 futures = "0.3.1"
 futures-timer = "3.0.1"
 wasm-timer = "0.2.0"
-libp2p = { version = "0.16.0", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.16.1", default-features = false, features = ["libp2p-websocket"] }
 log = "0.4.8"
 pin-project = "0.4.6"
 rand = "0.7.2"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 
 [dependencies]
 derive_more = "0.99.2"
-libp2p = { version = "0.16.0", default-features = false }
+libp2p = { version = "0.16.1", default-features = false }
 log = "0.4.8"
 sp-core = { path= "../../core" }
 sp-inherents = { version = "2.0.0", path = "../../inherents" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 futures = "0.3"
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
-libp2p = { version = "0.16.0", default-features = false }
+libp2p = { version = "0.16.1", default-features = false }
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 js-sys = "0.3.34"


### PR DESCRIPTION
We've made a few small fixes in 0.16.1 that I want to be sure Polkadot is using.