### PR TITLE
adding a ss58 format for Darwinia Network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -446,6 +446,8 @@ ss58_address_format!(
 		(36, "centrifuge", "Centrifuge Chain mainnet, direct checksum, standard account (*25519).")
 	SubstraTeeAccountDirect =>
 		(44, "substratee", "Any SubstraTEE off-chain network private account, direct checksum, standard account (*25519).")
+	DarwiniaAccountDirect =>
+		(18, "darwinia", "Darwinia Chain mainnet, direct checksum, standard account (*25519).")
 );
 
 /// Set the default "version" (actually, this is a bit of a misnomer and the version byte is


### PR DESCRIPTION
In order to prevent the re-usage across networks, decreasing the value at risk if a private key is lost, and also to identify easily.  We want to registry the Subkey Address Type as 18 for [Darwinia](https://github.com/darwinia-network/darwinia) mainnet, and we will use 42 in our last testnet.  If there are any concerns please kindly tell us.  

Many thanks for your hard-working on Substrate.