### PR TITLE
removes use of sc_client::Client from sc_finality_grandpa

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -42,9 +42,7 @@ macro_rules! new_full_start {
 					.ok_or_else(|| sc_service::Error::SelectChainRequired)?;
 
 				let (grandpa_block_import, grandpa_link) =
-					grandpa::block_import::<_, _, _, node_template_runtime::RuntimeApi, _>(
-						client.clone(), &*client, select_chain
-					)?;
+					grandpa::block_import(client.clone(), &*client, select_chain)?;
 
 				let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
 					grandpa_block_import.clone(), client.clone(),
@@ -202,7 +200,7 @@ pub fn new_light(config: Configuration<GenesisConfig>)
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let grandpa_block_import = grandpa::light_block_import::<_, _, _, RuntimeApi>(
+			let grandpa_block_import = grandpa::light_block_import(
 				client.clone(), backend, &*client.clone(), Arc::new(fetch_checker),
 			)?;
 			let finality_proof_import = grandpa_block_import.clone();

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -314,7 +314,7 @@ pub fn new_light(config: NodeConfiguration)
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let grandpa_block_import = grandpa::light_block_import::<_, _, _, RuntimeApi>(
+			let grandpa_block_import = grandpa::light_block_import(
 				client.clone(),
 				backend,
 				&*client,

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -169,6 +169,14 @@ pub trait BlockImportOperation<Block: BlockT> {
 	fn mark_head(&mut self, id: BlockId<Block>) -> sp_blockchain::Result<()>;
 }
 
+/// trait for performing operations on the backend
+pub trait ClientBackend<Block: BlockT, B: Backend<Block>> {
+	/// Lock the import lock, and run operations inside.
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
+		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+		Err: From<sp_blockchain::Error>;
+}
+
 /// Finalize Facilities
 pub trait Finalizer<Block: BlockT, B: Backend<Block>> {
 	/// Mark all blocks up to given as finalized in operation.

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -172,9 +172,10 @@ pub trait BlockImportOperation<Block: BlockT> {
 /// trait for performing operations on the backend
 pub trait ClientBackend<Block: BlockT, B: Backend<Block>> {
 	/// Lock the import lock, and run operations inside.
-	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
-		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
-		Err: From<sp_blockchain::Error>;
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err>
+		where
+			F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+			Err: From<sp_blockchain::Error>;
 }
 
 /// Finalize Facilities

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -169,8 +169,8 @@ pub trait BlockImportOperation<Block: BlockT> {
 	fn mark_head(&mut self, id: BlockId<Block>) -> sp_blockchain::Result<()>;
 }
 
-/// trait for performing operations on the backend
-pub trait ClientBackend<Block: BlockT, B: Backend<Block>> {
+/// Interface for performing operations on the backend.
+pub trait LockImportRun<Block: BlockT, B: Backend<Block>> {
 	/// Lock the import lock, and run operations inside.
 	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err>
 		where

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -20,6 +20,7 @@ sp-arithmetic = { version = "2.0.0-alpha.1", path = "../../primitives/arithmetic
 sp-runtime = { version = "2.0.0-alpha.1", path = "../../primitives/runtime" }
 sp-consensus = { version = "0.8.0-alpha.1", path = "../../primitives/consensus/common" }
 sp-core = { version = "2.0.0-alpha.1", path = "../../primitives/core" }
+sp-api = { version = "2.0.0-alpha.1", path = "../../primitives/api" }
 sc-telemetry = { version = "2.0.0-alpha.1", path = "../telemetry" }
 sc-keystore = { version = "2.0.0-alpha.1", path = "../keystore" }
 serde_json = "1.0.41"

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -25,18 +25,14 @@ use parity_scale_codec::{Decode, Encode};
 use futures::prelude::*;
 use futures_timer::Delay;
 use parking_lot::RwLock;
-use sp_blockchain::{HeaderBackend, Error as ClientError};
+use sp_blockchain::{HeaderBackend, Error as ClientError, HeaderMetadata};
+use std::marker::PhantomData;
 
 use sc_client_api::{
-	BlockchainEvents,
-	backend::{AuxStore, Backend},
-	Finalizer,
-	call_executor::CallExecutor,
+	backend::Backend,
 	utils::is_descendent_of,
 };
-use sc_client::{
-	apply_aux, Client,
-};
+use sc_client::apply_aux;
 use finality_grandpa::{
 	BlockNumberOps, Equivocation, Error as GrandpaError, round::State as RoundState,
 	voter, voter_set::VoterSet,
@@ -377,8 +373,8 @@ impl<Block: BlockT> SharedVoterSetState<Block> {
 }
 
 /// The environment we run GRANDPA in.
-pub(crate) struct Environment<B, E, Block: BlockT, N: NetworkT<Block>, RA, SC, VR> {
-	pub(crate) client: Arc<Client<B, E, Block, RA>>,
+pub(crate) struct Environment<Backend, Block: BlockT, C, N: NetworkT<Block>, SC, VR> {
+	pub(crate) client: Arc<C>,
 	pub(crate) select_chain: SC,
 	pub(crate) voters: Arc<VoterSet<AuthorityId>>,
 	pub(crate) config: Config,
@@ -388,9 +384,10 @@ pub(crate) struct Environment<B, E, Block: BlockT, N: NetworkT<Block>, RA, SC, V
 	pub(crate) set_id: SetId,
 	pub(crate) voter_set_state: SharedVoterSetState<Block>,
 	pub(crate) voting_rule: VR,
+	pub(crate) _phantom: PhantomData<Backend>,
 }
 
-impl<B, E, Block: BlockT, N: NetworkT<Block>, RA, SC, VR> Environment<B, E, Block, N, RA, SC, VR> {
+impl<Backend, Block: BlockT, C, N: NetworkT<Block>, SC, VR> Environment<Backend, Block, C, N, SC, VR> {
 	/// Updates the voter set state using the given closure. The write lock is
 	/// held during evaluation of the closure and the environment's voter set
 	/// state is set to its result if successful.
@@ -406,17 +403,16 @@ impl<B, E, Block: BlockT, N: NetworkT<Block>, RA, SC, VR> Environment<B, E, Bloc
 	}
 }
 
-impl<Block: BlockT, B, E, N, RA, SC, VR>
+impl<BE, Block: BlockT, C, N, SC, VR>
 	finality_grandpa::Chain<Block::Hash, NumberFor<Block>>
-for Environment<B, E, Block, N, RA, SC, VR>
+for Environment<BE, Block, C, N, SC, VR>
 where
 	Block: 'static,
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + Send + Sync,
+	BE: Backend<Block>,
+	C: crate::ClientForGrandpa<Block, BE>,
  	N: NetworkT<Block> + 'static + Send,
 	SC: SelectChain<Block> + 'static,
-	VR: VotingRule<Block, Client<B, E, Block, RA>>,
-	RA: Send + Sync,
+	VR: VotingRule<Block, C>,
 	NumberFor<Block>: BlockNumberOps,
 {
 	fn ancestry(&self, base: Block::Hash, block: Block::Hash) -> Result<Vec<Block::Hash>, GrandpaError> {
@@ -432,7 +428,7 @@ where
 			return None;
 		}
 
-		let base_header = match self.client.header(&BlockId::Hash(block)).ok()? {
+		let base_header = match self.client.header(BlockId::Hash(block)).ok()? {
 			Some(h) => h,
 			None => {
 				debug!(target: "afg", "Encountered error finding best chain containing {:?}: couldn't find base block", block);
@@ -450,7 +446,7 @@ where
 
 		match self.select_chain.finality_target(block, None) {
 			Ok(Some(best_hash)) => {
-				let best_header = self.client.header(&BlockId::Hash(best_hash)).ok()?
+				let best_header = self.client.header(BlockId::Hash(best_hash)).ok()?
 					.expect("Header known to exist after `finality_target` call; qed");
 
 				// check if our vote is currently being limited due to a pending change
@@ -474,7 +470,7 @@ where
 							break;
 						}
 
-						target_header = self.client.header(&BlockId::Hash(*target_header.parent_hash())).ok()?
+						target_header = self.client.header(BlockId::Hash(*target_header.parent_hash())).ok()?
 							.expect("Header known to exist after `finality_target` call; qed");
 					}
 
@@ -519,17 +515,16 @@ where
 }
 
 
-pub(crate) fn ancestry<B, Block: BlockT, E, RA>(
-	client: &Client<B, E, Block, RA>,
+pub(crate) fn ancestry<Block: BlockT, Client>(
+	client: &Arc<Client>,
 	base: Block::Hash,
 	block: Block::Hash,
 ) -> Result<Vec<Block::Hash>, GrandpaError> where
-	B: Backend<Block>,
-	E: CallExecutor<Block>,
+	Client: HeaderMetadata<Block, Error = sp_blockchain::Error>,
 {
 	if base == block { return Err(GrandpaError::NotDescendent) }
 
-	let tree_route_res = sp_blockchain::tree_route(client, block, base);
+	let tree_route_res = sp_blockchain::tree_route(&**client, block, base);
 
 	let tree_route = match tree_route_res {
 		Ok(tree_route) => tree_route,
@@ -550,19 +545,17 @@ pub(crate) fn ancestry<B, Block: BlockT, E, RA>(
 	Ok(tree_route.retracted().iter().skip(1).map(|e| e.hash).collect())
 }
 
-impl<B, E, Block: BlockT, N, RA, SC, VR>
+impl<B, Block: BlockT, C, N, SC, VR>
 	voter::Environment<Block::Hash, NumberFor<Block>>
-for Environment<B, E, Block, N, RA, SC, VR>
+for Environment<B, Block, C, N, SC, VR>
 where
 	Block: 'static,
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + 'static + Send + Sync,
+	B: Backend<Block>,
+	C: crate::ClientForGrandpa<Block, B> + 'static,
  	N: NetworkT<Block> + 'static + Send,
-	RA: 'static + Send + Sync,
 	SC: SelectChain<Block> + 'static,
-	VR: VotingRule<Block, Client<B, E, Block, RA>>,
+	VR: VotingRule<Block, C>,
 	NumberFor<Block>: BlockNumberOps,
-	Client<B, E, Block, RA>: AuxStore,
 {
 	type Timer = Pin<Box<dyn Future<Output = Result<(), Self::Error>> + Send>>;
 	type Id = AuthorityId;
@@ -882,7 +875,7 @@ where
 		commit: Commit<Block>,
 	) -> Result<(), Self::Error> {
 		finalize_block(
-			&*self.client,
+			self.client.clone(),
 			&self.authority_set,
 			&self.consensus_changes,
 			Some(self.config.justification_period.into()),
@@ -940,8 +933,8 @@ impl<Block: BlockT> From<GrandpaJustification<Block>> for JustificationOrCommit<
 /// authority set change is enacted then a justification is created (if not
 /// given) and stored with the block when finalizing it.
 /// This method assumes that the block being finalized has already been imported.
-pub(crate) fn finalize_block<B, Block: BlockT, E, RA>(
-	client: &Client<B, E, Block, RA>,
+pub(crate) fn finalize_block<BE, Block, Client>(
+	client: Arc<Client>,
 	authority_set: &SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 	consensus_changes: &SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
 	justification_period: Option<NumberFor<Block>>,
@@ -949,16 +942,16 @@ pub(crate) fn finalize_block<B, Block: BlockT, E, RA>(
 	number: NumberFor<Block>,
 	justification_or_commit: JustificationOrCommit<Block>,
 ) -> Result<(), CommandOrError<Block::Hash, NumberFor<Block>>> where
-	B: Backend<Block>,
-	E: CallExecutor<Block> + Send + Sync,
-	RA: Send + Sync,
+	Block:  BlockT,
+	BE: Backend<Block>,
+	Client: crate::ClientForGrandpa<Block, BE>,
 {
 	// NOTE: lock must be held through writing to DB to avoid race. this lock
 	//       also implicitly synchronizes the check for last finalized number
 	//       below.
 	let mut authority_set = authority_set.inner().write();
 
-	let status = client.chain_info();
+	let status = client.info();
 	if number <= status.finalized_number && client.hash(number)? == Some(hash) {
 		// This can happen after a forced change (triggered by the finality tracker when finality is stalled), since
 		// the voter will be restarted at the median last finalized block, which can be lower than the local best
@@ -981,14 +974,14 @@ pub(crate) fn finalize_block<B, Block: BlockT, E, RA>(
 	let mut consensus_changes = consensus_changes.lock();
 	let canon_at_height = |canon_number| {
 		// "true" because the block is finalized
-		canonical_at_height(client, (hash, number), true, canon_number)
+		canonical_at_height(&*client, (hash, number), true, canon_number)
 	};
 
 	let update_res: Result<_, Error> = client.lock_import_and_run(|import_op| {
 		let status = authority_set.apply_standard_changes(
 			hash,
 			number,
-			&is_descendent_of::<Block, _>(client, None),
+			&is_descendent_of::<Block, _>(&*client, None),
 		).map_err(|e| Error::Safety(e.to_string()))?;
 
 		// check if this is this is the first finalization of some consensus changes
@@ -1031,7 +1024,7 @@ pub(crate) fn finalize_block<B, Block: BlockT, E, RA>(
 				// finalization to remote nodes
 				if !justification_required {
 					if let Some(justification_period) = justification_period {
-						let last_finalized_number = client.chain_info().finalized_number;
+						let last_finalized_number = client.info().finalized_number;
 						justification_required =
 							(!last_finalized_number.is_zero() || number - last_finalized_number == justification_period) &&
 							(last_finalized_number / justification_period != number / justification_period);
@@ -1040,7 +1033,7 @@ pub(crate) fn finalize_block<B, Block: BlockT, E, RA>(
 
 				if justification_required {
 					let justification = GrandpaJustification::from_commit(
-						client,
+						&client,
 						round_number,
 						commit,
 					)?;

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -56,7 +56,10 @@ use futures::prelude::*;
 use futures::StreamExt;
 use log::{debug, info};
 use futures::channel::mpsc;
-use sc_client_api::{ClientBackend, BlockchainEvents, CallExecutor, backend::{AuxStore, Backend}, ExecutionStrategy, Finalizer, TransactionFor};
+use sc_client_api::{
+	LockImportRun, BlockchainEvents, CallExecutor,
+	backend::{AuxStore, Backend}, ExecutionStrategy, Finalizer, TransactionFor,
+};
 use sp_blockchain::{HeaderBackend, Error as ClientError, HeaderMetadata};
 use sc_client::Client;
 use parity_scale_codec::{Decode, Encode};
@@ -259,8 +262,9 @@ impl<Block: BlockT, Client> BlockStatus<Block> for Arc<Client> where
 
 /// A trait that includes all the client functionalities grandpa requires.
 /// Ideally this would be a trait alias, we're not there yet.
+/// tracking issue https://github.com/rust-lang/rust/issues/41517
 pub trait ClientForGrandpa<Block, BE>:
-	ClientBackend<Block, BE> + Finalizer<Block, BE> + AuxStore
+	LockImportRun<Block, BE> + Finalizer<Block, BE> + AuxStore
 	+ HeaderMetadata<Block, Error = sp_blockchain::Error> + HeaderBackend<Block>
 	+ BlockchainEvents<Block> + ProvideRuntimeApi<Block>
 	+ BlockImport<Block, Transaction = TransactionFor<BE, Block>, Error = sp_consensus::Error>
@@ -273,7 +277,7 @@ impl<Block, BE, T> ClientForGrandpa<Block, BE> for T
 	where
 		BE: Backend<Block>,
 		Block: BlockT,
-		T: ClientBackend<Block, BE> + Finalizer<Block, BE> + AuxStore
+		T: LockImportRun<Block, BE> + Finalizer<Block, BE> + AuxStore
 			+ HeaderMetadata<Block, Error = sp_blockchain::Error> + HeaderBackend<Block>
 			+ BlockchainEvents<Block> + ProvideRuntimeApi<Block>
 			+ BlockImport<Block, Transaction = TransactionFor<BE, Block>, Error = sp_consensus::Error>,

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -56,15 +56,15 @@ use futures::prelude::*;
 use futures::StreamExt;
 use log::{debug, info};
 use futures::channel::mpsc;
-use sc_client_api::{BlockchainEvents, CallExecutor, backend::{AuxStore, Backend}, ExecutionStrategy};
-use sp_blockchain::{HeaderBackend, Error as ClientError};
+use sc_client_api::{ClientBackend, BlockchainEvents, CallExecutor, backend::{AuxStore, Backend}, ExecutionStrategy, Finalizer, TransactionFor};
+use sp_blockchain::{HeaderBackend, Error as ClientError, HeaderMetadata};
 use sc_client::Client;
 use parity_scale_codec::{Decode, Encode};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{NumberFor, Block as BlockT, DigestFor, Zero};
 use sc_keystore::KeyStorePtr;
 use sp_inherents::InherentDataProviders;
-use sp_consensus::SelectChain;
+use sp_consensus::{SelectChain, BlockImport};
 use sp_core::Pair;
 use sc_telemetry::{telemetry, CONSENSUS_INFO, CONSENSUS_DEBUG};
 use serde_json;
@@ -109,6 +109,8 @@ use sp_finality_grandpa::{AuthorityList, AuthorityPair, AuthoritySignature, SetI
 
 // Re-export these two because it's just so damn convenient.
 pub use sp_finality_grandpa::{AuthorityId, ScheduledChange};
+use sp_api::ProvideRuntimeApi;
+use std::marker::PhantomData;
 
 #[cfg(test)]
 mod tests;
@@ -245,10 +247,8 @@ pub(crate) trait BlockStatus<Block: BlockT> {
 	fn block_number(&self, hash: Block::Hash) -> Result<Option<NumberFor<Block>>, Error>;
 }
 
-impl<B, E, Block: BlockT, RA> BlockStatus<Block> for Arc<Client<B, E, Block, RA>> where
-	B: Backend<Block>,
-	E: CallExecutor<Block> + Send + Sync,
-	RA: Send + Sync,
+impl<Block: BlockT, Client> BlockStatus<Block> for Arc<Client> where
+	Client: HeaderBackend<Block>,
 	NumberFor<Block>: BlockNumberOps,
 {
 	fn block_number(&self, hash: Block::Hash) -> Result<Option<NumberFor<Block>>, Error> {
@@ -256,6 +256,28 @@ impl<B, E, Block: BlockT, RA> BlockStatus<Block> for Arc<Client<B, E, Block, RA>
 			.map_err(|e| Error::Blockchain(format!("{:?}", e)))
 	}
 }
+
+/// A trait that includes all the client functionalities grandpa requires.
+/// Ideally this would be a trait alias, we're not there yet.
+pub trait ClientForGrandpa<Block, BE>:
+	ClientBackend<Block, BE> + Finalizer<Block, BE> + AuxStore
+	+ HeaderMetadata<Block, Error = sp_blockchain::Error> + HeaderBackend<Block>
+	+ BlockchainEvents<Block> + ProvideRuntimeApi<Block>
+	+ BlockImport<Block, Transaction = TransactionFor<BE, Block>, Error = sp_consensus::Error>
+	where
+		BE: Backend<Block>,
+		Block: BlockT,
+{}
+
+impl<Block, BE, T> ClientForGrandpa<Block, BE> for T
+	where
+		BE: Backend<Block>,
+		Block: BlockT,
+		T: ClientBackend<Block, BE> + Finalizer<Block, BE> + AuxStore
+			+ HeaderMetadata<Block, Error = sp_blockchain::Error> + HeaderBackend<Block>
+			+ BlockchainEvents<Block> + ProvideRuntimeApi<Block>
+			+ BlockImport<Block, Transaction = TransactionFor<BE, Block>, Error = sp_consensus::Error>,
+{}
 
 /// Something that one can ask to do a block sync request.
 pub(crate) trait BlockSyncRequester<Block: BlockT> {
@@ -348,8 +370,8 @@ impl<H, N> fmt::Display for CommandOrError<H, N> {
 	}
 }
 
-pub struct LinkHalf<B, E, Block: BlockT, RA, SC> {
-	client: Arc<Client<B, E, Block, RA>>,
+pub struct LinkHalf<Block: BlockT, C, SC> {
+	client: Arc<C>,
 	select_chain: SC,
 	persistent_data: PersistentData<Block>,
 	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
@@ -390,22 +412,20 @@ impl<B, E, Block: BlockT, RA> GenesisAuthoritySetProvider<Block> for Client<B, E
 
 /// Make block importer and link half necessary to tie the background voter
 /// to it.
-pub fn block_import<B, E, Block: BlockT, RA, SC>(
-	client: Arc<Client<B, E, Block, RA>>,
+pub fn block_import<BE, Block: BlockT, Client, SC>(
+	client: Arc<Client>,
 	genesis_authorities_provider: &dyn GenesisAuthoritySetProvider<Block>,
 	select_chain: SC,
 ) -> Result<(
-		GrandpaBlockImport<B, E, Block, RA, SC>,
-		LinkHalf<B, E, Block, RA, SC>
+		GrandpaBlockImport<BE, Block, Client, SC>,
+		LinkHalf<Block, Client, SC>,
 	), ClientError>
 where
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + Send + Sync,
-	RA: Send + Sync,
 	SC: SelectChain<Block>,
-	Client<B, E, Block, RA>: AuxStore,
+	BE: Backend<Block> + 'static,
+	Client: ClientForGrandpa<Block, BE> + 'static,
 {
-	let chain_info = client.chain_info();
+	let chain_info = client.info();
 	let genesis_hash = chain_info.genesis_hash;
 
 	let persistent_data = aux_schema::load_persistent(
@@ -440,10 +460,10 @@ where
 	))
 }
 
-fn global_communication<Block: BlockT, B, E, N, RA>(
+fn global_communication<BE, Block: BlockT, C, N>(
 	set_id: SetId,
 	voters: &Arc<VoterSet<AuthorityId>>,
-	client: &Arc<Client<B, E, Block, RA>>,
+	client: Arc<C>,
 	network: &NetworkBridge<Block, N>,
 	keystore: &Option<KeyStorePtr>,
 ) -> (
@@ -455,10 +475,9 @@ fn global_communication<Block: BlockT, B, E, N, RA>(
 		Error = CommandOrError<Block::Hash, NumberFor<Block>>,
 	> + Unpin,
 ) where
-	B: Backend<Block>,
-	E: CallExecutor<Block> + Send + Sync,
+	BE: Backend<Block> + 'static,
+	C: ClientForGrandpa<Block, BE> + 'static,
 	N: NetworkT<Block>,
-	RA: Send + Sync,
 	NumberFor<Block>: BlockNumberOps,
 {
 	let is_voter = is_voter(voters, keystore).is_some();
@@ -487,20 +506,18 @@ fn global_communication<Block: BlockT, B, E, N, RA>(
 
 /// Register the finality tracker inherent data provider (which is used by
 /// GRANDPA), if not registered already.
-fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT, RA>(
-	client: Arc<Client<B, E, Block, RA>>,
+fn register_finality_tracker_inherent_data_provider<Block: BlockT, Client>(
+	client: Arc<Client>,
 	inherent_data_providers: &InherentDataProviders,
 ) -> Result<(), sp_consensus::Error> where
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + Send + Sync + 'static,
-	RA: Send + Sync + 'static,
+	Client: HeaderBackend<Block> + 'static,
 {
 	if !inherent_data_providers.has_provider(&sp_finality_tracker::INHERENT_IDENTIFIER) {
 		inherent_data_providers
 			.register_provider(sp_finality_tracker::InherentDataProvider::new(move || {
 				#[allow(deprecated)]
 				{
-					let info = client.chain_info();
+					let info = client.info();
 					telemetry!(CONSENSUS_INFO; "afg.finalized";
 						"finalized_number" => ?info.finalized_number,
 						"finalized_hash" => ?info.finalized_hash,
@@ -515,11 +532,11 @@ fn register_finality_tracker_inherent_data_provider<B, E, Block: BlockT, RA>(
 }
 
 /// Parameters used to run Grandpa.
-pub struct GrandpaParams<B, E, Block: BlockT, N, RA, SC, VR, X> {
+pub struct GrandpaParams<Block: BlockT, C, N, SC, VR, X> {
 	/// Configuration for the GRANDPA service.
 	pub config: Config,
 	/// A link to the block import worker.
-	pub link: LinkHalf<B, E, Block, RA, SC>,
+	pub link: LinkHalf<Block, C, SC>,
 	/// The Network instance.
 	pub network: N,
 	/// The inherent data providers.
@@ -534,20 +551,18 @@ pub struct GrandpaParams<B, E, Block: BlockT, N, RA, SC, VR, X> {
 
 /// Run a GRANDPA voter as a task. Provide configuration and a link to a
 /// block import worker that has already been instantiated with `block_import`.
-pub fn run_grandpa_voter<B, E, Block: BlockT, N, RA, SC, VR, X>(
-	grandpa_params: GrandpaParams<B, E, Block, N, RA, SC, VR, X>,
+pub fn run_grandpa_voter<Block: BlockT, BE: 'static, C, N, SC, VR, X>(
+	grandpa_params: GrandpaParams<Block, C, N, SC, VR, X>,
 ) -> sp_blockchain::Result<impl Future<Output = ()> + Unpin + Send + 'static> where
 	Block::Hash: Ord,
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + Send + Sync + 'static,
+	BE: Backend<Block> + 'static,
 	N: NetworkT<Block> + Send + Sync + Clone + 'static,
 	SC: SelectChain<Block> + 'static,
-	VR: VotingRule<Block, Client<B, E, Block, RA>> + Clone + 'static,
+	VR: VotingRule<Block, C> + Clone + 'static,
 	NumberFor<Block>: BlockNumberOps,
 	DigestFor<Block>: Encode,
-	RA: Send + Sync + 'static,
 	X: futures::Future<Output=()> + Clone + Send + Unpin + 'static,
-	Client<B, E, Block, RA>: AuxStore,
+	C: ClientForGrandpa<Block, BE> + 'static,
 {
 	let GrandpaParams {
 		mut config,
@@ -629,27 +644,25 @@ pub fn run_grandpa_voter<B, E, Block: BlockT, N, RA, SC, VR, X>(
 
 /// Future that powers the voter.
 #[must_use]
-struct VoterWork<B, E, Block: BlockT, N: NetworkT<Block>, RA, SC, VR> {
+struct VoterWork<B, Block: BlockT, C, N: NetworkT<Block>, SC, VR> {
 	voter: Pin<Box<dyn Future<Output = Result<(), CommandOrError<Block::Hash, NumberFor<Block>>>> + Send>>,
-	env: Arc<Environment<B, E, Block, N, RA, SC, VR>>,
+	env: Arc<Environment<B, Block, C, N, SC, VR>>,
 	voter_commands_rx: mpsc::UnboundedReceiver<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	network: NetworkBridge<Block, N>,
 }
 
-impl<B, E, Block, N, RA, SC, VR> VoterWork<B, E, Block, N, RA, SC, VR>
+impl<B, Block, C, N, SC, VR> VoterWork<B, Block, C, N, SC, VR>
 where
 	Block: BlockT,
+	B: Backend<Block> + 'static,
+	C: ClientForGrandpa<Block, B> + 'static,
 	N: NetworkT<Block> + Sync,
 	NumberFor<Block>: BlockNumberOps,
-	RA: 'static + Send + Sync,
-	E: CallExecutor<Block> + Send + Sync + 'static,
-	B: Backend<Block> + 'static,
 	SC: SelectChain<Block> + 'static,
-	VR: VotingRule<Block, Client<B, E, Block, RA>> + Clone + 'static,
-	Client<B, E, Block, RA>: AuxStore,
+	VR: VotingRule<Block, C> + Clone + 'static,
 {
 	fn new(
-		client: Arc<Client<B, E, Block, RA>>,
+		client: Arc<C>,
 		config: Config,
 		network: NetworkBridge<Block, N>,
 		select_chain: SC,
@@ -670,6 +683,7 @@ where
 			authority_set: persistent_data.authority_set.clone(),
 			consensus_changes: persistent_data.consensus_changes.clone(),
 			voter_set_state: persistent_data.set_state.clone(),
+			_phantom: PhantomData,
 		});
 
 		let mut work = VoterWork {
@@ -700,7 +714,7 @@ where
 			"authority_id" => authority_id.to_string(),
 		);
 
-		let chain_info = self.env.client.chain_info();
+		let chain_info = self.env.client.info();
 		telemetry!(CONSENSUS_INFO; "afg.authority_set";
 			"number" => ?chain_info.finalized_number,
 			"hash" => ?chain_info.finalized_hash,
@@ -724,7 +738,7 @@ where
 				let global_comms = global_communication(
 					self.env.set_id,
 					&self.env.voters,
-					&self.env.client,
+					self.env.client.clone(),
 					&self.env.network,
 					&self.env.config.keystore,
 				);
@@ -789,6 +803,7 @@ where
 					consensus_changes: self.env.consensus_changes.clone(),
 					network: self.env.network.clone(),
 					voting_rule: self.env.voting_rule.clone(),
+					_phantom: PhantomData,
 				});
 
 				self.rebuild_voter();
@@ -813,17 +828,15 @@ where
 	}
 }
 
-impl<B, E, Block, N, RA, SC, VR> Future for VoterWork<B, E, Block, N, RA, SC, VR>
+impl<B, Block, C, N, SC, VR> Future for VoterWork<B, Block, C, N, SC, VR>
 where
 	Block: BlockT,
+	B: Backend<Block> + 'static,
 	N: NetworkT<Block> + Sync,
 	NumberFor<Block>: BlockNumberOps,
-	RA: 'static + Send + Sync,
-	E: CallExecutor<Block> + Send + Sync + 'static,
-	B: Backend<Block> + 'static,
 	SC: SelectChain<Block> + 'static,
-	VR: VotingRule<Block, Client<B, E, Block, RA>> + Clone + 'static,
-	Client<B, E, Block, RA>: AuxStore,
+	C: ClientForGrandpa<Block, B> + 'static,
+	VR: VotingRule<Block, C> + Clone + 'static,
 {
 	type Output = Result<(), Error>;
 
@@ -868,15 +881,13 @@ where
 /// discards all GRANDPA messages (otherwise, we end up banning nodes that send
 /// us a `Neighbor` message, since there is no registered gossip validator for
 /// the engine id defined in the message.)
-pub fn setup_disabled_grandpa<B, E, Block: BlockT, RA, N>(
-	client: Arc<Client<B, E, Block, RA>>,
+pub fn setup_disabled_grandpa<Block: BlockT, Client, N>(
+	client: Arc<Client>,
 	inherent_data_providers: &InherentDataProviders,
 	network: N,
 ) -> Result<(), sp_consensus::Error> where
-	B: Backend<Block> + 'static,
-	E: CallExecutor<Block> + Send + Sync + 'static,
-	RA: Send + Sync + 'static,
 	N: NetworkT<Block> + Send + Clone + 'static,
+	Client: HeaderBackend<Block> + 'static,
 {
 	register_finality_tracker_inherent_data_provider(
 		client,

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -18,10 +18,7 @@
 
 use super::*;
 use environment::HasVoted;
-use sc_network_test::{
-	Block, Hash, TestNetFactory, BlockImportAdapter, Peer,
-	PeersClient, PassThroughVerifier,
-};
+use sc_network_test::{Block, Hash, TestNetFactory, BlockImportAdapter, Peer, PeersClient, PassThroughVerifier, PeersFullClient};
 use sc_network::config::{ProtocolConfig, Roles, BoxFinalityProofRequestBuilder};
 use parking_lot::Mutex;
 use futures_timer::Delay;
@@ -60,10 +57,8 @@ type PeerData =
 	Mutex<
 		Option<
 			LinkHalf<
-				substrate_test_runtime_client::Backend,
-				substrate_test_runtime_client::Executor,
 				Block,
-				substrate_test_runtime_client::runtime::RuntimeApi,
+				PeersFullClient,
 				LongestChain<substrate_test_runtime_client::Backend, Block>
 			>
 		>
@@ -1654,6 +1649,7 @@ fn grandpa_environment_respects_voting_rules() {
 			voters: Arc::new(authority_set.current_authorities()),
 			network,
 			voting_rule,
+			_phantom: PhantomData,
 		}
 	};
 

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -18,7 +18,10 @@
 
 use super::*;
 use environment::HasVoted;
-use sc_network_test::{Block, Hash, TestNetFactory, BlockImportAdapter, Peer, PeersClient, PassThroughVerifier, PeersFullClient};
+use sc_network_test::{
+	Block, Hash, TestNetFactory, BlockImportAdapter, Peer,
+	PeersClient, PassThroughVerifier, PeersFullClient,
+};
 use sc_network::config::{ProtocolConfig, Roles, BoxFinalityProofRequestBuilder};
 use parking_lot::Mutex;
 use futures_timer::Delay;

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -66,7 +66,7 @@ pub use sc_client_api::{
 	backend::{
 		self, BlockImportOperation, PrunableStateChangesTrieStorage,
 		ClientImportOperation, Finalizer, ImportSummary, NewBlockState,
-		ClientBackend, changes_tries_state_at_block,
+		LockImportRun, changes_tries_state_at_block,
 	},
 	client::{
 		ImportNotifications, FinalityNotification, FinalityNotifications, BlockImportNotification,
@@ -218,7 +218,7 @@ impl<B, E, Block, RA> BlockOf for Client<B, E, Block, RA> where
 	type Type = Block;
 }
 
-impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA>
+impl<B, E, Block, RA> LockImportRun<Block, B> for Client<B, E, Block, RA>
 	where
 		B: backend::Backend<Block>,
 		E: CallExecutor<Block>,
@@ -258,7 +258,7 @@ impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA>
 	}
 }
 
-impl<B, E, Block, RA> ClientBackend<Block, B> for &Client<B, E, Block, RA>
+impl<B, E, Block, RA> LockImportRun<Block, B> for &Client<B, E, Block, RA>
 	where
 		Block: BlockT,
 		B: backend::Backend<Block>,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -66,7 +66,7 @@ pub use sc_client_api::{
 	backend::{
 		self, BlockImportOperation, PrunableStateChangesTrieStorage,
 		ClientImportOperation, Finalizer, ImportSummary, NewBlockState,
-		changes_tries_state_at_block,
+		ClientBackend, changes_tries_state_at_block,
 	},
 	client::{
 		ImportNotifications, FinalityNotification, FinalityNotifications, BlockImportNotification,
@@ -216,6 +216,57 @@ impl<B, E, Block, RA> BlockOf for Client<B, E, Block, RA> where
 	Block: BlockT,
 {
 	type Type = Block;
+}
+
+impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA> where
+	B: backend::Backend<Block>,
+	E: CallExecutor<Block>,
+	Block: BlockT,
+{
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
+		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+		Err: From<sp_blockchain::Error>,
+	{
+		let inner = || {
+			let _import_lock = self.backend.get_import_lock().write();
+
+			let mut op = ClientImportOperation {
+				op: self.backend.begin_operation()?,
+				notify_imported: None,
+				notify_finalized: Vec::new(),
+			};
+
+			let r = f(&mut op)?;
+
+			let ClientImportOperation { op, notify_imported, notify_finalized } = op;
+			self.backend.commit_operation(op)?;
+			self.notify_finalized(notify_finalized)?;
+
+			if let Some(notify_imported) = notify_imported {
+				self.notify_imported(notify_imported)?;
+			}
+
+			Ok(r)
+		};
+
+		let result = inner();
+		*self.importing_block.write() = None;
+
+		result
+	}
+}
+
+impl<B, E, Block, RA> ClientBackend<Block, B> for &Client<B, E, Block, RA> where
+	B: backend::Backend<Block>,
+	E: CallExecutor<Block>,
+	Block: BlockT,
+{
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
+		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+		Err: From<sp_blockchain::Error>,
+	{
+		(**self).lock_import_and_run(f)
+	}
 }
 
 impl<B, E, Block, RA> Client<B, E, Block, RA> where
@@ -833,39 +884,6 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 			inherent_digests,
 			&self.backend
 		)
-	}
-
-	/// Lock the import lock, and run operations inside.
-	pub fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
-		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
-		Err: From<sp_blockchain::Error>,
-	{
-		let inner = || {
-			let _import_lock = self.backend.get_import_lock().write();
-
-			let mut op = ClientImportOperation {
-				op: self.backend.begin_operation()?,
-				notify_imported: None,
-				notify_finalized: Vec::new(),
-			};
-
-			let r = f(&mut op)?;
-
-			let ClientImportOperation { op, notify_imported, notify_finalized } = op;
-			self.backend.commit_operation(op)?;
-			self.notify_finalized(notify_finalized)?;
-
-			if let Some(notify_imported) = notify_imported {
-				self.notify_imported(notify_imported)?;
-			}
-
-			Ok(r)
-		};
-
-		let result = inner();
-		*self.importing_block.write() = None;
-
-		result
 	}
 
 	/// Apply a checked and validated block to an operation. If a justification is provided

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -218,14 +218,16 @@ impl<B, E, Block, RA> BlockOf for Client<B, E, Block, RA> where
 	type Type = Block;
 }
 
-impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA> where
-	B: backend::Backend<Block>,
-	E: CallExecutor<Block>,
-	Block: BlockT,
+impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA>
+	where
+		B: backend::Backend<Block>,
+		E: CallExecutor<Block>,
+		Block: BlockT,
 {
-	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
-		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
-		Err: From<sp_blockchain::Error>,
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err>
+		where
+			F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+			Err: From<sp_blockchain::Error>,
 	{
 		let inner = || {
 			let _import_lock = self.backend.get_import_lock().write();
@@ -256,14 +258,16 @@ impl<B, E, Block, RA> ClientBackend<Block, B> for Client<B, E, Block, RA> where
 	}
 }
 
-impl<B, E, Block, RA> ClientBackend<Block, B> for &Client<B, E, Block, RA> where
-	B: backend::Backend<Block>,
-	E: CallExecutor<Block>,
-	Block: BlockT,
+impl<B, E, Block, RA> ClientBackend<Block, B> for &Client<B, E, Block, RA>
+	where
+		Block: BlockT,
+		B: backend::Backend<Block>,
+		E: CallExecutor<Block>,
 {
-	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err> where
-		F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
-		Err: From<sp_blockchain::Error>,
+	fn lock_import_and_run<R, Err, F>(&self, f: F) -> Result<R, Err>
+		where
+			F: FnOnce(&mut ClientImportOperation<Block, B>) -> Result<R, Err>,
+			Err: From<sp_blockchain::Error>,
 	{
 		(**self).lock_import_and_run(f)
 	}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -98,7 +98,7 @@ pub use crate::{
 	client::{
 		new_with_backend,
 		new_in_mem,
-		BlockBody, ImportNotifications, FinalityNotifications, BlockchainEvents,
+		BlockBody, ImportNotifications, FinalityNotifications, BlockchainEvents, ClientBackend,
 		BlockImportNotification, Client, ClientInfo, ExecutionStrategies, FinalityNotification,
 		LongestChain, BlockOf, ProvideUncles, BadBlocks, ForkBlocks, apply_aux,
 	},

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -98,7 +98,7 @@ pub use crate::{
 	client::{
 		new_with_backend,
 		new_in_mem,
-		BlockBody, ImportNotifications, FinalityNotifications, BlockchainEvents, ClientBackend,
+		BlockBody, ImportNotifications, FinalityNotifications, BlockchainEvents, LockImportRun,
 		BlockImportNotification, Client, ClientInfo, ExecutionStrategies, FinalityNotification,
 		LongestChain, BlockOf, ProvideUncles, BadBlocks, ForkBlocks, apply_aux,
 	},


### PR DESCRIPTION
See #4452

Introduces a new trait `ClientBackend` to `sc_client_api`, for methods that interact with the backend.
eg `fn lock_import_and_run`

