### PR TITLE
Add steps setting to benchmarking CLI

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 224,
-	impl_version: 2,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -819,7 +819,7 @@ impl_runtime_apis! {
 		fn dispatch_benchmark(
 			module: Vec<u8>,
 			extrinsic: Vec<u8>,
-			steps: u32,
+			steps: Vec<u32>,
 			repeat: u32,
 		) -> Option<Vec<frame_benchmarking::BenchmarkResults>> {
 			use frame_benchmarking::Benchmarking;

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -138,7 +138,7 @@ macro_rules! impl_benchmark {
 		$( $name:ident ),*
 	) => {
 		impl<T: Trait> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T> {
-			fn run_benchmark(extrinsic: Vec<u8>, steps: u32, repeat: u32) -> Result<Vec<$crate::BenchmarkResults>, &'static str> {
+			fn run_benchmark(extrinsic: Vec<u8>, steps: Vec<u32>, repeat: u32) -> Result<Vec<$crate::BenchmarkResults>, &'static str> {
 				// Map the input to the selected benchmark.
 				let extrinsic = sp_std::str::from_utf8(extrinsic.as_slice())
 					.map_err(|_| "Could not find extrinsic")?;
@@ -151,15 +151,21 @@ macro_rules! impl_benchmark {
 				$crate::benchmarking::commit_db();
 				$crate::benchmarking::wipe_db();
 
-				// first one is set_identity.
 				let components = <SelectedBenchmark as $crate::BenchmarkingSetup<T, crate::Call<T>, RawOrigin<T::AccountId>>>::components(&selected_benchmark);
-				// results go here
 				let mut results: Vec<$crate::BenchmarkResults> = Vec::new();
+
+				// Default number of steps for a component.
+				let mut prev_steps = &10;
+
 				// Select the component we will be benchmarking. Each component will be benchmarked.
-				for (name, low, high) in components.iter() {
+				for (idx, (name, low, high)) in components.iter().enumerate() {
+					// Get the number of steps for this component.
+					let steps = steps.get(idx).unwrap_or(&prev_steps);
+					prev_steps = steps;
+
 					// Create up to `STEPS` steps for that component between high and low.
 					let step_size = ((high - low) / steps).max(1);
-					let num_of_steps = (high - low) / step_size;
+					let num_of_steps = (high - low) / step_size + 1;
 					for s in 0..num_of_steps {
 						// This is the value we will be testing for component `name`
 						let component_value = low + step_size * s;
@@ -167,7 +173,7 @@ macro_rules! impl_benchmark {
 						// Select the mid value for all the other components.
 						let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
 							.map(|(n, l, h)|
-								(*n, if n == name { component_value } else { (h - l) / 2 + l })
+								(*n, if n == name { component_value } else { *h })
 							).collect();
 
 						// Run the benchmark `repeat` times.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -40,7 +40,7 @@ sp_api::decl_runtime_apis! {
 		fn dispatch_benchmark(
 			module: Vec<u8>,
 			extrinsic: Vec<u8>,
-			steps: u32,
+			steps: Vec<u32>,
 			repeat: u32,
 		) -> Option<Vec<BenchmarkResults>>;
 	}
@@ -78,7 +78,7 @@ pub trait Benchmarking<T> {
 	/// - `extrinsic`: The name of extrinsic function you want to benchmark encoded as bytes.
 	/// - `steps`: The number of sample points you want to take across the range of parameters.
 	/// - `repeat`: The number of times you want to repeat a benchmark.
-	fn run_benchmark(extrinsic: Vec<u8>, steps: u32, repeat: u32) -> Result<Vec<T>, &'static str>;
+	fn run_benchmark(extrinsic: Vec<u8>, steps: Vec<u32>, repeat: u32) -> Result<Vec<T>, &'static str>;
 }
 
 /// The required setup for creating a benchmark.

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -36,8 +36,8 @@ pub struct BenchmarkCmd {
 	pub extrinsic: String,
 
 	/// Select how many samples we should take across the variable components.
-	#[structopt(short, long)]
-	pub steps: String,
+	#[structopt(short, long, use_delimiter = true)]
+	pub steps: Vec<u32>,
 
 	/// Select how many repetitions of this benchmark should run.
 	#[structopt(short, long, default_value = "1")]
@@ -98,18 +98,13 @@ impl BenchmarkCmd {
 			None, // heap pages
 		);
 
-		let steps: Vec<u32> = self.steps
-			.split(',')
-			.map(|step| step.parse::<u32>().expect("failed to parse step"))
-			.collect();
-
 		let result = StateMachine::<_, _, NumberFor<BB>, _>::new(
 			&state,
 			None,
 			&mut changes,
 			&executor,
 			"Benchmark_dispatch_benchmark",
-			&(&self.pallet, &self.extrinsic, steps, self.repeat).encode(),
+			&(&self.pallet, &self.extrinsic, self.steps.clone(), self.repeat).encode(),
 			Default::default(),
 		)
 		.execute(strategy.into())

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -36,8 +36,8 @@ pub struct BenchmarkCmd {
 	pub extrinsic: String,
 
 	/// Select how many samples we should take across the variable components.
-	#[structopt(short, long, default_value = "1")]
-	pub steps: u32,
+	#[structopt(short, long)]
+	pub steps: String,
 
 	/// Select how many repetitions of this benchmark should run.
 	#[structopt(short, long, default_value = "1")]
@@ -97,13 +97,19 @@ impl BenchmarkCmd {
 			wasm_method,
 			None, // heap pages
 		);
+
+		let steps: Vec<u32> = self.steps
+			.split(',')
+			.map(|step| step.parse::<u32>().expect("failed to parse step"))
+			.collect();
+
 		let result = StateMachine::<_, _, NumberFor<BB>, _>::new(
 			&state,
 			None,
 			&mut changes,
 			&executor,
 			"Benchmark_dispatch_benchmark",
-			&(&self.pallet, &self.extrinsic, self.steps, self.repeat).encode(),
+			&(&self.pallet, &self.extrinsic, steps, self.repeat).encode(),
 			Default::default(),
 		)
 		.execute(strategy.into())


### PR DESCRIPTION
Changes:
- Make `--steps` option to take as input a serie of numbers separated by comma (e.g. `10,50,30`) denoting the number of steps for each component of the corresponding extrinsic. Previously it was using the same steps number for all the components. Example:
`substrate benchmark --chain dev --execution=native  --extrinsic set_identity --pallet pallet-identity --steps 50,100 --repeat 1`
- Set the max value for the other components as default in order to hit worst case.
- Other nits.