### PR TITLE
Add storage root recalculation time to benchmarks

### DIFF
--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -31,7 +31,7 @@ pub enum BenchmarkParameter {
 /// Results from running benchmarks on a FRAME pallet.
 /// Contains duration of the function call in nanoseconds along with the benchmark parameters
 /// used for that benchmark result.
-pub type BenchmarkResults = (Vec<(BenchmarkParameter, u32)>, u128);
+pub type BenchmarkResults = (Vec<(BenchmarkParameter, u32)>, u128, u128);
 
 sp_api::decl_runtime_apis! {
 	/// Runtime api for benchmarking a FRAME runtime.

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -124,12 +124,13 @@ impl BenchmarkCmd {
 			// Print the table header
 			results[0].0.iter().for_each(|param| print!("{:?},", param.0));
 
-			print!("time\n");
+			print!("extrinsic_time,storage_root_time\n");
 			// Print the values
 			results.iter().for_each(|result| {
 				let parameters = &result.0;
 				parameters.iter().for_each(|param| print!("{:?},", param.1));
-				print!("{:?}\n", result.1);
+				// Print extrinsic time and storage root time
+				print!("{:?},{:?}\n", result.1, result.2);
 			});
 
 			eprintln!("Done.");


### PR DESCRIPTION
This is a small PR which additionally adds storage root recalculation time to our pallet benchmarking setup.

Storage root recalculation is measured using:

```
sp_io::storage::root
```

Results now look like:

```
Pallet: "pallet-identity", Extrinsic: "add_registrar", Steps: 10, Repeat: 100
r,extrinsic_time,storage_root_time
1,305000,65000
1,97000,39000
1,281000,39000
1,102000,41000
```