### PR TITLE
Remove CratesOrPath variant

### DIFF
--- a/utils/wasm-builder-runner/src/lib.rs
+++ b/utils/wasm-builder-runner/src/lib.rs
@@ -139,11 +139,10 @@ impl WasmBuilderSelectSource {
 		version: &'static str,
 		path: &'static str,
 	) -> WasmBuilder {
-		WasmBuilder {
-			source: WasmBuilderSource::CratesOrPath { version, path },
-			rust_flags: Vec::new(),
-			file_name: None,
-			project_cargo_toml: self.0,
+		if Path::new(path).exists() {
+			self.with_wasm_builder_from_path(path)
+		} else {
+			self.with_wasm_builder_from_crates(version)
 		}
 	}
 
@@ -280,11 +279,6 @@ pub enum WasmBuilderSource {
 	},
 	/// Use the given version released on crates.io.
 	Crates(&'static str),
-	/// Use the given version released on crates.io or from the given path.
-	CratesOrPath {
-		version: &'static str,
-		path: &'static str,
-	}
 }
 
 impl WasmBuilderSource {
@@ -301,15 +295,6 @@ impl WasmBuilderSource {
 			}
 			WasmBuilderSource::Crates(version) => {
 				format!("version = \"{}\"", version)
-			}
-			WasmBuilderSource::CratesOrPath { version, path } => {
-				replace_back_slashes(
-					format!(
-						"path = \"{}\", version = \"{}\"",
-						manifest_dir.join(path).display(),
-						version
-					)
-				)
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that this lines in `build.rs` gives an error when `util/wasm-builder` is not found locally:
```rust
	WasmBuilder::new()
		.with_current_project()
		.with_wasm_builder_from_crates_or_path("1.0.9", "../../../utils/wasm-builder")
		.export_heap_base()
		.import_memory()
		.build()
```

Error:
```
Caused by:
  process didn't exit successfully: `/Users/ericlim/project/something/target/debug/build/something-runtime-b9cbca8cf16d835c/build-script-build` (exit code: 1)
--- stderr
error: failed to read `/Users/ericlim/utils/wasm-builder/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

This PR addresses one way to go around this problem (not the best solution but let me know!)