### PR TITLE
Adds documentation for `wipe` and `commit`

### DIFF
--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -203,13 +203,21 @@ pub trait Externalities: ExtensionStore {
 	/// Returns the SCALE encoded hash.
 	fn storage_changes_root(&mut self, parent: &[u8]) -> Result<Option<Vec<u8>>, ()>;
 
-	fn wipe(&mut self) {
-		unimplemented!()
-	}
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	/// Benchmarking related functionality and shouldn't be used anywhere else!
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	///
+	/// Wipes all changes from caches and the database.
+	///
+	/// The state will be resetted to genesis.
+	fn wipe(&mut self);
 
-	fn commit(&mut self) {
-		unimplemented!()
-	}
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	/// Benchmarking related functionality and shouldn't be used anywhere else!
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	///
+	/// Commits all changes to the database and clears all caches.
+	fn commit(&mut self);
 }
 
 /// Extension for the [`Externalities`] trait.

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -209,7 +209,7 @@ pub trait Externalities: ExtensionStore {
 	///
 	/// Wipes all changes from caches and the database.
 	///
-	/// The state will be resetted to genesis.
+	/// The state will be reset to genesis.
 	fn wipe(&mut self);
 
 	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -298,6 +298,10 @@ impl Externalities for BasicExternalities {
 	fn storage_changes_root(&mut self, _parent: &[u8]) -> Result<Option<Vec<u8>>, ()> {
 		Ok(None)
 	}
+
+	fn wipe(&mut self) {}
+
+	fn commit(&mut self) {}
 }
 
 impl sp_externalities::ExtensionStore for BasicExternalities {


### PR DESCRIPTION
This adds documentation to `wipe` and `commit` of `Externalities`.
Besides that it removes the default implementation that would just panic
and requires that all implementers of the trait implement the functions.

