### PR TITLE
add ss58 prefix for Acala & Laminar

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -436,12 +436,20 @@ ss58_address_format!(
 		(0, "polkadot", "Polkadot Relay-chain, direct checksum, standard account (*25519).")
 	KusamaAccountDirect =>
 		(2, "kusama", "Kusama Relay-chain, direct checksum, standard account (*25519).")
-	DothereumAccountDirect =>
-		(20, "dothereum", "Dothereum Para-chain, direct checksum, standard account (*25519).")
-	KulupuAccountDirect =>
-		(16, "kulupu", "Kulupu mainnet, direct checksum, standard account (*25519).")
 	EdgewareAccountDirect =>
 		(7, "edgeware", "Edgeware mainnet, direct checksum, standard account (*25519).")
+	KaruraAccountDirect =>
+		(8, "karura", "Acala Karura canary network, direct checksum, standard account (*25519).")
+	ReynoldsAccountDirect =>
+		(9, "reynolds", "Laminar Reynolds canary network, direct checksum, standard account (*25519).")
+	AcalaAccountDirect =>
+		(10, "acala", "Acala mainnet, direct checksum, standard account (*25519).")
+	LaminarAccountDirect =>
+		(11, "laminar", "Laminar mainnet, direct checksum, standard account (*25519).")
+	KulupuAccountDirect =>
+		(16, "kulupu", "Kulupu mainnet, direct checksum, standard account (*25519).")
+	DothereumAccountDirect =>
+		(20, "dothereum", "Dothereum Para-chain, direct checksum, standard account (*25519).")
 	CentrifugeAccountDirect =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, direct checksum, standard account (*25519).")
 	SubstraTeeAccountDirect =>


### PR DESCRIPTION
We would like to claim those ss58 prefixes:

- 8: Acala Karura canary network
- 9: Laminar Reynolds canary network
- 10: Acala mainnet
- 11: Laminar mainnet

We will be using 42 for Acala Mandala Testnet & Laminar Turbulence Testnet.

Also sorted the networks by prefix.