### PR TITLE
Fix substrate default storage location

### DIFF
--- a/.maintain/Dockerfile
+++ b/.maintain/Dockerfile
@@ -20,7 +20,6 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 	export PATH="$PATH:$HOME/.cargo/bin" && \
 	rustup toolchain install nightly && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
-	rustup default nightly && \
 	rustup default stable && \
 	cargo build "--$PROFILE"
 
@@ -34,9 +33,10 @@ ARG PROFILE=release
 RUN mv /usr/share/ca* /tmp && \
 	rm -rf /usr/share/*  && \
 	mv /tmp/ca-certificates /usr/share/ && \
-	mkdir -p /root/.local/share/Polkadot && \
-	ln -s /root/.local/share/Polkadot /data && \
-	useradd -m -u 1000 -U -s /bin/sh -d /substrate substrate
+	useradd -m -u 1000 -U -s /bin/sh -d /substrate substrate && \
+	mkdir -p /substrate/.local/share/substrate && \
+	chown -R substrate:substrate /substrate/.local && \
+	ln -s /substrate/.local/share/substrate /data
 
 COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
 
@@ -49,7 +49,7 @@ RUN rm -rf /usr/lib/python* && \
 	rm -rf /usr/bin /usr/sbin /usr/share/man
 
 USER substrate
-EXPOSE 30333 9933 9944
+EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
 
 CMD ["/usr/local/bin/substrate"]


### PR DESCRIPTION
This PR contains the following:
- same fix than in #5059 
- fix substrate default chain location (old issue finally fixed)
- add prometheus port to the list of hinted exposed ports

So this PR means we no longer *have to* provide the `-d /data` to substrate to make the volume mounting works.