### PR TITLE
*: Rename prometheus-exporter crate to substrate-prometheus-endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4989,19 +4989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-exporter"
-version = "0.8.0-alpha.2"
-dependencies = [
- "async-std",
- "derive_more",
- "futures-util",
- "hyper 0.13.2",
- "log 0.4.8",
- "prometheus",
- "tokio 0.2.11",
-]
-
-[[package]]
 name = "prost"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5686,7 +5673,6 @@ dependencies = [
  "log 0.4.8",
  "names",
  "parity-util-mem",
- "prometheus-exporter",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -5703,6 +5689,7 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "structopt",
+ "substrate-prometheus-endpoint",
  "tempfile",
  "time",
  "tokio 0.2.11",
@@ -6413,7 +6400,6 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.0",
- "prometheus-exporter",
  "sc-chain-spec",
  "sc-client",
  "sc-client-api",
@@ -6442,6 +6428,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-transaction-pool",
+ "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "sysinfo",
  "target_info",
@@ -7659,6 +7646,19 @@ dependencies = [
  "sp-runtime",
  "sp-transaction-pool",
  "substrate-test-runtime-client",
+]
+
+[[package]]
+name = "substrate-prometheus-endpoint"
+version = "0.8.0-alpha.2"
+dependencies = [
+ "async-std",
+ "derive_more",
+ "futures-util",
+ "hyper 0.13.2",
+ "log 0.4.8",
+ "prometheus",
+ "tokio 0.2.11",
 ]
 
 [[package]]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -33,7 +33,7 @@ sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 sc-service = { version = "0.8.0-alpha.2", default-features = false, path = "../service" }
 sp-state-machine = { version = "0.8.0-alpha.2", path = "../../primitives/state-machine" }
 sc-telemetry = { version = "2.0.0-alpha.2", path = "../telemetry" }
-prometheus-exporter = { path = "../../utils/prometheus" , version = "0.8.0-alpha.2"}
+substrate-prometheus-endpoint = { path = "../../utils/prometheus" , version = "0.8.0-alpha.2"}
 sp-keyring = { version = "2.0.0-alpha.2", path = "../../primitives/keyring" }
 names = "0.11.0"
 structopt = "0.3.8"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -56,7 +56,7 @@ sc-rpc = { version = "2.0.0-alpha.2", path = "../rpc" }
 sc-telemetry = { version = "2.0.0-alpha.2", path = "../telemetry" }
 sc-offchain = { version = "2.0.0-alpha.2", path = "../offchain" }
 parity-multiaddr = { package = "parity-multiaddr", version = "0.5.0" }
-prometheus-exporter = { path = "../../utils/prometheus" , version = "0.8.0-alpha.2"}
+substrate-prometheus-endpoint = { path = "../../utils/prometheus" , version = "0.8.0-alpha.2"}
 sc-tracing = { version = "2.0.0-alpha.2", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.5.1", default-features = false, features = ["primitive-types"] }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -53,7 +53,7 @@ use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 use sc_telemetry::{telemetry, SUBSTRATE_INFO};
 use sp_transaction_pool::{MaintainedTransactionPool, ChainEvent};
 use sp_blockchain;
-use prometheus_exporter::{register, Gauge, U64, F64, Registry, PrometheusError, Opts, GaugeVec};
+use substrate_prometheus_endpoint::{register, Gauge, U64, F64, Registry, PrometheusError, Opts, GaugeVec};
 
 struct ServiceMetrics {
 	block_height_number: GaugeVec<U64>,
@@ -1020,7 +1020,7 @@ ServiceBuilder<
 			));
 		}
 
-		// Prometheus exporter and metrics
+		// Prometheus endpoint and metrics
 		let metrics = if let Some(port) = config.prometheus_port {
 			let registry = match prometheus_registry {
 				Some(registry) => registry,
@@ -1030,7 +1030,7 @@ ServiceBuilder<
 			let metrics = ServiceMetrics::register(&registry)?;
 
 			let future = select(
-				prometheus_exporter::init_prometheus(port, registry).boxed(),
+				substrate_prometheus_endpoint::init_prometheus(port, registry).boxed(),
 				exit.clone()
 			).map(drop);
 

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -93,7 +93,7 @@ pub struct Configuration<G, E = NoExtension> {
 	pub rpc_ws_max_connections: Option<usize>,
 	/// CORS settings for HTTP & WS servers. `None` if all origins are allowed.
 	pub rpc_cors: Option<Vec<String>>,
-	/// Prometheus exporter Port. `None` if disabled.
+	/// Prometheus endpoint Port. `None` if disabled.
 	pub prometheus_port: Option<SocketAddr>,
 	/// Telemetry service URL. `None` if disabled.
 	pub telemetry_endpoints: Option<TelemetryEndpoints>,

--- a/client/service/src/error.rs
+++ b/client/service/src/error.rs
@@ -53,8 +53,8 @@ impl<'a> From<&'a str> for Error {
 	}
 }
 
-impl From<prometheus_exporter::PrometheusError> for Error {
-	fn from(e: prometheus_exporter::PrometheusError) -> Self {
+impl From<substrate_prometheus_endpoint::PrometheusError> for Error {
+	fn from(e: substrate_prometheus_endpoint::PrometheusError) -> Self {
 		Error::Other(format!("Prometheus error: {}", e))
 	}
 }

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-description = "Prometheus exporter server"
-name = "prometheus-exporter"
+description = "Endpoint to expose Prometheus metrics"
+name = "substrate-prometheus-endpoint"
 version = "0.8.0-alpha.2"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]

--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -65,7 +65,7 @@ mod known_os {
 		Http(hyper::http::Error),
 		/// i/o error.
 		Io(std::io::Error),
-		#[display(fmt = "Prometheus exporter port {} already in use.", _0)]
+		#[display(fmt = "Prometheus port {} already in use.", _0)]
 		PortInUse(SocketAddr)
 	}
 


### PR DESCRIPTION
This patch renames the crate for the following two reasons:

1. The prometheus-exporter crate introduces native in-process Prometheus
style instrumentation to the Substrate project. Within the Prometheus
ecosystem the term "exporter" is used for external processes exposing
metrics for e.g. the Linux Kernel. In-process exposition would be
described via the term "endpoint".

2. "prometheus-exporter" is generic and ignores the fact that it is only
usable within the context of Substrate. In addition the name
"prometheus-exporter" is already taken on crates.io.


Fixes https://github.com/paritytech/substrate/issues/5074