### PR TITLE
rename `browser-utils` to `substrate-browser-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,31 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "browser-utils"
-version = "0.8.0-alpha.2"
-dependencies = [
- "chrono",
- "clear_on_drop",
- "console_error_panic_hook",
- "console_log",
- "futures 0.1.29",
- "futures 0.3.4",
- "futures-timer 3.0.1",
- "js-sys",
- "kvdb-web",
- "libp2p",
- "log 0.4.8",
- "rand 0.6.5",
- "rand 0.7.3",
- "sc-chain-spec",
- "sc-informant",
- "sc-network",
- "sc-service",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "bs58"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,7 +3323,6 @@ name = "node-cli"
 version = "2.0.0-alpha.2"
 dependencies = [
  "assert_cmd",
- "browser-utils",
  "frame-benchmarking-cli",
  "frame-support",
  "frame-system",
@@ -3406,6 +3380,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "structopt",
+ "substrate-browser-utils",
  "substrate-build-script-utils",
  "tempfile",
  "tracing",
@@ -7617,6 +7592,31 @@ dependencies = [
  "pbkdf2",
  "schnorrkel",
  "sha2",
+]
+
+[[package]]
+name = "substrate-browser-utils"
+version = "0.8.0-alpha.2"
+dependencies = [
+ "chrono",
+ "clear_on_drop",
+ "console_error_panic_hook",
+ "console_log",
+ "futures 0.1.29",
+ "futures 0.3.4",
+ "futures-timer 3.0.1",
+ "js-sys",
+ "kvdb-web",
+ "libp2p",
+ "log 0.4.8",
+ "rand 0.6.5",
+ "rand 0.7.3",
+ "sc-chain-spec",
+ "sc-informant",
+ "sc-network",
+ "sc-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -98,7 +98,7 @@ node-inspect = { version = "0.8.0-alpha.2", optional = true, path = "../inspect"
 # WASM-specific dependencies
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { path = "../../../utils/browser", optional = true , version = "0.8.0-alpha.2"}
+browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.8.0-alpha.2" }
 
 [dev-dependencies]
 sc-keystore = { version = "2.0.0-alpha.2", path = "../../../client/keystore" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "browser-utils"
+name = "substrate-browser-utils"
 version = "0.8.0-alpha.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utilities for creating a browser light-client."


### PR DESCRIPTION
It's a good idea to give the crate a more descriptive name before publishing on crates.io.