### PR TITLE
Use function trait objects for exchangeable host functions

### DIFF
--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
@@ -147,8 +147,8 @@ fn generate_exchangeable_host_function(method: &TraitItemMethod) -> Result<Token
 			#[allow(non_upper_case_globals)]
 			#[doc = #doc_string]
 			pub static #exchangeable_function : #crate_::wasm::ExchangeableFunction<
-				fn ( #( #arg_types ),* ) #output
-			> = #crate_::wasm::ExchangeableFunction::new(extern_host_function_impls::#function);
+				&dyn Fn ( #( #arg_types ),* ) #output
+			> = #crate_::wasm::ExchangeableFunction::new(&extern_host_function_impls::#function);
 		}
 	)
 }

--- a/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -210,7 +210,17 @@ wasm_export_functions! {
 		assert!(!test_api::overwrite_native_function_implementation());
 
 		let _guard = test_api::host_overwrite_native_function_implementation
-			.replace_implementation(new_implementation);
+			.replace_implementation(&new_implementation);
+
+		assert!(test_api::overwrite_native_function_implementation());
+	}
+
+	fn test_overwrite_native_function_implementation_with_closure() {
+		// Check native implementation
+		assert!(!test_api::overwrite_native_function_implementation());
+
+		let _guard = test_api::host_overwrite_native_function_implementation
+			.replace_implementation(&|| true);
 
 		assert!(test_api::overwrite_native_function_implementation());
 	}


### PR DESCRIPTION
**Motivation**

The current state of exchangeable functions is that they all expect
raw function pointers: they're initialized with raw pointers to the
initial function, which means that every replacement must also be
a raw function pointer.

The problem with this arrangement is that this prevents us from
swapping in a closure. In Cumulus, we've discovered a case for which
it would be very convenient to swap in a closure which captures an
additional piece of data. This change enables this possibility.

**Drawbacks**

Function calls to a trait object pass through an additional layer
of indirection, which produces a negligable but non-zero additional
cost per function call.

**Breaking Changes**

Every call `foo.replace_implementation(new_impl)` must change to
`foo.replace_implementation(&new_impl)`, which is a simple but
possibly pervasive change.