### PR TITLE
Split ext_clear_storage out from ext_set_storage

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 234,
+	spec_version: 235,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/contracts/COMPLEXITY.md
+++ b/frame/contracts/COMPLEXITY.md
@@ -261,9 +261,20 @@ Each external function invoked from a contract can involve some overhead.
 This function receives a `key` and `value` as arguments. It consists of the following steps:
 
 1. Reading the sandbox memory for `key` and `value` (see sandboxing memory get).
-2. Setting the storage by the given `key` with the given `value` (see `set_storage`).
+2. Setting the storage at the given `key` to the given `value` (see `set_storage`).
 
 **complexity**: Complexity is proportional to the size of the `value`. This function induces a DB write of size proportional to the `value` size (if flushed to the storage), so should be priced accordingly.
+
+## ext_clear_storage
+
+This function receives a `key` as argument. It consists of the following steps:
+
+1. Reading the sandbox memory for `key` (see sandboxing memory get).
+2. Clearing the storage at the given `key` (see `set_storage`).
+
+**complexity**: Complexity is constant. This function induces a DB write to clear the storage entry
+(upon being flushed to the storage) and should be priced accordingly. The price should generally be
+low enough to motivate clearing of unused contract storage.
 
 ## ext_get_storage
 

--- a/frame/contracts/COMPLEXITY.md
+++ b/frame/contracts/COMPLEXITY.md
@@ -273,8 +273,7 @@ This function receives a `key` as argument. It consists of the following steps:
 2. Clearing the storage at the given `key` (see `set_storage`).
 
 **complexity**: Complexity is constant. This function induces a DB write to clear the storage entry
-(upon being flushed to the storage) and should be priced accordingly. The price should generally be
-low enough to motivate clearing of unused contract storage.
+(upon being flushed to the storage) and should be priced accordingly.
 
 ## ext_get_storage
 

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -770,7 +770,8 @@ fn run_out_of_gas() {
 const CODE_SET_RENT: &str = r#"
 (module
 	(import "env" "ext_dispatch_call" (func $ext_dispatch_call (param i32 i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
+	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
+	(import "env" "ext_clear_storage" (func $ext_clear_storage (param i32)))
 	(import "env" "ext_set_rent_allowance" (func $ext_set_rent_allowance (param i32 i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
 	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
@@ -780,7 +781,6 @@ const CODE_SET_RENT: &str = r#"
 	(func $call_0
 		(call $ext_set_storage
 			(i32.const 1)
-			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
 		)
@@ -788,11 +788,8 @@ const CODE_SET_RENT: &str = r#"
 
 	;; remove the value inserted by call_1
 	(func $call_1
-		(call $ext_set_storage
+		(call $ext_clear_storage
 			(i32.const 1)
-			(i32.const 0)
-			(i32.const 0)
-			(i32.const 0)
 		)
 	)
 
@@ -852,7 +849,6 @@ const CODE_SET_RENT: &str = r#"
 		)
 		(call $ext_set_storage
 			(i32.const 0)
-			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
 		)
@@ -1327,7 +1323,7 @@ fn default_rent_allowance_on_instantiate() {
 
 const CODE_RESTORATION: &str = r#"
 (module
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
+	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
 	(import "env" "ext_restore_to" (func $ext_restore_to (param i32 i32 i32 i32 i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
@@ -1352,7 +1348,6 @@ const CODE_RESTORATION: &str = r#"
 		;; Data to restore
 		(call $ext_set_storage
 			(i32.const 0)
-			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
 		)
@@ -1360,7 +1355,6 @@ const CODE_RESTORATION: &str = r#"
 		;; ACL
 		(call $ext_set_storage
 			(i32.const 100)
-			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
 		)
@@ -1377,8 +1371,8 @@ const CODE_RESTORATION: &str = r#"
 
 	;; Code hash of SET_RENT
 	(data (i32.const 264)
-		"\14\eb\65\3c\86\98\d6\b2\3d\8d\3c\4a\54\c6\c4\71"
-		"\b9\fc\19\36\df\ca\a0\a1\f2\dc\ad\9d\e5\36\0b\25"
+		"\c2\1c\41\10\a5\22\d8\59\1c\4c\77\35\dd\2d\bf\a1"
+		"\13\0b\50\93\76\9b\92\31\97\b7\c5\74\26\aa\38\2a"
 	)
 
 	;; Rent allowance
@@ -1624,7 +1618,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 const CODE_STORAGE_SIZE: &str = r#"
 (module
 	(import "env" "ext_get_storage" (func $ext_get_storage (param i32) (result i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
+	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
 	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "memory" (memory 16 16))
@@ -1657,7 +1651,6 @@ const CODE_STORAGE_SIZE: &str = r#"
 		;; place a garbage value in storage, the size of which is specified by the call input.
 		(call $ext_set_storage
 			(i32.const 0)		;; Pointer to storage key
-			(i32.const 1)		;; Value is not null
 			(i32.const 0)		;; Pointer to value
 			(i32.load (i32.const 32))	;; Size of value
 		)
@@ -2278,7 +2271,7 @@ const CODE_DESTROY_AND_TRANSFER: &str = r#"
 	(import "env" "ext_scratch_size" (func $ext_scratch_size (result i32)))
 	(import "env" "ext_scratch_read" (func $ext_scratch_read (param i32 i32 i32)))
 	(import "env" "ext_get_storage" (func $ext_get_storage (param i32) (result i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32 i32)))
+	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
 	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
 	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
@@ -2340,7 +2333,6 @@ const CODE_DESTROY_AND_TRANSFER: &str = r#"
 		;; Store the return address.
 		(call $ext_set_storage
 			(i32.const 16)	;; Pointer to the key
-			(i32.const 1)	;; Value is not null
 			(i32.const 80)	;; Pointer to the value
 			(i32.const 8)	;; Length of the value
 		)

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -368,13 +368,6 @@ define_env!(Env, <E: Ext>,
 			// Bail out if value length exceeds the set maximum value size.
 			return Err(sp_sandbox::HostError);
 		}
-		if value_len == 0 {
-			// Bail out on setting storage to an emptry entry.
-			//
-			// We might remove this constraint later if there are actual
-			// use cases that require setting empty contract storage entries.
-			return Err(sp_sandbox::HostError);
-		}
 		let mut key: StorageKey = [0; 32];
 		read_sandbox_memory_into_buf(ctx, key_ptr, &mut key)?;
 		let value = Some(read_sandbox_memory(ctx, value_ptr, value_len)?);


### PR DESCRIPTION
This PR splits the
```
ext_set_storage(key_ptr: u32, value_non_null: u32, value_ptr: u32, value_len: u32);
```
into two APIs:
```
ext_set_storage(key_ptr: u32, value_ptr: u32, value_len: u32);
ext_clear_storage(key_ptr: u32);
```

## Motivation

We perform this change to make it simpler for static analyzers to analyze the underlying code semantically.

The old API with its `value_non_null` parameter is theoretically impossible to analyze statically since the `value_non_null` parameter could be any runtime computed value. So it is potentially very hard for static analyzers to apply the correct gas costs in the case where we want to differentiate between setting and clearing contract storage entries.

**Why do we want to differentiate between those two operations?**

The operations have completely different semantics:
- The one API is updating a value of a storage entry,
- the other is clearing the value of a storage entry.

Also as described above this makes it far simpler for static analyzers (or in some cases even possible) to reason about the underlying code. It slightly reduces overhead in some situations but that should generally be negligible.

## Open Questions

While working on this PR one particular question arosed:

How do we currently treat empty storage entries? E.g. when setting `ext_set_storage` with a `value_len` of 0? This semantically is different from having a cleaned-up contract storage entry and thus should be taken into account for rental fees.

Since we were not aware of any smart contract use cases that could even profit from creating or having occupied empty storage entries we also disallowed having them in the adjusted `ext_set_storage`. Upon trying to set a contract storage entry to be empty this function will trigger a host error and the contract will trap.

We might change the semantics of this particular scenario once we are aware of a proper smart contracts use case.

## Task List of this PR

- [x] Introduced `ext_clear_storage`
- [x] Adjusted semantics of `ext_set_storage`
- [x] Adjusted `COMPLEXITY.md`
- [x] Adjusted SEAL tests