### PR TITLE
Update to SCALE 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4590,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
+checksum = "f509c5e67ca0605ee17dcd3f91ef41cadd685c75a298fb6261b781a5acb3f910"
 dependencies = [
  "arrayvec 0.5.1",
  "bitvec",
@@ -4603,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e513ff3e406f3ede6796dcdc83d0b32ffb86668cea1ccf7363118abeb00476"
+checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet template"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 safe-mix = { default-features = false, version = '1.0.0' }
 
 [dependencies.frame-support]
@@ -41,8 +41,8 @@ path = "../../../../primitives/runtime"
 [features]
 default = ['std']
 std = [
-    'codec/std',
-    'frame-support/std',
-    'safe-mix/std',
-    'system/std'
+	'codec/std',
+	'frame-support/std',
+	'safe-mix/std',
+	'system/std'
 ]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
 aura = { version = "2.0.0-alpha.2", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }
 balances = { version = "2.0.0-alpha.2", default-features = false, package = "pallet-balances", path = "../../../frame/balances" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # third-party dependencies
-codec = { package = "parity-scale-codec", version = "1.0.6" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 serde = { version = "1.0.102", features = ["derive"] }
 futures = { version = "0.3.1", features = ["compat"] }
 hex-literal = "0.2.1"

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 node-primitives = { version = "2.0.0-alpha.2", path = "../primitives" }
 node-runtime = { version = "2.0.0-alpha.2", path = "../runtime" }
 sc-executor = { version = "0.8.0-alpha.2", path = "../../../client/executor" }

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 derive_more = "0.99"
 log = "0.4.8"
 sc-cli = { version = "0.8.0-alpha.2", path = "../../../client/cli" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/paritytech/substrate/"
 [dependencies]
 
 # third-party dependencies
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 integer-sqrt = { version = "0.1.2" }
 rustc-hex = { version = "2.0", optional = true }
 serde = { version = "1.0.102", optional = true }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -14,7 +14,7 @@ pallet-balances = { version = "2.0.0-alpha.2", path = "../../../frame/balances" 
 sc-client = { version = "0.8.0-alpha.2", path = "../../../client/" }
 sc-client-db = { version = "0.8.0-alpha.2", path = "../../../client/db/", features = ["kvdb-rocksdb"] }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../../../client/api/" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 pallet-contracts = { version = "2.0.0-alpha.2", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "2.0.0-alpha.2", path = "../../../frame/grandpa" }
 pallet-indices = { version = "2.0.0-alpha.2", path = "../../../frame/indices" }

--- a/bin/node/transaction-factory/Cargo.toml
+++ b/bin/node/transaction-factory/Cargo.toml
@@ -12,7 +12,7 @@ sp-block-builder = { version = "2.0.0-alpha.2", path = "../../../primitives/bloc
 sc-cli = { version = "0.8.0-alpha.2", path = "../../../client/cli" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../../../client/api" }
 sc-client = { version = "0.8.0-alpha.2", path = "../../../client" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../../../primitives/consensus/common" }
 log = "0.4.8"
 sp-core = { version = "2.0.0-alpha.2", path = "../../../primitives/core" }

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -20,7 +20,7 @@ rustc-hex = "2.0.1"
 substrate-bip39 = "0.3.1"
 hex = "0.4.0"
 hex-literal = "0.2.1"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 frame-system = { version = "2.0.0-alpha.2", path = "../../../frame/system" }
 pallet-balances = { version = "2.0.0-alpha.2", path = "../../../frame/balances" }
 pallet-transaction-payment = { version = "2.0.0-alpha.2", path = "../../../frame/transaction-payment" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,7 +11,7 @@ description = "Substrate Client and associated logic."
 [dependencies]
 sc-block-builder = { version = "0.8.0-alpha.2", path = "block-builder" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "api" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../primitives/consensus/common" }
 derive_more = { version = "0.99.2" }
 sc-executor = { version = "0.8.0-alpha.2", path = "executor" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sc-client-api"
 
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../../primitives/consensus/common" }
 derive_more = { version = "0.99.2" }
 sc-executor = { version = "0.8.0-alpha.2", path = "../executor" }

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -14,7 +14,7 @@ prost-build = "0.6.1"
 
 [dependencies]
 bytes = "0.5.0"
-codec = { package = "parity-scale-codec", default-features = false, version = "1.0.3" }
+codec = { package = "parity-scale-codec", default-features = false, version = "1.2.0" }
 derive_more = "0.99.2"
 futures = "0.3.1"
 futures-timer = "3.0.1"

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -11,7 +11,7 @@ description = "Basic implementation of block-authoring logic."
 [dependencies]
 log = "0.4.8"
 futures = "0.3.1"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-api = { version = "2.0.0-alpha.2", path = "../../primitives/api" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../primitives/runtime" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -18,4 +18,4 @@ sp-blockchain = { version = "2.0.0-alpha.2", path = "../../primitives/blockchain
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 sp-block-builder = { version = "2.0.0-alpha.2", path = "../../primitives/block-builder" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../api" }
-codec = { package = "parity-scale-codec", version = "1.0.6", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -14,7 +14,7 @@ sp-consensus-aura = { version = "0.8.0-alpha.2", path = "../../../primitives/con
 sp-block-builder = { version = "2.0.0-alpha.2", path = "../../../primitives/block-builder" }
 sc-client = { version = "0.8.0-alpha.2", path = "../../" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../../api" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../../../primitives/consensus/common" }
 derive_more = "0.99.2"
 futures = "0.3.1"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sc-consensus-babe"
 
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 sp-consensus-babe = { version = "0.8.0-alpha.2", path = "../../../primitives/consensus/babe" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../../primitives/core" }
 sp-application-crypto = { version = "2.0.0-alpha.2", path = "../../../primitives/application-crypto" }

--- a/client/consensus/epochs/Cargo.toml
+++ b/client/consensus/epochs/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 parking_lot = "0.10.0"
 fork-tree = { version = "2.0.0-alpha.2", path = "../../../utils/fork-tree" }
 sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-alpha.2"}

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", path = "../../../primitives/core" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime" }

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../../api" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../../primitives/core" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../../primitives/blockchain" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -18,7 +18,7 @@ kvdb-memorydb = "0.4.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
 parity-util-mem = { version = "0.5.1", default-features = false, features = ["std"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 
 sc-client-api = { version = "2.0.0-alpha.2", path = "../api" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sc-executor"
 
 [dependencies]
 derive_more = "0.99.2"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-io = { version = "2.0.0-alpha.2", path = "../../primitives/io" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 sp-trie = { version = "2.0.0-alpha.2", path = "../../primitives/trie" }

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sc-executor-common/"
 [dependencies]
 log = "0.4.8"
 derive_more = "0.99.2"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 wasmi = "0.6.2"
 sp-core = { version = "2.0.0-alpha.2", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.2", path = "../../../primitives/allocator" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sc-execturo-wasmi"
 log = "0.4.8"
 wasmi = "0.6.2"
 parity-wasm = "0.41.0"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-executor-common = { version = "0.8.0-alpha.2", path = "../common" }
 sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime-interface" }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -12,7 +12,7 @@ description = "Defines a `WasmRuntime` that uses the Wasmtime JIT to execute."
 log = "0.4.8"
 wasmi = "0.6.2"
 parity-wasm = "0.41.0"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-executor-common = { version = "0.8.0-alpha.2", path = "../common" }
 sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime-interface" }

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 rand = "0.7.2"
 assert_matches = "1.3.0"
-parity-scale-codec = { version = "1.0.0", features = ["derive"] }
+parity-scale-codec = { version = "1.2.0", features = ["derive"] }
 sp-arithmetic = { version = "2.0.0-alpha.2", path = "../../primitives/arithmetic" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../primitives/runtime" }
 sp-consensus = { version = "0.8.0-alpha.1", path = "../../primitives/consensus/common" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -16,7 +16,7 @@ prost-build = "0.6.1"
 [dependencies]
 bitflags = "1.2.0"
 bytes = "0.5.0"
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 derive_more = "0.99.2"
 either = "1.5.3"
 erased-serde = "0.3.9"

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.8"
 threadpool = "1.7"
 num_cpus = "1.10"
 sp-offchain = { version = "2.0.0-alpha.2", path = "../../primitives/offchain" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 parking_lot = "0.10.0"
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 rand = "0.7.2"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Substrate RPC interfaces."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 derive_more = "0.99.2"
 futures = { version = "0.3.1", features = ["compat"] }
 jsonrpc-core = "14.0.3"

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -13,7 +13,7 @@ sc-rpc-api = { version = "0.8.0-alpha.2", path = "../rpc-api" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../api" }
 sc-client = { version = "0.8.0-alpha.2", path = "../" }
 sp-api = { version = "2.0.0-alpha.2", path = "../../primitives/api" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 futures = { version = "0.3.1", features = ["compat"] }
 jsonrpc-pubsub = "14.0.3"
 log = "0.4.8"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -47,7 +47,7 @@ sc-client-api = { version = "2.0.0-alpha.2", path = "../api" }
 sc-client = { version = "0.8.0-alpha.2", path = "../" }
 sp-api = { version = "2.0.0-alpha.2", path = "../../primitives/api" }
 sc-client-db = { version = "0.8.0-alpha.2", path = "../db" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-executor = { version = "0.8.0-alpha.2", path = "../executor" }
 sc-transaction-pool = { version = "2.0.0-alpha.2", path = "../transaction-pool" }
 sp-transaction-pool = { version = "2.0.0-alpha.2", path = "../../primitives/transaction-pool" }

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -12,7 +12,7 @@ description = "State database maintenance. Handles canonicalization and pruning 
 parking_lot = "0.10.0"
 log = "0.4.8"
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "0.7.0"

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Substrate transaction pool implementation."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 derive_more = "0.99.2"
 futures = { version = "0.3.1", features = ["compat"] }
 futures-diagnose = "1.0"

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -24,7 +24,7 @@ linked-hash-map = "0.5.2"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../../test-utils/runtime" }
 criterion = "0.3"
 

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME asset management pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 # Needed for various traits. In our case, `OnFinalize`.
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 # Needed for type-safe access to storage DB.

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME AURA consensus pallet"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -11,7 +11,7 @@ description = "FRAME pallet for authority discovery"
 [dependencies]
 sp-authority-discovery = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/authority-discovery" }
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-authorship = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/authorship" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -10,7 +10,7 @@ description = "Consensus extension module for BABE consensus. Collects on-chain 
 
 [dependencies]
 hex-literal = "0.2.1"
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet to manage balances"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Macro for benchmarking a FRAME runtime."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.1.2", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-api = { version = "2.0.0-alpha.2", path = "../../primitives/api", default-features = false }
 sp-runtime-interface = { version = "2.0.0-alpha.2", path = "../../primitives/runtime-interface", default-features = false }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../primitives/runtime", default-features = false }

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -10,7 +10,7 @@ description = "Collective system: Members of a set of account IDs can make their
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -11,7 +11,7 @@ description = "FRAME pallet for WASM contracts"
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 pwasm-utils = { version = "0.12.0", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 parity-wasm = { version = "0.41.0", default-features = false }
 wasmi-validation = { version = "0.3.0", default-features = false }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -10,7 +10,7 @@ description = "A crate that hosts a common definitions that are relevant for the
 
 [dependencies]
 # This crate should not rely on any of the frame primitives.
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../../primitives/runtime" }
 

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Node-specific RPC methods for interaction with contracts."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -10,7 +10,7 @@ description = "Runtime API definition required by Contracts RPC extensions."
 
 [dependencies]
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/api" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/runtime" }
 pallet-contracts-primitives = { version = "2.0.0-alpha.2", default-features = false, path = "../../common" }

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for democracy"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME election pallet for PHRAGMEN"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 sp-phragmen = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/phragmen" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for elections"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME EVM contracts pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }
 pallet-timestamp = { version = "2.0.0-alpha.2", default-features = false, path = "../timestamp" }

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet for offchain worker"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }
 serde = { version = "1.0.101", optional = true }

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME example pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }
 pallet-balances = { version = "2.0.0-alpha.2", default-features = false, path = "../balances" }

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME executives engine"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }
 serde = { version = "1.0.101", optional = true }

--- a/frame/finality-tracker/Cargo.toml
+++ b/frame/finality-tracker/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/pallet-finality-tracker"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/generic-asset/Cargo.toml
+++ b/frame/generic-asset/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for generic asset management"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
@@ -23,10 +23,10 @@ sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 [features]
 default = ["std"]
 std =[
-    "serde/std",
-    "codec/std",
-    "sp-std/std",
-    "sp-runtime/std",
-    "frame-support/std",
-    "frame-system/std",
+	"serde/std",
+	"codec/std",
+	"sp-std/std",
+	"sp-runtime/std",
+	"frame-support/std",
+	"frame-system/std",
 ]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for GRANDPA finality gadget"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-finality-grandpa = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME identity management pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -11,7 +11,7 @@ description = "FRAME's I'm online pallet"
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/application-crypto" }
 pallet-authorship = { version = "2.0.0-alpha.2", default-features = false, path = "../authorship" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME indices management pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-keyring = { version = "2.0.0-alpha.2", optional = true, path = "../../primitives/keyring" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME membership management pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }

--- a/frame/metadata/Cargo.toml
+++ b/frame/metadata/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Decodable variant of the RuntimeMetadata."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for nick management"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME offences pallet"
 
 [dependencies]
 pallet-balances = { version = "2.0.0-alpha.2", default-features = false, path = "../balances" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME randomness collective flip pallet"
 
 [dependencies]
 safe-mix = { version = "1.0", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME account recovery pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for scored pools"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME sessions pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/staking" }

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME society pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.2"}
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet staking"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-keyring = { version = "2.0.0-alpha.2", optional = true, path = "../../primitives/keyring" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-phragmen = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/phragmen" }

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for sudo"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -11,7 +11,7 @@ description = "Support code for the runtime."
 [dependencies]
 log = "0.4"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "11.0.0-alpha.2", default-features = false, path = "../metadata" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.2"}

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-io ={ path = "../../../primitives/io", default-features = false , version = "2.0.0-alpha.2"}
 sp-state-machine = { version = "0.8.0-alpha.2", optional = true, path = "../../../primitives/state-machine" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../" }

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME system module"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { path = "../../primitives/io", default-features = false, version = "2.0.0-alpha.2" }

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -10,7 +10,7 @@ description = "Runtime API definition required by System RPC extensions."
 
 [dependencies]
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/api" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/pallet-timestamp"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet to manage transaction payments"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "RPC interface for the transaction payment module."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -11,7 +11,7 @@ description = "RPC runtime API for transaction payment FRAME pallet"
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/api" }
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../../../primitives/runtime" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../../../support" }

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet to manage treasury"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/runtime" }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME utilities pallet"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 frame-support = { version = "2.0.0-alpha.2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.2", default-features = false, path = "../system" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/core" }

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME pallet for manage vesting"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Substrate runtime api primitives"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-api-proc-macro = { version = "2.0.0-alpha.2", path = "proc-macro" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -16,7 +16,7 @@ sp-runtime = { version = "2.0.0-alpha.2", path = "../../runtime" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../blockchain" }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../../../primitives/consensus/common" }
 sc-block-builder = { version = "0.8.0-alpha.2", path = "../../../client/block-builder" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-state-machine = { version = "0.8.0-alpha.2", path = "../../../primitives/state-machine" }
 trybuild = "1.0.17"
 rustversion = "1.0.0"

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sp-application-crypto"
 
 [dependencies]
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/io" }
@@ -25,7 +25,7 @@ std = [ "full_crypto", "sp-core/std", "codec/std", "serde", "sp-std/std", "sp-io
 # or Intel SGX.
 # For the regular wasm runtime builds this should not be used.
 full_crypto = [
-    "sp-core/full_crypto",
+	"sp-core/full_crypto",
 	# Don't add `panic_handler` and `alloc_error_handler` since they are expected to be provided
 	# by the user anyway.
 	"sp-io/disable_panic_handler",

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sp-arithmetic"
 
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 integer-sqrt = "0.1.2"
 num-traits = { version = "0.2.8", default-features = false }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../application-crypto" }
-codec = { package = "parity-scale-codec", default-features = false, version = "1.0.3" }
+codec = { package = "parity-scale-codec", default-features = false, version = "1.2.0" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../api" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../inherents" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
 [features]
 default = [ "std" ]

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -12,7 +12,7 @@ description = "The block builder runtime api."
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../api" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../inherents" }
 
 [features]

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.8"
 lru = "0.4.0"
 parking_lot = "0.10.0"
 derive_more = "0.99.2"
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-consensus = { version = "0.8.0-alpha.2", path = "../consensus/common" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../runtime" }
 sp-block-builder = { version = "2.0.0-alpha.2", path = "../block-builder" }

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../../application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../std" }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../api" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../runtime" }

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../../application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../std" }
 schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated"], optional = true }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../api" }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -23,7 +23,7 @@ futures-diagnose = "1.0"
 sp-std = { version = "2.0.0-alpha.2", path = "../../std" }
 sp-version = { version = "2.0.0-alpha.2", path = "../../version" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../runtime" }
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 parking_lot = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -13,7 +13,7 @@ sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../../ap
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../../runtime" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../../core" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sp-core"
 
 [dependencies]
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 rustc-hex = { version = "2.0.1", default-features = false }
 log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sp-finality-grandpa"
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../api" }

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "FRAME module that tracks the last finalized block, as perceived by block authors."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/std" }
 

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/sp-inherents"
 parking_lot = { version = "0.10.0", optional = true }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.2", optional = true }
 
 [features]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sp-io"
 
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -14,7 +14,7 @@ sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../wasm-interface", def
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-runtime-interface-proc-macro = { version = "2.0.0-alpha.2", path = "proc-macro" }
 sp-externalities = { version = "0.8.0-alpha.2", optional = true, path = "../externalities" }
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 static_assertions = "1.0.0"
 primitive-types = { version = "0.6.2", default-features = false }
 

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sp-runtime"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.1.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../application-crypto" }
 sp-arithmetic = { version = "2.0.0-alpha.2", default-features = false, path = "../arithmetic" }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -14,7 +14,7 @@ sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-io = { version = "2.0.0-alpha.2", default-features = false, path = "../io" }
 sp-wasm-interface = { version = "2.0.0-alpha.2", default-features = false, path = "../wasm-interface" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 
 [dev-dependencies]
 wabt = "0.9.2"

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 description = "A crate which contains primitives that are useful for implementation that uses staking approaches in general. Definitions related to sessions, slashing, etc go here."
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -18,7 +18,7 @@ trie-root = "0.16.0"
 sp-trie = { version = "2.0.0-alpha.2", path = "../trie" }
 sp-core = { version = "2.0.0-alpha.2", path = "../core" }
 sp-panic-handler = { version = "2.0.0-alpha.2", path = "../panic-handler" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 num-traits = "0.2.8"
 rand = "0.7.2"
 sp-externalities = { version = "0.8.0-alpha.2", path = "../externalities" }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 sp-application-crypto = { version = "2.0.0-alpha.2", default-features = false, path = "../application-crypto" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-core = { version = "2.0.0-alpha.2", default-features = false, path = "../core" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -12,7 +12,7 @@ description = "Substrate core types and inherents for timestamps."
 sp-api = { version = "2.0.0-alpha.2", default-features = false, path = "../api" }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../inherents" }
 impl-trait-for-tuples = "0.1.3"
 wasm-timer = "0.2"

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/sp-transaction-pool"
 
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", optional = true }
+codec = { package = "parity-scale-codec", version = "1.2.0", optional = true }
 derive_more = { version = "0.99.2", optional = true }
 futures = { version = "0.3.1", optional = true }
 log = { version = "0.4.8", optional = true }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -14,7 +14,7 @@ name = "bench"
 harness = false
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.20.0", default-features = false }

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-version"
 [dependencies]
 impl-serde = { version = "0.2.3", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "1.1.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-alpha.2", default-features = false, path = "../std" }
 sp-runtime = { version = "2.0.0-alpha.2", default-features = false, path = "../runtime" }
 

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-wasm-interface"
 wasmi = { version = "0.6.2", optional = true }
 impl-trait-for-tuples = "0.1.2"
 sp-std = { version = "2.0.0-alpha.2", path = "../std", default-features = false }
-codec = { package = "parity-scale-codec", version = "1.1.2", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 
 [features]
 default = [ "std" ]

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -17,7 +17,7 @@ sc-executor = { version = "0.8.0-alpha.2", path = "../../client/executor" }
 futures = "0.3.1"
 hash-db = "0.15.2"
 sp-keyring = { version = "2.0.0-alpha.2", path = "../../primitives/keyring" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-core = { version = "2.0.0-alpha.2", path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../primitives/runtime" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../primitives/blockchain" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -15,7 +15,7 @@ sp-consensus-aura = { version = "0.8.0-alpha.2", default-features = false, path 
 sp-consensus-babe = { version = "0.8.0-alpha.2", default-features = false, path = "../../primitives/consensus/babe" }
 sp-block-builder = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/block-builder" }
 cfg-if = "0.1.10"
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 frame-executive = { version = "2.0.0-alpha.2", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "2.0.0-alpha.2", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-alpha.2", optional = true, path = "../../primitives/keyring" }

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -16,7 +16,7 @@ substrate-test-runtime = { version = "2.0.0-dev", path = "../../runtime" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime" }
 sp-api = { version = "2.0.0-alpha.2", path = "../../../primitives/api" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../../primitives/blockchain" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-client-api = { version = "2.0.0-alpha.2", path = "../../../client/api" }
 sc-client = { version = "0.8.0-alpha.2", path = "../../../client/" }
 futures = "0.3.1"

--- a/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/test-utils/runtime/transaction-pool/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../client" }
 parking_lot = "0.10.0"
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 sp-blockchain = { version = "2.0.0-alpha.2", path = "../../../primitives/blockchain" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime" }
 sp-transaction-pool = { version = "2.0.0-alpha.2", path = "../../../primitives/transaction-pool" }

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -10,4 +10,4 @@ description = "Utility library for managing tree-like ordered data with logic fo
 documentation = "https://docs.rs/fork-tree"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -17,4 +17,4 @@ sc-client-db = { version = "0.8.0-alpha.2", path = "../../../client/db" }
 sc-executor = { version = "0.8.0-alpha.2", path = "../../../client/executor" }
 sp-runtime = { version = "2.0.0-alpha.2", path = "../../../primitives/runtime" }
 structopt = "0.3.8"
-codec = { version = "1.1.2", package = "parity-scale-codec" }
+codec = { version = "1.2.0", package = "parity-scale-codec" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -10,7 +10,7 @@ description = "FRAME's system exposed over Substrate RPC"
 
 [dependencies]
 sc-client = { version = "0.8.0-alpha.2", path = "../../../../client/" }
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.2.0" }
 futures = "0.3.1"
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"


### PR DESCRIPTION
This updates `parity-scale-codec` to `1.2.0`, which includes multiple
performance improvements and a fix that bounds the capacity of a vector
at decoding.

