### PR TITLE
Drop db-cache default from 1gig to 32mb

### DIFF
--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -55,7 +55,7 @@ pub struct ImportParams {
 	pub execution_strategies: ExecutionStrategies,
 
 	/// Limit the memory the database cache can use.
-	#[structopt(long = "db-cache", value_name = "MiB", default_value = "1024")]
+	#[structopt(long = "db-cache", value_name = "MiB", default_value = "32")]
 	pub database_cache_size: u32,
 
 	/// Specify the state cache size.


### PR DESCRIPTION
Through rigorous analysis *coughcough* ... random testing, we've noticed that the db-cache default is a lot higher than it needs to be. This PR drops it from 1gig to defaulting to 32mb. This has a few added benefits:

- a lower footprint without obvious decrease in bps imported
- leaks should be easier and quicker to detect (rather than only after the 1gig of DB cache is filled)