### PR TITLE
Remove `sender` from `Applyable`.

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -118,7 +118,7 @@ impl<
 where
 	Block::Extrinsic: Checkable<Context> + Codec,
 	CheckedOf<Block::Extrinsic, Context>:
-		Applyable<AccountId=System::AccountId, DispatchInfo=DispatchInfo> +
+		Applyable<DispatchInfo=DispatchInfo> +
 		GetDispatchInfo,
 	CallOf<Block::Extrinsic, Context>: Dispatchable,
 	OriginOf<Block::Extrinsic, Context>: From<Option<System::AccountId>>,
@@ -143,7 +143,7 @@ impl<
 where
 	Block::Extrinsic: Checkable<Context> + Codec,
 	CheckedOf<Block::Extrinsic, Context>:
-		Applyable<AccountId=System::AccountId, DispatchInfo=DispatchInfo> +
+		Applyable<DispatchInfo=DispatchInfo> +
 		GetDispatchInfo,
 	CallOf<Block::Extrinsic, Context>: Dispatchable,
 	OriginOf<Block::Extrinsic, Context>: From<Option<System::AccountId>>,

--- a/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -45,13 +45,8 @@ where
 	Origin: From<Option<AccountId>>,
 	Info: Clone,
 {
-	type AccountId = AccountId;
 	type Call = Call;
 	type DispatchInfo = Info;
-
-	fn sender(&self) -> Option<&Self::AccountId> {
-		self.signed.as_ref().map(|x| &x.0)
-	}
 
 	fn validate<U: ValidateUnsigned<Call = Self::Call>>(
 		&self,

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -410,11 +410,8 @@ impl<Origin, Call, Extra, Info> Applyable for TestXt<Call, Extra> where
 	Origin: From<Option<u64>>,
 	Info: Clone,
 {
-	type AccountId = u64;
 	type Call = Call;
 	type DispatchInfo = Info;
-
-	fn sender(&self) -> Option<&Self::AccountId> { self.signature.as_ref().map(|x| &x.0) }
 
 	/// Checks to see if this is a valid *transaction*. It returns information on it if so.
 	fn validate<U: ValidateUnsigned<Call=Self::Call>>(

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -876,17 +876,11 @@ impl SignedExtension for () {
 /// Also provides information on to whom this information is attributable and an index that allows
 /// each piece of attributable information to be disambiguated.
 pub trait Applyable: Sized + Send + Sync {
-	/// ID of the account that is responsible for this piece of information (sender).
-	type AccountId: Member + MaybeDisplay;
-
 	/// Type by which we can dispatch. Restricts the `UnsignedValidator` type.
 	type Call;
 
 	/// An opaque set of information attached to the transaction.
 	type DispatchInfo: Clone;
-
-	/// Returns a reference to the sender if any.
-	fn sender(&self) -> Option<&Self::AccountId>;
 
 	/// Checks to see if this is a valid *transaction*. It returns information on it if so.
 	fn validate<V: ValidateUnsigned<Call=Self::Call>>(


### PR DESCRIPTION
It looks like `Applyable::sender` along with its `Applyable::AccountId` are not used within primitives/FRAME. This PR just removes that.

The runtime behavior is not changed.