### PR TITLE
Use 128mb for db cache default

### DIFF
--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -55,7 +55,7 @@ pub struct ImportParams {
 	pub execution_strategies: ExecutionStrategies,
 
 	/// Limit the memory the database cache can use.
-	#[structopt(long = "db-cache", value_name = "MiB", default_value = "32")]
+	#[structopt(long = "db-cache", value_name = "MiB", default_value = "128")]
 	pub database_cache_size: u32,
 
 	/// Specify the state cache size.


### PR DESCRIPTION
During another rigorous analysis, little values of cache lead to increased cpu usage during node normal operation (probably due to rocksdb needs to do uncompressing of data from system cache) 