### PR TITLE
Remove substrate-ui.parity.io from CORS whitelist

### DIFF
--- a/client/cli/src/commands/runcmd.rs
+++ b/client/cli/src/commands/runcmd.rs
@@ -140,9 +140,8 @@ pub struct RunCmd {
 	///
 	/// A comma-separated list of origins (protocol://domain or special `null`
 	/// value). Value of `all` will disable origin validation. Default is to
-	/// allow localhost, https://polkadot.js.org and
-	/// https://substrate-ui.parity.io origins. When running in --dev mode the
-	/// default is to allow all origins.
+	/// allow localhost and https://polkadot.js.org origins. When running in 
+	/// --dev mode the default is to allow all origins.
 	#[structopt(long = "rpc-cors", value_name = "ORIGINS", parse(try_from_str = parse_cors))]
 	pub rpc_cors: Option<Cors>,
 
@@ -408,7 +407,6 @@ impl RunCmd {
 				"https://localhost:*".into(),
 				"https://127.0.0.1:*".into(),
 				"https://polkadot.js.org".into(),
-				"https://substrate-ui.parity.io".into(),
 			])
 		}).into();
 


### PR DESCRIPTION
The only up-to-date deployment of PolkadotJS apps is currently on https://polkadot.js.org/apps/.
https://substrate-ui.parity.io is only useful as deliberately kept outdated version of Apps, to be used for projects still on Substrate 1.0
It cannot be used with the up-to-date chains running the Substrate 2.0 codebase, and probably won't be maintained much longer.
