### PR TITLE
Expose the `runtime-benchmarks` feature to the cli crate

### DIFF
--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -151,3 +151,4 @@ wasmtime = [
 	"sc-cli/wasmtime",
 	"sc-service/wasmtime",
 ]
+runtime-benchmarks = [ "node-runtime/runtime-benchmarks" ]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -132,4 +132,9 @@ std = [
 	"pallet-recovery/std",
 	"pallet-vesting/std",
 ]
-runtime-benchmarks = ["frame-benchmarking"]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"pallet-timestamp/runtime-benchmarks",
+	"pallet-identity/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+]


### PR DESCRIPTION
This exposes the `runtime-benchmarks` feature via the cli crate and
makes sure the benchmarking can be enabled. This requires that the user
goes to `bin/node/cli` and runs `cargo build --features
runtime-benchmarks` to build a node that has the feature enabled.

