### PR TITLE
Increment quote crate version since version not found at 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5108,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 [dependencies]
 proc-macro-crate = "0.1.4"
 proc-macro2 = "1.0.6"
-quote = "=1.0.2"
+quote = "=1.0.3"
 syn = "1.0.7"
 
 [dev-dependencies]

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0.7", features = ["full", "visit"] }
-quote = "=1.0.2"
+quote = "=1.0.3"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
 

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -14,5 +14,5 @@ proc-macro = true
 [dependencies]
 frame-support-procedural-tools = { version = "2.0.0-alpha.2", path = "./tools" }
 proc-macro2 = "1.0.6"
-quote = "=1.0.2"
+quote = "=1.0.3"
 syn = { version = "1.0.7", features = ["full"] }

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -11,6 +11,6 @@ description = "Proc macro helpers for procedural macros"
 [dependencies]
 frame-support-procedural-tools-derive = { version = "2.0.0-alpha.2", path = "./derive" }
 proc-macro2 = "1.0.6"
-quote = "=1.0.2"
+quote = "=1.0.3"
 syn = { version = "1.0.7", features = ["full", "visit"] }
 proc-macro-crate = "0.1.4"

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.6"
-quote = { version = "=1.0.2", features = ["proc-macro"] }
+quote = { version = "=1.0.3", features = ["proc-macro"] }
 syn = { version = "1.0.7", features = ["proc-macro" ,"full", "extra-traits", "parsing"] }

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/sp-api-proc-macro"
 proc-macro = true
 
 [dependencies]
-quote = "=1.0.2"
+quote = "=1.0.3"
 syn = { version = "1.0.8", features = ["full", "fold", "extra-traits", "visit"] }
 proc-macro2 = "1.0.6"
 blake2-rfc = { version = "0.2.18", default-features = false }

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-debug-derive"
 proc-macro = true
 
 [dependencies]
-quote = "=1.0.2"
+quote = "=1.0.3"
 syn = "1.0.7"
 proc-macro2 = "1.0"
 

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0.5", features = ["full", "visit", "fold", "extra-traits"] }
-quote = "=1.0.2"
+quote = "=1.0.3"
 proc-macro2 = "1.0.3"
 Inflector = "0.11.4"
 proc-macro-crate = "0.1.4"


### PR DESCRIPTION
This PR increments the version after my cargo was unable to find version 1.0.2 of `quote` in the registry.

```
error: failed to select a version for the requirement `quote = "= 1.0.2"`
  candidate versions found which didn't match: 1.0.3, 1.0.1, 1.0.0, ...
  location searched: crates.io index
required by package `frame-support-procedural-tools v2.0.0-alpha.3 (https://github.com/hicommonwealth/substrate.git?branch=drew.up#3042e415)`
    ... which is depended on by `frame-support-procedural v2.0.0-alpha.3 (https://github.com/hicommonwealth/substrate.git?branch=drew.up#3042e415)`
    ... which is depended on by `frame-support v2.0.0-alpha.3 (https://github.com/hicommonwealth/substrate.git?branch=drew.up#3042e415)`
```