### PR TITLE
Adding a ss58 format for Plasm Network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -436,6 +436,8 @@ ss58_address_format!(
 		(0, "polkadot", "Polkadot Relay-chain, direct checksum, standard account (*25519).")
 	KusamaAccountDirect =>
 		(2, "kusama", "Kusama Relay-chain, direct checksum, standard account (*25519).")
+	PlasmAccountDirect =>
+		(5, "plasm", "Plasm Network, direct checksum, standard account (*25519).")
 	EdgewareAccountDirect =>
 		(7, "edgeware", "Edgeware mainnet, direct checksum, standard account (*25519).")
 	KaruraAccountDirect =>


### PR DESCRIPTION
This small PR adds ss58 prefix for Plasm Network project: https://www.plasmnet.io/