### PR TITLE
Don't use skip signature check by default

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -298,7 +298,7 @@ impl_runtime_apis! {
 		}
 
 		fn apply_trusted_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			Executive::apply_trusted_extrinsic(extrinsic)
+			Executive::apply_extrinsic(extrinsic)
 		}
 
 		fn finalize_block() -> <Block as BlockT>::Header {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -706,7 +706,7 @@ impl_runtime_apis! {
 		}
 
 		fn apply_trusted_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-			Executive::apply_trusted_extrinsic(extrinsic)
+			Executive::apply_extrinsic(extrinsic)
 		}
 
 		fn finalize_block() -> <Block as BlockT>::Header {

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -203,7 +203,7 @@ impl<A, B, Block, C> ProposerInner<B, Block, C, A>
 				inherent_data
 			)?
 		{
-			block_builder.push_trusted(extrinsic)?;
+			block_builder.push(extrinsic)?;
 		}
 
 		// proceed with transactions
@@ -226,7 +226,7 @@ impl<A, B, Block, C> ProposerInner<B, Block, C, A>
 			let pending_tx_data = pending_tx.data().clone();
 			let pending_tx_hash = pending_tx.hash().clone();
 			trace!("[{:?}] Pushing to the block.", pending_tx_hash);
-			match sc_block_builder::BlockBuilder::push_trusted(&mut block_builder, pending_tx_data) {
+			match sc_block_builder::BlockBuilder::push(&mut block_builder, pending_tx_data) {
 				Ok(()) => {
 					debug!("[{:?}] Pushed to the block.", pending_tx_hash);
 				}


### PR DESCRIPTION
As discussed in #5112, seems there are some corner cases that make this optimisation rather unsafe.

We'll revisit it soon to make it safe or use batching/parallelization/caching(with runtime version awareness) instead.