### PR TITLE
Fix NotificationStreamClosed reported when it shouldn't

### DIFF
--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -21,7 +21,7 @@
 
 pub use crate::chain::{Client, FinalityProofProvider};
 pub use crate::on_demand_layer::OnDemand;
-pub use crate::service::TransactionPool;
+pub use crate::service::{TransactionPool, EmptyTransactionPool};
 pub use libp2p::{identity, core::PublicKey, wasm_ext::ExtTransport, build_multiaddr};
 
 // Note: this re-export shouldn't be part of the public API of the crate and will be removed in

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -803,7 +803,6 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 				remote: peer,
 				protocols: self.protocol_name_by_engine.keys().cloned().collect(),
 			}
-
 		} else {
 			CustomMessageOutcome::None
 		}

--- a/client/network/src/protocol/light_dispatch.rs
+++ b/client/network/src/protocol/light_dispatch.rs
@@ -273,7 +273,7 @@ impl<B: BlockT> LightDispatch<B> where
 				info!("Invalid remote {} response from peer {}", rtype, peer);
 				network.report_peer(&peer, ReputationChange::new_fatal("Invalid remote response"));
 				network.disconnect_peer(&peer);
-				self.remove_peer(peer);
+				self.remove_peer(&peer);
 				return;
 			},
 		};
@@ -285,7 +285,7 @@ impl<B: BlockT> LightDispatch<B> where
 				info!("Failed to check remote {} response from peer {}: {}", rtype, peer, error);
 				network.report_peer(&peer, ReputationChange::new_fatal("Failed remote response check"));
 				network.disconnect_peer(&peer);
-				self.remove_peer(peer);
+				self.remove_peer(&peer);
 
 				if retry_count > 0 {
 					(retry_count - 1, Some(retry_request_data))
@@ -299,7 +299,7 @@ impl<B: BlockT> LightDispatch<B> where
 				info!("Unexpected response to remote {} from peer", rtype);
 				network.report_peer(&peer, ReputationChange::new_fatal("Unexpected remote response"));
 				network.disconnect_peer(&peer);
-				self.remove_peer(peer);
+				self.remove_peer(&peer);
 
 				(retry_count, Some(retry_request_data))
 			},
@@ -337,7 +337,7 @@ impl<B: BlockT> LightDispatch<B> where
 	}
 
 	/// Call this when we disconnect from a node.
-	pub fn on_disconnect(&mut self, network: impl LightDispatchNetwork<B>, peer: PeerId) {
+	pub fn on_disconnect(&mut self, network: impl LightDispatchNetwork<B>, peer: &PeerId) {
 		self.remove_peer(peer);
 		self.dispatch(network);
 	}
@@ -523,15 +523,15 @@ impl<B: BlockT> LightDispatch<B> where
 	/// Removes a peer from the list of known peers.
 	///
 	/// Puts back the active request that this node was performing into `pending_requests`.
-	fn remove_peer(&mut self, peer: PeerId) {
-		self.best_blocks.remove(&peer);
+	fn remove_peer(&mut self, peer: &PeerId) {
+		self.best_blocks.remove(peer);
 
-		if let Some(request) = self.active_peers.remove(&peer) {
+		if let Some(request) = self.active_peers.remove(peer) {
 			self.pending_requests.push_front(request);
 			return;
 		}
 
-		if let Some(idle_index) = self.idle_peers.iter().position(|i| *i == peer) {
+		if let Some(idle_index) = self.idle_peers.iter().position(|i| i == peer) {
 			self.idle_peers.swap_remove_back(idle_index);
 		}
 	}

--- a/client/network/src/protocol/light_dispatch.rs
+++ b/client/network/src/protocol/light_dispatch.rs
@@ -860,7 +860,7 @@ pub mod tests {
 		assert_eq!(1, total_peers(&light_dispatch));
 		assert!(!light_dispatch.best_blocks.is_empty());
 
-		light_dispatch.on_disconnect(&mut network_interface, peer0);
+		light_dispatch.on_disconnect(&mut network_interface, &peer0);
 		assert_eq!(0, total_peers(&light_dispatch));
 		assert!(light_dispatch.best_blocks.is_empty());
 	}

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -80,6 +80,37 @@ pub trait TransactionPool<H: ExHashT, B: BlockT>: Send + Sync {
 	fn transaction(&self, hash: &H) -> Option<B::Extrinsic>;
 }
 
+/// Dummy implementation of the [`TransactionPool`] trait for a transaction pool that is always
+/// empty and discards all incoming transactions.
+///
+/// Requires the "hash" type to implement the `Default` trait.
+///
+/// Useful for testing purposes.
+pub struct EmptyTransactionPool;
+
+impl<H: ExHashT + Default, B: BlockT> TransactionPool<H, B> for EmptyTransactionPool {
+	fn transactions(&self) -> Vec<(H, B::Extrinsic)> {
+		Vec::new()
+	}
+
+	fn hash_of(&self, _transaction: &B::Extrinsic) -> H {
+		Default::default()
+	}
+
+	fn import(
+		&self,
+		_report_handle: ReportHandle,
+		_who: PeerId,
+		_rep_change_good: ReputationChange,
+		_rep_change_bad: ReputationChange,
+		_transaction: B::Extrinsic
+	) {}
+
+	fn on_broadcasted(&self, _: HashMap<H, Vec<String>>) {}
+
+	fn transaction(&self, _h: &H) -> Option<B::Extrinsic> { None }
+}
+
 /// A cloneable handle for reporting cost/benefits of peers.
 #[derive(Clone)]
 pub struct ReportHandle {

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -46,18 +46,18 @@ use sp_consensus::block_import::{BlockImport, ImportResult};
 use sp_consensus::Error as ConsensusError;
 use sp_consensus::{BlockOrigin, ForkChoiceStrategy, BlockImportParams, BlockCheckParams, JustificationImport};
 use futures::prelude::*;
-use sc_network::{NetworkWorker, NetworkStateInfo, NetworkService, ReportHandle, config::ProtocolId};
+use sc_network::{NetworkWorker, NetworkStateInfo, NetworkService, config::ProtocolId};
 use sc_network::config::{NetworkConfiguration, TransportConfig, BoxFinalityProofRequestBuilder};
 use libp2p::PeerId;
 use parking_lot::Mutex;
 use sp_core::H256;
-use sc_network::config::{ProtocolConfig, TransactionPool};
+use sc_network::config::ProtocolConfig;
 use sp_runtime::generic::{BlockId, OpaqueDigestItemId};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::Justification;
 use substrate_test_runtime_client::{self, AccountKeyring};
 
-pub use sc_network::EmptyTransactionPool;
+pub use sc_network::config::EmptyTransactionPool;
 pub use substrate_test_runtime_client::runtime::{Block, Extrinsic, Hash, Transfer};
 pub use substrate_test_runtime_client::{TestClient, TestClientBuilder, TestClientBuilderExt};
 

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -57,6 +57,7 @@ use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::Justification;
 use substrate_test_runtime_client::{self, AccountKeyring};
 
+pub use sc_network::EmptyTransactionPool;
 pub use substrate_test_runtime_client::runtime::{Block, Extrinsic, Hash, Transfer};
 pub use substrate_test_runtime_client::{TestClient, TestClientBuilder, TestClientBuilderExt};
 
@@ -380,31 +381,6 @@ impl<D> Peer<D> {
 	pub fn failed_verifications(&self) -> HashMap<<Block as BlockT>::Hash, String> {
 		self.verifier.failed_verifications.lock().clone()
 	}
-}
-
-pub struct EmptyTransactionPool;
-
-impl TransactionPool<Hash, Block> for EmptyTransactionPool {
-	fn transactions(&self) -> Vec<(Hash, Extrinsic)> {
-		Vec::new()
-	}
-
-	fn hash_of(&self, _transaction: &Extrinsic) -> Hash {
-		Hash::default()
-	}
-
-	fn import(
-		&self,
-		_report_handle: ReportHandle,
-		_who: PeerId,
-		_rep_change_good: sc_network::ReputationChange,
-		_rep_change_bad: sc_network::ReputationChange,
-		_transaction: Extrinsic
-	) {}
-
-	fn on_broadcasted(&self, _: HashMap<Hash, Vec<String>>) {}
-
-	fn transaction(&self, _h: &Hash) -> Option<Extrinsic> { None }
 }
 
 /// Implements `BlockImport` for any `Transaction`. Internally the transaction is


### PR DESCRIPTION
For backwards-compatibility reasons, right now the lifetime of a "notifications substream" is still tied to the lifetime of a handshake on the main substream.

At the moment, we report that we opened substreams when a handshake succeeds, and we report that we closed substreams when we disconnected.
However this left a bug: if a node connects then disconnects before the handshake, then we'd report that we closed substreams even though we have never reported that they were open.

While this bug doesn't really have bad consequences, it is the reason why the `polkadot_sub_libp2p_opened_notification_streams` metric is underflowing at the moment.
