### PR TITLE
Add ext_transfer call

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 236,
+	spec_version: 237,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/contracts/COMPLEXITY.md
+++ b/frame/contracts/COMPLEXITY.md
@@ -291,6 +291,21 @@ performed. Moreover, the DB read has to be synchronous and no progress can be ma
 **complexity**: The memory and computing complexity is proportional to the size of the fetched value. This function performs a
 DB read.
 
+## ext_transfer
+
+This function receives the following arguments:
+
+- `account` buffer of a marshaled `AccountId`,
+- `value` buffer of a marshaled `Balance`,
+
+It consists of the following steps:
+
+1. Loading `account` buffer from the sandbox memory (see sandboxing memory get) and then decoding it.
+2. Loading `value` buffer from the sandbox memory and then decoding it.
+4. Invoking the executive function `transfer`.
+
+Loading of `account` and `value` buffers should be charged. This is because the sizes of buffers are specified by the calling code, even though marshaled representations are, essentially, of constant size. This can be fixed by assigning an upper bound for sizes of `AccountId` and `Balance`.
+
 ## ext_call
 
 This function receives the following arguments:

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -120,6 +120,14 @@ pub trait Ext {
 		input_data: Vec<u8>,
 	) -> Result<(AccountIdOf<Self::T>, ExecReturnValue), ExecError>;
 
+	/// Transfer some amount of funds into the specified account.
+	fn transfer(
+		&mut self,
+		to: &AccountIdOf<Self::T>,
+		value: BalanceOf<Self::T>,
+		gas_meter: &mut GasMeter<Self::T>,
+	) -> Result<(), DispatchError>;
+
 	/// Call (possibly transferring some amount of funds) into the specified account.
 	fn call(
 		&mut self,
@@ -329,6 +337,24 @@ where
 			timestamp: self.timestamp.clone(),
 			block_number: self.block_number.clone(),
 		}
+	}
+
+	/// Transfer balance to `dest` without calling any contract code.
+	pub fn transfer(
+		&mut self,
+		dest: T::AccountId,
+		value: BalanceOf<T>,
+		gas_meter: &mut GasMeter<T>
+	) -> Result<(), DispatchError> {
+		let sender = self.self_account.clone();
+		transfer(
+			gas_meter,
+			TransferCause::Call,
+			&sender,
+			&dest,
+			value,
+			self,
+		)
 	}
 
 	/// Make a call to the specified address, optionally transferring some funds.
@@ -704,6 +730,15 @@ where
 		input_data: Vec<u8>,
 	) -> Result<(AccountIdOf<T>, ExecReturnValue), ExecError> {
 		self.ctx.instantiate(endowment, gas_meter, code_hash, input_data)
+	}
+
+	fn transfer(
+		&mut self,
+		to: &T::AccountId,
+		value: BalanceOf<T>,
+		gas_meter: &mut GasMeter<T>,
+	) -> Result<(), DispatchError> {
+		self.ctx.transfer(to.clone(), value, gas_meter)
 	}
 
 	fn call(

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -346,11 +346,10 @@ where
 		value: BalanceOf<T>,
 		gas_meter: &mut GasMeter<T>
 	) -> Result<(), DispatchError> {
-		let sender = self.self_account.clone();
 		transfer(
 			gas_meter,
 			TransferCause::Call,
-			&sender,
+			&self.self_account.clone(),
 			&dest,
 			value,
 			self,

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -405,6 +405,50 @@ define_env!(Env, <E: Ext>,
 		}
 	},
 
+	// Transfer some value to another account.
+	//
+	// If the value transfer was succesful zero is returned. Otherwise a non-zero value is returned.
+	// The scratch buffer is not touched. The receiver can be a plain account or a contract.
+	//
+	// - account_ptr: a pointer to the address of the beneficiary account
+	//   Should be decodable as an `T::AccountId`. Traps otherwise.
+	// - account_len: length of the address buffer.
+	// - value_ptr: a pointer to the buffer with value, how much value to send.
+	//   Should be decodable as a `T::Balance`. Traps otherwise.
+	// - value_len: length of the value buffer.
+	ext_transfer(
+		ctx,
+		account_ptr: u32,
+		account_len: u32,
+		value_ptr: u32,
+		value_len: u32
+	) -> u32 => {
+		let callee: <<E as Ext>::T as frame_system::Trait>::AccountId =
+			read_sandbox_memory_as(ctx, account_ptr, account_len)?;
+		let value: BalanceOf<<E as Ext>::T> =
+			read_sandbox_memory_as(ctx, value_ptr, value_len)?;
+
+		let ext = &mut ctx.ext;
+		let result = ctx.gas_meter.with_nested(ctx.gas_meter.gas_left(), |nested_meter| {
+			match nested_meter {
+				Some(nested_meter) => {
+					ext.transfer(
+						&callee,
+						value,
+						nested_meter,
+					)
+				}
+				// there is not enough gas to allocate for the nested call.
+				None => Err(sp_runtime::DispatchError::Other("Out of gas.")),
+			}
+		});
+
+		match result {
+			Ok(_) => Ok(STATUS_SUCCESS.into()),
+			Err(_) => Ok(TRAP_RETURN_CODE),
+		}
+	},
+
 	// Make a call to another contract.
 	//
 	// If the called contract runs to completion, then this returns the status code the callee

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -407,8 +407,9 @@ define_env!(Env, <E: Ext>,
 
 	// Transfer some value to another account.
 	//
-	// If the value transfer was succesful zero is returned. Otherwise a non-zero value is returned.
-	// The scratch buffer is not touched. The receiver can be a plain account or a contract.
+	// If the value transfer was succesful zero is returned. Otherwise one is returned.
+	// The scratch buffer is not touched. The receiver can be a plain account or
+	// a contract.
 	//
 	// - account_ptr: a pointer to the address of the beneficiary account
 	//   Should be decodable as an `T::AccountId`. Traps otherwise.
@@ -430,8 +431,8 @@ define_env!(Env, <E: Ext>,
 
 		let ext = &mut ctx.ext;
 		match ext.transfer(&callee, value, ctx.gas_meter) {
-			Ok(_) => Ok(STATUS_SUCCESS.into()),
-			Err(_) => Ok(TRAP_RETURN_CODE),
+			Ok(_) => Ok(0),
+			Err(_) => Ok(1),
 		}
 	},
 

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -429,8 +429,7 @@ define_env!(Env, <E: Ext>,
 		let value: BalanceOf<<E as Ext>::T> =
 			read_sandbox_memory_as(ctx, value_ptr, value_len)?;
 
-		let ext = &mut ctx.ext;
-		match ext.transfer(&callee, value, ctx.gas_meter) {
+		match ctx.ext.transfer(&callee, value, ctx.gas_meter) {
 			Ok(_) => Ok(0),
 			Err(_) => Ok(1),
 		}

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -429,21 +429,7 @@ define_env!(Env, <E: Ext>,
 			read_sandbox_memory_as(ctx, value_ptr, value_len)?;
 
 		let ext = &mut ctx.ext;
-		let result = ctx.gas_meter.with_nested(ctx.gas_meter.gas_left(), |nested_meter| {
-			match nested_meter {
-				Some(nested_meter) => {
-					ext.transfer(
-						&callee,
-						value,
-						nested_meter,
-					)
-				},
-				// there is not enough gas to allocate for the nested call.
-				None => Err(sp_runtime::DispatchError::Other("Out of gas.")),
-			}
-		});
-
-		match result {
+		match ext.transfer(&callee, value, ctx.gas_meter) {
 			Ok(_) => Ok(STATUS_SUCCESS.into()),
 			Err(_) => Ok(TRAP_RETURN_CODE),
 		}

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -421,7 +421,7 @@ define_env!(Env, <E: Ext>,
 		account_ptr: u32,
 		account_len: u32,
 		value_ptr: u32,
-		value_len: u32,
+		value_len: u32
 	) -> u32 => {
 		let callee: <<E as Ext>::T as frame_system::Trait>::AccountId =
 			read_sandbox_memory_as(ctx, account_ptr, account_len)?;

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -421,7 +421,7 @@ define_env!(Env, <E: Ext>,
 		account_ptr: u32,
 		account_len: u32,
 		value_ptr: u32,
-		value_len: u32
+		value_len: u32,
 	) -> u32 => {
 		let callee: <<E as Ext>::T as frame_system::Trait>::AccountId =
 			read_sandbox_memory_as(ctx, account_ptr, account_len)?;
@@ -437,7 +437,7 @@ define_env!(Env, <E: Ext>,
 						value,
 						nested_meter,
 					)
-				}
+				},
 				// there is not enough gas to allocate for the nested call.
 				None => Err(sp_runtime::DispatchError::Other("Out of gas.")),
 			}


### PR DESCRIPTION
This PR adds the following contract syscall:

```
ext_transfer(account_ptr: u32, account_len: u32, value_ptr: u32, value_len: u32);
```

It behaves similarly to `ext_call`. The differences are:

- Saves three arguments `input_ptr, input_len, gas_limit`.
- Garanteed to never execute code at the destination account (in case it is a contract).

# Motivation

Using `ext_call` for balance transfers has one major flaw: You need to know which kind of contract you are calling because otherwise you do not know if you are actually triggering contract code execution for the input you are passing. Nothing stops a contract from acting on an empty input in an arbitrary way.

Sparing the contract the hassle of passing gas costs and saving some overhead is merely a bonus.

closes #5027