### PR TITLE
Fix staking bug

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 230,
+	spec_version: 231,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -156,6 +156,8 @@ pub trait SessionManager<ValidatorId> {
 	/// `new_index` is strictly greater than from previous call.
 	///
 	/// The first session start at index 0.
+	///
+	/// `new_session(session)` is guaranteed to be called before `end_session(session-1)`.
 	fn new_session(new_index: SessionIndex) -> Option<Vec<ValidatorId>>;
 	/// End the session.
 	///

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1659,17 +1659,12 @@ impl<T: Trait> Module<T> {
 	/// End a session potentially ending an era.
 	fn end_session(session_index: SessionIndex) {
 		if let Some(active_era) = Self::active_era() {
-			let next_active_era_start_session_index =
+			if let Some(next_active_era_start_session_index) =
 				Self::eras_start_session_index(active_era.index + 1)
-					.unwrap_or_else(|| {
-						frame_support::print(
-							"Error: start_session_index must be set for active_era + 1"
-						);
-						0
-					});
-
-			if next_active_era_start_session_index == session_index + 1 {
-				Self::end_era(active_era, session_index);
+			{
+				if next_active_era_start_session_index == session_index + 1 {
+					Self::end_era(active_era, session_index);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
the property `"Error: start_session_index must be set for active_era + 1"` is false, there can be no future era planned yet, there is a future era planned only one session before the end of the era is kusama.

Although this was a bug, the behavior wasn't broken because in case no era is planned, then index 0 is returned and the comparison:
```rust
if next_active_era_start_session_index == session_index + 1 {
```
would return false which is good because no era was planned thus, the session doesn't end an era.
