### PR TITLE
Increase node template max block weight

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -120,7 +120,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1_000_000;
+	pub const MaximumBlockWeight: Weight = 1_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;


### PR DESCRIPTION
This PR increases the node template's maximum block weight from 1 million (`1_000_000`) to 1 billion (`1_000_000_000`) to match the main Substrate node. The former lower weight is the exact weight of a balance transfer which means that after a timestamp is in the block there isn't enough room left for even a single balance transfer.

A mystery that I haven't solved is why this just became a problem when none of those weight have changed in 9 months since https://github.com/paritytech/substrate/pull/3157

Cross reference: https://github.com/substrate-developer-hub/substrate-node-template/pull/25

Dumb question: Does this require a spec version bump? I think it does.