### PR TITLE
client: don't log on 0 gossip messages

### DIFF
--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -356,7 +356,10 @@ impl<B: BlockT> ConsensusGossip<B> {
 		who: PeerId,
 		messages: Vec<ConsensusMessage>,
 	) {
-		trace!(target:"gossip", "Received {} messages from peer {}", messages.len(), who);
+		if !messages.is_empty() {
+			trace!(target: "gossip", "Received {} messages from peer {}", messages.len(), who);
+		}
+
 		for message in messages {
 			let message_hash = HashFor::<B>::hash(&message.data[..]);
 


### PR DESCRIPTION
When we receive a batch of gossip messages we will call into all registered gossip validators with potentially no messages (they are filtered beforehand by gossip engine id), in which case we don't want to log a useless statement that we have received 0 messages.