### PR TITLE
Add 6 as address type of ss58 for Bifrost Network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -438,6 +438,8 @@ ss58_address_format!(
 		(2, "kusama", "Kusama Relay-chain, direct checksum, standard account (*25519).")
 	PlasmAccountDirect =>
 		(5, "plasm", "Plasm Network, direct checksum, standard account (*25519).")
+	BifrostAccountDirect =>
+		(6, "bifrost", "Bifrost mainnet, direct checksum, standard account (*25519).")
 	EdgewareAccountDirect =>
 		(7, "edgeware", "Edgeware mainnet, direct checksum, standard account (*25519).")
 	KaruraAccountDirect =>


### PR DESCRIPTION
Our team is going to take 6 as address type of ss58 for Bifrost Network. https://bifrost.codes/