### PR TITLE
Make sc-offchain tests more resilient on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,6 +6282,7 @@ version = "2.0.0-alpha.3"
 dependencies = [
  "bytes 0.5.4",
  "env_logger 0.7.1",
+ "fdlimit",
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,7 +2642,7 @@ dependencies = [
  "libp2p-wasm-ext",
  "libp2p-websocket",
  "libp2p-yamux",
- "parity-multiaddr 0.7.2",
+ "parity-multiaddr 0.7.3",
  "parity-multihash 0.2.3",
  "parking_lot 0.10.0",
  "pin-project",
@@ -2666,7 +2666,7 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.8",
  "multistream-select",
- "parity-multiaddr 0.7.2",
+ "parity-multiaddr 0.7.3",
  "parity-multihash 0.2.3",
  "parking_lot 0.10.0",
  "pin-project",
@@ -4585,9 +4585,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26df883298bc3f4e92528b4c5cc9f806b791955b136da3e5e939ed9de0fd958b"
+checksum = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
 dependencies = [
  "arrayref",
  "bs58 0.3.0",

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -32,12 +32,12 @@ hyper = "0.13.2"
 hyper-rustls = "0.19"
 
 [dev-dependencies]
-sc-client-db = { version = "0.8.0-alpha.2", default-features = true, path = "../db/" }
 env_logger = "0.7.0"
-substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
-tokio = "0.2"
+sc-client-db = { version = "0.8.0-alpha.2", default-features = true, path = "../db/" }
 sc-transaction-pool = { version = "2.0.0-alpha.2", path = "../../client/transaction-pool" }
 sp-transaction-pool = { version = "2.0.0-alpha.2", path = "../../primitives/transaction-pool" }
+substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
+tokio = "0.2"
 
 [features]
 default = []

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -33,6 +33,7 @@ hyper-rustls = "0.19"
 
 [dev-dependencies]
 env_logger = "0.7.0"
+fdlimit = "0.1"
 sc-client-db = { version = "0.8.0-alpha.2", default-features = true, path = "../db/" }
 sc-transaction-pool = { version = "2.0.0-alpha.2", path = "../../client/transaction-pool" }
 sp-transaction-pool = { version = "2.0.0-alpha.2", path = "../../primitives/transaction-pool" }

--- a/client/offchain/src/api/http.rs
+++ b/client/offchain/src/api/http.rs
@@ -699,6 +699,11 @@ mod tests {
 				let _ = tokio::runtime::Runtime::new().unwrap().block_on(future);
 			}
 
+			// We spawn quite a bit threads here due to how async API works for
+			// offchain workers, so be sure to raise the FD limit (particularly
+			// useful for macOS where the default soft limit may not be enough).
+			fdlimit::raise_fd_limit();
+
 			let (api, worker) = http();
 			std::thread::spawn(move || tokio_run(worker));
 

--- a/client/offchain/src/api/http.rs
+++ b/client/offchain/src/api/http.rs
@@ -699,9 +699,10 @@ mod tests {
 				let _ = tokio::runtime::Runtime::new().unwrap().block_on(future);
 			}
 
-			// We spawn quite a bit threads here due to how async API works for
-			// offchain workers, so be sure to raise the FD limit (particularly
-			// useful for macOS where the default soft limit may not be enough).
+			// We spawn quite a bit of HTTP servers here due to how async API
+			// works for offchain workers, so be sure to raise the FD limit
+			// (particularly useful for macOS where the default soft limit may
+			// not be enough).
 			fdlimit::raise_fd_limit();
 
 			let (api, worker) = http();

--- a/client/offchain/src/api/http.rs
+++ b/client/offchain/src/api/http.rs
@@ -304,7 +304,7 @@ impl HttpApi {
 				let mut output = Vec::with_capacity(ids.len());
 				let mut must_wait_more = false;
 				for id in ids {
-					output.push(match self.requests.get_mut(id) {
+					output.push(match self.requests.get(id) {
 						None => HttpRequestStatus::Invalid,
 						Some(HttpApiRequest::NotDispatched(_, _)) =>
 							unreachable!("we replaced all the NotDispatched with Dispatched earlier; qed"),
@@ -322,10 +322,8 @@ impl HttpApi {
 				// Are we ready to call `return`?
 				let is_done = if let future::MaybeDone::Done(_) = deadline {
 					true
-				} else if !must_wait_more {
-					true
 				} else {
-					false
+					!must_wait_more
 				};
 
 				if is_done {


### PR DESCRIPTION
This PR fixes the test code loop caused by low fd limit on macOS by increasing the limit programmatically for the test code.

Reproduced on Linux using `ulimit -S -n 50` and confirmed the fix from this PR.
Just to be sure, it'd be great to also confirm the fix on macOS (I don't have access to a Mac).

Closes #5102 

(also did some small drive-by fixes, I can split them off this PR if needed)