### PR TITLE
client/service/src/builder.rs: Add build_info metric

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1013,6 +1013,16 @@ ServiceBuilder<
 
 		// Prometheus metrics
 		let metrics = if let Some(PrometheusConfig { port, registry }) = config.prometheus_config.clone() {
+			// Set static metrics.
+			register(Gauge::<U64>::with_opts(
+				Opts::new(
+					"build_info",
+					"A metric with a constant '1' value labeled by name, version, and commit."
+				).const_label("name", config.impl_name)
+					.const_label("version", config.impl_version)
+					.const_label("commit", config.impl_commit)
+			)?, &registry)?.set(1);
+
 			let metrics = ServiceMetrics::register(&registry)?;
 			metrics.node_roles.set(u64::from(config.roles.bits()));
 			spawn_handle.spawn(
@@ -1023,6 +1033,7 @@ ServiceBuilder<
 		} else {
 			None
 		};
+
 		// Periodically notify the telemetry.
 		let transaction_pool_ = transaction_pool.clone();
 		let client_ = client.clone();

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -61,7 +61,6 @@ struct ServiceMetrics {
 	memory_usage_bytes: Gauge<U64>,
 	cpu_usage_percentage: Gauge<F64>,
 	network_per_sec_bytes: GaugeVec<U64>,
-	node_roles: Gauge<U64>,
 	database_cache: Gauge<U64>,
 	state_cache: Gauge<U64>,
 	state_db: GaugeVec<U64>,
@@ -86,9 +85,6 @@ impl ServiceMetrics {
 			network_per_sec_bytes: register(GaugeVec::new(
 				Opts::new("network_per_sec_bytes", "Networking bytes per second"),
 				&["direction"]
-			)?, registry)?,
-			node_roles: register(Gauge::new(
-				"node_roles", "The roles the node is running as",
 			)?, registry)?,
 			database_cache: register(Gauge::new(
 				"database_cache_bytes", "RocksDB cache size in bytes",
@@ -1011,7 +1007,7 @@ ServiceBuilder<
 			);
 		}
 
-		// Prometheus metrics
+		// Prometheus metrics.
 		let metrics = if let Some(PrometheusConfig { port, registry }) = config.prometheus_config.clone() {
 			// Set static metrics.
 			register(Gauge::<U64>::with_opts(
@@ -1020,15 +1016,19 @@ ServiceBuilder<
 					"A metric with a constant '1' value labeled by name, version, and commit."
 				).const_label("name", config.impl_name)
 					.const_label("version", config.impl_version)
-					.const_label("commit", config.impl_commit)
+					.const_label("commit", config.impl_commit),
 			)?, &registry)?.set(1);
+			register(Gauge::<U64>::new(
+				"node_roles", "The roles the node is running as",
+			)?, &registry)?.set(u64::from(config.roles.bits()));
 
 			let metrics = ServiceMetrics::register(&registry)?;
-			metrics.node_roles.set(u64::from(config.roles.bits()));
+
 			spawn_handle.spawn(
 				"prometheus-endpoint",
 				prometheus_endpoint::init_prometheus(port, registry).map(drop)
 			);
+
 			Some(metrics)
 		} else {
 			None

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1014,7 +1014,8 @@ ServiceBuilder<
 				Opts::new(
 					"build_info",
 					"A metric with a constant '1' value labeled by name, version, and commit."
-				).const_label("name", config.impl_name)
+				)
+					.const_label("name", config.impl_name)
 					.const_label("version", config.impl_version)
 					.const_label("commit", config.impl_commit),
 			)?, &registry)?.set(1);


### PR DESCRIPTION
Add static Prometheus metric exposing the chain name, the version and
the commit.

```bash
curl localhost:9615/metrics | grep -E "build_info"

# HELP substrate_build_info A metric with a constant '1' value labeled by name, version, and commit.
# TYPE substrate_build_info gauge
substrate_build_info{commit="607e197f0",name="Substrate Node",version="2.0.0-alpha.3"} 1
```

Fixes https://github.com/paritytech/substrate/issues/5181.


In addition this pull request contains a second commit: 

- client/service/src/builder.rs: Move node_role to static metrics

    The Prometheus metrics `node_role` is static and thus there is no need
to keep a reference of it within `ServiceMetrics`. This follows the
example of the `build_info` metric.
    