### PR TITLE
Use `System::initialize`

### DIFF
--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -134,6 +134,6 @@ pub fn run_to_block(n: u64) {
 			System::on_finalize(System::block_number());
 		}
 		System::set_block_number(System::block_number() + 1);
-		System::on_initialize(System::block_number());
+		System::initialize(System::block_number());
 	}
 }

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -187,7 +187,7 @@ pub fn run_to_block(n: u64) {
 			System::on_finalize(System::block_number());
 		}
 		System::set_block_number(System::block_number() + 1);
-		System::on_initialize(System::block_number());
+		System::initialize(System::block_number());
 		Society::on_initialize(System::block_number());
 	}
 }


### PR DESCRIPTION
This is a super small PR which fixes two instances in tests where `System::on_initialize` was use instead of `System::initialize` in the runtime tests.

Should have no impact to the tests or the runtime, just something found when looking at other code.

We should consider a follow up PR which makes `System` also use the `on_initialize` and have the macros ensure that System is the first pallet in the `AllModules` list.