### PR TITLE
Create release-tagging github action

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - name: Set Git tag
         uses: s3krit/walking-tag-action@master
-        # Avoid running this step twice when it's a prerelease (once for the prereleased action and once for the published action)
         with:
           TAG_NAME: release
           TAG_MESSAGE: Latest release

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -4,7 +4,7 @@ name: Retag release
 
 on:
   release:
-    types: [ published, prereleased ]
+    types: [ published ]
 
 jobs:
   build:
@@ -14,7 +14,6 @@ jobs:
       - name: Set Git tag
         uses: s3krit/walking-tag-action@master
         # Avoid running this step twice when it's a prerelease (once for the prereleased action and once for the published action)
-        if: ( github.event.release.prerelease == true && github.event.action == 'prereleased' ) || github.event.release.prerelease == false
         with:
           TAG_NAME: release
           TAG_MESSAGE: Latest release

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -1,0 +1,20 @@
+# Github action to ensure the `release` tag always tracks latest release
+
+name: Automate new issues
+
+on:
+  release:
+    types: [ published, prereleased ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set Git tag
+        uses: s3krit/walking-tag-action@master
+        with:
+          TAG_NAME: release
+          TAG_MESSAGE: Latest release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -1,6 +1,6 @@
 # Github action to ensure the `release` tag always tracks latest release
 
-name: Automate new issues
+name: Retag release
 
 on:
   release:
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Set Git tag
         uses: s3krit/walking-tag-action@master
+        # Avoid running this step twice when it's a prerelease (once for the prereleased action and once for the published action)
+        if: ( github.event.release.prerelease == true && github.event.action == 'prereleased' ) || github.event.release.prerelease == false
         with:
           TAG_NAME: release
           TAG_MESSAGE: Latest release


### PR DESCRIPTION
The intent of the `release` tag is to always track the current/latest release (used in CI scripts like `check_runtime.sh`). This github action will run whenever a new release is prereleased or published, and force an update to the `release` tag.

Note: there's a small bug at the moment whereby for prereleases, the action will run twice, and one of the two jobs will fail. Currently WIP until I find out if I can fix this.