### PR TITLE
Emit events to bonding and unbonding ops in Staking pallet

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1163,7 +1163,7 @@ decl_module! {
 			if ledger.total < old_total {
 				// Already checked that this won't overflow by entry condition.
 				let value = old_total - ledger.total;
-				Self::deposit_event(RawEvent::Withdrawn(stash, value))
+				Self::deposit_event(RawEvent::Withdrawn(stash, value));
 			}
 		}
 

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -897,6 +897,16 @@ decl_event!(
 		/// An old slashing report from a prior era was discarded because it could
 		/// not be processed.
 		OldSlashingReportDiscarded(SessionIndex),
+		/// An account has bonded this amount.
+		///
+		/// NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,
+		/// it will not be emitted for staking rewards when they are added to stake.
+		Bonded(AccountId, Balance),
+		/// An account has unbonded this amount.
+		Unbonded(AccountId, Balance),
+		/// An account has called `withdraw_unbonded` and removed unbonding chunks worth `Balance`
+		/// from the unlocking queue.
+		Withdrawn(AccountId, Balance),
 	}
 );
 
@@ -967,6 +977,8 @@ decl_module! {
 		///
 		/// The dispatch origin for this call must be _Signed_ by the stash account.
 		///
+		/// Emits `Bonded`.
+		///
 		/// # <weight>
 		/// - Independent of the arguments. Moderate complexity.
 		/// - O(1).
@@ -1007,6 +1019,7 @@ decl_module! {
 
 			let stash_balance = T::Currency::free_balance(&stash);
 			let value = value.min(stash_balance);
+			Self::deposit_event(RawEvent::Bonded(stash.clone(), value));
 			let item = StakingLedger {
 				stash,
 				total: value,
@@ -1026,6 +1039,8 @@ decl_module! {
 		///
 		/// The dispatch origin for this call must be _Signed_ by the stash, not the controller.
 		///
+		/// Emits `Bonded`.
+		///
 		/// # <weight>
 		/// - Independent of the arguments. Insignificant complexity.
 		/// - O(1).
@@ -1044,6 +1059,7 @@ decl_module! {
 				let extra = extra.min(max_additional);
 				ledger.total += extra;
 				ledger.active += extra;
+				Self::deposit_event(RawEvent::Bonded(stash, extra));
 				Self::update_ledger(&controller, &ledger);
 			}
 		}
@@ -1060,6 +1076,8 @@ decl_module! {
 		/// to be called first to remove some of the chunks (if possible).
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		///
+		/// Emits `Unbonded`.
 		///
 		/// See also [`Call::withdraw_unbonded`].
 		///
@@ -1084,6 +1102,7 @@ decl_module! {
 			let mut value = value.min(ledger.active);
 
 			if !value.is_zero() {
+				let stash = &ledger.stash;
 				ledger.active -= value;
 
 				// Avoid there being a dust balance left in the staking system.
@@ -1096,6 +1115,7 @@ decl_module! {
 				let era = Self::current_era().unwrap_or(0) + T::BondingDuration::get();
 				ledger.unlocking.push(UnlockChunk { value, era });
 				Self::update_ledger(&controller, &ledger);
+				Self::deposit_event(RawEvent::Unbonded(stash.clone(), value));
 			}
 		}
 
@@ -1105,6 +1125,8 @@ decl_module! {
 		/// whatever it wants.
 		///
 		/// The dispatch origin for this call must be _Signed_ by the controller, not the stash.
+		///
+		/// Emits `Withdrawn`.
 		///
 		/// See also [`Call::unbond`].
 		///
@@ -1119,6 +1141,7 @@ decl_module! {
 		fn withdraw_unbonded(origin) {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
+			let (stash, old_total) = (ledger.stash.clone(), ledger.total.clone());
 			if let Some(current_era) = Self::current_era() {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}
@@ -1126,15 +1149,21 @@ decl_module! {
 			if ledger.unlocking.is_empty() && ledger.active.is_zero() {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
-				// left. We can now safely remove this.
-				let stash = ledger.stash;
-				// remove all staking-related information.
+				// left. We can now safely remove all staking-related information.
 				Self::kill_stash(&stash)?;
 				// remove the lock.
 				T::Currency::remove_lock(STAKING_ID, &stash);
 			} else {
 				// This was the consequence of a partial unbond. just update the ledger and move on.
 				Self::update_ledger(&controller, &ledger);
+			}
+
+			// `old_total` should never be less than the new total because
+			// `consolidate_unlocked` strictly subtracts balance.
+			if ledger.total < old_total {
+				// Already checked that this won't overflow by entry condition.
+				let value = old_total - ledger.total;
+				Self::deposit_event(RawEvent::Withdrawn(stash, value))
 			}
 		}
 

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1102,7 +1102,6 @@ decl_module! {
 			let mut value = value.min(ledger.active);
 
 			if !value.is_zero() {
-				let stash = &ledger.stash;
 				ledger.active -= value;
 
 				// Avoid there being a dust balance left in the staking system.
@@ -1115,7 +1114,7 @@ decl_module! {
 				let era = Self::current_era().unwrap_or(0) + T::BondingDuration::get();
 				ledger.unlocking.push(UnlockChunk { value, era });
 				Self::update_ledger(&controller, &ledger);
-				Self::deposit_event(RawEvent::Unbonded(stash.clone(), value));
+				Self::deposit_event(RawEvent::Unbonded(ledger.stash.clone(), value));
 			}
 		}
 
@@ -1141,7 +1140,7 @@ decl_module! {
 		fn withdraw_unbonded(origin) {
 			let controller = ensure_signed(origin)?;
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
-			let (stash, old_total) = (ledger.stash.clone(), ledger.total.clone());
+			let (stash, old_total) = (ledger.stash.clone(), ledger.total);
 			if let Some(current_era) = Self::current_era() {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/5223

The reason to emit events is to find out the actual change to the staking ledger as users could call `bond`, `bond_extra`, `unbond`, or `withdraw_unbonded` with a different `value` than will actually update the staking ledger.