### PR TITLE
Allow to expose a subset of unsafe RPCs

### DIFF
--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -279,6 +279,12 @@ macro_rules! substrate_cli_subcommands {
 				}
 			}
 
+			fn unsafe_rpc_expose(&self) -> $crate::Result<bool> {
+				match self {
+					$($enum::$variant(cmd) => cmd.unsafe_rpc_expose()),*
+				}
+			}
+
 			fn rpc_ws_max_connections(&self) -> $crate::Result<::std::option::Option<usize>> {
 				match self {
 					$($enum::$variant(cmd) => cmd.rpc_ws_max_connections()),*

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -249,6 +249,13 @@ pub trait CliConfiguration: Sized {
 		Ok(Default::default())
 	}
 
+	/// Returns `Ok(true) if potentially unsafe RPC is to be exposed.
+	///
+	/// By default this is `false`.
+	fn unsafe_rpc_expose(&self) -> Result<bool> {
+		Ok(Default::default())
+	}
+
 	/// Get the RPC websockets maximum connections (`None` if unlimited).
 	///
 	/// By default this is `None`.
@@ -419,6 +426,7 @@ pub trait CliConfiguration: Sized {
 			execution_strategies: self.execution_strategies(is_dev)?,
 			rpc_http: self.rpc_http()?,
 			rpc_ws: self.rpc_ws()?,
+			unsafe_rpc_expose: self.unsafe_rpc_expose()?,
 			rpc_ws_max_connections: self.rpc_ws_max_connections()?,
 			rpc_cors: self.rpc_cors(is_dev)?,
 			prometheus_config: self.prometheus_config()?,

--- a/client/rpc-api/src/author/error.rs
+++ b/client/rpc-api/src/author/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
 	/// Invalid session keys encoding.
 	#[display(fmt="Session keys are not encoded correctly")]
 	InvalidSessionKeys,
+	/// Call to an unsafe RPC was denied.
+	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
 }
 
 impl std::error::Error for Error {
@@ -65,6 +67,7 @@ impl std::error::Error for Error {
 			Error::Client(ref err) => Some(&**err),
 			Error::Pool(ref err) => Some(err),
 			Error::Verification(ref err) => Some(&**err),
+			Error::UnsafeRpcCalled(ref err) => Some(err),
 			_ => None,
 		}
 	}
@@ -152,6 +155,7 @@ impl From<Error> for rpc::Error {
 					request to insert the key successfully.".into()
 				),
 			},
+			Error::UnsafeRpcCalled(e) => e.into(),
 			e => errors::internal(e),
 		}
 	}

--- a/client/rpc-api/src/lib.rs
+++ b/client/rpc-api/src/lib.rs
@@ -22,11 +22,13 @@
 
 mod errors;
 mod helpers;
+mod policy;
 mod subscriptions;
 
 pub use jsonrpc_core::IoHandlerExtension as RpcExtension;
 pub use subscriptions::{Subscriptions, TaskExecutor};
 pub use helpers::Receiver;
+pub use policy::DenyUnsafe;
 
 pub mod author;
 pub mod chain;

--- a/client/rpc-api/src/offchain/error.rs
+++ b/client/rpc-api/src/offchain/error.rs
@@ -27,11 +27,16 @@ pub enum Error {
 	/// Unavailable storage kind error.
 	#[display(fmt="This storage kind is not available yet.")]
 	UnavailableStorageKind,
+	/// Call to an unsafe RPC was denied.
+	UnsafeRpcCalled(crate::policy::UnsafeRpcError),
 }
 
 impl std::error::Error for Error {
 	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-		None
+		match self {
+			Self::UnsafeRpcCalled(err) => Some(err),
+			_ => None,
+		}
 	}
 }
 
@@ -46,6 +51,7 @@ impl From<Error> for rpc::Error {
 				message: "This storage kind is not available yet" .into(),
 				data: None,
 			},
+			Error::UnsafeRpcCalled(e) => e.into(),
 		}
 	}
 }

--- a/client/rpc-api/src/policy.rs
+++ b/client/rpc-api/src/policy.rs
@@ -1,0 +1,60 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Policy-related types.
+//!
+//! Contains a `DenyUnsafe` type that can be used to deny potentially unsafe
+//! RPC when accessed externally.
+
+use jsonrpc_core as rpc;
+
+/// Signifies whether a potentially unsafe RPC should be denied.
+#[derive(Clone, Copy)]
+pub enum DenyUnsafe {
+    /// Denies only potentially unsafe RPCs.
+    Yes,
+    /// Allows calling every RPCs.
+    No
+}
+
+impl DenyUnsafe {
+    /// Returns `Ok(())` if the RPCs considered unsafe are safe to call,
+    /// otherwise returns `Err(UnsafeRpcError)`.
+    pub fn check_if_safe(self) -> Result<(), UnsafeRpcError> {
+        match self {
+            DenyUnsafe::Yes => Err(UnsafeRpcError),
+            DenyUnsafe::No => Ok(())
+        }
+    }
+}
+
+/// Signifies whether an RPC considered unsafe is denied to be called externally.
+#[derive(Debug)]
+pub struct UnsafeRpcError;
+
+impl std::fmt::Display for UnsafeRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RPC call is unsafe to be called externally")
+    }
+}
+
+impl std::error::Error for UnsafeRpcError {}
+
+impl From<UnsafeRpcError> for rpc::Error {
+    fn from(_: UnsafeRpcError) -> rpc::Error {
+        rpc::Error::method_not_found()
+    }
+}

--- a/client/rpc-api/src/policy.rs
+++ b/client/rpc-api/src/policy.rs
@@ -22,7 +22,7 @@
 use jsonrpc_core as rpc;
 
 /// Signifies whether a potentially unsafe RPC should be denied.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum DenyUnsafe {
     /// Denies only potentially unsafe RPCs.
     Yes,

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -72,14 +72,16 @@ pub trait SystemApi<Hash, Number> {
 
 	/// Returns currently connected peers
 	#[rpc(name = "system_peers", returns = "Vec<PeerInfo<Hash, Number>>")]
-	fn system_peers(&self) -> Receiver<Vec<PeerInfo<Hash, Number>>>;
+	fn system_peers(&self)
+		-> Compat<BoxFuture<'static, jsonrpc_core::Result<Vec<PeerInfo<Hash, Number>>>>>;
 
 	/// Returns current state of the network.
 	///
 	/// **Warning**: This API is not stable.
 	// TODO: make this stable and move structs https://github.com/paritytech/substrate/issues/1890
 	#[rpc(name = "system_networkState", returns = "jsonrpc_core::Value")]
-	fn system_network_state(&self) -> Receiver<jsonrpc_core::Value>;
+	fn system_network_state(&self)
+		-> Compat<BoxFuture<'static, jsonrpc_core::Result<jsonrpc_core::Value>>>;
 
 	/// Adds a reserved peer. Returns the empty string or an error. The string
 	/// parameter should encode a `p2p` multiaddr.

--- a/client/rpc/src/author/tests.rs
+++ b/client/rpc/src/author/tests.rs
@@ -83,6 +83,7 @@ impl TestSetup {
 			pool: self.pool.clone(),
 			subscriptions: Subscriptions::new(Arc::new(self.runtime.executor())),
 			keystore: self.keystore.clone(),
+			deny_unsafe: DenyUnsafe::No,
 		}
 	}
 }

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -22,7 +22,7 @@
 
 mod metadata;
 
-pub use sc_rpc_api::Subscriptions;
+pub use sc_rpc_api::{DenyUnsafe, Subscriptions};
 pub use self::metadata::Metadata;
 pub use rpc::IoHandlerExtension as RpcExtension;
 

--- a/client/rpc/src/offchain/mod.rs
+++ b/client/rpc/src/offchain/mod.rs
@@ -21,6 +21,7 @@ mod tests;
 
 /// Re-export the API for backward compatibility.
 pub use sc_rpc_api::offchain::*;
+use sc_rpc_api::DenyUnsafe;
 use self::error::{Error, Result};
 use sp_core::{
 	Bytes,
@@ -34,13 +35,15 @@ use std::sync::Arc;
 pub struct Offchain<T: OffchainStorage> {
 	/// Offchain storage
 	storage: Arc<RwLock<T>>,
+	deny_unsafe: DenyUnsafe,
 }
 
 impl<T: OffchainStorage> Offchain<T> {
 	/// Create new instance of Offchain API.
-	pub fn new(storage: T) -> Self {
+	pub fn new(storage: T, deny_unsafe: DenyUnsafe) -> Self {
 		Offchain {
 			storage: Arc::new(RwLock::new(storage)),
+			deny_unsafe,
 		}
 	}
 }
@@ -48,6 +51,8 @@ impl<T: OffchainStorage> Offchain<T> {
 impl<T: OffchainStorage + 'static> OffchainApi for Offchain<T> {
 	/// Set offchain local storage under given key and prefix.
 	fn set_local_storage(&self, kind: StorageKind, key: Bytes, value: Bytes) -> Result<()> {
+		self.deny_unsafe.check_if_safe()?;
+
 		let prefix = match kind {
 			StorageKind::PERSISTENT => sp_offchain::STORAGE_PREFIX,
 			StorageKind::LOCAL => return Err(Error::UnavailableStorageKind),
@@ -58,6 +63,8 @@ impl<T: OffchainStorage + 'static> OffchainApi for Offchain<T> {
 
 	/// Get offchain local storage under given key and prefix.
 	fn get_local_storage(&self, kind: StorageKind, key: Bytes) -> Result<Option<Bytes>> {
+		self.deny_unsafe.check_if_safe()?;
+
 		let prefix = match kind {
 			StorageKind::PERSISTENT => sp_offchain::STORAGE_PREFIX,
 			StorageKind::LOCAL => return Err(Error::UnavailableStorageKind),

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1002,7 +1002,7 @@ ServiceBuilder<
 
 		// RPC
 		let (system_rpc_tx, system_rpc_rx) = tracing_unbounded("mpsc_system_rpc");
-		let gen_handler = || {
+		let gen_handler = |deny_unsafe: sc_rpc::DenyUnsafe| {
 			use sc_rpc::{chain, state, author, system, offchain};
 
 			let system_info = sc_rpc::system::SystemInfo {
@@ -1065,8 +1065,9 @@ ServiceBuilder<
 				rpc_extensions.clone(),
 			))
 		};
-		let rpc_handlers = gen_handler();
 		let rpc = start_rpc_servers(&config, gen_handler)?;
+		// This is used internally, so don't restrict access to unsafe RPC
+		let rpc_handlers = gen_handler(sc_rpc::DenyUnsafe::No);
 
 		spawn_handle.spawn(
 			"network-worker",

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1044,6 +1044,7 @@ ServiceBuilder<
 				transaction_pool.clone(),
 				subscriptions,
 				keystore.clone(),
+				deny_unsafe,
 			);
 			let system = system::System::new(system_info, system_rpc_tx.clone(), deny_unsafe);
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1045,7 +1045,7 @@ ServiceBuilder<
 				subscriptions,
 				keystore.clone(),
 			);
-			let system = system::System::new(system_info, system_rpc_tx.clone());
+			let system = system::System::new(system_info, system_rpc_tx.clone(), deny_unsafe);
 
 			let maybe_offchain_rpc = offchain_storage.clone()
 			.map(|storage| {

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -46,6 +46,7 @@ use sp_runtime::traits::{
 use sp_api::ProvideRuntimeApi;
 use sc_executor::{NativeExecutor, NativeExecutionDispatch};
 use std::{
+	collections::HashMap,
 	io::{Read, Write, Seek},
 	marker::PhantomData, sync::Arc, pin::Pin
 };
@@ -1046,26 +1047,23 @@ ServiceBuilder<
 			);
 			let system = system::System::new(system_info, system_rpc_tx.clone());
 
-			match offchain_storage.clone() {
-				Some(storage) => {
-					let offchain = sc_rpc::offchain::Offchain::new(storage);
-					sc_rpc_server::rpc_handler((
-						state::StateApi::to_delegate(state),
-						chain::ChainApi::to_delegate(chain),
-						offchain::OffchainApi::to_delegate(offchain),
-						author::AuthorApi::to_delegate(author),
-						system::SystemApi::to_delegate(system),
-						rpc_extensions.clone(),
-					))
-				},
-				None => sc_rpc_server::rpc_handler((
-					state::StateApi::to_delegate(state),
-					chain::ChainApi::to_delegate(chain),
-					author::AuthorApi::to_delegate(author),
-					system::SystemApi::to_delegate(system),
-					rpc_extensions.clone(),
-				))
-			}
+			let maybe_offchain_rpc = offchain_storage.clone()
+			.map(|storage| {
+				let offchain = sc_rpc::offchain::Offchain::new(storage);
+				// FIXME: Use plain Option (don't collect into HashMap) when we upgrade to jsonrpc 14.1
+				// https://github.com/paritytech/jsonrpc/commit/20485387ed06a48f1a70bf4d609a7cde6cf0accf
+				let delegate = offchain::OffchainApi::to_delegate(offchain);
+					delegate.into_iter().collect::<HashMap<_, _>>()
+			}).unwrap_or_default();
+
+			sc_rpc_server::rpc_handler((
+				state::StateApi::to_delegate(state),
+				chain::ChainApi::to_delegate(chain),
+				maybe_offchain_rpc,
+				author::AuthorApi::to_delegate(author),
+				system::SystemApi::to_delegate(system),
+				rpc_extensions.clone(),
+			))
 		};
 		let rpc_handlers = gen_handler();
 		let rpc = start_rpc_servers(&config, gen_handler)?;

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1049,7 +1049,7 @@ ServiceBuilder<
 
 			let maybe_offchain_rpc = offchain_storage.clone()
 			.map(|storage| {
-				let offchain = sc_rpc::offchain::Offchain::new(storage);
+				let offchain = sc_rpc::offchain::Offchain::new(storage, deny_unsafe);
 				// FIXME: Use plain Option (don't collect into HashMap) when we upgrade to jsonrpc 14.1
 				// https://github.com/paritytech/jsonrpc/commit/20485387ed06a48f1a70bf4d609a7cde6cf0accf
 				let delegate = offchain::OffchainApi::to_delegate(offchain);

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -59,6 +59,8 @@ pub struct Configuration {
 	pub wasm_method: WasmExecutionMethod,
 	/// Execution strategies.
 	pub execution_strategies: ExecutionStrategies,
+	/// Whether potentially unsafe RPC is considered safe to be exposed.
+	pub unsafe_rpc_expose: bool,
 	/// RPC over HTTP binding address. `None` if disabled.
 	pub rpc_http: Option<SocketAddr>,
 	/// RPC over Websockets binding address. `None` if disabled.

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -511,7 +511,7 @@ mod waiting {
 
 /// Starts RPC servers that run in their own thread, and returns an opaque object that keeps them alive.
 #[cfg(not(target_os = "unknown"))]
-fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
+fn start_rpc_servers<H: FnMut(sc_rpc::DenyUnsafe) -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 	config: &Configuration,
 	mut gen_handler: H
 ) -> Result<Box<dyn std::any::Any + Send + Sync>, error::Error> {
@@ -533,13 +533,22 @@ fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 		})
 	}
 
+	fn deny_unsafe(addr: &Option<SocketAddr>, unsafe_rpc_expose: bool) -> sc_rpc::DenyUnsafe {
+		let is_exposed_addr = addr.map(|x| x.ip().is_loopback()).unwrap_or(false);
+		if is_exposed_addr && !unsafe_rpc_expose {
+			sc_rpc::DenyUnsafe::Yes
+		} else {
+			sc_rpc::DenyUnsafe::No
+		}
+	}
+
 	Ok(Box::new((
 		maybe_start_server(
 			config.rpc_http,
 			|address| sc_rpc_server::start_http(
 				address,
 				config.rpc_cors.as_ref(),
-				gen_handler(),
+				gen_handler(deny_unsafe(&config.rpc_http, config.unsafe_rpc_expose)),
 			),
 		)?.map(|s| waiting::HttpServer(Some(s))),
 		maybe_start_server(
@@ -548,7 +557,7 @@ fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 				address,
 				config.rpc_ws_max_connections,
 				config.rpc_cors.as_ref(),
-				gen_handler(),
+				gen_handler(deny_unsafe(&config.rpc_ws, config.unsafe_rpc_expose)),
 			),
 		)?.map(|s| waiting::WsServer(Some(s))),
 	)))
@@ -556,7 +565,7 @@ fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 
 /// Starts RPC servers that run in their own thread, and returns an opaque object that keeps them alive.
 #[cfg(target_os = "unknown")]
-fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
+fn start_rpc_servers<H: FnMut(sc_rpc::DenyUnsafe) -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 	_: &Configuration,
 	_: H
 ) -> Result<Box<dyn std::any::Any + Send + Sync>, error::Error> {

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -536,7 +536,11 @@ fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 	Ok(Box::new((
 		maybe_start_server(
 			config.rpc_http,
-			|address| sc_rpc_server::start_http(address, config.rpc_cors.as_ref(), gen_handler()),
+			|address| sc_rpc_server::start_http(
+				address,
+				config.rpc_cors.as_ref(),
+				gen_handler(),
+			),
 		)?.map(|s| waiting::HttpServer(Some(s))),
 		maybe_start_server(
 			config.rpc_ws,
@@ -546,7 +550,7 @@ fn start_rpc_servers<H: FnMut() -> sc_rpc_server::RpcHandler<sc_rpc::Metadata>>(
 				config.rpc_cors.as_ref(),
 				gen_handler(),
 			),
-		)?.map(|s| waiting::WsServer(Some(s))).map(Mutex::new),
+		)?.map(|s| waiting::WsServer(Some(s))),
 	)))
 }
 

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -184,6 +184,7 @@ fn node_config<G: RuntimeGenesis + 'static, E: ChainSpecExtension + Clone + 'sta
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: sc_service::config::WasmExecutionMethod::Interpreted,
 		execution_strategies: Default::default(),
+		unsafe_rpc_expose: false,
 		rpc_http: None,
 		rpc_ws: None,
 		rpc_ws_max_connections: None,

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -86,6 +86,7 @@ where
 		rpc_cors: Default::default(),
 		rpc_http: Default::default(),
 		rpc_ws: Default::default(),
+		unsafe_rpc_expose: false,
 		rpc_ws_max_connections: Default::default(),
 		state_cache_child_ratio: Default::default(),
 		state_cache_size: Default::default(),


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/2303

Introduces machinery which allows us to deny/allow certain "unsafe" RPCs if we're exposing it to the network. The last bits (configuration) are fairly easy to add; in the meantime, I'd like to get some feedback on the initial implementation.

The aim is to provide a very simple filtering out-of-box and recommend using something like https://github.com/tomusdrw/jsonrpc-proxy for anything more complicated. We decided against a separate blacklist/whitelist with @tomusdrw since this would make things unnecessarily more scattered and harder to navigate.

Unresolved/To do:
- [ ] Should the configuration leverage existing `--unsafe-{rpc,ws}-external` flags?
- [ ] Should the setting be separate for HTTP and WS servers?
- [ ] Make sure every "unsafe" RPC is included and checked here
- [ ] Should tests be added for each API modified?
