### PR TITLE
Add iteration with key information when using $hash_concat

### DIFF
--- a/frame/support/src/hash.rs
+++ b/frame/support/src/hash.rs
@@ -16,7 +16,7 @@
 
 //! Hash utilities.
 
-use codec::Codec;
+use codec::{Codec, Decode};
 use sp_std::prelude::Vec;
 use sp_io::hashing::{blake2_128, blake2_256, twox_64, twox_128, twox_256};
 
@@ -57,6 +57,20 @@ pub trait StorageHasher: 'static {
 	fn hash(x: &[u8]) -> Self::Output;
 }
 
+/// Trait to retrieve some info from hash of type `Key` encoded.
+pub trait StorageHasherInfo<Key> {
+	/// Some info contained in the hash of type `Key` encoded.
+	type Info;
+
+	/// Decode the hash and then decode the info from the decoded hash.
+	///
+	/// # WARNING
+	///
+	/// Even if info is (), input must be modified to have read the entire encoded hash.
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>;
+}
+
 /// Hash storage keys with `concat(twox64(key), key)`
 pub struct Twox64Concat;
 impl StorageHasher for Twox64Concat {
@@ -67,6 +81,16 @@ impl StorageHasher for Twox64Concat {
 			.chain(x.into_iter())
 			.cloned()
 			.collect::<Vec<_>>()
+	}
+}
+
+impl<Key: Decode> StorageHasherInfo<Key> for Twox64Concat {
+	type Info = Key;
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 8])?;
+		Key::decode(input)
 	}
 }
 
@@ -83,12 +107,32 @@ impl StorageHasher for Blake2_128Concat {
 	}
 }
 
+impl<Key: Decode> StorageHasherInfo<Key> for Blake2_128Concat {
+	type Info = Key;
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 16])?;
+		Key::decode(input)
+	}
+}
+
 /// Hash storage keys with blake2 128
 pub struct Blake2_128;
 impl StorageHasher for Blake2_128 {
 	type Output = [u8; 16];
 	fn hash(x: &[u8]) -> [u8; 16] {
 		blake2_128(x)
+	}
+}
+
+impl<Key> StorageHasherInfo<Key> for Blake2_128 {
+	type Info = ();
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 16])?;
+		Ok(())
 	}
 }
 
@@ -101,12 +145,32 @@ impl StorageHasher for Blake2_256 {
 	}
 }
 
+impl<Key> StorageHasherInfo<Key> for Blake2_256 {
+	type Info = ();
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 32])?;
+		Ok(())
+	}
+}
+
 /// Hash storage keys with twox 128
 pub struct Twox128;
 impl StorageHasher for Twox128 {
 	type Output = [u8; 16];
 	fn hash(x: &[u8]) -> [u8; 16] {
 		twox_128(x)
+	}
+}
+
+impl<Key> StorageHasherInfo<Key> for Twox128 {
+	type Info = ();
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 16])?;
+		Ok(())
 	}
 }
 
@@ -119,9 +183,20 @@ impl StorageHasher for Twox256 {
 	}
 }
 
+impl<Key> StorageHasherInfo<Key> for Twox256 {
+	type Info = ();
+	fn decode_hash_and_then_info<I: codec::Input>(input: &mut I)
+		-> Result<Self::Info, codec::Error>
+	{
+		input.read(&mut [0u8; 32])?;
+		Ok(())
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::Encode;
 
 	#[test]
 	fn test_twox_64_concat() {
@@ -133,5 +208,35 @@ mod tests {
 	fn test_blake2_128_concat() {
 		let r = Blake2_128Concat::hash(b"foo");
 		assert_eq!(r.split_at(16), (&blake2_128(b"foo")[..], &b"foo"[..]))
+	}
+
+	#[test]
+	fn test_storage_hasher_info() {
+		type KeyType = [u8; 15];
+		let key: KeyType = [3u8; 15];
+
+		let mut r = &Twox64Concat::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Twox64Concat as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(key));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
+
+		let mut r = &Twox128::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Twox128 as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(()));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
+
+		let mut r = &Twox256::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Twox256 as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(()));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
+
+		let mut r = &Blake2_128Concat::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Blake2_128Concat as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(key));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
+
+		let mut r = &Blake2_128::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Blake2_128 as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(()));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
+
+		let mut r = &Blake2_256::hash(&(&key).encode()[..])[..];
+		assert_eq!(<Blake2_256 as StorageHasherInfo<KeyType>>::decode_hash_and_then_info(&mut r), Ok(()));
+		assert_eq!(r.len(), 0); // Assert input has indeed decoded the hash.
 	}
 }

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -68,7 +68,7 @@ pub mod weights;
 
 pub use self::hash::{
 	Twox256, Twox128, Blake2_256, Blake2_128, Twox64Concat, Blake2_128Concat, Hashable,
-	StorageHasher
+	StorageHasher, StorageHasherInfo
 };
 pub use self::storage::{
 	StorageValue, StorageMap, StorageLinkedMap, StorageDoubleMap, StoragePrefixedMap


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/4362

When iterating on a storage_map which use twox_64_concat we must be able to get the key alongside the value. This PR create a new function on StoragePrefixedMap to make it possible.

### In future PR:

DoubleMap::iter_prefix (which iter on all the second key associated to one first key) can't iterate with key information yet. I will do in a following PR

### Additionnal notes

The fact the the iteration stop immediately if a value fail to decode was made to follow the same behavior of StoragPrefixedMap::iter(). Though maybe we should move both implementation to just ignore failed to decode value.

### Alternative implementation

If having () instead of key when the hasher doesn't give information is too confusing we could also go in another direction by making such function available with a `where` statement.

Though to do so I would actually prefer merging StorageMap and generator::StorageMap and having the function `iter_with_info()... where Hasher: HasherWithInfo`.