### PR TITLE
Add an `estimate-heapsize` feature to `node-cli` for Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "parity-scale-codec",
+ "parity-util-mem",
  "rand 0.7.3",
  "sc-authority-discovery",
  "sc-basic-authorship",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -100,6 +100,9 @@ wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
 browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.8.0-alpha.2" }
 
+# We need to use this `estimate-heapsize` feature on android.
+parity-util-mem = { version = "0.5.1", default-features = false, features = ["estimate-heapsize"], optional = true }
+
 [dev-dependencies]
 sc-keystore = { version = "2.0.0-alpha.2", path = "../../../client/keystore" }
 sc-consensus-babe = { version = "0.8.0-alpha.2", features = ["test-helpers"], path = "../../../client/consensus/babe" }
@@ -152,3 +155,4 @@ wasmtime = [
 	"sc-service/wasmtime",
 ]
 runtime-benchmarks = [ "node-runtime/runtime-benchmarks" ]
+estimate-heapsize = [ "parity-util-mem" ]


### PR DESCRIPTION
`parity-util-mem` gives the following runtime error on android:
`
Thread 'main' panicked at 'internal error: entered unreachable code: estimate heapsize or feature allocator needed', /home/ashley/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-util-mem-0.5.1/src/allocators.rs:117
`

The PR adds an `estimate-heapsize` feature to `node-cli` that pulls in `parity-util-mem` with it's `estimate-heapsize` feature. This prevents the above runtime error.