### PR TITLE
Remove `extern crate proc_macro`

### DIFF
--- a/client/chain-spec/derive/src/lib.rs
+++ b/client/chain-spec/derive/src/lib.rs
@@ -16,8 +16,6 @@
 
 //! Macros to derive chain spec extension traits implementation.
 
-extern crate proc_macro;
-
 mod impls;
 
 use proc_macro::TokenStream;

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -160,7 +160,6 @@ mod benchmarking;
 
 use sp_std::prelude::*;
 use sp_std::{cmp, result, mem, fmt::Debug, ops::BitOr, convert::Infallible};
-use sp_io::hashing::twox_64;
 use codec::{Codec, Encode, Decode};
 use frame_support::{
 	StorageValue, Parameter, decl_event, decl_storage, decl_module, decl_error, ensure,
@@ -179,9 +178,6 @@ use sp_runtime::{
 	},
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
-use frame_support::storage::migration::{
-	get_storage_value, take_storage_value, put_storage_value, StorageIterator, have_storage_value
-};
 
 pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1555,12 +1555,11 @@ mod tests {
 	};
 	use sp_core::H256;
 	use sp_runtime::{
-		traits::{BlakeTwo256, IdentityLookup, Bounded, BadOrigin, OnRuntimeUpgrade},
+		traits::{BlakeTwo256, IdentityLookup, Bounded, BadOrigin},
 		testing::Header, Perbill,
 	};
 	use pallet_balances::{BalanceLock, Error as BalancesError};
 	use frame_system::EnsureSignedBy;
-	use sp_storage::Storage;
 
 	const AYE: Vote = Vote{ aye: true, conviction: Conviction::None };
 	const NAY: Vote = Vote{ aye: false, conviction: Conviction::None };

--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -1,4 +1,20 @@
-extern crate proc_macro;
+// Copyright 2017-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Proc macro to generate the reward curve functions and tests.
 
 mod log;
 

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -20,8 +20,6 @@
 
 #![recursion_limit="512"]
 
-extern crate proc_macro;
-
 mod storage;
 mod construct_runtime;
 

--- a/frame/support/procedural/tools/derive/src/lib.rs
+++ b/frame/support/procedural/tools/derive/src/lib.rs
@@ -20,8 +20,6 @@
 
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::parse_macro_input;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -348,9 +348,8 @@ mod tests {
 	use sp_runtime::{
 		Perbill,
 		testing::Header,
-		traits::{BlakeTwo256, IdentityLookup, Identity, OnRuntimeUpgrade},
+		traits::{BlakeTwo256, IdentityLookup, Identity},
 	};
-	use sp_storage::Storage;
 
 	impl_outer_origin! {
 		pub enum Origin for Test  where system = frame_system {}

--- a/primitives/api/proc-macro/src/lib.rs
+++ b/primitives/api/proc-macro/src/lib.rs
@@ -17,7 +17,6 @@
 //! Macros for declaring and implementing runtime apis.
 
 #![recursion_limit = "512"]
-extern crate proc_macro;
 
 use proc_macro::TokenStream;
 

--- a/primitives/debug-derive/src/lib.rs
+++ b/primitives/debug-derive/src/lib.rs
@@ -31,8 +31,6 @@
 //!	assert_eq!(format!("{:?}", MyStruct), "MyStruct");
 //! ```
 
-extern crate proc_macro;
-
 mod impls;
 
 use proc_macro::TokenStream;

--- a/primitives/runtime-interface/proc-macro/src/lib.rs
+++ b/primitives/runtime-interface/proc-macro/src/lib.rs
@@ -25,8 +25,6 @@
 //! 3. The [`PassByEnum`](derive.PassByInner.html) derive macro for implementing `PassBy` with `Enum`.
 //! 4. The [`PassByInner`](derive.PassByInner.html) derive macro for implementing `PassBy` with `Inner`.
 
-extern crate proc_macro;
-
 use syn::{parse_macro_input, ItemTrait, DeriveInput};
 
 mod pass_by;

--- a/primitives/sr-api/proc-macro/src/lib.rs
+++ b/primitives/sr-api/proc-macro/src/lib.rs
@@ -17,7 +17,6 @@
 //! Macros for declaring and implementing runtime apis.
 
 #![recursion_limit = "512"]
-extern crate proc_macro;
 
 use proc_macro::TokenStream;
 


### PR DESCRIPTION
as it looks like it is no longer needed https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#use-proc_macro:tokenstream;-now-works

and some unused imports. 