### PR TITLE
Create a Benchmark Chainspec

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -358,6 +358,35 @@ pub fn local_testnet_config() -> ChainSpec {
 	)
 }
 
+fn benchmark_genesis() -> GenesisConfig {
+	testnet_genesis(
+		vec![
+			get_authority_keys_from_seed("Alice"),
+		],
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		Some({
+			(0..50_000).map(|i| {
+					get_account_id_from_seed::<sr25519::Public>(&i.to_string())
+			}).collect()
+		}),
+		false,
+	)
+}
+
+/// Benchmark config (multivalidator Alice + Bob) w/ 50_000 funded accounts.
+pub fn benchmark_config() -> ChainSpec {
+	ChainSpec::from_genesis(
+		"Benchmark",
+		"benchmark",
+		benchmark_genesis,
+		vec![],
+		None,
+		None,
+		None,
+		Default::default(),
+	)
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::*;

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -373,7 +373,7 @@ fn benchmark_genesis() -> GenesisConfig {
 	)
 }
 
-/// Benchmark config (multivalidator Alice + Bob) w/ 50_000 funded accounts.
+/// Benchmark config (single validator Alice) w/ 50_000 funded accounts.
 pub fn benchmark_config() -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Benchmark",

--- a/bin/node/cli/src/lib.rs
+++ b/bin/node/cli/src/lib.rs
@@ -59,6 +59,9 @@ pub enum ChainSpec {
 	FlamingFir,
 	/// Whatever the current runtime is with the "global testnet" defaults.
 	StagingTestnet,
+	/// Whatever the current runtime is, with just Alice as an auth and 50_000
+	/// pre-funded users.
+	Benchmark,
 }
 
 /// Get a chain config from a spec setting.
@@ -69,6 +72,7 @@ impl ChainSpec {
 			ChainSpec::Development => chain_spec::development_config(),
 			ChainSpec::LocalTestnet => chain_spec::local_testnet_config(),
 			ChainSpec::StagingTestnet => chain_spec::staging_testnet_config(),
+			ChainSpec::Benchmark => chain_spec::benchmark_config(),
 		})
 	}
 
@@ -78,6 +82,7 @@ impl ChainSpec {
 			"local" => Some(ChainSpec::LocalTestnet),
 			"" | "fir" | "flaming-fir" => Some(ChainSpec::FlamingFir),
 			"staging" => Some(ChainSpec::StagingTestnet),
+			"benchmark" => Some(ChainSpec::Benchmark),
 			_ => None,
 		}
 	}

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -30,7 +30,8 @@ const DEFAULT_DB_CONFIG_PATH : &'static str = "db";
 /// Shared parameters used by all `CoreParams`.
 #[derive(Debug, StructOpt, Clone)]
 pub struct SharedParams {
-	/// Specify the chain specification (one of dev, local or staging).
+	/// Specify the chain specification (one of flaming-fir, dev, local, staging, or benchmark).
+	/// By default, the selected chain specification is flaming-fir.
 	#[structopt(long = "chain", value_name = "CHAIN_SPEC")]
 	pub chain: Option<String>,
 

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -116,15 +116,4 @@ benchmarks! {
 		let balance_amount = existential_deposit.saturating_mul(e.into());
 		let _ = <Balances<T> as Currency<_>>::make_free_balance_be(&user, balance_amount);
 	}: set_balance(RawOrigin::Root, user_lookup, 0.into(), 0.into())
-
-	confirm_genesis {
-		let x in 1 .. 1;
-		let mut iter = frame_system::Account::<T>::iter();
-		let mut user_count = 0;
-		while let Some(_) = iter.next() {
-			user_count += 1;
-		}
-	}: {
-		assert!(user_count >= 1);
-	}
 }

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -116,4 +116,15 @@ benchmarks! {
 		let balance_amount = existential_deposit.saturating_mul(e.into());
 		let _ = <Balances<T> as Currency<_>>::make_free_balance_be(&user, balance_amount);
 	}: set_balance(RawOrigin::Root, user_lookup, 0.into(), 0.into())
+
+	confirm_genesis {
+		let x in 1 .. 1;
+		let mut iter = frame_system::Account::<T>::iter();
+		let mut user_count = 0;
+		while let Some(_) = iter.next() {
+			user_count += 1;
+		}
+	}: {
+		assert!(user_count >= 1);
+	}
 }


### PR DESCRIPTION
This PR adds a new `--chain benchmark` which is the same as the `--chain dev` chain specification, but additionally adds 50,000 funded users.

This also critically fixes the `wipe_db` function to reset the database to the genesis state.

We can continue to expand this chain spec to increase the complexity of of the genesis state of the benchmarks.

I have also included a `benchmark.json`, which is a pre-calculated version of the Benchmark genesis, and contains a Wasm runtime which includes the benchmarking runtime APIs.