### PR TITLE
Rename Map is_linked -> unused, keeping backwards compat

### DIFF
--- a/frame/metadata/src/lib.rs
+++ b/frame/metadata/src/lib.rs
@@ -289,9 +289,9 @@ pub enum StorageEntryType {
 		hasher: StorageHasher,
 		key: DecodeDifferentStr,
 		value: DecodeDifferentStr,
-		is_linked: bool,
+		// is_linked flag previously, unused now to keep backwards compat
+		unused: bool,
 	},
-	Unused,
 	DoubleMap {
 		hasher: StorageHasher,
 		key1: DecodeDifferentStr,

--- a/frame/support/procedural/src/storage/metadata.rs
+++ b/frame/support/procedural/src/storage/metadata.rs
@@ -41,7 +41,7 @@ fn storage_line_metadata_type(scrate: &TokenStream, line: &StorageLineDefExt) ->
 					hasher: #scrate::metadata::#hasher,
 					key: #scrate::metadata::DecodeDifferent::Encode(#key),
 					value: #scrate::metadata::DecodeDifferent::Encode(#value_type),
-					is_linked: false,
+					unused: false,
 				}
 			}
 		},

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -498,7 +498,7 @@ mod tests {
 						hasher: StorageHasher::Twox64Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("u64"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructData(PhantomData::<Test>))
@@ -512,7 +512,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("u32"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructOptionLinkedMap(PhantomData::<Test>))
@@ -526,7 +526,7 @@ mod tests {
 						hasher: StorageHasher::Identity,
 						key: DecodeDifferent::Encode("T::BlockNumber"),
 						value: DecodeDifferent::Encode("T::BlockNumber"),
-						is_linked: false
+						unused: false
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructGenericData(PhantomData::<Test>))
@@ -540,7 +540,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("T::BlockNumber"),
 						value: DecodeDifferent::Encode("T::BlockNumber"),
-						is_linked: false
+						unused: false
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructGenericData2(PhantomData::<Test>))

--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -244,7 +244,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructMAPU32(PhantomData::<TraitImpl>))
@@ -258,7 +258,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructPUBMAPU32(PhantomData::<TraitImpl>))
@@ -272,7 +272,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructMAPU32MYDEF(PhantomData::<TraitImpl>))
@@ -286,7 +286,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructPUBMAPU32MYDEF(PhantomData::<TraitImpl>))
@@ -300,7 +300,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructGETMAPU32(PhantomData::<TraitImpl>))
@@ -314,7 +314,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructPUBGETMAPU32(PhantomData::<TraitImpl>))
@@ -328,7 +328,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructGETMAPU32MYDEF(PhantomData::<TraitImpl>))
@@ -342,7 +342,7 @@ mod tests {
 						hasher: StorageHasher::Blake2_128Concat,
 						key: DecodeDifferent::Encode("u32"),
 						value: DecodeDifferent::Encode("String"),
-						is_linked: false,
+						unused: false,
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructPUBGETMAPU32MYDEF(PhantomData::<TraitImpl>))

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -390,7 +390,7 @@ const EXPECTED_METADATA: StorageMetadata = StorageMetadata {
 					hasher: StorageHasher::Identity,
 					key: DecodeDifferent::Encode("u64"),
 					value: DecodeDifferent::Encode("u64"),
-					is_linked: false,
+					unused: false,
 				},
 				default: DecodeDifferent::Encode(
 					DefaultByteGetter(


### PR DESCRIPTION
PR into `gav-refactor-hashing` branch (sep. due to the tests being updated as well)

- removes Tombstone
- rename `is_linked`