### PR TITLE
ci: check_runtime: fetch release tag

### DIFF
--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -30,8 +30,9 @@ github_label () {
 boldprint "latest 10 commits of ${CI_COMMIT_REF_NAME}"
 git log --graph --oneline --decorate=short -n 10
 
-boldprint "make sure the master branch is available in shallow clones"
+boldprint "make sure the master branch and release tag are available in shallow clones"
 git fetch --depth=${GIT_DEPTH:-100} origin master
+git fetch --depth=${GIT_DEPTH:-100} origin release
 
 
 boldprint "check if the wasm sources changed"


### PR DESCRIPTION
fixes https://gitlab.parity.io/parity/substrate/-/jobs/418272
release tag is more than 100 commits away in the history.