### PR TITLE
ci: check_runtime: fetch release tag ii

### DIFF
--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -33,6 +33,8 @@ git log --graph --oneline --decorate=short -n 10
 boldprint "make sure the master branch and release tag are available in shallow clones"
 git fetch --depth=${GIT_DEPTH:-100} origin master
 git fetch --depth=${GIT_DEPTH:-100} origin release
+git tag release FETCH_HEAD
+git log -n1 release
 
 
 boldprint "check if the wasm sources changed"


### PR DESCRIPTION
fix release tag not being properly fetched e.g. https://gitlab.parity.io/parity/substrate/-/jobs/418866#L21