### PR TITLE
client/network/src/protocol: Refactor Prometheus metric logic

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -154,8 +154,7 @@ impl Metrics {
 				register(g, r)?
 			},
 			obsolete_requests: {
-				// TODO: Should this be a counter?
-				let g = Gauge::new("sync_obsolete_requests", "Total number of obsolete requests")?;
+				let g = Gauge::new("sync_obsolete_requests", "Number of obsolete requests")?;
 				register(g, r)?
 			},
 			peers: {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -156,43 +156,43 @@ impl Metrics {
 	fn register(r: &Registry) -> Result<Self, PrometheusError> {
 		Ok(Metrics {
 			handshaking_peers: {
-				let g = Gauge::new("sync_handshaking_peers", "number of newly connected peers")?;
+				let g = Gauge::new("sync_handshaking_peers", "Number of newly connected peers")?;
 				register(g, r)?
 			},
 			obsolete_requests: {
-				let g = Gauge::new("sync_obsolete_requests", "total number of obsolete requests")?;
+				let g = Gauge::new("sync_obsolete_requests", "Total number of obsolete requests")?;
 				register(g, r)?
 			},
 			peers: {
-				let g = Gauge::new("sync_peers", "number of peers we sync with")?;
+				let g = Gauge::new("sync_peers", "Number of peers we sync with")?;
 				register(g, r)?
 			},
 			queued_blocks: {
-				let g = Gauge::new("sync_queued_blocks", "number of blocks in import queue")?;
+				let g = Gauge::new("sync_queued_blocks", "Number of blocks in import queue")?;
 				register(g, r)?
 			},
 			fork_targets: {
-				let g = Gauge::new("sync_fork_targets", "fork sync targets")?;
+				let g = Gauge::new("sync_fork_targets", "Fork sync targets")?;
 				register(g, r)?
 			},
 			justifications_pending: {
 				let g = Gauge::new(
 					"sync_extra_justifications_pending",
-					"number of pending extra justifications requests"
+					"Number of pending extra justifications requests"
 				)?;
 				register(g, r)?
 			},
 			justifications_active: {
 				let g = Gauge::new(
 					"sync_extra_justifications_active",
-					"number of active extra justifications requests"
+					"Number of active extra justifications requests"
 				)?;
 				register(g, r)?
 			},
 			justifications_failed: {
 				let g = Gauge::new(
 					"sync_extra_justifications_failed",
-					"number of failed extra justifications requests"
+					"Number of failed extra justifications requests"
 				)?;
 				register(g, r)?
 			},
@@ -206,28 +206,28 @@ impl Metrics {
 			finality_proofs_pending: {
 				let g = Gauge::new(
 					"sync_extra_finality_proofs_pending",
-					"number of pending extra finality proof requests"
+					"Number of pending extra finality proof requests"
 				)?;
 				register(g, r)?
 			},
 			finality_proofs_active: {
 				let g = Gauge::new(
 					"sync_extra_finality_proofs_active",
-					"number of active extra finality proof requests"
+					"Number of active extra finality proof requests"
 				)?;
 				register(g, r)?
 			},
 			finality_proofs_failed: {
 				let g = Gauge::new(
 					"sync_extra_finality_proofs_failed",
-					"number of failed extra finality proof requests"
+					"Number of failed extra finality proof requests"
 				)?;
 				register(g, r)?
 			},
 			finality_proofs_importing: {
 				let g = Gauge::new(
 					"sync_extra_finality_proofs_importing",
-					"number of importing extra finality proof requests"
+					"Number of importing extra finality proof requests"
 				)?;
 				register(g, r)?
 			},


### PR DESCRIPTION
I have the following suggestions for the Prometheus metrics within `client/network/src/protocol.rs`:

1. Start Prometheus metric help with capital

2. Differentiate metric status as label 

    Prometheus query language is powerful through its multi-dimensional data
model. Metric names are hirarchical whereas labels enable data to become
multi-dimensional.

    Exposing the justification of finality-proof status as a label allows
for more powerful queries.

3. Remove 'Total' from non counter metric help

    The word 'total' is reserved for accumulating counters. Counters have to
be monotonically increasing. `obsolete_requests` can decrease, thereby
it is defined as a `Gauge` and not a `Counter`.

    For more details on metric naming see
https://prometheus.io/docs/practices/naming/