### PR TITLE
Fixed a couple of syncing issues

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -598,6 +598,11 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		self.sync.status().queued_blocks
 	}
 
+	/// Number of processed blocks.
+	pub fn num_processed_blocks(&self) -> usize {
+		self.sync.num_processed_blocks()
+	}
+
 	/// Number of active sync requests.
 	pub fn num_sync_requests(&self) -> usize {
 		self.sync.num_sync_requests()

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -85,7 +85,7 @@ mod rep {
 	pub const INCOMPLETE_HEADER: Rep = Rep::new(-(1 << 20), "Incomplete header");
 
 	/// Reputation change for peers which send us a block which we fail to verify.
-	pub const VERIFICATION_FAIL: Rep = Rep::new(-(1 << 20), "Block verification failed");
+	pub const VERIFICATION_FAIL: Rep = Rep::new(-(1 << 29), "Block verification failed");
 
 	/// Reputation change for peers which send us a known bad block.
 	pub const BAD_BLOCK: Rep = Rep::new(-(1 << 29), "Bad block");
@@ -138,6 +138,8 @@ pub struct ChainSync<B: BlockT> {
 	block_announce_validator: Box<dyn BlockAnnounceValidator<B> + Send>,
 	/// Maximum number of peers to ask the same blocks in parallel.
 	max_parallel_downloads: u32,
+	/// Total numbet of processed blocks (imported or failed).
+	processed_blocks: usize,
 }
 
 /// All the data we have about a Peer that we are trying to sync with
@@ -318,6 +320,7 @@ impl<B: BlockT> ChainSync<B> {
 			is_idle: false,
 			block_announce_validator,
 			max_parallel_downloads,
+			processed_blocks: 0,
 		}
 	}
 
@@ -355,6 +358,11 @@ impl<B: BlockT> ChainSync<B> {
 	/// Number of active sync requests.
 	pub fn num_sync_requests(&self) -> usize {
 		self.fork_targets.len()
+	}
+
+	/// Number of processed blocks.
+	pub fn num_processed_blocks(&self) -> usize {
+		self.processed_blocks
 	}
 
 	/// Handle a new connected peer.
@@ -649,7 +657,7 @@ impl<B: BlockT> ChainSync<B> {
 	pub fn on_block_data
 		(&mut self, who: PeerId, request: Option<BlockRequest<B>>, response: BlockResponse<B>) -> Result<OnBlockData<B>, BadPeer>
 	{
-		let new_blocks: Vec<IncomingBlock<B>> =
+		let mut new_blocks: Vec<IncomingBlock<B>> =
 			if let Some(peer) = self.peers.get_mut(&who) {
 				let mut blocks = response.blocks;
 				if request.as_ref().map_or(false, |r| r.direction == message::Direction::Descending) {
@@ -767,6 +775,12 @@ impl<B: BlockT> ChainSync<B> {
 			} else {
 				Vec::new()
 			};
+
+		let orig_len = new_blocks.len();
+		new_blocks.retain(|b| !self.queue_blocks.contains(&b.hash));
+		if new_blocks.len() != orig_len {
+			debug!(target: "sync", "Ignoring {} blocks that are already queued", orig_len - new_blocks.len());
+		}
 
 		let is_recent = new_blocks.first()
 			.map(|block| {
@@ -895,7 +909,7 @@ impl<B: BlockT> ChainSync<B> {
 		let mut output = Vec::new();
 
 		let mut has_error = false;
-		let mut hashes = vec![];
+		let mut hashes = Vec::with_capacity(results.len());
 		for (result, hash) in results {
 			hashes.push(hash);
 
@@ -943,39 +957,40 @@ impl<B: BlockT> ChainSync<B> {
 				},
 				Err(BlockImportError::IncompleteHeader(who)) => {
 					if let Some(peer) = who {
-						info!("Peer sent block with incomplete header to import");
+						warn!("Peer sent block with incomplete header to import");
 						output.push(Err(BadPeer(peer, rep::INCOMPLETE_HEADER)));
 						output.extend(self.restart());
 					}
 				},
 				Err(BlockImportError::VerificationFailed(who, e)) => {
 					if let Some(peer) = who {
-						info!("Verification failed from peer: {}", e);
+						warn!("Verification failed for block {:?} received from peer: {}, {:?}", hash, peer, e);
 						output.push(Err(BadPeer(peer, rep::VERIFICATION_FAIL)));
 						output.extend(self.restart());
 					}
 				},
 				Err(BlockImportError::BadBlock(who)) => {
 					if let Some(peer) = who {
-						info!("Block received from peer has been blacklisted");
+						info!("Block {:?} received from peer {} has been blacklisted", hash, peer);
 						output.push(Err(BadPeer(peer, rep::BAD_BLOCK)));
-						output.extend(self.restart());
 					}
 				},
 				Err(BlockImportError::MissingState) => {
 					// This may happen if the chain we were requesting upon has been discarded
 					// in the meantime because other chain has been finalized.
 					// Don't mark it as bad as it still may be synced if explicitly requested.
-					trace!(target: "sync", "Obsolete block");
+					trace!(target: "sync", "Obsolete block {:?}", hash);
 				},
-				Err(BlockImportError::UnknownParent) |
-				Err(BlockImportError::Cancelled) |
-				Err(BlockImportError::Other(_)) => {
+				e @ Err(BlockImportError::UnknownParent) |
+				e @ Err(BlockImportError::Other(_)) => {
+					warn!(target: "sync", "Error importing block {:?}: {:?}", hash, e);
 					output.extend(self.restart());
 				},
+				Err(BlockImportError::Cancelled) => {}
 			};
 		}
 
+		self.processed_blocks += hashes.len();
 		for hash in hashes {
 			self.queue_blocks.remove(&hash);
 		}
@@ -1094,7 +1109,7 @@ impl<B: BlockT> ChainSync<B> {
 		if let PeerSyncState::AncestorSearch(_, _) = peer.state {
 			return OnBlockAnnounce::Nothing
 		}
-		// If the announced block is the best they have seen, our common number
+		// If the announced block is the best they have and is not ahead of us, our common number
 		// is either one further ahead or it's the one they just announced, if we know about it.
 		if is_best {
 			if known {
@@ -1169,6 +1184,7 @@ impl<B: BlockT> ChainSync<B> {
 	/// Restart the sync process.
 	fn restart<'a>(&'a mut self) -> impl Iterator<Item = Result<(PeerId, BlockRequest<B>), BadPeer>> + 'a {
 		self.queue_blocks.clear();
+		self.processed_blocks = 0;
 		self.blocks.clear();
 		let info = self.client.info();
 		self.best_queued_hash = info.best_hash;

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -375,6 +375,11 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		self.network_service.user_protocol().num_queued_blocks()
 	}
 
+	/// Returns the number of processed blocks.
+	pub fn num_processed_blocks(&self) -> usize {
+		self.network_service.user_protocol().num_processed_blocks()
+	}
+
 	/// Number of active sync requests.
 	pub fn num_sync_requests(&self) -> usize {
 		self.network_service.user_protocol().num_sync_requests()

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -207,6 +207,11 @@ impl<D> Peer<D> {
 		self.network.num_connected_peers()
 	}
 
+	/// Returns the number of processed blocks.
+	pub fn num_processed_blocks(&self) -> usize {
+		self.network.num_processed_blocks()
+	}
+
 	/// Returns true if we have no peer.
 	pub fn is_offline(&self) -> bool {
 		self.num_peers() == 0

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -657,3 +657,40 @@ fn full_sync_requires_block_body() {
 	net.block_until_idle();
 	assert_eq!(net.peer(1).client.info().best_number, 0);
 }
+
+#[test]
+fn imports_stale_once() {
+	let _ = ::env_logger::try_init();
+
+	fn import_with_announce(net: &mut TestNet, hash: H256) {
+		// Announce twice
+		net.peer(0).announce_block(hash, Vec::new());
+		net.peer(0).announce_block(hash, Vec::new());
+
+		block_on(futures::future::poll_fn::<(), _>(|cx| {
+			net.poll(cx);
+			if net.peer(1).client().header(&BlockId::Hash(hash)).unwrap().is_some() {
+				Poll::Ready(())
+			} else {
+				Poll::Pending
+			}
+		}));
+	}
+
+	// given the network with 2 full nodes
+	let mut net = TestNet::new(2);
+
+	// let them connect to each other
+	net.block_until_sync();
+
+	// check that NEW block is imported from announce message
+	let new_hash = net.peer(0).push_blocks(1, false);
+	import_with_announce(&mut net, new_hash);
+	assert_eq!(net.peer(1).num_processed_blocks(), 1);
+
+	// check that KNOWN STALE block is imported from announce message
+	let known_stale_hash = net.peer(0).push_blocks_at(BlockId::Number(0), 1, true);
+	import_with_announce(&mut net, known_stale_hash);
+	assert_eq!(net.peer(1).num_processed_blocks(), 2);
+}
+


### PR DESCRIPTION
This fixes a couple of issues observed on one of the validators:

* When syncing to old forks we don't check if the downloaded block is already in the queue. This may cause the same block to be added to the queue multiple times on restart. 

* When receiving announcement for some known block we set common block for that peer to be the announced block. The code assumes that if the block is known it is lower than our best blocks. This is not true since reorgs to previous (lower) blocks is possible. Fixed that check.