### PR TITLE
Print non-output messages to stderr in subkey

### DIFF
--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -135,7 +135,6 @@ trait Crypto: Sized {
 					);
 				},
 			}
-
 		} else if let Ok((public_key, v)) =
 			<Self::Pair as Pair>::Public::from_string_with_version(uri)
 		{

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -81,7 +81,7 @@ trait Crypto: Sized {
 	{
 		if let Ok((pair, seed)) = Self::Pair::from_phrase(uri, password) {
 			let public_key = Self::public_from_pair(&pair);
-			
+
 			match output {
 				OutputType::Json => {
 					let json = json!({
@@ -135,7 +135,7 @@ trait Crypto: Sized {
 					);
 				},
 			}
-			
+
 		} else if let Ok((public_key, v)) =
 			<Self::Pair as Pair>::Public::from_string_with_version(uri)
 		{
@@ -167,7 +167,7 @@ trait Crypto: Sized {
 				},
 			}
 		} else {
-			println!("Invalid phrase/URI given");
+			eprintln!("Invalid phrase/URI given");
 		}
 	}
 }

--- a/bin/utils/subkey/src/rpc.rs
+++ b/bin/utils/subkey/src/rpc.rs
@@ -42,7 +42,7 @@ impl RpcClient {
 					client.insert_key(key_type, suri, public).map(|_| ())
 				})
 				.map_err(|e| {
-					println!("Error inserting key: {:?}", e);
+					eprintln!("Error inserting key: {:?}", e);
 				})
 		);
 	}

--- a/bin/utils/subkey/src/vanity.rs
+++ b/bin/utils/subkey/src/vanity.rs
@@ -69,7 +69,7 @@ pub(super) fn generate_key<C: Crypto>(desired: &str) -> Result<KeyPair<C>, &'sta
 		return Err("Pattern must not be empty");
 	}
 
-	println!("Generating key containing pattern '{}'", desired);
+	eprintln!("Generating key containing pattern '{}'", desired);
 
 	let top = 45 + (desired.len() * 48);
 	let mut best = 0;
@@ -94,14 +94,14 @@ pub(super) fn generate_key<C: Crypto>(desired: &str) -> Result<KeyPair<C>, &'sta
 				score: score,
 			};
 			if best >= top {
-				println!("best: {} == top: {}", best, top);
+				eprintln!("best: {} == top: {}", best, top);
 				return Ok(keypair);
 			}
 		}
 		done += 1;
 
 		if done % good_waypoint(done) == 0 {
-			println!("{} keys searched; best is {}/{} complete", done, best, top);
+			eprintln!("{} keys searched; best is {}/{} complete", done, best, top);
 		}
 	}
 }


### PR DESCRIPTION
This PR has a very simple motivation that the `subkey` utility should only print "real" output to `stdout` while direct other messages like errors or vanity progress to `stderr`.

I only modified some of `println!` to `eprintln!`. And I only checked `subkey`.
