### PR TITLE
ci: check_runtime: fetch release tag iii

### DIFF
--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -33,7 +33,7 @@ git log --graph --oneline --decorate=short -n 10
 boldprint "make sure the master branch and release tag are available in shallow clones"
 git fetch --depth=${GIT_DEPTH:-100} origin master
 git fetch --depth=${GIT_DEPTH:-100} origin release
-git tag release FETCH_HEAD
+git tag -f release FETCH_HEAD
 git log -n1 release
 
 


### PR DESCRIPTION
fix for https://gitlab.parity.io/parity/substrate/-/jobs/421175 when the release tag was withing git depth of cloning.