### PR TITLE
sc-network: Return on Poll::Pending.

### DIFF
--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -200,15 +200,19 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin,
 								Err(err) => return Poll::Ready(Some(Err(err))),
 							}
 						},
-						Poll::Pending =>
-							*this.handshake = NotificationsInSubstreamHandshake::PendingSend(msg),
+						Poll::Pending => {
+							*this.handshake = NotificationsInSubstreamHandshake::PendingSend(msg);
+							return Poll::Pending
+						}
 					},
 				NotificationsInSubstreamHandshake::Close =>
 					match Sink::poll_close(this.socket.as_mut(), cx)? {
 						Poll::Ready(()) =>
 							*this.handshake = NotificationsInSubstreamHandshake::Sent,
-						Poll::Pending =>
-							*this.handshake = NotificationsInSubstreamHandshake::Close,
+						Poll::Pending => {
+							*this.handshake = NotificationsInSubstreamHandshake::Close;
+							return Poll::Pending
+						}
 					},
 			}
 		}


### PR DESCRIPTION
If polling encounters a `Poll::Pending` we need to return it instead of continuing the loop which may turn it into a blocking operation, causing problems with executors.

For context see: https://github.com/paritytech/polkadot/issues/909.