### PR TITLE
Add sp_std::prelude to offchain worker example 

### DIFF
--- a/frame/example-offchain-worker/src/lib.rs
+++ b/frame/example-offchain-worker/src/lib.rs
@@ -54,6 +54,7 @@ use sp_runtime::{
 	traits::Zero,
 	transaction_validity::{InvalidTransaction, ValidTransaction, TransactionValidity},
 };
+use sp_std::prelude::*;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Not sure if it can work without it at all in runtime?