### PR TITLE
client/network-gossip: Remove obsolete trait bounds

### DIFF
--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -31,7 +31,7 @@ pub struct GossipEngine<B: BlockT> {
 	state_machine: ConsensusGossip<B>,
 	network: Box<dyn Network<B>>,
 	periodic_maintenance_interval: futures_timer::Delay,
-	network_event_stream: Pin<Box<dyn Stream<Item = Event> + Send>>,
+	network_event_stream: Pin<Box<dyn Stream<Item = Event>>>,
 	engine_id: ConsensusEngineId,
 }
 

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -29,7 +29,7 @@ use std::{borrow::Cow, pin::Pin, sync::Arc, task::{Context, Poll}};
 /// top of it.
 pub struct GossipEngine<B: BlockT> {
 	state_machine: ConsensusGossip<B>,
-	network: Box<dyn Network<B> + Send>,
+	network: Box<dyn Network<B>>,
 	periodic_maintenance_interval: futures_timer::Delay,
 	network_event_stream: Pin<Box<dyn Stream<Item = Event> + Send>>,
 	engine_id: ConsensusEngineId,
@@ -39,7 +39,7 @@ impl<B: BlockT> Unpin for GossipEngine<B> {}
 
 impl<B: BlockT> GossipEngine<B> {
 	/// Create a new instance.
-	pub fn new<N: Network<B> + Send + Clone + 'static>(
+	pub fn new<N: Network<B> + 'static>(
 		mut network: N,
 		engine_id: ConsensusEngineId,
 		protocol_name: impl Into<Cow<'static, [u8]>>,

--- a/client/network-gossip/src/lib.rs
+++ b/client/network-gossip/src/lib.rs
@@ -70,7 +70,7 @@ mod validator;
 /// Abstraction over a network.
 pub trait Network<B: BlockT> {
 	/// Returns a stream of events representing what happens on the network.
-	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>>;
+	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event>>>;
 
 	/// Adjust the reputation of a node.
 	fn report_peer(&self, peer_id: PeerId, reputation: ReputationChange);
@@ -98,7 +98,7 @@ pub trait Network<B: BlockT> {
 }
 
 impl<B: BlockT, H: ExHashT> Network<B> for Arc<NetworkService<B, H>> {
-	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event>>> {
 		Box::pin(NetworkService::event_stream(self))
 	}
 


### PR DESCRIPTION
- client/network-gossip: Remove obsolete Send requirement for event_stream

  With 78cdd3b there is no need for the `Network` to be `Send` given that
  `GossipEngine` does not depend on background tasks anymore.

- client/network-gossip: Remove obsolete `Send` bound on `Network`

  With 78cdd3b there is no need for the `event_stream` to be `Send` given
 that `GossipEngine` does not depend on background tasks anymore.

