### PR TITLE
alpha.4 release fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -578,7 +578,7 @@ publish-to-crates-io:
   <<:                              *docker-env
   only:
     - tags
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+    - ci-release
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check ${CARGO_UNLEASH_PKG_DEF}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-example"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-example-offchain-worker"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7544,7 +7544,7 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7866,7 +7866,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-utils"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 
 [[package]]
 name = "substrate-wasm-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.3"
+version = "0.8.0-alpha.4"
 dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.8.0-alpha.3"
+version = "0.8.0-alpha.4"
 dependencies = [
  "assert_matches",
  "log 0.4.8",

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -21,7 +21,7 @@ sp-panic-handler = { version = "2.0.0-alpha.4", path = "../../primitives/panic-h
 wasmi = "0.6.2"
 parity-wasm = "0.41.0"
 lazy_static = "1.4.0"
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../primitives/runtime-interface" }
 sp-externalities = { version = "0.8.0-alpha.4", path = "../../primitives/externalities" }
 sc-executor-common = { version = "0.8.0-alpha.4", path = "common" }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -25,8 +25,8 @@ sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../primitives/wasm-i
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../primitives/runtime-interface" }
 sp-externalities = { version = "0.8.0-alpha.4", path = "../../primitives/externalities" }
 sc-executor-common = { version = "0.8.0-alpha.4", path = "common" }
-sc-executor-wasmi = { version = "0.8.0-alpha.2", path = "wasmi" }
-sc-executor-wasmtime = { version = "0.8.0-alpha.2", path = "wasmtime", optional = true }
+sc-executor-wasmi = { version = "0.8.0-alpha.4", path = "wasmi" }
+sc-executor-wasmtime = { version = "0.8.0-alpha.4", path = "wasmtime", optional = true }
 parking_lot = "0.10.0"
 log = "0.4.8"
 libsecp256k1 = "0.3.4"

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "1.2.0" }
 wasmi = "0.6.2"
 sp-core = { version = "2.0.0-alpha.4", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.4", path = "../../../primitives/allocator" }
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime-interface" }
 sp-serializer = { version = "2.0.0-alpha.4", path = "../../../primitives/serializer" }
 

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -15,7 +15,7 @@ wasmi = "0.6.2"
 parity-wasm = "0.41.0"
 codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-executor-common = { version = "0.8.0-alpha.4", path = "../common" }
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-alpha.4", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.4", path = "../../../primitives/allocator" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.3"
+version = "0.8.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "This crate provides an implementation of `WasmRuntime` that is baked by wasmi."
-documentation = "https://docs.rs/sc-execturo-wasmi"
+documentation = "https://docs.rs/sc-executor-wasmi"
 
 [dependencies]
 log = "0.4.8"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-executor-wasmtime"
-version = "0.8.0-alpha.3"
+version = "0.8.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -14,7 +14,7 @@ scoped-tls = "1.0"
 parity-wasm = "0.41.0"
 codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-executor-common = { version = "0.8.0-alpha.4", path = "../common" }
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../../primitives/wasm-interface" }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/wasm-interface" }
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-alpha.4", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.4", path = "../../../primitives/allocator" }

--- a/frame/benchmark/Cargo.toml
+++ b/frame/benchmark/Cargo.toml
@@ -4,6 +4,9 @@ version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "Patterns to benchmark in a FRAME runtime."
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -21,7 +21,7 @@ sp-io = { version = "2.0.0-alpha.4", path = "../../primitives/io" }
 hex-literal = "0.2.1"
 pallet-balances = { version = "2.0.0-alpha.4", path = "../balances" }
 sp-core = { version = "2.0.0-alpha.4", path = "../../primitives/core" }
-substrate-test-utils = { version = "2.0.0-alpha.2", path = "../../test-utils" }
+substrate-test-utils = { version = "2.0.0-alpha.4", path = "../../test-utils" }
 serde = { version = "1.0.101" }
 
 [features]

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-example-offchain-worker"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-example"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -30,7 +30,7 @@ sp-core = { version = "2.0.0-alpha.4", path = "../../primitives/core" }
 pallet-balances = { version = "2.0.0-alpha.4", path = "../balances" }
 pallet-timestamp = { version = "2.0.0-alpha.4", path = "../timestamp" }
 pallet-staking-reward-curve = { version = "2.0.0-alpha.4",  path = "../staking/reward-curve" }
-substrate-test-utils = { version = "2.0.0-alpha.2", path = "../../test-utils" }
+substrate-test-utils = { version = "2.0.0-alpha.4", path = "../../test-utils" }
 frame-benchmarking = { version = "2.0.0-alpha.4", path = "../benchmarking" }
 rand_chacha = { version = "0.2" }
 

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sp-allocator"
 [dependencies]
 sp-std = { version = "2.0.0-alpha.4", path = "../std", default-features = false }
 sp-core = { version = "2.0.0-alpha.4", path = "../core", default-features = false }
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../wasm-interface", default-features = false }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../wasm-interface", default-features = false }
 log = { version = "0.4.8", optional = true }
 derive_more = { version = "0.99.2", optional = true }
 

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -17,7 +17,7 @@ sp-core = { version = "2.0.0-alpha.4", default-features = false, path = "../core
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../std" }
 libsecp256k1 = { version = "0.3.4", optional = true }
 sp-state-machine = { version = "0.8.0-alpha.4", optional = true, path = "../../primitives/state-machine" }
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../../primitives/wasm-interface", default-features = false }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../primitives/wasm-interface", default-features = false }
 sp-runtime-interface = { version = "2.0.0-alpha.4", default-features = false, path = "../runtime-interface" }
 sp-trie = { version = "2.0.0-alpha.4", optional = true, path = "../../primitives/trie" }
 sp-externalities = { version = "0.8.0-alpha.4", optional = true, path = "../externalities" }

--- a/primitives/phragmen/Cargo.toml
+++ b/primitives/phragmen/Cargo.toml
@@ -14,7 +14,7 @@ sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../std" 
 sp-runtime = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/runtime" }
 
 [dev-dependencies]
-substrate-test-utils = { version = "2.0.0-alpha.2", path = "../../test-utils" }
+substrate-test-utils = { version = "2.0.0-alpha.4", path = "../../test-utils" }
 sp-io ={ version = "2.0.0-alpha.4", path = "../../primitives/io" }
 rand = "0.7.2"
 

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -10,7 +10,7 @@ description = "Substrate runtime interface"
 documentation = "https://docs.rs/sp-runtime-interface/"
 
 [dependencies]
-sp-wasm-interface = { version = "2.0.0-alpha.2", path = "../wasm-interface", default-features = false }
+sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../wasm-interface", default-features = false }
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../std" }
 sp-runtime-interface-proc-macro = { version = "2.0.0-alpha.4", path = "proc-macro" }
 sp-externalities = { version = "0.8.0-alpha.4", optional = true, path = "../externalities" }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -13,7 +13,7 @@ wasmi = { version = "0.6.2", optional = true }
 sp-core = { version = "2.0.0-alpha.4", default-features = false, path = "../core" }
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../std" }
 sp-io = { version = "2.0.0-alpha.4", default-features = false, path = "../io" }
-sp-wasm-interface = { version = "2.0.0-alpha.2", default-features = false, path = "../wasm-interface" }
+sp-wasm-interface = { version = "2.0.0-alpha.4", default-features = false, path = "../wasm-interface" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 
 [dev-dependencies]

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-test-utils"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"


### PR DESCRIPTION
The CI failed because it missed some cargo metadata and had some version mismatches. This fixes it.

It also to roling release tags, switches to triggering the unleash-process whenever it sees `ci-release` (which we force reset) and we tag the appropriate version after it succeeded