### PR TITLE
Add more generated utils to the image

### DIFF
--- a/.maintain/Dockerfile
+++ b/.maintain/Dockerfile
@@ -39,6 +39,10 @@ RUN mv /usr/share/ca* /tmp && \
 	ln -s /substrate/.local/share/substrate /data
 
 COPY --from=builder /substrate/target/$PROFILE/substrate /usr/local/bin
+COPY --from=builder /substrate/target/$PROFILE/subkey /usr/local/bin
+COPY --from=builder /substrate/target/$PROFILE/node-rpc-client /usr/local/bin
+COPY --from=builder /substrate/target/$PROFILE/node-template /usr/local/bin
+COPY --from=builder /substrate/target/$PROFILE/chain-spec-builder /usr/local/bin
 
 # checks
 RUN ldd /usr/local/bin/substrate && \


### PR DESCRIPTION
Since we build them anyway, utilities such as subkey and the chain-spec-builder can be included in the image.

The new content can be checked with:
```
docker run --rm -it chevdor/substrate:20200318-8516190a8 ls -al /usr/local/bin
```

Subkey for instance can be used with:
```
docker run --rm -it chevdor/substrate:20200318-8516190a8 subkey --help
```

chain-spec-build:
```
docker run --rm -it chevdor/substrate:20200318-8516190a8 chain-spec-builder --help
```

etc...