### PR TITLE
grandpa: support for hard forking any pending standard changes

### DIFF
--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -538,17 +538,13 @@ impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Clie
 		authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 		send_voter_commands: mpsc::UnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 		consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
-		authority_set_hard_forks: Vec<(
-			SetId,
-			Block::Hash,
-			PendingChange<Block::Hash, NumberFor<Block>>,
-		)>,
+		authority_set_hard_forks: Vec<(SetId, PendingChange<Block::Hash, NumberFor<Block>>)>,
 	) -> GrandpaBlockImport<Backend, Block, Client, SC> {
 		// check for and apply any forced authority set hard fork that applies
 		// to the *current* authority set.
-		if let Some((_, _, change)) = authority_set_hard_forks
+		if let Some((_, change)) = authority_set_hard_forks
 			.iter()
-			.find(|(set_id, _, _)| *set_id == authority_set.set_id())
+			.find(|(set_id, _)| *set_id == authority_set.set_id())
 		{
 			let mut authority_set = authority_set.inner().write();
 			authority_set.current_authorities = change.next_authorities.clone();
@@ -559,7 +555,7 @@ impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Clie
 		// authority set changes.
 		let authority_set_hard_forks = authority_set_hard_forks
 			.into_iter()
-			.map(|(_, hash, change)| (hash, change))
+			.map(|(_, change)| (change.canon_hash, change))
 			.collect::<HashMap<_, _>>();
 
 		// check for and apply any forced authority set hard fork that apply to
@@ -567,6 +563,7 @@ impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Clie
 		// they were announced.
 		{
 			let mut authority_set = authority_set.inner().write();
+
 			authority_set.pending_standard_changes = authority_set
 				.pending_standard_changes
 				.clone()

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -30,7 +30,7 @@ use sp_consensus::{
 	BlockCheckParams, BlockImportParams, ImportResult, JustificationImport,
 	SelectChain,
 };
-use sp_finality_grandpa::{GRANDPA_ENGINE_ID, ScheduledChange, ConsensusLog};
+use sp_finality_grandpa::{ConsensusLog, ScheduledChange, SetId, GRANDPA_ENGINE_ID};
 use sp_runtime::Justification;
 use sp_runtime::generic::{BlockId, OpaqueDigestItemId};
 use sp_runtime::traits::{
@@ -59,6 +59,7 @@ pub struct GrandpaBlockImport<Backend, Block: BlockT, Client, SC> {
 	authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 	send_voter_commands: mpsc::UnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 	consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
+	authority_set_hard_forks: HashMap<Block::Hash, PendingChange<Block::Hash, NumberFor<Block>>>,
 	_phantom: PhantomData<Backend>,
 }
 
@@ -72,6 +73,7 @@ impl<Backend, Block: BlockT, Client, SC: Clone> Clone for
 			authority_set: self.authority_set.clone(),
 			send_voter_commands: self.send_voter_commands.clone(),
 			consensus_changes: self.consensus_changes.clone(),
+			authority_set_hard_forks: self.authority_set_hard_forks.clone(),
 			_phantom: PhantomData,
 		}
 	}
@@ -212,9 +214,16 @@ where
 	Client: crate::ClientForGrandpa<Block, BE>,
 {
 	// check for a new authority set change.
-	fn check_new_change(&self, header: &Block::Header, hash: Block::Hash)
-		-> Option<PendingChange<Block::Hash, NumberFor<Block>>>
-	{
+	fn check_new_change(
+		&self,
+		header: &Block::Header,
+		hash: Block::Hash,
+	) -> Option<PendingChange<Block::Hash, NumberFor<Block>>> {
+		// check for forced authority set hard forks
+		if let Some(change) = self.authority_set_hard_forks.get(&hash) {
+			return Some(change.clone());
+		}
+
 		// check for forced change.
 		if let Some((median_last_finalized, change)) = find_forced_change::<Block>(header) {
 			return Some(PendingChange {
@@ -529,13 +538,53 @@ impl<Backend, Block: BlockT, Client, SC> GrandpaBlockImport<Backend, Block, Clie
 		authority_set: SharedAuthoritySet<Block::Hash, NumberFor<Block>>,
 		send_voter_commands: mpsc::UnboundedSender<VoterCommand<Block::Hash, NumberFor<Block>>>,
 		consensus_changes: SharedConsensusChanges<Block::Hash, NumberFor<Block>>,
+		authority_set_hard_forks: Vec<(
+			SetId,
+			Block::Hash,
+			PendingChange<Block::Hash, NumberFor<Block>>,
+		)>,
 	) -> GrandpaBlockImport<Backend, Block, Client, SC> {
+		// check for and apply any forced authority set hard fork that applies
+		// to the *current* authority set.
+		if let Some((_, _, change)) = authority_set_hard_forks
+			.iter()
+			.find(|(set_id, _, _)| *set_id == authority_set.set_id())
+		{
+			let mut authority_set = authority_set.inner().write();
+			authority_set.current_authorities = change.next_authorities.clone();
+		}
+
+		// index authority set hard forks by block hash so that they can be used
+		// by any node syncing the chain and importing a block hard fork
+		// authority set changes.
+		let authority_set_hard_forks = authority_set_hard_forks
+			.into_iter()
+			.map(|(_, hash, change)| (hash, change))
+			.collect::<HashMap<_, _>>();
+
+		// check for and apply any forced authority set hard fork that apply to
+		// any *pending* standard changes, checking by the block hash at which
+		// they were announced.
+		{
+			let mut authority_set = authority_set.inner().write();
+			authority_set.pending_standard_changes = authority_set
+				.pending_standard_changes
+				.clone()
+				.map(&mut |hash, _, original| {
+					authority_set_hard_forks
+						.get(&hash)
+						.cloned()
+						.unwrap_or(original)
+				});
+		}
+
 		GrandpaBlockImport {
 			inner,
 			select_chain,
 			authority_set,
 			send_voter_commands,
 			consensus_changes,
+			authority_set_hard_forks,
 			_phantom: PhantomData,
 		}
 	}

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -417,6 +417,35 @@ pub fn block_import<BE, Block: BlockT, Client, SC>(
 	client: Arc<Client>,
 	genesis_authorities_provider: &dyn GenesisAuthoritySetProvider<Block>,
 	select_chain: SC,
+) -> Result<
+	(
+		GrandpaBlockImport<BE, Block, Client, SC>,
+		LinkHalf<Block, Client, SC>,
+	),
+	ClientError,
+>
+where
+	SC: SelectChain<Block>,
+	BE: Backend<Block> + 'static,
+	Client: ClientForGrandpa<Block, BE> + 'static,
+{
+	block_import_with_authority_set_hard_forks(
+		client,
+		genesis_authorities_provider,
+		select_chain,
+		Default::default(),
+	)
+}
+
+/// Make block importer and link half necessary to tie the background voter to
+/// it. A vector of authority set hard forks can be passed, any authority set
+/// change signaled at the given block (either already signalled or in a further
+/// block when importing it) will be replaced by a standard change with the
+/// given static authorities.
+pub fn block_import_with_authority_set_hard_forks<BE, Block: BlockT, Client, SC>(
+	client: Arc<Client>,
+	genesis_authorities_provider: &dyn GenesisAuthoritySetProvider<Block>,
+	select_chain: SC,
 	authority_set_hard_forks: Vec<(SetId, (Block::Hash, NumberFor<Block>), AuthorityList)>,
 ) -> Result<
 	(

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -444,6 +444,7 @@ where
 
 	let (voter_commands_tx, voter_commands_rx) = mpsc::unbounded();
 
+	// FIXME
 	Ok((
 		GrandpaBlockImport::new(
 			client.clone(),
@@ -451,6 +452,7 @@ where
 			persistent_data.authority_set.clone(),
 			voter_commands_tx,
 			persistent_data.consensus_changes.clone(),
+			Default::default(),
 		),
 		LinkHalf {
 			client,


### PR DESCRIPTION
This PR adds support in GRANDPA for defining tuples `(SetId, (BlockHash, BlockNumber), AuthorityList)` which will be replace any existing pending authority set changes and additionally will also replace the signalled authority set change when importing a hard fork block (e.g. when syncing the chain after the fact). 