### PR TITLE
Prompt error if vanity pattern is not valid base58

### DIFF
--- a/bin/utils/subkey/src/vanity.rs
+++ b/bin/utils/subkey/src/vanity.rs
@@ -65,11 +65,7 @@ fn calculate_score(_desired: &str, key: &str) -> usize {
 /// Validate whether the char is allowed to be used in base58.
 /// num 0, lower l, upper I and O are not allowed.
 fn validate_base58(c :char) -> bool {
-	if !c.is_alphanumeric() || "0lIO".contains(c) {
-		false
-	} else {
-		true
-	}
+	c.is_alphanumeric() && !"0lIO".contains(c)
 }
 
 pub(super) fn generate_key<C: Crypto>(desired: &str) -> Result<KeyPair<C>, &'static str> where

--- a/bin/utils/subkey/src/vanity.rs
+++ b/bin/utils/subkey/src/vanity.rs
@@ -173,6 +173,22 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn test_invalid_pattern() {
+		assert!(generate_key::<Ed25519>("").is_err());
+		assert!(generate_key::<Ed25519>("0").is_err());
+		assert!(generate_key::<Ed25519>("l").is_err());
+		assert!(generate_key::<Ed25519>("I").is_err());
+		assert!(generate_key::<Ed25519>("O").is_err());
+		assert!(generate_key::<Ed25519>("!").is_err());
+	}
+
+	#[test]
+	fn test_valid_pattern() {
+		assert!(generate_key::<Ed25519>("o").is_ok());
+		assert!(generate_key::<Ed25519>("L").is_ok());
+	}
+
 	#[cfg(feature = "bench")]
 	#[bench]
 	fn bench_paranoiac(b: &mut Bencher) {

--- a/bin/utils/subkey/src/vanity.rs
+++ b/bin/utils/subkey/src/vanity.rs
@@ -62,11 +62,26 @@ fn calculate_score(_desired: &str, key: &str) -> usize {
 	0
 }
 
+/// Validate whether the char is allowed to be used in base58.
+/// num 0, lower l, upper I and O are not allowed.
+fn validate_base58(c :char) -> bool {
+	if !c.is_alphanumeric() || "0lIO".contains(c) {
+		false
+	} else {
+		true
+	}
+}
+
 pub(super) fn generate_key<C: Crypto>(desired: &str) -> Result<KeyPair<C>, &'static str> where
 		PublicOf<C>: PublicT,
 {
 	if desired.is_empty() {
 		return Err("Pattern must not be empty");
+	}
+
+	if !desired.chars().all(validate_base58) {
+		return Err("Pattern can only contains valid characters in base58 \
+			(all alphanumeric except for 0, l, I and O)");
 	}
 
 	eprintln!("Generating key containing pattern '{}'", desired);


### PR DESCRIPTION
The `vanity` subcommand of `subkey` will search for an address with a pattern. Since the address are subject to base58 encoding, the characters in the pattern should also narrow to base58. Otherwise the search will never end which is the current behaviour.

This PR fix the problem by prompting an error when user provide an invalid pattern.