### PR TITLE
Safe logger initialisation in test.

### DIFF
--- a/client/finality-grandpa/src/communication/tests.rs
+++ b/client/finality-grandpa/src/communication/tests.rs
@@ -357,7 +357,7 @@ fn good_commit_leads_to_relay() {
 
 #[test]
 fn bad_commit_leads_to_report() {
-	env_logger::init();
+	let _ = env_logger::try_init();
 	let private = [Ed25519Keyring::Alice, Ed25519Keyring::Bob, Ed25519Keyring::Charlie];
 	let public = make_ids(&private[..]);
 	let voter_set = Arc::new(public.iter().cloned().collect::<VoterSet<AuthorityId>>());


### PR DESCRIPTION
`env_logger::init()` can lead to panics on concurrent test execution.

See: https://gitlab.parity.io/parity/substrate/-/jobs/422283