### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.5.2",
  "impl-rlp",
  "impl-serde 0.2.3",
  "tiny-keccak 1.5.0",
@@ -1218,10 +1218,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.5.2",
  "impl-rlp",
  "impl-serde 0.2.3",
- "primitive-types",
+ "primitive-types 0.6.2",
  "uint",
 ]
 
@@ -1234,7 +1234,7 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "primitive-types",
+ "primitive-types 0.6.2",
  "rlp",
  "serde",
  "sha3",
@@ -1246,7 +1246,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66534d42e13d50f9101bed87cb568fd5aa929c600c3c13f8dadbbf39f5635945"
 dependencies = [
- "primitive-types",
+ "primitive-types 0.6.2",
 ]
 
 [[package]]
@@ -1257,7 +1257,7 @@ checksum = "39bc5b592803ca644781fe2290b7305ea5182f7c9516d615ddfb2308c2cab639"
 dependencies = [
  "evm-core",
  "evm-runtime",
- "primitive-types",
+ "primitive-types 0.6.2",
 ]
 
 [[package]]
@@ -1267,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389e4b447fb26971a9c76c8aa49c0ab435f8e46e8fc46e1bc4ebf01f3c2b428f"
 dependencies = [
  "evm-core",
- "primitive-types",
+ "primitive-types 0.6.2",
  "sha3",
 ]
 
@@ -1371,7 +1371,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
 dependencies = [
  "byteorder 1.3.4",
- "libc",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32529fc42e86ec06e5047092082aab9ad459b070c5d2a76b14f4f5ce70bf2e84"
+dependencies = [
+ "byteorder 1.3.4",
  "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
@@ -4127,7 +4138,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.7.0",
  "rlp",
  "serde",
  "sha3",
@@ -4658,7 +4669,7 @@ dependencies = [
  "lru",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
- "primitive-types",
+ "primitive-types 0.6.2",
  "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
@@ -4673,6 +4684,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
+ "primitive-types 0.7.0",
  "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
@@ -4925,7 +4937,20 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.5.2",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde 0.3.0",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
+dependencies = [
+ "fixed-hash 0.6.0",
  "impl-codec",
  "impl-rlp",
  "impl-serde 0.3.0",
@@ -5707,7 +5732,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "names",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -5812,7 +5837,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "quickcheck",
  "rand 0.7.3",
@@ -6169,7 +6194,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
  "log 0.4.8",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "sc-client-api",
  "sc-network",
  "sc-service",
@@ -6437,7 +6462,7 @@ dependencies = [
  "log 0.4.8",
  "parity-multiaddr",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "sc-chain-spec",
  "sc-client",
@@ -6556,7 +6581,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "serde",
  "sp-blockchain",
@@ -6577,7 +6602,7 @@ dependencies = [
  "futures-timer 2.0.2",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "sc-client-api",
  "sc-transaction-graph",
@@ -7016,7 +7041,7 @@ dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.7.0",
  "rand 0.7.3",
  "serde",
  "sp-debug-derive",
@@ -7151,10 +7176,10 @@ dependencies = [
  "log 0.4.8",
  "num-traits",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "pretty_assertions",
- "primitive-types",
+ "primitive-types 0.7.0",
  "rand 0.7.3",
  "regex",
  "rustc-hex",
@@ -7298,7 +7323,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "paste",
  "rand 0.7.3",
  "serde",
@@ -7316,7 +7341,7 @@ name = "sp-runtime-interface"
 version = "2.0.0-alpha.4"
 dependencies = [
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.7.0",
  "rustversion",
  "sp-core",
  "sp-externalities",
@@ -7444,7 +7469,7 @@ name = "sp-test-primitives"
 version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -7768,7 +7793,7 @@ dependencies = [
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "sc-block-builder",
  "sc-client",
  "sc-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,18 +3166,6 @@ checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 
 [[package]]
 name = "merlin"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0942b357c1b4d0dc43ba724674ec89c3218e6ca2b3e8269e7cb53bcecd2f6e"
-dependencies = [
- "byteorder 1.3.4",
- "keccak",
- "rand_core 0.4.2",
- "zeroize",
-]
-
-[[package]]
-name = "merlin"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
@@ -5902,7 +5890,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "log 0.4.8",
- "merlin 1.3.0",
+ "merlin",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -6634,7 +6622,7 @@ dependencies = [
  "arrayvec 0.5.1",
  "curve25519-dalek",
  "getrandom",
- "merlin 2.0.0",
+ "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -242,9 +242,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
+checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
 dependencies = [
  "cc",
  "libc",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.1"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99de13bb6361e01e493b3db7928085dcc474b7ba4f5481818e53a89d76b8393f"
+checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -497,15 +497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "c_linked_list"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -579,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "js-sys",
  "num-integer",
@@ -592,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "f92986241798376849e1a007827041fed9bb36195822c2049d18e174420e0534"
 dependencies = [
  "glob 0.3.0",
  "libc",
@@ -691,29 +682,13 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
-dependencies = [
- "core-foundation-sys 0.6.2",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1120,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "doc-comment"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
+checksum = "807e5847c39ad6a11eac66de492ed1406f76a260eb8656e8740cad9eabc69c27"
 
 [[package]]
 name = "ed25519-dalek"
@@ -1370,9 +1345,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fdlimit"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9084c55bb76efb1496328976db88320fe7d9ee86e649e83c4ecce3ba7a9a35d1"
+checksum = "0da54a593b34c71b889ee45f5b5bb900c74148c5f7f8c6a9479ee7899f69603c"
 dependencies = [
  "libc",
 ]
@@ -1940,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2d17dbd803c2fc86cb1b613adf63192046a7176f383a8302594654752c4c4a"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1982,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
+checksum = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -1995,7 +1970,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab",
- "tokio 0.2.12",
+ "tokio 0.2.13",
  "tokio-util",
 ]
 
@@ -2198,15 +2173,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
+checksum = "e7b15203263d1faa615f9337d79c1d37959439dc46c2b4faab33286fadc2a1c5"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.1",
+ "h2 0.2.2",
  "http 0.2.0",
  "http-body 0.3.1",
  "httparse",
@@ -2215,7 +2190,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.12",
+ "tokio 0.2.13",
  "tower-service",
  "want 0.3.0",
 ]
@@ -2229,11 +2204,11 @@ dependencies = [
  "bytes 0.5.4",
  "ct-logs",
  "futures-util",
- "hyper 0.13.2",
+ "hyper 0.13.3",
  "log 0.4.8",
  "rustls 0.17.0",
  "rustls-native-certs",
- "tokio 0.2.12",
+ "tokio 0.2.13",
  "tokio-rustls",
  "webpki",
 ]
@@ -2382,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3313,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -3324,8 +3299,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 0.3.4",
- "security-framework-sys 0.3.3",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -3723,12 +3698,12 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 dependencies = [
  "memchr",
- "version_check 0.1.5",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -4425,7 +4400,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "parity-scale-codec",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "serde",
  "sp-core",
  "sp-io",
@@ -4902,9 +4877,9 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "predicates"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1188bf092c81c18228c383b190c069a8a613c18a046ffa9fdfc0f5fc8fb2da8a"
+checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
 dependencies = [
  "difference",
  "predicates-core",
@@ -4962,28 +4937,28 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
+checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
+checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
  "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -5079,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.10.1"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6686ddd96a8dbe2687b5f2a687b2cfb520854010ec480f2d74c32e7c9873d3c5"
+checksum = "37a5325d019a4d837d3abde0a836920f959e33d350f77b5f1e289e061e774942"
 
 [[package]]
 name = "pwasm-utils"
@@ -5182,7 +5157,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
 ]
@@ -5199,11 +5174,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core 0.5.1",
 ]
 
@@ -5388,18 +5363,18 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder 1.3.4",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 
 [[package]]
 name = "region"
@@ -5540,7 +5515,7 @@ dependencies = [
  "openssl-probe",
  "rustls 0.17.0",
  "schannel",
- "security-framework 0.4.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -5746,7 +5721,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "tempfile",
  "time",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -6001,7 +5976,7 @@ dependencies = [
  "substrate-test-runtime-client",
  "substrate-test-runtime-transaction-pool",
  "tempfile",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -6178,7 +6153,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "tempfile",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -6321,7 +6296,7 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "hyper 0.13.2",
+ "hyper 0.13.3",
  "hyper-rustls",
  "log 0.4.8",
  "num_cpus",
@@ -6340,7 +6315,7 @@ dependencies = [
  "sp-transaction-pool",
  "substrate-test-runtime-client",
  "threadpool",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -6682,35 +6657,14 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
-dependencies = [
- "core-foundation 0.6.4",
- "core-foundation-sys 0.6.2",
- "libc",
- "security-framework-sys 0.3.3",
-]
-
-[[package]]
-name = "security-framework"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
 dependencies = [
  "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
- "security-framework-sys 0.4.1",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
-dependencies = [
- "core-foundation-sys 0.6.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -6719,7 +6673,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -6968,12 +6922,6 @@ dependencies = [
  "static_assertions",
  "thiserror",
 ]
-
-[[package]]
-name = "sourcefile"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 
 [[package]]
 name = "sp-allocator"
@@ -7614,9 +7562,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bcbed7d48956fcbb5d80c6b95aedb553513de0a1b451ea92679d999c010e98"
+checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
 dependencies = [
  "clap",
  "lazy_static",
@@ -7625,9 +7573,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
+checksum = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -7741,7 +7689,7 @@ dependencies = [
  "sc-rpc-api",
  "serde",
  "sp-storage",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -7774,10 +7722,10 @@ dependencies = [
  "async-std",
  "derive_more",
  "futures-util",
- "hyper 0.13.2",
+ "hyper 0.13.3",
  "log 0.4.8",
  "prometheus",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -8208,9 +8156,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34bee1facdc352fba10c9c58b654e6ecb6a2250167772bf86071f7c5f2f5061"
+checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -8341,7 +8289,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls 0.17.0",
- "tokio 0.2.12",
+ "tokio 0.2.13",
  "webpki",
 ]
 
@@ -8464,7 +8412,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.12",
+ "tokio 0.2.13",
 ]
 
 [[package]]
@@ -8580,9 +8528,9 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "trybuild"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ff1b18659a2218332848d76ad1c867ce4c6ee37b085e6bc8de9a6d11401220"
+checksum = "24b4e093c5ed1a60b22557090120aa14f90ca801549c0949d775ea07c1407720"
 dependencies = [
  "glob 0.3.0",
  "lazy_static",
@@ -8692,12 +8640,13 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7ffb36714206d2f5f05d61a2bc350415c642f2c54433f0ebf829afbe41d570"
+checksum = "f38e01ad4b98f042e166c1bf9a13f9873a99d79eaa171ce7ca81e6dd0f895d8a"
 dependencies = [
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures-io",
+ "futures-util",
  "futures_codec",
 ]
 
@@ -8749,13 +8698,12 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 
 [[package]]
 name = "vergen"
-version = "3.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
+checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
 dependencies = [
  "bitflags",
  "chrono",
- "failure",
 ]
 
 [[package]]
@@ -8839,9 +8787,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8849,9 +8797,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
+checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8864,9 +8812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbdd49e3e28b40dec6a9ba8d17798245ce32b019513a845369c641b275135d9"
+checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8876,9 +8824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8886,9 +8834,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8899,25 +8847,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
-
-[[package]]
-name = "wasm-bindgen-webidl"
-version = "0.2.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
-dependencies = [
- "anyhow",
- "heck",
- "log 0.4.8",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "weedle",
-]
+checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
 
 [[package]]
 name = "wasm-gc-api"
@@ -9039,33 +8971,30 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7b16105405ca2aa2376ba522d8d4b1a11604941dd3bb7df9fd2ece60f8d16a"
+checksum = "4efb62ecebf5cc9dbf2954309a20d816289c6550c0597a138b9e811cefc05007"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56173f7f4fb59aebe35a7e71423845e1c6c7144bfb56362d497931b6b3bed0f6"
+checksum = "ffdea5e25273cc3a62f3ae3a1a4c7d7996625875b50c0b4475fee6698c2b069c"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
+checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
 dependencies = [
- "anyhow",
  "js-sys",
- "sourcefile",
  "wasm-bindgen",
- "wasm-bindgen-webidl",
 ]
 
 [[package]]
@@ -9138,19 +9067,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "weedle"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "which"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,18 +2518,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
 dependencies = [
  "parity-bytes",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
+ "smallvec 1.2.0",
+]
+
+[[package]]
+name = "kvdb"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
+dependencies = [
+ "parity-util-mem 0.6.0",
  "smallvec 1.2.0",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9355274e5a9e0a7e8ef43916950eae3949024de2a8dffe4d5a6c13974a37c8e"
+checksum = "4aa954d12cfac958822dfd77aab34f3eec71f103b918c4ab79ab59a36ee594ea"
 dependencies = [
- "kvdb",
- "parity-util-mem",
+ "kvdb 0.5.0",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
 ]
 
@@ -2541,11 +2551,11 @@ checksum = "1fecd50b14a534125228d7039951f92aaff742aff151c04546347aba4d3b4fbc"
 dependencies = [
  "fs-swap",
  "interleaved-ordered",
- "kvdb",
+ "kvdb 0.4.0",
  "log 0.4.8",
  "num_cpus",
  "owning_ref",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "regex",
  "rocksdb",
@@ -2554,16 +2564,16 @@ dependencies = [
 
 [[package]]
 name = "kvdb-web"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a985c47b4c46429e96033ebf6eaed784a81ceccb4e5df13d63f3b9078a4df81"
+checksum = "26f96eec962af83cdf7c83036b3dbb0ae6a1249ddab746820618e2567ca8ebcd"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "kvdb",
+ "kvdb 0.5.0",
  "kvdb-memorydb",
  "log 0.4.8",
- "parity-util-mem",
+ "parity-util-mem 0.6.0",
  "send_wrapper 0.3.0",
  "wasm-bindgen",
  "web-sys",
@@ -3158,7 +3168,7 @@ dependencies = [
  "ahash",
  "hash-db",
  "hashbrown",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
 ]
 
 [[package]]
@@ -3176,6 +3186,18 @@ dependencies = [
  "byteorder 1.3.4",
  "keccak",
  "rand_core 0.4.2",
+ "zeroize 1.1.0",
+]
+
+[[package]]
+name = "merlin"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
+dependencies = [
+ "byteorder 1.3.4",
+ "keccak",
+ "rand_core 0.5.1",
  "zeroize 1.1.0",
 ]
 
@@ -4672,6 +4694,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-util-mem"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e42755f26e5ea21a6a819d9e63cbd70713e9867a2b767ec2cc65ca7659532c5"
+dependencies = [
+ "cfg-if",
+ "impl-trait-for-tuples",
+ "parity-util-mem-derive",
+ "parking_lot 0.10.0",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "parity-util-mem-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,7 +5736,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "names",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -5734,7 +5769,7 @@ dependencies = [
  "futures 0.3.4",
  "hash-db",
  "hex-literal",
- "kvdb",
+ "kvdb 0.5.0",
  "kvdb-memorydb",
  "log 0.4.8",
  "parity-scale-codec",
@@ -5771,7 +5806,7 @@ dependencies = [
  "futures 0.3.4",
  "hash-db",
  "hex-literal",
- "kvdb",
+ "kvdb 0.5.0",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",
@@ -5800,13 +5835,13 @@ version = "0.8.0-alpha.4"
 dependencies = [
  "env_logger 0.7.1",
  "hash-db",
- "kvdb",
+ "kvdb 0.5.0",
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "quickcheck",
  "rand 0.7.3",
@@ -5874,7 +5909,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "log 0.4.8",
- "merlin",
+ "merlin 1.3.0",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -5894,7 +5929,7 @@ dependencies = [
  "sc-network-test",
  "sc-service",
  "sc-telemetry",
- "schnorrkel",
+ "schnorrkel 0.8.5",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6163,7 +6198,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
  "log 0.4.8",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "sc-client-api",
  "sc-network",
  "sc-service",
@@ -6431,7 +6466,7 @@ dependencies = [
  "log 0.4.8",
  "parity-multiaddr",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "sc-chain-spec",
  "sc-client",
@@ -6496,7 +6531,7 @@ dependencies = [
  "env_logger 0.7.1",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
  "sc-client-api",
@@ -6550,7 +6585,7 @@ dependencies = [
  "linked-hash-map",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "serde",
  "sp-blockchain",
@@ -6571,7 +6606,7 @@ dependencies = [
  "futures-timer 2.0.2",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "sc-client-api",
  "sc-transaction-graph",
@@ -6604,13 +6639,31 @@ checksum = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
 dependencies = [
  "curve25519-dalek 1.2.3",
  "failure",
- "merlin",
+ "merlin 1.3.0",
  "rand 0.6.5",
  "rand_core 0.4.2",
  "rand_os",
  "sha2",
  "subtle 2.2.2",
  "zeroize 0.9.3",
+]
+
+[[package]]
+name = "schnorrkel"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.1",
+ "curve25519-dalek 2.0.0",
+ "getrandom",
+ "merlin 2.0.0",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "sha2",
+ "subtle 2.2.2",
+ "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -7103,7 +7156,7 @@ name = "sp-consensus-babe"
 version = "0.8.0-alpha.4"
 dependencies = [
  "parity-scale-codec",
- "schnorrkel",
+ "schnorrkel 0.8.5",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -7144,14 +7197,14 @@ dependencies = [
  "log 0.4.8",
  "num-traits",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "parking_lot 0.10.0",
  "pretty_assertions",
  "primitive-types",
  "rand 0.7.3",
  "regex",
  "rustc-hex",
- "schnorrkel",
+ "schnorrkel 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -7291,7 +7344,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "paste",
  "rand 0.7.3",
  "serde",
@@ -7437,7 +7490,7 @@ name = "sp-test-primitives"
 version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -7637,13 +7690,13 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be511be555a3633e71739a79e4ddff6a6aaa6579fa6114182a51d72c3eb93c5"
+checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
 dependencies = [
  "hmac",
  "pbkdf2",
- "schnorrkel",
+ "schnorrkel 0.9.1",
  "sha2",
 ]
 
@@ -7761,7 +7814,7 @@ dependencies = [
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.5.2",
  "sc-block-builder",
  "sc-client",
  "sc-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,28 +1200,28 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
+checksum = "9e7abcddbdd5db30aeed4deb586adc4824e6c247e2f7238d1187f752893f096b"
 dependencies = [
  "crunchy",
- "fixed-hash 0.5.2",
+ "fixed-hash 0.6.0",
  "impl-rlp",
- "impl-serde 0.2.3",
- "tiny-keccak 1.5.0",
+ "impl-serde 0.3.0",
+ "tiny-keccak 2.0.1",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+checksum = "964c23cdee0ca07d5be2a628b46d5c11a2134ce554a8c16d8dbc2db647e4fd4d"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.5.2",
+ "fixed-hash 0.6.0",
  "impl-rlp",
- "impl-serde 0.2.3",
- "primitive-types 0.6.2",
+ "impl-serde 0.3.0",
+ "primitive-types 0.7.0",
  "uint",
 ]
 
@@ -4663,14 +4663,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9344bc978467339b9ae688f9dcf279d1aaa0ccfc88e9a780c729b765a82d57d5"
 dependencies = [
  "cfg-if",
- "ethereum-types",
- "hashbrown",
  "impl-trait-for-tuples",
- "lru",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
- "primitive-types 0.6.2",
- "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
 
@@ -4681,7 +4676,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e42755f26e5ea21a6a819d9e63cbd70713e9867a2b767ec2cc65ca7659532c5"
 dependencies = [
  "cfg-if",
+ "ethereum-types",
+ "hashbrown",
  "impl-trait-for-tuples",
+ "lru",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
  "primitive-types 0.7.0",
@@ -4940,7 +4938,6 @@ dependencies = [
  "fixed-hash 0.5.2",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.3.0",
  "uint",
 ]
 
@@ -6527,7 +6524,7 @@ dependencies = [
  "env_logger 0.7.1",
  "log 0.4.8",
  "parity-scale-codec",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
  "sc-client-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,7 +4430,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "serde",
  "sp-core",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e7abcddbdd5db30aeed4deb586adc4824e6c247e2f7238d1187f752893f096b"
 dependencies = [
  "crunchy",
- "fixed-hash 0.6.0",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde 0.3.0",
  "tiny-keccak 2.0.1",
@@ -1218,23 +1218,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964c23cdee0ca07d5be2a628b46d5c11a2134ce554a8c16d8dbc2db647e4fd4d"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.6.0",
+ "fixed-hash",
  "impl-rlp",
  "impl-serde 0.3.0",
- "primitive-types 0.7.0",
+ "primitive-types",
  "uint",
 ]
 
 [[package]]
 name = "evm"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272f65e18a2b6449b682bfcdf6c3ccc63db0b93898d89c0fb237548bbfc764a5"
+checksum = "e3fd803d8dd69ee382f5d2010b6da5442bf41f94e46606357e8ebb994021cc7a"
 dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "primitive-types 0.6.2",
+ "primitive-types",
  "rlp",
  "serde",
  "sha3",
@@ -1242,32 +1242,32 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66534d42e13d50f9101bed87cb568fd5aa929c600c3c13f8dadbbf39f5635945"
+checksum = "06f59a5b6832f6826a0d222f354ac4a83747b6b7cadc6b539056daafea948536"
 dependencies = [
- "primitive-types 0.6.2",
+ "primitive-types",
 ]
 
 [[package]]
 name = "evm-gasometer"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bc5b592803ca644781fe2290b7305ea5182f7c9516d615ddfb2308c2cab639"
+checksum = "66330d03fbd117156b3c54a7d41d22b40ba8bf2a07b80f23f95359e22eada4da"
 dependencies = [
  "evm-core",
  "evm-runtime",
- "primitive-types 0.6.2",
+ "primitive-types",
 ]
 
 [[package]]
 name = "evm-runtime"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389e4b447fb26971a9c76c8aa49c0ab435f8e46e8fc46e1bc4ebf01f3c2b428f"
+checksum = "ca05dc5b906d3c93b8e679a6dc0973c9d072e9962f8b4483530eb9a0ffc14ea5"
 dependencies = [
  "evm-core",
- "primitive-types 0.6.2",
+ "primitive-types",
  "sha3",
 ]
 
@@ -1362,18 +1362,6 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.9.0",
  "rand 0.6.5",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
-dependencies = [
- "byteorder 1.3.4",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -4126,7 +4114,7 @@ dependencies = [
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
- "primitive-types 0.7.0",
+ "primitive-types",
  "rlp",
  "serde",
  "sha3",
@@ -4670,7 +4658,7 @@ dependencies = [
  "lru",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
- "primitive-types 0.7.0",
+ "primitive-types",
  "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
@@ -4919,23 +4907,11 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
-dependencies = [
- "fixed-hash 0.5.2",
- "impl-codec",
- "impl-rlp",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5e4b9943a2da369aec5e96f7c10ebc74fcf434d39590d974b0a3460e6f67fbb"
 dependencies = [
- "fixed-hash 0.6.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde 0.3.0",
@@ -7026,7 +7002,7 @@ dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
- "primitive-types 0.7.0",
+ "primitive-types",
  "rand 0.7.3",
  "serde",
  "sp-debug-derive",
@@ -7164,7 +7140,7 @@ dependencies = [
  "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "pretty_assertions",
- "primitive-types 0.7.0",
+ "primitive-types",
  "rand 0.7.3",
  "regex",
  "rustc-hex",
@@ -7326,7 +7302,7 @@ name = "sp-runtime-interface"
 version = "2.0.0-alpha.4"
 dependencies = [
  "parity-scale-codec",
- "primitive-types 0.7.0",
+ "primitive-types",
  "rustversion",
  "sp-core",
  "sp-externalities",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,19 +1005,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
-dependencies = [
- "byteorder 1.3.4",
- "clear_on_drop",
- "digest",
- "rand_core 0.3.1",
- "subtle 2.2.2",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
@@ -1026,7 +1013,7 @@ dependencies = [
  "digest",
  "rand_core 0.5.1",
  "subtle 2.2.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1106,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 dependencies = [
  "clear_on_drop",
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "rand 0.7.3",
  "sha2",
 ]
@@ -2687,7 +2674,7 @@ dependencies = [
  "thiserror",
  "unsigned-varint",
  "void",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2851,7 +2838,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15a8a3d71f898beb6f854c8aae27aa1d198e0d1f2e49412261c2d90ef39675a"
 dependencies = [
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "futures 0.3.4",
  "lazy_static",
  "libp2p-core",
@@ -2863,7 +2850,7 @@ dependencies = [
  "snow",
  "static_assertions",
  "x25519-dalek",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3186,7 +3173,7 @@ dependencies = [
  "byteorder 1.3.4",
  "keccak",
  "rand_core 0.4.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3198,7 +3185,7 @@ dependencies = [
  "byteorder 1.3.4",
  "keccak",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5929,7 +5916,7 @@ dependencies = [
  "sc-network-test",
  "sc-service",
  "sc-telemetry",
- "schnorrkel 0.8.5",
+ "schnorrkel",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6278,7 +6265,7 @@ dependencies = [
  "unsigned-varint",
  "void",
  "wasm-timer",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -6633,37 +6620,20 @@ dependencies = [
 
 [[package]]
 name = "schnorrkel"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eacd8381b3c37840c9c9f40472af529e49975bdcbc24f83c31059fd6539023d3"
-dependencies = [
- "curve25519-dalek 1.2.3",
- "failure",
- "merlin 1.3.0",
- "rand 0.6.5",
- "rand_core 0.4.2",
- "rand_os",
- "sha2",
- "subtle 2.2.2",
- "zeroize 0.9.3",
-]
-
-[[package]]
-name = "schnorrkel"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021b403afe70d81eea68f6ea12f6b3c9588e5d536a94c3bf80f15e7faa267862"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.1",
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "getrandom",
  "merlin 2.0.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2",
  "subtle 2.2.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -7156,7 +7126,7 @@ name = "sp-consensus-babe"
 version = "0.8.0-alpha.4"
 dependencies = [
  "parity-scale-codec",
- "schnorrkel 0.8.5",
+ "schnorrkel",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -7204,7 +7174,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "rustc-hex",
- "schnorrkel 0.8.5",
+ "schnorrkel",
  "serde",
  "serde_json",
  "sha2",
@@ -7219,7 +7189,7 @@ dependencies = [
  "tiny-keccak 2.0.1",
  "twox-hash",
  "wasmi",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -7696,7 +7666,7 @@ checksum = "c004e8166d6e0aa3a9d5fa673e5b7098ff25f930de1013a21341988151e681bb"
 dependencies = [
  "hmac",
  "pbkdf2",
- "schnorrkel 0.9.1",
+ "schnorrkel",
  "sha2",
 ]
 
@@ -9205,9 +9175,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "curve25519-dalek 2.0.0",
+ "curve25519-dalek",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -9230,12 +9200,6 @@ dependencies = [
  "rand 0.7.3",
  "thiserror",
 ]
-
-[[package]]
-name = "zeroize"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,17 +2500,6 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03080afe6f42cd996da9f568d6add5d7fb5ee2ea7fb7802d2d2cbd836958fd87"
-dependencies = [
- "parity-bytes",
- "parity-util-mem 0.5.2",
- "smallvec 1.2.0",
-]
-
-[[package]]
-name = "kvdb"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
@@ -2525,24 +2514,24 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa954d12cfac958822dfd77aab34f3eec71f103b918c4ab79ab59a36ee594ea"
 dependencies = [
- "kvdb 0.5.0",
+ "kvdb",
  "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fecd50b14a534125228d7039951f92aaff742aff151c04546347aba4d3b4fbc"
+checksum = "b3f14c3a10c8894d26175e57e9e26032e6d6c49c30cbe2468c5bf5f6b64bb0be"
 dependencies = [
  "fs-swap",
  "interleaved-ordered",
- "kvdb 0.4.0",
+ "kvdb",
  "log 0.4.8",
  "num_cpus",
  "owning_ref",
- "parity-util-mem 0.5.2",
+ "parity-util-mem 0.6.0",
  "parking_lot 0.10.0",
  "regex",
  "rocksdb",
@@ -2557,7 +2546,7 @@ checksum = "26f96eec962af83cdf7c83036b3dbb0ae6a1249ddab746820618e2567ca8ebcd"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "kvdb 0.5.0",
+ "kvdb",
  "kvdb-memorydb",
  "log 0.4.8",
  "parity-util-mem 0.6.0",
@@ -4593,12 +4582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-bytes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c276d76c5333b8c2579e02d49a06733a55b8282d2d9b13e8d53b6406bd7e30a"
-
-[[package]]
 name = "parity-multiaddr"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4673,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.10.0",
+ "smallvec 1.2.0",
  "winapi 0.3.8",
 ]
 
@@ -5756,7 +5740,7 @@ dependencies = [
  "futures 0.3.4",
  "hash-db",
  "hex-literal",
- "kvdb 0.5.0",
+ "kvdb",
  "kvdb-memorydb",
  "log 0.4.8",
  "parity-scale-codec",
@@ -5793,7 +5777,7 @@ dependencies = [
  "futures 0.3.4",
  "hash-db",
  "hex-literal",
- "kvdb 0.5.0",
+ "kvdb",
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",
@@ -5822,7 +5806,7 @@ version = "0.8.0-alpha.4"
 dependencies = [
  "env_logger 0.7.1",
  "hash-db",
- "kvdb 0.5.0",
+ "kvdb",
  "kvdb-memorydb",
  "kvdb-rocksdb",
  "linked-hash-map",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,8 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 [[package]]
 name = "cranelift-bforest"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
 dependencies = [
  "cranelift-entity",
 ]
@@ -732,7 +733,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
 dependencies = [
  "byteorder 1.3.4",
  "cranelift-bforest",
@@ -750,7 +752,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -759,12 +762,14 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701b599783305a58c25027a4d73f2d6b599b2d8ef3f26677275f480b4d51e05d"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88e792b28e1ebbc0187b72ba5ba880dad083abe9231a99d19604d10c9e73f38"
 dependencies = [
  "serde",
 ]
@@ -772,7 +777,8 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518344698fa6c976d853319218415fdfb4f1bc6b42d0b2e2df652e55dff1f778"
 dependencies = [
  "cranelift-codegen",
  "log 0.4.8",
@@ -783,7 +789,8 @@ dependencies = [
 [[package]]
 name = "cranelift-native"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32daf082da21c0c05d93394ff4842c2ab7c4991b1f3186a1d952f8ac660edd0b"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -793,7 +800,8 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.59.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2aa816f554a3ef739a5d17ca3081a1f8983f04c944ea8ff60fb8d9dd8cd2d7b"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -6128,7 +6136,7 @@ dependencies = [
  "sp-core",
  "sp-runtime-interface",
  "sp-wasm-interface",
- "wasmtime",
+ "substrate-wasmtime",
 ]
 
 [[package]]
@@ -7889,6 +7897,75 @@ name = "substrate-wasm-builder-runner"
 version = "1.0.5"
 
 [[package]]
+name = "substrate-wasmtime"
+version = "0.13.0-threadsafe.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e512629525ecfe43bffe1f3d9e6bb0f08bf01155288ef27fcaae4ea086e4a9d"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "cfg-if",
+ "lazy_static",
+ "libc",
+ "region",
+ "rustc-demangle",
+ "substrate-wasmtime-jit",
+ "substrate-wasmtime-runtime",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-profiling",
+ "wat",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "substrate-wasmtime-jit"
+version = "0.13.0-threadsafe.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20de5564886d2bcffdd351c9cd114ceb50758aa58eac3cedb14faabf7f93b91"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "more-asserts",
+ "region",
+ "substrate-wasmtime-runtime",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-debug",
+ "wasmtime-environ",
+ "wasmtime-profiling",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "substrate-wasmtime-runtime"
+version = "0.13.0-threadsafe.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d08846f04293a7fc27eeb30f06262ca2e1b4ee20f5192cec1f3ce201e08ceb8"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "memoffset",
+ "more-asserts",
+ "region",
+ "thiserror",
+ "wasmtime-environ",
+ "wasmtime-profiling",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8900,31 +8977,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
-name = "wasmtime"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
-dependencies = [
- "anyhow",
- "backtrace",
- "cfg-if",
- "lazy_static",
- "libc",
- "region",
- "rustc-demangle",
- "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-jit",
- "wasmtime-profiling",
- "wasmtime-runtime",
- "wat",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "wasmtime-debug"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3d007436043bf55ec252d2f4dc1d35834157b5e2f148da839ca502e611cfe1"
 dependencies = [
  "anyhow",
  "faerie",
@@ -8939,7 +8995,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f3dea0e60c076dd0da27fa10c821323903c9554c617ed32eaab8e7a7e36c89"
 dependencies = [
  "anyhow",
  "base64 0.11.0",
@@ -8965,33 +9022,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-jit"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "cranelift-wasm",
- "more-asserts",
- "region",
- "target-lexicon",
- "thiserror",
- "wasmparser",
- "wasmtime-debug",
- "wasmtime-environ",
- "wasmtime-profiling",
- "wasmtime-runtime",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "wasmtime-profiling"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984d29c8add3381e60d649f4e3e2a501da900fc2d2586e139502eec32fe0ebc8"
 dependencies = [
  "gimli",
  "goblin",
@@ -9001,26 +9035,6 @@ dependencies = [
  "scroll",
  "serde",
  "target-lexicon",
-]
-
-[[package]]
-name = "wasmtime-runtime"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/wasmtime?branch=a-thread-safe-api#851887d84d03543f931f6312448d0dd5d8a9324e"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if",
- "indexmap",
- "lazy_static",
- "libc",
- "memoffset",
- "more-asserts",
- "region",
- "thiserror",
- "wasmtime-environ",
- "wasmtime-profiling",
- "winapi 0.3.8",
 ]
 
 [[package]]

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7.2"
 clap = "2.33.0"
 tiny-bip39 = "0.7"
 rustc-hex = "2.0.1"
-substrate-bip39 = "0.3.1"
+substrate-bip39 = "0.4.1"
 hex = "0.4.0"
 hex-literal = "0.2.1"
 codec = { package = "parity-scale-codec", version = "1.2.0" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ hash-db = { version = "0.15.2" }
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0-alpha.4", path = "../primitives/inherents" }
 sp-keyring = { version = "2.0.0-alpha.4", path = "../primitives/keyring" }
-kvdb = "0.4.0"
+kvdb = "0.5.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
 sp-core = { version = "2.0.0-alpha.4", path = "../primitives/core" }
@@ -41,5 +41,5 @@ tracing = "0.1.10"
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../test-utils/runtime/client" }
-kvdb-memorydb = "0.4.0"
+kvdb-memorydb = "0.5.0"
 sp-panic-handler = { version = "2.0.0-alpha.4", path = "../primitives/panic-handler" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -23,7 +23,7 @@ sp-blockchain = { version = "2.0.0-alpha.4", path = "../../primitives/blockchain
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-alpha.4", path = "../../primitives/keyring" }
-kvdb = "0.4.0"
+kvdb = "0.5.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
 sp-core = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/core" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4.0"
 app_dirs = "1.2.1"
 tokio = { version = "0.2.9", features = [ "signal", "rt-core", "rt-threaded" ] }
 futures = "0.3.1"
-fdlimit = "0.1.1"
+fdlimit = "0.1.4"
 serde_json = "1.0.41"
 sc-informant = { version = "0.8.0-alpha.4", path = "../informant" }
 sp-panic-handler = { version = "2.0.0-alpha.4", path = "../../primitives/panic-handler" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -39,7 +39,7 @@ names = "0.11.0"
 structopt = "0.3.8"
 sc-tracing = { version = "2.0.0-alpha.4", path = "../tracing" }
 chrono = "0.4.10"
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 rpassword = "4.0.1"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3.1"
 futures-timer = "3.0.1"
 parking_lot = "0.10.0"
 log = "0.4.8"
-schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.9", features = ["preaudit_deprecated"] }
 rand = "0.7.2"
 merlin = "1.2.1"
 pdqselect = "0.1.0"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -42,7 +42,7 @@ parking_lot = "0.10.0"
 log = "0.4.8"
 schnorrkel = { version = "0.9", features = ["preaudit_deprecated"] }
 rand = "0.7.2"
-merlin = "1.2.1"
+merlin = "2.0"
 pdqselect = "0.1.0"
 derive_more = "0.99.2"
 

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -17,7 +17,7 @@ kvdb-rocksdb = { version = "0.7", optional = true }
 kvdb-memorydb = "0.5.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["std"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
 
 sc-client-api = { version = "2.0.0-alpha.4", path = "../api" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -13,7 +13,7 @@ parking_lot = "0.10.0"
 log = "0.4.8"
 rand = "0.7"
 kvdb = "0.5.0"
-kvdb-rocksdb = { version = "0.6", optional = true }
+kvdb-rocksdb = { version = "0.7", optional = true }
 kvdb-memorydb = "0.5.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
@@ -37,7 +37,7 @@ sp-keyring = { version = "2.0.0-alpha.4", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 quickcheck = "0.9"
-kvdb-rocksdb = "0.6"
+kvdb-rocksdb = "0.7"
 tempfile = "3"
 
 [features]

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -12,9 +12,9 @@ description = "Client backend that uses RocksDB database as storage."
 parking_lot = "0.10.0"
 log = "0.4.8"
 rand = "0.7"
-kvdb = "0.4.0"
+kvdb = "0.5.0"
 kvdb-rocksdb = { version = "0.6", optional = true }
-kvdb-memorydb = "0.4.0"
+kvdb-memorydb = "0.5.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
 parity-util-mem = { version = "0.5.2", default-features = false, features = ["std"] }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -18,7 +18,7 @@ sp-wasm-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/was
 sp-runtime-interface = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-alpha.4", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.4", path = "../../../primitives/allocator" }
-wasmtime = { git = "https://github.com/paritytech/wasmtime", branch = "a-thread-safe-api" }
+wasmtime = { package = "substrate-wasmtime", version = "0.13.0-threadsafe.1" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 ansi_term = "0.12.1"
 futures = "0.3.1"
 log = "0.4.8"
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 wasm-timer = "0.2"
 sc-client-api = { version = "2.0.0-alpha.4", path = "../api" }
 sc-network = { version = "0.8.0-alpha.4", path = "../network" }

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -33,7 +33,7 @@ hyper-rustls = "0.20"
 
 [dev-dependencies]
 env_logger = "0.7.0"
-fdlimit = "0.1"
+fdlimit = "0.1.4"
 sc-client-db = { version = "0.8.0-alpha.4", default-features = true, path = "../db/" }
 sc-transaction-pool = { version = "2.0.0-alpha.4", path = "../../client/transaction-pool" }
 sp-transaction-pool = { version = "2.0.0-alpha.4", path = "../../primitives/transaction-pool" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -59,7 +59,7 @@ parity-multiaddr = { package = "parity-multiaddr", version = "0.7.3" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" , version = "0.8.0-alpha.4"}
 sc-tracing = { version = "2.0.0-alpha.4", path = "../tracing" }
 tracing = "0.1.10"
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -14,7 +14,7 @@ tokio = "0.1.22"
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
 env_logger = "0.7.0"
-fdlimit = "0.1.1"
+fdlimit = "0.1.4"
 futures = { version = "0.3.1", features = ["compat"] }
 sc-service = { version = "0.8.0-alpha.4", default-features = false, path = "../../service" }
 sc-network = { version = "0.8.0-alpha.4", path = "../../network" }

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.8"
 sc-client-api = { version = "2.0.0-alpha.4", path = "../api" }
 sp-core = { version = "2.0.0-alpha.4", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
-parity-util-mem = "0.5.2"
+parity-util-mem = "0.6"
 parity-util-mem-derive = "0.1.0"
 
 [dev-dependencies]

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -24,7 +24,7 @@ sp-transaction-pool = { version = "2.0.0-alpha.4", path = "../../primitives/tran
 sc-client-api = { version = "2.0.0-alpha.4", path = "../api" }
 sp-blockchain = { version = "2.0.0-alpha.4", path = "../../primitives/blockchain" }
 futures-timer = "2.0"
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [dev-dependencies]
 sp-keyring = { version = "2.0.0-alpha.4", path = "../../primitives/keyring" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -19,7 +19,7 @@ sp-blockchain = { version = "2.0.0-alpha.4", path = "../../../primitives/blockch
 sp-core = { version = "2.0.0-alpha.4", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime" }
 sp-transaction-pool = { version = "2.0.0-alpha.4", path = "../../../primitives/transaction-pool" }
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 linked-hash-map = "0.5.2"
 
 [dev-dependencies]

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -19,7 +19,7 @@ sp-core = { version = "2.0.0-alpha.4", default-features = false, path = "../../p
 sp-runtime = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/io" }
-primitive-types = { version = "0.6.2", default-features = false, features = ["rlp"] }
+primitive-types = { version = "0.7.0", default-features = false, features = ["rlp"] }
 rlp = { version = "0.4", default-features = false }
 evm = { version = "0.15", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -21,7 +21,7 @@ sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../../pr
 sp-io = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/io" }
 primitive-types = { version = "0.7.0", default-features = false, features = ["rlp"] }
 rlp = { version = "0.4", default-features = false }
-evm = { version = "0.15", default-features = false }
+evm = { version = "0.16", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 
 [features]

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-debug-derive = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/debug-derive" }
 
 [dev-dependencies]
-primitive-types = "0.6.2"
+primitive-types = "0.7.0"
 rand = "0.7.2"
 criterion = "0.3"
 

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0"
 [dependencies]
 sp-arithmetic = { version = "2.0.0", path = ".." }
 honggfuzz = "0.5"
-primitive-types = "0.6.2"
+primitive-types = "0.7.0"
 num-bigint = "0.2"
 num-traits = "0.2"
 

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 sp-application-crypto = { version = "2.0.0-alpha.4", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../../std" }
-schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.9", features = ["preaudit_deprecated"], optional = true }
 sp-api = { version = "2.0.0-alpha.4", default-features = false, path = "../../api" }
 sp-consensus = { version = "0.8.0-alpha.4", optional = true, path = "../common" }
 sp-inherents = { version = "2.0.0-alpha.4", default-features = false, path = "../../inherents" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -16,7 +16,7 @@ rustc-hex = { version = "2.0.1", default-features = false }
 log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
-primitive-types = { version = "0.6.2", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.7.0", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.3.0", optional = true }
 wasmi = { version = "0.6.2", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
@@ -33,7 +33,7 @@ parking_lot = { version = "0.10.0", optional = true }
 sp-debug-derive = { version = "2.0.0-alpha.4", path = "../debug-derive" }
 sp-externalities = { version = "0.8.0-alpha.4", optional = true, path = "../externalities" }
 sp-storage = { version = "2.0.0-alpha.4", default-features = false, path = "../storage" }
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 futures = { version = "0.3.1", optional = true }
 
 # full crypto
@@ -75,7 +75,6 @@ std = [
 	"primitive-types/serde",
 	"primitive-types/byteorder",
 	"primitive-types/rustc-hex",
-	"primitive-types/libc",
 	"impl-serde",
 	"codec/std",
 	"hash256-std-hasher/std",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.1", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.3", default-features = false, features = ["u64_backend", "alloc"], optional = true }
 blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
-schnorrkel = { version = "0.8.5", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
+schnorrkel = { version = "0.9", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
 sha2 = { version = "0.8.0", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -23,7 +23,7 @@ hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.1.0", optional = true }
 rand = { version = "0.7.2", optional = true }
-substrate-bip39 = { version = "0.3.1", optional = true }
+substrate-bip39 = { version = "0.4.1", optional = true }
 tiny-bip39 = { version = "0.7", optional = true }
 regex = { version = "1.3.1", optional = true }
 num-traits = { version = "0.2.8", default-features = false }

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -16,7 +16,7 @@ sp-runtime-interface-proc-macro = { version = "2.0.0-alpha.4", path = "proc-macr
 sp-externalities = { version = "0.8.0-alpha.4", optional = true, path = "../externalities" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 static_assertions = "1.0.0"
-primitive-types = { version = "0.6.2", default-features = false }
+primitive-types = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 sp-runtime-interface-test-wasm = { version = "2.0.0-dev", path = "test-wasm" }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -23,7 +23,7 @@ paste = "0.1.6"
 rand = { version = "0.7.2", optional = true }
 impl-trait-for-tuples = "0.1.3"
 sp-inherents = { version = "2.0.0-alpha.4", default-features = false, path = "../inherents" }
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 
 [dev-dependencies]

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -14,7 +14,7 @@ codec = { package = "parity-scale-codec", version = "1.2.0", default-features = 
 sp-core = { version = "2.0.0-alpha.4", default-features = false, path = "../core" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-runtime = { version = "2.0.0-alpha.4", default-features = false, path = "../runtime" }
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [features]
 default = [

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -40,7 +40,7 @@ sc-client = { version = "0.8.0-alpha.4", optional = true, path = "../../client" 
 sp-trie = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "2.0.0-alpha.4", default-features = false, path = "../../primitives/transaction-pool" }
 trie-db = { version = "0.20.0", default-features = false }
-parity-util-mem = { version = "0.5.2", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [dev-dependencies]
 sc-block-builder = { version = "0.8.0-alpha.4", path = "../../client/block-builder" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -18,11 +18,11 @@ console_log = "0.1.2"
 js-sys = "0.3.34"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.7"
-kvdb-web = "0.4"
+kvdb-web = "0.5"
 sc-informant = { version = "0.8.0-alpha.4", path = "../../client/informant" }
 sc-service = { version = "0.8.0-alpha.4", path = "../../client/service", default-features = false }
-sc-network = { path = "../../client/network" , version = "0.8.0-alpha.4"}
-sc-chain-spec = { path = "../../client/chain-spec" , version = "2.0.0-alpha.4"}
+sc-network = { path = "../../client/network", version = "0.8.0-alpha.4"}
+sc-chain-spec = { path = "../../client/chain-spec", version = "2.0.0-alpha.4"}
 
 # Imported just for the `no_cc` feature
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }


### PR DESCRIPTION
refs #4753

This:

- [x] removes git-dependency of wasmtime, switches to released substrate-wasmtime
- [x] update fdlimit to 0.1.4
- [x] update parity-common dependencies (waiting for crates.io releases)
- [x] update to latest substrate-bip39
- [x] update `schnorrkel` & `merlin`
- [x] cargo update
- [x] primitive-types (mismatch through `evm-*` modules): https://github.com/sorpaas/rust-evm/pull/3