### PR TITLE
EVM storage tracing

### DIFF
--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -42,3 +42,4 @@ std = [
 	"evm/std",
 	"pallet-timestamp/std",
 ]
+storage-tracing = []

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -145,6 +145,11 @@ decl_event! {
 		Log(Log),
 		/// A contract has been created at given address.
 		Created(H160),
+
+		/// A batch of all indices written during last call (see "storage_tracing" feature)
+		StorageWritten(backend::StorageWritten),
+		/// An indicator that the storage was reset during last call (see "storage tracing" feature)
+		StorageReset(backend::StorageReset),
 	}
 }
 


### PR DESCRIPTION
This PR adds storage tracing into EVM module. This is implemented as special event emitted every time a constructor/method of a smart contract is called. The event contains digest of all storage indices affected during the call, i.e. all indices storage was written by. When storage is reset another kind of Event is emitted.