### PR TITLE
Ensure schnorrkel is always _at least_ 0.9.1

### DIFF
--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3.1"
 futures-timer = "3.0.1"
 parking_lot = "0.10.0"
 log = "0.4.8"
-schnorrkel = { version = "0.9", features = ["preaudit_deprecated"] }
+schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"] }
 rand = "0.7.2"
 merlin = "2.0"
 pdqselect = "0.1.0"

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/paritytech/substrate/"
 sp-application-crypto = { version = "2.0.0-alpha.4", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../../std" }
-schnorrkel = { version = "0.9", features = ["preaudit_deprecated"], optional = true }
+schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"], optional = true }
 sp-api = { version = "2.0.0-alpha.4", default-features = false, path = "../../api" }
 sp-consensus = { version = "0.8.0-alpha.4", optional = true, path = "../common" }
 sp-inherents = { version = "2.0.0-alpha.4", default-features = false, path = "../../inherents" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -40,7 +40,7 @@ futures = { version = "0.3.1", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.3", default-features = false, features = ["u64_backend", "alloc"], optional = true }
 blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
-schnorrkel = { version = "0.9", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
+schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
 sha2 = { version = "0.8.0", default-features = false, optional = true }
 hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }


### PR DESCRIPTION
following up #4808 this makes sure we use the latest minor of schnorrkel, because before there was a potential incompatibility issue.