### PR TITLE
Replace hex with rustc_hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,12 +2005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
 name = "hex-literal"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,7 +3527,6 @@ dependencies = [
  "pallet-utility",
  "pallet-vesting",
  "parity-scale-codec",
- "rustc-hex",
  "serde",
  "sp-api",
  "sp-authority-discovery",
@@ -6181,9 +6174,9 @@ name = "sc-keystore"
 version = "2.0.0-alpha.4"
 dependencies = [
  "derive_more",
- "hex",
  "parking_lot 0.10.0",
  "rand 0.7.3",
+ "rustc-hex",
  "serde_json",
  "sp-application-crypto",
  "sp-core",
@@ -6347,7 +6340,6 @@ dependencies = [
  "log 0.4.8",
  "parity-scale-codec",
  "parking_lot 0.10.0",
- "rustc-hex",
  "sc-block-builder",
  "sc-client",
  "sc-client-api",
@@ -7141,7 +7133,6 @@ dependencies = [
  "futures 0.3.4",
  "hash-db",
  "hash256-std-hasher",
- "hex",
  "hex-literal",
  "impl-serde 0.3.0",
  "lazy_static",
@@ -7618,7 +7609,6 @@ dependencies = [
  "derive_more",
  "frame-system",
  "futures 0.1.29",
- "hex",
  "hex-literal",
  "hyper 0.12.35",
  "itertools",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/paritytech/substrate/"
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
 integer-sqrt = { version = "0.1.2" }
-rustc-hex = { version = "2.0", optional = true }
 serde = { version = "1.0.102", optional = true }
 
 # primitives
@@ -108,7 +107,6 @@ std = [
 	"sp-core/std",
 	"pallet-randomness-collective-flip/std",
 	"sp-std/std",
-	"rustc-hex",
 	"serde",
 	"pallet-session/std",
 	"sp-api/std",

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -16,9 +16,8 @@ sp-runtime = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime" }
 rand = "0.7.2"
 clap = "2.33.0"
 tiny-bip39 = "0.7"
-rustc-hex = "2.0.1"
+rustc-hex = "2.1.0"
 substrate-bip39 = "0.4.1"
-hex = "0.4.0"
 hex-literal = "0.2.1"
 codec = { package = "parity-scale-codec", version = "1.2.0" }
 frame-system = { version = "2.0.0-alpha.4", path = "../../../frame/system" }

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/sc-keystore"
 derive_more = "0.99.2"
 sp-core = { version = "2.0.0-alpha.4", path = "../../primitives/core" }
 sp-application-crypto = { version = "2.0.0-alpha.4", path = "../../primitives/application-crypto" }
-hex = "0.4.0"
+rustc-hex = "2.1.0"
 rand = "0.7.2"
 serde_json = "1.0.41"
 subtle = "2.1.1"

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -35,7 +35,7 @@ nohash-hasher = "0.2.0"
 parking_lot = "0.10.0"
 prost = "0.6.1"
 rand = "0.7.2"
-rustc-hex = "2.0.1"
+rustc-hex = "2.1.0"
 sc-block-builder = { version = "0.8.0-alpha.4", path = "../block-builder" }
 sc-client = { version = "0.8.0-alpha.4", path = "../" }
 sc-client-api = { version = "2.0.0-alpha.4", path = "../api" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -38,7 +38,6 @@ parking_lot = "0.10.0"
 assert_matches = "1.3.0"
 futures01 = { package = "futures", version = "0.1.29" }
 sc-network = { version = "0.8.0-alpha.4", path = "../network" }
-rustc-hex = "2.0.1"
 sp-io = { version = "2.0.0-alpha.4", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/sp-core"
 [dependencies]
 sp-std = { version = "2.0.0-alpha.4", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false, features = ["derive"] }
-rustc-hex = { version = "2.0.1", default-features = false }
+rustc-hex = { version = "2.1.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
@@ -42,7 +42,6 @@ blake2-rfc = { version = "0.2.18", default-features = false, optional = true }
 tiny-keccak = { version = "2.0.1", features = ["keccak"], optional = true }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated", "u64_backend"], default-features = false, optional = true }
 sha2 = { version = "0.8.0", default-features = false, optional = true }
-hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"], optional = true }
 
@@ -85,7 +84,6 @@ std = [
 	"twox-hash/std",
 	"blake2-rfc/std",
 	"ed25519-dalek/std",
-	"hex/std",
 	"base58",
 	"substrate-bip39",
 	"tiny-bip39",
@@ -115,7 +113,6 @@ full_crypto = [
 	"blake2-rfc",
 	"tiny-keccak",
 	"schnorrkel",
-	"hex",
 	"sha2",
 	"twox-hash",
 	"libsecp256k1",

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -32,6 +32,7 @@ use codec::{Encode, Decode};
 use regex::Regex;
 #[cfg(feature = "std")]
 use base58::{FromBase58, ToBase58};
+use rustc_hex::FromHex;
 
 use zeroize::Zeroize;
 #[doc(hidden)]
@@ -493,7 +494,7 @@ impl<T: Sized + AsMut<[u8]> + AsRef<[u8]> + Default + Derive> Ss58Codec for T {
 			.map(|r| r.as_str())
 			.unwrap_or(DEV_ADDRESS);
 		let addr = if s.starts_with("0x") {
-			let d = hex::decode(&s[2..]).map_err(|_| PublicError::InvalidFormat)?;
+			let d: Vec<u8> = s[2..].from_hex().map_err(|_| PublicError::InvalidFormat)?;
 			let mut r = Self::default();
 			if d.len() == r.as_ref().len() {
 				r.as_mut().copy_from_slice(&d);
@@ -831,8 +832,8 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 		let password = password_override.or_else(|| cap.name("password").map(|m| m.as_str()));
 
 		let (root, seed) = if phrase.starts_with("0x") {
-			hex::decode(&phrase[2..]).ok()
-				.and_then(|seed_vec| {
+			phrase[2..].from_hex().ok()
+				.and_then(|seed_vec: Vec<u8>| {
 					let mut seed = Self::Seed::default();
 					if seed.as_ref().len() == seed_vec.len() {
 						seed.as_mut().copy_from_slice(&seed_vec);

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -39,6 +39,7 @@ use serde::{de, Serializer, Serialize, Deserializer, Deserialize};
 use crate::crypto::{Public as TraitPublic, UncheckedFrom, CryptoType, Derive};
 #[cfg(feature = "full_crypto")]
 use secp256k1::{PublicKey, SecretKey};
+use rustc_hex::{ToHex, FromHex};
 
 /// A secret seed (which is bytewise essentially equivalent to a SecretKey).
 ///
@@ -221,14 +222,14 @@ impl sp_std::convert::TryFrom<&[u8]> for Signature {
 #[cfg(feature = "std")]
 impl Serialize for Signature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-		serializer.serialize_str(&hex::encode(self))
+		serializer.serialize_str(&self.0.to_hex::<String>())
 	}
 }
 
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for Signature {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
+		let signature_hex = String::deserialize(deserializer)?.from_hex::<Vec<u8>>()
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
 		Ok(Signature::try_from(signature_hex.as_ref())
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?)

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -41,6 +41,7 @@ use serde::{de, Serializer, Serialize, Deserializer, Deserialize};
 use crate::{crypto::{Public as TraitPublic, UncheckedFrom, CryptoType, Derive}};
 use sp_runtime_interface::pass_by::PassByInner;
 use sp_std::ops::Deref;
+use rustc_hex::{FromHex, ToHex};
 
 /// A secret seed. It's not called a "secret key" because ring doesn't expose the secret keys
 /// of the key pair (yeah, dumb); as such we're forced to remember the seed manually if we
@@ -204,14 +205,14 @@ impl sp_std::convert::TryFrom<&[u8]> for Signature {
 #[cfg(feature = "std")]
 impl Serialize for Signature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-		serializer.serialize_str(&hex::encode(self))
+		serializer.serialize_str(&self.0.to_hex::<String>())
 	}
 }
 
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for Signature {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
+		let signature_hex = String::deserialize(deserializer)?.from_hex::<Vec<u8>>()
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
 		Ok(Signature::try_from(signature_hex.as_ref())
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?)

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -43,6 +43,7 @@ use crate::{crypto::{Public as TraitPublic, UncheckedFrom, CryptoType, Derive}};
 use crate::hash::{H256, H512};
 use codec::{Encode, Decode};
 use sp_std::ops::Deref;
+use rustc_hex::{FromHex, ToHex};
 
 #[cfg(feature = "std")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -205,14 +206,14 @@ impl sp_std::convert::TryFrom<&[u8]> for Signature {
 #[cfg(feature = "std")]
 impl Serialize for Signature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-		serializer.serialize_str(&hex::encode(self))
+		serializer.serialize_str(&self.0.to_hex::<String>())
 	}
 }
 
 #[cfg(feature = "std")]
 impl<'de> Deserialize<'de> for Signature {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
+		let signature_hex = String::deserialize(deserializer)?.from_hex::<Vec<u8>>()
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?;
 		Ok(Signature::try_from(signature_hex.as_ref())
 			.map_err(|e| de::Error::custom(format!("{:?}", e)))?)


### PR DESCRIPTION
Closes #5296.

As for me, `hex` is slightly more ergonomic, but unfortunately `rustc_hex` is used by some other dependencies.