### PR TITLE
Sensible way of selecting Prime member

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 239,
+	spec_version: 240,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -210,7 +210,7 @@ mod migration {
 			::new(b"PhragmenElection", b"VotesOf")
 			.drain()
 		{
-			if let Some(stake) = take_storage_item::<_, BalanceOf<T>, Twox64Concat>(b"PhragmenElection", b"VotesOf", &who) {
+			if let Some(stake) = take_storage_item::<_, BalanceOf<T>, Twox64Concat>(b"PhragmenElection", b"StakeOf", &who) {
 				Voting::<T>::insert(who, (stake, votes));
 			}
 		}

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -190,7 +190,7 @@ pub fn remove_storage_prefix(module: &[u8], item: &[u8], hash: &[u8]) {
 pub fn take_storage_item<K: Encode + Sized, T: Decode + Sized, H: StorageHasher>(
 	module: &[u8],
 	item: &[u8],
-	key: EncodeLike<K>,
+	key: K,
 ) -> Option<T> {
-	take_storage_value(module, item, &item_key.using_encoded(H::hash))
+	take_storage_value(module, item, key.using_encoded(H::hash).as_ref())
 }

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -185,3 +185,12 @@ pub fn remove_storage_prefix(module: &[u8], item: &[u8], hash: &[u8]) {
 	key[32..].copy_from_slice(hash);
 	frame_support::storage::unhashed::kill_prefix(&key)
 }
+
+/// Get a particular value in storage by the `module`, the map's `item` name and the key `hash`.
+pub fn take_storage_item<K: Encode + Sized, T: Decode + Sized, H: StorageHasher>(
+	module: &[u8],
+	item: &[u8],
+	key: EncodeLike<K>,
+) -> Option<T> {
+	take_storage_value(module, item, &item_key.using_encoded(H::hash))
+}

--- a/primitives/phragmen/src/lib.rs
+++ b/primitives/phragmen/src/lib.rs
@@ -149,16 +149,14 @@ pub type SupportMap<A> = BTreeMap<A, Support<A>>;
 /// responsibility of the caller to make sure only those candidates who have a sensible economic
 /// value are passed in. From the perspective of this function, a candidate can easily be among the
 /// winner with no backing stake.
-pub fn elect<AccountId, Balance, FS, C, R>(
+pub fn elect<AccountId, Balance, C, R>(
 	candidate_count: usize,
 	minimum_candidate_count: usize,
 	initial_candidates: Vec<AccountId>,
-	initial_voters: Vec<(AccountId, Vec<AccountId>)>,
-	stake_of: FS,
+	initial_voters: Vec<(AccountId, Balance, Vec<AccountId>)>,
 ) -> Option<PhragmenResult<AccountId, R>> where
 	AccountId: Default + Ord + Member,
 	Balance: Default + Copy + AtLeast32Bit,
-	for<'r> FS: Fn(&'r AccountId) -> Balance,
 	C: Convert<Balance, u64> + Convert<u128, Balance>,
 	R: PerThing,
 {
@@ -191,8 +189,7 @@ pub fn elect<AccountId, Balance, FS, C, R>(
 
 	// collect voters. use `c_idx_cache` for fast access and aggregate `approval_stake` of
 	// candidates.
-	voters.extend(initial_voters.into_iter().map(|(who, votes)| {
-		let voter_stake = stake_of(&who);
+	voters.extend(initial_voters.into_iter().map(|(who, voter_stake, votes)| {
 		let mut edges: Vec<Edge<AccountId>> = Vec::with_capacity(votes.len());
 		for v in votes {
 			if let Some(idx) = c_idx_cache.get(&v) {

--- a/primitives/phragmen/src/mock.rs
+++ b/primitives/phragmen/src/mock.rs
@@ -335,12 +335,11 @@ pub(crate) fn run_and_compare(
 	min_to_elect: usize,
 ) {
 	// run fixed point code.
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Perbill>(
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Perbill>(
 		to_elect,
 		min_to_elect,
 		candidates.clone(),
-		voters.clone(),
-		&stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	// run float poc code.

--- a/primitives/phragmen/src/tests.rs
+++ b/primitives/phragmen/src/tests.rs
@@ -80,12 +80,12 @@ fn phragmen_poc_works() {
 		(30, vec![2, 3]),
 	];
 
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let stake_of = create_stake_of(&[(10, 10), (20, 20), (30, 30)]);
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates,
-		voters,
-		create_stake_of(&[(10, 10), (20, 20), (30, 30)]),
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(2, 40), (3, 50)]);
@@ -149,12 +149,11 @@ fn phragmen_accuracy_on_large_scale_only_validators() {
 		(5, (u64::max_value() - 2).into()),
 	]);
 
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates.clone(),
-		auto_generate_self_voters(&candidates),
-		stake_of,
+		auto_generate_self_voters(&candidates).iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(1, 18446744073709551614u128), (5, 18446744073709551613u128)]);
@@ -180,12 +179,11 @@ fn phragmen_accuracy_on_large_scale_validators_and_nominators() {
 		(14, u64::max_value().into()),
 	]);
 
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(2, 36893488147419103226u128), (1, 36893488147419103219u128)]);
@@ -212,12 +210,11 @@ fn phragmen_accuracy_on_small_scale_self_vote() {
 		(30, 1),
 	]);
 
-	let PhragmenResult { winners, assignments: _ } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments: _ } = elect::<_, _, TestCurrencyToVote, Output>(
 		3,
 		3,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(20, 2), (10, 1), (30, 1)]);
@@ -243,12 +240,11 @@ fn phragmen_accuracy_on_small_scale_no_self_vote() {
 		(3, 1),
 	]);
 
-	let PhragmenResult { winners, assignments: _ } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments: _ } = elect::<_, _, TestCurrencyToVote, Output>(
 		3,
 		3,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(20, 2), (10, 1), (30, 1)]);
@@ -277,12 +273,11 @@ fn phragmen_large_scale_test() {
 		(50, 990000000000000000),
 	]);
 
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(24, 1490000000000200000u128), (22, 1490000000000100000u128)]);
@@ -304,12 +299,11 @@ fn phragmen_large_scale_test_2() {
 		(50, nom_budget.into()),
 	]);
 
-	let PhragmenResult { winners, assignments } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments } = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq_uvec!(winners, vec![(2, 1000000000004000000u128), (4, 1000000000004000000u128)]);
@@ -369,12 +363,11 @@ fn elect_has_no_entry_barrier() {
 		(2, 10),
 	]);
 
-	let PhragmenResult { winners, assignments: _ } = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let PhragmenResult { winners, assignments: _ } = elect::<_, _, TestCurrencyToVote, Output>(
 		3,
 		3,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	// 30 is elected with stake 0. The caller is responsible for stripping this.
@@ -397,12 +390,11 @@ fn minimum_to_elect_is_respected() {
 		(2, 10),
 	]);
 
-	let maybe_result = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let maybe_result = elect::<_, _, TestCurrencyToVote, Output>(
 		10,
 		10,
 		candidates,
-		voters,
-		stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	);
 
 	assert!(maybe_result.is_none());
@@ -424,12 +416,11 @@ fn self_votes_should_be_kept() {
 		(1, 8),
 	]);
 
-	let result = elect::<_, _, _, TestCurrencyToVote, Output>(
+	let result = elect::<_, _, TestCurrencyToVote, Output>(
 		2,
 		2,
 		candidates,
-		voters,
-		&stake_of,
+		voters.iter().map(|(ref v, ref vs)| (v.clone(), stake_of(v), vs.clone())).collect::<Vec<_>>(),
 	).unwrap();
 
 	assert_eq!(result.winners, vec![(20, 28), (10, 18)]);


### PR DESCRIPTION
Fixes #5290 

This just uses Borda count for now.

This also combines the `StakeOf` and `VotesOf` items which were inexplicably separated, thus causing two trie ops when one was required.