### PR TITLE
Switch Treasury to `on_initialize`, Tips `KeepAlive`

### DIFF
--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -20,7 +20,7 @@ use super::*;
 
 use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account};
-use sp_runtime::traits::OnFinalize;
+use sp_runtime::traits::OnInitialize;
 
 use crate::Module as Treasury;
 
@@ -82,7 +82,7 @@ fn create_tips<T: Trait>(t: u32, hash: T::Hash, value: BalanceOf<T>) -> Result<(
 	Ok(())
 }
 
-// Create proposals that are approved for use in `on_finalize`.
+// Create proposals that are approved for use in `on_initialize`.
 fn create_approved_proposals<T: Trait>(n: u32) -> Result<(), &'static str> {
 	for i in 0 .. n {
 		let (caller, value, lookup) = setup_proposal::<T>(i);
@@ -199,13 +199,13 @@ benchmarks! {
 		let caller = account("caller", t, SEED);
 	}: _(RawOrigin::Signed(caller), hash)
 
-	on_finalize {
+	on_initialize {
 		let p in 0 .. 100;
 		let pot_account = Treasury::<T>::account_id();
 		let value = T::Currency::minimum_balance().saturating_mul(1_000_000_000.into());
 		let _ = T::Currency::make_free_balance_be(&pot_account, value);
 		create_approved_proposals::<T>(p)?;
 	}: {
-		Treasury::<T>::on_finalize(T::BlockNumber::zero());
+		Treasury::<T>::on_initialize(T::BlockNumber::zero());
 	}
 }

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -6,7 +6,7 @@ use sp_core::H256;
 use sp_runtime::{
 	Perbill,
 	testing::Header,
-	traits::{BlakeTwo256, OnFinalize, IdentityLookup, BadOrigin},
+	traits::{BlakeTwo256, OnInitialize, IdentityLookup, BadOrigin},
 };
 
 impl_outer_origin! {
@@ -287,7 +287,7 @@ fn accepted_spend_proposal_ignored_outside_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(1);
+		<Treasury as OnInitialize<u64>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 100);
 	});
@@ -300,7 +300,7 @@ fn unused_pot_should_diminish() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
 
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 50);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 50);
 	});
@@ -314,7 +314,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::reject_proposal(Origin::ROOT, 0));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 0);
 		assert_eq!(Treasury::pot(), 50);
 	});
@@ -365,7 +365,7 @@ fn accepted_spend_proposal_enacted_on_spend_period() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
 		assert_eq!(Treasury::pot(), 0);
 	});
@@ -380,11 +380,11 @@ fn pot_underflow_should_not_diminish() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		let _ = Balances::deposit_into_existing(&Treasury::account_id(), 100).unwrap();
-		<Treasury as OnFinalize<u64>>::on_finalize(4);
+		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Balances::free_balance(3), 150); // Fund has been spent
 		assert_eq!(Treasury::pot(), 25); // Pot has finally changed
 	});
@@ -402,13 +402,13 @@ fn treasury_account_doesnt_get_deleted() {
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), treasury_balance, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), Treasury::pot(), 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 1));
 
-		<Treasury as OnFinalize<u64>>::on_finalize(4);
+		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 1); // but the account is still there
 	});
@@ -433,7 +433,7 @@ fn inexistent_account_works() {
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 1, 3));
 		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 1));
-		<Treasury as OnFinalize<u64>>::on_finalize(2);
+		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed
 
@@ -441,7 +441,7 @@ fn inexistent_account_works() {
 		assert_eq!(Treasury::pot(), 99); // Pot now contains funds
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 100); // Account does exist
 
-		<Treasury as OnFinalize<u64>>::on_finalize(4);
+		<Treasury as OnInitialize<u64>>::on_initialize(4);
 
 		assert_eq!(Treasury::pot(), 0); // Pot has changed
 		assert_eq!(Balances::free_balance(3), 99); // Balance of `3` has changed

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -60,6 +60,8 @@ impl Contains<u64> for TenToFourteen {
 	fn sorted_members() -> Vec<u64> {
 		vec![10, 11, 12, 13, 14]
 	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn add(_: &u64) { unimplemented!() }
 }
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);


### PR DESCRIPTION
A reduction of https://github.com/paritytech/substrate/pull/5314/files

This simply updates the pallet to use `on_initialize` instead of `on_finalize`, and updates the `tip` logic so that it keeps the Treasury account alive.