### PR TITLE
*: Replace custom cpu memory metrics with Prometheus crate metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.1",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ dependencies = [
  "itoa",
  "log 0.4.8",
  "net2",
- "rustc_version",
+ "rustc_version 0.2.3",
  "time",
  "tokio 0.1.22",
  "tokio-buf",
@@ -3141,7 +3141,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -3690,6 +3690,12 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "nom"
@@ -4696,7 +4702,7 @@ checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.6.2",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -4719,7 +4725,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "rustc_version",
+ "rustc_version 0.2.3",
  "smallvec 0.6.13",
  "winapi 0.3.8",
 ]
@@ -4979,6 +4985,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "procinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
+dependencies = [
+ "byteorder 0.5.3",
+ "libc",
+ "nom 1.2.4",
+ "rustc_version 0.1.7",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4987,6 +5005,8 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
+ "procinfo",
  "protobuf",
  "quick-error",
  "spin",
@@ -5287,7 +5307,7 @@ checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
 dependencies = [
  "bitflags",
  "cc",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -5464,6 +5484,15 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+dependencies = [
+ "semver 0.1.20",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -5543,7 +5572,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -6671,6 +6700,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+
+[[package]]
+name = "semver"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
@@ -6889,7 +6924,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "rustc_version",
+ "rustc_version 0.2.3",
  "sha2",
  "subtle 2.2.2",
  "x25519-dalek",

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -10,11 +10,15 @@ repository = "https://github.com/paritytech/substrate/"
 
 [dependencies]
 log = "0.4.8"
-prometheus = "0.7"
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 derive_more = "0.99"
+
+# WASM
+[target.'cfg(target_os = "unknown")'.dependencies]
+prometheus = "0.7"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-std = { version = "1.0.1", features = ["unstable"] }
 hyper = { version = "0.13.1", default-features = false, features = ["stream"] }
+prometheus = { version = "0.7", features = ["process"] }
 tokio = "0.2"


### PR DESCRIPTION
The Prometheus Rust crate offers process related metrics with the
`process` feature. This patch enables the feature on non-wasm platforms
and registers the process metrics with the Substrate registry. In
addition it removes the existing manually exposed cpu and memory
metrics.

The first block of metrics is replaced by the second block of metrics.

```
\# HELP substrate_cpu_usage_percentage Node CPU usage
\# TYPE substrate_cpu_usage_percentage gauge
substrate_cpu_usage_percentage 1.2066365480422974

\ # HELP substrate_memory_usage_bytes Node memory usage
\ # TYPE substrate_memory_usage_bytes gauge
substrate_memory_usage_bytes 86628
```

```
\# HELP substrate_process_cpu_seconds_total Total user and system CPU time spent in seconds.
\# TYPE substrate_process_cpu_seconds_total counter
substrate_process_cpu_seconds_total 1.05

\# HELP substrate_process_max_fds Maximum number of open file descriptors.
\# TYPE substrate_process_max_fds gauge
substrate_process_max_fds 1048576

\# HELP substrate_process_open_fds Number of open file descriptors.
\# TYPE substrate_process_open_fds gauge
substrate_process_open_fds 99

\# HELP substrate_process_resident_memory_bytes Resident memory size in bytes.
\# TYPE substrate_process_resident_memory_bytes gauge
substrate_process_resident_memory_bytes 104386560

\# HELP substrate_process_start_time_seconds Start time of the process since unix epoch in seconds.
\# TYPE substrate_process_start_time_seconds gauge
substrate_process_start_time_seconds 1584963169.7

\# HELP substrate_process_virtual_memory_bytes Virtual memory size in bytes.
\# TYPE substrate_process_virtual_memory_bytes gauge
substrate_process_virtual_memory_bytes 2903089152
```
