### PR TITLE
Add default rocksdb feature to `frame-benchmarking-cli`

### DIFF
--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -24,6 +24,4 @@ codec = { version = "1.2.0", package = "parity-scale-codec" }
 
 [features]
 default = ["rocksdb"]
-# The RocksDB feature activates the RocksDB database backend. If it is not activated, and you pass
-# a path to a database, an error will be produced at runtime.
 rocksdb = ["sc-client-db/kvdb-rocksdb"]

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -21,3 +21,9 @@ sp-runtime = { version = "2.0.0-alpha.4", path = "../../../primitives/runtime" }
 sp-state-machine = { version = "0.8.0-alpha.4", path = "../../../primitives/state-machine" }
 structopt = "0.3.8"
 codec = { version = "1.2.0", package = "parity-scale-codec" }
+
+[features]
+default = ["rocksdb"]
+# The RocksDB feature activates the RocksDB database backend. If it is not activated, and you pass
+# a path to a database, an error will be produced at runtime.
+rocksdb = ["sc-client-db/kvdb-rocksdb"]


### PR DESCRIPTION
This duplicates the behavior of `client/service` and adds a default feature of `rocksdb` to the `frame-benchmarking-cli`.

Closes https://github.com/paritytech/substrate/issues/5363