### PR TITLE
Add `runtime-benchmarks` compile/test in CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,7 +261,7 @@ test-runtime-benchmarks:
       - $DEPLOY_TAG
   script:
     - cd bin/node/cli
-    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features runtime-benchmarks
+    - BUILD_DUMMY_WASM_BINARY=1 time cargo check --verbose --features runtime-benchmarks
     - sccache -s
 
 test-linux-stable-int:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,6 +248,22 @@ test-wasmtime:
     - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features wasmtime
     - sccache -s
 
+test-runtime-benchmarks:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS: -Cdebug-assertions=y
+    RUST_BACKTRACE: 1
+  except:
+    variables:
+      - $DEPLOY_TAG
+  script:
+    - cd bin/node/cli
+    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --features runtime-benchmarks
+    - sccache -s
+
 test-linux-stable-int:
   <<:                              *test-linux
   except:


### PR DESCRIPTION
This adds a new CI job which compiles and tests the Substrate node with the feature flag `runtime-benchmarks` to ensure nothing is broken or gets broken.

I see one issue already:

```
error[E0046]: not all trait items implemented, missing: `add`
   --> /Users/shawntabrizi/.cargo/git/checkouts/substrate-7e08433d4c370a21/feac1d9/frame/elections-phragmen/src/lib.rs:773:1
    |
773 | impl<T: Trait> Contains<T::AccountId> for Module<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `add` in implementation
    |
    = help: implement the missing item: `fn add(_: &T) { todo!() }`
```

Eventually, when benchmarks automatically create tests which verify the benchmarks work, this will be especially helpful.