### PR TITLE
on_initialize return weight consumed and default cost to default DispatchInfo instead of zero

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -953,33 +953,4 @@ mod tests {
 		is_submit_signed_transaction::<SubmitTransaction>();
 		is_sign_and_submit_transaction::<SubmitTransaction>();
 	}
-
-	#[test]
-	fn empty_block_weight_should_not_exceed_limits() {
-		let check_for_block = |b| {
-			let block_hooks_weight = AllModules::on_initialize(b);
-
-			assert_eq!(
-				block_hooks_weight,
-				0,
-				"This test might fail simply because the value being compared to has increased to a \
-				module declaring a new weight for a hook or call. In this case update the test and \
-				happily move on.",
-			);
-
-			// Invariant. Always must be like this to have a sane chain.
-			assert!(block_hooks_weight < MaximumBlockWeight::get());
-
-			// Warning.
-			if block_hooks_weight > MaximumBlockWeight::get() / 2 {
-				println!(
-					"block hooks weight is consuming more than a block's capacity. You probably want \
-					to re-think this. This test will fail now."
-				);
-				assert!(false);
-			}
-		};
-
-		let _ = (0..100_000).for_each(check_for_block);
-	}
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -929,6 +929,7 @@ impl_runtime_apis! {
 mod tests {
 	use super::*;
 	use frame_system::offchain::{SignAndSubmitTransaction, SubmitSignedTransaction};
+	use frame_support::traits::OnInitialize;
 
 	#[test]
 	fn validate_transaction_submitter_bounds() {
@@ -954,12 +955,9 @@ mod tests {
 	}
 
 	#[test]
-	fn block_hooks_weight_should_not_exceed_limits() {
-		use frame_support::weights::WeighBlock;
+	fn empty_block_weight_should_not_exceed_limits() {
 		let check_for_block = |b| {
-			let block_hooks_weight =
-				<AllModules as WeighBlock<BlockNumber>>::on_initialize(b) +
-				<AllModules as WeighBlock<BlockNumber>>::on_finalize(b);
+			let block_hooks_weight = AllModules::on_initialize(b);
 
 			assert_eq!(
 				block_hooks_weight,

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::traits::{FindAuthor, VerifySeal, Get};
 use codec::{Encode, Decode};
 use frame_system::ensure_none;
 use sp_runtime::traits::{Header as HeaderT, One, Zero};
-use frame_support::weights::SimpleDispatchInfo;
+use frame_support::weights::{Weight, SimpleDispatchInfo, WeighData};
 use sp_inherents::{InherentIdentifier, ProvideInherent, InherentData};
 use sp_authorship::{INHERENT_IDENTIFIER, UnclesInherentData, InherentError};
 
@@ -185,7 +185,7 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		type Error = Error<T>;
 
-		fn on_initialize(now: T::BlockNumber) {
+		fn on_initialize(now: T::BlockNumber) -> Weight {
 			let uncle_generations = T::UncleGenerations::get();
 			// prune uncles that are older than the allowed number of generations.
 			if uncle_generations <= now {
@@ -196,6 +196,8 @@ decl_module! {
 			<Self as Store>::DidSetUncles::put(false);
 
 			T::EventHandler::note_author(Self::author());
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		fn on_finalize() {

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -23,7 +23,10 @@
 pub use pallet_timestamp;
 
 use sp_std::{result, prelude::*};
-use frame_support::{decl_storage, decl_module, traits::{FindAuthor, Get, Randomness as RandomnessT}};
+use frame_support::{
+	decl_storage, decl_module, traits::{FindAuthor, Get, Randomness as RandomnessT},
+	weights::{Weight, SimpleDispatchInfo, WeighData},
+};
 use sp_timestamp::OnTimestampSet;
 use sp_runtime::{generic::DigestItem, ConsensusEngineId, Perbill, PerThing};
 use sp_runtime::traits::{IsMember, SaturatedConversion, Saturating, Hash};
@@ -171,8 +174,10 @@ decl_module! {
 		const ExpectedBlockTime: T::Moment = T::ExpectedBlockTime::get();
 
 		/// Initialization
-		fn on_initialize(now: T::BlockNumber) {
+		fn on_initialize(now: T::BlockNumber) -> Weight {
 			Self::do_initialize(now);
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		/// Block finalization

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -17,8 +17,9 @@
 //! Consensus extension module tests for BABE consensus.
 
 use super::*;
+use frame_support::traits::OnFinalize;
 use mock::{new_test_ext, Babe, System};
-use sp_runtime::{traits::OnFinalize, testing::{Digest, DigestItem}};
+use sp_runtime::testing::{Digest, DigestItem};
 use sp_consensus_vrf::schnorrkel::{RawVRFOutput, RawVRFProof};
 use pallet_session::ShouldEndSession;
 

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -170,7 +170,7 @@ use sp_runtime::{
 use codec::{Ref, Decode};
 use frame_support::{
 	decl_module, decl_storage, decl_event, decl_error, ensure, Parameter,
-	weights::SimpleDispatchInfo,
+	weights::{SimpleDispatchInfo, Weight, WeighData},
 	traits::{
 		Currency, ReservableCurrency, LockableCurrency, WithdrawReason, LockIdentifier, Get,
 		OnUnbalanced, BalanceStatus
@@ -499,8 +499,10 @@ decl_module! {
 
 		fn deposit_event() = default;
 
-		fn on_runtime_upgrade() {
+		fn on_runtime_upgrade() -> Weight {
 			Self::migrate();
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		/// Propose a sensitive action to be taken.
@@ -813,10 +815,12 @@ decl_module! {
 			<DispatchQueue<T>>::put(items);
 		}
 
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if let Err(e) = Self::begin_block(n) {
 				sp_runtime::print(e);
 			}
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		/// Specify a proxy that is already open to us. Called by the stash.

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -87,8 +87,9 @@ use sp_runtime::{
 	print, DispatchResult, DispatchError, Perbill, traits::{Zero, StaticLookup, Convert},
 };
 use frame_support::{
-	decl_storage, decl_event, ensure, decl_module, decl_error, weights::SimpleDispatchInfo,
-	storage::{StorageMap, IterableStorageMap}, traits::{
+	decl_storage, decl_event, ensure, decl_module, decl_error,
+	weights::{SimpleDispatchInfo, Weight, WeighData}, storage::{StorageMap, IterableStorageMap},
+	traits::{
 		Currency, Get, LockableCurrency, LockIdentifier, ReservableCurrency, WithdrawReasons,
 		ChangeMembers, OnUnbalanced, WithdrawReason, Contains, BalanceStatus
 	}
@@ -223,8 +224,10 @@ decl_module! {
 
 		fn deposit_event() = default;
 
-		fn on_runtime_upgrade() {
+		fn on_runtime_upgrade() -> Weight {
 			migration::migrate::<T>();
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		const CandidacyBond: BalanceOf<T> = T::CandidacyBond::get();
@@ -461,11 +464,13 @@ decl_module! {
 		}
 
 		/// What to do at the end of each block. Checks if an election needs to happen or not.
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if let Err(e) = Self::end_block(n) {
 				print("Guru meditation");
 				print(e);
 			}
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -30,7 +30,7 @@ use sp_runtime::{
 };
 use frame_support::{
 	decl_storage, decl_event, ensure, decl_module, decl_error,
-	weights::SimpleDispatchInfo,
+	weights::{Weight, SimpleDispatchInfo, WeighData},
 	traits::{
 		Currency, ExistenceRequirement, Get, LockableCurrency, LockIdentifier, BalanceStatus,
 		OnUnbalanced, ReservableCurrency, WithdrawReason, WithdrawReasons, ChangeMembers
@@ -698,11 +698,12 @@ decl_module! {
 			<TermDuration<T>>::put(count);
 		}
 
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if let Err(e) = Self::end_block(n) {
 				print("Guru meditation");
 				print(e);
 			}
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -256,7 +256,10 @@
 use sp_std::marker::PhantomData;
 use frame_support::{
 	dispatch::DispatchResult, decl_module, decl_storage, decl_event,
-	weights::{SimpleDispatchInfo, DispatchInfo, DispatchClass, ClassifyDispatch, WeighData, Weight, PaysFee},
+	weights::{
+		SimpleDispatchInfo, DispatchInfo, DispatchClass, ClassifyDispatch, WeighData, Weight,
+		PaysFee,
+	},
 };
 use sp_std::prelude::*;
 use frame_benchmarking::{benchmarks, account};
@@ -516,14 +519,14 @@ decl_module! {
 		// This function could also very well have a weight annotation, similar to any other. The
 		// only difference being that if it is not annotated, the default is
 		// `SimpleDispatchInfo::zero()`, which resolves into no weight.
-		#[weight = SimpleDispatchInfo::FixedNormal(1000)]
-		fn on_initialize(_n: T::BlockNumber) {
+		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			// Anything that needs to be done at the start of the block.
 			// We don't do anything here.
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		// The signature could also look like: `fn on_finalize()`
-		#[weight = SimpleDispatchInfo::FixedNormal(2000)]
 		fn on_finalize(_n: T::BlockNumber) {
 			// Anything that needs to be done at the end of the block.
 			// We just kill our dummy storage item.
@@ -688,14 +691,17 @@ benchmarks!{
 mod tests {
 	use super::*;
 
-	use frame_support::{assert_ok, impl_outer_origin, parameter_types, weights::GetDispatchInfo};
+	use frame_support::{
+		assert_ok, impl_outer_origin, parameter_types, weights::GetDispatchInfo,
+		traits::{OnInitialize, OnFinalize}
+	};
 	use sp_core::H256;
 	// The testing primitives are very useful for avoiding having to work with signatures
 	// or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 	use sp_runtime::{
 		Perbill,
 		testing::Header,
-		traits::{BlakeTwo256, OnInitialize, OnFinalize, IdentityLookup},
+		traits::{BlakeTwo256, IdentityLookup},
 	};
 
 	impl_outer_origin! {

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -75,16 +75,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_std::{prelude::*, marker::PhantomData};
-use frame_support::{storage::StorageValue, weights::{GetDispatchInfo, WeighBlock, DispatchInfo}};
+use frame_support::{
+	storage::StorageValue, weights::{GetDispatchInfo, DispatchInfo},
+	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade},
+};
 use sp_runtime::{
 	generic::Digest, ApplyExtrinsicResult,
 	traits::{
-		self, Header, Zero, One, Checkable, Applyable, CheckEqual, OnFinalize, OnInitialize,
-		NumberFor, Block as BlockT, OffchainWorker, Dispatchable, Saturating, OnRuntimeUpgrade,
+		self, Header, Zero, One, Checkable, Applyable, CheckEqual, ValidateUnsigned, NumberFor,
+		Block as BlockT, OffchainWorker, Dispatchable, Saturating,
 	},
 	transaction_validity::TransactionValidity,
 };
-use sp_runtime::traits::ValidateUnsigned;
 use codec::{Codec, Encode};
 use frame_system::{extrinsics_root, DigestOf};
 
@@ -111,8 +113,7 @@ impl<
 		OnRuntimeUpgrade +
 		OnInitialize<System::BlockNumber> +
 		OnFinalize<System::BlockNumber> +
-		OffchainWorker<System::BlockNumber> +
-		WeighBlock<System::BlockNumber>,
+		OffchainWorker<System::BlockNumber>,
 > ExecuteBlock<Block> for Executive<System, Block, Context, UnsignedValidator, AllModules>
 where
 	Block::Extrinsic: Checkable<Context> + Codec,
@@ -137,8 +138,7 @@ impl<
 		OnRuntimeUpgrade +
 		OnInitialize<System::BlockNumber> +
 		OnFinalize<System::BlockNumber> +
-		OffchainWorker<System::BlockNumber> +
-		WeighBlock<System::BlockNumber>,
+		OffchainWorker<System::BlockNumber>,
 > Executive<System, Block, Context, UnsignedValidator, AllModules>
 where
 	Block::Extrinsic: Checkable<Context> + Codec,
@@ -179,10 +179,8 @@ where
 		if Self::runtime_upgraded() {
 			// System is not part of `AllModules`, so we need to call this manually.
 			<frame_system::Module::<System> as OnRuntimeUpgrade>::on_runtime_upgrade();
-			<AllModules as OnRuntimeUpgrade>::on_runtime_upgrade();
-			<frame_system::Module<System>>::register_extra_weight_unchecked(
-				<AllModules as WeighBlock<System::BlockNumber>>::on_runtime_upgrade()
-			);
+			let weight = <AllModules as OnRuntimeUpgrade>::on_runtime_upgrade();
+			<frame_system::Module<System>>::register_extra_weight_unchecked(weight);
 		}
 		<frame_system::Module<System>>::initialize(
 			block_number,
@@ -192,13 +190,8 @@ where
 			frame_system::InitKind::Full,
 		);
 		<frame_system::Module<System> as OnInitialize<System::BlockNumber>>::on_initialize(*block_number);
-		<AllModules as OnInitialize<System::BlockNumber>>::on_initialize(*block_number);
-		<frame_system::Module<System>>::register_extra_weight_unchecked(
-			<AllModules as WeighBlock<System::BlockNumber>>::on_initialize(*block_number)
-		);
-		<frame_system::Module<System>>::register_extra_weight_unchecked(
-			<AllModules as WeighBlock<System::BlockNumber>>::on_finalize(*block_number)
-		);
+		let weight = <AllModules as OnInitialize<System::BlockNumber>>::on_initialize(*block_number);
+		<frame_system::Module<System>>::register_extra_weight_unchecked(weight);
 
 		frame_system::Module::<System>::note_finished_initialize();
 	}
@@ -400,7 +393,7 @@ mod tests {
 	use hex_literal::hex;
 
 	mod custom {
-		use frame_support::weights::SimpleDispatchInfo;
+		use frame_support::weights::{SimpleDispatchInfo, Weight};
 
 		pub trait Trait: frame_system::Trait {}
 
@@ -422,11 +415,11 @@ mod tests {
 
 				// module hooks.
 				// one with block number arg and one without
-				#[weight = SimpleDispatchInfo::FixedNormal(25)]
-				fn on_initialize(n: T::BlockNumber) {
+				fn on_initialize(n: T::BlockNumber) -> Weight {
 					println!("on_initialize({})", n);
+					175
 				}
-				#[weight = SimpleDispatchInfo::FixedNormal(150)]
+
 				fn on_finalize() {
 					println!("on_finalize(?)");
 				}

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -77,13 +77,13 @@
 use sp_std::{prelude::*, marker::PhantomData};
 use frame_support::{
 	storage::StorageValue, weights::{GetDispatchInfo, DispatchInfo},
-	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade},
+	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade, OffchainWorker},
 };
 use sp_runtime::{
 	generic::Digest, ApplyExtrinsicResult,
 	traits::{
 		self, Header, Zero, One, Checkable, Applyable, CheckEqual, ValidateUnsigned, NumberFor,
-		Block as BlockT, OffchainWorker, Dispatchable, Saturating,
+		Block as BlockT, Dispatchable, Saturating,
 	},
 	transaction_validity::TransactionValidity,
 };

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -207,9 +207,11 @@ mod tests {
 	use sp_core::H256;
 	use sp_runtime::{
 		testing::Header, Perbill,
-		traits::{BlakeTwo256, IdentityLookup, OnFinalize, Header as HeaderT},
+		traits::{BlakeTwo256, IdentityLookup, Header as HeaderT},
 	};
-	use frame_support::{assert_ok, impl_outer_origin, parameter_types, weights::Weight};
+	use frame_support::{
+		assert_ok, impl_outer_origin, parameter_types, weights::Weight, traits::OnFinalize
+	};
 	use frame_system as system;
 	use std::cell::RefCell;
 

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -18,7 +18,8 @@
 
 #![cfg(test)]
 
-use sp_runtime::{testing::{H256, Digest}, traits::{Header, OnFinalize}};
+use sp_runtime::{testing::{H256, Digest}, traits::Header};
+use frame_support::traits::OnFinalize;
 use crate::mock::*;
 use frame_system::{EventRecord, Phase};
 use codec::{Decode, Encode};

--- a/frame/im-online/src/tests.rs
+++ b/frame/im-online/src/tests.rs
@@ -190,7 +190,7 @@ fn late_heartbeat_should_fail() {
 
 #[test]
 fn should_generate_heartbeats() {
-	use sp_runtime::traits::OffchainWorker;
+	use frame_support::traits::OffchainWorker;
 
 	let mut ext = new_test_ext();
 	let (offchain, _state) = TestOffchainExt::new();

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -25,6 +25,7 @@ use sp_runtime::traits::{
 	StaticLookup, Member, LookupError, Zero, One, BlakeTwo256, Hash, Saturating, AtLeast32Bit
 };
 use frame_support::{Parameter, decl_module, decl_error, decl_event, decl_storage, ensure};
+use frame_support::weights::{Weight, SimpleDispatchInfo, WeighData};
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, ReservableCurrency, Get, BalanceStatus::Reserved};
 use frame_support::storage::migration::take_storage_value;
@@ -98,8 +99,10 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system = frame_system {
 		fn deposit_event() = default;
 
-		fn on_initialize() {
+		fn on_initialize() -> Weight {
 			Self::migrations();
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		/// Assign an previously unassigned index.

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -27,6 +27,7 @@ mod tests;
 use sp_std::vec::Vec;
 use frame_support::{
 	decl_module, decl_event, decl_storage, Parameter,
+	weights::{Weight, SimpleDispatchInfo, WeighData},
 };
 use sp_runtime::traits::Hash;
 use sp_staking::{
@@ -86,10 +87,12 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		fn deposit_event() = default;
 
-		fn on_runtime_upgrade() {
+		fn on_runtime_upgrade() -> Weight {
 			Reports::<T>::remove_all();
 			ConcurrentReportsIndex::<T>::remove_all();
 			ReportsByKindIndex::remove_all();
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -54,7 +54,10 @@
 
 use sp_std::{prelude::*, convert::TryInto};
 use sp_runtime::traits::Hash;
-use frame_support::{decl_module, decl_storage, traits::Randomness};
+use frame_support::{
+	decl_module, decl_storage, traits::Randomness,
+	weights::{Weight, SimpleDispatchInfo, WeighData}
+};
 use safe_mix::TripletMix;
 use codec::Encode;
 use frame_system::Trait;
@@ -69,7 +72,7 @@ fn block_number_to_index<T: Trait>(block_number: T::BlockNumber) -> usize {
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-		fn on_initialize(block_number: T::BlockNumber) {
+		fn on_initialize(block_number: T::BlockNumber) -> Weight {
 			let parent_hash = <frame_system::Module<T>>::parent_hash();
 
 			<RandomMaterial<T>>::mutate(|ref mut values| if values.len() < RANDOM_MATERIAL_LEN as usize {
@@ -78,6 +81,8 @@ decl_module! {
 				let index = block_number_to_index::<T>(block_number);
 				values[index] = parent_hash;
 			});
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }
@@ -156,9 +161,11 @@ mod tests {
 	use sp_runtime::{
 		Perbill,
 		testing::Header,
-		traits::{BlakeTwo256, OnInitialize, Header as _, IdentityLookup},
+		traits::{BlakeTwo256, Header as _, IdentityLookup},
 	};
-	use frame_support::{impl_outer_origin, parameter_types, weights::Weight, traits::Randomness};
+	use frame_support::{
+		impl_outer_origin, parameter_types, weights::Weight, traits::{Randomness, OnInitialize},
+	};
 
 	#[derive(Clone, PartialEq, Eq)]
 	pub struct Test;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -21,12 +21,13 @@ use super::*;
 use frame_support::{
 	impl_outer_origin, impl_outer_dispatch, impl_outer_event, parameter_types,
 	weights::Weight,
+	traits::{OnInitialize, OnFinalize},
 };
 use sp_core::H256;
 // The testing primitives are very useful for avoiding having to work with signatures
 // or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 use sp_runtime::{
-	Perbill, traits::{BlakeTwo256, IdentityLookup, OnInitialize, OnFinalize}, testing::Header,
+	Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };
 use crate as recovery;
 

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -96,6 +96,7 @@ use sp_std::{
 use frame_support::{
 	decl_module, decl_storage, decl_event, ensure, decl_error,
 	traits::{ChangeMembers, InitializeMembers, Currency, Get, ReservableCurrency},
+	weights::{Weight, SimpleDispatchInfo, WeighData},
 };
 use frame_system::{self as system, ensure_root, ensure_signed};
 use sp_runtime::{
@@ -245,11 +246,12 @@ decl_module! {
 
 		/// Every `Period` blocks the `Members` set is refreshed from the
 		/// highest scoring members in the pool.
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if n % T::Period::get() == Zero::zero() {
 				let pool = <Pool<T, I>>::get();
 				<Module<T, I>>::refresh_members(pool, ChangeReceiver::MembershipChanged);
 			}
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 
 		/// Add `origin` to the pool of candidates.

--- a/frame/scored-pool/src/tests.rs
+++ b/frame/scored-pool/src/tests.rs
@@ -19,8 +19,8 @@
 use super::*;
 use mock::*;
 
-use frame_support::{assert_ok, assert_noop};
-use sp_runtime::traits::{OnInitialize, BadOrigin};
+use frame_support::{assert_ok, assert_noop, traits::OnInitialize};
+use sp_runtime::traits::BadOrigin;
 
 type ScoredPool = Module<Test>;
 type System = frame_system::Module<Test>;

--- a/frame/session/src/historical.rs
+++ b/frame/session/src/historical.rs
@@ -310,12 +310,12 @@ impl<T: Trait, D: AsRef<[u8]>> frame_support::traits::KeyOwnerProofSystem<(KeyTy
 mod tests {
 	use super::*;
 	use sp_core::crypto::key_types::DUMMY;
-	use sp_runtime::{traits::OnInitialize, testing::UintAuthorityId};
+	use sp_runtime::testing::UintAuthorityId;
 	use crate::mock::{
 		NEXT_VALIDATORS, force_new_session,
 		set_next_validators, Test, System, Session,
 	};
-	use frame_support::traits::KeyOwnerProofSystem;
+	use frame_support::traits::{KeyOwnerProofSystem, OnInitialize};
 
 	type Historical = Module<Test>;
 

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -102,12 +102,14 @@
 use sp_std::{prelude::*, marker::PhantomData, ops::{Sub, Rem}};
 use codec::Decode;
 use sp_runtime::{KeyTypeId, Perbill, RuntimeAppPublic, BoundToRuntimeAppPublic};
-use frame_support::weights::SimpleDispatchInfo;
 use sp_runtime::traits::{Convert, Zero, Member, OpaqueKeys};
 use sp_staking::SessionIndex;
-use frame_support::{ensure, decl_module, decl_event, decl_storage, decl_error, ConsensusEngineId};
-use frame_support::{traits::{Get, FindAuthor, ValidatorRegistration}, Parameter};
-use frame_support::dispatch::{self, DispatchResult, DispatchError};
+use frame_support::{
+	ensure, decl_module, decl_event, decl_storage, decl_error, ConsensusEngineId, Parameter,
+	weights::{Weight, SimpleDispatchInfo, WeighData},
+	traits::{Get, FindAuthor, ValidatorRegistration},
+	dispatch::{self, DispatchResult, DispatchError},
+};
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
@@ -495,10 +497,12 @@ decl_module! {
 
 		/// Called when a block is initialized. Will rotate session if it is the last
 		/// block of the current session.
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			if T::ShouldEndSession::should_end_session(n) {
 				Self::rotate_session();
 			}
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/session/src/tests.rs
+++ b/frame/session/src/tests.rs
@@ -17,9 +17,9 @@
 // Tests for the Session Pallet
 
 use super::*;
-use frame_support::assert_ok;
+use frame_support::{traits::OnInitialize, assert_ok};
 use sp_core::crypto::key_types::DUMMY;
-use sp_runtime::{traits::OnInitialize, testing::UintAuthorityId};
+use sp_runtime::testing::UintAuthorityId;
 use mock::{
 	NEXT_VALIDATORS, SESSION_CHANGED, TEST_SESSION_CHANGED, authorities, force_new_session,
 	set_next_validators, set_session_length, session_changed, Test, Origin, System, Session,

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -260,7 +260,7 @@ use sp_runtime::{Percent, ModuleId, RuntimeDebug,
 	}
 };
 use frame_support::{decl_error, decl_module, decl_storage, decl_event, ensure, dispatch::DispatchResult};
-use frame_support::weights::SimpleDispatchInfo;
+use frame_support::weights::{SimpleDispatchInfo, Weight, WeighData};
 use frame_support::traits::{
 	Currency, ReservableCurrency, Randomness, Get, ChangeMembers, BalanceStatus,
 	ExistenceRequirement::AllowDeath
@@ -1028,7 +1028,7 @@ decl_module! {
 			Self::deposit_event(RawEvent::NewMaxMembers(max));
 		}
 
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let mut members = vec![];
 
 			// Run a candidate/membership rotation
@@ -1045,6 +1045,8 @@ decl_module! {
 				}
 				Self::rotate_challenge(&mut members);
 			}
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -18,14 +18,16 @@
 
 use super::*;
 
-use frame_support::{impl_outer_origin, parameter_types, ord_parameter_types};
+use frame_support::{
+	impl_outer_origin, parameter_types, ord_parameter_types, traits::{OnInitialize, OnFinalize}
+};
 use sp_core::H256;
 // The testing primitives are very useful for avoiding having to work with signatures
 // or public keys. `u64` is used as the `AccountId` and no `Signature`s are required.
 use sp_runtime::{
 	Perbill,
 	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup, OnInitialize, OnFinalize},
+	traits::{BlakeTwo256, IdentityLookup},
 };
 use frame_system::EnsureSignedBy;
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -19,14 +19,15 @@
 use std::{collections::{HashSet, HashMap}, cell::RefCell};
 use sp_runtime::{Perbill, KeyTypeId};
 use sp_runtime::curve::PiecewiseLinear;
-use sp_runtime::traits::{IdentityLookup, Convert, OpaqueKeys, OnInitialize, OnFinalize, SaturatedConversion};
+use sp_runtime::traits::{IdentityLookup, Convert, OpaqueKeys, SaturatedConversion};
 use sp_runtime::testing::{Header, UintAuthorityId};
 use sp_staking::{SessionIndex, offence::{OffenceDetails, OnOffenceHandler}};
 use sp_core::{H256, crypto::key_types};
 use sp_io;
 use frame_support::{
 	assert_ok, impl_outer_origin, parameter_types, StorageValue, StorageMap,
-	StorageDoubleMap, IterableStorageMap, traits::{Currency, Get, FindAuthor}, weights::Weight,
+	StorageDoubleMap, IterableStorageMap,
+	traits::{Currency, Get, FindAuthor, OnFinalize, OnInitialize}, weights::Weight,
 };
 use crate::{
 	EraIndex, GenesisConfig, Module, Trait, StakerStatus, ValidatorPrefs, RewardDestination,

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -18,11 +18,11 @@
 
 use super::*;
 use mock::*;
-use sp_runtime::{assert_eq_error_rate, traits::{OnInitialize, BadOrigin}};
+use sp_runtime::{assert_eq_error_rate, traits::BadOrigin};
 use sp_staking::offence::OffenceDetails;
 use frame_support::{
 	assert_ok, assert_noop,
-	traits::{Currency, ReservableCurrency},
+	traits::{Currency, ReservableCurrency, OnInitialize},
 	StorageMap,
 };
 use pallet_balances::Error as BalancesError;

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -375,22 +375,22 @@ macro_rules! decl_module {
 	};
 	// compile_error on_finalize, given weight deprecated.
 	(@normalize
-	 $(#[$attr:meta])*
-	 pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
-	 for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-	 { $( $other_where_bounds:tt )* }
-	 { $( $deposit_event:tt )* }
-	 { $( $on_initialize:tt )* }
-	 { $( $on_runtime_upgrade:tt )* }
-	 {}
-	 { $( $offchain:tt )* }
-	 { $( $constants:tt )* }
-	 { $( $error_type:tt )* }
-	 [ $( $dispatchables:tt )* ]
-	 $(#[doc = $doc_attr:tt])*
-	 #[weight = $weight:expr]
-	 fn on_finalize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-	 $($rest:tt)*
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )* }
+		{}
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		#[weight = $weight:expr]
+		fn on_finalize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
 	) => {
 		compile_error!(
 			"`on_finalize` can't be given weight attribute anymore, weight must be returned by \

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -203,13 +203,13 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug {}
 /// Function signature must be `fn on_runtime_upgrade() -> frame_support::weights::Weight`.
 ///
 /// * `on_initialize`: Executes at the beginning of a block. Using this function will
-/// implement the [`OnInitialize`](../sp_runtime/traits/trait.OnInitialize.html) trait.
+/// implement the [`OnInitialize`](./trait.OnInitialize.html) trait.
 /// Function signature can be either:
 ///   * `fn on_initialize(n: BlockNumber) -> frame_support::weights::Weight` or
 ///   * `fn on_initialize() -> frame_support::weights::Weight`
 ///
 /// * `on_finalize`: Executes at the end of a block. Using this function will
-/// implement the [`OnFinalize`](../sp_runtime/traits/trait.OnFinalize.html) trait.
+/// implement the [`OnFinalize`](./traits/trait.OnFinalize.html) trait.
 /// Function signature can be either:
 ///   * `fn on_finalize(n: BlockNumber) -> frame_support::weights::Weight` or
 ///   * `fn on_finalize() -> frame_support::weights::Weight`

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -373,7 +373,7 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// compile_error on_finalize, given weight deprecated.
+	// compile_error on_finalize, given weight removed syntax.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
@@ -397,7 +397,7 @@ macro_rules! decl_module {
 			`on_initialize` or `on_runtime_upgrade` instead"
 		);
 	};
-	// compile_error on_runtime_upgrade, without Weight deprecated
+	// compile_error on_runtime_upgrade, without a given weight removed syntax.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -421,7 +421,7 @@ macro_rules! decl_module {
 			"`on_runtime_upgrade` must return Weight, signature has changed."
 		);
 	};
-	// compile_error on_runtime_upgrade, with Weight deprecated
+	// compile_error on_runtime_upgrade, given weight removed syntax.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -485,7 +485,7 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// compile_error on_initialize, without weight deprecated
+	// compile_error on_initialize, without a given weight removed syntax.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -509,7 +509,7 @@ macro_rules! decl_module {
 			"`on_initialize` must return Weight, signature has changed."
 		);
 	};
-	// compile_error on_initialize, with weight deprecated
+	// compile_error on_initialize, with given weight removed syntax.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -216,7 +216,7 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug {}
 ///
 /// * `offchain_worker`: Executes at the beginning of a block and produces extrinsics for a future block
 /// upon completion. Using this function will implement the
-/// [`OffchainWorker`](../sp_runtime/traits/trait.OffchainWorker.html) trait.
+/// [`OffchainWorker`](./traits/trait.OffchainWorker.html) trait.
 #[macro_export]
 macro_rules! decl_module {
 	// Entry point #1.
@@ -1118,7 +1118,7 @@ macro_rules! decl_module {
 		fn offchain_worker() { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OffchainWorker<$trait_instance::BlockNumber>
+			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn offchain_worker(_block_number_not_used: $trait_instance::BlockNumber) { $( $impl )* }
@@ -1131,7 +1131,7 @@ macro_rules! decl_module {
 		fn offchain_worker($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OffchainWorker<$trait_instance::BlockNumber>
+			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn offchain_worker($param: $param_ty) { $( $impl )* }
@@ -1143,7 +1143,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OffchainWorker<$trait_instance::BlockNumber>
+			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -25,7 +25,7 @@ pub use frame_metadata::{
 };
 pub use crate::weights::{
 	SimpleDispatchInfo, GetDispatchInfo, DispatchInfo, WeighData, ClassifyDispatch,
-	TransactionPriority, Weight, WeighBlock, PaysFee,
+	TransactionPriority, Weight, PaysFee,
 };
 pub use sp_runtime::{traits::Dispatchable, DispatchError, DispatchResult};
 pub use crate::traits::{CallMetadata, GetCallMetadata, GetCallName};
@@ -200,10 +200,20 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug {}
 /// is a runtime upgrade. This allows each module to upgrade its storage before the storage items are used.
 /// As such, **calling other modules must be avoided**!! Using this function will implement the
 /// [`OnRuntimeUpgrade`](../sp_runtime/traits/trait.OnRuntimeUpgrade.html) trait.
+/// Function signature must be `fn on_runtime_upgrade() -> frame_support::weights::Weight`.
+///
 /// * `on_initialize`: Executes at the beginning of a block. Using this function will
 /// implement the [`OnInitialize`](../sp_runtime/traits/trait.OnInitialize.html) trait.
+/// Function signature can be either:
+///   * `fn on_initialize(n: BlockNumber) -> frame_support::weights::Weight` or
+///   * `fn on_initialize() -> frame_support::weights::Weight`
+///
 /// * `on_finalize`: Executes at the end of a block. Using this function will
 /// implement the [`OnFinalize`](../sp_runtime/traits/trait.OnFinalize.html) trait.
+/// Function signature can be either:
+///   * `fn on_finalize(n: BlockNumber) -> frame_support::weights::Weight` or
+///   * `fn on_finalize() -> frame_support::weights::Weight`
+///
 /// * `offchain_worker`: Executes at the beginning of a block and produces extrinsics for a future block
 /// upon completion. Using this function will implement the
 /// [`OffchainWorker`](../sp_runtime/traits/trait.OffchainWorker.html) trait.
@@ -327,7 +337,7 @@ macro_rules! decl_module {
 			"`deposit_event` function is reserved and must follow the syntax: `$vis:vis fn deposit_event() = default;`"
 		);
 	};
-	// Add on_finalize, without a given weight.
+	// Add on_finalize
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
@@ -354,7 +364,6 @@ macro_rules! decl_module {
 			{ $( $on_initialize )* }
 			{ $( $on_runtime_upgrade )* }
 			{
-				#[weight = $crate::dispatch::SimpleDispatchInfo::zero()]
 				fn on_finalize( $( $param_name : $param ),* ) { $( $impl )* }
 			}
 			{ $( $offchain )* }
@@ -364,84 +373,31 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// Add on_finalize, given weight.
+	// compile_error on_finalize, given weight deprecated.
 	(@normalize
-		$(#[$attr:meta])*
-		pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
-		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-		{ $( $other_where_bounds:tt )* }
-		{ $( $deposit_event:tt )* }
-		{ $( $on_initialize:tt )* }
-		{ $( $on_runtime_upgrade:tt )* }
-		{}
-		{ $( $offchain:tt )* }
-		{ $( $constants:tt )* }
-		{ $( $error_type:tt )* }
-		[ $( $dispatchables:tt )* ]
-		$(#[doc = $doc_attr:tt])*
-		#[weight = $weight:expr]
-		fn on_finalize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-		$($rest:tt)*
+	 $(#[$attr:meta])*
+	 pub struct $mod_type:ident<$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?>
+	 for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+	 { $( $other_where_bounds:tt )* }
+	 { $( $deposit_event:tt )* }
+	 { $( $on_initialize:tt )* }
+	 { $( $on_runtime_upgrade:tt )* }
+	 {}
+	 { $( $offchain:tt )* }
+	 { $( $constants:tt )* }
+	 { $( $error_type:tt )* }
+	 [ $( $dispatchables:tt )* ]
+	 $(#[doc = $doc_attr:tt])*
+	 #[weight = $weight:expr]
+	 fn on_finalize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+	 $($rest:tt)*
 	) => {
-		$crate::decl_module!(@normalize
-			$(#[$attr])*
-			pub struct $mod_type<$trait_instance: $trait_name$(<I>, I: $instantiable $(= $module_default_instance)?)?>
-			for enum $call_type where origin: $origin_type, system = $system
-			{ $( $other_where_bounds )* }
-			{ $( $deposit_event )* }
-			{ $( $on_initialize )* }
-			{ $( $on_runtime_upgrade )* }
-			{
-				#[weight = $weight]
-				fn on_finalize( $( $param_name : $param ),* ) { $( $impl )* }
-			}
-			{ $( $offchain )* }
-			{ $( $constants )* }
-			{ $( $error_type )* }
-			[ $( $dispatchables )* ]
-			$($rest)*
+		compile_error!(
+			"`on_finalize` can't be given weight attribute anymore, weight must be returned by \
+			`on_initialize` or `on_runtime_upgrade` instead"
 		);
 	};
-	// Add on_runtime_upgrade, without a given weight.
-	(@normalize
-		$(#[$attr:meta])*
-		pub struct $mod_type:ident<
-			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
-		>
-		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-		{ $( $other_where_bounds:tt )* }
-		{ $( $deposit_event:tt )* }
-		{ $( $on_initialize:tt )* }
-		{}
-		{ $( $on_finalize:tt )* }
-		{ $( $offchain:tt )* }
-		{ $( $constants:tt )* }
-		{ $( $error_type:tt )* }
-		[ $( $dispatchables:tt )* ]
-		$(#[doc = $doc_attr:tt])*
-		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-		$($rest:tt)*
-	) => {
-		$crate::decl_module!(@normalize
-			$(#[$attr])*
-			pub struct $mod_type<$trait_instance: $trait_name$(<I>, I: $instantiable $(= $module_default_instance)?)?>
-			for enum $call_type where origin: $origin_type, system = $system
-			{ $( $other_where_bounds )* }
-			{ $( $deposit_event )* }
-			{ $( $on_initialize )* }
-			{
-				#[weight = $crate::dispatch::SimpleDispatchInfo::zero()]
-				fn on_runtime_upgrade( $( $param_name : $param ),* ) { $( $impl )* }
-			}
-			{ $( $on_finalize )* }
-			{ $( $offchain )* }
-			{ $( $constants )* }
-			{ $( $error_type )* }
-			[ $( $dispatchables )* ]
-			$($rest)*
-		);
-	};
-	// Add on_runtime_upgrade, given weight.
+	// compile_error on_runtime_upgrade, with Weight deprecated
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -462,6 +418,55 @@ macro_rules! decl_module {
 		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
 		$($rest:tt)*
 	) => {
+		compile_error!(
+			"`on_runtime_upgrade` can't be given weight attribute anymore, weight must be returned \
+			by the function directly."
+		);
+	};
+	// compile_error on_runtime_upgrade, without Weight deprecated
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{}
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!(
+			"`on_runtime_upgrade` must return Weight, signature has changed."
+		);
+	};
+	// Add on_runtime_upgrade
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{}
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
 		$crate::decl_module!(@normalize
 			$(#[$attr])*
 			pub struct $mod_type<$trait_instance: $trait_name$(<I>, I: $instantiable $(= $module_default_instance)?)?>
@@ -470,8 +475,7 @@ macro_rules! decl_module {
 			{ $( $deposit_event )* }
 			{ $( $on_initialize )* }
 			{
-				#[weight = $weight]
-				fn on_runtime_upgrade( $( $param_name : $param ),* ) { $( $impl )* }
+				fn on_runtime_upgrade( $( $param_name : $param ),* ) -> $return { $( $impl )* }
 			}
 			{ $( $on_finalize )* }
 			{ $( $offchain )* }
@@ -481,7 +485,7 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// Add on_initialize, without a given weight.
+	// Add on_initialize
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -498,7 +502,7 @@ macro_rules! decl_module {
 		{ $( $error_type:tt )* }
 		[ $( $dispatchables:tt )* ]
 		$(#[doc = $doc_attr:tt])*
-		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
 		$($rest:tt)*
 	) => {
 		$crate::decl_module!(@normalize
@@ -508,8 +512,7 @@ macro_rules! decl_module {
 			{ $( $other_where_bounds )* }
 			{ $( $deposit_event )* }
 			{
-				#[weight = $crate::dispatch::SimpleDispatchInfo::zero()]
-				fn on_initialize( $( $param_name : $param ),* ) { $( $impl )* }
+				fn on_initialize( $( $param_name : $param ),* ) -> $return { $( $impl )* }
 			}
 			{ $( $on_runtime_upgrade )* }
 			{ $( $on_finalize )* }
@@ -520,7 +523,7 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// Add on_initialize, given weight.
+	// compile_error on_initialize, with weight deprecated
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -541,23 +544,33 @@ macro_rules! decl_module {
 		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
 		$($rest:tt)*
 	) => {
-		$crate::decl_module!(@normalize
-			$(#[$attr])*
-			pub struct $mod_type<$trait_instance: $trait_name$(<I>, I: $instantiable $(= $module_default_instance)?)?>
-			for enum $call_type where origin: $origin_type, system = $system
-			{ $( $other_where_bounds )* }
-			{ $( $deposit_event )* }
-			{
-				#[weight = $weight]
-				fn on_initialize( $( $param_name : $param ),* ) { $( $impl )* }
-			}
-			{ $( $on_runtime_upgrade )* }
-			{ $( $on_finalize )* }
-			{ $( $offchain )* }
-			{ $( $constants )* }
-			{ $( $error_type )* }
-			[ $( $dispatchables )* ]
-			$($rest)*
+		compile_error!(
+			"`on_initialize` can't be given weight attribute anymore, weight must be returned \
+			by the function directly."
+		);
+	};
+	// compile_error on_initialize, without weight deprecated
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{}
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!(
+			"`on_initialize` must return Weight, signature has changed."
 		);
 	};
 	(@normalize
@@ -965,14 +978,13 @@ macro_rules! decl_module {
 	(@impl_on_initialize
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
-		#[weight = $weight:expr]
-		fn on_initialize() { $( $impl:tt )* }
+		fn on_initialize() -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnInitialize<$trait_instance::BlockNumber>
+			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn on_initialize(_block_number_not_used: $trait_instance::BlockNumber) {
+			fn on_initialize(_block_number_not_used: $trait_instance::BlockNumber) -> $return {
 				use $crate::sp_std::if_std;
 				if_std! {
 					use $crate::tracing;
@@ -987,14 +999,13 @@ macro_rules! decl_module {
 	(@impl_on_initialize
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
-		#[weight = $weight:expr]
-		fn on_initialize($param:ident : $param_ty:ty) { $( $impl:tt )* }
+		fn on_initialize($param:ident : $param_ty:ty) -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnInitialize<$trait_instance::BlockNumber>
+			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn on_initialize($param: $param_ty) {
+			fn on_initialize($param: $param_ty) -> $return {
 				use $crate::sp_std::if_std;
 				if_std! {
 					use $crate::tracing;
@@ -1011,7 +1022,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnInitialize<$trait_instance::BlockNumber>
+			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};
@@ -1019,14 +1030,13 @@ macro_rules! decl_module {
 	(@impl_on_runtime_upgrade
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
-		#[weight = $weight:expr]
-		fn on_runtime_upgrade() { $( $impl:tt )* }
+		fn on_runtime_upgrade() -> $return:ty { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnRuntimeUpgrade
+			$crate::traits::OnRuntimeUpgrade
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn on_runtime_upgrade() {
+			fn on_runtime_upgrade() -> $return {
 				use $crate::sp_std::if_std;
 				if_std! {
 					use $crate::tracing;
@@ -1043,7 +1053,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnRuntimeUpgrade
+			$crate::traits::OnRuntimeUpgrade
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};
@@ -1052,11 +1062,10 @@ macro_rules! decl_module {
 	(@impl_on_finalize
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
-		#[weight = $weight:expr]
 		fn on_finalize() { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnFinalize<$trait_instance::BlockNumber>
+			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_finalize(_block_number_not_used: $trait_instance::BlockNumber) {
@@ -1074,11 +1083,10 @@ macro_rules! decl_module {
 	(@impl_on_finalize
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
-		#[weight = $weight:expr]
 		fn on_finalize($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnFinalize<$trait_instance::BlockNumber>
+			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_finalize($param: $param_ty) {
@@ -1098,47 +1106,9 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 	) => {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::sp_runtime::traits::OnFinalize<$trait_instance::BlockNumber>
+			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-		}
-	};
-
-	(@impl_block_hooks_weight
-		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
-		{ $( $other_where_bounds:tt )* }
-		@runtime_upgrade $(
-			#[weight = $weight_runtime_update:expr]
-			fn on_runtime_upgrade($( $param_runtime_upgrade:ident : $param_ty_runtime_upgrade:ty )*) { $( $impl_runtime_upgrade:tt )* }
-		)?
-		@init $(
-			#[weight = $weight_initialize:expr]
-			fn on_initialize($( $param_initialize:ident : $param_ty_initialize:ty )*) { $( $impl_initialize:tt )* }
-		)?
-		@fin $(
-			#[weight = $weight_finalize:expr]
-			fn on_finalize($( $param_finalize:ident : $param_ty_finalize:ty )*) { $( $impl_finalize:tt )* }
-		)?
-	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-		$crate::dispatch::WeighBlock<$trait_instance::BlockNumber> for $module<$trait_instance$(, $instance)?> where
-			$( $other_where_bounds )*
-		{
-			$(
-				fn on_runtime_upgrade() -> $crate::dispatch::Weight {
-					<dyn $crate::dispatch::WeighData<()>>::weigh_data(&$weight_initialize, ())
-				}
-			)?
-			$(
-				fn on_initialize(n: $trait_instance::BlockNumber) -> $crate::dispatch::Weight {
-					<dyn $crate::dispatch::WeighData<$trait_instance::BlockNumber>>::weigh_data(&$weight_initialize, n)
-				}
-			)?
-			$(
-				fn on_finalize(n: $trait_instance::BlockNumber) -> $crate::dispatch::Weight {
-					<dyn $crate::dispatch::WeighData<$trait_instance::BlockNumber>>::weigh_data(&$weight_finalize, n)
-				}
-			)?
 		}
 	};
 
@@ -1400,15 +1370,6 @@ macro_rules! decl_module {
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
 			{ $( $other_where_bounds )* }
 			$( $on_finalize )*
-		}
-
-		$crate::decl_module! {
-			@impl_block_hooks_weight
-			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
-			{ $( $other_where_bounds )* }
-			@runtime_upgrade $( $on_runtime_upgrade )*
-			@init $( $on_initialize )*
-			@fin $( $on_finalize )*
 		}
 
 		$crate::decl_module! {
@@ -2076,9 +2037,10 @@ macro_rules! __check_reserved_fn_name {
 #[allow(dead_code)]
 mod tests {
 	use super::*;
-	use crate::sp_runtime::traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade};
 	use crate::weights::{DispatchInfo, DispatchClass};
-	use crate::traits::{CallMetadata, GetCallMetadata, GetCallName};
+	use crate::traits::{
+		CallMetadata, GetCallMetadata, GetCallName, OnInitialize, OnFinalize, OnRuntimeUpgrade
+	};
 
 	pub trait Trait: system::Trait + Sized where Self::AccountId: From<u32> {
 		type Origin;
@@ -2098,14 +2060,6 @@ mod tests {
 		}
 	}
 
-	struct BlockWeight;
-	impl<BlockNumber: Into<u32>> WeighData<BlockNumber> for BlockWeight {
-		fn weigh_data(&self, target: BlockNumber) -> Weight {
-			let target: u32 = target.into();
-			if target % 2 == 0 { 10 } else { 0 }
-		}
-	}
-
 	decl_module! {
 		pub struct Module<T: Trait> for enum Call where origin: T::Origin, T::AccountId: From<u32> {
 			/// Hi, this is a comment.
@@ -2117,12 +2071,9 @@ mod tests {
 			fn aux_4(_origin, _data: i32) -> DispatchResult { unreachable!() }
 			fn aux_5(_origin, _data: i32, #[compact] _data2: u32,) -> DispatchResult { unreachable!() }
 
-			#[weight = SimpleDispatchInfo::FixedNormal(7)]
-			fn on_initialize(n: T::BlockNumber,) { if n.into() == 42 { panic!("on_initialize") } }
-			#[weight = BlockWeight]
-			fn on_finalize(n: T::BlockNumber) { if n.into() == 42 { panic!("on_finalize") } }
-			#[weight = SimpleDispatchInfo::FixedOperational(69)]
-			fn on_runtime_upgrade() { }
+			fn on_initialize(n: T::BlockNumber,) -> Weight { if n.into() == 42 { panic!("on_initialize") } 7 }
+			fn on_finalize(n: T::BlockNumber,) { if n.into() == 42 { panic!("on_finalize") } }
+			fn on_runtime_upgrade() -> Weight { 10 }
 			fn offchain_worker() {}
 
 			#[weight = SimpleDispatchInfo::FixedOperational(5)]
@@ -2254,8 +2205,13 @@ mod tests {
 
 	#[test]
 	#[should_panic(expected = "on_initialize")]
-	fn on_initialize_should_work() {
+	fn on_initialize_should_work_1() {
 		<Module<TraitImpl> as OnInitialize<u32>>::on_initialize(42);
+	}
+
+	#[test]
+	fn on_initialize_should_work_2() {
+		assert_eq!(<Module<TraitImpl> as OnInitialize<u32>>::on_initialize(10), 7);
 	}
 
 	#[test]
@@ -2266,7 +2222,7 @@ mod tests {
 
 	#[test]
 	fn on_runtime_upgrade_should_work() {
-		<Module<TraitImpl> as OnRuntimeUpgrade>::on_runtime_upgrade();
+		assert_eq!(<Module<TraitImpl> as OnRuntimeUpgrade>::on_runtime_upgrade(), 10);
 	}
 
 	#[test]
@@ -2286,18 +2242,6 @@ mod tests {
 			Call::<TraitImpl>::aux_3().get_dispatch_info(),
 			DispatchInfo { weight: 3, class: DispatchClass::Normal, pays_fee: true },
 		);
-	}
-
-	#[test]
-	fn weight_for_block_hooks() {
-		// independent of block number
-		assert_eq!(<Test as WeighBlock<u32>>::on_initialize(0), 7);
-		assert_eq!(<Test as WeighBlock<u32>>::on_initialize(10), 7);
-		assert_eq!(<Test as WeighBlock<u32>>::on_initialize(100), 7);
-
-		// dependent
-		assert_eq!(<Test as WeighBlock<u32>>::on_finalize(2), 10);
-		assert_eq!(<Test as WeighBlock<u32>>::on_finalize(3), 0);
 	}
 
 	#[test]

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -397,6 +397,30 @@ macro_rules! decl_module {
 			`on_initialize` or `on_runtime_upgrade` instead"
 		);
 	};
+	// compile_error on_runtime_upgrade, without Weight deprecated
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{}
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!(
+			"`on_runtime_upgrade` must return Weight, signature has changed."
+		);
+	};
 	// compile_error on_runtime_upgrade, with Weight deprecated
 	(@normalize
 		$(#[$attr:meta])*
@@ -421,30 +445,6 @@ macro_rules! decl_module {
 		compile_error!(
 			"`on_runtime_upgrade` can't be given weight attribute anymore, weight must be returned \
 			by the function directly."
-		);
-	};
-	// compile_error on_runtime_upgrade, without Weight deprecated
-	(@normalize
-		$(#[$attr:meta])*
-		pub struct $mod_type:ident<
-			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
-		>
-		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-		{ $( $other_where_bounds:tt )* }
-		{ $( $deposit_event:tt )* }
-		{ $( $on_initialize:tt )* }
-		{}
-		{ $( $on_finalize:tt )* }
-		{ $( $offchain:tt )* }
-		{ $( $constants:tt )* }
-		{ $( $error_type:tt )* }
-		[ $( $dispatchables:tt )* ]
-		$(#[doc = $doc_attr:tt])*
-		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-		$($rest:tt)*
-	) => {
-		compile_error!(
-			"`on_runtime_upgrade` must return Weight, signature has changed."
 		);
 	};
 	// Add on_runtime_upgrade
@@ -485,6 +485,56 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
+	// compile_error on_initialize, without weight deprecated
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{}
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!(
+			"`on_initialize` must return Weight, signature has changed."
+		);
+	};
+	// compile_error on_initialize, with weight deprecated
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{}
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		#[weight = $weight:expr]
+		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!(
+			"`on_initialize` can't be given weight attribute anymore, weight must be returned \
+			by the function directly."
+		);
+	};
 	// Add on_initialize
 	(@normalize
 		$(#[$attr:meta])*
@@ -521,56 +571,6 @@ macro_rules! decl_module {
 			{ $( $error_type )* }
 			[ $( $dispatchables )* ]
 			$($rest)*
-		);
-	};
-	// compile_error on_initialize, with weight deprecated
-	(@normalize
-		$(#[$attr:meta])*
-		pub struct $mod_type:ident<
-			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
-		>
-		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-		{ $( $other_where_bounds:tt )* }
-		{ $( $deposit_event:tt )* }
-		{}
-		{ $( $on_runtime_upgrade:tt )* }
-		{ $( $on_finalize:tt )* }
-		{ $( $offchain:tt )* }
-		{ $( $constants:tt )* }
-		{ $( $error_type:tt )* }
-		[ $( $dispatchables:tt )* ]
-		$(#[doc = $doc_attr:tt])*
-		#[weight = $weight:expr]
-		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-		$($rest:tt)*
-	) => {
-		compile_error!(
-			"`on_initialize` can't be given weight attribute anymore, weight must be returned \
-			by the function directly."
-		);
-	};
-	// compile_error on_initialize, without weight deprecated
-	(@normalize
-		$(#[$attr:meta])*
-		pub struct $mod_type:ident<
-			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
-		>
-		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
-		{ $( $other_where_bounds:tt )* }
-		{ $( $deposit_event:tt )* }
-		{}
-		{ $( $on_runtime_upgrade:tt )* }
-		{ $( $on_finalize:tt )* }
-		{ $( $offchain:tt )* }
-		{ $( $constants:tt )* }
-		{ $( $error_type:tt )* }
-		[ $( $dispatchables:tt )* ]
-		$(#[doc = $doc_attr:tt])*
-		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
-		$($rest:tt)*
-	) => {
-		compile_error!(
-			"`on_initialize` must return Weight, signature has changed."
 		);
 	};
 	(@normalize

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1084,3 +1084,24 @@ impl OnRuntimeUpgrade for Tuple {
 	}
 }
 
+/// Off-chain computation trait.
+///
+/// Implementing this trait on a module allows you to perform long-running tasks
+/// that make (by default) validators generate transactions that feed results
+/// of those long-running computations back on chain.
+///
+/// NOTE: This function runs off-chain, so it can access the block state,
+/// but cannot preform any alterations. More specifically alterations are
+/// not forbidden, but they are not persisted in any way after the worker
+/// has finished.
+#[impl_for_tuples(30)]
+pub trait OffchainWorker<BlockNumber> {
+	/// This function is being called after every block import (when fully synced).
+	///
+	/// Implement this and use any of the `Offchain` `sp_io` set of APIs
+	/// to perform off-chain computations, calls and submit transactions
+	/// with results to trigger any on-chain changes.
+	/// Any state alterations are lost and are not persisted.
+	fn offchain_worker(_n: BlockNumber) {}
+}
+

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -37,9 +37,8 @@
 
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
-use impl_trait_for_tuples::impl_for_tuples;
 use codec::{Encode, Decode};
-use sp_arithmetic::traits::{Bounded, Zero};
+use sp_arithmetic::traits::Bounded;
 use sp_runtime::{
 	RuntimeDebug,
 	traits::SignedExtension,
@@ -67,50 +66,11 @@ pub trait ClassifyDispatch<T> {
 	fn classify_dispatch(&self, target: T) -> DispatchClass;
 }
 
-/// Means of determining the weight of a block's life cycle hooks: `on_initialize`, `on_finalize`,
-///  `on_runtime_upgrade`, and such.
-pub trait WeighBlock<BlockNumber> {
-	/// Return the weight of the block's on_runtime_upgrade hook.
-	fn on_runtime_upgrade() -> Weight { Zero::zero() }
-	/// Return the weight of the block's on_initialize hook.
-	fn on_initialize(_: BlockNumber) -> Weight { Zero::zero() }
-	/// Return the weight of the block's on_finalize hook.
-	fn on_finalize(_: BlockNumber) -> Weight { Zero::zero() }
-}
-
 /// Indicates if dispatch function should pay fees or not.
 /// If set to false, the block resource limits are applied, yet no fee is deducted.
 pub trait PaysFee<T> {
 	fn pays_fee(&self, _target: T) -> bool {
 		true
-	}
-}
-
-/// Maybe I can do something to remove the duplicate code here.
-#[impl_for_tuples(30)]
-impl<BlockNumber: Copy> WeighBlock<BlockNumber> for SingleModule {
-	fn on_runtime_upgrade() -> Weight {
-		let mut accumulated_weight: Weight = Zero::zero();
-		for_tuples!(
-			#( accumulated_weight = accumulated_weight.saturating_add(SingleModule::on_runtime_upgrade()); )*
-		);
-		accumulated_weight
-	}
-
-	fn on_initialize(n: BlockNumber) -> Weight {
-		let mut accumulated_weight: Weight = Zero::zero();
-		for_tuples!(
-			#( accumulated_weight = accumulated_weight.saturating_add(SingleModule::on_initialize(n)); )*
-		);
-		accumulated_weight
-	}
-
-	fn on_finalize(n: BlockNumber) -> Weight {
-		let mut accumulated_weight: Weight = Zero::zero();
-		for_tuples!(
-			#( accumulated_weight = accumulated_weight.saturating_add(SingleModule::on_finalize(n)); )*
-		);
-		accumulated_weight
 	}
 }
 

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -20,7 +20,7 @@ use super::*;
 
 use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account};
-use sp_runtime::traits::OnInitialize;
+use frame_support::traits::OnInitialize;
 
 use crate::Module as Treasury;
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -98,7 +98,7 @@ use frame_support::traits::{
 use sp_runtime::{Permill, ModuleId, Percent, RuntimeDebug, traits::{
 	Zero, EnsureOrigin, StaticLookup, AccountIdConversion, Saturating, Hash, BadOrigin
 }};
-use frame_support::{weights::SimpleDispatchInfo, traits::Contains};
+use frame_support::{weights::{Weight, WeighData, SimpleDispatchInfo}, traits::Contains};
 use codec::{Encode, Decode};
 use frame_system::{self as system, ensure_signed, ensure_root};
 
@@ -553,11 +553,13 @@ decl_module! {
 			Self::payout_tip(tip);
 		}
 
-		fn on_initialize(n: T::BlockNumber) {
+		fn on_initialize(n: T::BlockNumber) -> Weight {
 			// Check to see if we should spend some funds!
 			if (n % T::SpendPeriod::get()).is_zero() {
 				Self::spend_funds();
 			}
+
+			SimpleDispatchInfo::default().weigh_data(())
 		}
 	}
 }

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -1,12 +1,14 @@
 use super::*;
 
-use frame_support::{assert_noop, assert_ok, impl_outer_origin, parameter_types, weights::Weight};
-use frame_support::traits::Contains;
+use frame_support::{
+	assert_noop, assert_ok, impl_outer_origin, parameter_types, weights::Weight,
+	traits::{Contains, OnInitialize}
+};
 use sp_core::H256;
 use sp_runtime::{
 	Perbill,
 	testing::Header,
-	traits::{BlakeTwo256, OnInitialize, IdentityLookup, BadOrigin},
+	traits::{BlakeTwo256, IdentityLookup, BadOrigin},
 };
 
 impl_outer_origin! {

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -329,28 +329,6 @@ impl<T:
 	sp_std::ops::BitAnd<Self, Output = Self>
 > SimpleBitOps for T {}
 
-// TODO TODO: maybe move offchain worker as well
-/// Off-chain computation trait.
-///
-/// Implementing this trait on a module allows you to perform long-running tasks
-/// that make (by default) validators generate transactions that feed results
-/// of those long-running computations back on chain.
-///
-/// NOTE: This function runs off-chain, so it can access the block state,
-/// but cannot preform any alterations. More specifically alterations are
-/// not forbidden, but they are not persisted in any way after the worker
-/// has finished.
-#[impl_for_tuples(30)]
-pub trait OffchainWorker<BlockNumber> {
-	/// This function is being called after every block import (when fully synced).
-	///
-	/// Implement this and use any of the `Offchain` `sp_io` set of APIs
-	/// to perform off-chain computations, calls and submit transactions
-	/// with results to trigger any on-chain changes.
-	/// Any state alterations are lost and are not persisted.
-	fn offchain_worker(_n: BlockNumber) {}
-}
-
 /// Abstraction around hashing
 // Stupid bug in the Rust compiler believes derived
 // traits must be fulfilled by all type parameters.

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -329,30 +329,7 @@ impl<T:
 	sp_std::ops::BitAnd<Self, Output = Self>
 > SimpleBitOps for T {}
 
-/// The block finalization trait. Implementing this lets you express what should happen
-/// for your module when the block is ending.
-#[impl_for_tuples(30)]
-pub trait OnFinalize<BlockNumber> {
-	/// The block is being finalized. Implement to have something happen.
-	fn on_finalize(_n: BlockNumber) {}
-}
-
-/// The block initialization trait. Implementing this lets you express what should happen
-/// for your module when the block is beginning (right before the first extrinsic is executed).
-#[impl_for_tuples(30)]
-pub trait OnInitialize<BlockNumber> {
-	/// The block is being initialized. Implement to have something happen.
-	fn on_initialize(_n: BlockNumber) {}
-}
-
-/// The runtime upgrade trait. Implementing this lets you express what should happen
-/// when the runtime upgrades, and changes may need to occur to your module.
-#[impl_for_tuples(30)]
-pub trait OnRuntimeUpgrade {
-	/// Perform a module upgrade.
-	fn on_runtime_upgrade() {}
-}
-
+// TODO TODO: maybe move offchain worker as well
 /// Off-chain computation trait.
 ///
 /// Implementing this trait on a module allows you to perform long-running tasks


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/5372

done:
* OnInitialize, OnFinalize, OffchainWorker and OnRuntimeUpgrade trait in sp_runtime has been moved to frame__support
* OnInitiaize and OnRuntimeUpgrade now returns their respective weight needed for block
* the new signature for on_initialize in decl_module is `on_initialize(optional number) -> Weight {..}` making it mandatory to return a weight (as done in https://github.com/paritytech/substrate/pull/5357)
  same for on_runtime_upgrade
* old syntax for decl_module does show a meaningful error message.