### PR TITLE
Remove XX hash from contract API.

### DIFF
--- a/frame/contracts/COMPLEXITY.md
+++ b/frame/contracts/COMPLEXITY.md
@@ -480,7 +480,6 @@ This paragraph concerns the following supported built-in hash functions:
 - `SHA2` with 256-bit width
 - `KECCAK` with 256-bit width
 - `BLAKE2` with 128-bit and 256-bit widths
-- `TWOX` with 64-bit, 128-bit and 256-bit widths
 
 These functions compute a cryptographic hash on the given inputs and copy the
 resulting hash directly back into the sandboxed Wasm contract output buffer.

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -2747,9 +2747,6 @@ const CODE_CRYPTO_HASHES: &str = r#"
 	(import "env" "ext_hash_keccak_256" (func $ext_hash_keccak_256 (param i32 i32 i32)))
 	(import "env" "ext_hash_blake2_256" (func $ext_hash_blake2_256 (param i32 i32 i32)))
 	(import "env" "ext_hash_blake2_128" (func $ext_hash_blake2_128 (param i32 i32 i32)))
-	(import "env" "ext_hash_twox_256" (func $ext_hash_twox_256 (param i32 i32 i32)))
-	(import "env" "ext_hash_twox_128" (func $ext_hash_twox_128 (param i32 i32 i32)))
-	(import "env" "ext_hash_twox_64" (func $ext_hash_twox_64 (param i32 i32 i32)))
 
 	(import "env" "memory" (memory 1 1))
 
@@ -2760,9 +2757,6 @@ const CODE_CRYPTO_HASHES: &str = r#"
 		$ext_hash_keccak_256
 		$ext_hash_blake2_256
 		$ext_hash_blake2_128
-		$ext_hash_twox_256
-		$ext_hash_twox_128
-		$ext_hash_twox_64
 	)
 	(data (i32.const 1) "20202010201008") ;; Output sizes of the hashes in order in hex.
 
@@ -2793,9 +2787,6 @@ const CODE_CRYPTO_HASHES: &str = r#"
 	;; |     1 |    KECCAK |       256 |
 	;; |     2 |    BLAKE2 |       256 |
 	;; |     3 |    BLAKE2 |       128 |
-	;; |     4 |      TWOX |       256 |
-	;; |     5 |      TWOX |       128 |
-	;; |     6 |      TWOX |        64 |
 	;; ---------------------------------
 	(func (export "call") (result i32)
 		(local $chosen_hash_fn i32)
@@ -2860,9 +2851,6 @@ fn crypto_hashes() {
 			(dyn_hash_fn!(keccak_256), 32),
 			(dyn_hash_fn!(blake2_256), 32),
 			(dyn_hash_fn!(blake2_128), 16),
-			(dyn_hash_fn!(twox_256), 32),
-			(dyn_hash_fn!(twox_128), 16),
-			(dyn_hash_fn!(twox_64), 8),
 		];
 		// Test the given hash functions for the input: "_DEAD_BEEF"
 		for (n, (hash_fn, expected_size)) in test_cases.iter().enumerate() {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -30,9 +30,6 @@ use sp_io::hashing::{
 	keccak_256,
 	blake2_256,
 	blake2_128,
-	twox_256,
-	twox_128,
-	twox_64,
 	sha2_256,
 };
 
@@ -1117,78 +1114,6 @@ define_env!(Env, <E: Ext>,
 	//                 directly into this buffer.
 	ext_hash_blake2_128(ctx, input_ptr: u32, input_len: u32, output_ptr: u32) => {
 		compute_hash_on_intermediate_buffer(ctx, blake2_128, input_ptr, input_len, output_ptr)
-	},
-
-	// Computes the TWOX 256-bit hash on the given input buffer.
-	//
-	// Returns the result directly into the given output buffer.
-	//
-	// # Note
-	//
-	// - The `input` and `output` buffer may overlap.
-	// - The output buffer is expected to hold at least 32 bytes (256 bits).
-	// - It is the callers responsibility to provide an output buffer that
-	//   is large enough to hold the expected amount of bytes returned by the
-	//   chosen hash function.
-	//
-	// # Parameters
-	//
-	// - `input_ptr`: the pointer into the linear memory where the input
-	//                data is placed.
-	// - `input_len`: the length of the input data in bytes.
-	// - `output_ptr`: the pointer into the linear memory where the output
-	//                 data is placed. The function will write the result
-	//                 directly into this buffer.
-	ext_hash_twox_256(ctx, input_ptr: u32, input_len: u32, output_ptr: u32) => {
-		compute_hash_on_intermediate_buffer(ctx, twox_256, input_ptr, input_len, output_ptr)
-	},
-
-	// Computes the TWOX 128-bit hash on the given input buffer.
-	//
-	// Returns the result directly into the given output buffer.
-	//
-	// # Note
-	//
-	// - The `input` and `output` buffer may overlap.
-	// - The output buffer is expected to hold at least 16 bytes (128 bits).
-	// - It is the callers responsibility to provide an output buffer that
-	//   is large enough to hold the expected amount of bytes returned by the
-	//   chosen hash function.
-	//
-	// # Parameters
-	//
-	// - `input_ptr`: the pointer into the linear memory where the input
-	//                data is placed.
-	// - `input_len`: the length of the input data in bytes.
-	// - `output_ptr`: the pointer into the linear memory where the output
-	//                 data is placed. The function will write the result
-	//                 directly into this buffer.
-	ext_hash_twox_128(ctx, input_ptr: u32, input_len: u32, output_ptr: u32) => {
-		compute_hash_on_intermediate_buffer(ctx, twox_128, input_ptr, input_len, output_ptr)
-	},
-
-	// Computes the TWOX 64-bit hash on the given input buffer.
-	//
-	// Returns the result directly into the given output buffer.
-	//
-	// # Note
-	//
-	// - The `input` and `output` buffer may overlap.
-	// - The output buffer is expected to hold at least 8 bytes (64 bits).
-	// - It is the callers responsibility to provide an output buffer that
-	//   is large enough to hold the expected amount of bytes returned by the
-	//   chosen hash function.
-	//
-	// # Parameters
-	//
-	// - `input_ptr`: the pointer into the linear memory where the input
-	//                data is placed.
-	// - `input_len`: the length of the input data in bytes.
-	// - `output_ptr`: the pointer into the linear memory where the output
-	//                 data is placed. The function will write the result
-	//                 directly into this buffer.
-	ext_hash_twox_64(ctx, input_ptr: u32, input_len: u32, output_ptr: u32) => {
-		compute_hash_on_intermediate_buffer(ctx, twox_64, input_ptr, input_len, output_ptr)
 	},
 );
 


### PR DESCRIPTION
Two XX is an unsecure hash which is pretty fast. It is not clear how the contracts will use this and if there would be actual big differences with the crypto hashes.

So we just wipe this until we find good reasons to put it back.

Kudos to @Robbepop who spotted this.