### PR TITLE
Remove package aliases from node template

### DIFF
--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -27,8 +27,8 @@ sc-network = { version = "0.8.0-alpha.5", path = "../../../client/network" }
 sc-consensus-aura = { version = "0.8.0-alpha.5", path = "../../../client/consensus/aura" }
 sp-consensus-aura = { version = "0.8.0-alpha.5", path = "../../../primitives/consensus/aura" }
 sp-consensus = { version = "0.8.0-alpha.5", path = "../../../primitives/consensus/common" }
-grandpa = { version = "0.8.0-alpha.5", package = "sc-finality-grandpa", path = "../../../client/finality-grandpa" }
-grandpa-primitives = { version = "2.0.0-alpha.5", package = "sp-finality-grandpa", path = "../../../primitives/finality-grandpa" }
+sc-finality-grandpa = { version = "0.8.0-alpha.5", path = "../../../client/finality-grandpa" }
+sp-finality-grandpa = { version = "2.0.0-alpha.5", path = "../../../primitives/finality-grandpa" }
 sc-client = { version = "0.8.0-alpha.5", path = "../../../client/" }
 sc-client-api = { version = "2.0.0-alpha.5", path = "../../../client/api" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }

--- a/bin/node-template/node/src/chain_spec.rs
+++ b/bin/node-template/node/src/chain_spec.rs
@@ -4,7 +4,7 @@ use node_template_runtime::{
 	SudoConfig, SystemConfig, WASM_BINARY, Signature
 };
 use sp_consensus_aura::sr25519::{AuthorityId as AuraId};
-use grandpa_primitives::{AuthorityId as GrandpaId};
+use sp_finality_grandpa::{AuthorityId as GrandpaId};
 use sc_service;
 use sp_runtime::traits::{Verify, IdentifyAccount};
 

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -10,7 +10,7 @@ use sp_inherents::InherentDataProviders;
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sp_consensus_aura::sr25519::{AuthorityPair as AuraPair};
-use grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider, StorageAndProofProvider};
+use sc_finality_grandpa::{self, FinalityProofProvider as GrandpaFinalityProofProvider, StorageAndProofProvider};
 
 // Our native executor instance.
 native_executor_instance!(
@@ -44,7 +44,7 @@ macro_rules! new_full_start {
 					.ok_or_else(|| sc_service::Error::SelectChainRequired)?;
 
 				let (grandpa_block_import, grandpa_link) =
-					grandpa::block_import(client.clone(), &(client.clone() as Arc<_>), select_chain)?;
+					sc_finality_grandpa::block_import(client.clone(), &(client.clone() as Arc<_>), select_chain)?;
 
 				let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
 					grandpa_block_import.clone(), client.clone(),
@@ -135,7 +135,7 @@ pub fn new_full(config: Configuration)
 		None
 	};
 
-	let grandpa_config = grandpa::Config {
+	let grandpa_config = sc_finality_grandpa::Config {
 		// FIXME #1578 make this available through chainspec
 		gossip_duration: Duration::from_millis(333),
 		justification_period: 512,
@@ -153,13 +153,13 @@ pub fn new_full(config: Configuration)
 		// and vote data availability than the observer. The observer has not
 		// been tested extensively yet and having most nodes in a network run it
 		// could lead to finality stalls.
-		let grandpa_config = grandpa::GrandpaParams {
+		let grandpa_config = sc_finality_grandpa::GrandpaParams {
 			config: grandpa_config,
 			link: grandpa_link,
 			network: service.network(),
 			inherent_data_providers: inherent_data_providers.clone(),
 			telemetry_on_connect: Some(service.telemetry_on_connect_stream()),
-			voting_rule: grandpa::VotingRulesBuilder::default().build(),
+			voting_rule: sc_finality_grandpa::VotingRulesBuilder::default().build(),
 			prometheus_registry: service.prometheus_registry()
 		};
 
@@ -167,10 +167,10 @@ pub fn new_full(config: Configuration)
 		// if it fails we take down the service with it.
 		service.spawn_essential_task(
 			"grandpa-voter",
-			grandpa::run_grandpa_voter(grandpa_config)?
+			sc_finality_grandpa::run_grandpa_voter(grandpa_config)?
 		);
 	} else {
-		grandpa::setup_disabled_grandpa(
+		sc_finality_grandpa::setup_disabled_grandpa(
 			service.client(),
 			&inherent_data_providers,
 			service.network(),
@@ -204,7 +204,7 @@ pub fn new_light(config: Configuration)
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let grandpa_block_import = grandpa::light_block_import(
+			let grandpa_block_import = sc_finality_grandpa::light_block_import(
 				client.clone(),
 				backend,
 				&(client.clone() as Arc<_>),

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -17,9 +17,8 @@ default-features = false
 version = "2.0.0-alpha.5"
 path = "../../../../frame/support"
 
-[dependencies.system]
+[dependencies.frame-system]
 default-features = false
-package = 'frame-system'
 version = "2.0.0-alpha.5"
 path = "../../../../frame/system"
 [dev-dependencies.sp-core]
@@ -44,5 +43,5 @@ std = [
 	'codec/std',
 	'frame-support/std',
 	'safe-mix/std',
-	'system/std'
+	'frame-system/std'
 ]

--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -10,7 +10,7 @@
 /// https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs
 
 use frame_support::{decl_module, decl_storage, decl_event, decl_error, dispatch};
-use system::ensure_signed;
+use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
 mod mock;

--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -6,6 +6,7 @@ use frame_support::{impl_outer_origin, parameter_types, weights::Weight};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
 };
+use frame_system as system;
 
 impl_outer_origin! {
 	pub enum Origin for Test {}

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -483,5 +483,7 @@ mod tests {
 				2,
 			);
 		});
+
+		my_interface::say_hello_world("hey");
 	}
 }

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -456,13 +456,6 @@ mod tests {
 	use super::*;
 	use sp_runtime_interface::runtime_interface;
 
-	#[runtime_interface]
-	trait MyInterface {
-		fn say_hello_world(data: &str) {
-			println!("Hello world from: {}", data);
-		}
-	}
-
 	native_executor_instance!(
 		pub MyExecutor,
 		substrate_test_runtime::api::dispatch,

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -456,6 +456,13 @@ mod tests {
 	use super::*;
 	use sp_runtime_interface::runtime_interface;
 
+	#[runtime_interface]
+	trait MyInterface {
+		fn say_hello_world(data: &str) {
+			println!("Hello world from: {}", data);
+		}
+	}
+
 	native_executor_instance!(
 		pub MyExecutor,
 		substrate_test_runtime::api::dispatch,


### PR DESCRIPTION
A few months ago the majority of `Cargo.tmol` files throughout the Substrate code base were refactored to not alias crates. This PR cleans up a few that were missed in the node template.