### PR TITLE
Fix propagation in network

### DIFF
--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -651,9 +651,8 @@ where
 		self.pool.ready_transaction(hash)
 			.and_then(
 				// Only propagable transactions should be resolved for network service.
-				|tx| if tx.is_propagable() { Some(tx) } else { None }
+				|tx| if tx.is_propagable() { Some(tx.data.clone()) } else { None }
 			)
-			.map(|tx| tx.data().clone())
 	}
 }
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -648,7 +648,12 @@ where
 	}
 
 	fn transaction(&self, hash: &H) -> Option<B::Extrinsic> {
-		self.pool.ready_transaction(hash).map(|tx| tx.data().clone())
+		self.pool.ready_transaction(hash)
+			.and_then(
+				// Only propagable transactions should be resolved for network service.
+				|tx| if tx.is_propagable() { Some(tx) } else { None }
+			)
+			.map(|tx| tx.data().clone())
 	}
 }
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -651,7 +651,7 @@ where
 		self.pool.ready_transaction(hash)
 			.and_then(
 				// Only propagable transactions should be resolved for network service.
-				|tx| if tx.is_propagable() { Some(tx.data.clone()) } else { None }
+				|tx| if tx.is_propagable() { Some(tx.data().clone()) } else { None }
 			)
 	}
 }


### PR DESCRIPTION
Notification stream pops hashes for all transactions, and only propagable should be picked in network service. 