### PR TITLE
primitives: add missing cargo metadata to sp-arithmetic-fuzzer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ variables:
   ARCH:                            "x86_64"
   # FIXME set to release
   CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.10"
-  CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example pallet-example-* subkey chain-spec-builder"
+  CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example pallet-example-* subkey chain-spec-builder sp-arithmetic-fuzzer"
 
 
 .collect-artifacts:                &collect-artifacts

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -4,6 +4,10 @@ version = "2.0.0-alpha.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "Fuzzer for fixed point arithmetic primitives."
+documentation = "https://docs.rs/sp-arithmetic-fuzzer"
 
 [dependencies]
 sp-arithmetic = { version = "2.0.0-alpha.5", path = ".." }


### PR DESCRIPTION
After #5401 I noticed that CI failed on master (https://gitlab.parity.io/parity/substrate/-/jobs/432668), this PR adds the missing metadata.

Also, do we really want to get this particular crate published on crates.io?