### PR TITLE
Make AccountId32 hashable

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -553,7 +553,7 @@ pub trait Public: AsRef<[u8]> + AsMut<[u8]> + Default + Derive + CryptoType + Pa
 }
 
 /// An opaque 32-byte cryptographic identifier.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode)]
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode)]
 pub struct AccountId32([u8; 32]);
 
 impl UncheckedFrom<crate::hash::H256> for AccountId32 {

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -553,7 +553,8 @@ pub trait Public: AsRef<[u8]> + AsMut<[u8]> + Default + Derive + CryptoType + Pa
 }
 
 /// An opaque 32-byte cryptographic identifier.
-#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Hash))]
 pub struct AccountId32([u8; 32]);
 
 impl UncheckedFrom<crate::hash::H256> for AccountId32 {


### PR DESCRIPTION
I found myself wanting to use this as the key in a map (not in a runtime), and couldn't because it wasn't hashable. Didn't see any reason it shouldn't be.

Thanks!