### PR TITLE
Allow syncing to peers with finalized common block

### DIFF
--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -1108,10 +1108,12 @@ impl<B: BlockT> ChainSync<B> {
 		}
 		// If the announced block is the best they have and is not ahead of us, our common number
 		// is either one further ahead or it's the one they just announced, if we know about it.
-		if is_best && self.best_queued_number >= number {
-			if known {
+		if is_best {
+			if known && self.best_queued_number >= number {
 				peer.common_number = number
-			} else if header.parent_hash() == &self.best_queued_hash || known_parent {
+			} else if header.parent_hash() == &self.best_queued_hash
+				|| known_parent && self.best_queued_number >= number
+			{
 				peer.common_number = number - One::one();
 			}
 		}
@@ -1320,12 +1322,16 @@ fn peer_block_request<B: BlockT>(
 	finalized: NumberFor<B>,
 	best_num: NumberFor<B>,
 ) -> Option<(Range<NumberFor<B>>, BlockRequest<B>)> {
-	if peer.common_number < finalized {
-		return None;
-	}
 	if best_num >= peer.best_number {
 		// Will be downloaded as alternative fork instead.
 		return None;
+	}
+	if peer.common_number < finalized {
+		trace!(
+			target: "sync",
+			"Requesting pre-finalized chain from {:?}, common={}, finalized={}, peer best={}, our best={}",
+			id, finalized, peer.common_number, peer.best_number, best_num,
+		);
 	}
 	if let Some(range) = blocks.needed_blocks(
 		id.clone(),

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -694,3 +694,32 @@ fn imports_stale_once() {
 	assert_eq!(net.peer(1).num_processed_blocks(), 2);
 }
 
+#[test]
+fn can_sync_to_peers_with_wrong_common_block() {
+	let _ = ::env_logger::try_init();
+	let mut net = TestNet::new(2);
+
+	net.peer(0).push_blocks(2, true);
+	net.peer(1).push_blocks(2, true);
+	let fork_hash = net.peer(0).push_blocks_at(BlockId::Number(0), 2, false);
+	net.peer(1).push_blocks_at(BlockId::Number(0), 2, false);
+	// wait for connection
+	block_on(futures::future::poll_fn::<(), _>(|cx| {
+		net.poll(cx);
+		if net.peer(0).num_peers() == 0  || net.peer(1).num_peers() == 0 {
+			Poll::Pending
+		} else {
+			Poll::Ready(())
+		}
+	}));
+
+	// both peers re-org to the same fork without notifying each other
+	net.peer(0).client().finalize_block(BlockId::Hash(fork_hash), Some(Vec::new()), true).unwrap();
+	net.peer(1).client().finalize_block(BlockId::Hash(fork_hash), Some(Vec::new()), true).unwrap();
+	let final_hash = net.peer(0).push_blocks(1, false);
+
+	net.block_until_sync();
+
+	assert!(net.peer(1).client().header(&BlockId::Hash(final_hash)).unwrap().is_some());
+}
+


### PR DESCRIPTION
Root issue is this:
1. Our best block is N, all other peers have best block N'. Our common block with all other peers is N-1
2. We finalize N, all other peers also re-org to N and finalize it. At this point we assume all other peers are still on N' since the network protocol does not notify of re-orgs.
3. Since we now assume all peers are on a fork that we discarded after finalization we don't request anything from them.

Before #5277 it kinda worked because we'd update common block next time peers send us new block announcement. Relying on block announcements for this is still incorrect though. Reorgs that happen due to finalization don't produce any announcements. I believe this should be properly fixed by introducing a new network message that notifies of reorgs eventually.  For now I've removed the check for finalized chain when syncing. 

Fixes #5387