### PR TITLE
ci: check_polkadot: accept linking to polkadot pr

### DIFF
--- a/.maintain/gitlab/check_polkadot.sh
+++ b/.maintain/gitlab/check_polkadot.sh
@@ -50,7 +50,10 @@ then
   boldprint "this is pull request no ${CI_COMMIT_REF_NAME}"
   # get the last reference to a pr in polkadot
   comppr="$(curl -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME} \
-    | sed -n -r 's;^[[:space:]]+"body":[[:space:]]+".*polkadot companion: paritytech/polkadot#([0-9]+).*"[^"]+$;\1;p;$!d')"
+    | sed -n -r \
+      -e 's;^[[:space:]]+"body":[[:space:]]+".*polkadot companion: paritytech/polkadot#([0-9]+).*"[^"]+$;\1;p' \
+      -e 's;^[[:space:]]+"body":[[:space:]]+".*polkadot companion: https://github.com/paritytech/polkadot/pull/([0-9]+).*"[^"]+$;\1;p' \
+    | tail -n 1)"
   if [ "${comppr}" ]
   then
     boldprint "companion pr specified: #${comppr}"


### PR DESCRIPTION
fix for https://github.com/paritytech/substrate/pull/5262 to be able to use links in the reference of polkadot companions.

this is just for testing:
polkadot companion: https://github.com/paritytech/polkadot/pull/938