### PR TITLE
ci: check_polkadot: look for arbitrary link to polkadot pr eventually

### DIFF
--- a/.maintain/gitlab/check_polkadot.sh
+++ b/.maintain/gitlab/check_polkadot.sh
@@ -3,9 +3,11 @@
 # check if a pr is compatible with polkadot companion pr or master if not 
 # available
 #
-# mark companion pr in the body of the polkadot pr like
+# to override one that was just mentioned mark companion pr in the body of the 
+# polkadot pr like
 #
 # polkadot companion: paritytech/polkadot#567
+#
 
 
 github_api_substrate_pull_url="https://api.github.com/repos/paritytech/substrate/pulls"
@@ -29,7 +31,9 @@ polkadot companion: paritytech/polkadot#567
 
 
 it will then run cargo check from this polkadot's branch with substrate code 
-from this pull request.
+from this pull request. in absence of that string it will check if a polkadot 
+pr is mentioned and will use the last one instead. if none of the above can be 
+found it will check the build against polkadot:master.
 
 
 EOT
@@ -49,18 +53,27 @@ if expr match "${CI_COMMIT_REF_NAME}" '^[0-9]\+$' >/dev/null
 then
   boldprint "this is pull request no ${CI_COMMIT_REF_NAME}"
   # get the last reference to a pr in polkadot
-  comppr="$(curl -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME} \
-    | sed -n -r \
-      -e 's;^[[:space:]]+"body":[[:space:]]+".*polkadot companion: paritytech/polkadot#([0-9]+).*"[^"]+$;\1;p' \
-      -e 's;^[[:space:]]+"body":[[:space:]]+".*polkadot companion: https://github.com/paritytech/polkadot/pull/([0-9]+).*"[^"]+$;\1;p' \
+  pr_body="$(curl -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME} \
+    | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
+
+  pr_companion="$(echo "${pr_body}" | sed -n -r \
+      -e 's;^.*polkadot companion: paritytech/polkadot#([0-9]+).*$;\1;p' \
+      -e 's;^.*polkadot companion: https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
     | tail -n 1)"
-  if [ "${comppr}" ]
+  if [ -z "${pr_companion}" ]
   then
-    boldprint "companion pr specified: #${comppr}"
-    git fetch --depth 1 origin refs/pull/${comppr}/head:pr/${comppr}
-    git checkout pr/${comppr}
+    pr_companion="$(echo "${pr_body}" | sed -n -r \
+      's;^.*https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
+      | tail -n 1)"
+  fi
+
+  if [ "${pr_companion}" ]
+  then
+    boldprint "companion pr specified/detected: #${pr_companion}"
+    git fetch --depth 1 origin refs/pull/${pr_companion}/head:pr/${pr_companion}
+    git checkout pr/${pr_companion}
   else
-    boldprint "no companion pr declared - building polkadot:master"
+    boldprint "no companion pr found - building polkadot:master"
   fi
 else
   boldprint "this is not a pull request - building polkadot:master"


### PR DESCRIPTION
follow-up pr of https://github.com/paritytech/substrate/pull/5410

check for a reference to a polkadot pull request in the description of a pull request here if no explicit declaration can be found.

this pull request https://github.com/paritytech/polkadot/pull/916 is just set for testing.

this is for overwriting the pr mentioned in the description before:

polkadot companion: paritytech/polkadot#919