### PR TITLE
Fix staking tests false positive log error

### DIFF
--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -40,6 +40,8 @@ use crate::{
 	CompactAssignments, ValidatorIndex, NominatorIndex, Validators, OffchainAccuracy,
 };
 
+const INIT_TIMESTAMP: u64 = 30_000;
+
 /// The AccountId alias in this test module.
 pub(crate) type AccountId = u64;
 pub(crate) type AccountIndex = u64;
@@ -482,6 +484,14 @@ impl ExtBuilder {
 			let validators = Session::validators();
 			SESSION.with(|x| *x.borrow_mut() = (validators.clone(), HashSet::new()));
 		});
+
+		// We consider all test to start after timestamp is initialized
+		// This must be ensured by having `timestamp::on_initialize` called before
+		// `staking::on_initialize`
+		ext.execute_with(|| {
+			Timestamp::set_timestamp(INIT_TIMESTAMP);
+		});
+
 		ext
 	}
 }
@@ -593,7 +603,7 @@ pub fn start_session(session_index: SessionIndex) {
 	for i in Session::current_index()..session_index {
 		Staking::on_finalize(System::block_number());
 		System::set_block_number((i + 1).into());
-		Timestamp::set_timestamp(System::block_number() * 1000);
+		Timestamp::set_timestamp(System::block_number() * 1000 + INIT_TIMESTAMP);
 		Session::on_initialize(System::block_number());
 		Staking::on_initialize(System::block_number());
 	}

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -254,8 +254,6 @@ fn staking_should_work() {
 			// --- Block 1:
 			start_session(1);
 
-			Timestamp::set_timestamp(1); // Initialize time.
-
 			// remember + compare this along with the test.
 			assert_eq_uvec!(validator_controllers(), vec![20, 10]);
 
@@ -1039,7 +1037,6 @@ fn bond_extra_and_withdraw_unbonded_works() {
 		assert_ne!(Staking::eras_stakers(Staking::active_era().unwrap().index, 11), Exposure { total: 1000 + 100, own: 1000 + 100, others: vec![] });
 
 		// trigger next era.
-		Timestamp::set_timestamp(10);
 		start_era(2);
 		assert_eq!(Staking::active_era().unwrap().index, 2);
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -250,7 +250,7 @@ impl<T: Trait> UnixTime for Module<T> {
 		// now is duration since unix epoch in millisecond as documented in
 		// `sp_timestamp::InherentDataProvider`.
 		let now = Self::now();
-		sp_std::if_std! { 
+		sp_std::if_std! {
 			if now == T::Moment::zero() {
 				debug::error!(
 					"`pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0"


### PR DESCRIPTION
tests in staking were triggering the error:
```
[2020-03-26T15:55:16Z ERROR pallet_timestamp] `pallet_timestamp::UnixTime::now` is called at genesis, invalid value returned: 0
```

This is because in the test environment the timestamp was set at 0 as if the tests were happening at UNIX_EPOCH.

This PR fix this false positive.

Additionnal note: should we turn `frame_support::debug::error!` into a panic when compiled in debug mode? or should we make CI fail on those messages?
I don't know how to avoid having this happening again
