### PR TITLE
Make all `PerThing` types implement all trait methods on the type

### DIFF
--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{
 	weights::{Weight, SimpleDispatchInfo, WeighData},
 };
 use sp_timestamp::OnTimestampSet;
-use sp_runtime::{generic::DigestItem, ConsensusEngineId, Perbill, PerThing};
+use sp_runtime::{generic::DigestItem, ConsensusEngineId, Perbill};
 use sp_runtime::traits::{IsMember, SaturatedConversion, Saturating, Hash, One};
 use sp_staking::{
 	SessionIndex,

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -34,7 +34,7 @@ use sp_std::prelude::*;
 use codec::{self as codec, Encode, Decode};
 use frame_support::{decl_event, decl_storage, decl_module, decl_error, storage};
 use sp_runtime::{
-	DispatchResult, generic::{DigestItem, OpaqueDigestItemId}, traits::Zero, Perbill, PerThing,
+	DispatchResult, generic::{DigestItem, OpaqueDigestItemId}, traits::Zero, Perbill,
 };
 use sp_staking::{
 	SessionIndex,

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -81,7 +81,7 @@ use pallet_session::historical::IdentificationTuple;
 use sp_runtime::{
 	offchain::storage::StorageValueRef,
 	RuntimeDebug,
-	traits::{Convert, Member, Saturating, AtLeast32Bit}, Perbill, PerThing,
+	traits::{Convert, Member, Saturating, AtLeast32Bit}, Perbill,
 	transaction_validity::{
 		TransactionValidity, ValidTransaction, InvalidTransaction, TransactionSource,
 		TransactionPriority,

--- a/frame/staking/src/inflation.rs
+++ b/frame/staking/src/inflation.rs
@@ -19,7 +19,7 @@
 //! The staking rate in NPoS is the total amount of tokens staked by nominators and validators,
 //! divided by the total token supply.
 
-use sp_runtime::{Perbill, PerThing, traits::AtLeast32Bit, curve::PiecewiseLinear};
+use sp_runtime::{Perbill, traits::AtLeast32Bit, curve::PiecewiseLinear};
 
 /// The total payout to all validators (and their nominators) per era.
 ///

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -52,7 +52,7 @@ use super::{
 	EraIndex, Trait, Module, Store, BalanceOf, Exposure, Perbill, SessionInterface,
 	NegativeImbalanceOf, UnappliedSlash,
 };
-use sp_runtime::{traits::{Zero, Saturating}, PerThing, RuntimeDebug};
+use sp_runtime::{traits::{Zero, Saturating}, RuntimeDebug};
 use frame_support::{
 	StorageMap, StorageDoubleMap,
 	traits::{Currency, OnUnbalanced, Imbalance},

--- a/primitives/arithmetic/fuzzer/src/per_thing_rational.rs
+++ b/primitives/arithmetic/fuzzer/src/per_thing_rational.rs
@@ -24,8 +24,7 @@
 
 use honggfuzz::fuzz;
 use sp_arithmetic::{
-	PerThing, PerU16, Percent, Perbill, Perquintill, assert_eq_error_rate,
-	traits::SaturatedConversion,
+	PerThing, PerU16, Percent, Perbill, Perquintill, traits::SaturatedConversion,
 };
 
 fn main() {

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -19,9 +19,7 @@ use serde::{Serialize, Deserialize};
 
 use sp_std::{ops, fmt, prelude::*, convert::TryInto};
 use codec::{Encode, Decode, CompactAs};
-use crate::{
-	traits::{SaturatedConversion, UniqueSaturatedInto, Saturating, BaseArithmetic, Bounded},
-};
+use crate::traits::{SaturatedConversion, UniqueSaturatedInto, Saturating, BaseArithmetic, Bounded};
 use sp_debug_derive::RuntimeDebug;
 
 /// Something that implements a fixed point ration with an arbitrary granularity `X`, as _parts per
@@ -103,8 +101,8 @@ pub trait PerThing:
 	/// # }
 	/// ```
 	fn mul_collapse<N>(self, b: N) -> N
-	where N: Clone + From<Self::Inner> + UniqueSaturatedInto<Self::Inner> + ops::Rem<N, Output=N>
-		+ ops::Div<N, Output=N> + ops::Mul<N, Output=N> + ops::Add<N, Output=N>;
+		where N: Clone + From<Self::Inner> + UniqueSaturatedInto<Self::Inner> + ops::Rem<N, Output=N>
+			+ ops::Div<N, Output=N> + ops::Mul<N, Output=N> + ops::Add<N, Output=N>;
 }
 
 macro_rules! implement_per_thing {
@@ -259,12 +257,51 @@ macro_rules! implement_per_thing {
 				Self([x, 100][(x > 100) as usize] * ($max / 100))
 			}
 
-			/// Everything.
-			///
-			/// To avoid having to import `PerThing` when one needs to be used in test mocks.
-			#[cfg(feature = "std")]
+			/// See [`PerThing::one`].
 			pub fn one() -> Self {
 				<Self as PerThing>::one()
+			}
+
+			/// See [`PerThing::zero`].
+			pub fn zero() -> Self {
+				<Self as PerThing>::zero()
+			}
+
+			/// See [`PerThing::is_zero`].
+			pub fn is_zero(&self) -> bool {
+				PerThing::is_zero(self)
+			}
+
+			/// See [`PerThing::deconstruct`].
+			pub fn deconstruct(self) -> $type {
+				PerThing::deconstruct(self)
+			}
+
+			/// See [`PerThing::square`].
+			pub fn square(self) -> Self {
+				PerThing::square(self)
+			}
+
+			/// See [`PerThing::from_fraction`].
+			#[cfg(feature = "std")]
+			pub fn from_fraction(x: f64) -> Self {
+				<Self as PerThing>::from_fraction(x)
+			}
+
+			/// See [`PerThing::from_rational_approximation`].
+			pub fn from_rational_approximation<N>(p: N, q: N) -> Self
+				where N: Clone + Ord + From<$type> + TryInto<$type> +
+					TryInto<$upper_type> + ops::Div<N, Output=N> + ops::Rem<N, Output=N> +
+					ops::Add<N, Output=N> {
+				<Self as PerThing>::from_rational_approximation(p, q)
+			}
+
+			/// See [`PerThing::mul_collapse`].
+			pub fn mul_collapse<N>(self, b: N) -> N
+				where N: Clone + From<$type> + UniqueSaturatedInto<$type> +
+					ops::Rem<N, Output=N> + ops::Div<N, Output=N> + ops::Mul<N, Output=N> +
+					ops::Add<N, Output=N> {
+				PerThing::mul_collapse(self, b)
 			}
 		}
 

--- a/primitives/runtime/src/curve.rs
+++ b/primitives/runtime/src/curve.rs
@@ -16,7 +16,7 @@
 
 //! Provides some utilities to define a piecewise linear function.
 
-use crate::{Perbill, PerThing, traits::{AtLeast32Bit, SaturatedConversion}};
+use crate::{Perbill, traits::{AtLeast32Bit, SaturatedConversion}};
 use core::ops::Sub;
 
 /// Piecewise Linear function in [0, 1] -> [0, 1].


### PR DESCRIPTION
This removes the requirement to import `PerThing` to use a type that
implements the trait.

Fixes: https://github.com/paritytech/substrate/issues/5421