### PR TITLE
Provide easy conversions from common key types to `AccountId32`

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -618,7 +618,7 @@ impl From<AccountId32> for [u8; 32] {
 
 impl From<sr25519::Public> for AccountId32 {
 	fn from(k: sr25519::Public) -> Self {
-        k.0.into()
+		k.0.into()
 	}
 }
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -18,6 +18,7 @@
 //! Cryptographic utilities.
 // end::description[]
 
+use crate::{sr25519, ed25519};
 use sp_std::hash::Hash;
 use sp_std::vec::Vec;
 #[cfg(feature = "std")]
@@ -612,6 +613,18 @@ impl<'a> sp_std::convert::TryFrom<&'a [u8]> for AccountId32 {
 impl From<AccountId32> for [u8; 32] {
 	fn from(x: AccountId32) -> [u8; 32] {
 		x.0
+	}
+}
+
+impl From<sr25519::Public> for AccountId32 {
+	fn from(k: sr25519::Public) -> Self {
+        k.0.into()
+	}
+}
+
+impl From<ed25519::Public> for AccountId32 {
+	fn from(k: ed25519::Public) -> Self {
+		k.0.into()
 	}
 }
 


### PR DESCRIPTION
Forgive me if this is philosophically objectionable for some reason, if it is please enlighten me. After I made the change from old `AnySignature` to the new `MultiSignature` I found myself needing to do this in my rust client code quite a bit, and this change would avoid newtype wrappers or ugly `.0.into()` conversions.