### PR TITLE
Build for only one target for docs.rs

### DIFF
--- a/.maintain/node-template-release/Cargo.toml
+++ b/.maintain/node-template-release/Cargo.toml
@@ -16,3 +16,6 @@ git2 = "0.8"
 flate2 = "1.0"
 
 [workspace]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,3 +172,6 @@ members = [
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,3 @@ members = [
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -39,3 +39,6 @@ node-template-runtime = { version = "2.0.0-alpha.5", path = "../runtime" }
 [build-dependencies]
 vergen = "3.0.4"
 build-script-utils = { version = "2.0.0-alpha.5", package = "substrate-build-script-utils", path = "../../../utils/build-script-utils" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -45,3 +45,6 @@ std = [
 	'safe-mix/std',
 	'frame-system/std'
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -68,3 +68,6 @@ std = [
 	"transaction-payment/std",
 	"template/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -153,3 +153,6 @@ wasmtime = [
 	"sc-service/wasmtime",
 ]
 runtime-benchmarks = [ "node-runtime/runtime-benchmarks" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -52,3 +52,6 @@ stress-test = []
 [[bench]]
 name = "bench"
 harness = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -18,3 +18,6 @@ sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockch
 sp-core = { version = "2.0.0-alpha.5", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
 structopt = "0.3.8"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -21,3 +21,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -15,3 +15,6 @@ jsonrpc-core-client = { version = "14.0.3", features = ["http", "ws"] }
 log = "0.4.8"
 node-primitives = { version = "2.0.0-alpha.5", path = "../primitives" }
 sc-rpc = { version = "2.0.0-alpha.5", path = "../../../client/rpc" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -25,3 +25,6 @@ sc-keystore = { version = "2.0.0-alpha.5", path = "../../../client/keystore" }
 sc-consensus-epochs = { version = "0.8.0-alpha.5", path = "../../../client/consensus/epochs" }
 sp-consensus = { version = "0.8.0-alpha.5", path = "../../../primitives/consensus/common" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockchain" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -151,3 +151,6 @@ runtime-benchmarks = [
 	"pallet-im-online/runtime-benchmarks",
 	"pallet-democracy/runtime-benchmarks",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -56,3 +56,6 @@ sc-service = { version = "0.8.0-alpha.5", path = "../../../client/service", feat
 [[bench]]
 name = "import"
 harness = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/node/transaction-factory/Cargo.toml
+++ b/bin/node/transaction-factory/Cargo.toml
@@ -21,3 +21,6 @@ sp-api = { version = "2.0.0-alpha.5", path = "../../../primitives/api" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
 sc-service = { version = "0.8.0-alpha.5", default-features = false, path = "../../../client/service" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockchain" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -15,3 +15,6 @@ node-cli = { version = "2.0.0-alpha.5", path = "../../node/cli" }
 sp-core = { version = "2.0.0-alpha.5", path = "../../../primitives/core" }
 rand = "0.7.2"
 structopt = "0.3.8"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -34,3 +34,6 @@ serde_json = "1.0"
 
 [features]
 bench = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,3 +43,6 @@ tempfile = "3.1.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../test-utils/runtime/client" }
 kvdb-memorydb = "0.5.0"
 sp-panic-handler = { version = "2.0.0-alpha.5", path = "../primitives/panic-handler" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -39,3 +39,6 @@ sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/tran
 
 [dev-dependencies]
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -38,3 +38,6 @@ env_logger = "0.7.0"
 quickcheck = "0.9.0"
 sc-peerset = { version = "2.0.0-alpha.5", path = "../peerset" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client"}
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -29,3 +29,6 @@ futures-timer = "3.0.1"
 sc-transaction-pool = { version = "2.0.0-alpha.5", path = "../../client/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 parking_lot = "0.10.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -23,3 +23,6 @@ codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive
 [dev-dependencies]
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
 sp-trie = { version = "2.0.0-alpha.5", path = "../../primitives/trie" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -17,3 +17,6 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
 sc-telemetry = { version = "2.0.0-alpha.5", path = "../telemetry" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -18,3 +18,6 @@ quote = "1.0.3"
 syn = "1.0.7"
 
 [dev-dependencies]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -51,3 +51,6 @@ tempfile = "3.1.0"
 wasmtime = [
 	"sc-service/wasmtime",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -43,3 +43,6 @@ sc-service = { version = "0.8.0-alpha.5", path = "../../service" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -59,3 +59,6 @@ tempfile = "3.1.0"
 
 [features]
 test-helpers = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -30,3 +30,6 @@ substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../../tes
 sp-application-crypto = { version = "2.0.0-alpha.5", path = "../../../../primitives/application-crypto" }
 sp-keyring = { version = "2.0.0-alpha.5", path = "../../../../primitives/keyring" }
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/epochs/Cargo.toml
+++ b/client/consensus/epochs/Cargo.toml
@@ -15,3 +15,6 @@ fork-tree = { version = "2.0.0-alpha.5", path = "../../../utils/fork-tree" }
 sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-alpha.5"}
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockchain" }
 sc-client-api = { path = "../../api" , version = "2.0.0-alpha.5"}
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -35,3 +35,6 @@ substrate-test-runtime-transaction-pool = { path = "../../../test-utils/runtime/
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -23,3 +23,6 @@ log = "0.4.8"
 futures = { version = "0.3.1", features = ["compat"] }
 sp-timestamp = { version = "2.0.0-alpha.5", path = "../../../primitives/timestamp" }
 derive_more = "0.99.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -27,3 +27,6 @@ log = "0.4.8"
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/uncles/Cargo.toml
+++ b/client/consensus/uncles/Cargo.toml
@@ -16,3 +16,6 @@ sp-authorship = { version = "2.0.0-alpha.5", path = "../../../primitives/authors
 sp-consensus = { version = "0.8.0-alpha.5", path = "../../../primitives/consensus/common" }
 sp-inherents = { version = "2.0.0-alpha.5", path = "../../../primitives/inherents" }
 log = "0.4.8"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -43,3 +43,6 @@ tempfile = "3"
 [features]
 default = []
 test-helpers = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -52,3 +52,6 @@ wasmtime = [
 wasmi-errno = [
 	"wasmi/errno"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -22,3 +22,6 @@ sp-serializer = { version = "2.0.0-alpha.5", path = "../../../primitives/seriali
 
 [features]
 default = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -28,3 +28,6 @@ std = [
 	"sp-std/std",
 	"sp-allocator/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -19,3 +19,6 @@ sp-wasm-interface = { version = "2.0.0-alpha.5", path = "../../../primitives/was
 sp-runtime-interface = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-alpha.5", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-alpha.5", path = "../../../primitives/allocator" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -22,3 +22,6 @@ wasmtime = { package = "substrate-wasmtime", version = "0.13.0-threadsafe.1" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -52,3 +52,6 @@ env_logger = "0.7.0"
 tokio = { version = "0.2", features = ["rt-core"] }
 tempfile = "3.1.0"
 sp-api = { version = "2.0.0-alpha.5", path = "../../primitives/api" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -19,3 +19,6 @@ sc-network = { version = "0.8.0-alpha.5", path = "../network" }
 sc-service = { version = "0.8.0-alpha.5", default-features = false, path = "../service" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../primitives/blockchain" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -22,3 +22,6 @@ parking_lot = "0.10.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -22,3 +22,6 @@ wasm-timer = "0.2"
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -73,3 +73,6 @@ tempfile = "3.1.0"
 [features]
 default = []
 
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -29,3 +29,6 @@ env_logger = "0.7.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../../test-utils/runtime" }
 tempfile = "3.1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -42,3 +42,6 @@ tokio = "0.2"
 
 [features]
 default = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -19,3 +19,6 @@ wasm-timer = "0.2"
 
 [dev-dependencies]
 rand = "0.7.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -25,3 +25,6 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../primitives/transaction-pool" }
 sp-rpc = { version = "2.0.0-alpha.5", path = "../../primitives/rpc" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -19,3 +19,6 @@ sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 http = { package = "jsonrpc-http-server", version = "14.0.3" }
 ws = { package = "jsonrpc-ws-server", version = "14.0.3" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -42,3 +42,6 @@ sp-io = { version = "2.0.0-alpha.5", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"
 sc-transaction-pool = { version = "2.0.0-alpha.5", path = "../transaction-pool" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -66,3 +66,6 @@ substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-util
 sp-consensus-babe = { version = "0.8.0-alpha.5", path = "../../primitives/consensus/babe" }
 grandpa = { version = "0.8.0-alpha.5", package = "sc-finality-grandpa", path = "../finality-grandpa" }
 grandpa-primitives = { version = "2.0.0-alpha.5", package = "sp-finality-grandpa", path = "../../primitives/finality-grandpa" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -23,3 +23,6 @@ sc-client = { version = "0.8.0-alpha.5", path = "../../" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
 sp-core = { version = "2.0.0-alpha.5", path = "../../../primitives/core" }
 sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../../primitives/transaction-pool" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -19,3 +19,6 @@ parity-util-mem-derive = "0.1.0"
 
 [dev-dependencies]
 env_logger = "0.7.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -26,3 +26,6 @@ slog-json = { version = "2.3.0", features = ["nested-values"] }
 slog-scope = "4.1.2"
 take_mut = "0.2.2"
 void = "1.0.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -21,3 +21,6 @@ sc-telemetry = { version = "2.0.0-alpha.5", path = "../telemetry" }
 
 [dev-dependencies]
 tracing = "0.1.10"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -32,3 +32,6 @@ hex = "0.4"
 sp-keyring = { version = "2.0.0-alpha.5", path = "../../primitives/keyring" }
 substrate-test-runtime-transaction-pool = { version = "2.0.0-dev", path = "../../test-utils/runtime/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -31,3 +31,6 @@ criterion = "0.3"
 [[bench]]
 name = "basics"
 harness = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -46,3 +46,6 @@ std = [
 	"sp-timestamp/std",
 	"pallet-timestamp/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -39,3 +39,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -33,3 +33,6 @@ std = [
 	"sp-io/std",
 	"sp-authorship/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -45,3 +45,6 @@ std = [
 	"pallet-session/std",
 	"sp-io/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -35,3 +35,6 @@ std = [
 	"frame-system/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/benchmark/Cargo.toml
+++ b/frame/benchmark/Cargo.toml
@@ -31,3 +31,6 @@ std = [
 	"frame-benchmarking/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -30,3 +30,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -40,3 +40,6 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -48,3 +48,6 @@ std = [
 	"wasmi-validation/std",
 	"pallet-contracts-primitives/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -21,3 +21,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -24,3 +24,6 @@ pallet-contracts-rpc-runtime-api = { version = "0.8.0-alpha.5", path = "./runtim
 
 [dev-dependencies]
 serde_json = "1.0.41"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-runtime/std",
 	"pallet-contracts-primitives/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -41,3 +41,6 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -35,3 +35,6 @@ std = [
 	"sp-std/std",
 ]
 runtime-benchmarks = ["frame-support/runtime-benchmarks"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -34,3 +34,6 @@ std = [
 	"sp-runtime/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -42,3 +42,6 @@ std = [
 	"evm/std",
 	"pallet-timestamp/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -35,3 +35,6 @@ std = [
 	"sp-io/std",
 	"sp-std/std"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -35,3 +35,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/finality-tracker/Cargo.toml
+++ b/frame/finality-tracker/Cargo.toml
@@ -37,3 +37,6 @@ std = [
 	"sp-finality-tracker/std",
 	"sp-inherents/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/generic-asset/Cargo.toml
+++ b/frame/generic-asset/Cargo.toml
@@ -30,3 +30,6 @@ std =[
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -39,3 +39,6 @@ std = [
 	"pallet-session/std",
 	"pallet-finality-tracker/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -36,3 +36,6 @@ std = [
 	"frame-system/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -41,3 +41,6 @@ std = [
 	"frame-system/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -35,3 +35,6 @@ std = [
 	"sp-runtime/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -31,3 +31,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/metadata/Cargo.toml
+++ b/frame/metadata/Cargo.toml
@@ -22,3 +22,6 @@ std = [
 	"sp-core/std",
 	"serde",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -34,3 +34,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -30,3 +30,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -33,3 +33,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -40,3 +40,6 @@ std = [
 	"sp-trie/std",
 	"sp-io/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -26,3 +26,6 @@ std = [
 	"pallet-staking/std",
 	"pallet-session/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -38,3 +38,6 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -71,3 +71,6 @@ runtime-benchmarks = [
 	"rand_chacha",
 	"frame-benchmarking",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/staking/fuzz/Cargo.toml
+++ b/frame/staking/fuzz/Cargo.toml
@@ -33,3 +33,6 @@ members = ["."]
 [[bin]]
 name = "submit_solution"
 path = "fuzz_targets/submit_solution.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -19,3 +19,6 @@ proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -31,3 +31,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -50,3 +50,6 @@ std = [
 nightly = []
 strict = []
 runtime-benchmarks = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -16,3 +16,6 @@ frame-support-procedural-tools = { version = "2.0.0-alpha.5", path = "./tools" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
 syn = { version = "1.0.7", features = ["full"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro2 = "1.0.6"
 quote = "1.0.3"
 syn = { version = "1.0.7", features = ["full", "visit"] }
 proc-macro-crate = "0.1.4"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 proc-macro2 = "1.0.6"
 quote = { version = "1.0.3", features = ["proc-macro"] }
 syn = { version = "1.0.7", features = ["proc-macro" ,"full", "extra-traits", "parsing"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"sp-runtime/std",
 	"sp-state-machine",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -41,3 +41,6 @@ runtime-benchmarks = ["sp-runtime/runtime-benchmarks"]
 [[bench]]
 name = "bench"
 harness = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -18,3 +18,6 @@ std = [
 	"sp-api/std",
 	"codec/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -41,3 +41,6 @@ std = [
 	"sp-timestamp/std"
 ]
 runtime-benchmarks = ["frame-benchmarking", "sp-io"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -31,3 +31,6 @@ std = [
 	"frame-system/std",
 	"pallet-transaction-payment-rpc-runtime-api/std"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -20,3 +20,6 @@ sp-runtime = { version = "2.0.0-alpha.5", path = "../../../primitives/runtime" }
 sp-api = { version = "2.0.0-alpha.5", path = "../../../primitives/api" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../../primitives/blockchain" }
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-alpha.5", path = "./runtime-api" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -29,3 +29,6 @@ std = [
 	"sp-runtime/std",
 	"frame-support/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -38,3 +38,6 @@ runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -33,3 +33,6 @@ std = [
 	"sp-io/std",
 	"sp-std/std"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -37,3 +37,6 @@ std = [
 	"frame-system/std",
 ]
 runtime-benchmarks = ["frame-benchmarking"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -25,3 +25,6 @@ std = [
 	"log",
 	"derive_more",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"sp-version/std",
 	"hash-db",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -24,3 +24,6 @@ proc-macro-crate = "0.1.4"
 [features]
 default = [ "std" ]
 std = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -34,3 +34,6 @@ harness = false
 [features]
 default = [ "std" ]
 std = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -31,3 +31,6 @@ full_crypto = [
 	"sp-io/disable_panic_handler",
 	"sp-io/disable_oom",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -15,3 +15,6 @@ substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-u
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../runtime" }
 sp-api = { version = "2.0.0-alpha.5", path = "../../api" }
 sp-application-crypto = { version = "2.0.0-alpha.5", path = "../" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -36,3 +36,6 @@ std = [
 [[bench]]
 name = "bench"
 harness = false
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -27,3 +27,6 @@ path = "src/per_thing_rational.rs"
 [[bin]]
 name = "rational128"
 path = "src/rational128.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -22,3 +22,6 @@ std = [
 	"sp-inherents/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-api/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -20,3 +20,6 @@ sp-consensus = { version = "0.8.0-alpha.5", path = "../consensus/common" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../runtime" }
 sp-block-builder = { version = "2.0.0-alpha.5", path = "../block-builder" }
 sp-state-machine = { version = "0.8.0-alpha.5", path = "../state-machine" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -28,3 +28,6 @@ std = [
 	"sp-inherents/std",
 	"sp-timestamp/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -32,3 +32,6 @@ std = [
 	"sp-runtime/std",
 	"sp-timestamp/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -32,3 +32,6 @@ sp-test-primitives = { version = "2.0.0-dev", path = "../../test-primitives" }
 
 [features]
 default = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-core/std",
 	"codec/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-core/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -119,3 +119,6 @@ full_crypto = [
 	"libsecp256k1",
 	"sp-runtime-interface/disable_target_static_assertions",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -22,3 +22,6 @@ std = []
 
 [dev-dependencies]
 
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "https://docs.rs/sp-externalities"
 sp-storage = { version = "2.0.0-alpha.5", path = "../storage" }
 sp-std = { version = "2.0.0-alpha.5", path = "../std" }
 environmental = { version = "1.1.1" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -28,3 +28,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -20,3 +20,6 @@ std = [
 	"sp-std/std",
 	"sp-inherents/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -26,3 +26,6 @@ std = [
 	"sp-core/std",
 	"derive_more",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -46,3 +46,6 @@ std = [
 disable_panic_handler = []
 disable_oom = []
 disable_allocator = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -15,3 +15,6 @@ sp-core = { version = "2.0.0-alpha.5", path = "../core" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../runtime" }
 lazy_static = "1.4.0"
 strum = { version = "0.16.0", features = ["derive"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -18,3 +18,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std"
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/panic-handler/Cargo.toml
+++ b/primitives/panic-handler/Cargo.toml
@@ -12,3 +12,6 @@ documentation = "https://docs.rs/sp-panic-handler"
 [dependencies]
 backtrace = "0.3.38"
 log = "0.4.8"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/phragmen/Cargo.toml
+++ b/primitives/phragmen/Cargo.toml
@@ -29,3 +29,6 @@ std = [
 	"sp-std/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/phragmen/compact/Cargo.toml
+++ b/primitives/phragmen/compact/Cargo.toml
@@ -16,3 +16,6 @@ syn = { version = "1.0.7", features = ["full", "visit"] }
 quote = "1.0"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/phragmen/fuzzer/Cargo.toml
+++ b/primitives/phragmen/fuzzer/Cargo.toml
@@ -14,3 +14,6 @@ rand = "0.7.3"
 [[bin]]
 name = "reduce"
 path = "src/reduce.rs"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -14,3 +14,6 @@ sp-core = { version = "2.0.0-alpha.5", path = "../core" }
 
 [dev-dependencies]
 serde_json = "1.0.41"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -43,3 +43,6 @@ std = [
 # Disables static assertions in `impls.rs` that checks the word size. To prevent any footgun, the
 # check is changed into a runtime check.
 disable_target_static_assertions = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -18,3 +18,6 @@ quote = "1.0.3"
 proc-macro2 = "1.0.3"
 Inflector = "0.11.4"
 proc-macro-crate = "0.1.4"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -21,3 +21,6 @@ wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-run
 [features]
 default = [ "std" ]
 std = [ "sp-runtime-interface/std", "sp-std/std", "sp-core/std", "sp-io/std" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -21,3 +21,6 @@ wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-run
 [features]
 default = [ "std" ]
 std = [ "sp-runtime-interface/std", "sp-std/std", "sp-core/std", "sp-io/std" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -16,3 +16,6 @@ sp-runtime-interface-test-wasm-deprecated = { version = "2.0.0-dev", path = "../
 sp-state-machine = { version = "0.8.0-alpha.5", path = "../../../primitives/state-machine" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../runtime" }
 sp-io = { version = "2.0.0-alpha.5", path = "../../io" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -48,3 +48,6 @@ std = [
 	"parity-util-mem/std",
 	"hash256-std-hasher/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -31,3 +31,6 @@ std = [
 	"sp-wasm-interface/std",
 ]
 strict = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/serializer/Cargo.toml
+++ b/primitives/serializer/Cargo.toml
@@ -12,3 +12,6 @@ documentation = "https://docs.rs/sp-serializer"
 [dependencies]
 serde = "1.0.101"
 serde_json = "1.0.41"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -17,3 +17,6 @@ sp-runtime = { version = "2.0.0-alpha.5", optional = true, path = "../runtime" }
 [features]
 default = [ "std" ]
 std = [ "sp-api/std", "sp-std/std", "sp-runtime", "sp-core/std" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -20,3 +20,6 @@ std = [
 	"sp-runtime/std",
 	"sp-std/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -29,3 +29,6 @@ sp-runtime = { version = "2.0.0-alpha.5", path = "../runtime" }
 
 [features]
 default = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -13,3 +13,6 @@ documentation = "https://docs.rs/sp-std"
 [features]
 default = ["std"]
 std = []
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -18,3 +18,6 @@ sp-debug-derive = { version = "2.0.0-alpha.5", path = "../debug-derive" }
 [features]
 default = [ "std" ]
 std = [ "sp-std/std", "serde", "impl-serde" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -24,3 +24,6 @@ std = [
 	"sp-application-crypto/std",
 	"serde",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -26,3 +26,6 @@ std = [
 	"codec/std",
 	"sp-inherents/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -30,3 +30,6 @@ std = [
 	"sp-api/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -40,3 +40,6 @@ std = [
 	"trie-root/std",
 	"sp-core/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -26,3 +26,6 @@ std = [
 	"sp-std/std",
 	"sp-runtime/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -18,3 +18,6 @@ codec = { package = "parity-scale-codec", version = "1.2.0", default-features = 
 [features]
 default = [ "std" ]
 std = [ "wasmi", "sp-std/std", "codec/std" ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 license = "GPL-3.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -22,3 +22,6 @@ sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0-alpha.5", path = "../../primitives/runtime" }
 sp-blockchain = { version = "2.0.0-alpha.5", path = "../../primitives/blockchain" }
 sp-state-machine = { version = "0.8.0-alpha.5", path = "../../primitives/state-machine" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -87,3 +87,6 @@ std = [
 	"sp-transaction-pool/std",
 	"trie-db/std",
 ]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -20,3 +20,6 @@ codec = { package = "parity-scale-codec", version = "1.2.0" }
 sc-client-api = { version = "2.0.0-alpha.5", path = "../../../client/api" }
 sc-client = { version = "0.8.0-alpha.5", path = "../../../client/" }
 futures = "0.3.1"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/test-utils/runtime/transaction-pool/Cargo.toml
@@ -18,3 +18,6 @@ sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../../primitives/t
 sc-transaction-graph = { version = "2.0.0-alpha.5", path = "../../../client/transaction-pool/graph" }
 futures = { version = "0.3.1", features = ["compat"] }
 derive_more = "0.99.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -31,3 +31,6 @@ rand6 = { package = "rand", version = "0.6", features = ["wasm-bindgen"] }
 rand = { version = "0.7", features = ["wasm-bindgen"] }
 futures-timer = { version = "3.0.1", features = ["wasm-bindgen"]}
 chrono = { version = "0.4", features = ["wasmbind"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/build-script-utils/Cargo.toml
+++ b/utils/build-script-utils/Cargo.toml
@@ -9,3 +9,6 @@ repository = "https://github.com/paritytech/substrate/"
 description = "Crate with utility functions for `build.rs` scripts."
 
 [dependencies]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -11,3 +11,6 @@ documentation = "https://docs.rs/fork-tree"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.2.0", features = ["derive"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -25,3 +25,6 @@ codec = { version = "1.2.0", package = "parity-scale-codec" }
 [features]
 default = ["rocksdb"]
 rocksdb = ["sc-client-db/kvdb-rocksdb"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -21,3 +21,6 @@ sc-rpc-api = { version = "0.8.0-alpha.5", path = "../../../../client/rpc-api" }
 [dev-dependencies]
 frame-system = { version = "2.0.0-alpha.5", path = "../../../../frame/system" }
 tokio = "0.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -28,3 +28,6 @@ sp-transaction-pool = { version = "2.0.0-alpha.5", path = "../../../../primitive
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 sc-transaction-pool = { version = "2.0.0-alpha.5", path = "../../../../client/transaction-pool" }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -18,3 +18,6 @@ derive_more = "0.99"
 async-std = { version = "1.0.1", features = ["unstable"] }
 hyper = { version = "0.13.1", default-features = false, features = ["stream"] }
 tokio = "0.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/wasm-builder-runner/Cargo.toml
+++ b/utils/wasm-builder-runner/Cargo.toml
@@ -10,3 +10,6 @@ license = "GPL-3.0"
 homepage = "https://substrate.dev"
 
 [dependencies]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -19,3 +19,6 @@ fs2 = "0.4.3"
 wasm-gc-api = "0.1.11"
 atty = "0.2.13"
 itertools = "0.8.2"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
This PR specifies that we wish to only build for one target for docs.rs.
This will drastically reduce build time for docs.rs.

Closes #5378 