### PR TITLE
ci: check_polkadot: check for companion

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -63,7 +63,8 @@ then
   if [ -z "${pr_companion}" ]
   then
     pr_companion="$(echo "${pr_body}" | sed -n -r \
-      's;^.*https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
+      -e 's;^.*paritytech/polkadot/#([0-9]+).*$;\1;p' \
+      -e 's;^.*https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
       | tail -n 1)"
   fi
 


### PR DESCRIPTION
check for arbitrary `paritytech/polkadot#123` like strings as well