### PR TITLE
Remove DiscoveryNetBehaviour trait

### DIFF
--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -15,7 +15,7 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-	debug_info, discovery::DiscoveryBehaviour, discovery::DiscoveryOut, DiscoveryNetBehaviour,
+	debug_info, discovery::DiscoveryBehaviour, discovery::DiscoveryOut,
 	Event, protocol::event::DhtEvent, ExHashT,
 };
 use crate::protocol::{self, light_client_handler, CustomMessageOutcome, Protocol};

--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -247,14 +247,3 @@ pub use libp2p::{Multiaddr, PeerId};
 pub use libp2p::multiaddr;
 
 pub use sc_peerset::ReputationChange;
-
-/// Extension trait for `NetworkBehaviour` that also accepts discovering nodes.
-trait DiscoveryNetBehaviour {
-	/// Notify the protocol that we have learned about the existence of nodes.
-	///
-	/// Can (or most likely will) be called multiple times with the same `PeerId`s.
-	///
-	/// Also note that there is no notification for expired nodes. The implementer must add a TTL
-	/// system, or remove nodes that will fail to reach.
-	fn add_discovered_nodes(&mut self, nodes: impl Iterator<Item = PeerId>);
-}

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{DiscoveryNetBehaviour, config::ProtocolId};
+use crate::config::ProtocolId;
 use crate::utils::interval;
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
@@ -1537,6 +1537,13 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		self.sync.request_finality_proof(&hash, number)
 	}
 
+	/// Notify the protocol that we have learned about the existence of nodes.
+	///
+	/// Can be called multiple times with the same `PeerId`s.
+	pub fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
+		self.behaviour.add_discovered_nodes(peer_ids)
+	}
+
 	pub fn finality_proof_import_result(
 		&mut self,
 		request_block: (B::Hash, NumberFor<B>),
@@ -2116,12 +2123,6 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 
 	fn inject_listener_closed(&mut self, id: ListenerId) {
 		self.behaviour.inject_listener_closed(id);
-	}
-}
-
-impl<B: BlockT, H: ExHashT> DiscoveryNetBehaviour for Protocol<B, H> {
-	fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
-		self.behaviour.add_discovered_nodes(peer_ids)
 	}
 }
 

--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{DiscoveryNetBehaviour, config::ProtocolId};
+use crate::config::ProtocolId;
 use crate::protocol::message::generic::{Message as GenericMessage, ConsensusMessage};
 use crate::protocol::generic_proto::handler::{NotifsHandlerProto, NotifsHandlerOut, NotifsHandlerIn};
 use crate::protocol::generic_proto::upgrade::RegisteredProtocol;
@@ -399,6 +399,16 @@ impl GenericProto {
 		}
 	}
 
+	/// Notify the behaviour that we have learned about the existence of nodes.
+	///
+	/// Can be called multiple times with the same `PeerId`s.
+	pub fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
+		self.peerset.discovered(peer_ids.into_iter().map(|peer_id| {
+			debug!(target: "sub-libp2p", "PSM <= Discovered({:?})", peer_id);
+			peer_id
+		}));
+	}
+
 	/// Sends a notification to a peer.
 	///
 	/// Has no effect if the custom protocol is not open with the given peer.
@@ -698,15 +708,6 @@ impl GenericProto {
 			event: NotifsHandlerIn::Disable,
 		});
 		*state = PeerState::Disabled { open: false, connected_point, banned_until: None };
-	}
-}
-
-impl DiscoveryNetBehaviour for GenericProto {
-	fn add_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
-		self.peerset.discovered(peer_ids.into_iter().map(|peer_id| {
-			debug!(target: "sub-libp2p", "PSM <= Discovered({:?})", peer_id);
-			peer_id
-		}));
 	}
 }
 


### PR DESCRIPTION
Small clean up.

Removes the `DiscoveryNetBehaviour` trait and turns its method into a regular method. The trait is entirely internal to the network crate, so this is not a breaking change.

This trait was an earlier attempt at a first step to make the behaviour configurable, which we've given up for now considering the stability requirements of Substrate.
