### PR TITLE
Hide metadata function for in decl_event, and add doc for GenesisConfig

### DIFF
--- a/frame/support/procedural/src/storage/genesis_config/mod.rs
+++ b/frame/support/procedural/src/storage/genesis_config/mod.rs
@@ -66,6 +66,7 @@ fn decl_genesis_config_and_impl_default(
 	let genesis_where_clause = &genesis_config.genesis_where_clause;
 
 	quote!(
+		/// Genesis config for the module, allow to build genesis storage.
 		#[derive(#scrate::Serialize, #scrate::Deserialize)]
 		#[cfg(feature = "std")]
 		#[serde(rename_all = "camelCase")]
@@ -138,6 +139,7 @@ fn impl_build_storage(
 	quote!{
 		#[cfg(feature = "std")]
 		impl#genesis_impl GenesisConfig#genesis_struct #genesis_where_clause {
+			/// Build the storage for this module.
 			pub fn build_storage #fn_generic (&self) -> std::result::Result<
 				#scrate::sp_runtime::Storage,
 				String

--- a/frame/support/src/event.rs
+++ b/frame/support/src/event.rs
@@ -288,6 +288,7 @@ macro_rules! __decl_generic_event {
 		}
 		impl<$( $generic_param ),* $(, $instance)?> RawEvent<$( $generic_param ),* $(, $instance)?> {
 			#[allow(dead_code)]
+			#[doc(hidden)]
 			pub fn metadata() -> &'static [$crate::event::EventMetadata] {
 				$crate::__events_to_metadata!(; $( $events )* )
 			}


### PR DESCRIPTION
in the expansion of generic event we forgot to hide the function metadata from the doc,
but we do in the expansion of non generic event.

in the expansion of decl_storage GenesisConfig struct and one of its function doesn't have doc.

This fix it.