### PR TITLE
Move fast benchmarks macro into `frame_benchmarking`

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -872,7 +872,6 @@ impl_runtime_apis! {
 			use pallet_session_benchmarking::Module as SessionBench;
 			impl pallet_session_benchmarking::Trait for Runtime {}
 
-
 			let mut batches = Vec::<BenchmarkBatch>::new();
 			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat);
 			add_benchmark!(params, batches, b"balances", Balances);

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -884,6 +884,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, b"vesting", Vesting);
 			add_benchmark!(params, batches, b"democracy", Democracy);
 			add_benchmark!(params, batches, b"collective", Council);
+			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)
 		}
 	}

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -694,3 +694,65 @@ macro_rules! impl_benchmark {
 		}
 	}
 }
+
+
+/// This macro adds pallet benchmarks to a `Vec<BenchmarkBatch>` object.
+///
+/// First create an object that holds in the input parameters for the benchmark:
+///
+/// ```ignore
+/// let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat);
+/// ```
+///
+/// Then define a mutable local variable to hold your `BenchmarkBatch` object:
+///
+/// ```ignore
+/// let mut batches = Vec::<BenchmarkBatch>::new();
+/// ````
+///
+/// Then add the pallets you want to benchmark to this object, including the string
+/// you want to use target a particular pallet:
+///
+/// ```ignore
+/// pallet!(batches, b"balances", Balances);
+/// pallet!(batches, b"identity", Identity);
+/// pallet!(batches, b"session", SessionBench::<Runtime>);
+/// ...
+/// ```
+///
+/// At the end of `dispatch_benchmark`, you should return this batches object.
+#[macro_export]
+macro_rules! add_benchmark {
+	( $params:ident, $batches:ident, $name:literal, $( $location:tt )* ) => (
+		let (pallet, benchmark, lowest_range_values, highest_range_values, steps, repeat) = $params;
+		if &pallet[..] == &$name[..] || &pallet[..] == &b"*"[..] {
+			if &pallet[..] == &b"*"[..] || &benchmark[..] == &b"*"[..] {
+				for benchmark in $( $location )*::benchmarks().into_iter() {
+					$batches.push($crate::BenchmarkBatch {
+						results: $( $location )*::run_benchmark(
+							benchmark,
+							&lowest_range_values[..],
+							&highest_range_values[..],
+							&steps[..],
+							repeat,
+						)?,
+						pallet: pallet.to_vec(),
+						benchmark: benchmark.to_vec(),
+					});
+				}
+			} else {
+				$batches.push($crate::BenchmarkBatch {
+					results: $( $location )*::run_benchmark(
+						&benchmark[..],
+						&lowest_range_values[..],
+						&highest_range_values[..],
+						&steps[..],
+						repeat,
+					)?,
+					pallet: pallet.to_vec(),
+					benchmark: benchmark.clone(),
+				});
+			}
+		}
+	)
+}

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -714,9 +714,9 @@ macro_rules! impl_benchmark {
 /// you want to use target a particular pallet:
 ///
 /// ```ignore
-/// pallet!(batches, b"balances", Balances);
-/// pallet!(batches, b"identity", Identity);
-/// pallet!(batches, b"session", SessionBench::<Runtime>);
+/// add_benchmark!(params, batches, b"balances", Balances);
+/// add_benchmark!(params, batches, b"identity", Identity);
+/// add_benchmark!(params, batches, b"session", SessionBench::<Runtime>);
 /// ...
 /// ```
 ///


### PR DESCRIPTION
This iterates on https://github.com/paritytech/substrate/pull/5436.

* Moves the macro to `frame_benchmarking`
* Updates the name from `pallet!` to `add_benchmark!`
* Update the syntax and construction of the macro just a little bit to pass the non-local variables to the rust macro.
    > Its a little bit nasty, but imo not that bad.
* Adds some docs.