### PR TITLE
Add method to `sc-cli` to reset the `SIGPIPE` signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5822,6 +5822,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "names",
+ "nix",
  "parity-util-mem",
  "regex",
  "rpassword",

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -25,6 +25,8 @@ where
 	I: Iterator<Item = T>,
 	T: Into<std::ffi::OsString> + Clone,
 {
+	sc_cli::reset_signal_pipe_handler()?;
+
 	let args: Vec<_> = args.collect();
 	let opt = sc_cli::from_iter::<Cli, _>(args.clone(), &version);
 

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -44,6 +44,9 @@ parity-util-mem = { version = "0.6.0", default-features = false, features = ["pr
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 rpassword = "4.0.1"
 
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = "0.17.0"
+
 [dev-dependencies]
 tempfile = "3.1.0"
 

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -221,3 +221,21 @@ fn kill_color(s: &str) -> String {
 	}
 	RE.replace_all(s, "").to_string()
 }
+
+/// Reset the signal pipe (`SIGPIPE`) handler to the default one provided by the system.
+/// This will end the program on `SIGPIPE` instead of panicking.
+///
+/// This should be called before calling any cli method or printing any output.
+pub fn reset_signal_pipe_handler() -> Result<()> {
+	#[cfg(target_family = "unix")]
+	{
+		use nix::sys::signal;
+
+		unsafe {
+			signal::signal(signal::Signal::SIGPIPE, signal::SigHandler::SigDfl)
+				.map_err(|e| Error::Other(e.to_string()))?;
+		}
+	}
+
+	Ok(())
+}


### PR DESCRIPTION
The signal handler will be reset to the default system one. This means
the program will be exited instead of panicking. This is required to
support piping in the console.

Fixes: https://github.com/paritytech/substrate/issues/4248