### PR TITLE
GitHub Actions for build and test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,61 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Add wasm toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+    - name: Checkout master
+      uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ubuntu-18.04-substrate
+        path: target/release/substrate
+  
+  test-bins:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Add wasm toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+    - name: Checkout master
+      uses: actions/checkout@v2
+    - name: Tests
+      run: cargo test --bins
+
+#  test-lib:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - name: Add wasm toolchain
+#      uses: actions-rs/toolchain@v1
+#      with:
+#        toolchain: nightly
+#        target: wasm32-unknown-unknown
+#        override: true
+#    - name: Checkout master
+#      uses: actions/checkout@v2
+#    - name: Tests
+#      run: cargo test --lib


### PR DESCRIPTION
Automated build and test on Ubuntu 18.04 at every push and PR via GitHub Actions. The built artifact (i.e., the binary substrate exec file) is uploaded to GitHub Actions after each run. Since GitHub runners only have 14GB disk space, we are not able to run the entire test suite. We run test --bins instead.

See an example: https://github.com/second-state/substrate/actions/runs/66111620

✄ -----------------------------------------------------------------------------
