### PR TITLE
Fix Collective <-> Elections initialization.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,15 +178,16 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ad62275a8bda1c2c9a9303aea121eb04204272d3be0735d5dc1f49eb9ff9a9"
+checksum = "936fcf2c692b37c696cd0002c57752b2d9478402450c9ca4a463f6afae16d6f5"
 dependencies = [
  "doc-comment",
  "escargot",
  "predicates",
  "predicates-core",
  "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1054,9 +1055,9 @@ checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
 
 [[package]]
 name = "derive_more"
-version = "0.99.3"
+version = "0.99.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806e96c59a76a5ba6e18735b6cf833344671e61e7863f2edb5c518ea2cac95c"
+checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1188,18 +1189,18 @@ checksum = "516aa8d7a71cb00a1c4146f0798549b93d083d4f189b3ced8f3de6b8f11ee6c4"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d80305c9bd8cd78e3c753eb9fb110f83621e5211f1a3afffcc812b104daf9"
+checksum = "d88b6d1705e16a4d62e05ea61cc0496c2bd190f4fa8e5c1f11ce747be6bcf3d1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -2028,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 dependencies = [
  "libc",
 ]
@@ -3342,9 +3343,9 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multimap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
@@ -4860,9 +4861,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8292c1e1e81ddb552c4c90c36af201a0ce7e34995f55f0480f01052f242811c9"
+checksum = "092d791bf7847f70bbd49085489fba25fc2c193571752bff9e36e74e72403932"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -4870,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9c43f2645f06ee452544ad032886a75f3d1797b9487dcadcae9100ba58a51c"
+checksum = "406c23fb4c45cc6f68a9bbabb8ec7bd6f8cfcbd17e9e8f72c2460282f8325729"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -5160,9 +5161,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1b4a8efc42cf150049e8a490f618c7c60e82332405065f202a7e33aa5a1f06"
+checksum = "71964f34fd51cf04882d7ae3325fa0794d4cad66a03d0003f38d8ae4f63ba126"
 
 [[package]]
 name = "pwasm-utils"
@@ -5530,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.11"
+version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
+checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
 dependencies = [
  "cc",
  "lazy_static",
@@ -6877,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 dependencies = [
  "itoa",
  "ryu",
@@ -8227,18 +8228,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
+checksum = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
+checksum = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8276,9 +8277,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e255ec4f7d4aaccbede17dffcfb2e71434d17f5c921d5a06823b8e58a2bcd468"
+checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
  "hmac",
@@ -8936,6 +8937,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9159,18 +9169,18 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4d67ba9266f4fcaf2e8a1afadc5e2a959e51aecc07b1ecbdf85a6ddaf08bde"
+checksum = "0615ba420811bcda39cf80e8a1bd75997aec09222bda35165920a07ef15cc695"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9400dc1c8512087b2d974b1b9b0a6c4e6e26e7e8acf629e3e351165a1ed301"
+checksum = "095f615fbfcae695e3a4cea7d9f02f70561c81274c0142f45a12bf1e154d08bd"
 dependencies = [
  "wast",
 ]

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -278,13 +278,7 @@ pub fn testnet_genesis(
 						.map(|member| (member, STASH))
 						.collect(),
 		}),
-		pallet_collective_Instance1: Some(CouncilConfig {
-			members: endowed_accounts.iter()
-						.take((num_endowed_accounts + 1) / 2)
-						.cloned()
-						.collect(),
-			phantom: Default::default(),
-		}),
+		pallet_collective_Instance1: Some(CouncilConfig::default()),
 		pallet_collective_Instance2: Some(TechnicalCommitteeConfig {
 			members: endowed_accounts.iter()
 						.take((num_endowed_accounts + 1) / 2)

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -22,7 +22,7 @@ use serde::{Serialize, Deserialize};
 use node_runtime::{
 	AuthorityDiscoveryConfig, BabeConfig, BalancesConfig, ContractsConfig, CouncilConfig,
 	DemocracyConfig,GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus,
-	StakingConfig, ElectionsPhragmenConfig, IndicesConfig, SocietyConfig, SudoConfig, SystemConfig,
+	StakingConfig, ElectionsConfig, IndicesConfig, SocietyConfig, SudoConfig, SystemConfig,
 	TechnicalCommitteeConfig, WASM_BINARY,
 };
 use node_runtime::Block;
@@ -271,14 +271,13 @@ pub fn testnet_genesis(
 			.. Default::default()
 		}),
 		pallet_democracy: Some(DemocracyConfig::default()),
-		pallet_elections_phragmen: Some(ElectionsPhragmenConfig {
+		pallet_elections_phragmen: Some(ElectionsConfig {
 			members: endowed_accounts.iter()
 						.take((num_endowed_accounts + 1) / 2)
-						.cloned().
+						.cloned()
 						.map(|member| (member, STASH))
 						.collect(),
-			phantom: Default::default(),
-		})
+		}),
 		pallet_collective_Instance1: Some(CouncilConfig {
 			members: endowed_accounts.iter()
 						.take((num_endowed_accounts + 1) / 2)

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -20,9 +20,10 @@ use sc_chain_spec::ChainSpecExtension;
 use sp_core::{Pair, Public, crypto::UncheckedInto, sr25519};
 use serde::{Serialize, Deserialize};
 use node_runtime::{
-	AuthorityDiscoveryConfig, BabeConfig, BalancesConfig, ContractsConfig, CouncilConfig, DemocracyConfig,
-	GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus, StakingConfig,
-	IndicesConfig, SocietyConfig, SudoConfig, SystemConfig, TechnicalCommitteeConfig, WASM_BINARY,
+	AuthorityDiscoveryConfig, BabeConfig, BalancesConfig, ContractsConfig, CouncilConfig,
+	DemocracyConfig,GrandpaConfig, ImOnlineConfig, SessionConfig, SessionKeys, StakerStatus,
+	StakingConfig, ElectionsPhragmenConfig, IndicesConfig, SocietyConfig, SudoConfig, SystemConfig,
+	TechnicalCommitteeConfig, WASM_BINARY,
 };
 use node_runtime::Block;
 use node_runtime::constants::currency::*;
@@ -270,6 +271,14 @@ pub fn testnet_genesis(
 			.. Default::default()
 		}),
 		pallet_democracy: Some(DemocracyConfig::default()),
+		pallet_elections_phragmen: Some(ElectionsPhragmenConfig {
+			members: endowed_accounts.iter()
+						.take((num_endowed_accounts + 1) / 2)
+						.cloned().
+						.map(|member| (member, STASH))
+						.collect(),
+			phantom: Default::default(),
+		})
 		pallet_collective_Instance1: Some(CouncilConfig {
 			members: endowed_accounts.iter()
 						.take((num_endowed_accounts + 1) / 2)

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -418,6 +418,9 @@ impl pallet_elections_phragmen::Trait for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type ChangeMembers = Council;
+	// NOTE: this implies that council's genesis members cannot be set directly and must come from
+	// this module.
+	type InitializeMembers = Council;
 	type CurrencyToVote = CurrencyToVoteHandler;
 	type CandidacyBond = CandidacyBond;
 	type VotingBond = VotingBond;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -652,7 +652,7 @@ construct_runtime!(
 		Democracy: pallet_democracy::{Module, Call, Storage, Config, Event<T>},
 		Council: pallet_collective::<Instance1>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
 		TechnicalCommittee: pallet_collective::<Instance2>::{Module, Call, Storage, Origin<T>, Event<T>, Config<T>},
-		Elections: pallet_elections_phragmen::{Module, Call, Storage, Event<T>},
+		Elections: pallet_elections_phragmen::{Module, Call, Storage, Event<T>, Config<T>},
 		TechnicalMembership: pallet_membership::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
 		FinalityTracker: pallet_finality_tracker::{Module, Call, Inherent},
 		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -109,6 +109,7 @@ pub fn config_endowed(
 		pallet_collective_Instance1: Some(Default::default()),
 		pallet_collective_Instance2: Some(Default::default()),
 		pallet_membership_Instance1: Some(Default::default()),
+		pallet_elections_phragmen: Some(Default::default()),
 		pallet_sudo: Some(Default::default()),
 		pallet_treasury: Some(Default::default()),
 		pallet_society: Some(SocietyConfig {

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -10,6 +10,7 @@ description = "FRAME election pallet for PHRAGMEN"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.101", optional = true }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/runtime" }
 sp-phragmen = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/phragmen" }
 frame-support = { version = "2.0.0-alpha.5", default-features = false, path = "../support" }
@@ -22,11 +23,11 @@ hex-literal = "0.2.1"
 pallet-balances = { version = "2.0.0-alpha.5", path = "../balances" }
 sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core" }
 substrate-test-utils = { version = "2.0.0-alpha.5", path = "../../test-utils" }
-serde = { version = "1.0.101" }
 
 [features]
 default = ["std"]
 std = [
+	"serde",
 	"codec/std",
 	"frame-support/std",
 	"sp-runtime/std",

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -175,7 +175,7 @@ decl_storage! {
 				// make sure they have enough stake
 				assert!(
 					T::Currency::free_balance(member) >= *stake,
-					"Genesis member does not have enough stake"
+					"Genesis member does not have enough stake",
 				);
 
 				// reserve candidacy bond and set as members.
@@ -185,8 +185,8 @@ decl_storage! {
 				// Note: all members will only vote for themselves, hence they must be given exactly
 				// their own stake as total backing. Any sane election should behave as such.
 				// Nonetheless, stakes will be updated for term 1 onwards according to the election.
-				// TODO: can't use append here?
-				<Members<T>>::mutate(|members| members.push((member.clone(), *stake)));
+				<Members<T>>::append(&[(member.clone(), *stake)])
+					.expect("Failed to append genesis members.");
 
 				// set self-votes to make persistent.
 				<Module<T>>::vote(

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -153,7 +153,7 @@ decl_storage! {
 	trait Store for Module<T: Trait> as PhragmenElection {
 		// ---- State
 		/// The current elected membership. Sorted based on account id.
-		pub Members get(fn members): Vec<(T::AccountId, BalanceOf<T>)>;
+		pub Members get(fn members) config(): Vec<(T::AccountId, BalanceOf<T>)>;
 		/// The current runners_up. Sorted based on low to high merit (worse to best runner).
 		pub RunnersUp get(fn runners_up): Vec<(T::AccountId, BalanceOf<T>)>;
 		/// The total number of vote rounds that have happened, excluding the upcoming one.

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -91,7 +91,7 @@ use frame_support::{
 	weights::{SimpleDispatchInfo, Weight, WeighData}, storage::{StorageMap, IterableStorageMap},
 	traits::{
 		Currency, Get, LockableCurrency, LockIdentifier, ReservableCurrency, WithdrawReasons,
-		ChangeMembers, OnUnbalanced, WithdrawReason, Contains, BalanceStatus
+		ChangeMembers, OnUnbalanced, WithdrawReason, Contains, BalanceStatus, InitializeMembers,
 	}
 };
 use sp_phragmen::{build_support_map, ExtendedBalance};
@@ -117,6 +117,9 @@ pub trait Trait: frame_system::Trait {
 
 	/// What to do when the members change.
 	type ChangeMembers: ChangeMembers<Self::AccountId>;
+
+	/// What to do with genesis members
+	type InitializeMembers: InitializeMembers<Self::AccountId>;
 
 	/// Convert a balance into a number used for election calculation.
 	/// This must fit into a `u64` but is allowed to be sensibly lossy.
@@ -153,18 +156,51 @@ decl_storage! {
 	trait Store for Module<T: Trait> as PhragmenElection {
 		// ---- State
 		/// The current elected membership. Sorted based on account id.
-		pub Members get(fn members) config(): Vec<(T::AccountId, BalanceOf<T>)>;
+		pub Members get(fn members): Vec<(T::AccountId, BalanceOf<T>)>;
 		/// The current runners_up. Sorted based on low to high merit (worse to best runner).
 		pub RunnersUp get(fn runners_up): Vec<(T::AccountId, BalanceOf<T>)>;
 		/// The total number of vote rounds that have happened, excluding the upcoming one.
 		pub ElectionRounds get(fn election_rounds): u32 = Zero::zero();
 
 		/// Votes and locked stake of a particular voter.
-		pub Voting: map hasher(twox_64_concat) T::AccountId => (BalanceOf<T>, Vec<T::AccountId>);
+		pub Voting get(fn voting): map hasher(twox_64_concat) T::AccountId => (BalanceOf<T>, Vec<T::AccountId>);
 
 		/// The present candidate list. Sorted based on account-id. A current member or runner-up
 		/// can never enter this vector and is always implicitly assumed to be a candidate.
 		pub Candidates get(fn candidates): Vec<T::AccountId>;
+	} add_extra_genesis {
+		config(members): Vec<(T::AccountId, BalanceOf<T>)>;
+		build(|config: &GenesisConfig<T>| {
+			let members = config.members.iter().map(|(ref member, ref stake)| {
+				// make sure they have enough stake
+				assert!(
+					T::Currency::free_balance(member) >= *stake,
+					"Genesis member does not have enough stake"
+				);
+
+				// reserve candidacy bond and set as members.
+				T::Currency::reserve(&member, T::CandidacyBond::get())
+					.expect("Genesis member does not have enough balance to be a candidate");
+
+				// Note: all members will only vote for themselves, hence they must be given exactly
+				// their own stake as total backing. Any sane election should behave as such.
+				// Nonetheless, stakes will be updated for term 1 onwards according to the election.
+				// TODO: can't use append here?
+				<Members<T>>::mutate(|members| members.push((member.clone(), *stake)));
+
+				// set self-votes to make persistent.
+				<Module<T>>::vote(
+					T::Origin::from(Some(member.clone()).into()),
+					vec![member.clone()],
+					*stake,
+				).expect("Genesis member could not vote.");
+
+				member.clone()
+			}).collect::<Vec<T::AccountId>>();
+
+			// report genesis members to upstream, if any.
+			T::InitializeMembers::initialize_members(&members);
+		})
 	}
 }
 
@@ -844,7 +880,7 @@ mod tests {
 		Perbill, testing::Header, BuildStorage,
 		traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
 	};
-	use crate as elections;
+	use crate as elections_phragmen;
 	use frame_system as system;
 
 	parameter_types! {
@@ -980,6 +1016,7 @@ mod tests {
 		type Currency = Balances;
 		type CurrencyToVote = CurrencyToVoteHandler;
 		type ChangeMembers = TestChangeMembers;
+		type InitializeMembers = ();
 		type CandidacyBond = CandidacyBond;
 		type VotingBond = VotingBond;
 		type TermDuration = TermDuration;
@@ -1001,11 +1038,12 @@ mod tests {
 		{
 			System: system::{Module, Call, Event<T>},
 			Balances: pallet_balances::{Module, Call, Event<T>, Config<T>},
-			Elections: elections::{Module, Call, Event<T>},
+			Elections: elections_phragmen::{Module, Call, Event<T>, Config<T>},
 		}
 	);
 
 	pub struct ExtBuilder {
+		genesis_members: Vec<(u64, u64)>,
 		balance_factor: u64,
 		voter_bond: u64,
 		term_duration: u64,
@@ -1015,6 +1053,7 @@ mod tests {
 	impl Default for ExtBuilder {
 		fn default() -> Self {
 			Self {
+				genesis_members: vec![],
 				balance_factor: 1,
 				voter_bond: 2,
 				desired_runners_up: 0,
@@ -1036,10 +1075,15 @@ mod tests {
 			self.term_duration = duration;
 			self
 		}
+		pub fn genesis_members(mut self, members: Vec<(u64, u64)>) -> Self {
+			self.genesis_members = members;
+			self
+		}
 		pub fn build(self) -> sp_io::TestExternalities {
 			VOTING_BOND.with(|v| *v.borrow_mut() = self.voter_bond);
 			TERM_DURATION.with(|v| *v.borrow_mut() = self.term_duration);
 			DESIRED_RUNNERS_UP.with(|v| *v.borrow_mut() = self.desired_runners_up);
+			MEMBERS.with(|m| *m.borrow_mut() = self.genesis_members.iter().map(|(m, _)| m.clone()).collect::<Vec<_>>());
 			GenesisConfig {
 				pallet_balances: Some(pallet_balances::GenesisConfig::<Test>{
 					balances: vec![
@@ -1050,6 +1094,9 @@ mod tests {
 						(5, 50 * self.balance_factor),
 						(6, 60 * self.balance_factor)
 					],
+				}),
+				elections_phragmen: Some(elections_phragmen::GenesisConfig::<Test> {
+					members: self.genesis_members
 				}),
 			}.build_storage().unwrap().into()
 		}
@@ -1087,6 +1134,37 @@ mod tests {
 			assert_eq!(all_voters(), vec![]);
 			assert_eq!(Elections::votes_of(&1), vec![]);
 		});
+	}
+
+	#[test]
+	fn genesis_members_should_work() {
+		ExtBuilder::default().genesis_members(vec![(1, 10), (2, 20)]).build().execute_with(|| {
+			System::set_block_number(1);
+			assert_eq!(Elections::members(), vec![(1, 10), (2, 20)]);
+
+			assert_eq!(Elections::voting(1), (10, vec![1]));
+			assert_eq!(Elections::voting(2), (20, vec![2]));
+
+			// they will persist since they have self vote.
+			System::set_block_number(5);
+			assert_ok!(Elections::end_block(System::block_number()));
+
+			assert_eq!(Elections::members_ids(), vec![1, 2]);
+		})
+	}
+
+	#[test]
+	#[should_panic = "Genesis member does not have enough stake"]
+	fn genesis_members_cannot_over_stake_0() {
+		// 10 cannot lock 20 as their stake and extra genesis will panic.
+		ExtBuilder::default().genesis_members(vec![(1, 20), (2, 20)]).build();
+	}
+
+	#[test]
+	#[should_panic]
+	fn genesis_members_cannot_over_stake_1() {
+		// 10 cannot reserve 20 as voting bond and extra genesis will panic.
+		ExtBuilder::default().voter_bond(20).genesis_members(vec![(1, 10), (2, 20)]).build();
 	}
 
 	#[test]
@@ -1539,7 +1617,7 @@ mod tests {
 			assert_ok!(Elections::report_defunct_voter(Origin::signed(5), 3));
 			assert_eq!(
 				System::events()[7].event,
-				Event::elections(RawEvent::VoterReported(3, 5, true))
+				Event::elections_phragmen(RawEvent::VoterReported(3, 5, true))
 			);
 
 			assert_eq!(balances(&3), (28, 0));
@@ -1568,7 +1646,7 @@ mod tests {
 			assert_ok!(Elections::report_defunct_voter(Origin::signed(5), 4));
 			assert_eq!(
 				System::events()[7].event,
-				Event::elections(RawEvent::VoterReported(4, 5, false))
+				Event::elections_phragmen(RawEvent::VoterReported(4, 5, false))
 			);
 
 			assert_eq!(balances(&4), (35, 5));
@@ -1979,7 +2057,7 @@ mod tests {
 
 			assert_eq!(
 				System::events()[6].event,
-				Event::elections(RawEvent::NewTerm(vec![(4, 40), (5, 50)])),
+				Event::elections_phragmen(RawEvent::NewTerm(vec![(4, 40), (5, 50)])),
 			);
 		})
 	}

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -54,8 +54,8 @@ pub trait PerThing:
 	/// Build this type from a percent. Equivalent to `Self::from_parts(x * Self::ACCURACY / 100)`
 	/// but more accurate.
 	fn from_percent(x: Self::Inner) -> Self {
-		let a = x.min(100.into()); 
-		let b = Self::ACCURACY; 
+		let a = x.min(100.into());
+		let b = Self::ACCURACY;
 		// if Self::ACCURACY % 100 > 0 then we need the correction for accuracy
 		let c = rational_mul_correction::<Self::Inner, Self>(b, a, 100.into(), Rounding::Nearest);
 		Self::from_parts(a / 100.into() * b + c)
@@ -64,12 +64,12 @@ pub trait PerThing:
 	/// Return the product of multiplication of this value by itself.
 	fn square(self) -> Self {
 		let p = Self::Upper::from(self.deconstruct());
-		let q = Self::Upper::from(Self::ACCURACY); 
+		let q = Self::Upper::from(Self::ACCURACY);
 		Self::from_rational_approximation(p * p, q * q)
 	}
-	
+
 	/// Multiplication that always rounds down to a whole number. The standard `Mul` rounds to the
-	/// nearest whole number. 
+	/// nearest whole number.
 	///
 	/// ```rust
 	/// # use sp_arithmetic::{Percent, PerThing};
@@ -91,7 +91,7 @@ pub trait PerThing:
 	}
 
 	/// Multiplication that always rounds the result up to a whole number. The standard `Mul`
-	/// rounds to the nearest whole number. 
+	/// rounds to the nearest whole number.
 	///
 	/// ```rust
 	/// # use sp_arithmetic::{Percent, PerThing};
@@ -100,7 +100,7 @@ pub trait PerThing:
 	/// assert_eq!(Percent::from_percent(34) * 10u64, 3);
 	/// assert_eq!(Percent::from_percent(36) * 10u64, 4);
 	///
-	/// // round up 
+	/// // round up
 	/// assert_eq!(Percent::from_percent(34).mul_ceil(10u64), 4);
 	/// assert_eq!(Percent::from_percent(36).mul_ceil(10u64), 4);
 	/// # }
@@ -134,7 +134,7 @@ pub trait PerThing:
 	/// ```rust
 	/// # use sp_arithmetic::{Percent, PerThing};
 	/// # fn main () {
-	/// // round to nearest 
+	/// // round to nearest
 	/// assert_eq!(Percent::from_percent(60).saturating_reciprocal_mul(10u64), 17);
 	/// // round down
 	/// assert_eq!(Percent::from_percent(60).saturating_reciprocal_mul_floor(10u64), 16);
@@ -153,7 +153,7 @@ pub trait PerThing:
 	/// ```rust
 	/// # use sp_arithmetic::{Percent, PerThing};
 	/// # fn main () {
-	/// // round to nearest 
+	/// // round to nearest
 	/// assert_eq!(Percent::from_percent(61).saturating_reciprocal_mul(10u64), 16);
 	/// // round up
 	/// assert_eq!(Percent::from_percent(61).saturating_reciprocal_mul_ceil(10u64), 17);
@@ -166,7 +166,7 @@ pub trait PerThing:
 		saturating_reciprocal_mul::<N, Self>(b, self.deconstruct(), Rounding::Up)
 	}
 
-	/// Consume self and return the number of parts per thing. 
+	/// Consume self and return the number of parts per thing.
 	fn deconstruct(self) -> Self::Inner;
 
 	/// Build this type from a number of parts per thing.
@@ -199,9 +199,9 @@ pub trait PerThing:
 		ops::Div<N, Output=N> + ops::Rem<N, Output=N> + ops::Add<N, Output=N>;
 }
 
-/// The rounding method to use. 
+/// The rounding method to use.
 ///
-/// `Perthing`s are unsigned so `Up` means towards infinity and `Down` means towards zero.
+/// `PerThing`s are unsigned so `Up` means towards infinity and `Down` means towards zero.
 /// `Nearest` will round an exact half down.
 enum Rounding {
 	Up,
@@ -209,23 +209,23 @@ enum Rounding {
 	Nearest,
 }
 
-/// Saturating reciprocal multiplication. Compute `x / self`, saturating at the numeric 
+/// Saturating reciprocal multiplication. Compute `x / self`, saturating at the numeric
 /// bounds instead of overflowing.
 fn saturating_reciprocal_mul<N, P>(
-	x: N, 
+	x: N,
 	part: P::Inner,
 	rounding: Rounding,
 ) -> N
-where 
+where
 	N: Clone + From<P::Inner> + UniqueSaturatedInto<P::Inner> + ops::Div<N, Output=N> + ops::Mul<N,
 	Output=N> + ops::Add<N, Output=N> + ops::Rem<N, Output=N> + Saturating,
 	P: PerThing,
 {
 	let maximum: N = P::ACCURACY.into();
 	let c = rational_mul_correction::<N, P>(
-		x.clone(), 
-		P::ACCURACY, 
-		part, 
+		x.clone(),
+		P::ACCURACY,
+		part,
 		rounding,
 	);
 	(x / part.into()).saturating_mul(maximum).saturating_add(c)
@@ -233,11 +233,11 @@ where
 
 /// Overflow-prune multiplication. Accurately multiply a value by `self` without overflowing.
 fn overflow_prune_mul<N, P>(
-	x: N, 
+	x: N,
 	part: P::Inner,
 	rounding: Rounding,
-) -> N 
-where 
+) -> N
+where
 	N: Clone + From<P::Inner> + UniqueSaturatedInto<P::Inner> + ops::Div<N, Output=N> + ops::Mul<N,
 	Output=N> + ops::Add<N, Output=N> + ops::Rem<N, Output=N>,
 	P: PerThing,
@@ -245,9 +245,9 @@ where
 	let maximum: N = P::ACCURACY.into();
 	let part_n: N = part.into();
 	let c = rational_mul_correction::<N, P>(
-		x.clone(), 
-		part, 
-		P::ACCURACY, 
+		x.clone(),
+		part,
+		P::ACCURACY,
 		rounding,
 	);
 	(x / maximum) * part_n + c
@@ -258,15 +258,15 @@ where
 /// Take the remainder of `x / denom` and multiply by  `numer / denom`. The result can be added
 /// to `x / denom * numer` for an accurate result.
 fn rational_mul_correction<N, P>(
-	x: N, 
-	numer: P::Inner, 
-	denom: P::Inner, 
+	x: N,
+	numer: P::Inner,
+	denom: P::Inner,
 	rounding: Rounding,
 ) -> N
-where 
+where
 	N: From<P::Inner> + UniqueSaturatedInto<P::Inner> + ops::Div<N, Output=N> + ops::Mul<N,
-	Output=N> + ops::Add<N, Output=N> + ops::Rem<N, Output=N>, 
-	P: PerThing, 
+	Output=N> + ops::Add<N, Output=N> + ops::Rem<N, Output=N>,
+	P: PerThing,
 {
 	let numer_upper = P::Upper::from(numer);
 	let denom_n = N::from(denom);
@@ -282,7 +282,7 @@ where
 	match rounding {
 		// Already rounded down
 		Rounding::Down => {},
-		// Round up if the fractional part of the result is non-zero. 
+		// Round up if the fractional part of the result is non-zero.
 		Rounding::Up => if rem_mul_upper % denom_upper > 0.into() {
 			// `rem * numer / denom` is less than `numer`, so this will not overflow.
 			rem_mul_div_inner = rem_mul_div_inner + 1.into();
@@ -302,7 +302,7 @@ macro_rules! implement_per_thing {
 		$name:ident,
 		$test_mod:ident,
 		[$($test_units:tt),+],
-		$max:tt, 
+		$max:tt,
 		$type:ty,
 		$upper_type:ty,
 		$title:expr $(,)?
@@ -321,19 +321,19 @@ macro_rules! implement_per_thing {
 
 			const ACCURACY: Self::Inner = $max;
 
-			/// Consume self and return the number of parts per thing. 
+			/// Consume self and return the number of parts per thing.
 			fn deconstruct(self) -> Self::Inner { self.0 }
 
 			/// Build this type from a number of parts per thing.
 			fn from_parts(parts: Self::Inner) -> Self { Self(parts.min($max)) }
 
 			#[cfg(feature = "std")]
-			fn from_fraction(x: f64) -> Self { 
-				Self::from_parts((x * $max as f64) as Self::Inner) 
+			fn from_fraction(x: f64) -> Self {
+				Self::from_parts((x * $max as f64) as Self::Inner)
 			}
 
 			fn from_rational_approximation<N>(p: N, q: N) -> Self
-			where N: Clone + Ord + From<Self::Inner> + TryInto<Self::Inner> + TryInto<Self::Upper> 
+			where N: Clone + Ord + From<Self::Inner> + TryInto<Self::Inner> + TryInto<Self::Upper>
 				+ ops::Div<N, Output=N> + ops::Rem<N, Output=N> + ops::Add<N, Output=N>
 			{
 				let div_ceil = |x: N, f: N| -> N {
@@ -449,7 +449,7 @@ macro_rules! implement_per_thing {
 					ops::Add<N, Output=N> {
 				PerThing::mul_floor(self, b)
 			}
-			
+
 			/// See [`PerThing::mul_ceil`].
 			pub fn mul_ceil<N>(self, b: N) -> N
 				where N: Clone + From<$type> + UniqueSaturatedInto<$type> +
@@ -459,23 +459,23 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::saturating_reciprocal_mul`].
-			fn saturating_reciprocal_mul<N>(self, b: N) -> N
+			pub fn saturating_reciprocal_mul<N>(self, b: N) -> N
 				where N: Clone + From<$type> + UniqueSaturatedInto<$type> + ops::Rem<N, Output=N> +
 					ops::Div<N, Output=N> + ops::Mul<N, Output=N> + ops::Add<N, Output=N> +
 					Saturating {
 				PerThing::saturating_reciprocal_mul(self, b)
 			}
-			
+
 			/// See [`PerThing::saturating_reciprocal_mul_floor`].
-			fn saturating_reciprocal_mul_floor<N>(self, b: N) -> N
+			pub fn saturating_reciprocal_mul_floor<N>(self, b: N) -> N
 				where N: Clone + From<$type> + UniqueSaturatedInto<$type> + ops::Rem<N, Output=N> +
 					ops::Div<N, Output=N> + ops::Mul<N, Output=N> + ops::Add<N, Output=N> +
 					Saturating {
 				PerThing::saturating_reciprocal_mul_floor(self, b)
 			}
-			
+
 			/// See [`PerThing::saturating_reciprocal_mul_ceil`].
-			fn saturating_reciprocal_mul_ceil<N>(self, b: N) -> N
+			pub fn saturating_reciprocal_mul_ceil<N>(self, b: N) -> N
 				where N: Clone + From<$type> + UniqueSaturatedInto<$type> + ops::Rem<N, Output=N> +
 					ops::Div<N, Output=N> + ops::Mul<N, Output=N> + ops::Add<N, Output=N> +
 					Saturating {
@@ -524,7 +524,7 @@ macro_rules! implement_per_thing {
 							// x^2 always fits in Self::Upper if x fits in Self::Inner.
 							// Verified by a test.
 							s = Self::from_rational_approximation(
-								<$name as PerThing>::Upper::from(s.deconstruct()) * p, 
+								<$name as PerThing>::Upper::from(s.deconstruct()) * p,
 								q * q,
 							);
 						}
@@ -936,43 +936,43 @@ macro_rules! implement_per_thing {
 			fn saturating_pow_works() {
 				// x^0 == 1
 				assert_eq!(
-					$name::from_parts($max / 2).saturating_pow(0), 
+					$name::from_parts($max / 2).saturating_pow(0),
 					$name::from_parts($max),
 				);
 
 				// x^1 == x
 				assert_eq!(
-					$name::from_parts($max / 2).saturating_pow(1), 
+					$name::from_parts($max / 2).saturating_pow(1),
 					$name::from_parts($max / 2),
 				);
 
 				// x^2
 				assert_eq!(
-					$name::from_parts($max / 2).saturating_pow(2), 
+					$name::from_parts($max / 2).saturating_pow(2),
 					$name::from_parts($max / 2).square(),
 				);
 
 				// x^3
 				assert_eq!(
-					$name::from_parts($max / 2).saturating_pow(3), 
+					$name::from_parts($max / 2).saturating_pow(3),
 					$name::from_parts($max / 8),
 				);
 
 				// 0^n == 0
 				assert_eq!(
-					$name::from_parts(0).saturating_pow(3), 
+					$name::from_parts(0).saturating_pow(3),
 					$name::from_parts(0),
 				);
 
 				// 1^n == 1
 				assert_eq!(
-					$name::from_parts($max).saturating_pow(3), 
+					$name::from_parts($max).saturating_pow(3),
 					$name::from_parts($max),
 				);
 
 				// (x < 1)^inf == 0 (where 2.pow(31) ~ inf)
 				assert_eq!(
-					$name::from_parts($max / 2).saturating_pow(2usize.pow(31)), 
+					$name::from_parts($max / 2).saturating_pow(2usize.pow(31)),
 					$name::from_parts(0),
 				);
 			}
@@ -994,7 +994,7 @@ macro_rules! implement_per_thing {
 					$name::from_parts(1).saturating_reciprocal_mul($max),
 					<$type>::max_value(),
 				);
-				// round to nearest 
+				// round to nearest
 				assert_eq!(
 					$name::from_percent(60).saturating_reciprocal_mul(<$type>::from(10u8)),
 					17,
@@ -1004,12 +1004,12 @@ macro_rules! implement_per_thing {
 					$name::from_percent(60).saturating_reciprocal_mul_floor(<$type>::from(10u8)),
 					16,
 				);
-				// round to nearest 
+				// round to nearest
 				assert_eq!(
 					$name::from_percent(61).saturating_reciprocal_mul(<$type>::from(10u8)),
 					16,
 				);
-				// round up 
+				// round up
 				assert_eq!(
 					$name::from_percent(61).saturating_reciprocal_mul_ceil(<$type>::from(10u8)),
 					17,
@@ -1022,7 +1022,7 @@ macro_rules! implement_per_thing {
 					$name::from_percent(49).mul_floor(10 as $type),
 					4,
 				);
-				let a: $upper_type = $name::from_percent(50).mul_floor(($max as $upper_type).pow(2)); 
+				let a: $upper_type = $name::from_percent(50).mul_floor(($max as $upper_type).pow(2));
 				let b: $upper_type = ($max as $upper_type).pow(2) / 2;
 				if $max % 2 == 0 {
 					assert_eq!(a, b);
@@ -1036,27 +1036,27 @@ macro_rules! implement_per_thing {
 			fn rational_mul_correction_works() {
 				assert_eq!(
 					super::rational_mul_correction::<$type, $name>(
-						<$type>::max_value(), 
-						<$type>::max_value(), 
-						<$type>::max_value(), 
+						<$type>::max_value(),
+						<$type>::max_value(),
+						<$type>::max_value(),
 						super::Rounding::Nearest,
 					),
 					0,
 				);
 				assert_eq!(
 					super::rational_mul_correction::<$type, $name>(
-						<$type>::max_value() - 1, 
-						<$type>::max_value(), 
-						<$type>::max_value(), 
+						<$type>::max_value() - 1,
+						<$type>::max_value(),
+						<$type>::max_value(),
 						super::Rounding::Nearest,
 					),
 					<$type>::max_value() - 1,
 				);
 				assert_eq!(
 					super::rational_mul_correction::<$upper_type, $name>(
-						((<$type>::max_value() - 1) as $upper_type).pow(2), 
-						<$type>::max_value(), 
-						<$type>::max_value(), 
+						((<$type>::max_value() - 1) as $upper_type).pow(2),
+						<$type>::max_value(),
+						<$type>::max_value(),
 						super::Rounding::Nearest,
 					),
 					1,
@@ -1064,9 +1064,9 @@ macro_rules! implement_per_thing {
 				// ((max^2 - 1) % max) * max / max == max - 1
 				assert_eq!(
 					super::rational_mul_correction::<$upper_type, $name>(
-						(<$type>::max_value() as $upper_type).pow(2) - 1, 
-						<$type>::max_value(), 
-						<$type>::max_value(), 
+						(<$type>::max_value() as $upper_type).pow(2) - 1,
+						<$type>::max_value(),
+						<$type>::max_value(),
 						super::Rounding::Nearest,
 					),
 					(<$type>::max_value() - 1).into(),
@@ -1074,8 +1074,8 @@ macro_rules! implement_per_thing {
 				// (max % 2) * max / 2 == max / 2
 				assert_eq!(
 					super::rational_mul_correction::<$upper_type, $name>(
-						(<$type>::max_value() as $upper_type).pow(2), 
-						<$type>::max_value(), 
+						(<$type>::max_value() as $upper_type).pow(2),
+						<$type>::max_value(),
 						2 as $type,
 						super::Rounding::Nearest,
 					),
@@ -1084,9 +1084,9 @@ macro_rules! implement_per_thing {
 				// ((max^2 - 1) % max) * 2 / max == 2 (rounded up)
 				assert_eq!(
 					super::rational_mul_correction::<$upper_type, $name>(
-						(<$type>::max_value() as $upper_type).pow(2) - 1, 
+						(<$type>::max_value() as $upper_type).pow(2) - 1,
 						2 as $type,
-						<$type>::max_value(), 
+						<$type>::max_value(),
 						super::Rounding::Nearest,
 					),
 					2,
@@ -1094,9 +1094,9 @@ macro_rules! implement_per_thing {
 				// ((max^2 - 1) % max) * 2 / max == 1 (rounded down)
 				assert_eq!(
 					super::rational_mul_correction::<$upper_type, $name>(
-						(<$type>::max_value() as $upper_type).pow(2) - 1, 
+						(<$type>::max_value() as $upper_type).pow(2) - 1,
 						2 as $type,
-						<$type>::max_value(), 
+						<$type>::max_value(),
 						super::Rounding::Down,
 					),
 					1,


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/5097. 

Although, this mostly demonstrates the issue. This is kind of a footgun since the genesis value of collective and elections must be the same, otherwise the behaviour is even more obscure.  and I think a better way is to: 

- `trait ChangeMembers` should expose one function `initial_members()` that `elections()` can call and get the initial members. 

Basically, from the PoV of elections, whatever module we report the new members to, also gives us the initial ones. Hence, no need for a new trait and can be within the same trait.  

Although, this brings the question of: How much stake should we give to the initial members? the collective module does not know that. The current genesis approach is good in the sense that it makes it configurable. 

polkadot companion: https://github.com/paritytech/polkadot/pull/954

--- 

As noted also by @jacogr, polkadot names the elections module `ElectionPhragmen` while substrate master does `Elections`. Why is this? if no particular reason, would be better to have this breaking (for the UI) change now before 2.0? Fixing such stuff should make it easier for the UI to support both FF and Polkadot/Kusama. 