### PR TITLE
feat/blocks: add a stream for all blocks

### DIFF
--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -36,6 +36,10 @@ pub type ImportNotifications<Block> = mpsc::UnboundedReceiver<BlockImportNotific
 /// A stream of block finality notifications.
 pub type FinalityNotifications<Block> = mpsc::UnboundedReceiver<FinalityNotification<Block>>;
 
+
+/// A stream of block import events.
+pub type AllBlocksNotifications<Block> = mpsc::UnboundedReceiver<AllBlocksNotification<Block>>;
+
 /// Expected hashes of blocks at given heights.
 ///
 /// This may be used as chain spec extension to set trusted checkpoints, i.e.
@@ -63,6 +67,10 @@ pub trait BlockchainEvents<Block: BlockT> {
 	/// Get a stream of finality notifications. Not guaranteed to be fired for every
 	/// finalized block.
 	fn finality_notification_stream(&self) -> FinalityNotifications<Block>;
+
+	/// Get a block import stream of notification. Guaranteed to be fired for every
+	/// imported block.
+	fn all_blocks_notification_stream(&self) -> AllBlocksNotifications<Block>;
 
 	/// Get storage changes event stream.
 	///
@@ -241,4 +249,20 @@ pub struct FinalityNotification<Block: BlockT> {
 	pub hash: Block::Hash,
 	/// Imported block header.
 	pub header: Block::Header,
+}
+
+
+/// Summary of an imported block
+#[derive(Clone, Debug)]
+pub struct AllBlocksNotification<Block: BlockT> {
+	/// Determines if this block notification is part
+	/// of an initial sync of the node with the network.
+	/// Imported block header hash.
+	pub hash: Block::Hash,
+	/// Imported block origin.
+	pub origin: BlockOrigin,
+	/// Imported block header.
+	pub header: Block::Header,
+	/// Is this the new best block.
+	pub is_new_best: bool,
 }

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -36,7 +36,6 @@ pub type ImportNotifications<Block> = mpsc::UnboundedReceiver<BlockImportNotific
 /// A stream of block finality notifications.
 pub type FinalityNotifications<Block> = mpsc::UnboundedReceiver<FinalityNotification<Block>>;
 
-
 /// A stream of block import events.
 pub type AllBlocksNotifications<Block> = mpsc::UnboundedReceiver<AllBlocksNotification<Block>>;
 

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -68,7 +68,10 @@ pub trait BlockchainEvents<Block: BlockT> {
 	fn finality_notification_stream(&self) -> FinalityNotifications<Block>;
 
 	/// Get a block import stream of notification. Guaranteed to be fired for every
-	/// imported block.
+	/// imported block even when doing a major sync.
+	///
+	/// Use cautiously, cause it may have a significant impact on performance. Note that the events are being
+	/// sent using unbounded channel, so make sure to process them as soon as possible.
 	fn all_blocks_notification_stream(&self) -> AllBlocksNotifications<Block>;
 
 	/// Get storage changes event stream.

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -932,7 +932,7 @@ ServiceBuilder<
 					if let ChainEvent::BlockReceived { ref header, is_new_best, is_initial_sync, .. } = event {
 						let offchain = offchain.as_ref().and_then(|o| o.upgrade());
 						match offchain {
-							Some(offchain) if is_initial_sync || is_new_best => {
+							Some(offchain) if is_new_best && !is_initial_sync => {
 								notifications_spawn_handle.spawn(
 									"offchain-on-block",
 									offchain.on_block_imported(

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -983,7 +983,6 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 	}
 
 	fn notify_any_block_imported(&self, notify_import: &ImportSummary<Block>) -> sp_blockchain::Result<()> {
-
 		let notification = AllBlocksNotification::<Block> {
 			hash: notify_import.hash.clone(),
 			origin: notify_import.origin.clone(),

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -465,6 +465,10 @@ impl<PoolApi, Block> MaintainedTransactionPool for BasicPool<PoolApi, Block>
 					}
 				}.boxed()
 			}
+			ChainEvent::BlockReceived{ .. } => {
+				// nop, except for initial block sync, NewBlock handles this case
+				Box::pin(ready(()))
+			}
 		}
 	}
 }

--- a/primitives/transaction-pool/src/pool.rs
+++ b/primitives/transaction-pool/src/pool.rs
@@ -256,6 +256,17 @@ pub enum ChainEvent<B: BlockT> {
 		/// List of retracted blocks ordered by block number.
 		retracted: Vec<B::Hash>,
 	},
+
+	/// A block has been received and is added to the chain
+	BlockReceived {
+		/// Header of the just imported block.
+		header: B::Header,
+		/// Is this the new best block.
+		is_new_best: bool,
+		/// A block event cause by an initial sync of a node.
+		is_initial_sync: bool,
+	},
+	
 	/// An existing block has been finalized.
 	Finalized {
 		/// Hash of just finalized block


### PR DESCRIPTION
Provides a stream that guarantees to trigger on every block, imported, synced.
