### PR TITLE
Show network id/version in subkey

### DIFF
--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -79,7 +79,7 @@ trait Crypto: Sized {
 	) where
 		<Self::Pair as Pair>::Public: PublicT,
 	{
-		let v = network_override.unwrap_or(Ss58AddressFormat::default());
+		let v = network_override.unwrap_or_default();
 		if let Ok((pair, seed)) = Self::Pair::from_phrase(uri, password) {
 			let public_key = Self::public_from_pair(&pair);
 

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -79,6 +79,7 @@ trait Crypto: Sized {
 	) where
 		<Self::Pair as Pair>::Public: PublicT,
 	{
+		let v = network_override.unwrap_or(Ss58AddressFormat::default());
 		if let Ok((pair, seed)) = Self::Pair::from_phrase(uri, password) {
 			let public_key = Self::public_from_pair(&pair);
 
@@ -86,6 +87,7 @@ trait Crypto: Sized {
 				OutputType::Json => {
 					let json = json!({
 						"secretPhrase": uri,
+						"networkId": String::from(v),
 						"secretSeed": format_seed::<Self>(seed),
 						"publicKey": format_public_key::<Self>(public_key.clone()),
 						"accountId": format_account_id::<Self>(public_key),
@@ -95,11 +97,13 @@ trait Crypto: Sized {
 				},
 				OutputType::Text => {
 					println!("Secret phrase `{}` is account:\n  \
-						Secret seed:      {}\n  \
-						Public key (hex): {}\n  \
-						Account ID:       {}\n  \
-						SS58 Address:     {}",
+						Network ID/version: {}\n  \
+						Secret seed:        {}\n  \
+						Public key (hex):   {}\n  \
+						Account ID:         {}\n  \
+						SS58 Address:       {}",
 						uri,
+						String::from(v),
 						format_seed::<Self>(seed),
 						format_public_key::<Self>(public_key.clone()),
 						format_account_id::<Self>(public_key),
@@ -114,6 +118,7 @@ trait Crypto: Sized {
 				OutputType::Json => {
 					let json = json!({
 						"secretKeyUri": uri,
+						"networkId": String::from(v),
 						"secretSeed": if let Some(seed) = seed { format_seed::<Self>(seed) } else { "n/a".into() },
 						"publicKey": format_public_key::<Self>(public_key.clone()),
 						"accountId": format_account_id::<Self>(public_key),
@@ -123,11 +128,13 @@ trait Crypto: Sized {
 				},
 				OutputType::Text => {
 					println!("Secret Key URI `{}` is account:\n  \
-						Secret seed:      {}\n  \
-						Public key (hex): {}\n  \
-						Account ID:       {}\n  \
-						SS58 Address:     {}",
+						Network ID/version: {}\n  \
+						Secret seed:        {}\n  \
+						Public key (hex):   {}\n  \
+						Account ID:         {}\n  \
+						SS58 Address:       {}",
 						uri,
+						String::from(v),
 						if let Some(seed) = seed { format_seed::<Self>(seed) } else { "n/a".into() },
 						format_public_key::<Self>(public_key.clone()),
 						format_account_id::<Self>(public_key),


### PR DESCRIPTION
Showing the Network ID/Version when creating or inspecting with subkey
This helps a user to confirm the input parameters are correct when creating or inspecting a key with a specific network.