### PR TITLE
Make Dispatchable return the actual weight consumed

### DIFF
--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -161,6 +161,7 @@ use frame_support::{
 	decl_module, decl_event, decl_storage, decl_error, ensure,
 	Parameter, RuntimeDebug, weights::{GetDispatchInfo, SimpleDispatchInfo, FunctionOf},
 	traits::{Currency, ReservableCurrency, Get, BalanceStatus},
+	dispatch::PostDispatchInfo,
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
 
@@ -178,7 +179,7 @@ pub trait Trait: frame_system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// The overarching call type.
-	type Call: Parameter + Dispatchable<Origin=Self::Origin> + GetDispatchInfo;
+	type Call: Parameter + Dispatchable<Origin=Self::Origin, PostInfo=PostDispatchInfo> + GetDispatchInfo;
 
 	/// The currency mechanism.
 	type Currency: ReservableCurrency<Self::AccountId>;
@@ -348,6 +349,7 @@ decl_module! {
 			let target = Self::proxy(&who).ok_or(Error::<T>::NotAllowed)?;
 			ensure!(&target == &account, Error::<T>::NotAllowed);
 			call.dispatch(frame_system::RawOrigin::Signed(account).into())
+				.map(|_| ()).map_err(|e| e.error)
 		}
 
 		/// Allow ROOT to bypass the recovery process and set an a rescuer account

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -150,7 +150,11 @@ decl_module! {
 								Lookup::<T>::remove(id);
 							}
 						}
-						Self::deposit_event(RawEvent::Dispatched((now, index), maybe_id, r));
+						Self::deposit_event(RawEvent::Dispatched(
+							(now, index),
+							maybe_id,
+							r.map(|_| ()).map_err(|e| e.error)
+						));
 						result = cumulative_weight;
 						None
 					} else {

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -87,7 +87,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_std::prelude::*;
-use sp_runtime::{traits::{StaticLookup, Dispatchable}, DispatchError};
+use sp_runtime::traits::{StaticLookup, Dispatchable};
 
 use frame_support::{
 	Parameter, decl_module, decl_event, decl_storage, decl_error, ensure,
@@ -133,7 +133,6 @@ decl_module! {
 			let res = match call.dispatch(frame_system::RawOrigin::Root.into()) {
 				Ok(_) => true,
 				Err(e) => {
-					let e: DispatchError = e.into();
 					sp_runtime::print(e);
 					false
 				}
@@ -192,7 +191,6 @@ decl_module! {
 			let res = match call.dispatch(frame_system::RawOrigin::Signed(who).into()) {
 				Ok(_) => true,
 				Err(e) => {
-					let e: DispatchError = e.into();
 					sp_runtime::print(e);
 					false
 				}

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -25,10 +25,27 @@ pub use frame_metadata::{
 };
 pub use crate::weights::{
 	SimpleDispatchInfo, GetDispatchInfo, DispatchInfo, WeighData, ClassifyDispatch,
-	TransactionPriority, Weight, PaysFee,
+	TransactionPriority, Weight, PaysFee, PostDispatchInfo, WithPostDispatchInfo,
 };
-pub use sp_runtime::{traits::Dispatchable, DispatchError, DispatchResult};
+pub use sp_runtime::{traits::Dispatchable, DispatchError};
 pub use crate::traits::{CallMetadata, GetCallMetadata, GetCallName};
+
+/// The return typ of a `Dispatchable` in frame. When returned explicitly from
+/// a dispatchable function it allows overriding the default `PostDispatchInfo`
+/// returned from a dispatch.
+pub type DispatchResultWithPostInfo =
+	sp_runtime::DispatchResultWithInfo<crate::weights::PostDispatchInfo>;
+
+/// Unaugmented version of `DispatchResultWithPostInfo` that can be returned from
+/// dispatchable functions and is automatically converted to the augmented type. Should be
+/// used whenever the `PostDispatchInfo` does not need to be overwritten. As this should
+/// be the common case it is the implicit return type when none is specified.
+pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
+
+/// The error type contained in a `DispatchResultWithPostInfo`.
+pub type DispatchErrorWithPostInfo =
+	sp_runtime::DispatchErrorWithPostInfo<crate::weights::PostDispatchInfo>;
+
 
 /// A type that cannot be instantiated.
 pub enum Never {}
@@ -36,7 +53,7 @@ pub enum Never {}
 /// Serializable version of Dispatchable.
 /// This value can be used as a "function" in an extrinsic.
 pub trait Callable<T> {
-	type Call: Dispatchable + Codec + Clone + PartialEq + Eq;
+	type Call: Dispatchable<PostInfo=PostDispatchInfo> + Codec + Clone + PartialEq + Eq;
 }
 
 // dirty hack to work around serde_derive issue
@@ -113,6 +130,44 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug {}
 /// 		#[weight = SimpleDispatchInfo::default()]
 /// 		fn my_short_function(origin) {
 ///				// Your implementation
+/// 		}
+///		}
+/// }
+/// # fn main() {}
+/// ```
+///
+/// ### Consuming only portions of the annotated static weight
+///
+/// Per default a callable function consumes all of its static weight as declared via
+/// the #[weight] attribute. However, there are use cases where only a portion of this
+/// weight should be consumed. In that case the static weight is charged pre dispatch and
+/// the difference is refunded post dispatch.
+///
+/// In order to make use of this feature the function must return `DispatchResultWithPostInfo`
+/// in place of the default `DispatchResult`. Then the actually consumed weight can be returned.
+/// To consume a non default weight while returning an error
+/// [`WithPostDispatchInfo::with_weight`](./weight/trait.WithPostDispatchInfo.html) can be used
+/// to augment any error with custom weight information.
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate frame_support;
+/// # use frame_support::dispatch::{DispatchResultWithPostInfo, WithPostDispatchInfo};
+/// # use frame_support::weights::SimpleDispatchInfo;
+/// # use frame_system::{self as system, Trait, ensure_signed};
+/// decl_module! {
+/// 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+///			#[weight = SimpleDispatchInfo::FixedNormal(1_000_000)]
+/// 		fn my_long_function(origin, do_expensive_calc: bool) -> DispatchResultWithPostInfo {
+///				ensure_signed(origin).map_err(|e| e.with_weight(100_000))?;
+///				if do_expensive_calc {
+///					// do the expensive calculation
+///					// ...
+///					// return None to indicate that we are using all weight (the default)
+///					return Ok(None.into());
+///				}
+///				// expensive calculation not executed: use only a portion of the weight
+/// 			Ok(Some(100_000).into())
 /// 		}
 ///		}
 /// }
@@ -938,7 +993,7 @@ macro_rules! decl_module {
 		$ignore:ident
 		$mod_type:ident<$trait_instance:ident $(, $instance:ident)?> $fn_name:ident $origin:ident $system:ident [ $( $param_name:ident),* ]
 	) => {
-		<$mod_type<$trait_instance $(, $instance)?>>::$fn_name( $origin $(, $param_name )* )
+		<$mod_type<$trait_instance $(, $instance)?>>::$fn_name( $origin $(, $param_name )* ).map(Into::into).map_err(Into::into)
 	};
 
 	// no `deposit_event` function wanted
@@ -1538,7 +1593,8 @@ macro_rules! decl_module {
 		{
 			type Trait = $trait_instance;
 			type Origin = $origin_type;
-			fn dispatch(self, _origin: Self::Origin) -> $crate::sp_runtime::DispatchResult {
+			type PostInfo = $crate::weights::PostDispatchInfo;
+			fn dispatch(self, _origin: Self::Origin) -> $crate::dispatch::DispatchResultWithPostInfo {
 				match self {
 					$(
 						$call_type::$fn_name( $( $param_name ),* ) => {
@@ -1563,10 +1619,10 @@ macro_rules! decl_module {
 			where $( $other_where_bounds )*
 		{
 			#[doc(hidden)]
-			pub fn dispatch<D: $crate::dispatch::Dispatchable<Trait = $trait_instance>>(
+			pub fn dispatch<D: $crate::dispatch::Dispatchable<Trait = $trait_instance, PostInfo = $crate::weights::PostDispatchInfo>>(
 				d: D,
 				origin: D::Origin
-			) -> $crate::sp_runtime::DispatchResult {
+			) -> $crate::dispatch::DispatchResultWithPostInfo {
 				d.dispatch(origin)
 			}
 		}
@@ -1664,10 +1720,11 @@ macro_rules! impl_outer_dispatch {
 		impl $crate::dispatch::Dispatchable for $call_type {
 			type Origin = $origin;
 			type Trait = $call_type;
+			type PostInfo = $crate::weights::PostDispatchInfo;
 			fn dispatch(
 				self,
 				origin: $origin,
-			) -> $crate::sp_runtime::DispatchResult {
+			) -> $crate::dispatch::DispatchResultWithPostInfo {
 				$crate::impl_outer_dispatch! {
 					@DISPATCH_MATCH
 					self

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -157,19 +157,19 @@ impl<T> Parameter for T where T: Codec + EncodeLike + Clone + Eq + fmt::Debug {}
 /// # use frame_system::{self as system, Trait, ensure_signed};
 /// decl_module! {
 /// 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-///			#[weight = SimpleDispatchInfo::FixedNormal(1_000_000)]
+/// 		#[weight = SimpleDispatchInfo::FixedNormal(1_000_000)]
 /// 		fn my_long_function(origin, do_expensive_calc: bool) -> DispatchResultWithPostInfo {
-///				ensure_signed(origin).map_err(|e| e.with_weight(100_000))?;
-///				if do_expensive_calc {
-///					// do the expensive calculation
-///					// ...
-///					// return None to indicate that we are using all weight (the default)
-///					return Ok(None.into());
-///				}
-///				// expensive calculation not executed: use only a portion of the weight
+/// 			ensure_signed(origin).map_err(|e| e.with_weight(100_000))?;
+/// 			if do_expensive_calc {
+/// 				// do the expensive calculation
+/// 				// ...
+/// 				// return None to indicate that we are using all weight (the default)
+/// 				return Ok(None.into());
+/// 			}
+/// 			// expensive calculation not executed: use only a portion of the weight
 /// 			Ok(Some(100_000).into())
 /// 		}
-///		}
+/// 	}
 /// }
 /// # fn main() {}
 /// ```

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -209,7 +209,11 @@ macro_rules! assert_err {
 #[cfg(feature = "std")]
 macro_rules! assert_ok {
 	( $x:expr $(,)? ) => {
-		assert_eq!($x, Ok(()));
+		let is = $x;
+		match is {
+			Ok(_) => (),
+			_ => assert!(false, "Expected Ok(_). Got {:#?}", is),
+		}
 	};
 	( $x:expr, $y:expr $(,)? ) => {
 		assert_eq!($x, Ok($y));

--- a/primitives/runtime/src/generic/checked_extrinsic.rs
+++ b/primitives/runtime/src/generic/checked_extrinsic.rs
@@ -79,7 +79,7 @@ where
 			(None, pre)
 		};
 		let res = self.function.dispatch(Origin::from(maybe_who));
-		Extra::post_dispatch(pre, info.clone(), len);
-		Ok(res.map_err(Into::into))
+		Extra::post_dispatch(pre, info, len);
+		Ok(res.map(|_| ()).map_err(|e| e.error))
 	}
 }

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -353,9 +353,14 @@ impl From<DispatchError> for DispatchOutcome {
 	}
 }
 
-/// Result of a module function call; either nothing (functions are only called for "side effects")
-/// or an error message.
+/// This is the legacy return type of `Dispatchable`. It is still exposed for compatibilty
+/// reasons. The new return type is `DispatchResultWithInfo`.
+/// FRAME runtimes should use frame_support::dispatch::DispatchResult
 pub type DispatchResult = sp_std::result::Result<(), DispatchError>;
+
+/// Return type of a `Dispatchable` which contains the `DispatchResult` and additional information
+/// about the `Dispatchable` that is only known post dispatch.
+pub type DispatchResultWithInfo<T> = sp_std::result::Result<T, DispatchErrorWithPostInfo<T>>;
 
 /// Reason why a dispatch call failed
 #[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug)]
@@ -379,6 +384,18 @@ pub enum DispatchError {
 	},
 }
 
+/// Result of a `Dispatchable` which contains the `DispatchResult` and additional information
+/// about the `Dispatchable` that is only known post dispatch.
+#[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug)]
+pub struct DispatchErrorWithPostInfo<Info> where
+	Info: Eq + PartialEq + Clone + Copy + Encode + Decode + traits::Printable
+{
+	/// Addditional information about the `Dispatchable` which is only known post dispatch.
+	pub post_info: Info,
+	/// The actual `DispatchResult` indicating whether the dispatch was succesfull.
+	pub error: DispatchError,
+}
+
 impl DispatchError {
 	/// Return the same error but without the attached message.
 	pub fn stripped(self) -> Self {
@@ -386,6 +403,18 @@ impl DispatchError {
 			DispatchError::Module { index, error, message: Some(_) }
 				=> DispatchError::Module { index, error, message: None },
 			m => m,
+		}
+	}
+}
+
+impl<T, E> From<E> for DispatchErrorWithPostInfo<T> where
+	T: Eq + PartialEq + Clone + Copy + Encode + Decode + traits::Printable + Default,
+	E: Into<DispatchError>
+{
+	fn from(error: E) -> Self {
+		Self {
+			post_info: Default::default(),
+			error: error.into(),
 		}
 	}
 }
@@ -419,6 +448,14 @@ impl From<DispatchError> for &'static str {
 	}
 }
 
+impl<T> From<DispatchErrorWithPostInfo<T>> for &'static str where
+	T: Eq + PartialEq + Clone + Copy + Encode + Decode + traits::Printable
+{
+	fn from(err: DispatchErrorWithPostInfo<T>) -> &'static str {
+		err.error.into()
+	}
+}
+
 impl traits::Printable for DispatchError {
 	fn print(&self) {
 		"DispatchError".print();
@@ -434,6 +471,16 @@ impl traits::Printable for DispatchError {
 				}
 			}
 		}
+	}
+}
+
+impl<T> traits::Printable for DispatchErrorWithPostInfo<T> where
+	T: Eq + PartialEq + Clone + Copy + Encode + Decode + traits::Printable
+{
+	fn print(&self) {
+		self.error.print();
+		"PostInfo: ".print();
+		self.post_info.print();
 	}
 }
 

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -379,6 +379,6 @@ impl<Origin, Call, Extra, Info> Applyable for TestXt<Call, Extra> where
 			None
 		};
 
-		Ok(self.call.dispatch(maybe_who.into()).map_err(Into::into))
+		Ok(self.call.dispatch(maybe_who.into()).map(|_| ()).map_err(|e| e.error))
 	}
 }

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -642,8 +642,11 @@ pub trait Dispatchable {
 	type Origin;
 	/// ...
 	type Trait;
+	/// Additional information that is returned by `dispatch`. Can be used to supply the caller
+	/// with information about a `Dispatchable` that is ownly known post dispatch.
+	type PostInfo: Eq + PartialEq + Clone + Copy + Encode + Decode + Printable;
 	/// Actually dispatch this call and result the result of it.
-	fn dispatch(self, origin: Self::Origin) -> crate::DispatchResult;
+	fn dispatch(self, origin: Self::Origin) -> crate::DispatchResultWithInfo<Self::PostInfo>;
 }
 
 /// Means by which a transaction may be extended. This type embodies both the data and the logic


### PR DESCRIPTION
# Related Items

#5130: The GCD is an older alternate approach to the same problem. This PR seeks to replace it.
#5032: In this PR we lay the ground work that will eventually allow refunding. The linked PR therefore depends on the work done here. However, the linked PR is currently stand alone and will probably be rewritten given  the approach in this PR is deemed viable.

# Overview

Introduce an associated type `PostInfo`  to the `Dispatchable` trait that becomes part of its return type and implement it in frame so that it is used to return the a posteriori actual weight of a call.

It is done in a way that requires very little code changes to the existing frame pallets. The only pallets that need to be (minimally) changed are those that do dispatching (sudo, recovery, ...) because they need to deal with the new return typ of `Dispatchable::dispatch`.

# Motivation

We want dispatchables to be able to refund portions it their static a priori weight maximum. The reason for that is that there are dispatchables where the average weight consumed differs from the maximum. Without a refund we are charging too much weight in some cases. An example is `Balance::transfer` which is heavier when it needs to create the target account. The average case might be that the account already exists where we are then overcharging.

Having dispatchables returning their a posteriori actual weight allows us (in a different PR) to do a refund of the difference.

# High Level Changes

## Make `DispatchResultWithInfo` generic over the `PostInfo`

```rust
pub trait Dispatchable {
    ...
    type PostInfo;
    fn dispatch(self, origin: Self::Origin) -> DispatchResultWithPostInfo<Self::PostInfo>;
}

pub type DispatchResultWithInfo<T> = Result<T, DispatchErrorWithPostInfo<T>>;

pub struct DispatchErrorWithPostInfo<Info>
{
    pub post_info: Info,
    pub error: DispatchError,
}
```

The rationale for having the `PostInfo` duplicated to both variants and not having a containing struct is so that the result stays a `Result` for convenient `map`, `map_err` and `?` function calls.

## Implement `Dispatchable` in frame

```rust
pub struct PostDispatchInfo {
    /// Actual weight consumed by a call or `None` which stands for the worst case static weight.
    pub actual_weight: Option<Weight>,
}

pub type DispatchResultWithPostInfo = sp_runtime::DispatchResultWithPostInfo<PostDispatchInfo>;
```

`frame_support` re-exports `DispatchResultWithPostInfo` so that all of frame uses the concrete `PostDispatchInfo` we chose for frame. Existing frame code still uses the flat `DispatchResult`which is automatically converted (explained later).

The rationale for wrapping the `actual_weight` with a struct is that returning a plain `Weight` feels semantically weak to me: Is it a correction to the weight or the actual weight? Having the field makes it unambiguous. 

## Change `decl_module!` so that existing dispatchables still work

`decl_module!` calls `Into` at the appropriate places in order to allow preexisting frame code which returns `DispatchResult` to remain unchanged.  The actual `Dispatchable` implementation generated by the macro returns the `DispatchResultWithPostInfo` either from the default conversion or a user specified `PostDispatchInfo`.

A runtime Developer can decide to explicitly return a `DispatchResultWithPostInfo` in order to override the default value of "all weight was used".

## Add `WithPostDispatchInfo` trait

For easy augmentation of module specific errors with weight information we add a trait and automatically implement it for everything that is convertible into a `DispatchError` so that it can be used in the following way:

```rust
let who = ensure_signed(origin).map_err(|e| e.with_weight(100))?;
ensure!(who == me, Error::<T>::NotMe.with_weight(200_000));
```

# Future Work

The following items will be implemented in the near future and are not part of this PR on purpose

## Weight Refund

Actually evaluate the `PostDispatchInfo` in one way or another in order to do the weight refund. The working idea is to pass it as an additional Parameter to `SignedExtension::post_dispatch` where the refund can then happen.

## Return precise actual weight from frame calls

This will probably be done in multiple smaller PRs by the respective code owners or in a big PR by one awesome individual. The point is that this can be an incremental process if necessary.

This includes changing the return type to `DispatchResultWithPostInfo` and deal with the consequences.

# TODO
- [x] Make the weight return opt-in by matching for the return type in `decl_module!`
- [x] Update `decl_module!` documentation