### PR TITLE
src/service/src/builder: Fix memory metric exposed in bytes not KiB

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -77,7 +77,7 @@ impl ServiceMetrics {
 				"ready_transactions_number", "Number of transactions in the ready queue",
 			)?, registry)?,
 			memory_usage_bytes: register(Gauge::new(
-				"memory_usage_bytes", "Node memory usage",
+				"memory_usage_bytes", "Node memory (resident set size) usage",
 			)?, registry)?,
 			cpu_usage_percentage: register(Gauge::new(
 				"cpu_usage_percentage", "Node CPU usage",
@@ -1074,7 +1074,8 @@ ServiceBuilder<
 					.unwrap_or(0),
 			);
 			if let Some(metrics) = metrics.as_ref() {
-				metrics.memory_usage_bytes.set(memory);
+				// `sysinfo::Process::memory` returns memory usage in KiB and not bytes.
+				metrics.memory_usage_bytes.set(memory * 1024);
 				metrics.cpu_usage_percentage.set(f64::from(cpu_usage));
 				metrics.ready_transactions_number.set(txpool_status.ready as u64);
 


### PR DESCRIPTION
The library `sysinfo` exposes process memory as kibibytes and not bytes,
thus the value needs to be multiplied by 1024 to comply with the metric
name and the Prometheus base units [1].

[1] https://prometheus.io/docs/practices/naming/#base-units

