### PR TITLE
Increase limit on light client response size

### DIFF
--- a/client/network/src/protocol/generic_proto/handler/group.rs
+++ b/client/network/src/protocol/generic_proto/handler/group.rs
@@ -64,7 +64,6 @@ use libp2p::swarm::{
 	NegotiatedSubstream,
 };
 use log::{debug, error};
-use sp_runtime::ConsensusEngineId;
 use std::{borrow::Cow, error, io, str, task::{Context, Poll}};
 
 /// Implements the `IntoProtocolsHandler` trait of libp2p.

--- a/client/network/src/protocol/light_client_handler.rs
+++ b/client/network/src/protocol/light_client_handler.rs
@@ -77,7 +77,8 @@ use wasm_timer::Instant;
 /// Configuration options for `LightClientHandler` behaviour.
 #[derive(Debug, Clone)]
 pub struct Config {
-	max_data_size: usize,
+	max_request_size: usize,
+	max_response_size: usize,
 	max_pending_requests: usize,
 	inactivity_timeout: Duration,
 	request_timeout: Duration,
@@ -87,13 +88,15 @@ pub struct Config {
 impl Config {
 	/// Create a fresh configuration with the following options:
 	///
-	/// - max. data size = 64 MiB
+	/// - max. request size = 1 MiB
+	/// - max. response size = 16 MiB
 	/// - max. pending requests = 128
 	/// - inactivity timeout = 15s
 	/// - request timeout = 15s
 	pub fn new(id: &ProtocolId) -> Self {
 		let mut c = Config {
-			max_data_size: 64 * 1024 * 1024,
+			max_request_size: 1 * 1024 * 1024,
+			max_response_size: 16 * 1024 * 1024,
 			max_pending_requests: 128,
 			inactivity_timeout: Duration::from_secs(15),
 			request_timeout: Duration::from_secs(15),
@@ -103,9 +106,15 @@ impl Config {
 		c
 	}
 
-	/// Limit the max. length of incoming request bytes.
-	pub fn set_max_data_size(&mut self, v: usize) -> &mut Self {
-		self.max_data_size = v;
+	/// Limit the max. length in bytes of a request.
+	pub fn set_max_request_size(&mut self, v: usize) -> &mut Self {
+		self.max_request_size = v;
+		self
+	}
+
+	/// Limit the max. length in bytes of a response.
+	pub fn set_max_response_size(&mut self, v: usize) -> &mut Self {
+		self.max_response_size = v;
 		self
 	}
 
@@ -654,7 +663,7 @@ where
 
 	fn new_handler(&mut self) -> Self::ProtocolsHandler {
 		let p = InboundProtocol {
-			max_data_size: self.config.max_data_size,
+			max_request_size: self.config.max_request_size,
 			protocol: self.config.protocol.clone(),
 		};
 		OneShotHandler::new(SubstreamProtocol::new(p), self.config.inactivity_timeout)
@@ -841,7 +850,7 @@ where
 					let protocol = OutboundProtocol {
 						request: buf,
 						request_id: id,
-						max_data_size: self.config.max_data_size,
+						max_response_size: self.config.max_response_size,
 						protocol: self.config.protocol.clone(),
 					};
 					self.peers.get_mut(&peer).map(|info| info.status = PeerStatus::BusyWith(id));
@@ -1008,7 +1017,7 @@ pub enum Event<T> {
 #[derive(Debug, Clone)]
 pub struct InboundProtocol {
 	/// The max. request length in bytes.
-	max_data_size: usize,
+	max_request_size: usize,
 	/// The protocol to use for upgrade negotiation.
 	protocol: Bytes,
 }
@@ -1032,7 +1041,7 @@ where
 
     fn upgrade_inbound(self, mut s: T, _: Self::Info) -> Self::Future {
 		let future = async move {
-			let vec = read_one(&mut s, self.max_data_size).await?;
+			let vec = read_one(&mut s, self.max_request_size).await?;
 			match api::v1::light::Request::decode(&vec[..]) {
 				Ok(r) => Ok(Event::Request(r, s)),
 				Err(e) => Err(ReadOneError::Io(io::Error::new(io::ErrorKind::Other, e)))
@@ -1051,8 +1060,8 @@ pub struct OutboundProtocol {
 	request: Vec<u8>,
 	/// Local identifier for the request. Used to associate it with a response.
 	request_id: u64,
-	/// The max. request length in bytes.
-	max_data_size: usize,
+	/// The max. response length in bytes.
+	max_response_size: usize,
 	/// The protocol to use for upgrade negotiation.
 	protocol: Bytes,
 }
@@ -1077,7 +1086,7 @@ where
     fn upgrade_outbound(self, mut s: T, _: Self::Info) -> Self::Future {
 		let future = async move {
 			write_one(&mut s, &self.request).await?;
-			let vec = read_one(&mut s, self.max_data_size).await?;
+			let vec = read_one(&mut s, self.max_response_size).await?;
 			api::v1::light::Response::decode(&vec[..])
 				.map(|r| Event::Response(self.request_id, r))
 				.map_err(|e| {

--- a/client/network/src/protocol/light_client_handler.rs
+++ b/client/network/src/protocol/light_client_handler.rs
@@ -87,13 +87,13 @@ pub struct Config {
 impl Config {
 	/// Create a fresh configuration with the following options:
 	///
-	/// - max. data size = 1 MiB
+	/// - max. data size = 64 MiB
 	/// - max. pending requests = 128
 	/// - inactivity timeout = 15s
 	/// - request timeout = 15s
 	pub fn new(id: &ProtocolId) -> Self {
 		let mut c = Config {
-			max_data_size: 1024 * 1024,
+			max_data_size: 64 * 1024 * 1024,
 			max_pending_requests: 128,
 			inactivity_timeout: Duration::from_secs(15),
 			request_timeout: Duration::from_secs(15),


### PR DESCRIPTION
I'm working on a pull request that switches to this new light client protocol, but I realized that none of the requests are going through on Polkadot because the maximum response size is too low.
Even the most basic responses are 1.7MiB in size, so more than the default 1MiB.

Unfortunately this also causes the connection to be force-closed (and immediately reopened afterwards) because of https://github.com/libp2p/rust-libp2p/issues/1530

I'm opening this PR separately because we need it to be deployed on full nodes before light client can switch to this new protocol.
