### PR TITLE
ci: check_polkadot_companion_status: don't verify mergeable_state

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -76,11 +76,11 @@ then
   exit 0
 fi
 
-if jq -e '.mergeable and .mergeable_state == "clean"' < companion_pr.json >/dev/null
+if jq -e '.mergeable' < companion_pr.json >/dev/null
 then
   boldprint "polkadot pr #${pr_companion} mergeable"
 else
-  boldprint "polkadot pr #${pr_companion} not mergeable or clean"
+  boldprint "polkadot pr #${pr_companion} not mergeable"
   exit 1
 fi
 


### PR DESCRIPTION
disable check for `mergeable_status` on polkadot companion pr