### PR TITLE
Remove dependency assert_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,19 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
-dependencies = [
- "doc-comment",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "assert_matches"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,7 +3305,6 @@ dependencies = [
 name = "node-cli"
 version = "2.0.0-alpha.5"
 dependencies = [
- "assert_cmd",
  "frame-benchmarking-cli",
  "frame-support",
  "frame-system",
@@ -4845,32 +4831,6 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-
-[[package]]
-name = "predicates"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
-dependencies = [
- "difference",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
-dependencies = [
- "predicates-core",
- "treeline",
-]
 
 [[package]]
 name = "pretty_assertions"
@@ -8494,12 +8454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
-
-[[package]]
 name = "trie-bench"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8751,15 +8705,6 @@ dependencies = [
  "cc",
  "cmake",
  "glob 0.2.11",
-]
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -113,7 +113,6 @@ sc-consensus-epochs = { version = "0.8.0-alpha.5", path = "../../../client/conse
 sc-service-test = { version = "2.0.0-dev", path = "../../../client/service/test" }
 futures = "0.3.4"
 tempfile = "3.1.0"
-assert_cmd = "1.0"
 nix = "0.17"
 serde_json = "1.0"
 

--- a/bin/node/cli/tests/build_spec_works.rs
+++ b/bin/node/cli/tests/build_spec_works.rs
@@ -14,15 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use assert_cmd::cargo::cargo_bin;
 use std::process::Command;
 use tempfile::tempdir;
+
+mod common;
 
 #[test]
 fn build_spec_works() {
 	let base_path = tempdir().expect("could not create a temp dir");
 
-	let output = Command::new(cargo_bin("substrate"))
+	let output = Command::new(common::cargo_bin("substrate"))
 		.args(&["build-spec", "--dev", "-d"])
 		.arg(base_path.path())
 		.output()

--- a/bin/node/cli/tests/check_block_works.rs
+++ b/bin/node/cli/tests/check_block_works.rs
@@ -16,7 +16,6 @@
 
 #![cfg(unix)]
 
-use assert_cmd::cargo::cargo_bin;
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -28,7 +27,7 @@ fn check_block_works() {
 
 	common::run_dev_node_for_a_while(base_path.path());
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["check-block", "--dev", "--pruning", "archive", "-d"])
 		.arg(base_path.path())
 		.arg("1")

--- a/bin/node/cli/tests/factory.rs
+++ b/bin/node/cli/tests/factory.rs
@@ -16,7 +16,6 @@
 
 #![cfg(unix)]
 
-use assert_cmd::cargo::cargo_bin;
 use std::process::{Command, Stdio};
 use tempfile::tempdir;
 
@@ -26,7 +25,7 @@ mod common;
 fn factory_works() {
 	let base_path = tempdir().expect("could not create a temp dir");
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.stdout(Stdio::null())
 		.args(&["factory", "--dev", "-d"])
 		.arg(base_path.path())

--- a/bin/node/cli/tests/import_export_and_revert_work.rs
+++ b/bin/node/cli/tests/import_export_and_revert_work.rs
@@ -16,7 +16,6 @@
 
 #![cfg(unix)]
 
-use assert_cmd::cargo::cargo_bin;
 use std::{process::Command, fs};
 use tempfile::tempdir;
 
@@ -29,7 +28,7 @@ fn import_export_and_revert_work() {
 
 	common::run_dev_node_for_a_while(base_path.path());
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["export-blocks", "--dev", "--pruning", "archive", "-d"])
 		.arg(base_path.path())
 		.arg(&exported_blocks)
@@ -42,7 +41,7 @@ fn import_export_and_revert_work() {
 
 	let _ = fs::remove_dir_all(base_path.path().join("db"));
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["import-blocks", "--dev", "--pruning", "archive", "-d"])
 		.arg(base_path.path())
 		.arg(&exported_blocks)
@@ -50,7 +49,7 @@ fn import_export_and_revert_work() {
 		.unwrap();
 	assert!(status.success());
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["revert", "--dev", "--pruning", "archive", "-d"])
 		.arg(base_path.path())
 		.status()

--- a/bin/node/cli/tests/inspect_works.rs
+++ b/bin/node/cli/tests/inspect_works.rs
@@ -16,7 +16,6 @@
 
 #![cfg(unix)]
 
-use assert_cmd::cargo::cargo_bin;
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -28,7 +27,7 @@ fn inspect_works() {
 
 	common::run_dev_node_for_a_while(base_path.path());
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["inspect", "--dev", "--pruning", "archive", "-d"])
 		.arg(base_path.path())
 		.args(&["block", "1"])

--- a/bin/node/cli/tests/purge_chain_works.rs
+++ b/bin/node/cli/tests/purge_chain_works.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use assert_cmd::cargo::cargo_bin;
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -27,7 +26,7 @@ fn purge_chain_works() {
 
 	common::run_dev_node_for_a_while(base_path.path());
 
-	let status = Command::new(cargo_bin("substrate"))
+	let status = Command::new(common::cargo_bin("substrate"))
 		.args(&["purge-chain", "--dev", "-d"])
 		.arg(base_path.path())
 		.arg("-y")

--- a/bin/node/cli/tests/running_the_node_and_interrupt.rs
+++ b/bin/node/cli/tests/running_the_node_and_interrupt.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use assert_cmd::cargo::cargo_bin;
 use std::{convert::TryInto, process::Command, thread, time::Duration};
 use tempfile::tempdir;
 
@@ -28,7 +27,7 @@ fn running_the_node_works_and_can_be_interrupted() {
 
 	fn run_command_and_kill(signal: Signal) {
 		let base_path = tempdir().expect("could not create a temp dir");
-		let mut cmd = Command::new(cargo_bin("substrate"))
+		let mut cmd = Command::new(common::cargo_bin("substrate"))
 			.args(&["--dev", "-d"])
 			.arg(base_path.path())
 			.spawn()


### PR DESCRIPTION
We don't use many features of this dependency and it is causing problems on
the CI at the moment.

Related to: https://github.com/assert-rs/assert_cmd/pull/99 https://github.com/assert-rs/assert_cmd/pull/98 https://github.com/assert-rs/assert_cmd/pull/97