### PR TITLE
grandpa: sentry favorite peers

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -141,6 +141,7 @@ pub fn new_full(config: Configuration)
 		justification_period: 512,
 		name: Some(name),
 		observer_enabled: false,
+		favorite_peers: Default::default(),
 		keystore,
 		is_authority,
 	};

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -209,6 +209,7 @@ macro_rules! new_full {
 			None
 		};
 
+		// add reserved and sentry nodes as favorite peers to GRANDPA
 		let favorite_peers = reserved_nodes
 			.into_iter()
 			.chain(sentry_nodes.into_iter())

--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -1110,6 +1110,9 @@ impl<Block: BlockT> Inner<Block> {
 		let round_duration = self.config.gossip_duration * ROUND_DURATION;
 		let round_elapsed = self.round_start.elapsed();
 
+		if self.config.favorite_peers.contains(who) {
+			return true;
+		}
 
 		if !self.config.is_authority
 			&& round_elapsed < round_duration * PROPAGATION_ALL
@@ -1169,6 +1172,10 @@ impl<Block: BlockT> Inner<Block> {
 	fn global_message_allowed<N>(&self, who: &PeerId, peer: &PeerInfo<N>) -> bool {
 		let round_duration = self.config.gossip_duration * ROUND_DURATION;
 		let round_elapsed = self.round_start.elapsed();
+
+		if self.config.favorite_peers.contains(who) {
+			return true;
+		}
 
 		if peer.roles.is_authority() {
 			let authorities = self.peers.authorities();

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -52,6 +52,8 @@
 //! or prune any signaled changes based on whether the signaling block is
 //! included in the newly-finalized chain.
 
+use std::collections::HashSet;
+
 use futures::prelude::*;
 use futures::StreamExt;
 use log::{debug, info};
@@ -204,6 +206,10 @@ pub struct Config {
 	pub is_authority: bool,
 	/// Some local identifier of the voter.
 	pub name: Option<String>,
+	/// The set of favorite peers which we should treat preferably when gossiping messages
+	/// (i.e. we prioritize sending any data to them over other peers). The favorite peers
+	/// are usually reserved nodes and/or sentry nodes.
+	pub favorite_peers: HashSet<sc_network::PeerId>,
 	/// The keystore that manages the keys of this node.
 	pub keystore: Option<sc_keystore::KeyStorePtr>,
 }

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -221,7 +221,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 			}
 		}
 
-		// treat sentry nodes as reserved for the peerset, we always want to maintain contains to
+		// treat sentry nodes as reserved for the peerset, we always want to maintain connections to
 		// our sentries.
 		for sentry in params.network_config.sentry_nodes.iter() {
 			if !add_reserved(sentry) {


### PR DESCRIPTION
- Make sure sentry nodes are treated as reserved nodes from peer set (i.e. we try to maintain connections to sentry nodes);
  - Since we have the concept of priority groups maybe we should just create a new one for sentries?

- Treat sentry and reserved nodes preferably in GRANDPA gossip validator (i.e. never restrict sending any vote data to them);

The approach in this PR is just a hacky solution quickly done to figure out if this would fix the issue. We want to expose the information about a peer being a reserved/sentry node to GRANDPA gossip validator in a more generic way, so that this can also be used by other protocols (will also be useful in Polkadot).