### PR TITLE
babe: restore epoch changes migration code

### DIFF
--- a/client/consensus/babe/src/aux_schema.rs
+++ b/client/consensus/babe/src/aux_schema.rs
@@ -25,7 +25,7 @@ use sc_client_api::backend::AuxStore;
 use sp_blockchain::{Result as ClientResult, Error as ClientError};
 use sp_runtime::traits::Block as BlockT;
 use sp_consensus_babe::BabeBlockWeight;
-use sc_consensus_epochs::{EpochChangesFor, SharedEpochChanges};
+use sc_consensus_epochs::{EpochChangesFor, SharedEpochChanges, migration::EpochChangesForV0};
 use crate::Epoch;
 
 const BABE_EPOCH_CHANGES_VERSION: &[u8] = b"babe_epoch_changes_version";
@@ -57,7 +57,11 @@ pub(crate) fn load_epoch_changes<Block: BlockT, B: AuxStore>(
 	let version = load_decode::<_, u32>(backend, BABE_EPOCH_CHANGES_VERSION)?;
 
 	let maybe_epoch_changes = match version {
-		None | Some(BABE_EPOCH_CHANGES_CURRENT_VERSION) => load_decode::<_, EpochChangesFor<Block, Epoch>>(
+		None => load_decode::<_, EpochChangesForV0<Block, Epoch>>(
+			backend,
+			BABE_EPOCH_CHANGES_KEY,
+		)?.map(|v0| v0.migrate()),
+		Some(BABE_EPOCH_CHANGES_CURRENT_VERSION) => load_decode::<_, EpochChangesFor<Block, Epoch>>(
 			backend,
 			BABE_EPOCH_CHANGES_KEY,
 		)?,
@@ -122,4 +126,73 @@ pub(crate) fn load_block_weight<H: Encode, B: AuxStore>(
 	block_hash: H,
 ) -> ClientResult<Option<BabeBlockWeight>> {
 	load_decode(backend, block_weight_key(block_hash).as_slice())
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::Epoch;
+	use fork_tree::ForkTree;
+	use substrate_test_runtime_client;
+	use sp_core::H256;
+	use sp_runtime::traits::NumberFor;
+	use sc_consensus_epochs::{PersistedEpoch, PersistedEpochHeader, EpochHeader};
+	use sp_consensus::Error as ConsensusError;
+	use sc_network_test::Block as TestBlock;
+
+	#[test]
+	fn load_decode_from_v0_epoch_changes() {
+		let epoch = Epoch {
+			start_slot: 0,
+			authorities: vec![],
+			randomness: [0; 32],
+			epoch_index: 1,
+			duration: 100,
+		};
+		let client = substrate_test_runtime_client::new();
+		let mut v0_tree = ForkTree::<H256, NumberFor<TestBlock>, _>::new();
+		v0_tree.import::<_, ConsensusError>(
+			Default::default(),
+			Default::default(),
+			PersistedEpoch::Regular(epoch),
+			&|_, _| Ok(false), // Test is single item only so this can be set to false.
+		).unwrap();
+
+		client.insert_aux(
+			&[(BABE_EPOCH_CHANGES_KEY,
+			   &EpochChangesForV0::<TestBlock, Epoch>::from_raw(v0_tree).encode()[..])],
+			&[],
+		).unwrap();
+
+		assert_eq!(
+			load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(),
+			None,
+		);
+
+		let epoch_changes = load_epoch_changes::<TestBlock, _>(&client).unwrap();
+
+		assert!(
+			epoch_changes.lock()
+				.tree()
+				.iter()
+				.map(|(_, _, epoch)| epoch.clone())
+				.collect::<Vec<_>>() ==
+				vec![PersistedEpochHeader::Regular(EpochHeader {
+					start_slot: 0,
+					end_slot: 100,
+				})],
+		); // PersistedEpochHeader does not implement Debug, so we use assert! directly.
+
+		write_epoch_changes::<TestBlock, _, _>(
+			&epoch_changes.lock(),
+			|values| {
+				client.insert_aux(values, &[]).unwrap();
+			},
+		);
+
+		assert_eq!(
+			load_decode::<_, u32>(&client, BABE_EPOCH_CHANGES_VERSION).unwrap(),
+			Some(1),
+		);
+	}
 }

--- a/client/consensus/epochs/src/lib.rs
+++ b/client/consensus/epochs/src/lib.rs
@@ -16,6 +16,8 @@
 
 //! Generic utilities for epoch-based consensus engines.
 
+pub mod migration;
+
 use std::{sync::Arc, ops::Add, collections::BTreeMap, borrow::{Borrow, BorrowMut}};
 use parking_lot::Mutex;
 use codec::{Encode, Decode};

--- a/client/consensus/epochs/src/migration.rs
+++ b/client/consensus/epochs/src/migration.rs
@@ -1,0 +1,55 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Migration types for epoch changes.
+
+use std::collections::BTreeMap;
+use codec::{Encode, Decode};
+use fork_tree::ForkTree;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use crate::{Epoch, EpochChanges, PersistedEpoch, PersistedEpochHeader};
+
+/// Legacy definition of epoch changes.
+#[derive(Clone, Encode, Decode)]
+pub struct EpochChangesV0<Hash, Number, E: Epoch> {
+	inner: ForkTree<Hash, Number, PersistedEpoch<E>>,
+}
+
+/// Type alias for legacy definition of epoch changes.
+pub type EpochChangesForV0<Block, Epoch> = EpochChangesV0<<Block as BlockT>::Hash, NumberFor<Block>, Epoch>;
+
+impl<Hash, Number, E: Epoch> EpochChangesV0<Hash, Number, E> where
+	Hash: PartialEq + Ord + Copy,
+	Number: Ord + Copy,
+{
+	/// Create a new value of this type from raw.
+	pub fn from_raw(inner: ForkTree<Hash, Number, PersistedEpoch<E>>) -> Self {
+		Self { inner }
+	}
+
+	/// Migrate the type into current epoch changes definition.
+	pub fn migrate(self) -> EpochChanges<Hash, Number, E> {
+		let mut epochs = BTreeMap::new();
+
+		let inner = self.inner.map(&mut |hash, number, data| {
+			let header = PersistedEpochHeader::from(&data);
+			epochs.insert((*hash, *number), data);
+			header
+		});
+
+		EpochChanges { inner, epochs }
+	}
+}


### PR DESCRIPTION
This was removed in https://github.com/paritytech/substrate/pull/5291 but it's still too early to do it as it requires nodes still on Polkadot v0.7.26 to resync from scratch.

Fixes #5486 