### PR TITLE
ci: divide cache between branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ stages:
 variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
-  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
+  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
   CARGO_INCREMENTAL:               0
   CI_SERVER_NAME:                  "GitLab CI"


### PR DESCRIPTION
Previously `CARGO_HOME` was divided between CI jobs only, and it was fine. There was no sensible concurrency for the dependencies' sources. 
Since [1.41](https://github.com/rust-lang/cargo/issues/4007) we've been experiencing a lot of troubles with the corrupted cache.

This PR is a simple workaround:
Pros:
+ It **should stop** requiring cache purging because of the error

Cons:
- every **new** PR pipeline will download all the deps for every CI runner. 
- it will use more disk space on CI servers

On the bright side, it will be easier to clean cache only for those jobs which need that.