### PR TITLE
Remove unused dependency on safe-mix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "safe-mix",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -10,7 +10,6 @@ description = "FRAME pallet template"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-safe-mix = { default-features = false, version = '1.0.0' }
 
 [dependencies.frame-support]
 default-features = false
@@ -42,7 +41,6 @@ default = ['std']
 std = [
 	'codec/std',
 	'frame-support/std',
-	'safe-mix/std',
 	'frame-system/std'
 ]
 


### PR DESCRIPTION
This PR removes an unneeded dependency on `safe-mix` from the template pallet.