### PR TITLE
Better logging for notifications

### DIFF
--- a/client/network/src/protocol/generic_proto/handler/notif_out.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_out.rs
@@ -307,7 +307,7 @@ impl ProtocolsHandler for NotifsOutHandler {
 					if !matches!(substream.send(msg).now_or_never(), Some(Ok(_))) {
 						log::warn!(
 							target: "sub-libp2p",
-							"📞 Queue of notifications with {} is full, dropped message (protocol: {:?})",
+							"📞 Notifications queue with peer {} is full, dropped message (protocol: {:?})",
 							self.peer_id,
 							self.protocol_name,
 						);

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -44,7 +44,7 @@ use unsigned_varint::codec::UviBytes;
 /// Maximum allowed size of the two handshake messages, in bytes.
 const MAX_HANDSHAKE_SIZE: usize = 1024;
 /// Maximum number of buffered messages before we refuse to accept more.
-const MAX_PENDING_MESSAGES: usize = 1024;
+const MAX_PENDING_MESSAGES: usize = 256;
 
 /// Upgrade that accepts a substream, sends back a status message, then becomes a unidirectional
 /// stream of messages.

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -43,9 +43,8 @@ use unsigned_varint::codec::UviBytes;
 
 /// Maximum allowed size of the two handshake messages, in bytes.
 const MAX_HANDSHAKE_SIZE: usize = 1024;
-/// Maximum number of buffered messages before we consider the remote unresponsive and kill the
-/// substream.
-const MAX_PENDING_MESSAGES: usize = 256;
+/// Maximum number of buffered messages before we refuse to accept more.
+const MAX_PENDING_MESSAGES: usize = 1024;
 
 /// Upgrade that accepts a substream, sends back a status message, then becomes a unidirectional
 /// stream of messages.


### PR DESCRIPTION
Related to #5481 

Two changes:

- Better logging for when the queue is full.
~~- Increases the size of the buffer of pending messages to 1024 as a temporary fix while #5481 is properly tackled.~~ EDIT: reverted

The first change should obviously go in.
~~The second one is more a proposal, and I'd be ok if people are against doing this.~~
