### PR TITLE
Add a sub_libp2p_notifications_queues_size Prometheus metric

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -40,7 +40,7 @@ use sp_runtime::traits::{
 use sp_arithmetic::traits::SaturatedConversion;
 use message::{BlockAnnounce, Message};
 use message::generic::{Message as GenericMessage, ConsensusMessage};
-use prometheus_endpoint::{Registry, Gauge, GaugeVec, PrometheusError, Opts, register, U64};
+use prometheus_endpoint::{Registry, Gauge, GaugeVec, HistogramVec, PrometheusError, Opts, register, U64};
 use sync::{ChainSync, SyncState};
 use crate::service::{TransactionPool, ExHashT};
 use crate::config::{BoxFinalityProofRequestBuilder, Roles};
@@ -324,6 +324,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		block_announce_validator: Box<dyn BlockAnnounceValidator<B> + Send>,
 		metrics_registry: Option<&Registry>,
 		boot_node_ids: Arc<HashSet<PeerId>>,
+		queue_size_report: Option<HistogramVec>,
 	) -> error::Result<(Protocol<B, H>, sc_peerset::PeersetHandle)> {
 		let info = chain.info();
 		let sync = ChainSync::new(
@@ -346,7 +347,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 
 		let (peerset, peerset_handle) = sc_peerset::Peerset::from_config(peerset_config);
 		let versions = &((MIN_VERSION as u8)..=(CURRENT_VERSION as u8)).collect::<Vec<u8>>();
-		let mut behaviour = GenericProto::new(protocol_id.clone(), versions, peerset);
+		let mut behaviour = GenericProto::new(protocol_id.clone(), versions, peerset, queue_size_report);
 
 		let mut legacy_equiv_by_name = HashMap::new();
 

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -2053,6 +2053,7 @@ mod tests {
 			Box::new(DefaultBlockAnnounceValidator::new(client.clone())),
 			None,
 			Default::default(),
+			None,
 		).unwrap();
 
 		let dummy_peer_id = PeerId::random();

--- a/client/network/src/protocol/generic_proto/handler/notif_out.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_out.rs
@@ -34,6 +34,7 @@ use libp2p::swarm::{
 	NegotiatedSubstream,
 };
 use log::error;
+use prometheus_endpoint::Histogram;
 use smallvec::SmallVec;
 use std::{borrow::Cow, fmt, mem, pin::Pin, task::{Context, Poll}, time::Duration};
 use wasm_timer::Instant;
@@ -56,14 +57,17 @@ const INITIAL_KEEPALIVE_TIME: Duration = Duration::from_secs(5);
 pub struct NotifsOutHandlerProto {
 	/// Name of the protocol to negotiate.
 	protocol_name: Cow<'static, [u8]>,
+	/// Optional prometheus histogram to report message queue sizes variations.
+	queue_size_report: Option<Histogram>,
 }
 
 impl NotifsOutHandlerProto {
 	/// Builds a new [`NotifsOutHandlerProto`]. Will use the given protocol name for the
 	/// notifications substream.
-	pub fn new(protocol_name: impl Into<Cow<'static, [u8]>>) -> Self {
+	pub fn new(protocol_name: impl Into<Cow<'static, [u8]>>, queue_size_report: Option<Histogram>) -> Self {
 		NotifsOutHandlerProto {
 			protocol_name: protocol_name.into(),
+			queue_size_report,
 		}
 	}
 }
@@ -79,6 +83,7 @@ impl IntoProtocolsHandler for NotifsOutHandlerProto {
 		NotifsOutHandler {
 			protocol_name: self.protocol_name,
 			when_connection_open: Instant::now(),
+			queue_size_report: self.queue_size_report,
 			state: State::Disabled,
 			events_queue: SmallVec::new(),
 		}
@@ -102,6 +107,9 @@ pub struct NotifsOutHandler {
 
 	/// When the connection with the remote has been successfully established.
 	when_connection_open: Instant,
+
+	/// Optional prometheus histogram to report message queue sizes variations.
+	queue_size_report: Option<Histogram>,
 
 	/// Queue of events to send to the outside.
 	///
@@ -301,6 +309,9 @@ impl ProtocolsHandler for NotifsOutHandler {
 			NotifsOutHandlerIn::Send(msg) =>
 				if let State::Open { substream, .. } = &mut self.state {
 					if let Some(Ok(_)) = substream.send(msg).now_or_never() {
+						if let Some(metric) = &self.queue_size_report {
+							metric.observe(substream.queue_len() as f64);
+						}
 					} else {
 						log::warn!(
 							target: "sub-libp2p",
@@ -357,7 +368,10 @@ impl ProtocolsHandler for NotifsOutHandler {
 		match &mut self.state {
 			State::Open { substream, initial_message } =>
 				match Sink::poll_flush(Pin::new(substream), cx) {
-					Poll::Pending | Poll::Ready(Ok(())) => {},
+					Poll::Pending | Poll::Ready(Ok(())) =>
+						if let Some(metric) = &self.queue_size_report {
+							metric.observe(substream.queue_len() as f64);
+						},
 					Poll::Ready(Err(_)) => {
 						// We try to re-open a substream.
 						let initial_message = mem::replace(initial_message, Vec::new());

--- a/client/network/src/protocol/generic_proto/handler/notif_out.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_out.rs
@@ -57,7 +57,7 @@ const INITIAL_KEEPALIVE_TIME: Duration = Duration::from_secs(5);
 pub struct NotifsOutHandlerProto {
 	/// Name of the protocol to negotiate.
 	protocol_name: Cow<'static, [u8]>,
-	/// Optional prometheus histogram to report message queue sizes variations.
+	/// Optional Prometheus histogram to report message queue size variations.
 	queue_size_report: Option<Histogram>,
 }
 
@@ -368,10 +368,7 @@ impl ProtocolsHandler for NotifsOutHandler {
 		match &mut self.state {
 			State::Open { substream, initial_message } =>
 				match Sink::poll_flush(Pin::new(substream), cx) {
-					Poll::Pending | Poll::Ready(Ok(())) =>
-						if let Some(metric) = &self.queue_size_report {
-							metric.observe(substream.queue_len() as f64);
-						},
+					Poll::Pending | Poll::Ready(Ok(())) => {},
 					Poll::Ready(Err(_)) => {
 						// We try to re-open a substream.
 						let initial_message = mem::replace(initial_message, Vec::new());

--- a/client/network/src/protocol/generic_proto/tests.rs
+++ b/client/network/src/protocol/generic_proto/tests.rs
@@ -82,7 +82,7 @@ fn build_nodes() -> (Swarm<CustomProtoWithAddr>, Swarm<CustomProtoWithAddr>) {
 		});
 
 		let behaviour = CustomProtoWithAddr {
-			inner: GenericProto::new(&b"test"[..], &[1], peerset),
+			inner: GenericProto::new(&b"test"[..], &[1], peerset, None),
 			addrs: addrs
 				.iter()
 				.enumerate()

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -38,7 +38,7 @@ use futures::{prelude::*, ready};
 use futures_codec::Framed;
 use libp2p::core::{UpgradeInfo, InboundUpgrade, OutboundUpgrade, upgrade};
 use log::error;
-use std::{borrow::Cow, collections::VecDeque, io, iter, mem, pin::Pin, task::{Context, Poll}};
+use std::{borrow::Cow, collections::VecDeque, convert::TryFrom as _, io, iter, mem, pin::Pin, task::{Context, Poll}};
 use unsigned_varint::codec::UviBytes;
 
 /// Maximum allowed size of the two handshake messages, in bytes.
@@ -277,6 +277,13 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 				need_flush: false,
 			}))
 		})
+	}
+}
+
+impl<TSubstream> NotificationsOutSubstream<TSubstream> {
+	/// Returns the number of items in the queue, capped to `u32::max_value()`.
+	pub fn queue_len(&self) -> u32 {
+		u32::try_from(self.messages_queue.len()).unwrap_or(u32::max_value())
 	}
 }
 

--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -17,6 +17,7 @@
 use futures_util::{FutureExt, future::Future};
 pub use prometheus::{
 	Registry, Error as PrometheusError, Opts,
+	Histogram, HistogramOpts, HistogramVec,
 	core::{
 		GenericGauge as Gauge, GenericCounter as Counter,
 		GenericGaugeVec as GaugeVec, GenericCounterVec as CounterVec,


### PR DESCRIPTION
Reports on a `Histogram`, for each protocol, the queue size.

This means that if we send for example 2 messages, then we will report 2 then 1 then 0, or 2 then 0. Therefore the "sum" is rather meaningless, as when sending 2 messages it could be either 3 or 2.

Instead, the idea is to use the "buckets" feature of Prometheus to see the number of times where we reached a certain value.

One question is: should be really call `observe()` when we flush the queue? Should we not call it only when we push a message, so that the value represents the size that a queue had when we sent a message?
