### PR TITLE
Added Robonomics network standard account prefix

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -459,6 +459,8 @@ ss58_address_format!(
 		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
 	DarwiniaAccount =>
 		(18, "darwinia", "Darwinia Chain mainnet, standard account (*25519).")
+	RobonomicsAccount =>
+		(32, "robonomics", "Any Robonomics network standard account (*25519).")
 	CentrifugeAccount =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
 	SubstrateAccount =>


### PR DESCRIPTION
**Motivation**

Added standard account prefix for [Robonomics](https://robonomics.network) and [derivative](https://blog.aira.life/genesis-block-of-dao-ipci-on-robonomics-substrate-ed4b6f7f991) networks.
