### PR TITLE
cli: fix milliseconds formatting on logs

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -186,8 +186,8 @@ pub fn init_logger(pattern: &str) {
 			let name = ::std::thread::current()
 				.name()
 				.map_or_else(Default::default, |x| format!("{}", Colour::Blue.bold().paint(x)));
-			let millis = (now.tm_nsec as f32 / 1000000.0).round() as usize;
-			let timestamp = format!("{}.{:03}", timestamp, millis);
+			let millis = (now.tm_nsec as f32 / 1000000.0).floor() as usize;
+			let timestamp = format!("{}.{}", timestamp, millis);
 			format!(
 				"{} {} {} {}  {}",
 				Colour::Black.bold().paint(timestamp),


### PR DESCRIPTION
When formatting timestamps used for logging we convert from nanoseconds to milliseconds by dividing and rounding up, instead we should floor the result. Spotted here:

```
2020-04-02 18:03:46.055 main-tokio- INFO substrate  💤 Idle (0 peers), best: #462 (0x0635…d863), finalized #459 (0x7364…9476), ⬇ 0 ⬆ 0
2020-04-02 18:03:47.999 main-tokio- TRACE babe  extract timestamp
2020-04-02 18:03:47.999 main-tokio- TRACE babe  extract timestamp
2020-04-02 18:03:47.1000 main-tokio- TRACE babe  extract timestamp
```
