### PR TITLE
Companion PR ci sed issue.

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -59,7 +59,7 @@ then
   pr_ref="$(echo $pr_data | grep -Po '"ref"\s*:\s*"\K(?!master)[^"]*')"
   pr_body="$(echo "$pr_data" | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
 
-  pr_companion="$(echo "${pr_body}" | sed -n -r \
+  pr_companion="$(echo "${pr_data}" | sed -n -r \
       -e 's;^.*polkadot companion: paritytech/polkadot#([0-9]+).*$;\1;p' \
       -e 's;^.*polkadot companion: https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
     | tail -n 1)"

--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -57,6 +57,7 @@ then
   # get the last reference to a pr in polkadot
   pr_data="$(curl -sSL -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME})"
   pr_ref="$(echo $pr_data | grep -Po '"ref"\s*:\s*"\K(?!master)[^"]*')"
+  pr_body="$(echo "$pr_data" | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
 
   pr_companion="$(echo "${pr_data}" | sed -n -r \
       -e 's;^.*polkadot companion: paritytech/polkadot#([0-9]+).*$;\1;p' \
@@ -64,7 +65,7 @@ then
     | tail -n 1)"
   if [ -z "${pr_companion}" ]
   then
-    pr_companion="$(echo "${pr_data}" | sed -n -r \
+    pr_companion="$(echo "${pr_body}" | sed -n -r \
       's;^.*https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
       | tail -n 1)"
   fi

--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -57,7 +57,7 @@ then
   # get the last reference to a pr in polkadot
   pr_data="$(curl -sSL -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME})"
   pr_ref="$(echo $pr_data | grep -Po '"ref"\s*:\s*"\K(?!master)[^"]*')"
-  pr_body="$(echo $pr_data | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
+  pr_body="$(echo "$pr_data" | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
 
   pr_companion="$(echo "${pr_body}" | sed -n -r \
       -e 's;^.*polkadot companion: paritytech/polkadot#([0-9]+).*$;\1;p' \

--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -57,7 +57,6 @@ then
   # get the last reference to a pr in polkadot
   pr_data="$(curl -sSL -H "${github_header}" -s ${github_api_substrate_pull_url}/${CI_COMMIT_REF_NAME})"
   pr_ref="$(echo $pr_data | grep -Po '"ref"\s*:\s*"\K(?!master)[^"]*')"
-  pr_body="$(echo "$pr_data" | sed -n -r 's/^[[:space:]]+"body": (".*")[^"]+$/\1/p')"
 
   pr_companion="$(echo "${pr_data}" | sed -n -r \
       -e 's;^.*polkadot companion: paritytech/polkadot#([0-9]+).*$;\1;p' \
@@ -65,7 +64,7 @@ then
     | tail -n 1)"
   if [ -z "${pr_companion}" ]
   then
-    pr_companion="$(echo "${pr_body}" | sed -n -r \
+    pr_companion="$(echo "${pr_data}" | sed -n -r \
       's;^.*https://github.com/paritytech/polkadot/pull/([0-9]+).*$;\1;p' \
       | tail -n 1)"
   fi


### PR DESCRIPTION
Ci for companion on #4857 stopped working after #5468. I am not totally sure how to reproduce it, locally I simple uses zsh that seems to do a similar thing (pr_body fails to extract), when bash works just fine.
This change attempt to fix that by just removing the body extract, which is not very satisfying, I did not find a way to extract the body properly (I wonder if jq is available for ci).
