### PR TITLE
Run Runtime Benchmarks on Block One

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -567,6 +567,8 @@ macro_rules! impl_benchmark {
 
 						// Run the benchmark `repeat` times.
 						for _ in 0..repeat {
+							// Set the block number to 1 so events are deposited.
+							frame_system::Module::<T>::set_block_number(1.into());
 							// Set up the externalities environment for the setup we want to benchmark.
 							let closure_to_benchmark = <SelectedBenchmark as $crate::BenchmarkingSetup<T>>::instance(&selected_benchmark, &c)?;
 

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -504,7 +504,9 @@ macro_rules! impl_benchmark {
 	(
 		NO_INSTANCE $( $name:ident ),*
 	) => {
-		impl<T: Trait> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T> {
+		impl<T: Trait> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T>
+			where T: frame_system::Trait
+		{
 			fn benchmarks() -> Vec<&'static [u8]> {
 				vec![ $( stringify!($name).as_ref() ),* ]
 			}
@@ -602,7 +604,9 @@ macro_rules! impl_benchmark {
 	(
 		INSTANCE $( $name:ident ),*
 	) => {
-		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T, I> {
+		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T, I>:
+			where T: frame_system::Trait
+		{
 			fn benchmarks() -> Vec<&'static [u8]> {
 				vec![ $( stringify!($name).as_ref() ),* ]
 			}

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -604,7 +604,7 @@ macro_rules! impl_benchmark {
 	(
 		INSTANCE $( $name:ident ),*
 	) => {
-		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T, I>:
+		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T, I>
 			where T: frame_system::Trait
 		{
 			fn benchmarks() -> Vec<&'static [u8]> {
@@ -669,6 +669,8 @@ macro_rules! impl_benchmark {
 
 						// Run the benchmark `repeat` times.
 						for _ in 0..repeat {
+							// Set the block number to 1 so events are deposited.
+							frame_system::Module::<T>::set_block_number(1.into());
 							// Set up the externalities environment for the setup we want to benchmark.
 							let closure_to_benchmark = <SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>>::instance(&selected_benchmark, &c)?;
 

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -11,13 +11,14 @@ description = "FRAME example pallet"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-benchmarking = { version = "2.0.0-alpha.5", default-features = false, path = "../benchmarking" }
 frame-support = { version = "2.0.0-alpha.5", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-alpha.5", default-features = false, path = "../system" }
 pallet-balances = { version = "2.0.0-alpha.5", default-features = false, path = "../balances" }
 sp-runtime = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/io" }
+
+frame-benchmarking = { version = "2.0.0-alpha.5", default-features = false, path = "../benchmarking", optional = "true" }
 
 [dev-dependencies]
 sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core", default-features = false }
@@ -35,6 +36,7 @@ std = [
 	"sp-io/std",
 	"sp-std/std"
 ]
+runtime-benchmarks = ["frame-benchmarking"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -18,7 +18,7 @@ sp-runtime = { version = "2.0.0-alpha.5", default-features = false, path = "../.
 sp-std = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-alpha.5", default-features = false, path = "../../primitives/io" }
 
-frame-benchmarking = { version = "2.0.0-alpha.5", default-features = false, path = "../benchmarking", optional = "true" }
+frame-benchmarking = { version = "2.0.0-alpha.5", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
 sp-core = { version = "2.0.0-alpha.5", path = "../../primitives/core", default-features = false }

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -262,7 +262,6 @@ use frame_support::{
 	},
 };
 use sp_std::prelude::*;
-use frame_benchmarking::{benchmarks, account};
 use frame_system::{self as system, ensure_signed, ensure_root, RawOrigin};
 use codec::{Encode, Decode};
 use sp_runtime::{
@@ -651,39 +650,45 @@ impl<T: Trait + Send + Sync> SignedExtension for WatchDummy<T> {
 	}
 }
 
-benchmarks!{
-	_ {
-		// Define a common range for `b`.
-		let b in 1 .. 1000 => ();
-	}
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking {
+	use super::*;
+	use frame_benchmarking::{benchmarks, account};
 
-	// This will measure the execution time of `accumulate_dummy` for b in [1..1000] range.
-	accumulate_dummy {
-		let b in ...;
-		let caller = account("caller", 0, 0);
-	}: _ (RawOrigin::Signed(caller), b.into())
-
-	// This will measure the execution time of `set_dummy` for b in [1..1000] range.
-	set_dummy {
-		let b in ...;
-		let caller = account("caller", 0, 0);
-	}: set_dummy (RawOrigin::Signed(caller), b.into())
-
-	// This will measure the execution time of `set_dummy` for b in [1..10] range.
-	another_set_dummy {
-		let b in 1 .. 10;
-		let caller = account("caller", 0, 0);
-	}: set_dummy (RawOrigin::Signed(caller), b.into())
-
-	// This will measure the execution time of sorting a vector.
-	sort_vector {
-		let x in 0 .. 10000;
-		let mut m = Vec::<u32>::new();
-		for i in 0..x {
-			m.push(i);
+	benchmarks!{
+		_ {
+			// Define a common range for `b`.
+			let b in 1 .. 1000 => ();
 		}
-	}: {
-		m.sort();
+
+		// This will measure the execution time of `accumulate_dummy` for b in [1..1000] range.
+		accumulate_dummy {
+			let b in ...;
+			let caller = account("caller", 0, 0);
+		}: _ (RawOrigin::Signed(caller), b.into())
+
+		// This will measure the execution time of `set_dummy` for b in [1..1000] range.
+		set_dummy {
+			let b in ...;
+			let caller = account("caller", 0, 0);
+		}: set_dummy (RawOrigin::Signed(caller), b.into())
+
+		// This will measure the execution time of `set_dummy` for b in [1..10] range.
+		another_set_dummy {
+			let b in 1 .. 10;
+			let caller = account("caller", 0, 0);
+		}: set_dummy (RawOrigin::Signed(caller), b.into())
+
+		// This will measure the execution time of sorting a vector.
+		sort_vector {
+			let x in 0 .. 10000;
+			let mut m = Vec::<u32>::new();
+			for i in 0..x {
+				m.push(i);
+			}
+		}: {
+			m.sort();
+		}
 	}
 }
 

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -262,7 +262,7 @@ use frame_support::{
 	},
 };
 use sp_std::prelude::*;
-use frame_system::{self as system, ensure_signed, ensure_root, RawOrigin};
+use frame_system::{self as system, ensure_signed, ensure_root};
 use codec::{Encode, Decode};
 use sp_runtime::{
 	traits::{SignedExtension, Bounded, SaturatedConversion},
@@ -654,6 +654,7 @@ impl<T: Trait + Send + Sync> SignedExtension for WatchDummy<T> {
 mod benchmarking {
 	use super::*;
 	use frame_benchmarking::{benchmarks, account};
+	use frame_system::RawOrigin;
 
 	benchmarks!{
 		_ {


### PR DESCRIPTION
We made it so that events are not emitted on block zero, but did not bump the block number for running benchmarks.

This fixes that by setting the block number to one at the beginning of every benchmark.

EDIT: This additionally fixes a CI issue where benchmarks in the Example pallet weren't compiling to Wasm because they weren't behind a feature flag.