### PR TITLE
Improve warning about notifications queue and remove spurious triggers

### DIFF
--- a/client/network/src/protocol/generic_proto/handler/notif_out.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_out.rs
@@ -307,7 +307,7 @@ impl ProtocolsHandler for NotifsOutHandler {
 					if !matches!(substream.send(msg).now_or_never(), Some(Ok(_))) {
 						log::warn!(
 							target: "sub-libp2p",
-							"📞 Queue of notifications with {} is full, dropped message (protocol: {:?})",
+							"📞 Notifications queue with peer {} is full, dropped message (protocol: {:?})",
 							self.peer_id,
 							self.protocol_name,
 						);

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -44,7 +44,7 @@ use unsigned_varint::codec::UviBytes;
 /// Maximum allowed size of the two handshake messages, in bytes.
 const MAX_HANDSHAKE_SIZE: usize = 1024;
 /// Maximum number of buffered messages before we refuse to accept more.
-const MAX_PENDING_MESSAGES: usize = 1024;
+const MAX_PENDING_MESSAGES: usize = 256;
 
 /// Upgrade that accepts a substream, sends back a status message, then becomes a unidirectional
 /// stream of messages.

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -43,9 +43,8 @@ use unsigned_varint::codec::UviBytes;
 
 /// Maximum allowed size of the two handshake messages, in bytes.
 const MAX_HANDSHAKE_SIZE: usize = 1024;
-/// Maximum number of buffered messages before we consider the remote unresponsive and kill the
-/// substream.
-const MAX_PENDING_MESSAGES: usize = 256;
+/// Maximum number of buffered messages before we refuse to accept more.
+const MAX_PENDING_MESSAGES: usize = 1024;
 
 /// Upgrade that accepts a substream, sends back a status message, then becomes a unidirectional
 /// stream of messages.

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -284,6 +284,18 @@ impl<TSubstream> NotificationsOutSubstream<TSubstream> {
 	pub fn queue_len(&self) -> u32 {
 		u32::try_from(self.messages_queue.len()).unwrap_or(u32::max_value())
 	}
+
+	/// Push a message to the queue of messages.
+	///
+	/// This has the same effect as the `Sink::start_send` implementation.
+	pub fn push_message(&mut self, item: Vec<u8>) -> Result<(), NotificationsOutError> {
+		if self.messages_queue.len() >= MAX_PENDING_MESSAGES {
+			return Err(NotificationsOutError::Clogged);
+		}
+
+		self.messages_queue.push_back(item);
+		Ok(())
+	}
 }
 
 impl<TSubstream> Sink<Vec<u8>> for NotificationsOutSubstream<TSubstream>
@@ -296,12 +308,7 @@ impl<TSubstream> Sink<Vec<u8>> for NotificationsOutSubstream<TSubstream>
 	}
 
 	fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
-		if self.messages_queue.len() >= MAX_PENDING_MESSAGES {
-			return Err(NotificationsOutError::Clogged);
-		}
-
-		self.messages_queue.push_back(item);
-		Ok(())
+		self.push_message(item)
 	}
 
 	fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
Supercedes #5500 

Improves the logging for the queue being full, and fixes the fact that the warning is being printed when we fail to immediately flush the queue.
We now only push the element, and flushing is handled by the `poll` function.
This is how this code was originally intended to behave, and the fact that we were immediately trying to flush the queue was not intended.

We also now report the queue size to Prometheus even when it's full.
