### PR TITLE
Fix non-linux build of sc-client

### DIFF
--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -62,12 +62,12 @@ sc-tracing = { version = "2.0.0-alpha.5", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
-[target.'cfg(unix)'.dependencies]
-procfs = '0.7.8'
+
+[target.'cfg(any(unix, windows))'.dependencies]
 netstat2 = "0.8.1"
 
-[target.'cfg(windows)'.dependencies]
-netstat2 = "0.8.1"
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = '0.7.8'
 
 
 [dev-dependencies]

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -32,7 +32,7 @@ use netstat2::{TcpState, ProtocolSocketInfo, iterate_sockets_info, AddressFamily
 #[cfg(not(unix))]
 use sysinfo::get_current_pid;
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 use procfs;
 
 struct PrometheusMetrics {
@@ -187,7 +187,7 @@ pub struct MetricsService {
 	pid: Option<i32>,
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 impl MetricsService {
 	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
 		let process = procfs::process::Process::myself()
@@ -225,7 +225,7 @@ impl MetricsService {
 }
 
 
-#[cfg(windows)]
+#[cfg(all(any(unix, windows), not(target_os = "linux")))]
 impl MetricsService {
 	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
 		Self {

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -29,7 +29,7 @@ use sysinfo::{ProcessExt, System, SystemExt};
 #[cfg(any(unix, windows))]
 use netstat2::{TcpState, ProtocolSocketInfo, iterate_sockets_info, AddressFamilyFlags, ProtocolFlags};
 
-#[cfg(not(unix))]
+#[cfg(all(any(unix, windows), not(target_os = "linux")))]
 use sysinfo::get_current_pid;
 
 #[cfg(target_os = "linux")]

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -24,13 +24,10 @@ use sp_transaction_pool::PoolStatus;
 use sp_utils::metrics::register_globals;
 
 #[cfg(any(windows, unix))]
-use sysinfo::{ProcessExt, System, SystemExt};
+use sysinfo::{self, ProcessExt, SystemExt};
 
 #[cfg(any(unix, windows))]
 use netstat2::{TcpState, ProtocolSocketInfo, iterate_sockets_info, AddressFamilyFlags, ProtocolFlags};
-
-#[cfg(all(any(unix, windows), not(target_os = "linux")))]
-use sysinfo::get_current_pid;
 
 #[cfg(target_os = "linux")]
 use procfs;
@@ -183,7 +180,7 @@ struct ProcessInfo {
 pub struct MetricsService {
 	metrics: Option<PrometheusMetrics>,
 	#[cfg(any(windows, unix))]
-	system: System,
+	system: sysinfo::System,
 	pid: Option<i32>,
 }
 
@@ -195,7 +192,7 @@ impl MetricsService {
 
 		Self {
 			metrics,
-			system: System::new(),
+			system: sysinfo::System::new(),
 			pid: Some(process.pid),
 		}
 	}
@@ -224,19 +221,18 @@ impl MetricsService {
 	
 }
 
-
 #[cfg(all(any(unix, windows), not(target_os = "linux")))]
 impl MetricsService {
 	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
 		Self {
 			metrics,
-			system: System(),
-			pid: get_current_pid().ok()
+			system: sysinfo::System::new(),
+			pid: sysinfo::get_current_pid().ok()
 		}
 	}
 	
 	fn process_info(&mut self) -> ProcessInfo {
-		self.pid.map(|pid| self._process_info_for(pid)).or_else(ProcessInfo::default)
+		self.pid.map(|pid| self._process_info_for(&pid)).unwrap_or_else(ProcessInfo::default)
 	}
 }
 


### PR DESCRIPTION
following #5414, this adds a more specific plattform bound around the usage of `procfs` and fixes some minor bugs to to fix the build on mac and windows.