### PR TITLE
Revert "prepopulate CARGO_HOME caches"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,24 +63,6 @@ variables:
     - rustup show
     - cargo --version
     - sccache -s
-    # if there is no directory for this $CI_COMMIT_REF_NAME/$CI_JOB_NAME
-    # create such directory and
-    # copy recursively all the files from the newest dir which has $CI_JOB_NAME, if it exists
-    - |
-      if [[ ! -d $CARGO_HOME ]]; then
-        mkdir -p /ci-cache/${CI_PROJECT_NAME}/cargo/${CI_COMMIT_REF_NAME};
-        FRESH_CACHE=$(find /ci-cache/${CI_PROJECT_NAME}/cargo -mindepth 2 -maxdepth 2 \
-          -type d -name ${CI_JOB_NAME}  -exec stat --printf="%Y\t%n\n" {} \; |sort -n -r |head -1 |cut -f2);
-        if [[ -d $FRESH_CACHE ]]; then
-          echo "____Using" "$FRESH_CACHE" "to prepopulate the cache____";
-          cp -r "${FRESH_CACHE}" "${CARGO_HOME}";
-          touch ${CARGO_HOME}/config;
-        else
-          echo "_____No such cargo dir, proceeding from scratch_____";
-        fi
-      else
-        echo "____No need to prepopulate the cache____";
-      fi
   only:
     - master
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
@@ -96,7 +78,7 @@ variables:
   dependencies:                    []
   interruptible:                   true
   tags:
-    - ci2
+    - linux-docker
 
 .build-only:                       &build-only
   only:


### PR DESCRIPTION
Reverts paritytech/substrate#5505
Apparently, cache pre-population from other branches with other versions of deps can cause the `cargo` [bug](https://github.com/rust-lang/cargo/issues/4007).
To avoid it, everyone should rebase on this commit.

<details>
<summary>Logs</summary>

```
thread 'main' panicked at 'packages downloaded: failed to download `hermit-abi v0.1.10`
Caused by:
    0: unable to get packages from source
    1: failed to parse manifest at `/ci-cache/substrate/cargo/5515/check-web-wasm/registry/src/github.com-1ecc6299db9ec823/hermit-abi-0.1.10/Cargo.toml`
    2: no targets specified in the manifest
         either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
   0: cargo::ops::cargo_read_manifest::read_package
   1: cargo::sources::path::PathSource::read_packages
   2: <cargo::sources::path::PathSource as cargo::core::source::Source>::update
   3: cargo::sources::registry::RegistrySource::get_pkg
   4: <cargo::sources::registry::RegistrySource as cargo::core::source::Source>::download
   5: cargo::core::package::Downloads::start
   6: cargo::core::package::PackageSet::get_one
   7: core::iter::traits::iterator::Iterator::try_fold
   8: <core::iter::adapters::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
   9: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T,I>>::from_iter
  10: cargo::core::resolver::features::FeatureResolver::activate_pkg
  11: cargo::core::resolver::features::FeatureResolver::activate_fv
  12: cargo::core::resolver::features::FeatureResolver::activate_rec
  13: cargo::core::resolver::features::FeatureResolver::activate_fv
  14: cargo::core::resolver::features::FeatureResolver::activate_rec
  15: cargo::core::resolver::features::FeatureResolver::activate_pkg
  16: cargo::core::resolver::features::FeatureResolver::activate_pkg
  17: cargo::core::resolver::features::FeatureResolver::activate_pkg
  18: cargo::core::resolver::features::FeatureResolver::activate_pkg
  19: cargo::core::resolver::features::FeatureResolver::activate_fv
  20: cargo::core::resolver::features::FeatureResolver::activate_rec
  21: cargo::core::resolver::features::FeatureResolver::activate_pkg
  22: cargo::core::resolver::features::FeatureResolver::resolve
  23: cargo::ops::resolve::resolve_ws_with_opts
  24: cargo::ops::cargo_compile::compile_ws
  25: cargo::ops::cargo_compile::compile
  26: cargo::commands::build::exec
  27: cargo::cli::main
  28: cargo::main
  29: std::rt::lang_start::{{closure}}
  30: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
      std::panicking::try::do_call
             at src/libstd/panicking.rs:331
      std::panicking::try
             at src/libstd/panicking.rs:274
      std::panic::catch_unwind
             at src/libstd/panic.rs:394
      std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  31: main
  32: __libc_start_main
  33: <unknown>', src/tools/cargo/src/cargo/core/resolver/features.rs:573:9
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1069
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1439
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:511
  11: rust_begin_unwind
             at src/libstd/panicking.rs:419
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:111
  13: core::option::expect_none_failed
             at src/libcore/option.rs:1268
  14: core::iter::traits::iterator::Iterator::try_fold
  15: <core::iter::adapters::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
  16: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T,I>>::from_iter
  17: cargo::core::resolver::features::FeatureResolver::activate_pkg
  18: cargo::core::resolver::features::FeatureResolver::activate_fv
  19: cargo::core::resolver::features::FeatureResolver::activate_rec
  20: cargo::core::resolver::features::FeatureResolver::activate_fv
  21: cargo::core::resolver::features::FeatureResolver::activate_rec
  22: cargo::core::resolver::features::FeatureResolver::activate_pkg
  23: cargo::core::resolver::features::FeatureResolver::activate_pkg
  24: cargo::core::resolver::features::FeatureResolver::activate_pkg
  25: cargo::core::resolver::features::FeatureResolver::activate_pkg
  26: cargo::core::resolver::features::FeatureResolver::activate_fv
  27: cargo::core::resolver::features::FeatureResolver::activate_rec
  28: cargo::core::resolver::features::FeatureResolver::activate_pkg
  29: cargo::core::resolver::features::FeatureResolver::resolve
  30: cargo::ops::resolve::resolve_ws_with_opts
  31: cargo::ops::cargo_compile::compile_ws
  32: cargo::ops::cargo_compile::compile
  33: cargo::commands::build::exec
  34: cargo::cli::main
  35: cargo::main
  36: std::rt::lang_start::{{closure}}
  37: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  38: std::panicking::try::do_call
             at src/libstd/panicking.rs:331
  39: std::panicking::try
             at src/libstd/panicking.rs:274
  40: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  41: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  42: main
  43: __libc_start_main
  44: <unknown>
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
real	0m0.642s
user	0m0.436s
sys	0m0.181s
```

</details> 

Will think of how to reimplement the work around the bug. Maybe `cargo vendor` can help here.

In the meanwhile, every new branch's job on a new host will download and unpack all the deps from scratch.