### PR TITLE
Add build binaries for MacOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,6 +86,9 @@ variables:
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
     - /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/
     - web
+  tags:
+    - linux-docker
+    - osx
 
 
 
@@ -409,7 +412,8 @@ build-rust-doc-release:
     expire_in:                     7 days
     paths:
     - ./crate-docs
-  <<:                              *build-only
+  tags:
+    - linux-docker
   script:
     - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
     - BUILD_DUMMY_WASM_BINARY=1 RUSTDOCFLAGS="--html-in-header $(pwd)/.maintain/rustdoc-header.html" time cargo +nightly doc --release --all --verbose


### PR DESCRIPTION
Testing on Mac OS is not enabled at this stage.  It doesn't seem reasonable to test everything on every PR. I can add testing on MacOS for example with a tag. If necessary, write here and I will add it.

Thank you for your Pull Request!

Before you submitting, please check that:

- [ ] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR with appropriate labels if you have permissions to do so.
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres [the style guide](https://github.com/paritytech/polkadot/wiki/Style-Guide)
  - In particular, mind the maximal line length.
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
