### PR TITLE
Make `application-crypto` `std` feature internal

### DIFF
--- a/primitives/phragmen/src/reduce.rs
+++ b/primitives/phragmen/src/reduce.rs
@@ -305,7 +305,7 @@ fn reduce_4<A: IdentifierT>(assignments: &mut Vec<StakedAssignment<A>>) -> u32 {
 							}
 							(false, false) => {
 								// Neither of the edges was removed? impossible.
-								debug_assert!(false, "Duplicate voter (or other corrupt input).");
+								panic!("Duplicate voter (or other corrupt input).");
 							}
 						}
 					}


### PR DESCRIPTION
The macros should not generate code that requires that the calling crate
has a feature with the name `std` defined.
