### PR TITLE
client/authority-discovery: Terminate when network does

### DIFF
--- a/client/authority-discovery/src/error.rs
+++ b/client/authority-discovery/src/error.rs
@@ -40,17 +40,20 @@ pub enum Error {
 	MatchingHashedAuthorityIdWithAuthorityId,
 	/// Failed to set the authority discovery peerset priority group in the peerset module.
 	SettingPeersetPriorityGroup(String),
+	/// The sender side of the dht event stream has been closed likely due to the network
+	/// terminating.
+	DhtEventStreamTerminated,
 	/// Failed to encode a protobuf payload.
 	EncodingProto(prost::EncodeError),
 	/// Failed to decode a protobuf payload.
 	DecodingProto(prost::DecodeError),
-	/// Failed to encode or decode scale payload
+	/// Failed to encode or decode scale payload.
 	EncodingDecodingScale(codec::Error),
 	/// Failed to parse a libp2p multi address.
 	ParsingMultiaddress(libp2p::core::multiaddr::Error),
-	/// Failed to sign using a specific public key
+	/// Failed to sign using a specific public key.
 	MissingSignature(CryptoTypePublicPair),
-	/// Failed to sign using all public keys
+	/// Failed to sign using all public keys.
 	Signing,
 	/// Failed to register Prometheus metric.
 	Prometheus(prometheus_endpoint::PrometheusError),

--- a/client/authority-discovery/src/tests.rs
+++ b/client/authority-discovery/src/tests.rs
@@ -349,7 +349,7 @@ fn handle_dht_events_with_value_found_should_call_set_priority_group() {
 }
 
 #[test]
-fn terminate_when_event_stream_termiantes() {
+fn terminate_when_event_stream_terminates() {
 	let (dht_event_tx, dht_event_rx) = channel(1000);
 	let network: Arc<TestNetwork> = Arc::new(Default::default());
 	let key_store = KeyStore::new();
@@ -379,5 +379,4 @@ fn terminate_when_event_stream_termiantes() {
 			event channel is terminated.",
 		);
 	});
-
 }

--- a/client/authority-discovery/src/tests.rs
+++ b/client/authority-discovery/src/tests.rs
@@ -19,6 +19,7 @@ use std::{iter::FromIterator, sync::{Arc, Mutex}};
 use futures::channel::mpsc::channel;
 use futures::executor::block_on;
 use futures::future::poll_fn;
+use futures::poll;
 use libp2p::{kad, PeerId};
 
 use sp_api::{ProvideRuntimeApi, ApiRef};
@@ -345,4 +346,38 @@ fn handle_dht_events_with_value_found_should_call_set_priority_group() {
 	};
 
 	let _ = block_on(poll_fn(f));
+}
+
+#[test]
+fn terminate_when_event_stream_termiantes() {
+	let (dht_event_tx, dht_event_rx) = channel(1000);
+	let network: Arc<TestNetwork> = Arc::new(Default::default());
+	let key_store = KeyStore::new();
+	let test_api = Arc::new(TestApi {
+		authorities: vec![],
+	});
+
+	let mut authority_discovery = AuthorityDiscovery::new(
+		test_api,
+		network.clone(),
+		vec![],
+		key_store,
+		dht_event_rx.boxed(),
+		None,
+	);
+
+	block_on(async {
+		assert_eq!(Poll::Pending, poll!(&mut authority_discovery));
+
+		// Simulate termination of the network through dropping the sender side of the dht event
+		// channel.
+		drop(dht_event_tx);
+
+		assert_eq!(
+			Poll::Ready(()), poll!(&mut authority_discovery),
+			"Expect the authority discovery module to terminate once the sending side of the dht \
+			event channel is terminated.",
+		);
+	});
+
 }


### PR DESCRIPTION
When the dht event stream returns Poll::Ready(None) it is likely due to
the network terminating. When the network terminates due to the node
itself shutting down or due to a fatal error, there is no purpose in
continuing to run the authority discovery module.