### PR TITLE
babe, grandpa: restrict info logging during initial sync

### DIFF
--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -605,11 +605,16 @@ mod tests {
 		);
 
 		// finalizing "hash_c" won't enact the change signaled at "hash_a" but it will prune out "hash_b"
-		let status = authorities.apply_standard_changes("hash_c", 11, &is_descendent_of(|base, hash| match (*base, *hash) {
-			("hash_a", "hash_c") => true,
-			("hash_b", "hash_c") => false,
-			_ => unreachable!(),
-		})).unwrap();
+		let status = authorities.apply_standard_changes(
+			"hash_c",
+			11,
+			&is_descendent_of(|base, hash| match (*base, *hash) {
+				("hash_a", "hash_c") => true,
+				("hash_b", "hash_c") => false,
+				_ => unreachable!(),
+			}),
+			false,
+		).unwrap();
 
 		assert!(status.changed);
 		assert_eq!(status.new_set_block, None);
@@ -619,10 +624,15 @@ mod tests {
 		);
 
 		// finalizing "hash_d" will enact the change signaled at "hash_a"
-		let status = authorities.apply_standard_changes("hash_d", 15, &is_descendent_of(|base, hash| match (*base, *hash) {
-			("hash_a", "hash_d") => true,
-			_ => unreachable!(),
-		})).unwrap();
+		let status = authorities.apply_standard_changes(
+			"hash_d",
+			15,
+			&is_descendent_of(|base, hash| match (*base, *hash) {
+				("hash_a", "hash_d") => true,
+				_ => unreachable!(),
+			}),
+			false,
+		).unwrap();
 
 		assert!(status.changed);
 		assert_eq!(status.new_set_block, Some(("hash_d", 15)));
@@ -677,12 +687,18 @@ mod tests {
 		});
 
 		// trying to finalize past `change_c` without finalizing `change_a` first
-		match authorities.apply_standard_changes("hash_d", 40, &is_descendent_of) {
-			Err(fork_tree::Error::UnfinalizedAncestor) => {},
-			_ => unreachable!(),
-		}
+		assert!(matches!(
+			authorities.apply_standard_changes("hash_d", 40, &is_descendent_of, false),
+			Err(fork_tree::Error::UnfinalizedAncestor)
+		));
 
-		let status = authorities.apply_standard_changes("hash_b", 15, &is_descendent_of).unwrap();
+		let status = authorities.apply_standard_changes(
+			"hash_b",
+			15,
+			&is_descendent_of,
+			false,
+		).unwrap();
+
 		assert!(status.changed);
 		assert_eq!(status.new_set_block, Some(("hash_b", 15)));
 
@@ -690,7 +706,13 @@ mod tests {
 		assert_eq!(authorities.set_id, 1);
 
 		// after finalizing `change_a` it should be possible to finalize `change_c`
-		let status = authorities.apply_standard_changes("hash_d", 40, &is_descendent_of).unwrap();
+		let status = authorities.apply_standard_changes(
+			"hash_d",
+			40,
+			&is_descendent_of,
+			false,
+		).unwrap();
+
 		assert!(status.changed);
 		assert_eq!(status.new_set_block, Some(("hash_d", 40)));
 
@@ -823,20 +845,30 @@ mod tests {
 		assert!(authorities.add_pending_change(change_c, &is_descendent_of_a).is_err());
 
 		// too early.
-		assert!(authorities.apply_forced_changes("hash_a10", 10, &static_is_descendent_of(true)).unwrap().is_none());
+		assert!(
+			authorities.apply_forced_changes("hash_a10", 10, &static_is_descendent_of(true), false)
+				.unwrap()
+				.is_none()
+		);
 
 		// too late.
-		assert!(authorities.apply_forced_changes("hash_a16", 16, &static_is_descendent_of(true)).unwrap().is_none());
+		assert!(
+			authorities.apply_forced_changes("hash_a16", 16, &static_is_descendent_of(true), false)
+				.unwrap()
+				.is_none()
+		);
 
 		// on time -- chooses the right change.
 		assert_eq!(
-			authorities.apply_forced_changes("hash_a15", 15, &is_descendent_of_a).unwrap().unwrap(),
+			authorities.apply_forced_changes("hash_a15", 15, &is_descendent_of_a, false)
+				.unwrap()
+				.unwrap(),
 			(42, AuthoritySet {
 				current_authorities: set_a,
 				set_id: 1,
 				pending_standard_changes: ForkTree::new(),
 				pending_forced_changes: Vec::new(),
-			})
+			}),
 		);
 	}
 }

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -16,7 +16,7 @@
 
 use std::{sync::Arc, collections::HashMap};
 
-use log::{debug, trace, info};
+use log::{debug, trace};
 use parity_scale_codec::Encode;
 use parking_lot::RwLockWriteGuard;
 
@@ -27,7 +27,7 @@ use sp_api::{TransactionFor};
 
 use sp_consensus::{
 	BlockImport, Error as ConsensusError,
-	BlockCheckParams, BlockImportParams, ImportResult, JustificationImport,
+	BlockCheckParams, BlockImportParams, BlockOrigin, ImportResult, JustificationImport,
 	SelectChain,
 };
 use sp_finality_grandpa::{ConsensusLog, ScheduledChange, SetId, GRANDPA_ENGINE_ID};
@@ -128,7 +128,12 @@ impl<BE, Block: BlockT, Client, SC> JustificationImport<Block>
 		number: NumberFor<Block>,
 		justification: Justification,
 	) -> Result<(), Self::Error> {
-		GrandpaBlockImport::import_justification(self, hash, number, justification, false)
+		// this justification was requested by the sync service, therefore we
+		// are not sure if it should enact a change or not. it could have been a
+		// request made as part of initial sync but that means the justification
+		// wasn't part of the block and was requested asynchronously, probably
+		// makes sense to log in that case.
+		GrandpaBlockImport::import_justification(self, hash, number, justification, false, false)
 	}
 }
 
@@ -250,6 +255,7 @@ where
 		&self,
 		block: &mut BlockImportParams<Block, TransactionFor<Client, Block>>,
 		hash: Block::Hash,
+		initial_sync: bool,
 	) -> Result<PendingSetChanges<Block>, ConsensusError> {
 		// when we update the authorities, we need to hold the lock
 		// until the block is written to prevent a race if we need to restore
@@ -324,7 +330,9 @@ where
 		}
 
 		let applied_changes = {
-			let forced_change_set = guard.as_mut().apply_forced_changes(hash, number, &is_descendent_of)
+			let forced_change_set = guard
+				.as_mut()
+				.apply_forced_changes(hash, number, &is_descendent_of, initial_sync)
 				.map_err(|e| ConsensusError::ClientImport(e.to_string()))
 				.map_err(ConsensusError::from)?;
 
@@ -419,7 +427,10 @@ impl<BE, Block: BlockT, Client, SC> BlockImport<Block>
 			Err(e) => return Err(ConsensusError::ClientImport(e.to_string()).into()),
 		}
 
-		let pending_changes = self.make_authorities_changes(&mut block, hash)?;
+		// on initial sync we will restrict logging under info to avoid spam.
+		let initial_sync = block.origin == BlockOrigin::NetworkInitialSync;
+
+		let pending_changes = self.make_authorities_changes(&mut block, hash, initial_sync)?;
 
 		// we don't want to finalize on `inner.import_block`
 		let mut justification = block.justification.take();
@@ -492,7 +503,15 @@ impl<BE, Block: BlockT, Client, SC> BlockImport<Block>
 
 		match justification {
 			Some(justification) => {
-				self.import_justification(hash, number, justification, needs_justification).unwrap_or_else(|err| {
+				let import_res = self.import_justification(
+					hash,
+					number,
+					justification,
+					needs_justification,
+					initial_sync,
+				);
+
+				import_res.unwrap_or_else(|err| {
 					if needs_justification || enacts_consensus_change {
 						debug!(target: "afg", "Imported block #{} that enacts authority set change with \
 							invalid justification: {:?}, requesting justification from peers.", number, err);
@@ -604,6 +623,7 @@ where
 		number: NumberFor<Block>,
 		justification: Justification,
 		enacts_change: bool,
+		initial_sync: bool,
 	) -> Result<(), ConsensusError> {
 		let justification = GrandpaJustification::decode_and_verify_finalizes(
 			&justification,
@@ -625,12 +645,17 @@ where
 			hash,
 			number,
 			justification.into(),
+			initial_sync,
 		);
 
 		match result {
 			Err(CommandOrError::VoterCommand(command)) => {
-				info!(target: "afg", "👴 Imported justification for block #{} that triggers \
-					command {}, signaling voter.", number, command);
+				afg_log!(initial_sync,
+					"👴 Imported justification for block #{} that triggers \
+					command {}, signaling voter.",
+					number,
+					command,
+				);
 
 				// send the command to the voter
 				let _ = self.send_voter_commands.unbounded_send(command);

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -84,6 +84,28 @@ use std::time::Duration;
 use std::pin::Pin;
 use std::task::{Poll, Context};
 
+#[macro_use]
+mod macros {
+	// utility logging macro that takes as first argument a conditional to
+	// decide whether to log under debug or info level (useful to restrict
+	// logging under initial sync).
+	// defined in a separate module since we want to share the macro across this
+	// crate but not export it.
+	macro_rules! afg_log {
+		($condition:expr, $($msg: expr),+ $(,)?) => {
+			{
+				let log_level = if $condition {
+					log::Level::Debug
+				} else {
+					log::Level::Info
+				};
+
+				log::log!(target: "afg", log_level, $($msg),+);
+			}
+		};
+	}
+}
+
 mod authorities;
 mod aux_schema;
 mod communication;

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -84,26 +84,21 @@ use std::time::Duration;
 use std::pin::Pin;
 use std::task::{Poll, Context};
 
-#[macro_use]
-mod macros {
-	// utility logging macro that takes as first argument a conditional to
-	// decide whether to log under debug or info level (useful to restrict
-	// logging under initial sync).
-	// defined in a separate module since we want to share the macro across this
-	// crate but not export it.
-	macro_rules! afg_log {
-		($condition:expr, $($msg: expr),+ $(,)?) => {
-			{
-				let log_level = if $condition {
-					log::Level::Debug
-				} else {
-					log::Level::Info
-				};
+// utility logging macro that takes as first argument a conditional to
+// decide whether to log under debug or info level (useful to restrict
+// logging under initial sync).
+macro_rules! afg_log {
+	($condition:expr, $($msg: expr),+ $(,)?) => {
+		{
+			let log_level = if $condition {
+				log::Level::Debug
+			} else {
+				log::Level::Info
+			};
 
-				log::log!(target: "afg", log_level, $($msg),+);
-			}
-		};
-	}
+			log::log!(target: "afg", log_level, $($msg),+);
+		}
+	};
 }
 
 mod authorities;

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -124,6 +124,7 @@ fn grandpa_observer<BE, Block: BlockT, Client, S, F>(
 				finalized_hash,
 				finalized_number,
 				(round, commit).into(),
+				false,
 			) {
 				Ok(_) => {},
 				Err(e) => return future::err(e),


### PR DESCRIPTION
During initial sync the following consensus log messages are logged under debug to avoid spamming the output.

```
2020-04-06 19:59:57 👶 Next epoch starts at slot 262521879
2020-04-06 19:59:58 👶 New epoch 47 launching at block 0x456c…19f0 (block slot 262521879 >= start slot 262521879).
2020-04-06 19:59:58 👶 Next epoch starts at slot 262522479
2020-04-06 19:59:58 👴 Applying authority set change scheduled at block #28175
2020-04-06 19:59:58 👴 Applying GRANDPA set change to new set with 20 authorities
2020-04-06 19:59:58 👴 Imported justification for block #28175 that triggers command Changing authorities, signaling voter.
```