### PR TITLE
Phragmen solution should submit for current era and be checked against current era

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2309,7 +2309,7 @@ impl<T: Trait> Module<T> {
 		);
 
 		// check current era.
-		if let Some(current_era) = Self::active_era().map(|e| e.index) {
+		if let Some(current_era) = Self::current_era() {
 			ensure!(
 				current_era == era,
 				Error::<T>::PhragmenEarlySubmission,

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -505,6 +505,10 @@ pub fn active_era() -> EraIndex {
 	Staking::active_era().unwrap().index
 }
 
+pub fn current_era() -> EraIndex {
+	Staking::current_era().unwrap()
+}
+
 pub fn check_exposure_all(era: EraIndex) {
 	ErasStakers::<Test>::iter_prefix(era).for_each(check_exposure)
 }

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -612,9 +612,13 @@ pub fn start_session(session_index: SessionIndex) {
 	assert_eq!(Session::current_index(), session_index);
 }
 
+// This start and activate the era given.
+// Because the mock use pallet-session which delays session by one, this will be one session after
+// the election happened, not the first session after the election has happened.
 pub fn start_era(era_index: EraIndex) {
 	start_session((era_index * <SessionsPerEra as Get<u32>>::get()).into());
 	assert_eq!(Staking::current_era().unwrap(), era_index);
+	assert_eq!(Staking::active_era().unwrap().index, era_index);
 }
 
 pub fn current_total_payout_for_duration(duration: u64) -> u64 {

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -501,10 +501,6 @@ pub type Session = pallet_session::Module<Test>;
 pub type Timestamp = pallet_timestamp::Module<Test>;
 pub type Staking = Module<Test>;
 
-pub fn active_era() -> EraIndex {
-	Staking::active_era().unwrap().index
-}
-
 pub fn current_era() -> EraIndex {
 	Staking::current_era().unwrap()
 }

--- a/frame/staking/src/offchain_election.rs
+++ b/frame/staking/src/offchain_election.rs
@@ -113,15 +113,15 @@ pub(crate) fn compute_offchain_election<T: Trait>() -> Result<(), OffchainElecti
 	// process and prepare it for submission.
 	let (winners, compact, score) = prepare_submission::<T>(assignments, winners, true)?;
 
-	// defensive-only: active era can never be none except genesis.
-	let era = <Module<T>>::active_era().map(|e| e.index).unwrap_or_default();
+	// defensive-only: current era can never be none except genesis.
+	let current_era = <Module<T>>::current_era().unwrap_or_default();
 
 	// send it.
 	let call: <T as Trait>::Call = Call::submit_election_solution_unsigned(
 		winners,
 		compact,
 		score,
-		era,
+		current_era,
 	).into();
 
 	T::SubmitTransaction::submit_unsigned(call)


### PR DESCRIPTION
phragmen solution should be submitted for the current era. the pallet-session can decide to delay by one or multiple era and dynamically. The active era should only be used for rewards stuff.

Phragmen solution submittion submit solution for the next current era so they should be submitted in the current_era, regardless of the active_era.