### PR TITLE
Introduce weight refund

### DIFF
--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -344,16 +344,16 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(1),
-				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
-				topics: vec![],
-			},
-			EventRecord {
-				phase: Phase::ApplyExtrinsic(1),
 				event: Event::pallet_balances(pallet_balances::RawEvent::Transfer(
 					alice().into(),
 					bob().into(),
 					69 * DOLLARS,
 				)),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(1),
+				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
 				topics: vec![],
 			},
 			EventRecord {
@@ -397,11 +397,6 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(1),
-				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
-				topics: vec![],
-			},
-			EventRecord {
-				phase: Phase::ApplyExtrinsic(1),
 				event: Event::pallet_balances(
 					pallet_balances::RawEvent::Transfer(
 						bob().into(),
@@ -413,14 +408,14 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(1),
-				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 1000000, class: DispatchClass::Normal, pays_fee: true }
-				)),
+				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
 				topics: vec![],
 			},
 			EventRecord {
-				phase: Phase::ApplyExtrinsic(2),
-				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
+				phase: Phase::ApplyExtrinsic(1),
+				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
+					DispatchInfo { weight: 1000000, class: DispatchClass::Normal, pays_fee: true }
+				)),
 				topics: vec![],
 			},
 			EventRecord {
@@ -432,6 +427,11 @@ fn full_native_block_import_works() {
 						15 * DOLLARS,
 					)
 				),
+				topics: vec![],
+			},
+			EventRecord {
+				phase: Phase::ApplyExtrinsic(2),
+				event: Event::pallet_treasury(pallet_treasury::RawEvent::Deposit(fees * 8 / 10)),
 				topics: vec![],
 			},
 			EventRecord {

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -139,6 +139,21 @@ pub struct PostDispatchInfo {
 	pub actual_weight: Option<Weight>,
 }
 
+impl PostDispatchInfo {
+	/// Calculate how much (if any) weight was not used by the `Dispatchable`.
+	pub fn calc_unspent(&self, info: &DispatchInfo) -> Weight {
+		if let Some(actual_weight) = self.actual_weight {
+			if actual_weight >= info.weight {
+				0
+			} else {
+				info.weight - actual_weight
+			}
+		} else {
+			0
+		}
+	}
+}
+
 impl From<Option<Weight>> for PostDispatchInfo {
 	fn from(actual_weight: Option<Weight>) -> Self {
 		Self {


### PR DESCRIPTION
# Related PRs

#5032 predecessor and replaced by this PR
#5458 Groundwork that allows dispatchables to return the actual weight consumed
#5540 Groundwork that allows `SignedExtension` to access the actual weight

# Overview

This changes the `CheckWeight` and `ChargeTransactionPayment` signed extensions to refund portions of the annotated a priori maximum weight in their `post_dispatch` method. A  `Dispatchable` has the ability (since #5458) to  return the a posteriori weight that is lower than the annotated max weight. Here we make use of that information in order to do the actual refund.

# Motivation
We want dispatchables to be able to refund portions it their static a priori weight maximum. The reason for that is that there are dispatchables where the average weight consumed differs from the maximum. Without a refund we are charging too much weight in some cases. An example is `Currency::transfer` which is heavier when it needs to create the target account. The average case might be that the account already exists where we are then overcharging.