### PR TITLE
Do not prematurely emit CustomProtocolClosed on connection close.

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -914,7 +914,7 @@ impl NetworkBehaviour for GenericProto {
 				// in which case `CustomProtocolClosed` was already emitted.
 				let closed = open.is_empty();
 				open.retain(|c| c != conn);
-				if !closed {
+				if open.is_empty() && !closed {
 					debug!(target: "sub-libp2p", "External API <= Closed({})", peer_id);
 					let event = GenericProtoOut::CustomProtocolClosed {
 						peer_id: peer_id.clone(),


### PR DESCRIPTION
A follow-up patch to https://github.com/paritytech/substrate/pull/5278. I believe this to be the cause for https://github.com/paritytech/substrate/issues/5592 because `inject_connection_closed` prematurely triggers an emit of `CustomProtocolClosed`, but it should only do so if `open` is empty (and was not already empty before).
