### PR TITLE
Update runtime-benchmarks feature dependency in Cargo.toml

### DIFF
--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -152,6 +152,7 @@ runtime-benchmarks = [
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
 	"pallet-offences-benchmarking",
+	"pallet-offences/runtime-benchmarks",
 	"pallet-session-benchmarking",
 ]
 


### PR DESCRIPTION
This fixes a dependency issue preventing publishing of crates.