### PR TITLE
More robust sync

### DIFF
--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -190,7 +190,7 @@ pub enum PeerSyncState<B: BlockT> {
 	AncestorSearch {
 		start: NumberFor<B>,
 		current: NumberFor<B>,
-		state: AncestorSearchState<B>
+		state: AncestorSearchState<B>,
 	},
 	/// Actively downloading new blocks, starting from the given Number.
 	DownloadingNew(NumberFor<B>),


### PR DESCRIPTION
This adds additional protection against misbehaving peers.
*  When peers sends us blocks that we already have we decrease their reputation. This may happen during initial sync currently only if they lied about their common block.
* When doing initial ancestry search on connection, we might be actively syncing so it's hard to find a common block correctly. If the sync made progress while the search is in progress it is now aborted and the common block assumed to be found under certain conditions.