### PR TITLE
Benchmarks profile mode

### DIFF
--- a/bin/node/bench/src/core.rs
+++ b/bin/node/bench/src/core.rs
@@ -48,7 +48,7 @@ pub trait BenchmarkDescription {
 }
 
 pub trait Benchmark {
-	fn run(&mut self) -> std::time::Duration;
+	fn run(&mut self, mode: Mode) -> std::time::Duration;
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -84,6 +84,23 @@ impl fmt::Display for NsFormatter {
 	}
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Mode {
+	Regular,
+	Profile,
+}
+
+impl std::str::FromStr for Mode {
+    type Err = &'static str;
+    fn from_str(day: &str) -> Result<Self, Self::Err> {
+        match day {
+            "regular" => Ok(Mode::Regular),
+            "profile" => Ok(Mode::Profile),
+            _ => Err("Could not parse mode"),
+        }
+    }
+}
+
 impl fmt::Display for BenchmarkOutput {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -96,13 +113,16 @@ impl fmt::Display for BenchmarkOutput {
     }
 }
 
-pub fn run_benchmark(benchmark: Box<dyn BenchmarkDescription>) -> BenchmarkOutput {
+pub fn run_benchmark(
+	benchmark: Box<dyn BenchmarkDescription>,
+	mode: Mode,
+) -> BenchmarkOutput {
 	let name = benchmark.name().to_owned();
 	let mut benchmark = benchmark.setup();
 
 	let mut durations: Vec<u128> = vec![];
 	for _ in 0..50 {
-		let duration = benchmark.run();
+		let duration = benchmark.run(mode);
 		durations.push(duration.as_nanos());
 	}
 

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -35,7 +35,7 @@ use node_primitives::Block;
 use sc_client_api::backend::Backend;
 use sp_runtime::generic::BlockId;
 
-use crate::core::{self, Path};
+use crate::core::{self, Path, Mode};
 
 #[derive(Clone, Copy, Debug)]
 pub enum SizeType { Small, Medium, Large }
@@ -106,7 +106,7 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 }
 
 impl core::Benchmark for ImportBenchmark {
-	fn run(&mut self) -> std::time::Duration {
+	fn run(&mut self, mode: Mode) -> std::time::Duration {
 		let mut context = self.database.create_context(self.profile);
 
 		let _ = context.client.runtime_version_at(&BlockId::Number(0))
@@ -116,6 +116,10 @@ impl core::Benchmark for ImportBenchmark {
 		let start = std::time::Instant::now();
 		context.import_block(self.block.clone());
 		let elapsed = start.elapsed();
+
+		if mode == Mode::Profile {
+			std::thread::park_timeout(std::time::Duration::from_secs(2));
+		}
 
 		log::info!(
 			target: "bench-logistics",

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -17,7 +17,7 @@
 #[macro_use] mod core;
 mod import;
 
-use crate::core::run_benchmark;
+use crate::core::{run_benchmark, Mode as BenchmarkMode};
 use import::{ImportBenchmarkDescription, SizeType};
 use node_testing::bench::{Profile, KeyTypes};
 use structopt::StructOpt;
@@ -41,6 +41,15 @@ struct Opt {
 	///
 	/// Run with `--list` for the hint of what to filter.
 	filter: Option<String>,
+
+	/// Mode
+	///
+	/// "regular" for regular becnhmark
+	///
+	/// "profile" mode adds pauses between measurable runs,
+	/// so that actual interval can be selected in the profiler of choice.
+	#[structopt(short, long, default_value = "regular")]
+	mode: BenchmarkMode,
 }
 
 fn main() {
@@ -81,7 +90,7 @@ fn main() {
 	for benchmark in benchmarks {
 		if opt.filter.as_ref().map(|f| benchmark.path().has(f)).unwrap_or(true) {
 			log::info!("Starting {}", benchmark.name());
-			let result = run_benchmark(benchmark);
+			let result = run_benchmark(benchmark, opt.mode);
 			log::info!("{}", result);
 
 			results.push(result);


### PR DESCRIPTION
```
    -m, --mode <mode>    
            Mode
            
            "regular" for regular becnhmark
            
            "profile" mode adds pauses between measurable runs, so that actual interval can be selected in the profiler
            of choice. [default: regular]
```