### PR TITLE
Add tests for weight refund

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1914,6 +1914,44 @@ mod tests {
 	}
 
 	#[test]
+	fn signed_ext_check_weight_refund_works() {
+		new_test_ext().execute_with(|| {
+			let info = DispatchInfo { weight: 512, ..Default::default() };
+			let post_info = PostDispatchInfo { actual_weight: Some(128), };
+			let len = 0_usize;
+
+			AllExtrinsicsWeight::put(256);
+
+			let pre = CheckWeight::<Test>(PhantomData).pre_dispatch(&1, CALL, &info, len).unwrap();
+			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 256);
+
+			assert!(CheckWeight::<Test>::post_dispatch(
+				pre, &info, &post_info, len, &Ok(())).is_ok()
+			);
+			assert_eq!(AllExtrinsicsWeight::get().unwrap(), post_info.actual_weight.unwrap() + 256);
+		})
+	}
+
+	#[test]
+	fn signed_ext_check_weight_actual_weight_higher_than_max() {
+		new_test_ext().execute_with(|| {
+			let info = DispatchInfo { weight: 512, ..Default::default() };
+			let post_info = PostDispatchInfo { actual_weight: Some(700), };
+			let len = 0_usize;
+
+			AllExtrinsicsWeight::put(128);
+
+			let pre = CheckWeight::<Test>(PhantomData).pre_dispatch(&1, CALL, &info, len).unwrap();
+			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 128);
+
+			assert!(CheckWeight::<Test>::post_dispatch(
+				pre, &info, &post_info, len, &Ok(())).is_ok()
+			);
+			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 128);
+		})
+	}
+
+	#[test]
 	fn signed_ext_check_weight_fee_works() {
 		new_test_ext().execute_with(|| {
 			let free = DispatchInfo { weight: 0, ..Default::default() };

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1925,8 +1925,9 @@ mod tests {
 			let pre = CheckWeight::<Test>(PhantomData).pre_dispatch(&1, CALL, &info, len).unwrap();
 			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 256);
 
-			assert!(CheckWeight::<Test>::post_dispatch(
-				pre, &info, &post_info, len, &Ok(())).is_ok()
+			assert!(
+				CheckWeight::<Test>::post_dispatch(pre, &info, &post_info, len, &Ok(()))
+				.is_ok()
 			);
 			assert_eq!(AllExtrinsicsWeight::get().unwrap(), post_info.actual_weight.unwrap() + 256);
 		})

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1944,8 +1944,9 @@ mod tests {
 			let pre = CheckWeight::<Test>(PhantomData).pre_dispatch(&1, CALL, &info, len).unwrap();
 			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 128);
 
-			assert!(CheckWeight::<Test>::post_dispatch(
-				pre, &info, &post_info, len, &Ok(())).is_ok()
+			assert!(
+				CheckWeight::<Test>::post_dispatch(pre, &info, &post_info, len, &Ok(()))
+				.is_ok()
 			);
 			assert_eq!(AllExtrinsicsWeight::get().unwrap(), info.weight + 128);
 		})

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1933,7 +1933,7 @@ mod tests {
 	}
 
 	#[test]
-	fn signed_ext_check_weight_actual_weight_higher_than_max() {
+	fn signed_ext_check_weight_actual_weight_higher_than_max_is_capped() {
 		new_test_ext().execute_with(|| {
 			let info = DispatchInfo { weight: 512, ..Default::default() };
 			let post_info = PostDispatchInfo { actual_weight: Some(700), };


### PR DESCRIPTION
This adds tests that check whether the weight refund is working. It is a followup to #5584. Both `frame_system::CheckWeight` and `pallet_transaction_payment` are tested.