### PR TITLE
Give names to channels

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -176,7 +176,7 @@ macro_rules! new_full {
 			service.spawn_essential_task("babe-proposer", babe);
 
 			let network = service.network();
-			let dht_event_stream = network.event_stream().filter_map(|e| async move { match e {
+			let dht_event_stream = network.event_stream("authority-discovery").filter_map(|e| async move { match e {
 				Event::Dht(e) => Some(e),
 				_ => None,
 			}}).boxed();

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -188,7 +188,7 @@ mod tests {
 	struct TestNetwork {}
 
 	impl<B: BlockT> Network<B> for Arc<TestNetwork> {
-		fn event_stream(&self, _: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+		fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
 			let (_tx, rx) = futures::channel::mpsc::channel(0);
 
 			// Return rx and drop tx. Thus the given channel will yield `Poll::Ready(None)` on first

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -49,7 +49,7 @@ impl<B: BlockT> GossipEngine<B> {
 
 		// We grab the event stream before registering the notifications protocol, otherwise we
 		// might miss events.
-		let network_event_stream = network.event_stream();
+		let network_event_stream = network.event_stream(Box::leak(format!("proto-{:?}", protocol_name).into_box_str()));
 
 		network.register_notifications_protocol(engine_id, protocol_name.into());
 		state_machine.register_validator(&mut network, engine_id, validator);

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -49,9 +49,10 @@ impl<B: BlockT> GossipEngine<B> {
 
 		// We grab the event stream before registering the notifications protocol, otherwise we
 		// might miss events.
-		let network_event_stream = network.event_stream(Box::leak(format!("proto-{:?}", protocol_name).into_box_str()));
+		let protocol_name = protocol_name.into();
+		let network_event_stream = network.event_stream(Box::leak(format!("proto-{:?}", protocol_name).into_boxed_str()));
 
-		network.register_notifications_protocol(engine_id, protocol_name.into());
+		network.register_notifications_protocol(engine_id, protocol_name);
 		state_machine.register_validator(&mut network, engine_id, validator);
 
 		GossipEngine {
@@ -188,7 +189,7 @@ mod tests {
 	struct TestNetwork {}
 
 	impl<B: BlockT> Network<B> for Arc<TestNetwork> {
-		fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+		fn event_stream(&self, _: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
 			let (_tx, rx) = futures::channel::mpsc::channel(0);
 
 			// Return rx and drop tx. Thus the given channel will yield `Poll::Ready(None)` on first

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -49,10 +49,9 @@ impl<B: BlockT> GossipEngine<B> {
 
 		// We grab the event stream before registering the notifications protocol, otherwise we
 		// might miss events.
-		let protocol_name = protocol_name.into();
-		let network_event_stream = network.event_stream(Box::leak(format!("proto-{:?}", protocol_name).into_boxed_str()));
+		let network_event_stream = network.event_stream();
 
-		network.register_notifications_protocol(engine_id, protocol_name);
+		network.register_notifications_protocol(engine_id, protocol_name.into());
 		state_machine.register_validator(&mut network, engine_id, validator);
 
 		GossipEngine {

--- a/client/network-gossip/src/lib.rs
+++ b/client/network-gossip/src/lib.rs
@@ -70,7 +70,7 @@ mod validator;
 /// Abstraction over a network.
 pub trait Network<B: BlockT> {
 	/// Returns a stream of events representing what happens on the network.
-	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>>;
+	fn event_stream(&self, name: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>>;
 
 	/// Adjust the reputation of a node.
 	fn report_peer(&self, peer_id: PeerId, reputation: ReputationChange);
@@ -98,8 +98,8 @@ pub trait Network<B: BlockT> {
 }
 
 impl<B: BlockT, H: ExHashT> Network<B> for Arc<NetworkService<B, H>> {
-	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
-		Box::pin(NetworkService::event_stream(self))
+	fn event_stream(&self, name: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+		Box::pin(NetworkService::event_stream(self, name))
 	}
 
 	fn report_peer(&self, peer_id: PeerId, reputation: ReputationChange) {

--- a/client/network-gossip/src/lib.rs
+++ b/client/network-gossip/src/lib.rs
@@ -70,7 +70,7 @@ mod validator;
 /// Abstraction over a network.
 pub trait Network<B: BlockT> {
 	/// Returns a stream of events representing what happens on the network.
-	fn event_stream(&self, name: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>>;
+	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>>;
 
 	/// Adjust the reputation of a node.
 	fn report_peer(&self, peer_id: PeerId, reputation: ReputationChange);
@@ -98,8 +98,8 @@ pub trait Network<B: BlockT> {
 }
 
 impl<B: BlockT, H: ExHashT> Network<B> for Arc<NetworkService<B, H>> {
-	fn event_stream(&self, name: &'static str) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
-		Box::pin(NetworkService::event_stream(self, name))
+	fn event_stream(&self) -> Pin<Box<dyn Stream<Item = Event> + Send>> {
+		Box::pin(NetworkService::event_stream(self, "network-gossip"))
 	}
 
 	fn report_peer(&self, peer_id: PeerId, reputation: ReputationChange) {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -575,6 +575,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// If this method is called multiple times, the events are duplicated.
 	///
 	/// The stream never ends (unless the `NetworkWorker` gets shut down).
+	///
+	/// The name passed is used to identify the channel in the Prometheus metrics. Note that the
+	/// parameter is a `&'static str`, and not a `String`, in order to avoid accidentally having
+	/// an unbounded set of Prometheus metrics, which would be quite bad in terms of memory
 	pub fn event_stream(&self, name: &'static str) -> impl Stream<Item = Event> {
 		// Note: when transitioning to stable futures, remove the `Error` entirely
 		let (tx, rx) = out_events::channel(name);

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -575,9 +575,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// If this method is called multiple times, the events are duplicated.
 	///
 	/// The stream never ends (unless the `NetworkWorker` gets shut down).
-	pub fn event_stream(&self) -> impl Stream<Item = Event> {
+	pub fn event_stream(&self, name: &'static str) -> impl Stream<Item = Event> {
 		// Note: when transitioning to stable futures, remove the `Error` entirely
-		let (tx, rx) = out_events::channel();
+		let (tx, rx) = out_events::channel(name);
 		let _ = self.to_worker.unbounded_send(ServiceToWorkerMsg::EventStream(tx));
 		rx
 	}

--- a/client/network/src/service/out_events.rs
+++ b/client/network/src/service/out_events.rs
@@ -43,11 +43,11 @@ use std::{
 };
 
 /// Creates a new channel that can be associated to a [`OutChannels`].
-pub fn channel() -> (Sender, Receiver) {
+pub fn channel(name: &'static str) -> (Sender, Receiver) {
 	let (tx, rx) = mpsc::unbounded();
 	let metrics = Arc::new(Mutex::new(None));
-	let tx = Sender { inner: tx, metrics: metrics.clone() };
-	let rx = Receiver { inner: rx, metrics };
+	let tx = Sender { inner: tx, name, metrics: metrics.clone() };
+	let rx = Receiver { inner: rx, name, metrics };
 	(tx, rx)
 }
 
@@ -60,6 +60,7 @@ pub fn channel() -> (Sender, Receiver) {
 /// sync on drop. If someone adds a `#[derive(Clone)]` below, it is **wrong**.
 pub struct Sender {
 	inner: mpsc::UnboundedSender<Event>,
+	name: &'static str,
 	/// Clone of [`Receiver::metrics`].
 	metrics: Arc<Mutex<Option<Arc<Option<Metrics>>>>>,
 }
@@ -82,6 +83,7 @@ impl Drop for Sender {
 /// Receiving side of a channel.
 pub struct Receiver {
 	inner: mpsc::UnboundedReceiver<Event>,
+	name: &'static str,
 	/// Initially contains `None`, and will be set to a value once the corresponding [`Sender`]
 	/// is assigned to an instance of [`OutChannels`].
 	metrics: Arc<Mutex<Option<Arc<Option<Metrics>>>>>,
@@ -94,7 +96,7 @@ impl Stream for Receiver {
 		if let Some(ev) = ready!(Pin::new(&mut self.inner).poll_next(cx)) {
 			let metrics = self.metrics.lock().clone();
 			if let Some(Some(metrics)) = metrics.as_ref().map(|m| &**m) {
-				metrics.event_out(&ev);
+				metrics.event_out(&ev, self.name);
 			} else {
 				log::warn!("Inconsistency in out_events: event happened before sender associated");
 			}
@@ -161,7 +163,9 @@ impl OutChannels {
 		});
 
 		if let Some(metrics) = &*self.metrics {
-			metrics.event_in(&event, self.event_streams.len() as u64);
+			for ev in &self.event_streams {
+				metrics.event_in(&event, 1, ev.name);
+			}
 		}
 	}
 }
@@ -190,7 +194,7 @@ impl Metrics {
 					"Number of broadcast network events that have been sent or received across all \
 					 channels"
 				),
-				&["event_name", "action"]
+				&["event_name", "action", "name"]
 			)?, registry)?,
 			notifications_sizes: register(CounterVec::new(
 				Opts::new(
@@ -198,7 +202,7 @@ impl Metrics {
 					"Size of notification events that have been sent or received across all \
 					 channels"
 				),
-				&["protocol", "action"]
+				&["protocol", "action", "name"]
 			)?, registry)?,
 			num_channels: register(Gauge::new(
 				"sub_libp2p_out_events_num_channels",
@@ -207,60 +211,60 @@ impl Metrics {
 		})
 	}
 
-	fn event_in(&self, event: &Event, num: u64) {
+	fn event_in(&self, event: &Event, num: u64, name: &str) {
 		match event {
 			Event::Dht(_) => {
 				self.events_total
-					.with_label_values(&["dht", "sent"])
+					.with_label_values(&["dht", "sent", name])
 					.inc_by(num);
 			}
 			Event::NotificationStreamOpened { engine_id, .. } => {
 				self.events_total
-					.with_label_values(&[&format!("notif-open-{:?}", engine_id), "sent"])
+					.with_label_values(&[&format!("notif-open-{:?}", engine_id), "sent", name])
 					.inc_by(num);
 			},
 			Event::NotificationStreamClosed { engine_id, .. } => {
 				self.events_total
-					.with_label_values(&[&format!("notif-closed-{:?}", engine_id), "sent"])
+					.with_label_values(&[&format!("notif-closed-{:?}", engine_id), "sent", name])
 					.inc_by(num);
 			},
 			Event::NotificationsReceived { messages, .. } => {
 				for (engine_id, message) in messages {
 					self.events_total
-						.with_label_values(&[&format!("notif-{:?}", engine_id), "sent"])
+						.with_label_values(&[&format!("notif-{:?}", engine_id), "sent", name])
 						.inc_by(num);
 					self.notifications_sizes
-						.with_label_values(&[&engine_id_to_string(engine_id), "sent"])
+						.with_label_values(&[&engine_id_to_string(engine_id), "sent", name])
 						.inc_by(num.saturating_mul(u64::try_from(message.len()).unwrap_or(u64::max_value())));
 				}
 			},
 		}
 	}
 
-	fn event_out(&self, event: &Event) {
+	fn event_out(&self, event: &Event, name: &str) {
 		match event {
 			Event::Dht(_) => {
 				self.events_total
-					.with_label_values(&["dht", "received"])
+					.with_label_values(&["dht", "received", name])
 					.inc();
 			}
 			Event::NotificationStreamOpened { engine_id, .. } => {
 				self.events_total
-					.with_label_values(&[&format!("notif-open-{:?}", engine_id), "received"])
+					.with_label_values(&[&format!("notif-open-{:?}", engine_id), "received", name])
 					.inc();
 			},
 			Event::NotificationStreamClosed { engine_id, .. } => {
 				self.events_total
-					.with_label_values(&[&format!("notif-closed-{:?}", engine_id), "received"])
+					.with_label_values(&[&format!("notif-closed-{:?}", engine_id), "received", name])
 					.inc();
 			},
 			Event::NotificationsReceived { messages, .. } => {
 				for (engine_id, message) in messages {
 					self.events_total
-						.with_label_values(&[&format!("notif-{:?}", engine_id), "received"])
+						.with_label_values(&[&format!("notif-{:?}", engine_id), "received", name])
 						.inc();
 					self.notifications_sizes
-						.with_label_values(&[&engine_id_to_string(engine_id), "received"])
+						.with_label_values(&[&engine_id_to_string(engine_id), "received", name])
 						.inc_by(u64::try_from(message.len()).unwrap_or(u64::max_value()));
 				}
 			},

--- a/client/network/src/service/out_events.rs
+++ b/client/network/src/service/out_events.rs
@@ -43,6 +43,8 @@ use std::{
 };
 
 /// Creates a new channel that can be associated to a [`OutChannels`].
+///
+/// The name is used in Prometheus reports.
 pub fn channel(name: &'static str) -> (Sender, Receiver) {
 	let (tx, rx) = mpsc::unbounded();
 	let metrics = Arc::new(Mutex::new(None));

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -106,7 +106,7 @@ fn build_test_full_node(config: config::NetworkConfiguration)
 	.unwrap();
 
 	let service = worker.service().clone();
-	let event_stream = service.event_stream();
+	let event_stream = service.event_stream("test");
 
 	async_std::task::spawn(async move {
 		futures::pin_mut!(worker);


### PR DESCRIPTION
Calling `NetworkService::event_stream` now requires passing a name that helps identify it in the Prometheus metrics.

polkadot companion: https://github.com/paritytech/polkadot/pull/995
