### PR TITLE
Several tweaks to networking Prometheus metrics

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -953,14 +953,14 @@ impl Metrics {
 				},
 				&["direction", "protocol"]
 			)?, registry)?,
-			notifications_streams_closed_total: register(GaugeVec::new(
+			notifications_streams_closed_total: register(CounterVec::new(
 				Opts::new(
 					"sub_libp2p_notifications_streams_closed_total",
 					"Total number of notification substreams that have been closed"
 				),
 				&["protocol"]
 			)?, registry)?,
-			notifications_streams_opened_total: register(GaugeVec::new(
+			notifications_streams_opened_total: register(CounterVec::new(
 				Opts::new(
 					"sub_libp2p_notifications_streams_opened_total",
 					"Total number of notification substreams that have been opened"

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -860,7 +860,8 @@ struct Metrics {
 	network_per_sec_bytes: GaugeVec<U64>,
 	notifications_queues_size: HistogramVec,
 	notifications_sizes: HistogramVec,
-	opened_notification_streams: GaugeVec<U64>,
+	notifications_streams_closed_total: CounterVec<U64>,
+	notifications_streams_opened_total: CounterVec<U64>,
 	peers_count: Gauge<U64>,
 	peerset_num_discovered: Gauge<U64>,
 	peerset_num_requested: Gauge<U64>,
@@ -952,10 +953,17 @@ impl Metrics {
 				},
 				&["direction", "protocol"]
 			)?, registry)?,
-			opened_notification_streams: register(GaugeVec::new(
+			notifications_streams_closed_total: register(GaugeVec::new(
 				Opts::new(
-					"sub_libp2p_opened_notification_streams",
-					"Number of open notification substreams"
+					"sub_libp2p_notifications_streams_closed_total",
+					"Total number of notification substreams that have been closed"
+				),
+				&["protocol"]
+			)?, registry)?,
+			notifications_streams_opened_total: register(GaugeVec::new(
+				Opts::new(
+					"sub_libp2p_notifications_streams_opened_total",
+					"Total number of notification substreams that have been opened"
 				),
 				&["protocol"]
 			)?, registry)?,
@@ -988,10 +996,10 @@ impl Metrics {
 	fn update_with_network_event(&self, event: &Event) {
 		match event {
 			Event::NotificationStreamOpened { engine_id, .. } => {
-				self.opened_notification_streams.with_label_values(&[&engine_id_to_string(&engine_id)]).inc();
+				self.notifications_streams_opened_total.with_label_values(&[&engine_id_to_string(&engine_id)]).inc();
 			},
 			Event::NotificationStreamClosed { engine_id, .. } => {
-				self.opened_notification_streams.with_label_values(&[&engine_id_to_string(&engine_id)]).dec();
+				self.notifications_streams_closed_total.with_label_values(&[&engine_id_to_string(&engine_id)]).inc();
 			},
 			Event::NotificationsReceived { messages, .. } => {
 				for (engine_id, message) in messages {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -845,8 +845,8 @@ pub struct NetworkWorker<B: BlockT + 'static, H: ExHashT> {
 
 struct Metrics {
 	// This list is ordered alphabetically
-	connections_opened_total: CounterVec<U64>,
 	connections_closed_total: CounterVec<U64>,
+	connections_opened_total: CounterVec<U64>,
 	import_queue_blocks_submitted: Counter<U64>,
 	import_queue_finality_proofs_submitted: Counter<U64>,
 	import_queue_justifications_submitted: Counter<U64>,
@@ -874,19 +874,19 @@ impl Metrics {
 	fn register(registry: &Registry) -> Result<Self, PrometheusError> {
 		Ok(Self {
 			// This list is ordered alphabetically
+			connections_closed_total: register(CounterVec::new(
+				Opts::new(
+					"sub_libp2p_connections_closed_total",
+					"Total number of connections closed, by reason and direction"
+				),
+				&["direction", "reason"]
+			)?, registry)?,
 			connections_opened_total: register(CounterVec::new(
 				Opts::new(
 					"sub_libp2p_connections_opened_total",
 					"Total number of connections opened"
 				),
 				&["direction"]
-			)?, registry)?,
-			connections_closed_total: register(CounterVec::new(
-				Opts::new(
-					"sub_libp2p_connections_closed_total",
-					"Total number of connections closed, by reason"
-				),
-				&["direction", "reason"]
 			)?, registry)?,
 			import_queue_blocks_submitted: register(Counter::new(
 				"import_queue_blocks_submitted",

--- a/client/network/src/service/out_events.rs
+++ b/client/network/src/service/out_events.rs
@@ -35,7 +35,7 @@ use super::engine_id_to_string;
 
 use futures::{prelude::*, channel::mpsc, ready};
 use parking_lot::Mutex;
-use prometheus_endpoint::{register, CounterVec, Gauge, Opts, PrometheusError, Registry, U64};
+use prometheus_endpoint::{register, CounterVec, GaugeVec, Opts, PrometheusError, Registry, U64};
 use std::{
 	convert::TryFrom as _,
 	fmt, pin::Pin, sync::Arc,
@@ -77,7 +77,7 @@ impl Drop for Sender {
 	fn drop(&mut self) {
 		let metrics = self.metrics.lock();
 		if let Some(Some(metrics)) = metrics.as_ref().map(|m| &**m) {
-			metrics.num_channels.dec();
+			metrics.num_channels.with_label_values(&[self.name]).dec();
 		}
 	}
 }
@@ -151,11 +151,12 @@ impl OutChannels {
 		debug_assert!(metrics.is_none());
 		*metrics = Some(self.metrics.clone());
 		drop(metrics);
-		self.event_streams.push(sender);
 
 		if let Some(metrics) = &*self.metrics {
-			metrics.num_channels.inc();
+			metrics.num_channels.with_label_values(&[sender.name]).inc();
 		}
+
+		self.event_streams.push(sender);
 	}
 
 	/// Sends an event.
@@ -184,7 +185,7 @@ struct Metrics {
 	// This list is ordered alphabetically
 	events_total: CounterVec<U64>,
 	notifications_sizes: CounterVec<U64>,
-	num_channels: Gauge<U64>,
+	num_channels: GaugeVec<U64>,
 }
 
 impl Metrics {
@@ -206,9 +207,12 @@ impl Metrics {
 				),
 				&["protocol", "action", "name"]
 			)?, registry)?,
-			num_channels: register(Gauge::new(
-				"sub_libp2p_out_events_num_channels",
-				"Number of internal active channels that broadcast network events",
+			num_channels: register(GaugeVec::new(
+				Opts::new(
+					"sub_libp2p_out_events_num_channels",
+					"Number of internal active channels that broadcast network events",
+				),
+				&["name"]
 			)?, registry)?,
 		})
 	}


### PR DESCRIPTION
@mxinden Sorry to make you review all these changes, but you're "the Prometheus expert"!

This PR contains a couple of tweaks to the Prometheus metrics:

- Removed `connections` (a gauge) and replaced it with `connections_opened_total` (a counter), so that we no longer lose information about connections opening and closing quickly.
- Splits `connections_closed` by `in` and `out` for parity with `connections_opened_total`.
- Removed `opened_notification_streams` (a gauge) and replaced it with `notifications_streams_opened` and `notifications_streams_closed`, for the same reason.
- Added channel names to `num_channels`.
- Added a `reason` label to the `sub_libp2p_incoming_connections_handshake_errors_total` metric.
