### PR TITLE
Switch pre-release version to dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-builder"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "ansi_term 0.12.1",
  "node-cli",
@@ -1425,14 +1425,14 @@ checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-alpha.6"
+version = "11.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote 1.0.3",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "criterion 0.2.11",
  "frame-support",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "node-bench"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "log",
  "node-primitives",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "node-cli"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "assert_cmd",
  "frame-benchmarking-cli",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "node-executor"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "criterion 0.3.1",
  "frame-benchmarking",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "node-inspect"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "log",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "node-primitives"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "pretty_assertions",
  "sp-core",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "node-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "jsonrpc-core",
  "node-primitives",
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "node-rpc-client"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "env_logger 0.7.1",
  "futures 0.1.29",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "node-template"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
  "log",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "node-template-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "node-testing"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "criterion 0.3.1",
  "frame-support",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "node-transaction-factory"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-benchmark"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "assert_matches",
  "frame-support",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4109,7 +4109,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "evm",
  "frame-support",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-example"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-example-offchain-worker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-generic-asset"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4274,7 +4274,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-nicks"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4403,7 +4403,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-scored-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "env_logger 0.7.1",
  "frame-benchmarking",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-curve"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-template"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4592,7 +4592,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "bytes 0.5.4",
  "derive_more",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -5879,7 +5879,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "env_logger 0.7.1",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "fnv",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "env_logger 0.7.1",
  "hash-db",
@@ -5983,7 +5983,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "env_logger 0.7.1",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "env_logger 0.7.1",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-pow"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -6157,7 +6157,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -6178,7 +6178,7 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "log",
  "sc-client-api",
@@ -6191,7 +6191,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "log",
@@ -6241,7 +6241,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6255,7 +6255,7 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "cranelift-codegen",
@@ -6276,7 +6276,7 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "env_logger 0.7.1",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.4",
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "hex",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "async-std",
@@ -6410,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
@@ -6451,7 +6451,7 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "bytes 0.5.4",
  "env_logger 0.7.1",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
  "libp2p",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "assert_matches",
  "futures 0.1.29",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6586,7 +6586,7 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "exit-future",
@@ -6660,7 +6660,7 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "env_logger 0.7.1",
  "log",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "erased-serde",
  "log",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "assert_matches",
  "criterion 0.3.1",
@@ -6733,7 +6733,7 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "assert_matches",
  "derive_more",
@@ -7100,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "log",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7156,7 +7156,7 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7178,7 +7178,7 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "criterion 0.3.1",
  "integer-sqrt",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic-fuzzer"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "honggfuzz",
  "num-bigint",
@@ -7205,7 +7205,7 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7216,7 +7216,7 @@ dependencies = [
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7237,7 +7237,7 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "log",
@@ -7252,7 +7252,7 @@ dependencies = [
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -7260,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -7283,7 +7283,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7296,7 +7296,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7311,7 +7311,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-pow"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-vrf"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7377,7 +7377,7 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote 1.0.3",
@@ -7386,7 +7386,7 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "environmental",
  "sp-std",
@@ -7395,7 +7395,7 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7407,7 +7407,7 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7416,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -7427,7 +7427,7 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "hash-db",
  "libsecp256k1",
@@ -7444,7 +7444,7 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7454,7 +7454,7 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7462,7 +7462,7 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "backtrace",
  "log",
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "sp-phragmen"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "rand 0.7.3",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "sp-phragmen-compact"
-version = "2.0.0-dev.1"
+version = "2.0.0-dev"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7494,7 +7494,7 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -7503,7 +7503,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7543,7 +7543,7 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7589,7 +7589,7 @@ dependencies = [
 
 [[package]]
 name = "sp-sandbox"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "assert_matches",
  "parity-scale-codec",
@@ -7603,7 +7603,7 @@ dependencies = [
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -7611,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7630,7 +7630,7 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "hash-db",
  "hex-literal",
@@ -7650,11 +7650,11 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "impl-serde 0.2.3",
  "serde",
@@ -7676,7 +7676,7 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7689,7 +7689,7 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "derive_more",
  "futures 0.3.4",
@@ -7703,7 +7703,7 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "criterion 0.2.11",
  "hash-db",
@@ -7721,7 +7721,7 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
  "futures-core",
@@ -7731,7 +7731,7 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7742,7 +7742,7 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7857,7 +7857,7 @@ dependencies = [
 
 [[package]]
 name = "subkey"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "clap",
  "derive_more",
@@ -7898,7 +7898,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-browser-utils"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "chrono",
  "clear_on_drop",
@@ -7923,14 +7923,14 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "platforms",
 ]
 
 [[package]]
 name = "substrate-frame-rpc-support"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7946,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 dependencies = [
  "env_logger 0.7.1",
  "frame-system-rpc-runtime-api",
@@ -7969,7 +7969,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 dependencies = [
  "async-std",
  "derive_more",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-test-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 
 [[package]]
 name = "substrate-wasm-builder"

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Anonymous"]
 description = "Substrate Node template"
 edition = "2018"
@@ -20,25 +20,25 @@ futures = "0.3.4"
 log = "0.4.8"
 structopt = "0.3.8"
 
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../../client/executor" }
-sc-service = { version = "0.8.0-alpha.6", path = "../../../client/service" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../client/transaction-pool" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
-sc-network = { version = "0.8.0-alpha.6", path = "../../../client/network" }
-sc-consensus-aura = { version = "0.8.0-alpha.6", path = "../../../client/consensus/aura" }
-sp-consensus-aura = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/aura" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sc-finality-grandpa = { version = "0.8.0-alpha.6", path = "../../../client/finality-grandpa" }
-sp-finality-grandpa = { version = "2.0.0-alpha.6", path = "../../../primitives/finality-grandpa" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client/" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sc-basic-authorship = { path = "../../../client/basic-authorship", version = "0.8.0-alpha.6"}
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sc-executor = { version = "0.8.0-dev", path = "../../../client/executor" }
+sc-service = { version = "0.8.0-dev", path = "../../../client/service" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../../../client/transaction-pool" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }
+sc-network = { version = "0.8.0-dev", path = "../../../client/network" }
+sc-consensus-aura = { version = "0.8.0-dev", path = "../../../client/consensus/aura" }
+sp-consensus-aura = { version = "0.8.0-dev", path = "../../../primitives/consensus/aura" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sc-finality-grandpa = { version = "0.8.0-dev", path = "../../../client/finality-grandpa" }
+sp-finality-grandpa = { version = "2.0.0-dev", path = "../../../primitives/finality-grandpa" }
+sc-client = { version = "0.8.0-dev", path = "../../../client/" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sc-basic-authorship = { path = "../../../client/basic-authorship", version = "0.8.0-dev"}
 
-node-template-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
+node-template-runtime = { version = "2.0.0-dev", path = "../runtime" }
 
 [build-dependencies]
-substrate-build-script-utils = { version = "2.0.0-alpha.6", path = "../../../utils/build-script-utils" }
+substrate-build-script-utils = { version = "2.0.0-dev", path = "../../../utils/build-script-utils" }

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Anonymous']
 edition = '2018'
 name = 'pallet-template'
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
@@ -16,26 +16,26 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 
 [dependencies.frame-support]
 default-features = false
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 path = "../../../../frame/support"
 
 [dependencies.frame-system]
 default-features = false
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 path = "../../../../frame/system"
 [dev-dependencies.sp-core]
 default-features = false
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 path = "../../../../primitives/core"
 
 [dev-dependencies.sp-io]
 default-features = false
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 path = "../../../../primitives/io"
 
 [dev-dependencies.sp-runtime]
 default-features = false
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 path = "../../../../primitives/runtime"
 
 

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-template-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Anonymous"]
 edition = "2018"
 license = "Unlicense"
@@ -13,31 +13,31 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
-aura = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }
-balances = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-balances", path = "../../../frame/balances" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/support" }
-grandpa = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-grandpa", path = "../../../frame/grandpa" }
-randomness-collective-flip = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-randomness-collective-flip", path = "../../../frame/randomness-collective-flip" }
-sudo = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-sudo", path = "../../../frame/sudo" }
-system = { version = "2.0.0-alpha.6", default-features = false, package = "frame-system", path = "../../../frame/system" }
-timestamp = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-timestamp", path = "../../../frame/timestamp" }
-transaction-payment = { version = "2.0.0-alpha.6", default-features = false, package = "pallet-transaction-payment", path = "../../../frame/transaction-payment" }
-frame-executive = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/executive" }
+aura = { version = "2.0.0-dev", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }
+balances = { version = "2.0.0-dev", default-features = false, package = "pallet-balances", path = "../../../frame/balances" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../../frame/support" }
+grandpa = { version = "2.0.0-dev", default-features = false, package = "pallet-grandpa", path = "../../../frame/grandpa" }
+randomness-collective-flip = { version = "2.0.0-dev", default-features = false, package = "pallet-randomness-collective-flip", path = "../../../frame/randomness-collective-flip" }
+sudo = { version = "2.0.0-dev", default-features = false, package = "pallet-sudo", path = "../../../frame/sudo" }
+system = { version = "2.0.0-dev", default-features = false, package = "frame-system", path = "../../../frame/system" }
+timestamp = { version = "2.0.0-dev", default-features = false, package = "pallet-timestamp", path = "../../../frame/timestamp" }
+transaction-payment = { version = "2.0.0-dev", default-features = false, package = "pallet-transaction-payment", path = "../../../frame/transaction-payment" }
+frame-executive = { version = "2.0.0-dev", default-features = false, path = "../../../frame/executive" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/api" }
-sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "2.0.0-alpha.6"}
-sp-consensus-aura = { version = "0.8.0-alpha.6", default-features = false, path = "../../../primitives/consensus/aura" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/core" }
-sp-inherents = { path = "../../../primitives/inherents", default-features = false, version = "2.0.0-alpha.6"}
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/io" }
-sp-offchain = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/offchain" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-sp-session = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/session" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/transaction-pool" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/version" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/api" }
+sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "2.0.0-dev"}
+sp-consensus-aura = { version = "0.8.0-dev", default-features = false, path = "../../../primitives/consensus/aura" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-inherents = { path = "../../../primitives/inherents", default-features = false, version = "2.0.0-dev"}
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/io" }
+sp-offchain = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+sp-session = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/session" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-transaction-pool = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/version" }
 
-template = { version = "2.0.0-alpha.6", default-features = false, path = "../pallets/template", package = "pallet-template" }
+template = { version = "2.0.0-dev", default-features = false, path = "../pallets/template", package = "pallet-template" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-bench"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node integration benchmarks."
 edition = "2018"
@@ -10,11 +10,11 @@ license = "GPL-3.0"
 
 [dependencies]
 log = "0.4.8"
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-node-testing = { version = "2.0.0-alpha.6", path = "../testing" }
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api/" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+node-testing = { version = "2.0.0-dev", path = "../testing" }
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api/" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
 serde = "1.0.101"
 serde_json = "1.0.41"
 structopt = "0.3"

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-cli"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic Substrate node implementation in Rust."
 build = "build.rs"
@@ -45,74 +45,74 @@ structopt = { version = "0.3.8", optional = true }
 tracing = "0.1.10"
 
 # primitives
-sp-authority-discovery = { version = "2.0.0-alpha.6",  path = "../../../primitives/authority-discovery" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/babe" }
-grandpa-primitives = { version = "2.0.0-alpha.6", package = "sp-finality-grandpa", path = "../../../primitives/finality-grandpa" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/timestamp" }
-sp-finality-tracker = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/finality-tracker" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../../primitives/keyring" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
+sp-authority-discovery = { version = "2.0.0-dev",  path = "../../../primitives/authority-discovery" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../../primitives/consensus/babe" }
+grandpa-primitives = { version = "2.0.0-dev", package = "sp-finality-grandpa", path = "../../../primitives/finality-grandpa" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
+sp-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/finality-tracker" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sp-keyring = { version = "2.0.0-dev", path = "../../../primitives/keyring" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }
 
 # client dependencies
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client/" }
-sc-chain-spec = { version = "2.0.0-alpha.6", path = "../../../client/chain-spec" }
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../client/transaction-pool" }
-sc-network = { version = "0.8.0-alpha.6", path = "../../../client/network" }
-sc-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../client/consensus/babe" }
-grandpa = { version = "0.8.0-alpha.6", package = "sc-finality-grandpa", path = "../../../client/finality-grandpa" }
-sc-client-db = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/db" }
-sc-offchain = { version = "2.0.0-alpha.6", path = "../../../client/offchain" }
-sc-rpc = { version = "2.0.0-alpha.6", path = "../../../client/rpc" }
-sc-basic-authorship = { version = "0.8.0-alpha.6", path = "../../../client/basic-authorship" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/service" }
-sc-tracing = { version = "2.0.0-alpha.6", path = "../../../client/tracing" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../../../client/telemetry" }
-sc-authority-discovery = { version = "0.8.0-alpha.6",  path = "../../../client/authority-discovery" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api" }
+sc-client = { version = "0.8.0-dev", path = "../../../client/" }
+sc-chain-spec = { version = "2.0.0-dev", path = "../../../client/chain-spec" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../../../client/transaction-pool" }
+sc-network = { version = "0.8.0-dev", path = "../../../client/network" }
+sc-consensus-babe = { version = "0.8.0-dev", path = "../../../client/consensus/babe" }
+grandpa = { version = "0.8.0-dev", package = "sc-finality-grandpa", path = "../../../client/finality-grandpa" }
+sc-client-db = { version = "0.8.0-dev", default-features = false, path = "../../../client/db" }
+sc-offchain = { version = "2.0.0-dev", path = "../../../client/offchain" }
+sc-rpc = { version = "2.0.0-dev", path = "../../../client/rpc" }
+sc-basic-authorship = { version = "0.8.0-dev", path = "../../../client/basic-authorship" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../../client/service" }
+sc-tracing = { version = "2.0.0-dev", path = "../../../client/tracing" }
+sc-telemetry = { version = "2.0.0-dev", path = "../../../client/telemetry" }
+sc-authority-discovery = { version = "0.8.0-dev",  path = "../../../client/authority-discovery" }
 
 # frame dependencies
-pallet-indices = { version = "2.0.0-alpha.6", path = "../../../frame/indices" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/timestamp" }
-pallet-contracts = { version = "2.0.0-alpha.6", path = "../../../frame/contracts" }
-frame-system = { version = "2.0.0-alpha.6", path = "../../../frame/system" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../../../frame/balances" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../../../frame/transaction-payment" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/support" }
-pallet-im-online = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/im-online" }
-pallet-authority-discovery = { version = "2.0.0-alpha.6",  path = "../../../frame/authority-discovery" }
-pallet-staking = { version = "2.0.0-alpha.6",  path = "../../../frame/staking" }
+pallet-indices = { version = "2.0.0-dev", path = "../../../frame/indices" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../../frame/timestamp" }
+pallet-contracts = { version = "2.0.0-dev", path = "../../../frame/contracts" }
+frame-system = { version = "2.0.0-dev", path = "../../../frame/system" }
+pallet-balances = { version = "2.0.0-dev", path = "../../../frame/balances" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../../../frame/transaction-payment" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../../frame/support" }
+pallet-im-online = { version = "2.0.0-dev", default-features = false, path = "../../../frame/im-online" }
+pallet-authority-discovery = { version = "2.0.0-dev",  path = "../../../frame/authority-discovery" }
+pallet-staking = { version = "2.0.0-dev",  path = "../../../frame/staking" }
 
 # node-specific dependencies
-node-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
-node-rpc = { version = "2.0.0-alpha.6", path = "../rpc" }
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-node-executor = { version = "2.0.0-alpha.6", path = "../executor" }
+node-runtime = { version = "2.0.0-dev", path = "../runtime" }
+node-rpc = { version = "2.0.0-dev", path = "../rpc" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+node-executor = { version = "2.0.0-dev", path = "../executor" }
 
 # CLI-specific dependencies
-sc-cli = { version = "0.8.0-alpha.6", optional = true, path = "../../../client/cli" }
-frame-benchmarking-cli = { version = "2.0.0-alpha.6", optional = true, path = "../../../utils/frame/benchmarking-cli" }
-node-transaction-factory = { version = "0.8.0-alpha.6", optional = true, path = "../transaction-factory" }
-node-inspect = { version = "0.8.0-alpha.6", optional = true, path = "../inspect" }
+sc-cli = { version = "0.8.0-dev", optional = true, path = "../../../client/cli" }
+frame-benchmarking-cli = { version = "2.0.0-dev", optional = true, path = "../../../utils/frame/benchmarking-cli" }
+node-transaction-factory = { version = "0.8.0-dev", optional = true, path = "../transaction-factory" }
+node-inspect = { version = "0.8.0-dev", optional = true, path = "../inspect" }
 
 # WASM-specific dependencies
 wasm-bindgen = { version = "0.2.57", optional = true }
 wasm-bindgen-futures = { version = "0.4.7", optional = true }
-browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.8.0-alpha.6"}
+browser-utils = { package = "substrate-browser-utils", path = "../../../utils/browser", optional = true, version = "0.8.0-dev"}
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-node-executor = { version = "2.0.0-alpha.6", path = "../executor", features = [ "wasmtime" ] }
-sc-cli = { version = "0.8.0-alpha.6", optional = true, path = "../../../client/cli", features = [ "wasmtime" ] }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/service", features = [ "wasmtime" ] }
+node-executor = { version = "2.0.0-dev", path = "../executor", features = [ "wasmtime" ] }
+sc-cli = { version = "0.8.0-dev", optional = true, path = "../../../client/cli", features = [ "wasmtime" ] }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../../client/service", features = [ "wasmtime" ] }
 
 [dev-dependencies]
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../../client/keystore" }
-sc-consensus-babe = { version = "0.8.0-alpha.6", features = ["test-helpers"], path = "../../../client/consensus/babe" }
-sc-consensus-epochs = { version = "0.8.0-alpha.6", path = "../../../client/consensus/epochs" }
+sc-keystore = { version = "2.0.0-dev", path = "../../../client/keystore" }
+sc-consensus-babe = { version = "0.8.0-dev", features = ["test-helpers"], path = "../../../client/consensus/babe" }
+sc-consensus-epochs = { version = "0.8.0-dev", path = "../../../client/consensus/epochs" }
 sc-service-test = { version = "2.0.0-dev", path = "../../../client/service/test" }
 futures = "0.3.4"
 tempfile = "3.1.0"
@@ -124,13 +124,13 @@ platforms = "0.2.1"
 
 [build-dependencies]
 structopt = { version = "0.3.8", optional = true }
-node-transaction-factory = { version = "0.8.0-alpha.6", optional = true, path = "../transaction-factory" }
-node-inspect = { version = "0.8.0-alpha.6", optional = true, path = "../inspect" }
-frame-benchmarking-cli = { version = "2.0.0-alpha.6", optional = true, path = "../../../utils/frame/benchmarking-cli" }
-substrate-build-script-utils = { version = "2.0.0-alpha.6", optional = true, path = "../../../utils/build-script-utils" }
+node-transaction-factory = { version = "0.8.0-dev", optional = true, path = "../transaction-factory" }
+node-inspect = { version = "0.8.0-dev", optional = true, path = "../inspect" }
+frame-benchmarking-cli = { version = "2.0.0-dev", optional = true, path = "../../../utils/frame/benchmarking-cli" }
+substrate-build-script-utils = { version = "2.0.0-dev", optional = true, path = "../../../utils/build-script-utils" }
 
 [build-dependencies.sc-cli]
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 package = "sc-cli"
 path = "../../../client/cli"
 optional = true

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-executor"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node implementation in Rust."
 edition = "2018"
@@ -13,33 +13,33 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-node-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../../client/executor" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../../../primitives/trie" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+node-runtime = { version = "2.0.0-dev", path = "../runtime" }
+sc-executor = { version = "0.8.0-dev", path = "../../../client/executor" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
+sp-trie = { version = "2.0.0-dev", path = "../../../primitives/trie" }
 trie-root = "0.16.0"
-frame-benchmarking = { version = "2.0.0-alpha.6", path = "../../../frame/benchmarking" }
+frame-benchmarking = { version = "2.0.0-dev", path = "../../../frame/benchmarking" }
 
 [dev-dependencies]
 criterion = "0.3.0"
-frame-support = { version = "2.0.0-alpha.6", path = "../../../frame/support" }
-frame-system = { version = "2.0.0-alpha.6", path = "../../../frame/system" }
-node-testing = { version = "2.0.0-alpha.6", path = "../testing" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../../../frame/balances" }
-pallet-contracts = { version = "2.0.0-alpha.6", path = "../../../frame/contracts" }
-pallet-grandpa = { version = "2.0.0-alpha.6", path = "../../../frame/grandpa" }
-pallet-im-online = { version = "2.0.0-alpha.6", path = "../../../frame/im-online" }
-pallet-indices = { version = "2.0.0-alpha.6", path = "../../../frame/indices" }
-pallet-session = { version = "2.0.0-alpha.6", path = "../../../frame/session" }
-pallet-timestamp = { version = "2.0.0-alpha.6", path = "../../../frame/timestamp" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../../../frame/transaction-payment" }
-pallet-treasury = { version = "2.0.0-alpha.6", path = "../../../frame/treasury" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../../primitives/application-crypto" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-externalities = { version = "0.8.0-alpha.6", path = "../../../primitives/externalities" }
+frame-support = { version = "2.0.0-dev", path = "../../../frame/support" }
+frame-system = { version = "2.0.0-dev", path = "../../../frame/system" }
+node-testing = { version = "2.0.0-dev", path = "../testing" }
+pallet-balances = { version = "2.0.0-dev", path = "../../../frame/balances" }
+pallet-contracts = { version = "2.0.0-dev", path = "../../../frame/contracts" }
+pallet-grandpa = { version = "2.0.0-dev", path = "../../../frame/grandpa" }
+pallet-im-online = { version = "2.0.0-dev", path = "../../../frame/im-online" }
+pallet-indices = { version = "2.0.0-dev", path = "../../../frame/indices" }
+pallet-session = { version = "2.0.0-dev", path = "../../../frame/session" }
+pallet-timestamp = { version = "2.0.0-dev", path = "../../../frame/timestamp" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../../../frame/transaction-payment" }
+pallet-treasury = { version = "2.0.0-dev", path = "../../../frame/treasury" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../../primitives/application-crypto" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-externalities = { version = "0.8.0-dev", path = "../../../primitives/externalities" }
 substrate-test-client = { version = "2.0.0-dev", path = "../../../test-utils/client" }
 wabt = "0.9.2"
 

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-inspect"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 derive_more = "0.99"
 log = "0.4.8"
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/service" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../../client/service" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
 structopt = "0.3.8"

--- a/bin/node/primitives/Cargo.toml
+++ b/bin/node/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-primitives"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -11,11 +11,11 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 
 [dev-dependencies]
-sp-serializer = { version = "2.0.0-alpha.6", path = "../../../primitives/serializer" }
+sp-serializer = { version = "2.0.0-dev", path = "../../../primitives/serializer" }
 pretty_assertions = "0.6.1"
 
 [features]

--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-rpc-client"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,5 +16,5 @@ futures = "0.1.29"
 hyper = "0.12.35"
 jsonrpc-core-client = { version = "14.0.5", default-features = false, features = ["http"] }
 log = "0.4.8"
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-sc-rpc = { version = "2.0.0-alpha.6", path = "../../../client/rpc" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+sc-rpc = { version = "2.0.0-dev", path = "../../../client/rpc" }

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -11,20 +11,20 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client/" }
+sc-client = { version = "0.8.0-dev", path = "../../../client/" }
 jsonrpc-core = "14.0.3"
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-node-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-pallet-contracts-rpc = { version = "0.8.0-alpha.6", path = "../../../frame/contracts/rpc/" }
-pallet-transaction-payment-rpc = { version = "2.0.0-alpha.6", path = "../../../frame/transaction-payment/rpc/" }
-substrate-frame-rpc-system = { version = "2.0.0-alpha.6", path = "../../../utils/frame/rpc/system" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
-sc-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../client/consensus/babe" }
-sc-consensus-babe-rpc = { version = "0.8.0-alpha.6", path = "../../../client/consensus/babe/rpc" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/babe" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../../client/keystore" }
-sc-consensus-epochs = { version = "0.8.0-alpha.6", path = "../../../client/consensus/epochs" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+node-runtime = { version = "2.0.0-dev", path = "../runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+pallet-contracts-rpc = { version = "0.8.0-dev", path = "../../../frame/contracts/rpc/" }
+pallet-transaction-payment-rpc = { version = "2.0.0-dev", path = "../../../frame/transaction-payment/rpc/" }
+substrate-frame-rpc-system = { version = "2.0.0-dev", path = "../../../utils/frame/rpc/system" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }
+sc-consensus-babe = { version = "0.8.0-dev", path = "../../../client/consensus/babe" }
+sc-consensus-babe-rpc = { version = "0.8.0-dev", path = "../../../client/consensus/babe/rpc" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../../primitives/consensus/babe" }
+sc-keystore = { version = "2.0.0-dev", path = "../../../client/keystore" }
+sc-consensus-epochs = { version = "0.8.0-dev", path = "../../../client/consensus/epochs" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
@@ -19,67 +19,67 @@ integer-sqrt = { version = "0.1.2" }
 serde = { version = "1.0.102", optional = true }
 
 # primitives
-sp-authority-discovery = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/authority-discovery" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", default-features = false, path = "../../../primitives/consensus/babe" }
-sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "2.0.0-alpha.6"}
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/inherents" }
-node-primitives = { version = "2.0.0-alpha.6", default-features = false, path = "../primitives" }
-sp-offchain = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/offchain" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/staking" }
-sp-keyring = { version = "2.0.0-alpha.6", optional = true, path = "../../../primitives/keyring" }
-sp-session = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/session" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/transaction-pool" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/version" }
+sp-authority-discovery = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/authority-discovery" }
+sp-consensus-babe = { version = "0.8.0-dev", default-features = false, path = "../../../primitives/consensus/babe" }
+sp-block-builder = { path = "../../../primitives/block-builder", default-features = false, version = "2.0.0-dev"}
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/inherents" }
+node-primitives = { version = "2.0.0-dev", default-features = false, path = "../primitives" }
+sp-offchain = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/offchain" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/staking" }
+sp-keyring = { version = "2.0.0-dev", optional = true, path = "../../../primitives/keyring" }
+sp-session = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/session" }
+sp-transaction-pool = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/transaction-pool" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/version" }
 
 # frame dependencies
-frame-executive = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/executive" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/system" }
-frame-system-rpc-runtime-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
-pallet-authority-discovery = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/authority-discovery" }
-pallet-authorship = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/authorship" }
-pallet-babe = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/babe" }
-pallet-balances = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/balances" }
-pallet-collective = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/collective" }
-pallet-contracts = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/contracts" }
-pallet-contracts-primitives = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/contracts/common/" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0-alpha.6", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
-pallet-democracy = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/democracy" }
-pallet-elections-phragmen = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/elections-phragmen" }
-pallet-finality-tracker = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/finality-tracker" }
-pallet-grandpa = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/grandpa" }
-pallet-im-online = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/im-online" }
-pallet-indices = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/indices" }
-pallet-identity = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/identity" }
-pallet-membership = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/membership" }
-pallet-offences = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/offences" }
-pallet-offences-benchmarking = { version = "2.0.0-alpha.6", path = "../../../frame/offences/benchmarking", default-features = false, optional = true }
-pallet-randomness-collective-flip = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/randomness-collective-flip" }
-pallet-recovery = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/recovery" }
-pallet-session = { version = "2.0.0-alpha.6", features = ["historical"], path = "../../../frame/session", default-features = false }
-pallet-session-benchmarking = { version = "2.0.0-alpha.6", path = "../../../frame/session/benchmarking", default-features = false, optional = true }
-pallet-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/staking" }
-pallet-staking-reward-curve = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/staking/reward-curve" }
-pallet-scheduler = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/scheduler" }
-pallet-society = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/society" }
-pallet-sudo = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/sudo" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/timestamp" }
-pallet-treasury = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/treasury" }
-pallet-utility = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/utility" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/transaction-payment" }
-pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
-pallet-vesting = { version = "2.0.0-alpha.6", default-features = false, path = "../../../frame/vesting" }
+frame-executive = { version = "2.0.0-dev", default-features = false, path = "../../../frame/executive" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../../../frame/benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../../frame/support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../../../frame/system" }
+frame-system-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
+pallet-authority-discovery = { version = "2.0.0-dev", default-features = false, path = "../../../frame/authority-discovery" }
+pallet-authorship = { version = "2.0.0-dev", default-features = false, path = "../../../frame/authorship" }
+pallet-babe = { version = "2.0.0-dev", default-features = false, path = "../../../frame/babe" }
+pallet-balances = { version = "2.0.0-dev", default-features = false, path = "../../../frame/balances" }
+pallet-collective = { version = "2.0.0-dev", default-features = false, path = "../../../frame/collective" }
+pallet-contracts = { version = "2.0.0-dev", default-features = false, path = "../../../frame/contracts" }
+pallet-contracts-primitives = { version = "2.0.0-dev", default-features = false, path = "../../../frame/contracts/common/" }
+pallet-contracts-rpc-runtime-api = { version = "0.8.0-dev", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
+pallet-democracy = { version = "2.0.0-dev", default-features = false, path = "../../../frame/democracy" }
+pallet-elections-phragmen = { version = "2.0.0-dev", default-features = false, path = "../../../frame/elections-phragmen" }
+pallet-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../../../frame/finality-tracker" }
+pallet-grandpa = { version = "2.0.0-dev", default-features = false, path = "../../../frame/grandpa" }
+pallet-im-online = { version = "2.0.0-dev", default-features = false, path = "../../../frame/im-online" }
+pallet-indices = { version = "2.0.0-dev", default-features = false, path = "../../../frame/indices" }
+pallet-identity = { version = "2.0.0-dev", default-features = false, path = "../../../frame/identity" }
+pallet-membership = { version = "2.0.0-dev", default-features = false, path = "../../../frame/membership" }
+pallet-offences = { version = "2.0.0-dev", default-features = false, path = "../../../frame/offences" }
+pallet-offences-benchmarking = { version = "2.0.0-dev", path = "../../../frame/offences/benchmarking", default-features = false, optional = true }
+pallet-randomness-collective-flip = { version = "2.0.0-dev", default-features = false, path = "../../../frame/randomness-collective-flip" }
+pallet-recovery = { version = "2.0.0-dev", default-features = false, path = "../../../frame/recovery" }
+pallet-session = { version = "2.0.0-dev", features = ["historical"], path = "../../../frame/session", default-features = false }
+pallet-session-benchmarking = { version = "2.0.0-dev", path = "../../../frame/session/benchmarking", default-features = false, optional = true }
+pallet-staking = { version = "2.0.0-dev", default-features = false, path = "../../../frame/staking" }
+pallet-staking-reward-curve = { version = "2.0.0-dev", default-features = false, path = "../../../frame/staking/reward-curve" }
+pallet-scheduler = { version = "2.0.0-dev", default-features = false, path = "../../../frame/scheduler" }
+pallet-society = { version = "2.0.0-dev", default-features = false, path = "../../../frame/society" }
+pallet-sudo = { version = "2.0.0-dev", default-features = false, path = "../../../frame/sudo" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../../frame/timestamp" }
+pallet-treasury = { version = "2.0.0-dev", default-features = false, path = "../../../frame/treasury" }
+pallet-utility = { version = "2.0.0-dev", default-features = false, path = "../../../frame/utility" }
+pallet-transaction-payment = { version = "2.0.0-dev", default-features = false, path = "../../../frame/transaction-payment" }
+pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
+pallet-vesting = { version = "2.0.0-dev", default-features = false, path = "../../../frame/vesting" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
 
 [features]
 default = ["std"]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -128,7 +128,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 240,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 };
 

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-testing"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Test utilities for Substrate node."
 edition = "2018"
@@ -13,45 +13,45 @@ publish = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-pallet-balances = { version = "2.0.0-alpha.6", path = "../../../frame/balances" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client/" }
-sc-client-db = { version = "0.8.0-alpha.6", path = "../../../client/db/", features = ["kvdb-rocksdb"] }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api/" }
+pallet-balances = { version = "2.0.0-dev", path = "../../../frame/balances" }
+sc-client = { version = "0.8.0-dev", path = "../../../client/" }
+sc-client-db = { version = "0.8.0-dev", path = "../../../client/db/", features = ["kvdb-rocksdb"] }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api/" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-pallet-contracts = { version = "2.0.0-alpha.6", path = "../../../frame/contracts" }
-pallet-grandpa = { version = "2.0.0-alpha.6", path = "../../../frame/grandpa" }
-pallet-indices = { version = "2.0.0-alpha.6", path = "../../../frame/indices" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../../primitives/keyring" }
-node-executor = { version = "2.0.0-alpha.6", path = "../executor" }
-node-primitives = { version = "2.0.0-alpha.6", path = "../primitives" }
-node-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
-frame-support = { version = "2.0.0-alpha.6", path = "../../../frame/support" }
-pallet-session = { version = "2.0.0-alpha.6", path = "../../../frame/session" }
-pallet-society = { version = "2.0.0-alpha.6", path = "../../../frame/society" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-pallet-staking = { version = "2.0.0-alpha.6", path = "../../../frame/staking" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../../client/executor", features = ["wasmtime"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-frame-system = { version = "2.0.0-alpha.6", path = "../../../frame/system" }
+pallet-contracts = { version = "2.0.0-dev", path = "../../../frame/contracts" }
+pallet-grandpa = { version = "2.0.0-dev", path = "../../../frame/grandpa" }
+pallet-indices = { version = "2.0.0-dev", path = "../../../frame/indices" }
+sp-keyring = { version = "2.0.0-dev", path = "../../../primitives/keyring" }
+node-executor = { version = "2.0.0-dev", path = "../executor" }
+node-primitives = { version = "2.0.0-dev", path = "../primitives" }
+node-runtime = { version = "2.0.0-dev", path = "../runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
+frame-support = { version = "2.0.0-dev", path = "../../../frame/support" }
+pallet-session = { version = "2.0.0-dev", path = "../../../frame/session" }
+pallet-society = { version = "2.0.0-dev", path = "../../../frame/society" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+pallet-staking = { version = "2.0.0-dev", path = "../../../frame/staking" }
+sc-executor = { version = "0.8.0-dev", path = "../../../client/executor", features = ["wasmtime"] }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+frame-system = { version = "2.0.0-dev", path = "../../../frame/system" }
 substrate-test-client = { version = "2.0.0-dev", path = "../../../test-utils/client" }
-pallet-timestamp = { version = "2.0.0-alpha.6", path = "../../../frame/timestamp" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../../../frame/transaction-payment" }
-pallet-treasury = { version = "2.0.0-alpha.6", path = "../../../frame/treasury" }
+pallet-timestamp = { version = "2.0.0-dev", path = "../../../frame/timestamp" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../../../frame/transaction-payment" }
+pallet-treasury = { version = "2.0.0-dev", path = "../../../frame/treasury" }
 wabt = "0.9.2"
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-finality-tracker = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/finality-tracker" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/timestamp" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../../primitives/block-builder" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../../client/block-builder" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/finality-tracker" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/timestamp" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../../primitives/block-builder" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../../client/block-builder" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
 log = "0.4.8"
 tempfile = "3.1.0"
 fs_extra = "1"
 
 [dev-dependencies]
 criterion = "0.3.0"
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sc-service = { version = "0.8.0-alpha.6", path = "../../../client/service", features = ["rocksdb"] }
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sc-service = { version = "0.8.0-dev", path = "../../../client/service", features = ["rocksdb"] }

--- a/bin/node/transaction-factory/Cargo.toml
+++ b/bin/node/transaction-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-transaction-factory"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -11,16 +11,16 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../../primitives/block-builder" }
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../../client/block-builder" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../../primitives/block-builder" }
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../../client/block-builder" }
+sc-client = { version = "0.8.0-dev", path = "../../../client" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
 log = "0.4.8"
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/service" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../../client/service" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-spec-builder"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
@@ -13,9 +13,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../../client/keystore" }
-sc-chain-spec = { version = "2.0.0-alpha.6", path = "../../../client/chain-spec" }
-node-cli = { version = "2.0.0-alpha.6", path = "../../node/cli" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
+sc-keystore = { version = "2.0.0-dev", path = "../../../client/keystore" }
+sc-chain-spec = { version = "2.0.0-dev", path = "../../../client/chain-spec" }
+node-cli = { version = "2.0.0-dev", path = "../../node/cli" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
 rand = "0.7.2"
 structopt = "0.3.8"

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subkey"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,10 +12,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.1.29"
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-node-runtime = { version = "2.0.0-alpha.6", path = "../../node/runtime" }
-node-primitives = { version = "2.0.0-alpha.6", path = "../../node/primitives" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+node-runtime = { version = "2.0.0-dev", path = "../../node/runtime" }
+node-primitives = { version = "2.0.0-dev", path = "../../node/primitives" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
 rand = "0.7.2"
 clap = "2.33.0"
 tiny-bip39 = "0.7"
@@ -23,13 +23,13 @@ substrate-bip39 = "0.4.1"
 hex = "0.4.0"
 hex-literal = "0.2.1"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-frame-system = { version = "2.0.0-alpha.6", path = "../../../frame/system" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../../../frame/balances" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../../../frame/transaction-payment" }
+frame-system = { version = "2.0.0-dev", path = "../../../frame/system" }
+pallet-balances = { version = "2.0.0-dev", path = "../../../frame/balances" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../../../frame/transaction-payment" }
 rpassword = "4.0.1"
 itertools = "0.8.2"
 derive_more = { version = "0.99.2" }
-sc-rpc = { version = "2.0.0-alpha.6", path = "../../../client/rpc" }
+sc-rpc = { version = "2.0.0-dev", path = "../../../client/rpc" }
 jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
 libp2p = "0.18.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-client"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,33 +12,33 @@ description = "Substrate Client and associated logic."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-block-builder = { version = "0.8.0-alpha.6", path = "block-builder" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "api" }
+sc-block-builder = { version = "0.8.0-dev", path = "block-builder" }
+sc-client-api = { version = "2.0.0-dev", path = "api" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../primitives/consensus/common" }
+sp-consensus = { version = "0.8.0-dev", path = "../primitives/consensus/common" }
 derive_more = { version = "0.99.2" }
-sc-executor = { version = "0.8.0-alpha.6", path = "executor" }
-sp-externalities = { version = "0.8.0-alpha.6", path = "../primitives/externalities" }
+sc-executor = { version = "0.8.0-dev", path = "executor" }
+sp-externalities = { version = "0.8.0-dev", path = "../primitives/externalities" }
 fnv = { version = "1.0.6" }
 futures = { version = "0.3.1", features = ["compat"] }
 hash-db = { version = "0.15.2" }
 hex-literal = { version = "0.2.1" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../primitives/inherents" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../primitives/keyring" }
+sp-inherents = { version = "2.0.0-dev", path = "../primitives/inherents" }
+sp-keyring = { version = "2.0.0-dev", path = "../primitives/keyring" }
 kvdb = "0.5.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
-sp-core = { version = "2.0.0-alpha.6", path = "../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", path = "../primitives/std" }
-sp-version = { version = "2.0.0-alpha.6", path = "../primitives/version" }
-sp-api = { version = "2.0.0-alpha.6", path = "../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../primitives/utils" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../primitives/blockchain" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../primitives/state-machine" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "telemetry" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../primitives/trie" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-alpha.6", path = "../utils/prometheus" }
+sp-core = { version = "2.0.0-dev", path = "../primitives/core" }
+sp-std = { version = "2.0.0-dev", path = "../primitives/std" }
+sp-version = { version = "2.0.0-dev", path = "../primitives/version" }
+sp-api = { version = "2.0.0-dev", path = "../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../primitives/utils" }
+sp-blockchain = { version = "2.0.0-dev", path = "../primitives/blockchain" }
+sp-state-machine = { version = "0.8.0-dev", path = "../primitives/state-machine" }
+sc-telemetry = { version = "2.0.0-dev", path = "telemetry" }
+sp-trie = { version = "2.0.0-dev", path = "../primitives/trie" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-dev", path = "../utils/prometheus" }
 tracing = "0.1.10"
 
 [dev-dependencies]
@@ -46,4 +46,4 @@ env_logger = "0.7.0"
 tempfile = "3.1.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../test-utils/runtime/client" }
 kvdb-memorydb = "0.5.0"
-sp-panic-handler = { version = "2.0.0-alpha.6", path = "../primitives/panic-handler" }
+sp-panic-handler = { version = "2.0.0-dev", path = "../primitives/panic-handler" }

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-client-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,32 +15,32 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
 derive_more = { version = "0.99.2" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../executor" }
-sp-externalities = { version = "0.8.0-alpha.6", path = "../../primitives/externalities" }
+sc-executor = { version = "0.8.0-dev", path = "../executor" }
+sp-externalities = { version = "0.8.0-dev", path = "../../primitives/externalities" }
 fnv = { version = "1.0.6" }
 futures = { version = "0.3.1" }
 hash-db = { version = "0.15.2", default-features = false }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
 hex-literal = { version = "0.2.1" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 kvdb = "0.5.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
 lazy_static =  "1.4.0"
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/version" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../../primitives/trie" }
-sp-storage = { version = "2.0.0-alpha.6", path = "../../primitives/storage" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../../primitives/version" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
+sp-trie = { version = "2.0.0-dev", path = "../../primitives/trie" }
+sp-storage = { version = "2.0.0-dev", path = "../../primitives/storage" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
 
 [dev-dependencies]
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-authority-discovery"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
@@ -23,21 +23,21 @@ futures = "0.3.4"
 futures-timer = "3.0.1"
 libp2p = { version = "0.18.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
 log = "0.4.8"
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-alpha.6"}
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-dev"}
 prost = "0.6.1"
 rand = "0.7.2"
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../keystore" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
 serde_json = "1.0.41"
-sp-authority-discovery = { version = "2.0.0-alpha.6", path = "../../primitives/authority-discovery" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
+sp-authority-discovery = { version = "2.0.0-dev", path = "../../primitives/authority-discovery" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
 
 [dev-dependencies]
 env_logger = "0.7.0"
 quickcheck = "0.9.0"
-sc-peerset = { version = "2.0.0-alpha.6", path = "../peerset" }
+sc-peerset = { version = "2.0.0-dev", path = "../peerset" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client"}

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-basic-authorship"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,20 +15,20 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.8"
 futures = "0.3.4"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../primitives/inherents" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../block-builder" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sp-inherents = { version = "2.0.0-dev", path = "../../primitives/inherents" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+sc-block-builder = { version = "0.8.0-dev", path = "../block-builder" }
 tokio-executor = { version = "0.2.0-alpha.6", features = ["blocking"] }
 futures-timer = "3.0.1"
 
 [dev-dependencies]
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../../client/transaction-pool" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../../client/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 parking_lot = "0.10.0"

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-block-builder"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,16 +13,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../primitives/block-builder" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../primitives/block-builder" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 
 [dev-dependencies]
 substrate-test-runtime-client = { path = "../../test-utils/runtime/client" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../../primitives/trie" }
+sp-trie = { version = "2.0.0-dev", path = "../../primitives/trie" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-chain-spec"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,12 +12,12 @@ description = "Substrate chain configurations."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-chain-spec-derive = { version = "2.0.0-alpha.6", path = "./derive" }
+sc-chain-spec-derive = { version = "2.0.0-dev", path = "./derive" }
 impl-trait-for-tuples = "0.1.3"
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-chain-spec = { version = "2.0.0-alpha.6", path = "../../primitives/chain-spec" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-chain-spec = { version = "2.0.0-dev", path = "../../primitives/chain-spec" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-chain-spec-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-cli"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate CLI interface."
 edition = "2018"
@@ -26,23 +26,23 @@ tokio = { version = "0.2.9", features = [ "signal", "rt-core", "rt-threaded" ] }
 futures = "0.3.4"
 fdlimit = "0.1.4"
 serde_json = "1.0.41"
-sc-informant = { version = "0.8.0-alpha.6", path = "../informant" }
-sp-panic-handler = { version = "2.0.0-alpha.6", path = "../../primitives/panic-handler" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../primitives/version" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../service" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
-substrate-prometheus-endpoint = { path = "../../utils/prometheus" , version = "0.8.0-alpha.6"}
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sc-informant = { version = "0.8.0-dev", path = "../informant" }
+sp-panic-handler = { version = "2.0.0-dev", path = "../../primitives/panic-handler" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-version = { version = "2.0.0-dev", path = "../../primitives/version" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../service" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
+substrate-prometheus-endpoint = { path = "../../utils/prometheus" , version = "0.8.0-dev"}
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 names = "0.11.0"
 structopt = "0.3.8"
-sc-tracing = { version = "2.0.0-alpha.6", path = "../tracing" }
+sc-tracing = { version = "2.0.0-dev", path = "../tracing" }
 chrono = "0.4.10"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-aura"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Aura consensus algorithm for substrate"
 edition = "2018"
@@ -12,37 +12,37 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../../primitives/application-crypto" }
-sp-consensus-aura = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/aura" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../../primitives/block-builder" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../../client/block-builder" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../../primitives/application-crypto" }
+sp-consensus-aura = { version = "0.8.0-dev", path = "../../../primitives/consensus/aura" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../../primitives/block-builder" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../../client/block-builder" }
+sc-client = { version = "0.8.0-dev", path = "../../" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
 derive_more = "0.99.2"
 futures = "0.3.4"
 futures-timer = "3.0.1"
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../keystore" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sc-keystore = { version = "2.0.0-dev", path = "../../keystore" }
 log = "0.4.8"
 parking_lot = "0.10.0"
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../../primitives/version" }
-sc-consensus-slots = { version = "0.8.0-alpha.6", path = "../slots" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-timestamp = { version = "2.0.0-alpha.6", path = "../../../primitives/timestamp" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../../telemetry" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
+sp-version = { version = "2.0.0-dev", path = "../../../primitives/version" }
+sc-consensus-slots = { version = "0.8.0-dev", path = "../slots" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-timestamp = { version = "2.0.0-dev", path = "../../../primitives/timestamp" }
+sc-telemetry = { version = "2.0.0-dev", path = "../../telemetry" }
 
 [dev-dependencies]
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../../primitives/keyring" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../executor" }
-sc-network = { version = "0.8.0-alpha.6", path = "../../network" }
+sp-keyring = { version = "2.0.0-dev", path = "../../../primitives/keyring" }
+sc-executor = { version = "0.8.0-dev", path = "../../executor" }
+sc-network = { version = "0.8.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0-dev", path = "../../network/test" }
-sc-service = { version = "0.8.0-alpha.6", path = "../../service" }
+sc-service = { version = "0.8.0-dev", path = "../../service" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-babe"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "BABE consensus algorithm for substrate"
 edition = "2018"
@@ -14,31 +14,31 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/babe" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../../primitives/application-crypto" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../../primitives/consensus/babe" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../../primitives/application-crypto" }
 num-bigint = "0.2.3"
 num-rational = "0.2.2"
 num-traits = "0.2.8"
 serde = { version = "1.0.104", features = ["derive"] }
-sp-version = { version = "2.0.0-alpha.6", path = "../../../primitives/version" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../../primitives/io" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sp-timestamp = { version = "2.0.0-alpha.6", path = "../../../primitives/timestamp" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../../telemetry" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../keystore" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../" }
-sc-consensus-epochs = { version = "0.8.0-alpha.6", path = "../epochs" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../../primitives/block-builder" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sp-consensus-vrf = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/vrf" }
-sc-consensus-uncles = { version = "0.8.0-alpha.6", path = "../uncles" }
-sc-consensus-slots = { version = "0.8.0-alpha.6", path = "../slots" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-fork-tree = { version = "2.0.0-alpha.6", path = "../../../utils/fork-tree" }
+sp-version = { version = "2.0.0-dev", path = "../../../primitives/version" }
+sp-io = { version = "2.0.0-dev", path = "../../../primitives/io" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sp-timestamp = { version = "2.0.0-dev", path = "../../../primitives/timestamp" }
+sc-telemetry = { version = "2.0.0-dev", path = "../../telemetry" }
+sc-keystore = { version = "2.0.0-dev", path = "../../keystore" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
+sc-client = { version = "0.8.0-dev", path = "../../" }
+sc-consensus-epochs = { version = "0.8.0-dev", path = "../epochs" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../../primitives/block-builder" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sp-consensus-vrf = { version = "0.8.0-dev", path = "../../../primitives/consensus/vrf" }
+sc-consensus-uncles = { version = "0.8.0-dev", path = "../uncles" }
+sc-consensus-slots = { version = "0.8.0-dev", path = "../slots" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+fork-tree = { version = "2.0.0-dev", path = "../../../utils/fork-tree" }
 futures = "0.3.4"
 futures-timer = "3.0.1"
 parking_lot = "0.10.0"
@@ -50,13 +50,13 @@ pdqselect = "0.1.0"
 derive_more = "0.99.2"
 
 [dev-dependencies]
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../../primitives/keyring" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../executor" }
-sc-network = { version = "0.8.0-alpha.6", path = "../../network" }
+sp-keyring = { version = "2.0.0-dev", path = "../../../primitives/keyring" }
+sc-executor = { version = "0.8.0-dev", path = "../../executor" }
+sc-network = { version = "0.8.0-dev", path = "../../network" }
 sc-network-test = { version = "0.8.0-dev", path = "../../network/test" }
-sc-service = { version = "0.8.0-alpha.6", path = "../../service" }
+sc-service = { version = "0.8.0-dev", path = "../../service" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../block-builder" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../block-builder" }
 env_logger = "0.7.0"
 tempfile = "3.1.0"
 

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-babe-rpc"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "RPC extensions for the BABE consensus algorithm"
 edition = "2018"
@@ -12,24 +12,24 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-consensus-babe = { version = "0.8.0-alpha.6", path = "../" }
+sc-consensus-babe = { version = "0.8.0-dev", path = "../" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.3"
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../../primitives/consensus/babe" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../../../primitives/consensus/babe" }
 serde = { version = "1.0.104", features=["derive"] }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../../primitives/runtime" }
-sc-consensus-epochs = { version = "0.8.0-alpha.6", path = "../../epochs" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../../primitives/runtime" }
+sc-consensus-epochs = { version = "0.8.0-dev", path = "../../epochs" }
 futures = "0.3.4"
 derive_more = "0.99.2"
-sp-api = { version = "2.0.0-alpha.6", path = "../../../../primitives/api" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../../primitives/consensus/common" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../../primitives/core" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../../../keystore" }
+sp-api = { version = "2.0.0-dev", path = "../../../../primitives/api" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../../primitives/consensus/common" }
+sp-core = { version = "2.0.0-dev", path = "../../../../primitives/core" }
+sc-keystore = { version = "2.0.0-dev", path = "../../../keystore" }
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../../test-utils/runtime/client" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../../../primitives/application-crypto" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../../../primitives/keyring" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../../../primitives/application-crypto" }
+sp-keyring = { version = "2.0.0-dev", path = "../../../../primitives/keyring" }
 tempfile = "3.1.0"

--- a/client/consensus/epochs/Cargo.toml
+++ b/client/consensus/epochs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-epochs"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic epochs-based utilities for consensus"
 edition = "2018"
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 parking_lot = "0.10.0"
-fork-tree = { version = "2.0.0-alpha.6", path = "../../../utils/fork-tree" }
-sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-alpha.6"}
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sc-client-api = { path = "../../api" , version = "2.0.0-alpha.6"}
+fork-tree = { version = "2.0.0-dev", path = "../../../utils/fork-tree" }
+sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-dev"}
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sc-client-api = { path = "../../api" , version = "2.0.0-dev"}

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-manual-seal"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Manual sealing engine for Substrate"
 edition = "2018"
@@ -22,17 +22,17 @@ parking_lot = "0.10.0"
 serde = { version = "1.0", features=["derive"] }
 assert_matches = "1.3.0"
 
-sc-client = { path = "../../../client" , version = "0.8.0-alpha.6"}
-sc-client-api = { path = "../../../client/api" , version = "2.0.0-alpha.6"}
-sc-transaction-pool = { path = "../../transaction-pool" , version = "2.0.0-alpha.6"}
-sp-blockchain = { path = "../../../primitives/blockchain" , version = "2.0.0-alpha.6"}
-sp-consensus = { package = "sp-consensus", path = "../../../primitives/consensus/common" , version = "0.8.0-alpha.6"}
-sp-inherents = { path = "../../../primitives/inherents" , version = "2.0.0-alpha.6"}
-sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-alpha.6"}
-sp-transaction-pool = { path = "../../../primitives/transaction-pool" , version = "2.0.0-alpha.6"}
+sc-client = { path = "../../../client" , version = "0.8.0-dev"}
+sc-client-api = { path = "../../../client/api" , version = "2.0.0-dev"}
+sc-transaction-pool = { path = "../../transaction-pool" , version = "2.0.0-dev"}
+sp-blockchain = { path = "../../../primitives/blockchain" , version = "2.0.0-dev"}
+sp-consensus = { package = "sp-consensus", path = "../../../primitives/consensus/common" , version = "0.8.0-dev"}
+sp-inherents = { path = "../../../primitives/inherents" , version = "2.0.0-dev"}
+sp-runtime = {  path = "../../../primitives/runtime" , version = "2.0.0-dev"}
+sp-transaction-pool = { path = "../../../primitives/transaction-pool" , version = "2.0.0-dev"}
 
 [dev-dependencies]
-sc-basic-authorship = { path = "../../basic-authorship" , version = "0.8.0-alpha.6"}
+sc-basic-authorship = { path = "../../basic-authorship" , version = "0.8.0-dev"}
 substrate-test-runtime-client = { path = "../../../test-utils/runtime/client" , version = "2.0.0-dev"}
 substrate-test-runtime-transaction-pool = { path = "../../../test-utils/runtime/transaction-pool" , version = "2.0.0-dev"}
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-pow"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "PoW consensus algorithm for substrate"
 edition = "2018"
@@ -13,16 +13,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../../../primitives/block-builder" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
-sp-consensus-pow = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/pow" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
+sp-block-builder = { version = "2.0.0-dev", path = "../../../primitives/block-builder" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
+sp-consensus-pow = { version = "0.8.0-dev", path = "../../../primitives/consensus/pow" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
 log = "0.4.8"
 futures = { version = "0.3.1", features = ["compat"] }
-sp-timestamp = { version = "2.0.0-alpha.6", path = "../../../primitives/timestamp" }
+sp-timestamp = { version = "2.0.0-dev", path = "../../../primitives/timestamp" }
 derive_more = "0.99.2"

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-slots"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic slots-based utilities for consensus"
 edition = "2018"
@@ -14,15 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../../telemetry" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sc-telemetry = { version = "2.0.0-dev", path = "../../telemetry" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
 futures = "0.3.4"
 futures-timer = "3.0.1"
 parking_lot = "0.10.0"

--- a/client/consensus/uncles/Cargo.toml
+++ b/client/consensus/uncles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-consensus-uncles"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Generic uncle inclusion utilities for consensus"
 edition = "2018"
@@ -12,10 +12,10 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-authorship = { version = "2.0.0-alpha.6", path = "../../../primitives/authorship" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../../primitives/inherents" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-authorship = { version = "2.0.0-dev", path = "../../../primitives/authorship" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sp-inherents = { version = "2.0.0-dev", path = "../../../primitives/inherents" }
 log = "0.4.8"

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-client-db"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -22,20 +22,20 @@ hash-db = "0.15.2"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sc-client = { version = "0.8.0-alpha.6", path = "../" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../executor" }
-sc-state-db = { version = "0.8.0-alpha.6", path = "../state-db" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../../primitives/trie" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-alpha.6", path = "../../utils/prometheus" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sc-client = { version = "0.8.0-dev", path = "../" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sc-executor = { version = "0.8.0-dev", path = "../executor" }
+sc-state-db = { version = "0.8.0-dev", path = "../state-db" }
+sp-trie = { version = "2.0.0-dev", path = "../../primitives/trie" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-dev", path = "../../utils/prometheus" }
 
 [dev-dependencies]
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 quickcheck = "0.9"

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-executor"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,21 +15,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 derive_more = "0.99.2"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-trie = { version = "2.0.0-alpha.6", path = "../../primitives/trie" }
-sp-serializer = { version = "2.0.0-alpha.6", path = "../../primitives/serializer" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../primitives/version" }
-sp-panic-handler = { version = "2.0.0-alpha.6", path = "../../primitives/panic-handler" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-trie = { version = "2.0.0-dev", path = "../../primitives/trie" }
+sp-serializer = { version = "2.0.0-dev", path = "../../primitives/serializer" }
+sp-version = { version = "2.0.0-dev", path = "../../primitives/version" }
+sp-panic-handler = { version = "2.0.0-dev", path = "../../primitives/panic-handler" }
 wasmi = "0.6.2"
 parity-wasm = "0.41.0"
 lazy_static = "1.4.0"
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../../primitives/runtime-interface" }
-sp-externalities = { version = "0.8.0-alpha.6", path = "../../primitives/externalities" }
-sc-executor-common = { version = "0.8.0-alpha.6", path = "common" }
-sc-executor-wasmi = { version = "0.8.0-alpha.6", path = "wasmi" }
-sc-executor-wasmtime = { version = "0.8.0-alpha.6", path = "wasmtime", optional = true }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../../primitives/runtime-interface" }
+sp-externalities = { version = "0.8.0-dev", path = "../../primitives/externalities" }
+sc-executor-common = { version = "0.8.0-dev", path = "common" }
+sc-executor-wasmi = { version = "0.8.0-dev", path = "wasmi" }
+sc-executor-wasmtime = { version = "0.8.0-dev", path = "wasmtime", optional = true }
 parking_lot = "0.10.0"
 log = "0.4.8"
 libsecp256k1 = "0.3.4"
@@ -40,9 +40,9 @@ wabt = "0.9.2"
 hex-literal = "0.2.1"
 sc-runtime-test = { version = "2.0.0-dev", path = "runtime-test" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../test-utils/runtime" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
 test-case = "0.3.3"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
 
 [features]
 default = [ "std" ]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-executor-common"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -18,11 +18,11 @@ derive_more = "0.99.2"
 parity-wasm = "0.41.0"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 wasmi = "0.6.2"
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-allocator = { version = "2.0.0-alpha.6", path = "../../../primitives/allocator" }
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime-interface" }
-sp-serializer = { version = "2.0.0-alpha.6", path = "../../../primitives/serializer" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0-dev", path = "../../../primitives/allocator" }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../../../primitives/runtime-interface" }
+sp-serializer = { version = "2.0.0-dev", path = "../../../primitives/serializer" }
 
 [features]
 default = []

--- a/client/executor/runtime-test/Cargo.toml
+++ b/client/executor/runtime-test/Cargo.toml
@@ -13,12 +13,12 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/io" }
-sp-sandbox = { version = "0.8.0-alpha.6", default-features = false, path = "../../../primitives/sandbox" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-sp-allocator = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/allocator" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/io" }
+sp-sandbox = { version = "0.8.0-dev", default-features = false, path = "../../../primitives/sandbox" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+sp-allocator = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/allocator" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-executor-wasmi"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,8 +16,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.8"
 wasmi = "0.6.2"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-executor-common = { version = "0.8.0-alpha.6", path = "../common" }
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime-interface" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-allocator = { version = "2.0.0-alpha.6", path = "../../../primitives/allocator" }
+sc-executor-common = { version = "0.8.0-dev", path = "../common" }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../../../primitives/runtime-interface" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0-dev", path = "../../../primitives/allocator" }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-executor-wasmtime"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,11 +16,11 @@ log = "0.4.8"
 scoped-tls = "1.0"
 parity-wasm = "0.41.0"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-executor-common = { version = "0.8.0-alpha.6", path = "../common" }
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/wasm-interface" }
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime-interface" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-allocator = { version = "2.0.0-alpha.6", path = "../../../primitives/allocator" }
+sc-executor-common = { version = "0.8.0-dev", path = "../common" }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../../../primitives/wasm-interface" }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../../../primitives/runtime-interface" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-allocator = { version = "2.0.0-dev", path = "../../../primitives/allocator" }
 wasmtime = { package = "substrate-wasmtime", version = "0.13.0-threadsafe.1" }
 wasmtime_runtime = { package = "substrate-wasmtime-runtime", version = "0.13.0-threadsafe.1" }
 wasmtime-environ = "0.12.0"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-finality-grandpa"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-fork-tree = { version = "2.0.0-alpha.6", path = "../../utils/fork-tree" }
+fork-tree = { version = "2.0.0-dev", path = "../../utils/fork-tree" }
 futures = "0.3.4"
 futures-timer = "3.0.1"
 log = "0.4.8"
@@ -22,37 +22,37 @@ parking_lot = "0.10.0"
 rand = "0.7.2"
 assert_matches = "1.3.0"
 parity-scale-codec = { version = "1.3.0", features = ["derive"] }
-sp-arithmetic = { version = "2.0.0-alpha.6", path = "../../primitives/arithmetic" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../keystore" }
+sp-arithmetic = { version = "2.0.0-dev", path = "../../primitives/arithmetic" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
+sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
 serde_json = "1.0.41"
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../" }
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../primitives/inherents" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sc-network-gossip = { version = "0.8.0-alpha.6", path = "../network-gossip" }
-sp-finality-tracker = { version = "2.0.0-alpha.6", path = "../../primitives/finality-tracker" }
-sp-finality-grandpa = { version = "2.0.0-alpha.6", path = "../../primitives/finality-grandpa" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-alpha.6"}
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../block-builder" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-client = { version = "0.8.0-dev", path = "../" }
+sp-inherents = { version = "2.0.0-dev", path = "../../primitives/inherents" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sc-network-gossip = { version = "0.8.0-dev", path = "../network-gossip" }
+sp-finality-tracker = { version = "2.0.0-dev", path = "../../primitives/finality-tracker" }
+sp-finality-grandpa = { version = "2.0.0-dev", path = "../../primitives/finality-grandpa" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-dev"}
+sc-block-builder = { version = "0.8.0-dev", path = "../block-builder" }
 finality-grandpa = { version = "0.11.2", features = ["derive-codec"] }
 pin-project = "0.4.6"
 
 [dev-dependencies]
 finality-grandpa = { version = "0.11.2", features = ["derive-codec", "test-helpers"] }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0-dev", path = "../network/test" }
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-dev",  path = "../../test-utils/runtime/client" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/babe" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../primitives/consensus/babe" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
 env_logger = "0.7.0"
 tokio = { version = "0.2", features = ["rt-core"] }
 tempfile = "3.1.0"
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-informant"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate informant."
 edition = "2018"
@@ -17,8 +17,8 @@ futures = "0.3.4"
 log = "0.4.8"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 wasm-timer = "0.2"
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../service" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../service" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-keystore"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../primitives/application-crypto" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../primitives/application-crypto" }
 hex = "0.4.0"
 rand = "0.7.2"
 serde_json = "1.0.41"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Gossiping for the Substrate network protocol"
 name = "sc-network-gossip"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -19,9 +19,9 @@ futures-timer = "3.0.1"
 libp2p = { version = "0.18.0", default-features = false, features = ["websocket"] }
 log = "0.4.8"
 lru = "0.4.3"
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
 wasm-timer = "0.2"
 
 [dev-dependencies]

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate network protocol"
 name = "sc-network"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -25,7 +25,7 @@ derive_more = "0.99.2"
 either = "1.5.3"
 erased-serde = "0.3.9"
 fnv = "1.0.6"
-fork-tree = { version = "2.0.0-alpha.6", path = "../../utils/fork-tree" }
+fork-tree = { version = "2.0.0-dev", path = "../../utils/fork-tree" }
 futures = "0.3.4"
 futures_codec = "0.3.3"
 futures-timer = "3.0.1"
@@ -39,24 +39,24 @@ parking_lot = "0.10.0"
 prost = "0.6.1"
 rand = "0.7.2"
 hex = "0.4.0"
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../block-builder" }
-sc-client = { version = "0.8.0-alpha.6", path = "../" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-peerset = { version = "2.0.0-alpha.6", path = "../peerset" }
+sc-block-builder = { version = "0.8.0-dev", path = "../block-builder" }
+sc-client = { version = "0.8.0-dev", path = "../" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-peerset = { version = "2.0.0-dev", path = "../peerset" }
 pin-project = "0.4.6"
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 slog = { version = "2.5.2", features = ["nested-values"] }
 slog_derive = "0.2.0"
 smallvec = "0.6.10"
-sp-arithmetic = { version = "2.0.0-alpha.6", path = "../../primitives/arithmetic" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/babe" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-alpha.6", path = "../../utils/prometheus" }
+sp-arithmetic = { version = "2.0.0-dev", path = "../../primitives/arithmetic" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../primitives/consensus/babe" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-dev", path = "../../utils/prometheus" }
 thiserror = "1"
 unsigned-varint = { version = "0.3.1", features = ["futures", "futures-codec"] }
 void = "1.0.2"
@@ -74,7 +74,7 @@ env_logger = "0.7.0"
 libp2p = { version = "0.18.0", default-features = false, features = ["secio"] }
 quickcheck = "0.9.0"
 rand = "0.7.2"
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../test-utils/runtime" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -13,21 +13,21 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-network = { version = "0.8.0-alpha.6", path = "../" }
+sc-network = { version = "0.8.0-dev", path = "../" }
 log = "0.4.8"
 parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 rand = "0.7.2"
 libp2p = { version = "0.18.0", default-features = false, features = ["libp2p-websocket"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../block-builder" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/babe" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sc-client = { version = "0.8.0-dev", path = "../../" }
+sc-client-api = { version = "2.0.0-dev", path = "../../api" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../block-builder" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../../primitives/consensus/babe" }
 env_logger = "0.7.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../../test-utils/runtime" }

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate offchain workers"
 name = "sc-offchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -13,23 +13,23 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 bytes = "0.5"
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
 fnv = "1.0.6"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 log = "0.4.8"
 threadpool = "1.7"
 num_cpus = "1.10"
-sp-offchain = { version = "2.0.0-alpha.6", path = "../../primitives/offchain" }
+sp-offchain = { version = "2.0.0-dev", path = "../../primitives/offchain" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 parking_lot = "0.10.0"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 rand = "0.7.2"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../keystore" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 hyper = "0.13.2"
@@ -38,9 +38,9 @@ hyper-rustls = "0.20"
 [dev-dependencies]
 env_logger = "0.7.0"
 fdlimit = "0.1.4"
-sc-client-db = { version = "0.8.0-alpha.6", default-features = true, path = "../db/" }
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../../client/transaction-pool" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
+sc-client-db = { version = "0.8.0-dev", default-features = true, path = "../db/" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../../client/transaction-pool" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.2"
 

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -3,7 +3,7 @@ description = "Connectivity manager based on reputation"
 homepage = "http://parity.io"
 license = "GPL-3.0"
 name = "sc-peerset"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 repository = "https://github.com/paritytech/substrate/"
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.4"
 libp2p = { version = "0.18.0", default-features = false }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils"}
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils"}
 log = "0.4.8"
 serde_json = "1.0.41"
 wasm-timer = "0.2"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-rpc-api"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -21,11 +21,11 @@ jsonrpc-derive = "14.0.3"
 jsonrpc-pubsub = "14.0.3"
 log = "0.4.8"
 parking_lot = "0.10.0"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../primitives/version" }
-sp-runtime = { path = "../../primitives/runtime" , version = "2.0.0-alpha.6"}
-sp-chain-spec = { path = "../../primitives/chain-spec" , version = "2.0.0-alpha.6"}
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-version = { version = "2.0.0-dev", path = "../../primitives/version" }
+sp-runtime = { path = "../../primitives/runtime" , version = "2.0.0-dev"}
+sp-chain-spec = { path = "../../primitives/chain-spec" , version = "2.0.0-dev"}
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
-sp-rpc = { version = "2.0.0-alpha.6", path = "../../primitives/rpc" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+sp-rpc = { version = "2.0.0-dev", path = "../../primitives/rpc" }

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-rpc-server"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,7 +17,7 @@ pubsub = { package = "jsonrpc-pubsub", version = "14.0.3" }
 log = "0.4.8"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 http = { package = "jsonrpc-http-server", version = "14.0.3" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,38 +12,38 @@ description = "Substrate Client RPC"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-rpc-api = { version = "0.8.0-alpha.6", path = "../rpc-api" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
+sc-rpc-api = { version = "0.8.0-dev", path = "../rpc-api" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-client = { version = "0.8.0-dev", path = "../" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 futures = { version = "0.3.1", features = ["compat"] }
 jsonrpc-pubsub = "14.0.3"
 log = "0.4.8"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 rpc = { package = "jsonrpc-core", version = "14.0.3" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../primitives/version" }
+sp-version = { version = "2.0.0-dev", path = "../../primitives/version" }
 serde_json = "1.0.41"
-sp-session = { version = "2.0.0-alpha.6", path = "../../primitives/session" }
-sp-offchain = { version = "2.0.0-alpha.6", path = "../../primitives/offchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-rpc = { version = "2.0.0-alpha.6", path = "../../primitives/rpc" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sp-chain-spec = { version = "2.0.0-alpha.6", path = "../../primitives/chain-spec" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../executor" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../client/block-builder" }
-sc-keystore = { version = "2.0.0-alpha.6", path = "../keystore" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
+sp-session = { version = "2.0.0-dev", path = "../../primitives/session" }
+sp-offchain = { version = "2.0.0-dev", path = "../../primitives/offchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-rpc = { version = "2.0.0-dev", path = "../../primitives/rpc" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sp-chain-spec = { version = "2.0.0-dev", path = "../../primitives/chain-spec" }
+sc-executor = { version = "0.8.0-dev", path = "../executor" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../client/block-builder" }
+sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
 hash-db = { version = "0.15.2", default-features = false }
 parking_lot = "0.10.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 futures01 = { package = "futures", version = "0.1.29" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../transaction-pool" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../transaction-pool" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-service"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -35,32 +35,32 @@ exit-future = "0.2.0"
 serde = "1.0.101"
 serde_json = "1.0.41"
 sysinfo = "0.12.0"
-sc-keystore = { version = "2.0.0-alpha.6", path = "../keystore" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-session = { version = "2.0.0-alpha.6", path = "../../primitives/session" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../primitives/application-crypto" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sc-network = { version = "0.8.0-alpha.6", path = "../network" }
-sc-chain-spec = { version = "2.0.0-alpha.6", path = "../chain-spec" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sc-client-db = { version = "0.8.0-alpha.6", path = "../db" }
+sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-session = { version = "2.0.0-dev", path = "../../primitives/session" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../primitives/application-crypto" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sc-network = { version = "0.8.0-dev", path = "../network" }
+sc-chain-spec = { version = "2.0.0-dev", path = "../chain-spec" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sc-client = { version = "0.8.0-dev", path = "../" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sc-client-db = { version = "0.8.0-dev", path = "../db" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../executor" }
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../transaction-pool" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
-sc-rpc-server = { version = "2.0.0-alpha.6", path = "../rpc-servers" }
-sc-rpc = { version = "2.0.0-alpha.6", path = "../rpc" }
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
-sc-offchain = { version = "2.0.0-alpha.6", path = "../offchain" }
+sc-executor = { version = "0.8.0-dev", path = "../executor" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../transaction-pool" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+sc-rpc-server = { version = "2.0.0-dev", path = "../rpc-servers" }
+sc-rpc = { version = "2.0.0-dev", path = "../rpc" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
+sc-offchain = { version = "2.0.0-dev", path = "../offchain" }
 parity-multiaddr = { package = "parity-multiaddr", version = "0.7.3" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" , version = "0.8.0-alpha.6"}
-sc-tracing = { version = "2.0.0-alpha.6", path = "../tracing" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" , version = "0.8.0-dev"}
+sc-tracing = { version = "2.0.0-dev", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
@@ -74,6 +74,6 @@ procfs = '0.7.8'
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/babe" }
-grandpa = { version = "0.8.0-alpha.6", package = "sc-finality-grandpa", path = "../finality-grandpa" }
-grandpa-primitives = { version = "2.0.0-alpha.6", package = "sp-finality-grandpa", path = "../../primitives/finality-grandpa" }
+sp-consensus-babe = { version = "0.8.0-dev", path = "../../primitives/consensus/babe" }
+grandpa = { version = "0.8.0-dev", package = "sc-finality-grandpa", path = "../finality-grandpa" }
+grandpa-primitives = { version = "2.0.0-dev", package = "sp-finality-grandpa", path = "../../primitives/finality-grandpa" }

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -19,10 +19,10 @@ log = "0.4.8"
 env_logger = "0.7.0"
 fdlimit = "0.1.4"
 futures = { version = "0.3.1", features = ["compat"] }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../service" }
-sc-network = { version = "0.8.0-alpha.6", path = "../../network" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../service" }
+sc-network = { version = "0.8.0-dev", path = "../../network" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sc-client = { version = "0.8.0-dev", path = "../../" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-state-db"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parking_lot = "0.10.0"
 log = "0.4.8"
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 parity-util-mem = "0.6"
 parity-util-mem-derive = "0.1.0"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-telemetry"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Telemetry utils"
 edition = "2018"

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-tracing"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -20,7 +20,7 @@ serde_json = "1.0.41"
 slog = { version = "2.5.2", features = ["nested-values"] }
 tracing-core = "0.1.7"
 
-sc-telemetry = { version = "2.0.0-alpha.6", path = "../telemetry" }
+sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
 
 [dev-dependencies]
 tracing = "0.1.10"

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-transaction-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -19,20 +19,20 @@ futures-diagnose = "1.0"
 log = "0.4.8"
 parking_lot = "0.10.0"
 wasm-timer = "0.2"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../primitives/utils" }
-sc-transaction-graph = { version = "2.0.0-alpha.6", path = "./graph" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../primitives/transaction-pool" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../api" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils" }
+sc-transaction-graph = { version = "2.0.0-dev", path = "./graph" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+sc-client-api = { version = "2.0.0-dev", path = "../api" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
 intervalier = "0.4.0"
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 hex = "0.4"
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-transaction-pool = { version = "2.0.0-dev", path = "../../test-utils/runtime/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-transaction-graph"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -18,11 +18,11 @@ log = "0.4.8"
 parking_lot = "0.10.0"
 serde = { version = "1.0.101", features = ["derive"] }
 wasm-timer = "0.2"
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../../primitives/utils" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-utils = { version = "2.0.0-dev", path = "../../../primitives/utils" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 linked-hash-map = "0.5.2"
 

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-assets"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,16 +15,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 # Needed for various traits. In our case, `OnFinalize`.
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 # Needed for type-safe access to storage DB.
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
 # `system` module provides us with all sorts of useful stuff and macros depend on it being around.
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 
 [features]
 default = ["std"]

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-aura"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,20 +12,20 @@ description = "FRAME AURA consensus pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../session" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features = false, version = "0.8.0-alpha.6"}
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/timestamp" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../timestamp" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../session" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+sp-consensus-aura = { path = "../../primitives/consensus/aura", default-features = false, version = "0.8.0-dev"}
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../primitives/timestamp" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../timestamp" }
 
 
 [dev-dependencies]

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-authority-discovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,20 +12,20 @@ description = "FRAME pallet for authority discovery"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-authority-discovery = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/authority-discovery" }
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/application-crypto" }
+sp-authority-discovery = { version = "2.0.0-dev", default-features = false, path = "../../primitives/authority-discovery" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-pallet-session = { version = "2.0.0-alpha.6", features = ["historical" ], path = "../session", default-features = false }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+pallet-session = { version = "2.0.0-dev", features = ["historical" ], path = "../session", default-features = false }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
 
 [features]
 default = ["std"]

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-authorship"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 description = "Block and Uncle Author tracking for the FRAME"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -12,15 +12,15 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-authorship = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/authorship" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-authorship = { version = "2.0.0-dev", default-features = false, path = "../../primitives/authorship" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
 impl-trait-for-tuples = "0.1.3"
 
 [features]

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-babe"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,21 +14,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../timestamp" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/timestamp" }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../session" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", default-features = false, path = "../../primitives/consensus/babe" }
-sp-consensus-vrf = { version = "0.8.0-alpha.6", default-features = false, path = "../../primitives/consensus/vrf" }
-sp-io = { path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../timestamp" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../primitives/timestamp" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../session" }
+sp-consensus-babe = { version = "0.8.0-dev", default-features = false, path = "../../primitives/consensus/babe" }
+sp-consensus-vrf = { version = "0.8.0-dev", default-features = false, path = "../../primitives/consensus/vrf" }
+sp-io = { path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-balances"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,16 +14,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../transaction-payment" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../transaction-payment" }
 
 [features]
 default = ["std"]

--- a/frame/benchmark/Cargo.toml
+++ b/frame/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-benchmark"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,12 +14,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [features]
 default = ["std"]

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,13 +15,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 linregress = "0.1"
 paste = "0.1"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-api = { version = "2.0.0-alpha.6", path = "../../primitives/api", default-features = false }
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../../primitives/runtime-interface", default-features = false }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", path = "../../primitives/std", default-features = false }
-sp-io = { path = "../../primitives/io", default-features = false, version = "2.0.0-alpha.6"}
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-api = { version = "2.0.0-dev", path = "../../primitives/api", default-features = false }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../../primitives/runtime-interface", default-features = false }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime", default-features = false }
+sp-std = { version = "2.0.0-dev", path = "../../primitives/std", default-features = false }
+sp-io = { path = "../../primitives/io", default-features = false, version = "2.0.0-dev"}
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [features]
 default = [ "std" ]

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-collective"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
 hex-literal = "0.2.1"
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,22 +17,22 @@ pwasm-utils = { version = "0.12.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 parity-wasm = { version = "0.41.0", default-features = false }
 wasmi-validation = { version = "0.3.0", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-sandbox = { version = "0.8.0-alpha.6", default-features = false, path = "../../primitives/sandbox" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-contracts-primitives = { version = "2.0.0-alpha.6", default-features = false, path = "common" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-sandbox = { version = "0.8.0-dev", default-features = false, path = "../../primitives/sandbox" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-contracts-primitives = { version = "2.0.0-dev", default-features = false, path = "common" }
 
 [dev-dependencies]
 wabt = "0.9.2"
 assert_matches = "1.3.0"
 hex-literal = "0.2.1"
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-pallet-timestamp = { version = "2.0.0-alpha.6", path = "../timestamp" }
-pallet-randomness-collective-flip = { version = "2.0.0-alpha.6", path = "../randomness-collective-flip" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+pallet-timestamp = { version = "2.0.0-dev", path = "../timestamp" }
+pallet-randomness-collective-flip = { version = "2.0.0-dev", path = "../randomness-collective-flip" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-primitives"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 # This crate should not rely on any of the frame primitives.
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,14 +16,14 @@ codec = { package = "parity-scale-codec", version = "1.3.0" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.3"
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-rpc = { version = "2.0.0-alpha.6", path = "../../../primitives/rpc" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-rpc = { version = "2.0.0-dev", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-pallet-contracts-primitives = { version = "2.0.0-alpha.6", path = "../common" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0-alpha.6", path = "./runtime-api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+pallet-contracts-primitives = { version = "2.0.0-dev", path = "../common" }
+pallet-contracts-rpc-runtime-api = { version = "0.8.0-dev", path = "./runtime-api" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,11 +12,11 @@ description = "Runtime API definition required by Contracts RPC extensions."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/api" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/runtime" }
-pallet-contracts-primitives = { version = "2.0.0-alpha.6", default-features = false, path = "../../common" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
+pallet-contracts-primitives = { version = "2.0.0-dev", default-features = false, path = "../../common" }
 
 [features]
 default = ["std"]

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-democracy"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,18 +14,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-pallet-scheduler = { version = "2.0.0-alpha.6", path = "../scheduler" }
-sp-storage = { version = "2.0.0-alpha.6", path = "../../primitives/storage" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+pallet-scheduler = { version = "2.0.0-dev", path = "../scheduler" }
+sp-storage = { version = "2.0.0-dev", path = "../../primitives/storage" }
 hex-literal = "0.2.1"
 
 [features]

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-elections-phragmen"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,19 +14,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-phragmen = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/phragmen" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-phragmen = { version = "2.0.0-dev", default-features = false, path = "../../primitives/phragmen" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 hex-literal = "0.2.1"
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-pallet-scheduler = { version = "2.0.0-alpha.6", path = "../scheduler" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-substrate-test-utils = { version = "2.0.0-alpha.6", path = "../../test-utils" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+pallet-scheduler = { version = "2.0.0-dev", path = "../scheduler" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+substrate-test-utils = { version = "2.0.0-dev", path = "../../test-utils" }
 
 [features]
 default = ["std"]

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-elections"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,16 +14,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
 hex-literal = "0.2.1"
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-evm"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../timestamp" }
-pallet-balances = { version = "2.0.0-alpha.6", default-features = false, path = "../balances" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../timestamp" }
+pallet-balances = { version = "2.0.0-dev", default-features = false, path = "../balances" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 primitive-types = { version = "0.7.0", default-features = false, features = ["rlp"] }
 rlp = { version = "0.4", default-features = false }
 evm = { version = "0.16", default-features = false }

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-example-offchain-worker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"
@@ -13,13 +13,13 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 serde = { version = "1.0.101", optional = true }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 lite-json = { version = "0.1", default-features = false }
 
 [features]

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-example"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-balances = { version = "2.0.0-alpha.6", default-features = false, path = "../balances" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-balances = { version = "2.0.0-dev", default-features = false, path = "../balances" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core", default-features = false }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-executive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,20 +13,20 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 serde = { version = "1.0.101", optional = true }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
 hex-literal = "0.2.1"
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-io ={ path = "../../primitives/io", version = "2.0.0-alpha.6"}
-pallet-indices = { version = "2.0.0-alpha.6", path = "../indices" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-pallet-transaction-payment = { version = "2.0.0-alpha.6", path = "../transaction-payment" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../primitives/version" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-io ={ path = "../../primitives/io", version = "2.0.0-dev"}
+pallet-indices = { version = "2.0.0-dev", path = "../indices" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+pallet-transaction-payment = { version = "2.0.0-dev", path = "../transaction-payment" }
+sp-version = { version = "2.0.0-dev", path = "../../primitives/version" }
 
 [features]
 default = ["std"]

--- a/frame/finality-tracker/Cargo.toml
+++ b/frame/finality-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-finality-tracker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,17 +16,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-finality-tracker = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/finality-tracker" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../../primitives/finality-tracker" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 impl-trait-for-tuples = "0.1.3"
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 [features]
 default = ["std"]

--- a/frame/generic-asset/Cargo.toml
+++ b/frame/generic-asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-generic-asset"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Centrality Developers <support@centrality.ai>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-io ={ version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-io ={ version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-grandpa"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,18 +14,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-finality-grandpa = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/finality-grandpa" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../session" }
-pallet-finality-tracker = { version = "2.0.0-alpha.6", default-features = false, path = "../finality-tracker" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-finality-grandpa = { version = "2.0.0-dev", default-features = false, path = "../../primitives/finality-grandpa" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../session" }
+pallet-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../finality-tracker" }
 
 [dev-dependencies]
-sp-io ={ version = "2.0.0-alpha.6", path = "../../primitives/io" }
+sp-io ={ version = "2.0.0-dev", path = "../../primitives/io" }
 
 [features]
 default = ["std"]

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-identity"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,16 +15,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-im-online"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,20 +12,20 @@ description = "FRAME's I'm online pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/application-crypto" }
-pallet-authorship = { version = "2.0.0-alpha.6", default-features = false, path = "../authorship" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
+pallet-authorship = { version = "2.0.0-dev", default-features = false, path = "../authorship" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../session" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../session" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [features]
 default = ["std", "pallet-session/historical"]

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-indices"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,16 +14,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-keyring = { version = "2.0.0-alpha.6", optional = true, path = "../../primitives/keyring" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-keyring = { version = "2.0.0-dev", optional = true, path = "../../primitives/keyring" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-membership"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/metadata/Cargo.toml
+++ b/frame/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-metadata"
-version = "11.0.0-alpha.6"
+version = "11.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,8 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-nicks"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,15 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-offences"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,18 +12,18 @@ description = "FRAME offences pallet"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-pallet-balances = { version = "2.0.0-alpha.6", default-features = false, path = "../balances" }
+pallet-balances = { version = "2.0.0-dev", default-features = false, path = "../balances" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/offences/benchmarking/Cargo.toml
+++ b/frame/offences/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-offences-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/staking" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../../benchmarking" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../../system" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../support" }
-pallet-im-online = { version = "2.0.0-alpha.6", default-features = false, path = "../../im-online" }
-pallet-offences = { version = "2.0.0-alpha.6", default-features = false, features = ["runtime-benchmarks"], path = "../../offences" }
-pallet-staking = { version = "2.0.0-alpha.6", default-features = false, features = ["runtime-benchmarks"], path = "../../staking" }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../../session" }
-sp-io = { path = "../../../primitives/io", default-features = false, version = "2.0.0-alpha.6"}
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/staking" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../../benchmarking" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../../system" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../support" }
+pallet-im-online = { version = "2.0.0-dev", default-features = false, path = "../../im-online" }
+pallet-offences = { version = "2.0.0-dev", default-features = false, features = ["runtime-benchmarks"], path = "../../offences" }
+pallet-staking = { version = "2.0.0-dev", default-features = false, features = ["runtime-benchmarks"], path = "../../staking" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../../session" }
+sp-io = { path = "../../../primitives/io", default-features = false, version = "2.0.0-dev"}
 
 
 [features]

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 safe-mix = { version = "1.0", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 
 [features]
 default = ["std"]

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-recovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,15 +15,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/scheduler/Cargo.toml
+++ b/frame/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-scheduler"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Unlicense"
@@ -11,15 +11,15 @@ description = "FRAME example pallet"
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.2.0", default-features = false }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core", default-features = false }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-scored-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,15 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-session"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,19 +14,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../timestamp" }
-sp-trie = { optional = true, path = "../../primitives/trie", default-features = false, version = "2.0.0-alpha.6"}
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../timestamp" }
+sp-trie = { optional = true, path = "../../primitives/trie", default-features = false, version = "2.0.0-dev"}
+sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
 impl-trait-for-tuples = "0.1.3"
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../../primitives/application-crypto" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../../primitives/application-crypto" }
 lazy_static = "1.4.0"
 
 [features]

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-session-benchmarking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,22 +12,22 @@ description = "FRAME sessions pallet benchmarking"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../../system" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../../benchmarking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../support" }
-pallet-staking = { version = "2.0.0-alpha.6", default-features = false, features = ["runtime-benchmarks"], path = "../../staking" }
-pallet-session = { version = "2.0.0-alpha.6", default-features = false, path = "../../session" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../../system" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../../benchmarking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../support" }
+pallet-staking = { version = "2.0.0-dev", default-features = false, features = ["runtime-benchmarks"], path = "../../staking" }
+pallet-session = { version = "2.0.0-dev", default-features = false, path = "../../session" }
 
 [dev-dependencies]
 serde = { version = "1.0.101" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-pallet-staking-reward-curve = { version = "2.0.0-alpha.6", path = "../../staking/reward-curve" }
-sp-io ={ path = "../../../primitives/io", version = "2.0.0-alpha.6"}
-pallet-timestamp = { version = "2.0.0-alpha.6", path = "../../timestamp" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+pallet-staking-reward-curve = { version = "2.0.0-dev", path = "../../staking/reward-curve" }
+sp-io ={ path = "../../../primitives/io", version = "2.0.0-dev"}
+pallet-timestamp = { version = "2.0.0-dev", path = "../../timestamp" }
+pallet-balances = { version = "2.0.0-dev", path = "../../balances" }
 
 [features]
 default = ["std"]

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-society"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,16 +14,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 rand_chacha = { version = "0.2", default-features = false }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,35 +14,35 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-phragmen = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/phragmen" }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-staking = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/staking" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-session = { version = "2.0.0-alpha.6", features = ["historical"], path = "../session", default-features = false }
-pallet-authorship = { version = "2.0.0-alpha.6", default-features = false, path = "../authorship" }
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/application-crypto" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-phragmen = { version = "2.0.0-dev", default-features = false, path = "../../primitives/phragmen" }
+sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-session = { version = "2.0.0-dev", features = ["historical"], path = "../session", default-features = false }
+pallet-authorship = { version = "2.0.0-dev", default-features = false, path = "../authorship" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
 static_assertions = "1.1.0"
 
 # Optional imports for tesing-utils feature
-pallet-indices = { version = "2.0.0-alpha.6", optional = true, path = "../indices", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", optional = true, path = "../../primitives/core", default-features = false }
+pallet-indices = { version = "2.0.0-dev", optional = true, path = "../indices", default-features = false }
+sp-core = { version = "2.0.0-dev", optional = true, path = "../../primitives/core", default-features = false }
 rand = { version = "0.7.3", optional = true, default-features = false }
 
 # Optional imports for benchmarking
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 rand_chacha = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-storage = { version = "2.0.0-alpha.6", path = "../../primitives/storage" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-pallet-timestamp = { version = "2.0.0-alpha.6", path = "../timestamp" }
-pallet-staking-reward-curve = { version = "2.0.0-alpha.6",  path = "../staking/reward-curve" }
-substrate-test-utils = { version = "2.0.0-alpha.6", path = "../../test-utils" }
-frame-benchmarking = { version = "2.0.0-alpha.6", path = "../benchmarking" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-storage = { version = "2.0.0-dev", path = "../../primitives/storage" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+pallet-timestamp = { version = "2.0.0-dev", path = "../timestamp" }
+pallet-staking-reward-curve = { version = "2.0.0-dev",  path = "../staking/reward-curve" }
+substrate-test-utils = { version = "2.0.0-dev", path = "../../test-utils" }
+frame-benchmarking = { version = "2.0.0-dev", path = "../benchmarking" }
 rand_chacha = { version = "0.2" }
 parking_lot = "0.10.0"
 env_logger = "0.7.1"

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-staking-reward-curve"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -21,4 +21,4 @@ proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-sudo"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-support"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,24 +15,24 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4"
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-frame-metadata = { version = "11.0.0-alpha.6", default-features = false, path = "../metadata" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-arithmetic = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/arithmetic" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-frame-support-procedural = { version = "2.0.0-alpha.6", path = "./procedural" }
+frame-metadata = { version = "11.0.0-dev", default-features = false, path = "../metadata" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-arithmetic = { version = "2.0.0-dev", default-features = false, path = "../../primitives/arithmetic" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+frame-support-procedural = { version = "2.0.0-dev", path = "./procedural" }
 paste = "0.1.6"
 once_cell = { version = "1", default-features = false, optional = true }
-sp-state-machine = { version = "0.8.0-alpha.6", optional = true, path = "../../primitives/state-machine" }
+sp-state-machine = { version = "0.8.0-dev", optional = true, path = "../../primitives/state-machine" }
 bitmask = { version = "0.5.0", default-features = false }
 impl-trait-for-tuples = "0.1.3"
 tracing = { version = "0.1.10", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-frame-system = { version = "2.0.0-alpha.6", path = "../system" }
+frame-system = { version = "2.0.0-dev", path = "../system" }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-support-procedural"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-frame-support-procedural-tools = { version = "2.0.0-alpha.6", path = "./tools" }
+frame-support-procedural-tools = { version = "2.0.0-dev", path = "./tools" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
 syn = { version = "1.0.7", features = ["full"] }

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-support-procedural-tools"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,7 +12,7 @@ description = "Proc macro helpers for procedural macros"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-frame-support-procedural-tools-derive = { version = "2.0.0-alpha.6", path = "./derive" }
+frame-support-procedural-tools-derive = { version = "2.0.0-dev", path = "./derive" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
 syn = { version = "1.0.7", features = ["full", "visit"] }

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -14,12 +14,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-io ={ path = "../../../primitives/io", default-features = false , version = "2.0.0-alpha.6"}
-sp-state-machine = { version = "0.8.0-alpha.6", optional = true, path = "../../../primitives/state-machine" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/inherents" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/runtime" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../../primitives/core" }
+sp-io ={ path = "../../../primitives/io", default-features = false , version = "2.0.0-dev"}
+sp-state-machine = { version = "0.8.0-dev", optional = true, path = "../../../primitives/state-machine" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/inherents" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/runtime" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
 trybuild = "1.0.17"
 pretty_assertions = "0.6.1"
 

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-system"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { path = "../../primitives/io", default-features = false, version = "2.0.0-alpha.6"}
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/version" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { path = "../../primitives/io", default-features = false, version = "2.0.0-dev"}
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../../primitives/version" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
 impl-trait-for-tuples = "0.1.3"
 
 [dev-dependencies]
 criterion = "0.2.11"
-sp-externalities = { version = "0.8.0-alpha.6", path = "../../primitives/externalities" }
+sp-externalities = { version = "0.8.0-dev", path = "../../primitives/externalities" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 
 [features]

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-system-rpc-runtime-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,7 +12,7 @@ description = "Runtime API definition required by System RPC extensions."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/api" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 
 [features]

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-timestamp"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,19 +16,19 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io", optional = true }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/timestamp" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io", optional = true }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../primitives/timestamp" }
 impl-trait-for-tuples = "0.1.3"
 
 [dev-dependencies]
-sp-io ={ version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-io ={ version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-payment"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,16 +13,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-alpha.6", default-features = false, path = "./rpc/runtime-api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, path = "./rpc/runtime-api" }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-payment-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,10 +16,10 @@ codec = { package = "parity-scale-codec", version = "1.3.0" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.3"
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sp-rpc = { version = "2.0.0-alpha.6", path = "../../../primitives/rpc" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sp-rpc = { version = "2.0.0-dev", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-alpha.6", path = "./runtime-api" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-dev", path = "./runtime-api" }

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,11 +13,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/api" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../../support" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../../support" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-treasury"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,17 +14,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-pallet-balances = { version = "2.0.0-alpha.6", default-features = false, path = "../balances" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+pallet-balances = { version = "2.0.0-dev", default-features = false, path = "../balances" }
 
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-io ={ version = "2.0.0-alpha.6", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
+sp-io ={ version = "2.0.0-dev", path = "../../primitives/io" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
 
 [features]
 default = ["std"]

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-utility"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,18 +14,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
 
 [features]
 default = ["std"]

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-vesting"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,17 +15,17 @@ targets = ["x86_64-unknown-linux-gnu"]
 serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 enumflags2 = { version = "0.6.2" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../support" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../system" }
-frame-benchmarking = { version = "2.0.0-alpha.6", default-features = false, path = "../benchmarking", optional = true }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../system" }
+frame-benchmarking = { version = "2.0.0-dev", default-features = false, path = "../benchmarking", optional = true }
 
 [dev-dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-pallet-balances = { version = "2.0.0-alpha.6", path = "../balances" }
-sp-storage = { version = "2.0.0-alpha.6", path = "../../primitives/storage" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+pallet-balances = { version = "2.0.0-dev", path = "../balances" }
+sp-storage = { version = "2.0.0-dev", path = "../../primitives/storage" }
 hex-literal = "0.2.1"
 
 [features]

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-allocator"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,9 +13,9 @@ documentation = "https://docs.rs/sp-allocator"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "2.0.0-alpha.6", path = "../std", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", path = "../core", default-features = false }
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../wasm-interface", default-features = false }
+sp-std = { version = "2.0.0-dev", path = "../std", default-features = false }
+sp-core = { version = "2.0.0-dev", path = "../core", default-features = false }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../wasm-interface", default-features = false }
 log = { version = "0.4.8", optional = true }
 derive_more = { version = "0.99.2", optional = true }
 

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-api"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,12 +13,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-api-proc-macro = { version = "2.0.0-alpha.6", path = "proc-macro" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../version" }
-sp-state-machine = { version = "0.8.0-alpha.6", optional = true, path = "../../primitives/state-machine" }
+sp-api-proc-macro = { version = "2.0.0-dev", path = "proc-macro" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../version" }
+sp-state-machine = { version = "0.8.0-dev", optional = true, path = "../../primitives/state-machine" }
 hash-db = { version = "0.15.2", optional = true }
 
 [dev-dependencies]

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-api-proc-macro"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -12,22 +12,22 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", path = "../" }
+sp-api = { version = "2.0.0-dev", path = "../" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../version" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../runtime" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../blockchain" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../../primitives/consensus/common" }
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../../client/block-builder" }
+sp-version = { version = "2.0.0-dev", path = "../../version" }
+sp-runtime = { version = "2.0.0-dev", path = "../../runtime" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../blockchain" }
+sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../../client/block-builder" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
 trybuild = "1.0.17"
 rustversion = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3.0"
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../core" }
+sp-core = { version = "2.0.0-dev", path = "../../core" }
 
 [[bench]]
 name = "bench"

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-application-crypto"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Provides facilities for generating application specific crypto wrapper types."
@@ -14,11 +14,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
 
 [features]
 default = [ "std" ]

--- a/primitives/application-crypto/test/Cargo.toml
+++ b/primitives/application-crypto/test/Cargo.toml
@@ -13,8 +13,8 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../core" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../core" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../test-utils/runtime/client" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../api" }
-sp-application-crypto = { version = "2.0.0-alpha.6", path = "../" }
+sp-runtime = { version = "2.0.0-dev", path = "../../runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../api" }
+sp-application-crypto = { version = "2.0.0-dev", path = "../" }

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-arithmetic"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,9 +17,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 integer-sqrt = "0.1.2"
 num-traits = { version = "0.2.8", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-debug-derive = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/debug-derive" }
+sp-debug-derive = { version = "2.0.0-dev", default-features = false, path = "../../primitives/debug-derive" }
 primitive-types = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-arithmetic-fuzzer"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-arithmetic-fuzzer"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-arithmetic = { version = "2.0.0-alpha.6", path = ".." }
+sp-arithmetic = { version = "2.0.0-dev", path = ".." }
 honggfuzz = "0.5"
 primitive-types = "0.7.0"
 num-bigint = "0.2"

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-authority-discovery"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Authority discovery primitives"
 edition = "2018"
@@ -12,11 +12,11 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", default-features = false, version = "1.3.0" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-authorship"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Authorship primitives"
 edition = "2018"
@@ -12,9 +12,9 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../inherents" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../inherents" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-block-builder"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,11 +12,11 @@ description = "The block builder runtime api."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../inherents" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../inherents" }
 
 [features]
 default = [ "std" ]

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-blockchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -19,7 +19,7 @@ lru = "0.4.0"
 parking_lot = "0.10.0"
 derive_more = "0.99.2"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../consensus/common" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
-sp-block-builder = { version = "2.0.0-alpha.6", path = "../block-builder" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../state-machine" }
+sp-consensus = { version = "0.8.0-dev", path = "../consensus/common" }
+sp-runtime = { version = "2.0.0-dev", path = "../runtime" }
+sp-block-builder = { version = "2.0.0-dev", path = "../block-builder" }
+sp-state-machine = { version = "0.8.0-dev", path = "../state-machine" }

--- a/primitives/chain-spec/Cargo.toml
+++ b/primitives/chain-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-chain-spec"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-consensus-aura"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"
@@ -12,13 +12,13 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../std" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../runtime" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../inherents" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../timestamp" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../std" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../runtime" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../inherents" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../timestamp" }
 
 [features]
 default = ["std"]

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-consensus-babe"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for BABE consensus"
 edition = "2018"
@@ -12,15 +12,15 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../std" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../api" }
-sp-consensus = { version = "0.8.0-alpha.6", optional = true, path = "../common" }
-sp-consensus-vrf = { version = "0.8.0-alpha.6", path = "../vrf", default-features = false }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../inherents" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../runtime" }
-sp-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../timestamp" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../std" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../api" }
+sp-consensus = { version = "0.8.0-dev", optional = true, path = "../common" }
+sp-consensus-vrf = { version = "0.8.0-dev", path = "../vrf", default-features = false }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../inherents" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../runtime" }
+sp-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../timestamp" }
 
 [features]
 default = ["std"]

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-consensus"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,16 +17,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 derive_more = "0.99.2"
 libp2p = { version = "0.18.0", default-features = false }
 log = "0.4.8"
-sp-core = { path= "../../core", version = "2.0.0-alpha.6"}
-sp-inherents = { version = "2.0.0-alpha.6", path = "../../inherents" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
+sp-core = { path= "../../core", version = "2.0.0-dev"}
+sp-inherents = { version = "2.0.0-dev", path = "../../inherents" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
 futures = { version = "0.3.1", features = ["thread-pool"] }
 futures-timer = "3.0.1"
 futures-diagnose = "1.0"
-sp-std = { version = "2.0.0-alpha.6", path = "../../std" }
-sp-version = { version = "2.0.0-alpha.6", path = "../../version" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../runtime" }
-sp-utils = { version = "2.0.0-alpha.6", path = "../../utils" }
+sp-std = { version = "2.0.0-dev", path = "../../std" }
+sp-version = { version = "2.0.0-dev", path = "../../version" }
+sp-runtime = { version = "2.0.0-dev", path = "../../runtime" }
+sp-utils = { version = "2.0.0-dev", path = "../../utils" }
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 parking_lot = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-consensus-pow"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for Aura consensus"
 edition = "2018"
@@ -12,10 +12,10 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../api" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../runtime" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../core" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../runtime" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../core" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-consensus-vrf"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Primitives for VRF based consensus"
 edition = "2018"
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { version = "1.0.0", package = "parity-scale-codec", default-features = false }
 schnorrkel = { version = "0.9.1", features = ["preaudit_deprecated"], optional = true }
-sp-std = { version = "2.0.0-alpha.6", path = "../../std", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", path = "../../core", default-features = false }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../runtime" }
+sp-std = { version = "2.0.0-dev", path = "../../std", default-features = false }
+sp-core = { version = "2.0.0-dev", path = "../../core", default-features = false }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-core"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/sp-core"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
@@ -32,9 +32,9 @@ num-traits = { version = "0.2.8", default-features = false }
 zeroize = { version = "1.0.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false, optional = true }
 parking_lot = { version = "0.10.0", optional = true }
-sp-debug-derive = { version = "2.0.0-alpha.6", path = "../debug-derive" }
-sp-externalities = { version = "0.8.0-alpha.6", optional = true, path = "../externalities" }
-sp-storage = { version = "2.0.0-alpha.6", default-features = false, path = "../storage" }
+sp-debug-derive = { version = "2.0.0-dev", path = "../debug-derive" }
+sp-externalities = { version = "0.8.0-dev", optional = true, path = "../externalities" }
+sp-storage = { version = "2.0.0-dev", default-features = false, path = "../storage" }
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 futures = { version = "0.3.1", optional = true }
 
@@ -48,10 +48,10 @@ hex = { version = "0.4", default-features = false, optional = true }
 twox-hash = { version = "1.5.0", default-features = false, optional = true }
 libsecp256k1 = { version = "0.3.2", default-features = false, features = ["hmac"], optional = true }
 
-sp-runtime-interface = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime-interface" }
+sp-runtime-interface = { version = "2.0.0-dev", default-features = false, path = "../runtime-interface" }
 
 [dev-dependencies]
-sp-serializer = { version = "2.0.0-alpha.6", path = "../serializer" }
+sp-serializer = { version = "2.0.0-dev", path = "../serializer" }
 pretty_assertions = "0.6.1"
 hex-literal = "0.2.1"
 rand = "0.7.2"

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-debug-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-externalities"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -13,6 +13,6 @@ documentation = "https://docs.rs/sp-externalities"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-storage = { version = "2.0.0-alpha.6", path = "../storage" }
-sp-std = { version = "2.0.0-alpha.6", path = "../std" }
+sp-storage = { version = "2.0.0-dev", path = "../storage" }
+sp-std = { version = "2.0.0-dev", path = "../std" }
 environmental = { version = "1.1.1" }

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-finality-grandpa"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,12 +14,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-finality-tracker"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-inherents"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 parking_lot = { version = "0.10.0", optional = true }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.2", optional = true }
 

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-io"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,14 +16,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 libsecp256k1 = { version = "0.3.4", optional = true }
-sp-state-machine = { version = "0.8.0-alpha.6", optional = true, path = "../../primitives/state-machine" }
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../../primitives/wasm-interface", default-features = false }
-sp-runtime-interface = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime-interface" }
-sp-trie = { version = "2.0.0-alpha.6", optional = true, path = "../../primitives/trie" }
-sp-externalities = { version = "0.8.0-alpha.6", optional = true, path = "../externalities" }
+sp-state-machine = { version = "0.8.0-dev", optional = true, path = "../../primitives/state-machine" }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../../primitives/wasm-interface", default-features = false }
+sp-runtime-interface = { version = "2.0.0-dev", default-features = false, path = "../runtime-interface" }
+sp-trie = { version = "2.0.0-dev", optional = true, path = "../../primitives/trie" }
+sp-externalities = { version = "0.8.0-dev", optional = true, path = "../externalities" }
 log = { version = "0.4.8", optional = true }
 
 [features]

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-keyring"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 
 [dependencies]
-sp-core = { version = "2.0.0-alpha.6", path = "../core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
+sp-core = { version = "2.0.0-dev", path = "../core" }
+sp-runtime = { version = "2.0.0-dev", path = "../runtime" }
 lazy_static = "1.4.0"
 strum = { version = "0.16.0", features = ["derive"] }

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate offchain workers primitives"
 name = "sp-offchain"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -12,8 +12,8 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/panic-handler/Cargo.toml
+++ b/primitives/panic-handler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-panic-handler"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/phragmen/Cargo.toml
+++ b/primitives/phragmen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-phragmen"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -14,14 +14,14 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-sp-phragmen-compact = { version = "2.0.0-dev.1", path = "./compact" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+sp-phragmen-compact = { version = "2.0.0-dev", path = "./compact" }
 
 [dev-dependencies]
-substrate-test-utils = { version = "2.0.0-alpha.6", path = "../../test-utils" }
+substrate-test-utils = { version = "2.0.0-dev", path = "../../test-utils" }
 rand = "0.7.3"
-sp-phragmen = { path = "." , version = "2.0.0-alpha.6"}
+sp-phragmen = { path = "." , version = "2.0.0-dev"}
 
 [features]
 default = ["std"]

--- a/primitives/phragmen/compact/Cargo.toml
+++ b/primitives/phragmen/compact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-phragmen-compact"
-version = "2.0.0-dev.1"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-rpc"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", path = "../core" }
+sp-core = { version = "2.0.0-dev", path = "../core" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-runtime-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,19 +13,19 @@ documentation = "https://docs.rs/sp-runtime-interface/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-wasm-interface = { version = "2.0.0-alpha.6", path = "../wasm-interface", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-runtime-interface-proc-macro = { version = "2.0.0-alpha.6", path = "proc-macro" }
-sp-externalities = { version = "0.8.0-alpha.6", optional = true, path = "../externalities" }
+sp-wasm-interface = { version = "2.0.0-dev", path = "../wasm-interface", default-features = false }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-runtime-interface-proc-macro = { version = "2.0.0-dev", path = "proc-macro" }
+sp-externalities = { version = "0.8.0-dev", optional = true, path = "../externalities" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 static_assertions = "1.0.0"
 primitive-types = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 sp-runtime-interface-test-wasm = { version = "2.0.0-dev", path = "test-wasm" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
-sp-core = { version = "2.0.0-alpha.6", path = "../core" }
-sp-io = { version = "2.0.0-alpha.6", path = "../io" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
+sp-core = { version = "2.0.0-dev", path = "../core" }
+sp-io = { version = "2.0.0-dev", path = "../io" }
 rustversion = "1.0.0"
 trybuild = "1.0.23"
 

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "2.0.0-alpha.6", default-features = false, path = "../" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../io" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../core" }
+sp-runtime-interface = { version = "2.0.0-dev", default-features = false, path = "../" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../io" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../core" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "2.0.0-alpha.6", default-features = false, path = "../" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../io" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../core" }
+sp-runtime-interface = { version = "2.0.0-dev", default-features = false, path = "../" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../io" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../core" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -12,10 +12,10 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-runtime-interface = { version = "2.0.0-alpha.6", path = "../" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../../client/executor" }
+sp-runtime-interface = { version = "2.0.0-dev", path = "../" }
+sc-executor = { version = "0.8.0-dev", path = "../../../client/executor" }
 sp-runtime-interface-test-wasm = { version = "2.0.0-dev", path = "../test-wasm" }
 sp-runtime-interface-test-wasm-deprecated = { version = "2.0.0-dev", path = "../test-wasm-deprecated" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../runtime" }
-sp-io = { version = "2.0.0-alpha.6", path = "../../io" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
+sp-runtime = { version = "2.0.0-dev", path = "../../runtime" }
+sp-io = { version = "2.0.0-dev", path = "../../io" }

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-runtime"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -16,16 +16,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../application-crypto" }
-sp-arithmetic = { version = "2.0.0-alpha.6", default-features = false, path = "../arithmetic" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../io" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../application-crypto" }
+sp-arithmetic = { version = "2.0.0-dev", default-features = false, path = "../arithmetic" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../io" }
 log = { version = "0.4.8", optional = true }
 paste = "0.1.6"
 rand = { version = "0.7.2", optional = true }
 impl-trait-for-tuples = "0.1.3"
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../inherents" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../inherents" }
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-sandbox"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,10 +13,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 wasmi = { version = "0.6.2", optional = true }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../io" }
-sp-wasm-interface = { version = "2.0.0-alpha.6", default-features = false, path = "../wasm-interface" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../io" }
+sp-wasm-interface = { version = "2.0.0-dev", default-features = false, path = "../wasm-interface" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 
 [dev-dependencies]

--- a/primitives/serializer/Cargo.toml
+++ b/primitives/serializer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-serializer"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-session"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,10 +12,10 @@ description = "Primitives for sessions"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
-sp-runtime = { version = "2.0.0-alpha.6", optional = true, path = "../runtime" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
+sp-runtime = { version = "2.0.0-dev", optional = true, path = "../runtime" }
 
 [features]
 default = [ "std" ]

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-staking"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 
 [features]
 default = ["std"]

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-state-machine"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate State Machine"
 edition = "2018"
@@ -18,17 +18,17 @@ parking_lot = "0.10.0"
 hash-db = "0.15.2"
 trie-db = "0.20.1"
 trie-root = "0.16.0"
-sp-trie = { version = "2.0.0-alpha.6", path = "../trie" }
-sp-core = { version = "2.0.0-alpha.6", path = "../core" }
-sp-panic-handler = { version = "2.0.0-alpha.6", path = "../panic-handler" }
+sp-trie = { version = "2.0.0-dev", path = "../trie" }
+sp-core = { version = "2.0.0-dev", path = "../core" }
+sp-panic-handler = { version = "2.0.0-dev", path = "../panic-handler" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 num-traits = "0.2.8"
 rand = "0.7.2"
-sp-externalities = { version = "0.8.0-alpha.6", path = "../externalities" }
+sp-externalities = { version = "0.8.0-dev", path = "../externalities" }
 
 [dev-dependencies]
 hex-literal = "0.2.1"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../runtime" }
 
 [features]
 default = []

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-std"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-storage"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "Storage related primitives"
@@ -13,10 +13,10 @@ documentation = "https://docs.rs/sp-storage/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 impl-serde = { version = "0.2.3", optional = true }
-sp-debug-derive = { version = "2.0.0-alpha.6", path = "../debug-derive" }
+sp-debug-derive = { version = "2.0.0-dev", path = "../debug-derive" }
 
 [features]
 default = [ "std" ]

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -12,11 +12,11 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../application-crypto" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [features]

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-timestamp"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,11 +12,11 @@ description = "Substrate core types and inherents for timestamps."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../inherents" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../inherents" }
 impl-trait-for-tuples = "0.1.3"
 wasm-timer = { version = "0.2", optional = true }
 

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-transaction-pool"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -19,9 +19,9 @@ derive_more = { version = "0.99.2", optional = true }
 futures = { version = "0.3.1", optional = true }
 log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.101", features = ["derive"], optional = true}
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
-sp-utils = { version = "2.0.0-alpha.6", default-features = false, path = "../utils" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
+sp-utils = { version = "2.0.0-dev", default-features = false, path = "../utils" }
 
 [features]
 default = [ "std" ]

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-trie"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Patricia trie stuff using a parity-scale-codec node format"
 repository = "https://github.com/paritytech/substrate/"
@@ -18,19 +18,19 @@ harness = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.20.1", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 memory-db = { version = "0.20.0", default-features = false }
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../core" }
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../core" }
 
 [dev-dependencies]
 trie-bench = "0.21.0"
 trie-standardmap = "0.15.2"
 criterion = "0.2.11"
 hex-literal = "0.2.1"
-sp-runtime = { version = "2.0.0-alpha.6", path = "../runtime" }
+sp-runtime = { version = "2.0.0-dev", path = "../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/utils/Cargo.toml
+++ b/primitives/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-version"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,8 +17,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 impl-serde = { version = "0.2.3", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../std" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../runtime" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../std" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../runtime" }
 
 [features]
 default = ["std"]

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-wasm-interface"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 wasmi = { version = "0.6.2", optional = true }
 impl-trait-for-tuples = "0.1.2"
-sp-std = { version = "2.0.0-alpha.6", path = "../std", default-features = false }
+sp-std = { version = "2.0.0-dev", path = "../std", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 
 [features]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-test-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -12,16 +12,16 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../client/api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../client/" }
-sc-client-db = { version = "0.8.0-alpha.6", features = ["test-helpers"], path = "../../client/db" }
-sp-consensus = { version = "0.8.0-alpha.6", path = "../../primitives/consensus/common" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../client/executor" }
+sc-client-api = { version = "2.0.0-dev", path = "../../client/api" }
+sc-client = { version = "0.8.0-dev", path = "../../client/" }
+sc-client-db = { version = "0.8.0-dev", features = ["test-helpers"], path = "../../client/db" }
+sp-consensus = { version = "0.8.0-dev", path = "../../primitives/consensus/common" }
+sc-executor = { version = "0.8.0-dev", path = "../../client/executor" }
 futures = "0.3.4"
 hash-db = "0.15.2"
-sp-keyring = { version = "2.0.0-alpha.6", path = "../../primitives/keyring" }
+sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../primitives/runtime" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../primitives/blockchain" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
+sp-core = { version = "2.0.0-dev", path = "../../primitives/core" }
+sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -13,43 +13,43 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-application-crypto = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/application-crypto" }
-sp-consensus-aura = { version = "0.8.0-alpha.6", default-features = false, path = "../../primitives/consensus/aura" }
-sp-consensus-babe = { version = "0.8.0-alpha.6", default-features = false, path = "../../primitives/consensus/babe" }
-sp-block-builder = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/block-builder" }
+sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../../primitives/application-crypto" }
+sp-consensus-aura = { version = "0.8.0-dev", default-features = false, path = "../../primitives/consensus/aura" }
+sp-consensus-babe = { version = "0.8.0-dev", default-features = false, path = "../../primitives/consensus/babe" }
+sp-block-builder = { version = "2.0.0-dev", default-features = false, path = "../../primitives/block-builder" }
 cfg-if = "0.1.10"
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-frame-executive = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/executive" }
-sp-inherents = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/inherents" }
-sp-keyring = { version = "2.0.0-alpha.6", optional = true, path = "../../primitives/keyring" }
+frame-executive = { version = "2.0.0-dev", default-features = false, path = "../../frame/executive" }
+sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
+sp-keyring = { version = "2.0.0-dev", optional = true, path = "../../primitives/keyring" }
 log = { version = "0.4.8", optional = true }
 memory-db = { version = "0.20.0", default-features = false }
-sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-alpha.6"}
-sp-core = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/core" }
-sp-std = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/std" }
-sp-runtime-interface = { path = "../../primitives/runtime-interface", default-features = false, version = "2.0.0-alpha.6"}
-sp-io = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/io" }
-frame-support = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/support" }
-sp-version = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/version" }
+sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-dev"}
+sp-core = { version = "2.0.0-dev", default-features = false, path = "../../primitives/core" }
+sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
+sp-runtime-interface = { path = "../../primitives/runtime-interface", default-features = false, version = "2.0.0-dev"}
+sp-io = { version = "2.0.0-dev", default-features = false, path = "../../primitives/io" }
+frame-support = { version = "2.0.0-dev", default-features = false, path = "../../frame/support" }
+sp-version = { version = "2.0.0-dev", default-features = false, path = "../../primitives/version" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-session = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/session" }
-sp-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/api" }
-sp-runtime = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/runtime" }
-pallet-babe = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/babe" }
-frame-system = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/system" }
-frame-system-rpc-runtime-api = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/system/rpc/runtime-api" }
-pallet-timestamp = { version = "2.0.0-alpha.6", default-features = false, path = "../../frame/timestamp" }
-sc-client = { version = "0.8.0-alpha.6", optional = true, path = "../../client" }
-sp-trie = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/trie" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", default-features = false, path = "../../primitives/transaction-pool" }
+sp-session = { version = "2.0.0-dev", default-features = false, path = "../../primitives/session" }
+sp-api = { version = "2.0.0-dev", default-features = false, path = "../../primitives/api" }
+sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
+pallet-babe = { version = "2.0.0-dev", default-features = false, path = "../../frame/babe" }
+frame-system = { version = "2.0.0-dev", default-features = false, path = "../../frame/system" }
+frame-system-rpc-runtime-api = { version = "2.0.0-dev", default-features = false, path = "../../frame/system/rpc/runtime-api" }
+pallet-timestamp = { version = "2.0.0-dev", default-features = false, path = "../../frame/timestamp" }
+sc-client = { version = "0.8.0-dev", optional = true, path = "../../client" }
+sp-trie = { version = "2.0.0-dev", default-features = false, path = "../../primitives/trie" }
+sp-transaction-pool = { version = "2.0.0-dev", default-features = false, path = "../../primitives/transaction-pool" }
 trie-db = { version = "0.20.1", default-features = false }
 parity-util-mem = { version = "0.6.0", default-features = false, features = ["primitive-types"] }
 
 [dev-dependencies]
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../client/block-builder" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../client/executor" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../client/block-builder" }
+sc-executor = { version = "0.8.0-dev", path = "../../client/executor" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "./client" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../primitives/state-machine" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../primitives/state-machine" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../utils/wasm-builder-runner" }

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -12,14 +12,14 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-block-builder = { version = "0.8.0-alpha.6", path = "../../../client/block-builder" }
+sc-block-builder = { version = "0.8.0-dev", path = "../../../client/block-builder" }
 substrate-test-client = { version = "2.0.0-dev", path = "../../client" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../runtime" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../primitives/api" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../primitives/api" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sc-client-api = { version = "2.0.0-alpha.6", path = "../../../client/api" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client/" }
+sc-client-api = { version = "2.0.0-dev", path = "../../../client/api" }
+sc-client = { version = "0.8.0-dev", path = "../../../client/" }
 futures = "0.3.4"

--- a/test-utils/runtime/transaction-pool/Cargo.toml
+++ b/test-utils/runtime/transaction-pool/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../client" }
 parking_lot = "0.10.0"
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../primitives/blockchain" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../primitives/transaction-pool" }
-sc-transaction-graph = { version = "2.0.0-alpha.6", path = "../../../client/transaction-pool/graph" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../primitives/blockchain" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../primitives/transaction-pool" }
+sc-transaction-graph = { version = "2.0.0-dev", path = "../../../client/transaction-pool/graph" }
 futures = { version = "0.3.1", features = ["compat"] }
 derive_more = "0.99.2"

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-browser-utils"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utilities for creating a browser light-client."
 edition = "2018"
@@ -22,10 +22,10 @@ js-sys = "0.3.34"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.7"
 kvdb-web = "0.5"
-sc-informant = { version = "0.8.0-alpha.6", path = "../../client/informant" }
-sc-service = { version = "0.8.0-alpha.6", path = "../../client/service", default-features = false }
-sc-network = { path = "../../client/network", version = "0.8.0-alpha.6"}
-sc-chain-spec = { path = "../../client/chain-spec", version = "2.0.0-alpha.6"}
+sc-informant = { version = "0.8.0-dev", path = "../../client/informant" }
+sc-service = { version = "0.8.0-dev", path = "../../client/service", default-features = false }
+sc-network = { path = "../../client/network", version = "0.8.0-dev"}
+sc-chain-spec = { path = "../../client/chain-spec", version = "2.0.0-dev"}
 
 # Imported just for the `no_cc` feature
 clear_on_drop = { version = "0.2.3", features = ["no_cc"] }

--- a/utils/build-script-utils/Cargo.toml
+++ b/utils/build-script-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-build-script-utils"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fork-tree"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-benchmarking-cli"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,16 +12,16 @@ description = "CLI for benchmarking FRAME"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-frame-benchmarking = { version = "2.0.0-alpha.6", path = "../../../frame/benchmarking" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../primitives/core" }
-sc-service = { version = "0.8.0-alpha.6", default-features = false, path = "../../../client/service" }
-sc-cli = { version = "0.8.0-alpha.6", path = "../../../client/cli" }
-sc-client = { version = "0.8.0-alpha.6", path = "../../../client" }
-sc-client-db = { version = "0.8.0-alpha.6", path = "../../../client/db" }
-sc-executor = { version = "0.8.0-alpha.6", path = "../../../client/executor" }
-sp-externalities = { version = "0.8.0-alpha.6", path = "../../../primitives/externalities" }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../primitives/runtime" }
-sp-state-machine = { version = "0.8.0-alpha.6", path = "../../../primitives/state-machine" }
+frame-benchmarking = { version = "2.0.0-dev", path = "../../../frame/benchmarking" }
+sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
+sc-service = { version = "0.8.0-dev", default-features = false, path = "../../../client/service" }
+sc-cli = { version = "0.8.0-dev", path = "../../../client/cli" }
+sc-client = { version = "0.8.0-dev", path = "../../../client" }
+sc-client-db = { version = "0.8.0-dev", path = "../../../client/db" }
+sc-executor = { version = "0.8.0-dev", path = "../../../client/executor" }
+sp-externalities = { version = "0.8.0-dev", path = "../../../primitives/externalities" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../primitives/runtime" }
+sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
 structopt = "0.3.8"
 codec = { version = "1.3.0", package = "parity-scale-codec" }
 

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-frame-rpc-support"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>", "Andrew Dirksen <andrew@dirksen.com>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -17,10 +17,10 @@ jsonrpc-client-transports = { version = "14.0.5", default-features = false, feat
 jsonrpc-core = "14"
 codec = { package = "parity-scale-codec", version = "1" }
 serde = "1"
-frame-support = { version = "2.0.0-alpha.6", path = "../../../../frame/support" }
-sp-storage = { version = "2.0.0-alpha.6", path = "../../../../primitives/storage" }
-sc-rpc-api = { version = "0.8.0-alpha.6", path = "../../../../client/rpc-api" }
+frame-support = { version = "2.0.0-dev", path = "../../../../frame/support" }
+sp-storage = { version = "2.0.0-dev", path = "../../../../primitives/storage" }
+sc-rpc-api = { version = "0.8.0-dev", path = "../../../../client/rpc-api" }
 
 [dev-dependencies]
-frame-system = { version = "2.0.0-alpha.6", path = "../../../../frame/system" }
+frame-system = { version = "2.0.0-dev", path = "../../../../frame/system" }
 tokio = "0.2"

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-frame-rpc-system"
-version = "2.0.0-alpha.6"
+version = "2.0.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0"
@@ -12,7 +12,7 @@ description = "FRAME's system exposed over Substrate RPC"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client = { version = "0.8.0-alpha.6", path = "../../../../client/" }
+sc-client = { version = "0.8.0-dev", path = "../../../../client/" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 futures = "0.3.4"
 jsonrpc-core = "14.0.3"
@@ -20,14 +20,14 @@ jsonrpc-core-client = "14.0.5"
 jsonrpc-derive = "14.0.3"
 log = "0.4.8"
 serde = { version = "1.0.101", features = ["derive"] }
-sp-runtime = { version = "2.0.0-alpha.6", path = "../../../../primitives/runtime" }
-sp-api = { version = "2.0.0-alpha.6", path = "../../../../primitives/api" }
-frame-system-rpc-runtime-api = { version = "2.0.0-alpha.6", path = "../../../../frame/system/rpc/runtime-api" }
-sp-core = { version = "2.0.0-alpha.6", path = "../../../../primitives/core" }
-sp-blockchain = { version = "2.0.0-alpha.6", path = "../../../../primitives/blockchain" }
-sp-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../../primitives/transaction-pool" }
+sp-runtime = { version = "2.0.0-dev", path = "../../../../primitives/runtime" }
+sp-api = { version = "2.0.0-dev", path = "../../../../primitives/api" }
+frame-system-rpc-runtime-api = { version = "2.0.0-dev", path = "../../../../frame/system/rpc/runtime-api" }
+sp-core = { version = "2.0.0-dev", path = "../../../../primitives/core" }
+sp-blockchain = { version = "2.0.0-dev", path = "../../../../primitives/blockchain" }
+sp-transaction-pool = { version = "2.0.0-dev", path = "../../../../primitives/transaction-pool" }
 
 [dev-dependencies]
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../../../test-utils/runtime/client" }
 env_logger = "0.7.0"
-sc-transaction-pool = { version = "2.0.0-alpha.6", path = "../../../../client/transaction-pool" }
+sc-transaction-pool = { version = "2.0.0-dev", path = "../../../../client/transaction-pool" }

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Endpoint to expose Prometheus metrics"
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-alpha.6"
+version = "0.8.0-dev"
 license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"


### PR DESCRIPTION
`cargo unleash check`, run after every merge on master to make sure our crates are all in a releasable state, does only check what isn't released on crates.io yet. This is meant to a) allow us to restart the CI should crates.io API limits stop the release process and b) allow for single crates to be released by just setting a new version.

For that to work, the idea is that every crate is set to a never-released pre-release whenever the first changes happen and set the version whenever it is to be released. `cargo unleash check` will then make sure that the to-be-released crate has all its dependencies up, too.

However, we are not fully there yet. But to allow for `cargo unleash check` to work for us on `master` this PR resets all versions to the unreleased `-dev`-pre-release for now.