### PR TITLE
Add alternative RPC methods to system_networkState

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -464,6 +464,18 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		self.network_service.user_protocol_mut().on_block_finalized(hash, &header);
 	}
 
+	/// Returns the local `PeerId`.
+	pub fn local_peer_id(&self) -> &PeerId {
+		Swarm::<B, H>::local_peer_id(&self.network_service)
+	}
+
+	/// Returns the list of addresses we are listening on.
+	///
+	/// Does **NOT** include a trailing `/p2p/` with our `PeerId`.
+	pub fn listen_addresses(&self) -> impl Iterator<Item = &Multiaddr> {
+		Swarm::<B, H>::listeners(&self.network_service)
+	}
+
 	/// Get network state.
 	///
 	/// **Note**: Use this only for debugging. This API is unstable. There are warnings literally

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -60,14 +60,14 @@ pub trait SystemApi<Hash, Number> {
 	fn system_health(&self) -> Receiver<Health>;
 
 	/// Returns the base58-encoded PeerId of the node.
-	#[rpc(name = "system_local_peer_id", returns = "String")]
+	#[rpc(name = "system_localPeerId", returns = "String")]
 	fn system_local_peer_id(&self) -> Receiver<String>;
 
 	/// Returns the multiaddresses that the local node is listening on
 	///
 	/// The addresses include a trailing `/p2p/` with the local PeerId, and are thus suitable to
 	/// be passed to `system_addReservedPeer` or as a bootnode address for example.
-	#[rpc(name = "system_local_listen_addresses", returns = "Vec<String>")]
+	#[rpc(name = "system_localListenAddresses", returns = "Vec<String>")]
 	fn system_local_listen_addresses(&self) -> Receiver<Vec<String>>;
 
 	/// Returns currently connected peers

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -59,6 +59,17 @@ pub trait SystemApi<Hash, Number> {
 	#[rpc(name = "system_health", returns = "Health")]
 	fn system_health(&self) -> Receiver<Health>;
 
+	/// Returns the base58-encoded PeerId of the node.
+	#[rpc(name = "system_local_peer_id", returns = "String")]
+	fn system_local_peer_id(&self) -> Receiver<String>;
+
+	/// Returns the multiaddresses that the local node is listening on
+	///
+	/// The addresses include a trailing `/p2p/` with the local PeerId, and are thus suitable to
+	/// be passed to `system_addReservedPeer` or as a bootnode address for example.
+	#[rpc(name = "system_local_listen_addresses", returns = "Vec<String>")]
+	fn system_local_listen_addresses(&self) -> Receiver<Vec<String>>;
+
 	/// Returns currently connected peers
 	#[rpc(name = "system_peers", returns = "Vec<PeerInfo<Hash, Number>>")]
 	fn system_peers(&self) -> Receiver<Vec<PeerInfo<Hash, Number>>>;

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -41,6 +41,11 @@ pub struct System<B: traits::Block> {
 pub enum Request<B: traits::Block> {
 	/// Must return the health of the network.
 	Health(oneshot::Sender<Health>),
+	/// Must return the base58-encoded local `PeerId`.
+	LocalPeerId(oneshot::Sender<String>),
+	/// Must return the string representation of the addresses we listen on, including the
+	/// trailing `/p2p/`.
+	LocalListenAddresses(oneshot::Sender<Vec<String>>),
 	/// Must return information about the peers we are connected to.
 	Peers(oneshot::Sender<Vec<PeerInfo<B::Hash, <B::Header as HeaderT>::Number>>>),
 	/// Must return the state of the network.
@@ -93,6 +98,18 @@ impl<B: traits::Block> SystemApi<B::Hash, <B::Header as HeaderT>::Number> for Sy
 	fn system_health(&self) -> Receiver<Health> {
 		let (tx, rx) = oneshot::channel();
 		let _ = self.send_back.unbounded_send(Request::Health(tx));
+		Receiver(Compat::new(rx))
+	}
+
+	fn system_local_peer_id(&self) -> Receiver<String> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.send_back.unbounded_send(Request::LocalPeerId(tx));
+		Receiver(Compat::new(rx))
+	}
+
+	fn system_local_listen_addresses(&self) -> Receiver<Vec<String>> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.send_back.unbounded_send(Request::LocalListenAddresses(tx));
 		Receiver(Compat::new(rx))
 	}
 

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -55,6 +55,15 @@ fn api<T: Into<Option<Status>>>(sync: T) -> System<Block> {
 						should_have_peers,
 					});
 				},
+				Request::LocalPeerId(sender) => {
+					let _ = sender.send("QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string());
+				},
+				Request::LocalListenAddresses(sender) => {
+					let _ = sender.send(vec![
+						"/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),
+						"/ip4/127.0.0.1/tcp/30334/ws/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),
+					]);
+				},
 				Request::Peers(sender) => {
 					let mut peers = vec![];
 					for _peer in 0..status.peers {
@@ -205,6 +214,25 @@ fn system_health() {
 			is_syncing: false,
 			should_have_peers: false,
 		}
+	);
+}
+
+#[test]
+fn system_local_peer_id_works() {
+	assert_eq!(
+		api(None).system_local_peer_id().unwrap(),
+		"QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_owned(),
+	);
+}
+
+#[test]
+fn system_local_listen_addresses_works() {
+	assert_eq!(
+		api(None).system_local_listen_addresses().unwrap(),
+		vec![
+			"/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),
+			"/ip4/127.0.0.1/tcp/30334/ws/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),
+		]
 	);
 }
 

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -220,7 +220,7 @@ fn system_health() {
 #[test]
 fn system_local_peer_id_works() {
 	assert_eq!(
-		api(None).system_local_peer_id().unwrap(),
+		wait_receiver(api(None).system_local_peer_id()),
 		"QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_owned(),
 	);
 }
@@ -228,7 +228,7 @@ fn system_local_peer_id_works() {
 #[test]
 fn system_local_listen_addresses_works() {
 	assert_eq!(
-		api(None).system_local_listen_addresses().unwrap(),
+		wait_receiver(api(None).system_local_listen_addresses()),
 		vec![
 			"/ip4/198.51.100.19/tcp/30333/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),
 			"/ip4/127.0.0.1/tcp/30334/ws/p2p/QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string(),

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -367,6 +367,17 @@ fn build_network_future<
 						should_have_peers,
 					});
 				},
+				sc_rpc::system::Request::LocalPeerId(sender) => {
+					let _ = sender.send(network.local_peer_id().to_base58());
+				},
+				sc_rpc::system::Request::LocalListenAddresses(sender) => {
+					let peer_id = network.local_peer_id().clone().into();
+					let p2p_proto_suffix = sc_network::multiaddr::Protocol::P2p(peer_id);
+					let addresses = network.listen_addresses()
+						.map(|addr| addr.clone().with(p2p_proto_suffix.clone()).to_string())
+						.collect();
+					let _ = sender.send(addresses);
+				},
 				sc_rpc::system::Request::Peers(sender) => {
 					let _ = sender.send(network.peers_debug_info().into_iter().map(|(peer_id, p)|
 						sc_rpc::system::PeerInfo {


### PR DESCRIPTION
cc #5541

Adds alternative methods to `system_networkState` to get the local `PeerId` and local addresses we're listening on.
