### PR TITLE
Temporarily increase notifications buffer size

### DIFF
--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -44,7 +44,7 @@ use unsigned_varint::codec::UviBytes;
 /// Maximum allowed size of the two handshake messages, in bytes.
 const MAX_HANDSHAKE_SIZE: usize = 1024;
 /// Maximum number of buffered messages before we refuse to accept more.
-const MAX_PENDING_MESSAGES: usize = 256;
+const MAX_PENDING_MESSAGES: usize = 512;
 
 /// Upgrade that accepts a substream, sends back a status message, then becomes a unidirectional
 /// stream of messages.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -937,7 +937,7 @@ impl Metrics {
 						"sub_libp2p_notifications_queues_size",
 						"Total size of all the notification queues"
 					),
-					buckets: vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0],
+					buckets: vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0],
 				},
 				&["protocol"]
 			)?, registry)?,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -937,7 +937,7 @@ impl Metrics {
 						"sub_libp2p_notifications_queues_size",
 						"Total size of all the notification queues"
 					),
-					buckets: vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0],
+					buckets: vec![0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 511.0, 512.0],
 				},
 				&["protocol"]
 			)?, registry)?,


### PR DESCRIPTION
It seems that the queue size of GrandPa notifications now frequently reaches the 128-256 elements bucket, as seen on this graph:

![Screenshot from 2020-04-15 14-58-54](https://user-images.githubusercontent.com/1412254/79339895-dc9ec200-7f29-11ea-9ed7-ff329f1b794e.png)

Since the hard limit is 256, I can't actually know whether notifications are discarded or not. But whether they are or not, let's increase the limit until this is taken care of.

The proper solution is #5481
