### PR TITLE
Remove the tokio thread name

### DIFF
--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -80,7 +80,6 @@ where
 /// Build a tokio runtime with all features
 pub fn build_runtime() -> std::result::Result<tokio::runtime::Runtime, std::io::Error> {
 	tokio::runtime::Builder::new()
-		.thread_name("main-tokio-")
 		.threaded_scheduler()
 		.on_thread_start(||{
 			TOKIO_THREADS_ALIVE.inc();


### PR DESCRIPTION
This used to be a prefix, but all tokio threads now have the same name. It doesn't really make sense to rename them anymore.
https://docs.rs/tokio/0.2.18/tokio/runtime/struct.Builder.html#method.thread_name