### PR TITLE
Upgrade sysinfo to `0.13.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,9 +8260,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.12.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccb41798287e8e299a701b5560d886d6ca2c3e7115e9ea2cb68c123aec339b7"
+checksum = "5a0338198966bde7feb14b011a33d404a62a6e03b843352c71512a2a002634b7"
 dependencies = [
  "cfg-if",
  "doc-comment",

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -34,7 +34,7 @@ exit-future = "0.2.0"
 pin-project = "0.4.8"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.12.0"
+sysinfo = "0.13.3"
 sc-keystore = { version = "2.0.0-dev", path = "../keystore" }
 sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-dev", path = "../../primitives/runtime" }


### PR DESCRIPTION
This release includes a fix for an out of bound access that was reported
by one of the validators.

