### PR TITLE
subkey: compute and inspect a moduleid

### DIFF
--- a/bin/utils/subkey/README.adoc
+++ b/bin/utils/subkey/README.adoc
@@ -68,3 +68,16 @@ subkey sign-transaction \
 ```
 
 Will output a signed and encoded `UncheckedMortalCompactExtrinsic` as hex.
+
+=== Inspecting a module ID
+
+```bash
+subkey --network kusama moduleid "py/trsry"
+
+OUTPUT:
+Public Key URI `F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29` is account:
+  Network ID/version: kusama
+  Public key (hex):   0x6d6f646c70792f74727372790000000000000000000000000000000000000000
+  Account ID:         0x6d6f646c70792f74727372790000000000000000000000000000000000000000
+  SS58 Address:       F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29
+```

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -31,7 +31,7 @@ use sp_core::{
 	crypto::{set_default_ss58_version, Ss58AddressFormat, Ss58Codec},
 	ed25519, sr25519, ecdsa, Pair, Public, H256, hexdisplay::HexDisplay,
 };
-use sp_runtime::{traits::{IdentifyAccount, Verify}, generic::Era};
+use sp_runtime::{traits::{AccountIdConversion, IdentifyAccount, Verify}, generic::Era, ModuleId};
 use std::{
 	convert::{TryInto, TryFrom}, io::{stdin, Read}, str::FromStr, path::PathBuf, fs, fmt,
 };
@@ -318,6 +318,11 @@ fn get_app<'a, 'b>(usage: &'a str) -> App<'a, 'b> {
 					<key-type> 'Key type, examples: \"gran\", or \"imon\" '
 					[node-url] 'Node JSON-RPC endpoint, default \"http:://localhost:9933\"'
 				"),
+			SubCommand::with_name("moduleid")
+				.about("Inspect a module ID address")
+				.args_from_usage("
+					<id> 'The module ID used to derive the account'
+				")
 		])
 }
 
@@ -506,6 +511,20 @@ where
 				suri,
 				sp_core::Bytes(pair.public().as_ref().to_vec()),
 			);
+		}
+		("moduleid", Some(matches)) => {
+			let id = get_uri("id", &matches)?;
+			if id.len() != 8 {
+				Err("a module id must be a string of 8 characters")?
+			}
+
+			let id_fixed_array: [u8; 8] = id.as_bytes().try_into()
+				.map_err(|_| Error::Static("Cannot convert argument to moduleid: argument should be 8-character string"))?;
+
+			let account_id: AccountId = ModuleId(id_fixed_array).into_account();
+			let v = maybe_network.unwrap_or(Ss58AddressFormat::SubstrateAccountDirect);
+			
+			C::print_from_uri(&account_id.to_ss58check_with_version(v), password, maybe_network, output);
 		}
 		_ => print_usage(&matches),
 	}

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -522,7 +522,7 @@ where
 				.map_err(|_| Error::Static("Cannot convert argument to moduleid: argument should be 8-character string"))?;
 
 			let account_id: AccountId = ModuleId(id_fixed_array).into_account();
-			let v = maybe_network.unwrap_or(Ss58AddressFormat::SubstrateAccountDirect);
+			let v = maybe_network.unwrap_or(Ss58AddressFormat::SubstrateAccount);
 			
 			C::print_from_uri(&account_id.to_ss58check_with_version(v), password, maybe_network, output);
 		}


### PR DESCRIPTION
## Subkey inspection of module IDs
This PR adds a subcommand to subkey: `moduleid`. It can be used to display the public key and SS58 version of a moduleid, this can be used to compute the moduleid of the treasury or of a multisig for instance.
