### PR TITLE
Listen on ipv6 addesses by default as well

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -20,8 +20,6 @@ use sc_network::{
 	multiaddr::Protocol,
 };
 use sc_service::{ChainSpec, config::{Multiaddr, MultiaddrWithPeerId}};
-use std::iter;
-use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -48,9 +46,7 @@ pub struct NetworkParams {
 	pub listen_addr: Vec<Multiaddr>,
 
 	/// Specify p2p protocol TCP port.
-	///
-	/// Only used if --listen-addr is not specified.
-	#[structopt(long = "port", value_name = "PORT")]
+	#[structopt(long = "port", value_name = "PORT", conflicts_with_all = &[ "listen-addr" ])]
 	pub port: Option<u16>,
 
 	/// Forbid connecting to private IPv4 addresses (as specified in
@@ -106,11 +102,19 @@ impl NetworkParams {
 		node_key: NodeKeyConfig,
 	) -> NetworkConfiguration {
 		let port = self.port.unwrap_or(30333);
-		let mut listen_addresses = vec![iter::once(Protocol::Ip4(Ipv4Addr::new(0, 0, 0, 0)))
-			.chain(iter::once(Protocol::Tcp(port)))
-			.collect()];
 
-		listen_addresses.extend(self.listen_addr.iter().cloned());
+		let listen_addresses = if self.listen_addr.is_empty() {
+			vec![
+				Multiaddr::empty()
+					.with(Protocol::Ip4([0, 0, 0, 0].into()))
+					.with(Protocol::Tcp(port)),
+				Multiaddr::empty()
+					.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))
+					.with(Protocol::Tcp(port)),
+			]
+		} else {
+			self.listen_addr.clone()
+		};
 
 		let mut boot_nodes = chain_spec.boot_nodes().to_vec();
 		boot_nodes.extend(self.bootnodes.clone());


### PR DESCRIPTION
Instead of just listening on ipv4 by default, this enables listening on
ipv6 as well. While doing this, it also fixes a bug which lead to always
listen on all sockets, even if we specify listen addresses explicitly.

Partially fixes: https://github.com/paritytech/substrate/issues/5645