### PR TITLE
Refactor misleading log in discovery

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -375,9 +375,10 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 			list.extend(list_to_filter);
 		}
 
-		trace!(target: "sub-libp2p", "Addresses of {:?} are {:?}", peer_id, list);
+		if !list.is_empty() {
+			trace!(target: "sub-libp2p", "Addresses of {:?}: {:?}", peer_id, list);
 
-		if list.is_empty() {
+		} else {
 			let mut has_entry = false;
 			for k in self.kademlias.values_mut() {
 				if k.kbuckets_entries().any(|p| p == peer_id) {
@@ -386,15 +387,12 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 				}
 			}
 			if has_entry {
-				debug!(target: "sub-libp2p",
-					"Requested dialing to {:?} (peer in k-buckets), and no address was found",
-					peer_id);
+				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer in k-buckets)");
 			} else {
-				debug!(target: "sub-libp2p",
-					"Requested dialing to {:?} (peer not in k-buckets), and no address was found",
-					peer_id);
+				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer not in k-buckets)");
 			}
 		}
+
 		list
 	}
 

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -387,9 +387,9 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 				}
 			}
 			if has_entry {
-				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer in k-buckets)");
+				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer in k-buckets)", peer_id);
 			} else {
-				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer not in k-buckets)");
+				trace!(target: "sub-libp2p", "Addresses of {:?}: none (peer not in k-buckets)", peer_id);
 			}
 		}
 


### PR DESCRIPTION
Refactors a bit the log printing in `discovery.rs`.

We frequently call `addresses_of_peer` purely for debugging purposes, and it is thus wrong to emit a log message that says `"Requested dialing"`.
If the method is indeed called because we request dialing, there should be another line to indicate that.

Additionally, we now emit one line instead of two when no address is found.
