### PR TITLE
Revert listening on IPv6 by default

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -108,9 +108,6 @@ impl NetworkParams {
 				Multiaddr::empty()
 					.with(Protocol::Ip4([0, 0, 0, 0].into()))
 					.with(Protocol::Tcp(port)),
-				Multiaddr::empty()
-					.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))
-					.with(Protocol::Tcp(port)),
 			]
 		} else {
 			self.listen_addr.clone()


### PR DESCRIPTION
It leads to the following errors:

```
2020-04-17 16:40:25 Libp2p listener ListenerId(1) closed
2020-04-17 16:40:25 Libp2p => ListenerClosed: Err(Custom { kind: Other, error: Custom { kind: Other, error: Other(A(A(A(B(Underlying(B(Os { code: 98, kind: AddrInUse, message: "Address already in use" }))))))) } })

...

2020-04-17 16:43:13 Error on libp2p listener ListenerId(2): ::ffff:127.0.0.1 does not match any listen address
2020-04-17 16:43:13 Error on libp2p listener ListenerId(2): ::ffff:10.128.0.9 does not match any listen address
```

Let's revert this for the release of Polkadot 0.7.30 and open an issue instead.