### PR TITLE
Explicit 'extern crate proc_macro;' is needed for stable channel

### DIFF
--- a/client/chain-spec/derive/src/lib.rs
+++ b/client/chain-spec/derive/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod impls;
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(ChainSpecGroup)]

--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -19,6 +19,7 @@
 mod log;
 
 use log::log2;
+extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::{TokenStream as TokenStream2, Span};
 use proc_macro_crate::crate_name;

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -23,6 +23,7 @@
 mod storage;
 mod construct_runtime;
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 
 /// Declares strongly-typed wrappers around codec-compatible types in storage.

--- a/frame/support/procedural/tools/derive/src/lib.rs
+++ b/frame/support/procedural/tools/derive/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![recursion_limit = "128"]
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use syn::parse_macro_input;

--- a/primitives/api/proc-macro/src/lib.rs
+++ b/primitives/api/proc-macro/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![recursion_limit = "512"]
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 
 mod impl_runtime_apis;

--- a/primitives/debug-derive/src/lib.rs
+++ b/primitives/debug-derive/src/lib.rs
@@ -33,6 +33,7 @@
 
 mod impls;
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 
 #[proc_macro_derive(RuntimeDebug)]

--- a/primitives/phragmen/compact/src/lib.rs
+++ b/primitives/phragmen/compact/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Proc macro for phragmen compact assignment.
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::{TokenStream as TokenStream2, Span, Ident};
 use proc_macro_crate::crate_name;

--- a/primitives/sr-api/proc-macro/src/lib.rs
+++ b/primitives/sr-api/proc-macro/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![recursion_limit = "512"]
 
+extern crate proc_macro;
 use proc_macro::TokenStream;
 
 mod impl_runtime_apis;


### PR DESCRIPTION
As a follow-up to PR #3844, this PR is needed to make things work for rustc 1.42 stable with nightly features enabled.

The background is https://github.com/rust-lang/rust/pull/54116 and in particular see https://github.com/rust-lang/rust/issues/53166#issuecomment-421137230