### PR TITLE
Move around definitions in sc_network

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -246,7 +246,7 @@ pub mod config;
 pub mod error;
 pub mod network_state;
 
-pub use service::{NetworkService, NetworkStateInfo, NetworkWorker, ExHashT, ReportHandle};
+pub use service::{NetworkService, NetworkWorker};
 pub use protocol::PeerInfo;
 pub use protocol::event::{Event, DhtEvent, ObservedRole};
 pub use protocol::sync::SyncState;
@@ -264,3 +264,38 @@ pub use sc_peerset::ReputationChange;
 /// case of (possibly repeated) simultaneous dialing attempts between
 /// two peers, the per-peer connection limit is not set to 1 but 2.
 const MAX_CONNECTIONS_PER_PEER: usize = 2;
+
+/// Minimum Requirements for a Hash within Networking
+pub trait ExHashT: std::hash::Hash + Eq + std::fmt::Debug + Clone + Send + Sync + 'static {}
+
+impl<T> ExHashT for T where T: std::hash::Hash + Eq + std::fmt::Debug + Clone + Send + Sync + 'static
+{}
+
+/// A cloneable handle for reporting cost/benefits of peers.
+#[derive(Clone)]
+pub struct ReportHandle {
+	inner: sc_peerset::PeersetHandle, // wraps it so we don't have to worry about breaking API.
+}
+
+impl From<sc_peerset::PeersetHandle> for ReportHandle {
+	fn from(peerset_handle: sc_peerset::PeersetHandle) -> Self {
+		ReportHandle { inner: peerset_handle }
+	}
+}
+
+impl ReportHandle {
+	/// Report a given peer as either beneficial (+) or costly (-) according to the
+	/// given scalar.
+	pub fn report_peer(&self, who: PeerId, cost_benefit: ReputationChange) {
+		self.inner.report_peer(who, cost_benefit);
+	}
+}
+
+/// Trait for providing information about the local network state
+pub trait NetworkStateInfo {
+	/// Returns the local external addresses.
+	fn external_addresses(&self) -> Vec<Multiaddr>;
+
+	/// Returns the local Peer ID.
+	fn local_peer_id(&self) -> PeerId;
+}

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -14,8 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::config::ProtocolId;
-use crate::utils::interval;
+use crate::{
+	ExHashT,
+	chain::{Client, FinalityProofProvider},
+	config::{BoxFinalityProofRequestBuilder, ProtocolId, TransactionPool},
+	error,
+	utils::interval
+};
+
 use bytes::{Bytes, BytesMut};
 use futures::prelude::*;
 use generic_proto::{GenericProto, GenericProtoOut};
@@ -42,17 +48,13 @@ use message::{BlockAnnounce, Message};
 use message::generic::{Message as GenericMessage, ConsensusMessage, Roles};
 use prometheus_endpoint::{Registry, Gauge, GaugeVec, HistogramVec, PrometheusError, Opts, register, U64};
 use sync::{ChainSync, SyncState};
-use crate::service::{TransactionPool, ExHashT};
-use crate::config::BoxFinalityProofRequestBuilder;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::fmt::Write;
 use std::{cmp, io, num::NonZeroUsize, pin::Pin, task::Poll, time};
 use log::{log, Level, trace, debug, warn, error};
-use crate::chain::{Client, FinalityProofProvider};
 use sc_client_api::{ChangesProof, StorageProof};
-use crate::error;
 use util::LruHashSet;
 use wasm_timer::Instant;
 

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -95,7 +95,7 @@ fn build_test_full_node(config: config::NetworkConfiguration)
 		finality_proof_provider: None,
 		finality_proof_request_builder: None,
 		on_demand: None,
-		transaction_pool: Arc::new(crate::service::EmptyTransactionPool),
+		transaction_pool: Arc::new(crate::config::EmptyTransactionPool),
 		protocol_id: config::ProtocolId::from(&b"/test-protocol-name"[..]),
 		import_queue,
 		block_announce_validator: Box::new(


### PR DESCRIPTION
This is a purely internal change, to make the code a bit more readable. External APIs are untouched.

This PR moves the definitions of `ExHashT`, `TransactionPool`, `ReportHandle` and `NetworkStateInfo` out of the `service` module and directly where they are publicly re-exported.
