### PR TITLE
Move AuraPair import to new_full_start! macro in Node Template

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -18,7 +18,6 @@ use crate::chain_spec;
 use crate::cli::Cli;
 use crate::service;
 use sc_cli::SubstrateCli;
-use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> &'static str {

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -26,6 +26,8 @@ native_executor_instance!(
 macro_rules! new_full_start {
 	($config:expr) => {{
 		use std::sync::Arc;
+		use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
+		
 		let mut import_setup = None;
 		let inherent_data_providers = sp_inherents::InherentDataProviders::new();
 


### PR DESCRIPTION
This PR moves the following line from `command.rs`, to the new_full_start!` macro where it is actually used. This makes the code more readable, prevents users from deleting that import thinking it is never used.