### PR TITLE
Require `fn` token in `decl_storage` `get`

### DIFF
--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -346,7 +346,7 @@ decl_storage! {
 
 		/// Accounts for which there are locks in action which may be removed at some point in the
 		/// future. The value is the block number at which the lock expires and may be removed.
-		pub Locks get(locks): map hasher(twox_64_concat) T::AccountId => Option<T::BlockNumber>;
+		pub Locks get(fn locks): map hasher(twox_64_concat) T::AccountId => Option<T::BlockNumber>;
 
 		/// True if the last referendum tabled was submitted externally. False if it was a public
 		/// proposal.

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -69,7 +69,7 @@ decl_storage! {
 
 		/// Deferred reports that have been rejected by the offence handler and need to be submitted
 		/// at a later time.
-		DeferredOffences get(deferred_offences): Vec<DeferredOffenceOf<T>>;
+		DeferredOffences get(fn deferred_offences): Vec<DeferredOffenceOf<T>>;
 
 		/// A vector of reports of the same kind that happened at the same time slot.
 		ConcurrentReportsIndex:

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -402,18 +402,18 @@ impl<AccountId: PartialEq, Balance> BidKind<AccountId, Balance> {
 decl_storage! {
 	trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as Society {
 		/// The first member.
-		pub Founder get(founder) build(|config: &GenesisConfig<T, I>| config.members.first().cloned()):
+		pub Founder get(fn founder) build(|config: &GenesisConfig<T, I>| config.members.first().cloned()):
 			Option<T::AccountId>;
 
 		/// A hash of the rules of this society concerning membership. Can only be set once and
 		/// only by the founder.
-		pub Rules get(rules): Option<T::Hash>;
+		pub Rules get(fn rules): Option<T::Hash>;
 
 		/// The current set of candidates; bidders that are attempting to become members.
-		pub Candidates get(candidates): Vec<Bid<T::AccountId, BalanceOf<T, I>>>;
+		pub Candidates get(fn candidates): Vec<Bid<T::AccountId, BalanceOf<T, I>>>;
 
 		/// The set of suspended candidates.
-		pub SuspendedCandidates get(suspended_candidate):
+		pub SuspendedCandidates get(fn suspended_candidate):
 			map hasher(twox_64_concat) T::AccountId
 			=> Option<(BalanceOf<T, I>, BidKind<T::AccountId, BalanceOf<T, I>>)>;
 
@@ -421,7 +421,7 @@ decl_storage! {
 		pub Pot get(fn pot) config(): BalanceOf<T, I>;
 
 		/// The most primary from the most recently approved members.
-		pub Head get(head) build(|config: &GenesisConfig<T, I>| config.members.first().cloned()):
+		pub Head get(fn head) build(|config: &GenesisConfig<T, I>| config.members.first().cloned()):
 			Option<T::AccountId>;
 
 		/// The current set of members, ordered.

--- a/frame/support/procedural/src/storage/parse.rs
+++ b/frame/support/procedural/src/storage/parse.rs
@@ -166,7 +166,7 @@ struct DeclStorageLine {
 
 #[derive(Parse, ToTokens, Debug)]
 struct DeclStorageGetterBody {
-	fn_keyword: Option<Token![fn]>,
+	fn_keyword: Token![fn],
 	ident: Ident,
 }
 

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -271,8 +271,6 @@ mod tests {
 				map hasher(identity) T::BlockNumber => T::BlockNumber;
 			pub GenericData2 get(fn generic_data2):
 				map hasher(blake2_128_concat) T::BlockNumber => Option<T::BlockNumber>;
-			pub GetterNoFnKeyword get(fn no_fn): Option<u32>;
-
 			pub DataDM config(test_config) build(|_| vec![(15u32, 16u32, 42u64)]):
 				double_map hasher(twox_64_concat) u32, hasher(blake2_128_concat) u32 => u64;
 			pub GenericDataDM:
@@ -555,15 +553,6 @@ mod tests {
 					},
 					default: DecodeDifferent::Encode(
 						DefaultByteGetter(&__GetByteStructGenericData2(PhantomData::<Test>))
-					),
-					documentation: DecodeDifferent::Encode(&[]),
-				},
-				StorageEntryMetadata {
-					name: DecodeDifferent::Encode("GetterNoFnKeyword"),
-					modifier: StorageEntryModifier::Optional,
-					ty: StorageEntryType::Plain(DecodeDifferent::Encode("u32")),
-					default: DecodeDifferent::Encode(
-						DefaultByteGetter(&__GetByteStructGetterNoFnKeyword(PhantomData::<Test>))
 					),
 					documentation: DecodeDifferent::Encode(&[]),
 				},

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -271,7 +271,7 @@ mod tests {
 				map hasher(identity) T::BlockNumber => T::BlockNumber;
 			pub GenericData2 get(fn generic_data2):
 				map hasher(blake2_128_concat) T::BlockNumber => Option<T::BlockNumber>;
-			pub GetterNoFnKeyword get(no_fn): Option<u32>;
+			pub GetterNoFnKeyword get(fn no_fn): Option<u32>;
 
 			pub DataDM config(test_config) build(|_| vec![(15u32, 16u32, 42u64)]):
 				double_map hasher(twox_64_concat) u32, hasher(blake2_128_concat) u32 => u64;


### PR DESCRIPTION
The `fn` token was already for quite some time as an optional parameter.
It was introduced to make these functions better findable. This pr makes
the `fn` token required.