### PR TITLE
Enable yamux flow control by default

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -85,9 +85,11 @@ pub struct NetworkParams {
 	#[structopt(flatten)]
 	pub node_key_params: NodeKeyParams,
 
-	/// Experimental feature flag.
-	#[structopt(long = "use-yamux-flow-control")]
-	pub use_yamux_flow_control: bool,
+	/// Disable the yamux flow control. Enable this if the networking seems broken. This option
+	/// will be removed in the future once there is enough confidence that this feature is
+	/// properly working.
+	#[structopt(long = "no-yamux-flow-control")]
+	pub no_yamux_flow_control: bool,
 }
 
 impl NetworkParams {
@@ -137,7 +139,7 @@ impl NetworkParams {
 				enable_mdns: !is_dev && !self.no_mdns,
 				allow_private_ipv4: !self.no_private_ipv4,
 				wasm_external_transport: None,
-				use_yamux_flow_control: self.use_yamux_flow_control,
+				use_yamux_flow_control: !self.no_yamux_flow_control,
 			},
 			max_parallel_downloads: self.max_parallel_downloads,
 		}

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -87,7 +87,7 @@ pub struct NetworkParams {
 
 	/// Disable the yamux flow control. This option will be removed in the future once there is
 	/// enough confidence that this feature is properly working.
-	#[structopt(long = "no-yamux-flow-control")]
+	#[structopt(long)]
 	pub no_yamux_flow_control: bool,
 }
 

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -85,9 +85,8 @@ pub struct NetworkParams {
 	#[structopt(flatten)]
 	pub node_key_params: NodeKeyParams,
 
-	/// Disable the yamux flow control. Enable this if the networking seems broken. This option
-	/// will be removed in the future once there is enough confidence that this feature is
-	/// properly working.
+	/// Disable the yamux flow control. This option will be removed in the future once there is
+	/// enough confidence that this feature is properly working.
 	#[structopt(long = "no-yamux-flow-control")]
 	pub no_yamux_flow_control: bool,
 }


### PR DESCRIPTION
This flag exists because we wanted to test this feature on our nodes.
Unfortunately it has never been actually enabled in practice.

In order to move things forward a bit, let's enable the option by default.

I'm running Polkadot with the flag on on my Google Cloud node today and will report if something bad/weird happens.
