### PR TITLE
Fix leak in stream notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5995,6 +5995,7 @@ dependencies = [
  "sp-trie",
  "sp-utils",
  "sp-version",
+ "substrate-prometheus-endpoint",
 ]
 
 [[package]]

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -41,6 +41,7 @@ sc-telemetry = { version = "2.0.0-dev", path = "../telemetry" }
 sp-trie = { version = "2.0.0-dev", path = "../../primitives/trie" }
 sp-storage = { version = "2.0.0-dev", path = "../../primitives/storage" }
 sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transaction-pool" }
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-dev", path = "../../utils/prometheus" }
 
 [dev-dependencies]
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }

--- a/client/api/src/notifications.rs
+++ b/client/api/src/notifications.rs
@@ -218,6 +218,7 @@ impl<Block: BlockT> StorageNotifications<Block> {
 
 	fn remove_subscriber(&mut self, subscriber: SubscriberId) {
 		if let Some((_, filters, child_filters)) = self.sinks.remove(&subscriber) {
+			// FIXME: add metrics to count items in internal system
 			Self::remove_subscriber_from(
 				&subscriber,
 				&filters,
@@ -274,6 +275,7 @@ impl<Block: BlockT> StorageNotifications<Block> {
 	) -> StorageEventStream<Block::Hash> {
 		self.next_id += 1;
 		let current_id = self.next_id;
+		// FIXME add metrics to count active subscribers
 
 		// add subscriber for every key
 		let keys = Self::listen_from(

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -252,7 +252,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		fork_blocks: ForkBlocks<Block>,
 		bad_blocks: BadBlocks<Block>,
 		execution_extensions: ExecutionExtensions<Block>,
-		_prometheus_registry: Option<Registry>,
+		prometheus_registry: Option<Registry>,
 	) -> sp_blockchain::Result<Self> {
 		if backend.blockchain().header(BlockId::Number(Zero::zero()))?.is_none() {
 			let genesis_storage = build_genesis_storage.build_storage()?;
@@ -276,7 +276,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		Ok(Client {
 			backend,
 			executor,
-			storage_notifications: Default::default(),
+			storage_notifications: Mutex::new(StorageNotifications::new(prometheus_registry)),
 			import_notification_sinks: Default::default(),
 			finality_notification_sinks: Default::default(),
 			importing_block: Default::default(),


### PR DESCRIPTION
When an rpc client connects to a node, it subscribes to a few keys to receive update when they change. Internally that is offloaded to `client.notification_stream`, which holds the actual logic to figure out if it matches and trigger an event on an `unbounded` channel if it does.

When the RPC disconnects all these subscriptions are discarded, the Receivers drop, which would mean the notification stream will also drop them on the next trigger that matches them – eventually cleaning it up internally.

Well, that's the theory. But because it only checks for the dropped ones whenever they match, rarely (or effectively _never_) changing keys are not included in the check. And one of those rarely changing keys is one the Polkadot JS App is very interested in: the runtime version. Thus, whenever a client connects via rpc and subscribes to that (which it does at start up), it is added to the stream notifications, yet effectively never removed. Leading to us accumulating stale sinks that are never cleaned up.

This PR fixes this leak by iterating through all sinks on every `trigger` and remove those that not connected anymore. Thus we clean this upon effectively ever `trigger` cycle. 

_Note_: A cleaner way to resolve this issue would be to hand over the subscriber ID to the outside of stream notifications and provide an API to actively remove subcribers rather than relying on the implic drop to take place. So that the RPC could do that right on the connection drop (as it does for its own internal subscription system). But that is a more involved change that we don't want to do at the moment.

Todo:
 - [x] fix leak
 - [x] add metrics to prevent this from happening again