### PR TITLE
Allow missing functions when checking the new runtime's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "pretty_assertions",
+ "rustversion",
  "serde",
  "sp-core",
  "sp-inherents",
@@ -7635,6 +7636,7 @@ name = "sp-runtime-interface-test"
 version = "2.0.0-dev"
 dependencies = [
  "sc-executor",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-runtime-interface",

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -45,7 +45,6 @@ fn call_in_wasm<E: Externalities>(
 		execution_method,
 		Some(1024),
 		HostFunctions::host_functions(),
-		true,
 		8,
 	);
 	executor.call_in_wasm(
@@ -54,6 +53,7 @@ fn call_in_wasm<E: Externalities>(
 		function,
 		call_data,
 		ext,
+		sp_core::traits::MissingHostFunctions::Allow,
 	)
 }
 
@@ -511,7 +511,6 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		wasm_method,
 		Some(17),  // `17` is the initial number of pages compiled into the binary.
 		HostFunctions::host_functions(),
-		true,
 		8,
 	);
 	executor.call_in_wasm(
@@ -520,6 +519,7 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		"test_exhaust_heap",
 		&[0],
 		&mut ext.ext(),
+		sp_core::traits::MissingHostFunctions::Allow,
 	).unwrap();
 }
 

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -77,7 +77,6 @@ mod tests {
 			WasmExecutionMethod::Interpreted,
 			Some(8),
 			sp_io::SubstrateHostFunctions::host_functions(),
-			true,
 			8,
 		);
 		let res = executor.call_in_wasm(
@@ -86,6 +85,7 @@ mod tests {
 			"test_empty_return",
 			&[],
 			&mut ext,
+			sp_core::traits::MissingHostFunctions::Allow,
 		).unwrap();
 		assert_eq!(res, vec![0u8; 0]);
 	}

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -22,6 +22,7 @@ sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../..
 sp-core = { version = "2.0.0-dev", default-features = false, path = "../../../primitives/core" }
 trybuild = "1.0.17"
 pretty_assertions = "0.6.1"
+rustversion = "1.0.0"
 
 [features]
 default = ["std"]

--- a/frame/support/test/tests/construct_runtime_ui.rs
+++ b/frame/support/test/tests/construct_runtime_ui.rs
@@ -1,5 +1,22 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
 use std::env;
 
+#[rustversion::attr(not(stable), ignore)]
 #[test]
 fn ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/reserved_keyword.rs
+++ b/frame/support/test/tests/reserved_keyword.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
+#[rustversion::attr(not(stable), ignore)]
 #[test]
 fn reserved_keyword() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -2099,6 +2099,7 @@ pub(crate) mod tests {
 				_: &str,
 				_: &[u8],
 				_: &mut dyn sp_externalities::Externalities,
+				_: sp_core::traits::MissingHostFunctions,
 			) -> Result<Vec<u8>, String> {
 				Ok(self.0.clone())
 			}

--- a/primitives/core/src/traits.rs
+++ b/primitives/core/src/traits.rs
@@ -262,6 +262,23 @@ impl std::fmt::Display for CodeNotFound {
 	}
 }
 
+/// `Allow` or `Disallow` missing host functions when instantiating a WASM blob.
+#[derive(Clone, Copy, Debug)]
+pub enum MissingHostFunctions {
+	/// Any missing host function will be replaced by a stub that returns an error when
+	/// being called.
+	Allow,
+	/// Any missing host function will result in an error while instantiating the WASM blob,
+	Disallow,
+}
+
+impl MissingHostFunctions {
+	/// Are missing host functions allowed?
+	pub fn allowed(self) -> bool {
+		matches!(self, Self::Allow)
+	}
+}
+
 /// Something that can call a method in a WASM blob.
 pub trait CallInWasm: Send + Sync {
 	/// Call the given `method` in the given `wasm_blob` using `call_data` (SCALE encoded arguments)
@@ -280,6 +297,7 @@ pub trait CallInWasm: Send + Sync {
 		method: &str,
 		call_data: &[u8],
 		ext: &mut dyn Externalities,
+		missing_host_functions: MissingHostFunctions,
 	) -> Result<Vec<u8>, String>;
 }
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -329,7 +329,18 @@ pub trait Misc {
 
 		self.extension::<CallInWasmExt>()
 			.expect("No `CallInWasmExt` associated for the current context!")
-			.call_in_wasm(wasm, None, "Core_version", &[], &mut ext)
+			.call_in_wasm(
+				wasm,
+				None,
+				"Core_version",
+				&[],
+				&mut ext,
+				// If a runtime upgrade introduces new host functions that are not provided by
+				// the node, we should not fail at instantiation. Otherwise nodes that are
+				// updated could run this successfully and it could lead to a storage root
+				// mismatch when importing this block.
+				sp_core::traits::MissingHostFunctions::Allow,
+			)
 			.ok()
 	}
 }

--- a/primitives/runtime-interface/test/Cargo.toml
+++ b/primitives/runtime-interface/test/Cargo.toml
@@ -18,5 +18,6 @@ sp-runtime-interface-test-wasm = { version = "2.0.0-dev", path = "../test-wasm" 
 sp-runtime-interface-test-wasm-deprecated = { version = "2.0.0-dev", path = "../test-wasm-deprecated" }
 sp-state-machine = { version = "0.8.0-dev", path = "../../../primitives/state-machine" }
 sp-runtime = { version = "2.0.0-dev", path = "../../runtime" }
+sp-core = { version = "2.0.0-dev", path = "../../core" }
 sp-io = { version = "2.0.0-dev", path = "../../io" }
 tracing = "0.1.13"

--- a/primitives/runtime-interface/test/src/lib.rs
+++ b/primitives/runtime-interface/test/src/lib.rs
@@ -41,7 +41,6 @@ fn call_wasm_method<HF: HostFunctionsT>(binary: &[u8], method: &str) -> TestExte
 		sc_executor::WasmExecutionMethod::Interpreted,
 		Some(8),
 		host_functions,
-		false,
 		8,
 	);
 	executor.call_in_wasm(
@@ -50,6 +49,7 @@ fn call_wasm_method<HF: HostFunctionsT>(binary: &[u8], method: &str) -> TestExte
 		method,
 		&[],
 		&mut ext_ext,
+		sp_core::traits::MissingHostFunctions::Disallow,
 	).expect(&format!("Executes `{}`", method));
 
 	ext

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -811,6 +811,7 @@ mod tests {
 			_: &str,
 			_: &[u8],
 			_: &mut dyn Externalities,
+			_: sp_core::traits::MissingHostFunctions,
 		) -> std::result::Result<Vec<u8>, String> {
 			unimplemented!("Not required in tests.")
 		}


### PR DESCRIPTION
When upgrading a runtime, we check that the version of the new runtime
is incrementing the `spec_version` or the `spec_name` changes. To do
this, we need to initialize the runtime and call `Core_version`. When
initializing the runtime we check all imports and if we can fulfill
them. Up to now, we would fail when the node did not provide all the
required host functions. In Westend this lead to older nodes rejecting
the runtime upgrade, as the runtime version could not be extracted, but
newer nodes with these host functions succeeded and generated a
different state root. This pr allows missing host functions. A missing
host function is replaced by a stub that returns an error when being
called. As `Core_version` doesn't call any host function besides
`malloc` and `free`, this should make sure that all nodes (with and
without the required) host functions generate the same block. This does
not prevent that old nodes will fail to author blocks with the new
runtime.
