### PR TITLE
slots: fix slot lenience methods

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -580,8 +580,7 @@ mod test {
 		// if no slots are skipped there should be no lenience
 		assert_eq!(super::slot_lenience_exponential(1, &slot(2)), None);
 
-		// otherwise the lenience is incremented linearly with
-		// the number of skipped slots.
+		// otherwise the lenience is incremented exponentially every two slots
 		for n in 3..=17 {
 			assert_eq!(
 				super::slot_lenience_exponential(1, &slot(n)),


### PR DESCRIPTION
In both Aura and BABE we have a mechanism for allowing more time for block production in case slots were skipped (presumably due to a heavy extrinsic). There were two bugs in this code:
- The final calculation of lenience time was done in seconds using millseconds as input, as a result we'd end up backing off for hours rather than seconds/minutes.
- In the exponential backoff we'd always apply one step of backoff even if no slots were skipped.

Moved this code into the `slots` crate and added tests.