### PR TITLE
(demo) Runtime interface invocation on native no_std 

### DIFF
--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -53,3 +53,5 @@ std = [
 disable_panic_handler = []
 disable_oom = []
 disable_allocator = []
+
+native-nostd = []

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -564,7 +564,7 @@ pub trait Crypto {
 }
 
 /// Interface that provides functions for hashing with different algorithms.
-#[runtime_interface]
+#[runtime_interface(native_nostd)]
 pub trait Hashing {
 	/// Conduct a 256-bit Keccak hash.
 	fn keccak_256(data: &[u8]) -> [u8; 32] {

--- a/primitives/runtime-interface/proc-macro/src/lib.rs
+++ b/primitives/runtime-interface/proc-macro/src/lib.rs
@@ -31,38 +31,12 @@ mod pass_by;
 mod runtime_interface;
 mod utils;
 
-use syn::Result;
-use syn::parse::{Parse, ParseStream};
-
-enum Attrs {
-	WasmOnly,
-	NativeNoStd,
-	Normal
-}
-
-impl Parse for Attrs {
-	fn parse(input: ParseStream) -> Result<Self> {
-		if input.is_empty() {
-			return Ok(Attrs::Normal);
-		}
-		let lookahead = input.lookahead1();
-		if lookahead.peek(runtime_interface::keywords::wasm_only) {
-			input.parse::<runtime_interface::keywords::wasm_only>()?;
-			Ok(Attrs::WasmOnly)
-		} else if lookahead.peek(runtime_interface::keywords::native_nostd) {
-			input.parse::<runtime_interface::keywords::native_nostd>()?;
-			Ok(Attrs::NativeNoStd)
-		} else {
-			Err(lookahead.error())
-		}
-	}
-}
-
 #[proc_macro_attribute]
 pub fn runtime_interface(
 	attrs: proc_macro::TokenStream,
 	input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
+	use runtime_interface::keywords::Attrs;
 	let trait_def = parse_macro_input!(input as ItemTrait);
 	let attrs_def = parse_macro_input!(attrs as Attrs);
 

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/mod.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/mod.rs
@@ -32,17 +32,20 @@ mod trait_decl_impl;
 pub mod keywords {
 	// Custom keyword `wasm_only` that can be given as attribute to [`runtime_interface`].
 	syn::custom_keyword!(wasm_only);
+	syn::custom_keyword!(native_nostd);
 }
 
 /// Implementation of the `runtime_interface` attribute.
 ///
 /// It expects the trait definition the attribute was put above and if this should be an wasm only
 /// interface.
-pub fn runtime_interface_impl(trait_def: ItemTrait, is_wasm_only: bool) -> Result<TokenStream> {
-	let bare_functions = bare_function_interface::generate(&trait_def, is_wasm_only)?;
+pub fn runtime_interface_impl(trait_def: ItemTrait, is_wasm_only: bool, allow_native_nostd: bool)
+-> Result<TokenStream> {
+	let bare_functions = bare_function_interface::generate(
+			&trait_def, is_wasm_only, allow_native_nostd)?;
 	let crate_include = generate_runtime_interface_include();
 	let mod_name = Ident::new(&trait_def.ident.to_string().to_snake_case(), Span::call_site());
-	let trait_decl_impl = trait_decl_impl::process(&trait_def, is_wasm_only)?;
+	let trait_decl_impl = trait_decl_impl::process(&trait_def, is_wasm_only, allow_native_nostd)?;
 	let host_functions = host_function_interface::generate(&trait_def, is_wasm_only)?;
 	let vis = trait_def.vis;
 	let attrs = &trait_def.attrs;

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/mod.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/mod.rs
@@ -30,9 +30,35 @@ mod trait_decl_impl;
 
 /// Custom keywords supported by the `runtime_interface` attribute.
 pub mod keywords {
+	use syn::{Result, parse::{Parse, ParseStream}};
+
 	// Custom keyword `wasm_only` that can be given as attribute to [`runtime_interface`].
 	syn::custom_keyword!(wasm_only);
 	syn::custom_keyword!(native_nostd);
+
+	pub enum Attrs {
+		WasmOnly,
+		NativeNoStd,
+		Normal
+	}
+
+	impl Parse for Attrs {
+		fn parse(input: ParseStream) -> Result<Self> {
+			if input.is_empty() {
+				return Ok(Attrs::Normal);
+			}
+			let lookahead = input.lookahead1();
+			if lookahead.peek(wasm_only) {
+				input.parse::<wasm_only>()?;
+				Ok(Attrs::WasmOnly)
+			} else if lookahead.peek(native_nostd) {
+				input.parse::<native_nostd>()?;
+				Ok(Attrs::NativeNoStd)
+			} else {
+				Err(lookahead.error())
+			}
+		}
+	}
 }
 
 /// Implementation of the `runtime_interface` attribute.

--- a/primitives/runtime-interface/proc-macro/src/utils.rs
+++ b/primitives/runtime-interface/proc-macro/src/utils.rs
@@ -298,3 +298,20 @@ pub fn get_runtime_interface<'a>(trait_def: &'a ItemTrait)
 
 	Ok(RuntimeInterface { items: functions })
 }
+
+/// Returns a cfg attribute for wasm or non-wasm code block, considering if it supports native no-std..
+pub fn generate_cfg_attr(for_wasm: bool, native_nostd: bool) -> TokenStream {
+	if native_nostd {
+		if for_wasm {
+			quote!( #[cfg(all(not(feature = "std"), not(feature = "native-nostd")))] )
+		} else {
+			quote!( #[cfg(any(feature = "std", feature = "native-nostd"))] )
+		}
+	} else {
+		if for_wasm {
+			quote!( #[cfg(not(feature = "std"))] )
+		} else {
+			quote!( #[cfg(feature = "std")] )
+		}
+	}
+}

--- a/primitives/runtime-interface/src/lib.rs
+++ b/primitives/runtime-interface/src/lib.rs
@@ -290,6 +290,8 @@ pub use sp_runtime_interface_proc_macro::runtime_interface;
 pub use sp_externalities::{
 	set_and_run_with_externalities, with_externalities, Externalities, ExternalitiesExt, ExtensionStore,
 };
+#[cfg(not(feature = "std"))]
+pub trait Externalities {}
 
 #[doc(hidden)]
 pub use codec;


### PR DESCRIPTION
This PR demonstrates a way to fix #5547. I would like to get some feedback.

Usage:

1. Add `native_nostd` as an attr: `#[runtime_interface(native_nostd)]`
2. Enable `sp_io/native-nostd` feature in a no_std project's cargo.toml