### PR TITLE
Make GrandpaJustification::decode_and_verify_finalizes public

### DIFF
--- a/client/finality-grandpa/src/justification.rs
+++ b/client/finality-grandpa/src/justification.rs
@@ -88,7 +88,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 
 	/// Decode a GRANDPA justification and validate the commit and the votes'
 	/// ancestry proofs finalize the given block.
-	pub(crate) fn decode_and_verify_finalizes(
+	pub fn decode_and_verify_finalizes(
 		encoded: &[u8],
 		finalized_target: (Block::Hash, NumberFor<Block>),
 		set_id: u64,


### PR DESCRIPTION
The idea is to use that function in external crates to verify justification that came from untrusted source. Like:
1) someone calls `chain_getBlock` on Substrate node to get justification;
2) he then submits that justification to the Ethereum contract;
3) Ethereum contract needs a proof that justification is valid and finalizes block it needs.

We might also extract `GrandpaJustification` to separate crate, if you think it worth it (I would prefer not to do that **now**, though). Or probably expose some `fn verify_justification(Vec<u8>, ...) -> Result<(), Error>` instead of `GrandpaJustification::decode_and_verify_finalizes()` - we actually do not need `GrandpaJustification` itself, because it's opaque to external crates anyway.