### PR TITLE
Replace `TransactionBaseFee` with `ExtrinsicBaseWeight`

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -220,14 +220,12 @@ impl balances::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionBaseFee: Balance = 0;
 	pub const TransactionByteFee: Balance = 1;
 }
 
 impl transaction_payment::Trait for Runtime {
 	type Currency = balances::Module<Runtime>;
 	type OnTransactionPayment = ();
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = ConvertInto;
 	type FeeMultiplierUpdate = ();

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -33,7 +33,7 @@ use frame_system::{self, EventRecord, Phase};
 
 use node_runtime::{
 	Header, Block, UncheckedExtrinsic, CheckedExtrinsic, Call, Runtime, Balances,
-	System, TransactionPayment, Event, TransactionBaseFee, TransactionByteFee,
+	System, TransactionPayment, Event, TransactionByteFee, ExtrinsicBaseWeight,
 	constants::currency::*,
 };
 use node_primitives::{Balance, Hash};
@@ -54,11 +54,11 @@ pub const BLOATY_CODE: &[u8] = node_runtime::WASM_BINARY_BLOATY;
 fn transfer_fee<E: Encode>(extrinsic: &E, fee_multiplier: Fixed128) -> Balance {
 	let length_fee = TransactionByteFee::get() * (extrinsic.encode().len() as Balance);
 
+	let base_weight = ExtrinsicBaseWeight::get();
+	let base_fee = <Runtime as pallet_transaction_payment::Trait>::WeightToFee::convert(base_weight);
 	let weight = default_transfer_call().get_dispatch_info().weight;
-	let weight_fee = <Runtime as pallet_transaction_payment::Trait>
-		::WeightToFee::convert(weight);
+	let weight_fee = <Runtime as pallet_transaction_payment::Trait>::WeightToFee::convert(weight);
 
-	let base_fee = TransactionBaseFee::get();
 	base_fee + fee_multiplier.saturated_multiply_accumulate(length_fee + weight_fee)
 }
 

--- a/bin/node/executor/tests/fees.rs
+++ b/bin/node/executor/tests/fees.rs
@@ -25,7 +25,7 @@ use sp_runtime::{Fixed128, Perbill, traits::{Convert, BlakeTwo256}};
 use node_runtime::{
 	CheckedExtrinsic, Call, Runtime, Balances, TransactionPayment,
 	TransactionByteFee, WeightFeeCoefficient,
-	constants::currency::*,
+	constants::currency::*, ExtrinsicBaseWeight,
 };
 use node_runtime::impls::LinearWeightToFee;
 use node_primitives::Balance;
@@ -180,6 +180,9 @@ fn transaction_fee_is_correct_ultimate() {
 		// - Creation-fee of bob's account.
 		let mut balance_alice = (100 - 69) * DOLLARS;
 
+		let base_weight = ExtrinsicBaseWeight::get();
+		let base_fee = LinearWeightToFee::<WeightFeeCoefficient>::convert(base_weight);
+
 		let length_fee = TransactionByteFee::get() * (xt.clone().encode().len() as Balance);
 		balance_alice -= length_fee;
 
@@ -190,6 +193,7 @@ fn transaction_fee_is_correct_ultimate() {
 		// current weight of transfer = 200_000_000
 		// Linear weight to fee is 1:1 right now (1 weight = 1 unit of balance)
 		assert_eq!(weight_fee, weight as Balance);
+		balance_alice -= base_fee;
 		balance_alice -= weight_fee;
 		balance_alice -= tip;
 

--- a/bin/node/executor/tests/fees.rs
+++ b/bin/node/executor/tests/fees.rs
@@ -23,7 +23,7 @@ use frame_support::{
 use sp_core::{NeverNativeValue, map, storage::Storage};
 use sp_runtime::{Fixed128, Perbill, traits::{Convert, BlakeTwo256}};
 use node_runtime::{
-	CheckedExtrinsic, Call, Runtime, Balances, TransactionPayment, TransactionBaseFee,
+	CheckedExtrinsic, Call, Runtime, Balances, TransactionPayment,
 	TransactionByteFee, WeightFeeCoefficient,
 	constants::currency::*,
 };
@@ -173,15 +173,14 @@ fn transaction_fee_is_correct_ultimate() {
 	t.execute_with(|| {
 		assert_eq!(Balances::total_balance(&bob()), (10 + 69) * DOLLARS);
 		// Components deducted from alice's balances:
+		// - Base fee
 		// - Weight fee
 		// - Length fee
 		// - Tip
 		// - Creation-fee of bob's account.
 		let mut balance_alice = (100 - 69) * DOLLARS;
 
-		let length_fee = TransactionBaseFee::get() +
-			TransactionByteFee::get() *
-			(xt.clone().encode().len() as Balance);
+		let length_fee = TransactionByteFee::get() * (xt.clone().encode().len() as Balance);
 		balance_alice -= length_fee;
 
 		let weight = default_transfer_call().get_dispatch_info().weight;

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -229,7 +229,7 @@ fn submitted_transaction_should_be_valid() {
 		let res = Executive::validate_transaction(source, extrinsic);
 
 		assert_eq!(res.unwrap(), ValidTransaction {
-			priority: 2_411_380_000_000,
+			priority: 1_411_390_000_000,
 			requires: vec![],
 			provides: vec![(address, 0).encode()],
 			longevity: 128,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -218,7 +218,6 @@ impl pallet_balances::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const TransactionBaseFee: Balance = 1 * CENTS;
 	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 	// In the Substrate node, a weight of 10_000_000 (smallest non-zero weight)
 	// is mapped to 10_000_000 units of fees, hence:
@@ -230,7 +229,6 @@ parameter_types! {
 impl pallet_transaction_payment::Trait for Runtime {
 	type Currency = Balances;
 	type OnTransactionPayment = DealWithFees;
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = LinearWeightToFee<WeightFeeCoefficient>;
 	type FeeMultiplierUpdate = TargetedFeeAdjustment<TargetBlockFullness>;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -79,13 +79,11 @@ impl frame_system::Trait for Test {
 	type OnKilledAccount = ();
 }
 parameter_types! {
-	pub const TransactionBaseFee: u64 = 0;
 	pub const TransactionByteFee: u64 = 1;
 }
 impl pallet_transaction_payment::Trait for Test {
 	type Currency = Module<Test>;
 	type OnTransactionPayment = ();
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = ConvertInto;
 	type FeeMultiplierUpdate = ();

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -79,13 +79,11 @@ impl frame_system::Trait for Test {
 	type OnKilledAccount = Module<Test>;
 }
 parameter_types! {
-	pub const TransactionBaseFee: u64 = 0;
 	pub const TransactionByteFee: u64 = 1;
 }
 impl pallet_transaction_payment::Trait for Test {
 	type Currency = Module<Test>;
 	type OnTransactionPayment = ();
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
 	type WeightToFee = ConvertInto;
 	type FeeMultiplierUpdate = ();

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -519,13 +519,11 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const TransactionBaseFee: u64 = 10;
 		pub const TransactionByteFee: u64 = 0;
 	}
 	impl pallet_transaction_payment::Trait for Runtime {
 		type Currency = Balances;
 		type OnTransactionPayment = ();
-		type TransactionBaseFee = TransactionBaseFee;
 		type TransactionByteFee = TransactionByteFee;
 		type WeightToFee = ConvertInto;
 		type FeeMultiplierUpdate = ();

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -67,9 +67,6 @@ pub trait Trait: frame_system::Trait {
 	/// if any.
 	type OnTransactionPayment: OnUnbalanced<NegativeImbalanceOf<Self>>;
 
-	/// The fee to be paid for making a transaction; the base.
-	type TransactionBaseFee: Get<BalanceOf<Self>>;
-
 	/// The fee to be paid for making a transaction; the per-byte portion.
 	type TransactionByteFee: Get<BalanceOf<Self>>;
 
@@ -88,9 +85,6 @@ decl_storage! {
 
 decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-		/// The fee to be paid for making a transaction; the base.
-		const TransactionBaseFee: BalanceOf<T> = T::TransactionBaseFee::get();
-
 		/// The fee to be paid for making a transaction; the per-byte portion.
 		const TransactionByteFee: BalanceOf<T> = T::TransactionByteFee::get();
 
@@ -177,7 +171,8 @@ impl<T: Trait> Module<T> where
 			let targeted_fee_adjustment = NextFeeMultiplier::get();
 			let adjusted_fee = targeted_fee_adjustment.saturated_multiply_accumulate(adjustable_fee.saturated_into());
 
-			let base_fee = T::TransactionBaseFee::get();
+			let base_weight = T::ExtrinsicBaseWeight::get();
+			let base_fee = Self::weight_to_fee(base_weight);
 			base_fee.saturating_add(adjusted_fee.saturated_into()).saturating_add(tip)
 		} else {
 			tip
@@ -365,6 +360,15 @@ mod tests {
 		pub enum Origin for Runtime {}
 	}
 
+	thread_local! {
+		static EXTRINSIC_BASE_WEIGHT: RefCell<u64> = RefCell::new(0);
+	}
+
+	pub struct ExtrinsicBaseWeight;
+	impl Get<u64> for ExtrinsicBaseWeight {
+		fn get() -> u64 { EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow()) }
+	}
+
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub const MaximumBlockWeight: Weight = 1024;
@@ -387,7 +391,7 @@ mod tests {
 		type MaximumBlockWeight = MaximumBlockWeight;
 		type DbWeight = ();
 		type BlockExecutionWeight = ();
-		type ExtrinsicBaseWeight = ();
+		type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type Version = ();
@@ -409,14 +413,8 @@ mod tests {
 		type AccountStore = System;
 	}
 	thread_local! {
-		static TRANSACTION_BASE_FEE: RefCell<u64> = RefCell::new(0);
 		static TRANSACTION_BYTE_FEE: RefCell<u64> = RefCell::new(1);
 		static WEIGHT_TO_FEE: RefCell<u64> = RefCell::new(1);
-	}
-
-	pub struct TransactionBaseFee;
-	impl Get<u64> for TransactionBaseFee {
-		fn get() -> u64 { TRANSACTION_BASE_FEE.with(|v| *v.borrow()) }
 	}
 
 	pub struct TransactionByteFee;
@@ -434,7 +432,6 @@ mod tests {
 	impl Trait for Runtime {
 		type Currency = pallet_balances::Module<Runtime>;
 		type OnTransactionPayment = ();
-		type TransactionBaseFee = TransactionBaseFee;
 		type TransactionByteFee = TransactionByteFee;
 		type WeightToFee = WeightToFee;
 		type FeeMultiplierUpdate = ();
@@ -446,7 +443,7 @@ mod tests {
 
 	pub struct ExtBuilder {
 		balance_factor: u64,
-		base_fee: u64,
+		base_weight: u64,
 		byte_fee: u64,
 		weight_to_fee: u64
 	}
@@ -455,7 +452,7 @@ mod tests {
 		fn default() -> Self {
 			Self {
 				balance_factor: 1,
-				base_fee: 0,
+				base_weight: 0,
 				byte_fee: 1,
 				weight_to_fee: 1,
 			}
@@ -463,8 +460,8 @@ mod tests {
 	}
 
 	impl ExtBuilder {
-		pub fn base_fee(mut self, base_fee: u64) -> Self {
-			self.base_fee = base_fee;
+		pub fn base_weight(mut self, base_weight: u64) -> Self {
+			self.base_weight = base_weight;
 			self
 		}
 		pub fn byte_fee(mut self, byte_fee: u64) -> Self {
@@ -480,7 +477,7 @@ mod tests {
 			self
 		}
 		fn set_constants(&self) {
-			TRANSACTION_BASE_FEE.with(|v| *v.borrow_mut() = self.base_fee);
+			EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow_mut() = self.base_weight);
 			TRANSACTION_BYTE_FEE.with(|v| *v.borrow_mut() = self.byte_fee);
 			WEIGHT_TO_FEE.with(|v| *v.borrow_mut() = self.weight_to_fee);
 		}
@@ -523,7 +520,7 @@ mod tests {
 	fn signed_extension_transaction_payment_work() {
 		ExtBuilder::default()
 			.balance_factor(10)
-			.base_fee(5)
+			.base_weight(5)
 			.build()
 			.execute_with(||
 		{
@@ -558,7 +555,7 @@ mod tests {
 	fn signed_extension_transaction_payment_multiplied_refund_works() {
 		ExtBuilder::default()
 			.balance_factor(10)
-			.base_fee(5)
+			.base_weight(5)
 			.build()
 			.execute_with(||
 		{
@@ -606,7 +603,7 @@ mod tests {
 	#[test]
 	fn signed_extension_allows_free_transactions() {
 		ExtBuilder::default()
-			.base_fee(100)
+			.base_weight(100)
 			.balance_factor(0)
 			.build()
 			.execute_with(||
@@ -645,7 +642,7 @@ mod tests {
 	#[test]
 	fn signed_ext_length_fee_is_also_updated_per_congestion() {
 		ExtBuilder::default()
-			.base_fee(5)
+			.base_weight(5)
 			.balance_factor(10)
 			.build()
 			.execute_with(||
@@ -673,7 +670,7 @@ mod tests {
 		let ext = xt.encode();
 		let len = ext.len() as u32;
 		ExtBuilder::default()
-			.base_fee(5)
+			.base_weight(5)
 			.weight_fee(2)
 			.build()
 			.execute_with(||
@@ -687,7 +684,7 @@ mod tests {
 					weight: info.weight,
 					class: info.class,
 					partial_fee:
-						5 /* base */
+						5 * 2 /* base * weight_fee */
 						+ (
 							len as u64 /* len * 1 */
 							+ info.weight.min(MaximumBlockWeight::get()) as u64 * 2 /* weight * weight_to_fee */
@@ -701,7 +698,7 @@ mod tests {
 	#[test]
 	fn compute_fee_works_without_multiplier() {
 		ExtBuilder::default()
-			.base_fee(100)
+			.base_weight(100)
 			.byte_fee(10)
 			.balance_factor(0)
 			.build()
@@ -741,7 +738,7 @@ mod tests {
 	#[test]
 	fn compute_fee_works_with_multiplier() {
 		ExtBuilder::default()
-			.base_fee(100)
+			.base_weight(100)
 			.byte_fee(10)
 			.balance_factor(0)
 			.build()
@@ -774,7 +771,7 @@ mod tests {
 	#[test]
 	fn compute_fee_does_not_overflow() {
 		ExtBuilder::default()
-			.base_fee(100)
+			.base_weight(100)
 			.byte_fee(10)
 			.balance_factor(0)
 			.build()
@@ -801,7 +798,7 @@ mod tests {
 	fn refund_does_not_recreate_account() {
 		ExtBuilder::default()
 			.balance_factor(10)
-			.base_fee(5)
+			.base_weight(5)
 			.build()
 			.execute_with(||
 		{
@@ -828,7 +825,7 @@ mod tests {
 	fn actual_weight_higher_than_max_refunds_nothing() {
 		ExtBuilder::default()
 			.balance_factor(10)
-			.base_fee(5)
+			.base_weight(5)
 			.build()
 			.execute_with(||
 		{


### PR DESCRIPTION
This is a pretty simple PR which replaces the notion of `TransactionBaseFee` with `ExtrinsicBaseWeight` * `WeightToFee`.

We should confirm that Transaction Byte length should still be handled independent of the Substrate weight system, as it is now.