### PR TITLE
Replace NetworkWorker::poll with NetworkWorker::next_action

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -992,9 +992,11 @@ impl Metrics {
 }
 
 impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
-	/// Performs one action on the network, then returns.
+	/// Perform all the networking tasks.
 	///
-	/// The returned future is designed to be freely cancellable.
+	/// **Important**: At the moment, the returned `Future` only finishes if the networking as
+	/// a whole finished. In the future, however, it might finish more often. You **must** call
+	/// this method in a loop.
 	pub async fn next_action(&mut self) {
 		future::poll_fn(move |cx| Pin::new(&mut *self).poll(cx)).await
 	}

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -87,7 +87,7 @@ fn build_test_full_node(config: config::NetworkConfiguration)
 		None,
 	));
 
-	let worker = NetworkWorker::new(config::Params {
+	let mut worker = NetworkWorker::new(config::Params {
 		role: config::Role::Full,
 		executor: None,
 		network_config: config,
@@ -109,8 +109,9 @@ fn build_test_full_node(config: config::NetworkConfiguration)
 	let event_stream = service.event_stream("test");
 
 	async_std::task::spawn(async move {
-		futures::pin_mut!(worker);
-		let _ = worker.await;
+		loop {
+			worker.next_action().await;
+		}
 	});
 
 	(service, event_stream)

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -789,8 +789,12 @@ pub trait TestNetFactory: Sized {
 		self.mut_peers(|peers| {
 			for peer in peers {
 				trace!(target: "sync", "-- Polling {}", peer.id());
-				if let Poll::Ready(res) = Pin::new(&mut peer.network).poll(cx) {
-					res.unwrap();
+				loop {
+					let net_poll_future = peer.network.next_action();
+					futures::pin_mut!(net_poll_future);
+					if let Poll::Pending = net_poll_future.poll(cx) {
+						break;
+					}
 				}
 				trace!(target: "sync", "-- Polling complete {}", peer.id());
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -445,9 +445,9 @@ fn build_network_future<
 		});
 
 		// Main network polling.
-		if let Poll::Ready(Ok(())) = Pin::new(&mut network).poll(cx).map_err(|err| {
-			warn!(target: "service", "Error in network: {:?}", err);
-		}) {
+		let next_network_action = network.next_action();
+		futures::pin_mut!(next_network_action);
+		if let Poll::Ready(()) = next_network_action.poll(cx) {
 			return Poll::Ready(());
 		}
 


### PR DESCRIPTION
As a follow-up to that comment: https://github.com/paritytech/substrate/pull/5704#issuecomment-618252054

This opens the door for making the code async-awaitable in the future, without changing any behaviour right now.

polkadot companion: https://github.com/paritytech/polkadot/pull/1029