### PR TITLE
babe: remove error fallback from threshold calculation

### DIFF
--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -47,7 +47,7 @@ pub(super) fn calculate_primary_threshold(
 		authorities[authority_index].1 as f64 /
 		authorities.iter().map(|(_, weight)| weight).sum::<u64>() as f64;
 
-	assert!(theta > 0, "authority with weight 0.");
+	assert!(theta > 0.0, "authority with weight 0.");
 
 	let p = BigRational::from_float(1f64 - (1f64 - c).powf(theta)).expect(
 		"returns None when the given value is not finite; \
@@ -56,7 +56,7 @@ pub(super) fn calculate_primary_threshold(
 		 theta represents the validator's relative weight defined in (0, 1]; \
 		 powf will always return values in (0, 1] given both the \
 		 base and exponent are in that domain; \
-		 qed.";
+		 qed.",
 	);
 
 	let numer = p.numer().to_biguint().expect(
@@ -73,7 +73,13 @@ pub(super) fn calculate_primary_threshold(
 		 qed."
 	);
 
-	((BigUint::one() << 128) * numer / denom).to_u128()
+	((BigUint::one() << 128) * numer / denom).to_u128().expect(
+		"returns None if the underlying value cannot be represented with 128 bits; \
+		 we start with 1 << 128 which is one unit more than can be represented with 128 bits; \
+		 we multiple by p which is defined in [0, 1); \
+		 the result must be lower than 1 << 128 and representable with 128 bits; \
+		 qed.",
+	)
 }
 
 /// Returns true if the given VRF output is lower than the given threshold,

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -49,6 +49,11 @@ pub(super) fn calculate_primary_threshold(
 
 	assert!(theta > 0.0, "authority with weight 0.");
 
+	// NOTE: in the equation `p = 1 - (1 - c)^theta` the value of `p` is always
+	// capped by `c`. For all pratical purposes `c` should always be set to a
+	// value < 0.5, as such in the computations below we should never be near
+	// edge cases like `0.999999`.
+
 	let p = BigRational::from_float(1f64 - (1f64 - c).powf(theta)).expect(
 		"returns None when the given value is not finite; \
 		 c is a configuration parameter defined in (0, 1]; \

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -75,9 +75,9 @@ pub(super) fn calculate_primary_threshold(
 
 	((BigUint::one() << 128) * numer / denom).to_u128().expect(
 		"returns None if the underlying value cannot be represented with 128 bits; \
-		 we start with 1 << 128 which is one unit more than can be represented with 128 bits; \
+		 we start with 2^128 which is one more than can be represented with 128 bits; \
 		 we multiple by p which is defined in [0, 1); \
-		 the result must be lower than 1 << 128 and representable with 128 bits; \
+		 the result must be lower than 2^128 by at least one and thus representable with 128 bits; \
 		 qed.",
 	)
 }

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -62,14 +62,14 @@ pub(super) fn calculate_primary_threshold(
 	let numer = p.numer().to_biguint().expect(
 		"returns None when the given value is negative; \
 		 p is defined as `1 - n` where n is defined in (0, 1]; \
-		 p must be a value in (0, 1]; \
+		 p must be a value in [0, 1); \
 		 qed."
 	);
 
 	let denom = p.denom().to_biguint().expect(
 		"returns None when the given value is negative; \
 		 p is defined as `1 - n` where n is defined in (0, 1]; \
-		 p must be a value in (0, 1]; \
+		 p must be a value in [0, 1); \
 		 qed."
 	);
 

--- a/client/consensus/babe/src/authorship.rs
+++ b/client/consensus/babe/src/authorship.rs
@@ -61,16 +61,16 @@ pub(super) fn calculate_primary_threshold(
 
 	let numer = p.numer().to_biguint().expect(
 		"returns None when the given value is negative; \
-		 p is defined as `1 - n` where n is defined in (0, 1];
-			 p must be a value in (0, 1]; \
-			 qed."
+		 p is defined as `1 - n` where n is defined in (0, 1]; \
+		 p must be a value in (0, 1]; \
+		 qed."
 	);
 
 	let denom = p.denom().to_biguint().expect(
 		"returns None when the given value is negative; \
-		 p is defined as `1 - n` where n is defined in (0, 1];
-			 p must be a value in (0, 1]; \
-			 qed."
+		 p is defined as `1 - n` where n is defined in (0, 1]; \
+		 p must be a value in (0, 1]; \
+		 qed."
 	);
 
 	((BigUint::one() << 128) * numer / denom).to_u128()


### PR DESCRIPTION
When doing the primary threshold calculation in BABE we default to returning `u128::max_value()` in case any error happens in intermediary computations. The computations should not fail and instead "proofs" are given in expects.

Fixes #5753.