### PR TITLE
Rename `state-trace` traces to `storage`

### DIFF
--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -156,7 +156,7 @@ where
 		let _guard = sp_panic_handler::AbortGuard::force_abort();
 		let result = self.overlay.storage(key).map(|x| x.map(|x| x.to_vec())).unwrap_or_else(||
 			self.backend.storage(key).expect(EXT_NOT_ALLOWED_TO_FAIL));
-		trace!(target: "state-trace", "{:04x}: Get {}={:?}",
+		trace!(target: "storage", "{:04x}: Get {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result.as_ref().map(HexDisplay::from)
@@ -171,7 +171,7 @@ where
 			.map(|x| x.map(|x| H::hash(x)))
 			.unwrap_or_else(|| self.backend.storage_hash(key).expect(EXT_NOT_ALLOWED_TO_FAIL));
 
-		trace!(target: "state-trace", "{:04x}: Hash {}={:?}",
+		trace!(target: "storage", "{:04x}: Hash {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result,
@@ -193,7 +193,7 @@ where
 					.expect(EXT_NOT_ALLOWED_TO_FAIL)
 			);
 
-		trace!(target: "state-trace", "{:04x}: GetChild({}) {}={:?}",
+		trace!(target: "storage", "{:04x}: GetChild({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -217,7 +217,7 @@ where
 					.expect(EXT_NOT_ALLOWED_TO_FAIL)
 			);
 
-		trace!(target: "state-trace", "{:04x}: ChildHash({}) {}={:?}",
+		trace!(target: "storage", "{:04x}: ChildHash({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -234,7 +234,7 @@ where
 			_ => self.backend.exists_storage(key).expect(EXT_NOT_ALLOWED_TO_FAIL),
 		};
 
-		trace!(target: "state-trace", "{:04x}: Exists {}={:?}",
+		trace!(target: "storage", "{:04x}: Exists {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result,
@@ -257,7 +257,7 @@ where
 				.expect(EXT_NOT_ALLOWED_TO_FAIL),
 		};
 
-		trace!(target: "state-trace", "{:04x}: ChildExists({}) {}={:?}",
+		trace!(target: "storage", "{:04x}: ChildExists({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -309,7 +309,7 @@ where
 	}
 
 	fn place_storage(&mut self, key: StorageKey, value: Option<StorageValue>) {
-		trace!(target: "state-trace", "{:04x}: Put {}={:?}",
+		trace!(target: "storage", "{:04x}: Put {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			value.as_ref().map(HexDisplay::from)
@@ -330,7 +330,7 @@ where
 		key: StorageKey,
 		value: Option<StorageValue>,
 	) {
-		trace!(target: "state-trace", "{:04x}: PutChild({}) {}={:?}",
+		trace!(target: "storage", "{:04x}: PutChild({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -346,7 +346,7 @@ where
 		&mut self,
 		child_info: &ChildInfo,
 	) {
-		trace!(target: "state-trace", "{:04x}: KillChild({})",
+		trace!(target: "storage", "{:04x}: KillChild({})",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 		);
@@ -360,7 +360,7 @@ where
 	}
 
 	fn clear_prefix(&mut self, prefix: &[u8]) {
-		trace!(target: "state-trace", "{:04x}: ClearPrefix {}",
+		trace!(target: "storage", "{:04x}: ClearPrefix {}",
 			self.id,
 			HexDisplay::from(&prefix),
 		);
@@ -382,7 +382,7 @@ where
 		child_info: &ChildInfo,
 		prefix: &[u8],
 	) {
-		trace!(target: "state-trace", "{:04x}: ClearChildPrefix({}) {}",
+		trace!(target: "storage", "{:04x}: ClearChildPrefix({}) {}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&prefix),
@@ -403,7 +403,7 @@ where
 	fn storage_root(&mut self) -> Vec<u8> {
 		let _guard = sp_panic_handler::AbortGuard::force_abort();
 		if let Some(ref root) = self.storage_transaction_cache.transaction_storage_root {
-			trace!(target: "state-trace", "{:04x}: Root (cached) {}",
+			trace!(target: "storage", "{:04x}: Root (cached) {}",
 				self.id,
 				HexDisplay::from(&root.as_ref()),
 			);
@@ -411,7 +411,7 @@ where
 		}
 
 		let root = self.overlay.storage_root(self.backend, self.storage_transaction_cache);
-		trace!(target: "state-trace", "{:04x}: Root {}", self.id, HexDisplay::from(&root.as_ref()));
+		trace!(target: "storage", "{:04x}: Root {}", self.id, HexDisplay::from(&root.as_ref()));
 		root.encode()
 	}
 
@@ -429,7 +429,7 @@ where
 				.unwrap_or(
 					empty_child_trie_root::<Layout<H>>()
 				);
-			trace!(target: "state-trace", "{:04x}: ChildRoot({}) (cached) {}",
+			trace!(target: "storage", "{:04x}: ChildRoot({}) (cached) {}",
 				self.id,
 				HexDisplay::from(&storage_key),
 				HexDisplay::from(&root.as_ref()),
@@ -463,7 +463,7 @@ where
 					self.overlay.set_storage(prefixed_storage_key.into_inner(), Some(root.clone()));
 				}
 
-				trace!(target: "state-trace", "{:04x}: ChildRoot({}) {}",
+				trace!(target: "storage", "{:04x}: ChildRoot({}) {}",
 					self.id,
 					HexDisplay::from(&storage_key.as_ref()),
 					HexDisplay::from(&root.as_ref()),
@@ -477,7 +477,7 @@ where
 					.unwrap_or(
 						empty_child_trie_root::<Layout<H>>()
 					);
-				trace!(target: "state-trace", "{:04x}: ChildRoot({}) (no change) {}",
+				trace!(target: "storage", "{:04x}: ChildRoot({}) (no change) {}",
 					self.id,
 					HexDisplay::from(&storage_key.as_ref()),
 					HexDisplay::from(&root.as_ref()),
@@ -494,7 +494,7 @@ where
 			self.changes_trie_state.as_ref(),
 			Decode::decode(&mut &parent_hash[..]).map_err(|e|
 				trace!(
-					target: "state-trace",
+					target: "storage",
 					"Failed to decode changes root parent hash: {}",
 					e,
 				)
@@ -503,7 +503,7 @@ where
 			self.storage_transaction_cache,
 		);
 
-		trace!(target: "state-trace", "{:04x}: ChangesRoot({}) {:?}",
+		trace!(target: "storage", "{:04x}: ChangesRoot({}) {:?}",
 			self.id,
 			HexDisplay::from(&parent_hash),
 			root,

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -156,7 +156,7 @@ where
 		let _guard = sp_panic_handler::AbortGuard::force_abort();
 		let result = self.overlay.storage(key).map(|x| x.map(|x| x.to_vec())).unwrap_or_else(||
 			self.backend.storage(key).expect(EXT_NOT_ALLOWED_TO_FAIL));
-		trace!(target: "storage", "{:04x}: Get {}={:?}",
+		trace!(target: "state", "{:04x}: Get {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result.as_ref().map(HexDisplay::from)
@@ -171,7 +171,7 @@ where
 			.map(|x| x.map(|x| H::hash(x)))
 			.unwrap_or_else(|| self.backend.storage_hash(key).expect(EXT_NOT_ALLOWED_TO_FAIL));
 
-		trace!(target: "storage", "{:04x}: Hash {}={:?}",
+		trace!(target: "state", "{:04x}: Hash {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result,
@@ -193,7 +193,7 @@ where
 					.expect(EXT_NOT_ALLOWED_TO_FAIL)
 			);
 
-		trace!(target: "storage", "{:04x}: GetChild({}) {}={:?}",
+		trace!(target: "state", "{:04x}: GetChild({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -217,7 +217,7 @@ where
 					.expect(EXT_NOT_ALLOWED_TO_FAIL)
 			);
 
-		trace!(target: "storage", "{:04x}: ChildHash({}) {}={:?}",
+		trace!(target: "state", "{:04x}: ChildHash({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -234,7 +234,7 @@ where
 			_ => self.backend.exists_storage(key).expect(EXT_NOT_ALLOWED_TO_FAIL),
 		};
 
-		trace!(target: "storage", "{:04x}: Exists {}={:?}",
+		trace!(target: "state", "{:04x}: Exists {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			result,
@@ -257,7 +257,7 @@ where
 				.expect(EXT_NOT_ALLOWED_TO_FAIL),
 		};
 
-		trace!(target: "storage", "{:04x}: ChildExists({}) {}={:?}",
+		trace!(target: "state", "{:04x}: ChildExists({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -309,7 +309,7 @@ where
 	}
 
 	fn place_storage(&mut self, key: StorageKey, value: Option<StorageValue>) {
-		trace!(target: "storage", "{:04x}: Put {}={:?}",
+		trace!(target: "state", "{:04x}: Put {}={:?}",
 			self.id,
 			HexDisplay::from(&key),
 			value.as_ref().map(HexDisplay::from)
@@ -330,7 +330,7 @@ where
 		key: StorageKey,
 		value: Option<StorageValue>,
 	) {
-		trace!(target: "storage", "{:04x}: PutChild({}) {}={:?}",
+		trace!(target: "state", "{:04x}: PutChild({}) {}={:?}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&key),
@@ -346,7 +346,7 @@ where
 		&mut self,
 		child_info: &ChildInfo,
 	) {
-		trace!(target: "storage", "{:04x}: KillChild({})",
+		trace!(target: "state", "{:04x}: KillChild({})",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 		);
@@ -360,7 +360,7 @@ where
 	}
 
 	fn clear_prefix(&mut self, prefix: &[u8]) {
-		trace!(target: "storage", "{:04x}: ClearPrefix {}",
+		trace!(target: "state", "{:04x}: ClearPrefix {}",
 			self.id,
 			HexDisplay::from(&prefix),
 		);
@@ -382,7 +382,7 @@ where
 		child_info: &ChildInfo,
 		prefix: &[u8],
 	) {
-		trace!(target: "storage", "{:04x}: ClearChildPrefix({}) {}",
+		trace!(target: "state", "{:04x}: ClearChildPrefix({}) {}",
 			self.id,
 			HexDisplay::from(&child_info.storage_key()),
 			HexDisplay::from(&prefix),
@@ -403,7 +403,7 @@ where
 	fn storage_root(&mut self) -> Vec<u8> {
 		let _guard = sp_panic_handler::AbortGuard::force_abort();
 		if let Some(ref root) = self.storage_transaction_cache.transaction_storage_root {
-			trace!(target: "storage", "{:04x}: Root (cached) {}",
+			trace!(target: "state", "{:04x}: Root (cached) {}",
 				self.id,
 				HexDisplay::from(&root.as_ref()),
 			);
@@ -411,7 +411,7 @@ where
 		}
 
 		let root = self.overlay.storage_root(self.backend, self.storage_transaction_cache);
-		trace!(target: "storage", "{:04x}: Root {}", self.id, HexDisplay::from(&root.as_ref()));
+		trace!(target: "state", "{:04x}: Root {}", self.id, HexDisplay::from(&root.as_ref()));
 		root.encode()
 	}
 
@@ -429,7 +429,7 @@ where
 				.unwrap_or(
 					empty_child_trie_root::<Layout<H>>()
 				);
-			trace!(target: "storage", "{:04x}: ChildRoot({}) (cached) {}",
+			trace!(target: "state", "{:04x}: ChildRoot({}) (cached) {}",
 				self.id,
 				HexDisplay::from(&storage_key),
 				HexDisplay::from(&root.as_ref()),
@@ -463,7 +463,7 @@ where
 					self.overlay.set_storage(prefixed_storage_key.into_inner(), Some(root.clone()));
 				}
 
-				trace!(target: "storage", "{:04x}: ChildRoot({}) {}",
+				trace!(target: "state", "{:04x}: ChildRoot({}) {}",
 					self.id,
 					HexDisplay::from(&storage_key.as_ref()),
 					HexDisplay::from(&root.as_ref()),
@@ -477,7 +477,7 @@ where
 					.unwrap_or(
 						empty_child_trie_root::<Layout<H>>()
 					);
-				trace!(target: "storage", "{:04x}: ChildRoot({}) (no change) {}",
+				trace!(target: "state", "{:04x}: ChildRoot({}) (no change) {}",
 					self.id,
 					HexDisplay::from(&storage_key.as_ref()),
 					HexDisplay::from(&root.as_ref()),
@@ -503,7 +503,7 @@ where
 			self.storage_transaction_cache,
 		);
 
-		trace!(target: "storage", "{:04x}: ChangesRoot({}) {:?}",
+		trace!(target: "state", "{:04x}: ChangesRoot({}) {:?}",
 			self.id,
 			HexDisplay::from(&parent_hash),
 			root,

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -494,7 +494,7 @@ where
 			self.changes_trie_state.as_ref(),
 			Decode::decode(&mut &parent_hash[..]).map_err(|e|
 				trace!(
-					target: "storage",
+					target: "state",
 					"Failed to decode changes root parent hash: {}",
 					e,
 				)

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -301,7 +301,7 @@ impl<'a, B, H, N, Exec> StateMachine<'a, B, H, N, Exec> where
 
 		let id = ext.id;
 		trace!(
-			target: "storage", "{:04x}: Call {} at {:?}. Input={:?}",
+			target: "state", "{:04x}: Call {} at {:?}. Input={:?}",
 			id,
 			self.method,
 			self.backend,
@@ -318,7 +318,7 @@ impl<'a, B, H, N, Exec> StateMachine<'a, B, H, N, Exec> where
 		);
 
 		trace!(
-			target: "storage", "{:04x}: Return. Native={:?}, Result={:?}",
+			target: "state", "{:04x}: Return. Native={:?}, Result={:?}",
 			id,
 			was_native,
 			result,

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -301,7 +301,7 @@ impl<'a, B, H, N, Exec> StateMachine<'a, B, H, N, Exec> where
 
 		let id = ext.id;
 		trace!(
-			target: "state-trace", "{:04x}: Call {} at {:?}. Input={:?}",
+			target: "storage", "{:04x}: Call {} at {:?}. Input={:?}",
 			id,
 			self.method,
 			self.backend,
@@ -318,7 +318,7 @@ impl<'a, B, H, N, Exec> StateMachine<'a, B, H, N, Exec> where
 		);
 
 		trace!(
-			target: "state-trace", "{:04x}: Return. Native={:?}, Result={:?}",
+			target: "storage", "{:04x}: Return. Native={:?}, Result={:?}",
 			id,
 			was_native,
 			result,


### PR DESCRIPTION
- `-trace` suffix is redundant
- all methods are called "storage"