### PR TITLE
[ci] Increase check-gitlab-pipeline timeout

### DIFF
--- a/.maintain/github/check_gitlab_pipeline.sh
+++ b/.maintain/github/check_gitlab_pipeline.sh
@@ -11,7 +11,7 @@ fi
 echo "[+] Pipeline path: https://gitlab.parity.io/parity/substrate/pipelines/$PIPELINE_ID"
 
 # 130 minute job max
-for (( c=0; c < 130; c++ )); do
+for (( c=0; c < 180; c++ )); do
   out=$(curl -s "$SUBSTRATE_API_BASEURL/pipelines/$PIPELINE_ID" | jq -r .status)
   case $out in
     "success")


### PR DESCRIPTION
Current timeout for monitoring the tagged release pipeline is 130 minutes. Successful builds of this pipeline can sometimes take longer than that. Increase timeout to 3h.
ref https://github.com/paritytech/substrate/issues/5638