### PR TITLE
expose constants for identity pallet

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 244,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -560,6 +560,28 @@ mod weight_for {
 decl_module! {
 	// Simple declaration of the `Module` type. Lets the macro know what it's working on.
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		/// The amount held on deposit for a registered identity.
+		const BasicDeposit: BalanceOf<T> = T::BasicDeposit::get();
+
+		/// The amount held on deposit per additional field for a registered identity.
+		const FieldDeposit: BalanceOf<T> = T::FieldDeposit::get();
+
+		/// The amount held on deposit for a registered subaccount. This should account for the fact
+		/// that one storage item's value will increase by the size of an account ID, and there will be
+		/// another trie item whose value is the size of an account ID plus 32 bytes.
+		const SubAccountDeposit: BalanceOf<T> = T::SubAccountDeposit::get();
+
+		/// The maximum number of sub-accounts allowed per identified account.
+		const MaxSubAccounts: u32 = T::MaxSubAccounts::get();
+
+		/// Maximum number of additional fields that may be stored in an ID. Needed to bound the I/O
+		/// required to access an identity, but can be pretty high.
+		const MaxAdditionalFields: u32 = T::MaxAdditionalFields::get();
+
+		/// Maxmimum number of registrars allowed in the system. Needed to bound the complexity
+		/// of, e.g., updating judgements.
+		const MaxRegistrars: u32 = T::MaxRegistrars::get();
+
 		type Error = Error<T>;
 
 		fn deposit_event() = default;


### PR DESCRIPTION
Found they where missing while investing why my set_identity call failed.
