### PR TITLE
Add support for modules to require inherent to be present

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 244,
-	impl_version: 2,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -113,7 +113,7 @@ macro_rules! impl_outer_inherent {
 
 							if !found {
 								result.put_error(
-									&module::INHERENT_IDENTIFIER, &e
+									$module::INHERENT_IDENTIFIER, &e
 								).expect("There is only one fatal error; qed");
 								if e.is_fatal_error() {
 									return result
@@ -123,7 +123,7 @@ macro_rules! impl_outer_inherent {
 						Ok(None) => (),
 						Err(e) => {
 							result.put_error(
-								&module::INHERENT_IDENTIFIER, &e
+								$module::INHERENT_IDENTIFIER, &e
 							).expect("There is only one fatal error; qed");
 							if e.is_fatal_error() {
 								return result

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -77,7 +77,7 @@ macro_rules! impl_outer_inherent {
 				let mut result = $crate::inherent::CheckInherentsResult::new();
 				for xt in block.extrinsics() {
 					if $crate::inherent::Extrinsic::is_signed(xt).unwrap_or(false) {
-						break;
+						break
 					}
 
 					$(
@@ -88,7 +88,7 @@ macro_rules! impl_outer_inherent {
 										$module::INHERENT_IDENTIFIER, &e
 									).expect("There is only one fatal error; qed");
 									if e.is_fatal_error() {
-										return result;
+										return result
 									}
 								}
 							}
@@ -96,6 +96,30 @@ macro_rules! impl_outer_inherent {
 						}
 					)*
 				}
+
+				$(
+					if let Some(e) = $module::is_inherent_required(self) {
+						let found = block.extrinsics().any(|xt| {
+							if $crate::inherent::Extrinsic::is_signed(xt).unwrap_or(false) {
+								return false
+							}
+
+							match xt.function {
+								Call::$call(_) => true,
+								_ => false,
+							}
+						});
+
+						if !found {
+							result.put_error(
+								&module::INHERENT_IDENTIFIER, &e
+							).expect("There is only one fatal error; qed");
+							if e.is_fatal_error() {
+								return result
+							}
+						}
+					}
+				)*
 
 				result
 			}

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -100,7 +100,7 @@ macro_rules! impl_outer_inherent {
 				$(
 					match $module::is_inherent_required(self) {
 						Ok(Some(e)) => {
-							let found = block.extrinsics().any(|xt| {
+							let found = block.extrinsics().iter().any(|xt| {
 								if $crate::inherent::Extrinsic::is_signed(xt).unwrap_or(false) {
 									return false
 								}

--- a/primitives/inherents/src/lib.rs
+++ b/primitives/inherents/src/lib.rs
@@ -408,6 +408,10 @@ pub trait ProvideInherent {
 	/// Create an inherent out of the given `InherentData`.
 	fn create_inherent(data: &InherentData) -> Option<Self::Call>;
 
+	/// If `Some`, indicates that an inherent is required. Check will return the inner error if no
+	/// inherent is found.
+	fn is_inherent_required(_: &InherentData) -> Option<Self::Error> { None }
+
 	/// Check the given inherent if it is valid.
 	/// Checking the inherent is optional and can be omitted.
 	fn check_inherent(_: &Self::Call, _: &InherentData) -> Result<(), Self::Error> {

--- a/primitives/inherents/src/lib.rs
+++ b/primitives/inherents/src/lib.rs
@@ -409,8 +409,9 @@ pub trait ProvideInherent {
 	fn create_inherent(data: &InherentData) -> Option<Self::Call>;
 
 	/// If `Some`, indicates that an inherent is required. Check will return the inner error if no
-	/// inherent is found.
-	fn is_inherent_required(_: &InherentData) -> Option<Self::Error> { None }
+	/// inherent is found. If `Err`, indicates that the check failed and further operations should
+	/// be aborted.
+	fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> { Ok(None) }
 
 	/// Check the given inherent if it is valid.
 	/// Checking the inherent is optional and can be omitted.


### PR DESCRIPTION
This adds an additional function `is_inherent_required` to `ProvideInherent` trait. If a module implement this, it indicates that based on its interpretation of `InherentData`, an inherent of this module call type must be present in the current block.

This is particularly useful for pallets like `anyupgrade` for deliberate runtime hard forks. In those cases, the `InherentData` checks for block numbers, and if the block number is the current block, it requires an inherent to be present so that the hard fork code can be enacted.