### PR TITLE
delete duplicates runtime-benchmarks

### DIFF
--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -153,7 +153,6 @@ runtime-benchmarks = [
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
-	"pallet-collective/runtime-benchmarks",
 	"pallet-offences-benchmarking",
 	"pallet-session-benchmarking",
 ]


### PR DESCRIPTION
Delete duplicates runtime-benchmarks.
`"pallet-collective/runtime-benchmarks"` is duplicates in runtime-benchmarks.
