### PR TITLE
Remove background_tasks field in ServiceBuilder

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -665,7 +665,7 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 		)?;
 
 		if let Some(background_task) = background_task{
-			self.background_tasks.push(("txpool-background", background_task));
+			self.task_manager.spawn_handle().spawn("txpool-background", background_task);
 		}
 
 		Ok(ServiceBuilder {
@@ -946,12 +946,6 @@ ServiceBuilder<
 		};
 
 		let spawn_handle = task_manager.spawn_handle();
-
-		// Spawn background tasks which were stacked during the
-		// service building.
-		for (title, background_task) in background_tasks {
-			spawn_handle.spawn(title, background_task);
-		}
 
 		{
 			// block notifications

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -96,7 +96,6 @@ pub struct ServiceBuilder<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp,
 	rpc_extensions: TRpc,
 	remote_backend: Option<Arc<dyn RemoteBlockchain<TBl>>>,
 	marker: PhantomData<(TBl, TRtApi)>,
-	background_tasks: Vec<(&'static str, BackgroundTask)>,
 	block_announce_validator_builder: Option<Box<dyn FnOnce(Arc<TCl>) -> Box<dyn BlockAnnounceValidator<TBl> + Send> + Send>>,
 }
 
@@ -311,7 +310,6 @@ impl ServiceBuilder<(), (), (), (), (), (), (), (), (), (), ()> {
 			transaction_pool: Arc::new(()),
 			rpc_extensions: Default::default(),
 			remote_backend: None,
-			background_tasks: Default::default(),
 			block_announce_validator_builder: None,
 			marker: PhantomData,
 		})
@@ -395,7 +393,6 @@ impl ServiceBuilder<(), (), (), (), (), (), (), (), (), (), ()> {
 			transaction_pool: Arc::new(()),
 			rpc_extensions: Default::default(),
 			remote_backend: Some(remote_blockchain),
-			background_tasks: Default::default(),
 			block_announce_validator_builder: None,
 			marker: PhantomData,
 		})
@@ -469,7 +466,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -514,7 +510,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -553,7 +548,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -618,7 +612,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -682,7 +675,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: Arc::new(transaction_pool),
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -711,7 +703,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: self.block_announce_validator_builder,
 			marker: self.marker,
 		})
@@ -740,7 +731,6 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 			transaction_pool: self.transaction_pool,
 			rpc_extensions: self.rpc_extensions,
 			remote_backend: self.remote_backend,
-			background_tasks: self.background_tasks,
 			block_announce_validator_builder: Some(Box::new(block_announce_validator_builder)),
 			marker: self.marker,
 		})
@@ -852,7 +842,6 @@ ServiceBuilder<
 			transaction_pool,
 			rpc_extensions,
 			remote_backend,
-			background_tasks,
 			block_announce_validator_builder,
 		} = self;
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -647,7 +647,7 @@ impl<TBl, TRtApi, TCl, TFchr, TSc, TImpQu, TFprb, TFpp, TExPool, TRpc, Backend>
 
 	/// Defines which transaction pool to use.
 	pub fn with_transaction_pool<UExPool>(
-		mut self,
+		self,
 		transaction_pool_builder: impl FnOnce(
 			sc_transaction_pool::txpool::Options,
 			Arc<TCl>,


### PR DESCRIPTION
This PR removes the field `background_tasks` in the ServiceBuilder.

Instead of adding those tasks to a Vector and then spawning the tasks that are in the vector, we now directly spawn those tasks without adding them to the vector.
The field we're removing in this PR is the vector that is now useless.