### PR TITLE
add missing features for runtime-benchmarks

### DIFF
--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -39,7 +39,10 @@ std = [
 	"sp-runtime/std",
 	"sp-version/std",
 ]
-runtime-benchmarks = ["sp-runtime/runtime-benchmarks"]
+runtime-benchmarks = [
+	"sp-runtime/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
`cd frame/democracy/src && cargo test --features runtime-benchmarks` wasn't working