### PR TITLE
Avoid changing overlay committed layer.

### DIFF
--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -262,7 +262,7 @@ impl Externalities for BasicExternalities {
 		key: Vec<u8>,
 		value: Vec<u8>,
 	) {
-		let previous = self.inner.top.entry(key).or_insert_with(Default::default);
+		let previous = self.inner.top.entry(key).or_default();
 		crate::ext::append_to_storage(previous, value).expect("Failed to append to storage");
 	}
 

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -262,9 +262,8 @@ impl Externalities for BasicExternalities {
 		key: Vec<u8>,
 		value: Vec<u8>,
 	) {
-		let previous = self.storage(&key).unwrap_or_default();
-		let new = crate::ext::append_to_storage(previous, value).expect("Failed to append to storage");
-		self.place_storage(key.clone(), Some(new));
+		let previous = self.inner.top.entry(key).or_insert_with(Default::default);
+		crate::ext::append_to_storage(previous, value).expect("Failed to append to storage");
 	}
 
 	fn chain_id(&self) -> u64 { 42 }

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1127,28 +1127,6 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic]
-	fn append_on_standard_value_panic() {
-		let key = b"key".to_vec();
-		let mut state = new_in_mem::<BlakeTwo256>();
-		let backend = state.as_trie_backend().unwrap();
-		let mut overlay = OverlayedChanges::default();
-		let mut offchain_overlay = OffchainOverlayedChanges::default();
-		let mut cache = StorageTransactionCache::default();
-		let mut ext = Ext::new(
-			&mut overlay,
-			&mut offchain_overlay,
-			&mut cache,
-			backend,
-			changes_trie::disabled_state::<_, u64>(),
-			None,
-		);
-
-		ext.set_storage(key.clone(), b"existing".to_vec().encode());
-		ext.storage_append(key.clone(), b"Item".to_vec().encode());
-	}
-
-	#[test]
 	fn remove_then_append() {
 		let key = b"key".to_vec();
 		let mut state = new_in_mem::<BlakeTwo256>();

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1126,8 +1126,8 @@ mod tests {
 		}
 	}
 
-	#[should_panic]
 	#[test]
+	#[should_panic]
 	fn append_on_standard_value_panic() {
 		let key = b"key".to_vec();
 		let mut state = new_in_mem::<BlakeTwo256>();
@@ -1146,10 +1146,6 @@ mod tests {
 
 		ext.set_storage(key.clone(), b"existing".to_vec().encode());
 		ext.storage_append(key.clone(), b"Item".to_vec().encode());
-		assert_eq!(
-			ext.storage(key.as_slice()),
-			Some(vec![b"existing".to_vec(), b"Item".to_vec()].encode()),
-		);
 	}
 
 	#[test]

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1061,6 +1061,44 @@ mod tests {
 	}
 
 	#[test]
+	fn append_storage_works() {
+		let reference_data = vec![
+			b"data1".to_vec(),
+			b"2".to_vec(),
+			b"D3".to_vec(),
+			b"d4".to_vec(),
+		];
+		let key = b"key".to_vec();
+		let mut state = new_in_mem::<BlakeTwo256>();
+		let backend = state.as_trie_backend().unwrap();
+		let mut overlay = OverlayedChanges::default();
+		let mut offchain_overlay = OffchainOverlayedChanges::default();
+		let mut cache = StorageTransactionCache::default();
+		let mut ext = Ext::new(
+			&mut overlay,
+			&mut offchain_overlay,
+			&mut cache,
+			backend,
+			changes_trie::disabled_state::<_, u64>(),
+			None,
+		);
+
+		ext.storage_append(key.clone(), reference_data[0].encode());
+		assert_eq!(
+			ext.storage(key.as_slice()),
+			Some(vec![reference_data[0].clone()].encode()),
+		);
+		for i in reference_data.iter().skip(1) {
+			ext.storage_append(key.clone(), i.encode());
+		}
+		assert_eq!(
+			ext.storage(key.as_slice()),
+			Some(reference_data.encode()),
+		);
+	}
+
+
+	#[test]
 	fn prove_read_and_proof_check_works() {
 		let child_info = ChildInfo::new_default(b"sub1");
 		let child_info = &child_info;

--- a/primitives/state-machine/src/overlayed_changes.rs
+++ b/primitives/state-machine/src/overlayed_changes.rs
@@ -228,6 +228,7 @@ impl OverlayedChanges {
 	/// the value.
 	/// Warning this function register a change, so the mutable reference MUST be modified.
 	#[must_use = "A change was registered, so this value MUST be modified."]
+	#[must_use = "A change was registered, so this value MUST be modified."]
 	pub fn value_mut_or_insert_with(
 		&mut self,
 		key: &[u8],

--- a/primitives/state-machine/src/overlayed_changes.rs
+++ b/primitives/state-machine/src/overlayed_changes.rs
@@ -223,11 +223,28 @@ impl OverlayedChanges {
 			})
 	}
 
-	/// Returns mutable reference to either commited or propsective value.
-	pub fn value_mut(&mut self, key: &[u8]) -> Option<&mut Option<StorageValue>> {
-		// not using map because of double borrow inside closure
-		if let Some(entry) = self.prospective.top.get_mut(key) { return Some(&mut entry.value) }
-		return self.committed.top.get_mut(key).map(|entry| &mut entry.value);
+	/// Returns mutable reference to current changed value (prospective).
+	/// If there is no value in the overlay, the default callback is used to initiate
+	/// the value.
+	/// Warning this function register a change, so the mutable reference MUST be modified.
+	pub fn value_mut_or_insert_with(
+		&mut self,
+		key: &[u8],
+		init: impl Fn() -> StorageValue,
+	) -> &mut StorageValue {
+		let extrinsic_index = self.extrinsic_index();
+		let committed = &self.committed.top;
+		let entry = self.prospective.top.entry(key.to_vec())
+			.or_insert_with(|| committed.get(key).cloned().unwrap_or_default());
+		// we update change
+		if let Some(extrinsic) = extrinsic_index {
+			entry.extrinsics.get_or_insert_with(Default::default)
+				.insert(extrinsic);
+		}
+		if entry.value.is_none() {
+			entry.value = Some(init());
+		}
+		entry.value.as_mut().expect("Initialized above; qed")
 	}
 
 	/// Returns a double-Option: None if the key is unknown (i.e. and the query should be referred

--- a/primitives/state-machine/src/overlayed_changes.rs
+++ b/primitives/state-machine/src/overlayed_changes.rs
@@ -227,6 +227,7 @@ impl OverlayedChanges {
 	/// If there is no value in the overlay, the default callback is used to initiate
 	/// the value.
 	/// Warning this function register a change, so the mutable reference MUST be modified.
+	#[must_use = "A change was registered, so this value MUST be modified."]
 	pub fn value_mut_or_insert_with(
 		&mut self,
 		key: &[u8],
@@ -240,9 +241,7 @@ impl OverlayedChanges {
 				if let Some(overlay_state) = committed.get(key).cloned() {
 					overlay_state
 				} else {
-					let mut new_state = OverlayedValue::default();
-					new_state.value = Some(init());
-					new_state
+					OverlayedValue { value: Some(init()), ..Default::default() }
 				}
 			});
 

--- a/primitives/state-machine/src/overlayed_changes.rs
+++ b/primitives/state-machine/src/overlayed_changes.rs
@@ -228,7 +228,6 @@ impl OverlayedChanges {
 	/// the value.
 	/// Warning this function register a change, so the mutable reference MUST be modified.
 	#[must_use = "A change was registered, so this value MUST be modified."]
-	#[must_use = "A change was registered, so this value MUST be modified."]
 	pub fn value_mut_or_insert_with(
 		&mut self,
 		key: &[u8],


### PR DESCRIPTION
This PR changes the recent host append function to avoid removing content from committed layer (take on value_mut).
This is therefore consensus breaking from the previous implementation, but seems unavoidable to me (otherwhise fail extrinsic will clear previously committed data).

It also remove a copy and map access by appending on mutable pointer.
This lack testing but it seems rather important to me to have eyes on it sooner.

Note, that a safer implementation could just be to replace previous value_mut function by a 'storage' call and use memory copy to start.