### PR TITLE
Update docs for BeforeBestBlockBy

### DIFF
--- a/client/finality-grandpa/src/voting_rule.rs
+++ b/client/finality-grandpa/src/voting_rule.rs
@@ -68,7 +68,8 @@ impl<Block, B> VotingRule<Block, B> for () where
 }
 
 /// A custom voting rule that guarantees that our vote is always behind the best
-/// block, in the best case exactly one block behind it.
+/// block by at least N blocks. In the best case our vote is exactly N blocks
+/// behind the best block.
 #[derive(Clone)]
 pub struct BeforeBestBlockBy<N>(N);
 impl<Block, B> VotingRule<Block, B> for BeforeBestBlockBy<NumberFor<Block>> where


### PR DESCRIPTION
Corrects the docs for `sc_finality_grandpa::voting_rule::BeforeBestBlockBy`. The docs previously stated that the voting would lag behind the best block by exactly 1 block, but in reality the voting rule is parametric in the number of blocks to lag by.