### PR TITLE
Use header cache when creating state.

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1590,10 +1590,15 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 			_ => {}
 		}
 
-		match self.blockchain.header(block) {
-			Ok(Some(ref hdr)) => {
-				let hash = hdr.hash();
-				if !self.have_state_at(&hash, *hdr.number()) {
+		let hash = match block {
+			BlockId::Hash(h) => h,
+			BlockId::Number(n) => self.blockchain.hash(n)?.ok_or_else(||
+				sp_blockchain::Error::UnknownBlock(format!("Unknown block number {}", n)))?,
+		};
+
+		match self.blockchain.header_metadata(hash) {
+			Ok(ref hdr) => {
+				if !self.have_state_at(&hash, hdr.number) {
 					return Err(
 						sp_blockchain::Error::UnknownBlock(
 							format!("State already discarded for {:?}", block)
@@ -1601,8 +1606,8 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 					)
 				}
 				if let Ok(()) = self.storage.state_db.pin(&hash) {
-					let root = hdr.state_root();
-					let db_state = DbState::<Block>::new(self.storage.clone(), *root);
+					let root = hdr.state_root;
+					let db_state = DbState::<Block>::new(self.storage.clone(), root);
 					let state = RefTrackingState::new(
 						db_state,
 						self.storage.clone(),
@@ -1627,22 +1632,17 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 					)
 				}
 			},
-			Ok(None) => Err(
-				sp_blockchain::Error::UnknownBlock(
-					format!("Unknown state for block {:?}", block)
-				)
-			),
 			Err(e) => Err(e),
 		}
 	}
 
 	fn have_state_at(&self, hash: &Block::Hash, number: NumberFor<Block>) -> bool {
 		if self.is_archive {
-			match self.blockchain.header(BlockId::Hash(hash.clone())) {
-				Ok(Some(header)) => {
+			match self.blockchain.header_metadata(hash.clone()) {
+				Ok(header) => {
 					sp_state_machine::Storage::get(
 						self.storage.as_ref(),
-						&header.state_root(),
+						&header.state_root,
 						(&[], None),
 					).unwrap_or(None).is_some()
 				},

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1593,7 +1593,8 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		let hash = match block {
 			BlockId::Hash(h) => h,
 			BlockId::Number(n) => self.blockchain.hash(n)?.ok_or_else(||
-				sp_blockchain::Error::UnknownBlock(format!("Unknown block number {}", n)))?,
+				sp_blockchain::Error::UnknownBlock(format!("Unknown block number {}", n))
+			)?,
 		};
 
 		match self.blockchain.header_metadata(hash) {

--- a/client/service/src/client/mod.rs
+++ b/client/service/src/client/mod.rs
@@ -50,5 +50,8 @@ mod block_rules;
 
 pub use self::{
 	call_executor::LocalCallExecutor,
-	client::{new_with_backend, new_in_mem, Client, ClientConfig},
+	client::{Client, ClientConfig},
 };
+
+#[cfg(feature="test-helpers")]
+pub use self::client::{new_with_backend, new_in_mem};

--- a/primitives/blockchain/src/header_metadata.rs
+++ b/primitives/blockchain/src/header_metadata.rs
@@ -265,6 +265,8 @@ pub struct CachedHeaderMetadata<Block: BlockT> {
 	pub number: NumberFor<Block>,
 	/// Hash of parent header.
 	pub parent: Block::Hash,
+	/// Block state root.
+	pub state_root: Block::Hash,
 	/// Hash of an ancestor header. Used to jump through the tree.
 	ancestor: Block::Hash,
 }
@@ -275,6 +277,7 @@ impl<Block: BlockT> From<&Block::Header> for CachedHeaderMetadata<Block> {
 			hash: header.hash().clone(),
 			number: header.number().clone(),
 			parent: header.parent_hash().clone(),
+			state_root: header.state_root().clone(),
 			ancestor: header.parent_hash().clone(),
 		}
 	}


### PR DESCRIPTION
Currently each runtime call makes a header query to the database for the state root. This PR adds `state_root` to the header metadata cache so that it can be used for creating state objects.

Also fixed warnings in `client/service/client`