### PR TITLE
`node-bench` no-op block import

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -123,16 +123,19 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
-	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
+	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
+	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	/// This probably should not be changed unless you have specific
 	/// disk i/o conditions for the node.
 	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 25_000_000, // ~25 µs
-		write: 100_000_000, // ~100 µs
+		read: 25_000_000, // ~25 µs @ 200,000 items
+		write: 100_000_000, // ~100 µs @ 200,000 items
 	};
+	/// Importing a block with 0 txs takes ~5 ms
+	pub const BlockExecutionWeight: Weight = 5_000_000_000;
 }
 
 impl system::Trait for Runtime {
@@ -164,7 +167,7 @@ impl system::Trait for Runtime {
 	type DbWeight = DbWeight;
 	/// The weight of the overhead invoked on the block import process, independent of the
 	/// extrinsics included in that block.
-	type BlockExecutionWeight = ();
+	type BlockExecutionWeight = BlockExecutionWeight;
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -66,7 +66,7 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 
 		match self.block_type {
 			BlockType::RandomTransfers(_) => path.push("transfer"),
-			BlockType::RandomTransfersReaping(_) => path.push("transfer_reaping"),
+			BlockType::RandomTransfersReaping(_) => path.push("reaping_transfer"),
 			BlockType::Noop(_) => path.push("noop"),
 		}
 

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -37,6 +37,36 @@ use sp_runtime::generic::BlockId;
 
 use crate::core::{self, Path, Mode};
 
+#[derive(Clone, Copy, Debug, derive_more::Display)]
+pub enum SizeType {
+	#[display(fmt = "empty")]
+	Empty,
+	#[display(fmt = "small")]
+	Small,
+	#[display(fmt = "medium")]
+	Medium,
+	#[display(fmt = "large")]
+	Large,
+	#[display(fmt = "full")]
+	Full,
+	#[display(fmt = "custom")]
+	Custom,
+}
+
+impl SizeType {
+	fn transactions(&self) -> usize {
+		match self {
+			SizeType::Empty => 0,
+			SizeType::Small => 10,
+			SizeType::Medium => 100,
+			SizeType::Large => 500,
+			SizeType::Full => 4000,
+			// Custom SizeType will use the `--transactions` input parameter
+			SizeType::Custom => 0,
+		}
+	}
+}
+
 pub struct ImportBenchmarkDescription {
 	pub profile: Profile,
 	pub key_types: KeyTypes,
@@ -47,6 +77,7 @@ pub struct ImportBenchmark {
 	profile: Profile,
 	database: BenchDb,
 	block: Block,
+	size: SizeType,
 }
 
 impl core::BenchmarkDescription for ImportBenchmarkDescription {
@@ -63,6 +94,8 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 			KeyTypes::Sr25519 => path.push("sr25519"),
 			KeyTypes::Ed25519 => path.push("ed25519"),
 		}
+
+		path.push(&format!("{}", self.size));
 
 		match self.block_type {
 			BlockType::RandomTransfers(_) => path.push("transfer"),

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -54,7 +54,7 @@ pub enum SizeType {
 }
 
 impl SizeType {
-	fn transactions(&self) -> usize {
+	pub fn transactions(&self) -> usize {
 		match self {
 			SizeType::Empty => 0,
 			SizeType::Small => 10,
@@ -71,13 +71,13 @@ pub struct ImportBenchmarkDescription {
 	pub profile: Profile,
 	pub key_types: KeyTypes,
 	pub block_type: BlockType,
+	pub size: SizeType,
 }
 
 pub struct ImportBenchmark {
 	profile: Profile,
 	database: BenchDb,
 	block: Block,
-	size: SizeType,
 }
 
 impl core::BenchmarkDescription for ImportBenchmarkDescription {

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -96,8 +96,8 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 		}
 
 		match self.block_type {
-			BlockType::RandomTransfers(_) => path.push("transfer"),
-			BlockType::RandomTransfersReaping(_) => path.push("reaping_transfer"),
+			BlockType::RandomTransfersKeepAlive(_) => path.push("transfer_keep_alive"),
+			BlockType::RandomTransfersReaping(_) => path.push("transfer_reaping"),
 			BlockType::Noop(_) => path.push("noop"),
 		}
 

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -95,13 +95,13 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 			KeyTypes::Ed25519 => path.push("ed25519"),
 		}
 
-		path.push(&format!("{}", self.size));
-
 		match self.block_type {
 			BlockType::RandomTransfers(_) => path.push("transfer"),
 			BlockType::RandomTransfersReaping(_) => path.push("reaping_transfer"),
 			BlockType::Noop(_) => path.push("noop"),
 		}
+
+		path.push(&format!("{}", self.size));
 
 		path
 	}

--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -67,6 +67,7 @@ pub struct ImportBenchmarkDescription {
 	pub profile: Profile,
 	pub key_types: KeyTypes,
 	pub size: SizeType,
+	pub block_type: BlockType,
 }
 
 pub struct ImportBenchmark {
@@ -91,6 +92,12 @@ impl core::BenchmarkDescription for ImportBenchmarkDescription {
 		}
 
 		path.push(&format!("{}", self.size));
+
+		match self.block_type {
+			BlockType::RandomTransfers(_) => path.push("transfer"),
+			BlockType::RandomTransfersReaping(_) => path.push("transfer_reaping"),
+			BlockType::Noop(_) => path.push("noop"),
+		}
 
 		path
 	}

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -83,6 +83,12 @@ fn main() {
 			ImportBenchmarkDescription {
 				profile: *profile,
 				key_types: KeyTypes::Sr25519,
+				block_type: BlockType::RandomTransfersReaping(txs),
+			},
+		profile in [Profile::Wasm, Profile::Native].iter() =>
+			ImportBenchmarkDescription {
+				profile: *profile,
+				key_types: KeyTypes::Sr25519,
 				block_type: BlockType::Noop(txs),
 			},
 		(size, db_type) in

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -86,8 +86,9 @@ fn main() {
 				_ => size.transactions()
 			};
 			for block_type in [
-				BlockType::RandomTransfers(txs),
-				BlockType::Noop(txs)
+				BlockType::RandomTransfersKeepAlive(txs),
+				BlockType::RandomTransfersReaping(txs),
+				BlockType::Noop(txs),
 			].iter() {
 				import_benchmarks.push((profile.clone(), size.clone(), block_type.clone()));
 			}

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -26,7 +26,7 @@ use crate::core::{run_benchmark, Mode as BenchmarkMode};
 use crate::tempdb::DatabaseType;
 use import::{ImportBenchmarkDescription, SizeType};
 use trie::{TrieReadBenchmarkDescription, TrieWriteBenchmarkDescription, DatabaseSize};
-use node_testing::bench::{Profile, KeyTypes};
+use node_testing::bench::{Profile, KeyTypes, BlockType};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -51,7 +51,7 @@ struct Opt {
 
 	/// Mode
 	///
-	/// "regular" for regular becnhmark
+	/// "regular" for regular benchmark
 	///
 	/// "profile" mode adds pauses between measurable runs,
 	/// so that actual interval can be selected in the profiler of choice.
@@ -72,32 +72,38 @@ fn main() {
 				profile: *profile,
 				key_types: KeyTypes::Sr25519,
 				size: SizeType::Medium,
+				block_type: BlockType::RandomTransfers(0),
 			},
 		ImportBenchmarkDescription {
 			profile: Profile::Wasm,
 			key_types: KeyTypes::Sr25519,
 			size: SizeType::Empty,
+			block_type: BlockType::RandomTransfers(0),
 		},
 		ImportBenchmarkDescription {
 			profile: Profile::Native,
 			key_types: KeyTypes::Ed25519,
 			size: SizeType::Medium,
+			block_type: BlockType::RandomTransfers(0),
 		},
 		ImportBenchmarkDescription {
 			profile: Profile::Wasm,
 			key_types: KeyTypes::Sr25519,
 			size: SizeType::Full,
+			block_type: BlockType::RandomTransfers(0),
 		},
 		ImportBenchmarkDescription {
 			profile: Profile::Native,
 			key_types: KeyTypes::Sr25519,
 			size: SizeType::Full,
+			block_type: BlockType::RandomTransfers(0),
 		},
 		size in [SizeType::Small, SizeType::Large].iter() =>
 			ImportBenchmarkDescription {
 				profile: Profile::Native,
 				key_types: KeyTypes::Sr25519,
 				size: *size,
+				block_type: BlockType::RandomTransfers(0),
 			},
 		(size, db_type) in
 			[

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -95,8 +95,8 @@ fn main() {
 	}
 
 	let benchmarks = matrix!(
-		(profile, size, block_type) in import_benchmarks.iter()
-			=> ImportBenchmarkDescription {
+		(profile, size, block_type) in import_benchmarks.iter() =>
+			ImportBenchmarkDescription {
 				profile: *profile,
 				key_types: KeyTypes::Sr25519,
 				size: *size,

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -49,7 +49,7 @@ struct Opt {
 	/// Run with `--list` for the hint of what to filter.
 	filter: Option<String>,
 
-	/// Number of transactions to place inside of a block for block import.
+	/// Number of transactions for block import with `custom` size.
 	#[structopt(long)]
 	transactions: Option<usize>,
 

--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -49,7 +49,7 @@ struct Opt {
 	/// Run with `--list` for the hint of what to filter.
 	filter: Option<String>,
 
-	/// Number of transactions to run
+	/// Number of transactions to place inside of a block for block import.
 	#[structopt(long)]
 	txs: Option<usize>,
 

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -230,7 +230,7 @@ fn submitted_transaction_should_be_valid() {
 		let res = Executive::validate_transaction(source, extrinsic);
 
 		assert_eq!(res.unwrap(), ValidTransaction {
-			priority: 1_410_625_000_000,
+			priority: 1_410_740_000_000,
 			requires: vec![],
 			provides: vec![(address, 0).encode()],
 			longevity: 128,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -120,14 +120,17 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
-	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
+	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
+	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 25_000_000, // ~25 µs
-		write: 100_000_000, // ~100 µs
+		read: 25_000_000, // ~25 µs @ 200,000 items
+		write: 100_000_000, // ~100 µs @ 200,000 items
 	};
+	/// Importing a block with 0 txs takes ~5 ms
+	pub const BlockExecutionWeight: Weight = 5_000_000_000;
 }
 
 impl frame_system::Trait for Runtime {
@@ -144,7 +147,7 @@ impl frame_system::Trait for Runtime {
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type DbWeight = DbWeight;
-	type BlockExecutionWeight = ();
+	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -56,6 +56,7 @@ use sp_inherents::{InherentData, CheckInherentsResult};
 pub use sp_runtime::BuildStorage;
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
+ pub use frame_system::Call as SystemCall;
 pub use pallet_contracts::Gas;
 pub use frame_support::StorageValue;
 pub use pallet_staking::StakerStatus;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -56,7 +56,7 @@ use sp_inherents::{InherentData, CheckInherentsResult};
 pub use sp_runtime::BuildStorage;
 pub use pallet_timestamp::Call as TimestampCall;
 pub use pallet_balances::Call as BalancesCall;
- pub use frame_system::Call as SystemCall;
+pub use frame_system::Call as SystemCall;
 pub use pallet_contracts::Gas;
 pub use frame_support::StorageValue;
 pub use pallet_staking::StakerStatus;

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -303,7 +303,9 @@ impl BenchDb {
 							Call::Balances(
 								BalancesCall::transfer(
 									pallet_indices::address::Address::Id(receiver),
-									100*DOLLARS - node_runtime::ExistentialDeposit::get() - 1,
+									// Transfer so that ending balance would be 1 less than existential deposit
+									// so that we kill the sender account.
+									100*DOLLARS - (node_runtime::ExistentialDeposit::get() - 1),
 								)
 							)
 						},

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -43,6 +43,7 @@ use node_runtime::{
 	constants::currency::DOLLARS,
 	UncheckedExtrinsic,
 	MinimumPeriod,
+	SystemCall,
 	BalancesCall,
 	AccountId,
 	Signature,
@@ -132,13 +133,15 @@ pub enum BlockType {
 	RandomTransfers(usize),
 	/// Bunch of random transfers that drain all of the source balance.
 	RandomTransfersReaping(usize),
+	/// Bunch of "no-op" calls.
+	Noop(usize),
 }
 
 impl BlockType {
 	/// Number of transactions for this block type.
 	pub fn transactions(&self) -> usize {
 		match self {
-			Self::RandomTransfers(v) | Self::RandomTransfersReaping(v) => *v,
+			Self::RandomTransfers(v) | Self::RandomTransfersReaping(v) | Self::Noop(v) => *v,
 		}
 	}
 }
@@ -287,15 +290,29 @@ impl BenchDb {
 			let signed = self.keyring.sign(
 				CheckedExtrinsic {
 					signed: Some((sender, signed_extra(0, node_runtime::ExistentialDeposit::get() + 1))),
-					function: Call::Balances(
-						BalancesCall::transfer(
-							pallet_indices::address::Address::Id(receiver),
-							match block_type {
-								BlockType::RandomTransfers(_) => node_runtime::ExistentialDeposit::get() + 1,
-								BlockType::RandomTransfersReaping(_) => 100*DOLLARS - node_runtime::ExistentialDeposit::get() - 1,
-							}
-						)
-					),
+					function: match block_type {
+						BlockType::RandomTransfers(_) => {
+							Call::Balances(
+								BalancesCall::transfer(
+									pallet_indices::address::Address::Id(receiver),
+									node_runtime::ExistentialDeposit::get() + 1,
+								)
+							)
+						},
+						BlockType::RandomTransfersReaping(_) => {
+							Call::Balances(
+								BalancesCall::transfer(
+									pallet_indices::address::Address::Id(receiver),
+									100*DOLLARS - node_runtime::ExistentialDeposit::get() - 1,
+								)
+							)
+						},
+						BlockType::Noop(_) => {
+							Call::System(
+								SystemCall::remark(Vec::new())
+							)
+						},
+					},
 				},
 				version,
 				genesis_hash,

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -130,7 +130,7 @@ impl Clone for BenchDb {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum BlockType {
 	/// Bunch of random transfers.
-	RandomTransfers(usize),
+	RandomTransfersKeepAlive(usize),
 	/// Bunch of random transfers that drain all of the source balance.
 	RandomTransfersReaping(usize),
 	/// Bunch of "no-op" calls.
@@ -141,7 +141,7 @@ impl BlockType {
 	/// Number of transactions for this block type.
 	pub fn transactions(&self) -> usize {
 		match self {
-			Self::RandomTransfers(v) | Self::RandomTransfersReaping(v) | Self::Noop(v) => *v,
+			Self::RandomTransfersKeepAlive(v) | Self::RandomTransfersReaping(v) | Self::Noop(v) => *v,
 		}
 	}
 }
@@ -291,9 +291,9 @@ impl BenchDb {
 				CheckedExtrinsic {
 					signed: Some((sender, signed_extra(0, node_runtime::ExistentialDeposit::get() + 1))),
 					function: match block_type {
-						BlockType::RandomTransfers(_) => {
+						BlockType::RandomTransfersKeepAlive(_) => {
 							Call::Balances(
-								BalancesCall::transfer(
+								BalancesCall::transfer_keep_alive(
 									pallet_indices::address::Address::Id(receiver),
 									node_runtime::ExistentialDeposit::get() + 1,
 								)


### PR DESCRIPTION
This PR introduces a no-op variant of the block import benchmark.

This also introduces a `SizeType::Custom` variant which allows the user to input a custom number of transactions to try and place into a block through a `--transactions` input parameter.

Results using this branch on our i7 machine:

## Base Extrinsic Weight

```
cargo run --release -p node-bench -- ::node::import::wasm::sr25519::noop::custom --transactions 10000
```

```
2020-05-01 20:37:37 imported block with 10001 tx, took: 1.241417064s
2020-05-01 20:37:37 usage info: caches: (3.67 MiB state, 0 bytes db overlay), state db: (168 bytes non-canonical, 0 bytes pruning, 44 bytes pinned), i/o: (0 tx, 0 write, 0 read, 0 avg tx, 40001/50033 key cache reads/total, 18897 trie nodes writes)
2020-05-01 20:37:37 Import benchmark (Noop(10000), Wasm): avg 1.26 s, w_avg 1.26 s
```

So 1 no-op tx has an overhead of ~125 microseconds.

## Block Construction Weight

```
cargo run --release -p node-bench -- ::node::import::wasm::sr25519::noop::empty
```

```
2020-05-01 21:52:49 imported block with 1 tx, took: 4.95538ms
2020-05-01 21:52:49 usage info: caches: (1.85 MiB state, 0 bytes db overlay), state db: (168 bytes non-canonical, 0 bytes pruning, 44 bytes pinned), i/o: (0 tx, 0 write, 0 read, 0 avg tx, 2/31 key cache reads/total, 22 trie nodes writes)
2020-05-01 21:52:49 Import benchmark (Noop(0), Wasm): avg 4.980714 ms, w_avg 4.978451 ms
```

So an empty block has an overhead of ~5ms

## Full Block

Base weights have been updated to reflect these benchmarks.

The new full block contains 4530 txs

```
2020-05-01 23:03:29 imported block with 4530 tx, took: 873.44117ms
2020-05-01 23:03:29 usage info: caches: (4.11 MiB state, 0 bytes db overlay), state db: (168 bytes non-canonical, 0 bytes pruning, 44 bytes pinned), i/o: (0 tx, 0 write, 0 read, 0 avg tx, 18117/27207 key cache reads/total, 19298 trie nodes writes)
2020-05-01 23:03:29 Import benchmark (RandomTransfers(10000), Wasm): avg 0.88 s, w_avg 0.88 s
```
