### PR TITLE
Another state machine test

### DIFF
--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -1127,32 +1127,6 @@ mod tests {
 	}
 
 	#[test]
-	fn remove_then_append() {
-		let key = b"key".to_vec();
-		let mut state = new_in_mem::<BlakeTwo256>();
-		let backend = state.as_trie_backend().unwrap();
-		let mut overlay = OverlayedChanges::default();
-		let mut offchain_overlay = OffchainOverlayedChanges::default();
-		let mut cache = StorageTransactionCache::default();
-
-		let mut ext = Ext::new(
-			&mut overlay,
-			&mut offchain_overlay,
-			&mut cache,
-			backend,
-			changes_trie::disabled_state::<_, u64>(),
-			None,
-		);
-
-		ext.clear_storage(key.as_slice());
-		ext.storage_append(key.clone(), b"Item".to_vec().encode());
-		assert_eq!(
-			ext.storage(key.as_slice()),
-			Some(vec![b"Item".to_vec()].encode()),
-		);
-	}
-
-	#[test]
 	fn remove_with_append_then_rollback_appended_then_append_again() {
 
 		#[derive(codec::Encode, codec::Decode)]
@@ -1190,7 +1164,18 @@ mod tests {
 				changes_trie::disabled_state::<_, u64>(),
 				None,
 			);
+
+			assert_eq!(
+				ext.storage(key.as_slice()),
+				Some(vec![Item::InitializationItem].encode()),
+			);
+
 			ext.storage_append(key.clone(), Item::DiscardedItem.encode());
+
+			assert_eq!(
+				ext.storage(key.as_slice()),
+				Some(vec![Item::InitializationItem, Item::DiscardedItem].encode()),
+			);
 		}
 		overlay.discard_prospective();
 
@@ -1204,10 +1189,21 @@ mod tests {
 				changes_trie::disabled_state::<_, u64>(),
 				None,
 			);
+
+			assert_eq!(
+				ext.storage(key.as_slice()),
+				Some(vec![Item::InitializationItem].encode()),
+			);
+
 			ext.storage_append(key.clone(), Item::CommitedItem.encode());
+
+			assert_eq!(
+				ext.storage(key.as_slice()),
+				Some(vec![Item::InitializationItem, Item::CommitedItem].encode()),
+			);
+
 		}
 		overlay.commit_prospective();
-
 
 		// Then only initlaization item and second (commited) item should persist.
 		{


### PR DESCRIPTION
To be on the safe side with runtime upgrade, another test that reflects real state machine use case

when building block

1. initialize block (this kills storage and does `append` to it) 
2. push panicking (or too heavy) extrinsic (this does `append` that then rollbacks)
3. push ok extrinsic (this does `append` that then commits)

see that overlay is in correct state after