### PR TITLE
Refactor weight constants, Update to remove redundant overhead

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -34,7 +34,10 @@ pub use sp_runtime::{Permill, Perbill};
 pub use frame_support::{
 	StorageValue, construct_runtime, parameter_types,
 	traits::Randomness,
-	weights::{Weight, constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight}},
+	weights::{
+		Weight,
+		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+	},
 };
 
 /// Importing a template pallet
@@ -122,8 +125,7 @@ pub fn native_version() -> NativeVersion {
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
-	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
+	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -34,7 +34,7 @@ pub use sp_runtime::{Permill, Perbill};
 pub use frame_support::{
 	StorageValue, construct_runtime, parameter_types,
 	traits::Randomness,
-	weights::{Weight, RuntimeDbWeight},
+	weights::{Weight, constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight}},
 };
 
 /// Importing a template pallet
@@ -124,18 +124,9 @@ parameter_types! {
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
 	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
-	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
-	/// This probably should not be changed unless you have specific
-	/// disk i/o conditions for the node.
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 25_000_000, // ~25 µs @ 200,000 items
-		write: 100_000_000, // ~100 µs @ 200,000 items
-	};
-	/// Importing a block with 0 txs takes ~5 ms
-	pub const BlockExecutionWeight: Weight = 5_000_000_000;
 }
 
 impl system::Trait for Runtime {
@@ -164,7 +155,7 @@ impl system::Trait for Runtime {
 	/// Maximum weight of each block.
 	type MaximumBlockWeight = MaximumBlockWeight;
 	/// The weight of database operations that the runtime can invoke.
-	type DbWeight = DbWeight;
+	type DbWeight = RocksDbWeight;
 	/// The weight of the overhead invoked on the block import process, independent of the
 	/// extrinsics included in that block.
 	type BlockExecutionWeight = BlockExecutionWeight;

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -18,7 +18,7 @@ use codec::{Encode, Decode, Joiner};
 use frame_support::{
 	StorageValue, StorageMap,
 	traits::Currency,
-	weights::{GetDispatchInfo, DispatchInfo, DispatchClass},
+	weights::{GetDispatchInfo, DispatchInfo, DispatchClass, constants::ExtrinsicBaseWeight},
 };
 use sp_core::{
 	NeverNativeValue, map, traits::Externalities, storage::{well_known_keys, Storage},
@@ -33,7 +33,7 @@ use frame_system::{self, EventRecord, Phase};
 
 use node_runtime::{
 	Header, Block, UncheckedExtrinsic, CheckedExtrinsic, Call, Runtime, Balances,
-	System, TransactionPayment, Event, TransactionByteFee, ExtrinsicBaseWeight,
+	System, TransactionPayment, Event, TransactionByteFee,
 	constants::currency::*,
 };
 use node_primitives::{Balance, Hash};
@@ -359,9 +359,9 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(1),
-				// Balance Transfer 80_000_000 + 1 Read + 1 Write
+				// Balance Transfer 70_000_000 + 1 Read + 1 Write
 				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 80_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
+					DispatchInfo { weight: 70_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
 				)),
 				topics: vec![],
 			},
@@ -416,9 +416,9 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(1),
-				// Balance Transfer 80_000_000 + 1 Read + 1 Write
+				// Balance Transfer 70_000_000 + 1 Read + 1 Write
 				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 80_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
+					DispatchInfo { weight: 70_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
 				)),
 				topics: vec![],
 			},
@@ -440,9 +440,9 @@ fn full_native_block_import_works() {
 			},
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(2),
-				// Balance Transfer 80_000_000 + 1 Read + 1 Write
+				// Balance Transfer 70_000_000 + 1 Read + 1 Write
 				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 80_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
+					DispatchInfo { weight: 70_000_000 + 25_000_000 + 100_000_000, ..Default::default() }
 				)),
 				topics: vec![],
 			},

--- a/bin/node/executor/tests/fees.rs
+++ b/bin/node/executor/tests/fees.rs
@@ -18,14 +18,14 @@ use codec::{Encode, Joiner};
 use frame_support::{
 	StorageValue, StorageMap,
 	traits::Currency,
-	weights::GetDispatchInfo,
+	weights::{GetDispatchInfo, constants::ExtrinsicBaseWeight},
 };
 use sp_core::{NeverNativeValue, map, storage::Storage};
 use sp_runtime::{Fixed128, Perbill, traits::{Convert, BlakeTwo256}};
 use node_runtime::{
 	CheckedExtrinsic, Call, Runtime, Balances, TransactionPayment,
 	TransactionByteFee, WeightFeeCoefficient,
-	constants::currency::*, ExtrinsicBaseWeight,
+	constants::currency::*,
 };
 use node_runtime::impls::LinearWeightToFee;
 use node_primitives::Balance;

--- a/bin/node/executor/tests/submit_transaction.rs
+++ b/bin/node/executor/tests/submit_transaction.rs
@@ -230,7 +230,7 @@ fn submitted_transaction_should_be_valid() {
 		let res = Executive::validate_transaction(source, extrinsic);
 
 		assert_eq!(res.unwrap(), ValidTransaction {
-			priority: 1_410_740_000_000,
+			priority: 1_410_710_000_000,
 			requires: vec![],
 			provides: vec![(address, 0).encode()],
 			longevity: 128,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -23,7 +23,10 @@
 use sp_std::prelude::*;
 use frame_support::{
 	construct_runtime, parameter_types, debug,
-	weights::{Weight, constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight}},
+	weights::{
+		Weight,
+		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+	},
 	traits::{Currency, Randomness, OnUnbalanced, Imbalance, LockIdentifier},
 };
 use sp_core::u32_trait::{_1, _2, _3, _4};
@@ -119,7 +122,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
+	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -23,7 +23,7 @@
 use sp_std::prelude::*;
 use frame_support::{
 	construct_runtime, parameter_types, debug,
-	weights::{Weight, RuntimeDbWeight},
+	weights::{Weight, constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight}},
 	traits::{Currency, Randomness, OnUnbalanced, Imbalance, LockIdentifier},
 };
 use sp_core::u32_trait::{_1, _2, _3, _4};
@@ -120,17 +120,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub const MaximumBlockWeight: Weight = 2_000_000_000_000;
-	/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
-	pub const ExtrinsicBaseWeight: Weight = 125_000_000;
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-	pub const DbWeight: RuntimeDbWeight = RuntimeDbWeight {
-		read: 25_000_000, // ~25 µs @ 200,000 items
-		write: 100_000_000, // ~100 µs @ 200,000 items
-	};
-	/// Importing a block with 0 txs takes ~5 ms
-	pub const BlockExecutionWeight: Weight = 5_000_000_000;
 }
 
 impl frame_system::Trait for Runtime {
@@ -146,7 +138,7 @@ impl frame_system::Trait for Runtime {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
-	type DbWeight = DbWeight;
+	type DbWeight = RocksDbWeight;
 	type BlockExecutionWeight = BlockExecutionWeight;
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
 	type MaximumBlockLength = MaximumBlockLength;

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -432,11 +432,11 @@ decl_module! {
 		///   - `transfer_keep_alive` works the same way as `transfer`, but has an additional
 		///     check that the transfer will not kill the origin account.
 		/// ---------------------------------
-		/// - Base Weight: 80 µs, worst case scenario (account created, account removed)
+		/// - Base Weight: 73.64 µs, worst case scenario (account created, account removed)
 		/// - DB Weight: 1 Read and 1 Write to destination account
 		/// - Origin account is already in memory, so no DB operations for them.
 		/// # </weight>
-		#[weight = T::DbWeight::get().reads_writes(1, 1) + 80_000_000]
+		#[weight = T::DbWeight::get().reads_writes(1, 1) + 70_000_000]
 		pub fn transfer(
 			origin,
 			dest: <T::Lookup as StaticLookup>::Source,
@@ -460,7 +460,9 @@ decl_module! {
 		/// - Independent of the arguments.
 		/// - Contains a limited number of reads and writes.
 		/// ---------------------
-		/// - Base Weight: 32.6 µs
+		/// - Base Weight:
+		///     - Creating: 27.56 µs
+		///     - Killing: 35.11 µs
 		/// - DB Weight: 1 Read, 1 Write to `who`
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1) + 35_000_000]
@@ -505,7 +507,7 @@ decl_module! {
 		/// - Same as transfer, but additional read and write because the source account is
 		///   not assumed to be in the overlay.
 		/// # </weight>
-		#[weight = T::DbWeight::get().reads_writes(2, 2) + 80_000_000]
+		#[weight = T::DbWeight::get().reads_writes(2, 2) + 70_000_000]
 		pub fn force_transfer(
 			origin,
 			source: <T::Lookup as StaticLookup>::Source,
@@ -526,10 +528,10 @@ decl_module! {
 		/// [`transfer`]: struct.Module.html#method.transfer
 		/// # <weight>
 		/// - Cheaper than transfer because account cannot be killed.
-		/// - Base Weight: 57.36 µs
+		/// - Base Weight: 51.4 µs
 		/// - DB Weight: 1 Read and 1 Write to dest (sender is in overlay already)
 		/// #</weight>
-		#[weight = T::DbWeight::get().reads_writes(1, 1) + 60_000_000]
+		#[weight = T::DbWeight::get().reads_writes(1, 1) + 50_000_000]
 		pub fn transfer_keep_alive(
 			origin,
 			dest: <T::Lookup as StaticLookup>::Source,

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -144,8 +144,13 @@ pub type Weight = u64;
 /// These constants are specific to FRAME, and the current implementation of its various components.
 /// For example: FRAME System, FRAME Executive, our FRAME support libraries, etc...
 pub mod constants {
-	use super::*;
+	use super::{RuntimeDbWeight, Weight};
 	use crate::parameter_types;
+
+	pub const WEIGHT_PER_NANOS:  Weight = 1_000;
+	pub const WEIGHT_PER_MICROS: Weight = 1_000_000;
+	pub const WEIGHT_PER_MILLIS: Weight = 1_000_000_000;
+	pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
 
 	parameter_types! {
 		/// Importing a block with 0 txs takes ~5 ms

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -141,6 +141,34 @@ pub use sp_runtime::transaction_validity::TransactionPriority;
 /// Numeric range of a transaction weight.
 pub type Weight = u64;
 
+/// These constants are specific to the current pallet selection in the Substrate node.
+/// For example: Frame System, Pallet Balances, Pallet Staking, etc...
+/// Any significant changes to your runtime setup should probably use weights specific to your own
+/// runtime benchmarks.
+pub mod constants {
+	use super::*;
+	use crate::parameter_types;
+
+	parameter_types! {
+		/// Importing a block with 0 txs takes ~5 ms
+		pub const BlockExecutionWeight: Weight = 5_000_000_000;
+		/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
+		pub const ExtrinsicBaseWeight: Weight = 125_000_000;
+		/// By default, Substrate uses RocksDB, so this will be the weight used throughout
+		/// the runtime.
+		pub const RocksDbWeight: RuntimeDbWeight = RuntimeDbWeight {
+			read: 25_000_000, // ~25 µs @ 200,000 items
+			write: 100_000_000, // ~100 µs @ 200,000 items
+		};
+		/// ParityDB can be enabled with a feature flag, but is still experimental. These weights
+		/// are available for brave runtime engineers who may want to try this out as default.
+		pub const ParityDbWeight: RuntimeDbWeight = RuntimeDbWeight {
+			read: 8_000_000, // ~8 µs @ 200,000 items
+			write: 50_000_000, // ~50 µs @ 200,000 items
+		};
+	}
+}
+
 /// Means of weighing some particular kind of data (`T`).
 pub trait WeighData<T> {
 	/// Weigh the data `T` given by `target`. When implementing this for a dispatchable, `T` will be

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -147,27 +147,27 @@ pub mod constants {
 	use super::{RuntimeDbWeight, Weight};
 	use crate::parameter_types;
 
-	pub const WEIGHT_PER_NANOS:  Weight = 1_000;
-	pub const WEIGHT_PER_MICROS: Weight = 1_000_000;
-	pub const WEIGHT_PER_MILLIS: Weight = 1_000_000_000;
 	pub const WEIGHT_PER_SECOND: Weight = 1_000_000_000_000;
+	pub const WEIGHT_PER_MILLIS: Weight = WEIGHT_PER_SECOND / 1000; // 1_000_000_000
+	pub const WEIGHT_PER_MICROS: Weight = WEIGHT_PER_MILLIS / 1000; // 1_000_000
+	pub const WEIGHT_PER_NANOS:  Weight = WEIGHT_PER_MICROS / 1000; // 1_000
 
 	parameter_types! {
 		/// Importing a block with 0 txs takes ~5 ms
-		pub const BlockExecutionWeight: Weight = 5_000_000_000;
+		pub const BlockExecutionWeight: Weight = 5 * WEIGHT_PER_MILLIS;
 		/// Executing 10,000 System remarks (no-op) txs takes ~1.26 seconds -> ~125 µs per tx
-		pub const ExtrinsicBaseWeight: Weight = 125_000_000;
+		pub const ExtrinsicBaseWeight: Weight = 125 * WEIGHT_PER_MICROS;
 		/// By default, Substrate uses RocksDB, so this will be the weight used throughout
 		/// the runtime.
 		pub const RocksDbWeight: RuntimeDbWeight = RuntimeDbWeight {
-			read: 25_000_000, // ~25 µs @ 200,000 items
-			write: 100_000_000, // ~100 µs @ 200,000 items
+			read: 25 * WEIGHT_PER_MICROS,   // ~25 µs @ 200,000 items
+			write: 100 * WEIGHT_PER_MICROS, // ~100 µs @ 200,000 items
 		};
 		/// ParityDB can be enabled with a feature flag, but is still experimental. These weights
 		/// are available for brave runtime engineers who may want to try this out as default.
 		pub const ParityDbWeight: RuntimeDbWeight = RuntimeDbWeight {
-			read: 8_000_000, // ~8 µs @ 200,000 items
-			write: 50_000_000, // ~50 µs @ 200,000 items
+			read: 8 * WEIGHT_PER_MICROS,   // ~8 µs @ 200,000 items
+			write: 50 * WEIGHT_PER_MICROS, // ~50 µs @ 200,000 items
 		};
 	}
 }

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -141,10 +141,8 @@ pub use sp_runtime::transaction_validity::TransactionPriority;
 /// Numeric range of a transaction weight.
 pub type Weight = u64;
 
-/// These constants are specific to the current pallet selection in the Substrate node.
-/// For example: Frame System, Pallet Balances, Pallet Staking, etc...
-/// Any significant changes to your runtime setup should probably use weights specific to your own
-/// runtime benchmarks.
+/// These constants are specific to FRAME, and the current implementation of its various components.
+/// For example: FRAME System, FRAME Executive, our FRAME support libraries, etc...
 pub mod constants {
 	use super::*;
 	use crate::parameter_types;

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -205,16 +205,16 @@ mod weight_of {
 	use super::*;
 
 	/// - Base Weight:
-	///     - Create: 59.2 + 0.096 * S µs
-	///     - Approve: 42.27 + .116 * S µs
-	///     - Complete: 50.91 + .232 * S µs
+	///     - Create: 46.55 + 0.089 * S µs
+	///     - Approve: 34.03 + .112 * S µs
+	///     - Complete: 40.36 + .225 * S µs
 	/// - DB Weight:
 	///     - Reads: Multisig Storage, [Caller Account]
 	///     - Writes: Multisig Storage, [Caller Account]
 	/// - Plus Call Weight
 	pub fn as_multi<T: Trait>(other_sig_len: usize, call_weight: Weight) -> Weight {
 		call_weight
-			.saturating_add(60_000_000)
+			.saturating_add(45_000_000)
 			.saturating_add((other_sig_len as Weight).saturating_mul(250_000))
 			.saturating_add(T::DbWeight::get().reads_writes(1, 1))
 	}
@@ -236,7 +236,7 @@ decl_module! {
 		/// - `calls`: The calls to be dispatched from the same origin.
 		///
 		/// # <weight>
-		/// - Base weight: 15.64 + .987 * c µs
+		/// - Base weight: 14.39 + .987 * c µs
 		/// - Plus the sum of the weights of the `calls`.
 		/// - Plus one additional event. (repeat read/write)
 		/// # </weight>
@@ -280,7 +280,7 @@ decl_module! {
 		/// The dispatch origin for this call must be _Signed_.
 		///
 		/// # <weight>
-		/// - Base weight: 2.863 µs
+		/// - Base weight: 2.861 µs
 		/// - Plus the weight of the `call`
 		/// # </weight>
 		#[weight = FunctionOf(
@@ -339,9 +339,9 @@ decl_module! {
 		///   `MultisigDepositBase + threshold * MultisigDepositFactor`.
 		/// -------------------------------
 		/// - Base Weight:
-		///     - Create: 59.2 + 0.096 * S µs
-		///     - Approve: 42.27 + .116 * S µs
-		///     - Complete: 50.91 + .232 * S µs
+		///     - Create: 46.55 + 0.089 * S µs
+		///     - Approve: 34.03 + .112 * S µs
+		///     - Complete: 40.36 + .225 * S µs
 		/// - DB Weight:
 		///     - Reads: Multisig Storage, [Caller Account]
 		///     - Writes: Multisig Storage, [Caller Account]
@@ -471,8 +471,8 @@ decl_module! {
 		///   `MultisigDepositBase + threshold * MultisigDepositFactor`.
 		/// ----------------------------------
 		/// - Base Weight:
-		///     - Create: 56.3 + 0.107 * S
-		///     - Approve: 39.25 + 0.121 * S
+		///     - Create: 44.71 + 0.088 * S
+		///     - Approve: 31.48 + 0.116 * S
 		/// - DB Weight:
 		///     - Read: Multisig Storage, [Caller Account]
 		///     - Write: Multisig Storage, [Caller Account]
@@ -480,7 +480,7 @@ decl_module! {
 		#[weight = FunctionOf(
 			|args: (&u16, &Vec<T::AccountId>, &Option<Timepoint<T::BlockNumber>>, &[u8; 32])| {
 				T::DbWeight::get().reads_writes(1, 1)
-					.saturating_add(60_000_000)
+					.saturating_add(45_000_000)
 					.saturating_add((args.1.len() as Weight).saturating_mul(120_000))
 			},
 			DispatchClass::Normal,
@@ -554,7 +554,7 @@ decl_module! {
 		/// - I/O: 1 read `O(S)`, one remove.
 		/// - Storage: removes one item.
 		/// ----------------------------------
-		/// - Base Weight: 46.71 + 0.09 * S
+		/// - Base Weight: 37.6 + 0.084 * S
 		/// - DB Weight:
 		///     - Read: Multisig Storage, [Caller Account]
 		///     - Write: Multisig Storage, [Caller Account]
@@ -562,7 +562,7 @@ decl_module! {
 		#[weight = FunctionOf(
 			|args: (&u16, &Vec<T::AccountId>, &Timepoint<T::BlockNumber>, &[u8; 32])| {
 				T::DbWeight::get().reads_writes(1, 1)
-					.saturating_add(50_000_000)
+					.saturating_add(40_000_000)
 					.saturating_add((args.1.len() as Weight).saturating_mul(100_000))
 			},
 			DispatchClass::Normal,

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -194,11 +194,11 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, [Sender Account]
 		/// - Benchmark:
-		///     - Unlocked: 56.1 + .098 * l µs (min square analysis)
-		///     - Locked: 54.37 + .254 * l µs (min square analysis)
-		/// - Using 60 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
+		///     - Unlocked: 48.76 + .048 * l µs (min square analysis)
+		///     - Locked: 44.43 + .284 * l µs (min square analysis)
+		/// - Using 50 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
 		/// # </weight>
-		#[weight = 60_000_000 + T::DbWeight::get().reads_writes(2, 2)]
+		#[weight = 50_000_000 + T::DbWeight::get().reads_writes(2, 2)]
 		fn vest(origin) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::update_lock(who)
@@ -219,11 +219,11 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account
 		///     - Writes: Vesting Storage, Balances Locks, Target Account
 		/// - Benchmark:
-		///     - Unlocked: 58.09 + .104 * l µs (min square analysis)
-		///     - Locked: 55.35 + .255 * l µs (min square analysis)
-		/// - Using 60 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
+		///     - Unlocked: 44.3 + .294 * l µs (min square analysis)
+		///     - Locked: 48.16 + .103 * l µs (min square analysis)
+		/// - Using 50 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
 		/// # </weight>
-		#[weight = 60_000_000 + T::DbWeight::get().reads_writes(3, 3)]
+		#[weight = 50_000_000 + T::DbWeight::get().reads_writes(3, 3)]
 		fn vest_other(origin, target: <T::Lookup as StaticLookup>::Source) -> DispatchResult {
 			ensure_signed(origin)?;
 			Self::update_lock(T::Lookup::lookup(target)?)
@@ -244,10 +244,10 @@ decl_module! {
 		/// - DbWeight: 3 Reads, 3 Writes
 		///     - Reads: Vesting Storage, Balances Locks, Target Account, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, Target Account, [Sender Account]
-		/// - Benchmark: 111.4 + .345 * l µs (min square analysis)
-		/// - Using 115 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
+		/// - Benchmark: 100.3 + .365 * l µs (min square analysis)
+		/// - Using 100 µs fixed. Assuming less than 50 locks on any user, else we may want factor in number of locks.
 		/// # </weight>
-		#[weight = 115_000_000 + T::DbWeight::get().reads_writes(3, 3)]
+		#[weight = 100_000_000 + T::DbWeight::get().reads_writes(3, 3)]
 		pub fn vested_transfer(
 			origin,
 			target: <T::Lookup as StaticLookup>::Source,


### PR DESCRIPTION
This PR moves some of the FRAME specific weight constants (DbWeight, ExtrinsicBaseWeight, BlockExecutionWeight) to the `frame-support` library. Since we already make heavy assumptions about how to derive these weights based on our specific setup of FRAME, it makes sense to move these thing into there.

Additionally, this updates some weight values across various extrinsic to make them even a bit more lightweight!

We found that we had double counted the overhead implied by a Heavy DB by testing our DB Trie stats with a full DB and also testing our runtime with a full chain spec. The full chain spec in the runtime was not needed since we assume now every DB read will be ~200K item (5 trie look ups) heavy.

As a result, we get some lower weights!

This updates:
* Balances
* Vesting
* Utility

TODO in another PR: Update all weights to use these consts