### PR TITLE
Add repository metadata to grandpa-rpc-crate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,9 +222,9 @@ test-dependency-rules:
 unleash-check:
   stage:                           test
   <<:                              *docker-env
-  # only:
-  #   - master
-  #   - tags
+   only:
+     - master
+     - tags
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,9 +222,9 @@ test-dependency-rules:
 unleash-check:
   stage:                           test
   <<:                              *docker-env
-  only:
-    - master
-    - tags
+  # only:
+  #   - master
+  #   - tags
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -3,6 +3,7 @@ name = "sc-finality-grandpa-rpc"
 version = "0.8.0-dev"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "RPC extensions for the GRANDPA finality gadget"
+repository = "https://github.com/paritytech/substrate/"
 edition = "2018"
 license = "GPL-3.0"
 


### PR DESCRIPTION
[Releasing is broken again, because of missing metadata in a cargo.toml](https://gitlab.parity.io/parity/substrate/-/jobs/493356#L1863).

This fixes that.

Enabled `cargo unleash check` on the PR to check it works, will be reverted before merge.