### PR TITLE
Remove extra backtick in comments

### DIFF
--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -779,7 +779,7 @@ pub trait SignedExtension: Codec + Debug + Sync + Send + Clone + Eq + PartialEq 
 
 	/// Returns the list of unique identifier for this signed extension.
 	///
-	/// As a [`SignedExtension`] can be a tuple of [`SignedExtension`]`s we need to return a `Vec`
+	/// As a [`SignedExtension`] can be a tuple of [`SignedExtension`]s we need to return a `Vec`
 	/// that holds all the unique identifiers. Each individual `SignedExtension` must return
 	/// *exactly* one identifier.
 	///


### PR DESCRIPTION
This is a minor fix to a doc comment. You can see the old version rendering incorrectly at https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html#method.identifier