### PR TITLE
Fix staking fuzzer + make it check in ci.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,7 +242,7 @@ test-frame-staking:
       - $DEPLOY_TAG
   script:
     - cd frame/staking/
-    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features std
+    - WASM_BUILD_NO_COLOR=1 time cargo test --release --verbose --no-default-features --features "std testing-utils"
     - sccache -s
 
 test-frame-examples-compile-to-wasm:
@@ -334,7 +334,7 @@ check-web-wasm:
     - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
     - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
     # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
-    - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features "browser" --target=wasm32-unknown-unknown -Z features=itarget
+    - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown -Z features=itarget
     - sccache -s
 
 test-full-crypto-feature:
@@ -400,14 +400,14 @@ build-linux-substrate:             &build-binary
     - printf '\n# building node-template\n\n'
     - ./.maintain/node-template-release.sh ./artifacts/substrate/substrate-node-template.tar.gz
     - sccache -s
-    
+
 
 build-linux-subkey:                &build-subkey
   <<:                              *build-binary
   before_script:
     - mkdir -p ./artifacts/subkey
   script:
-    - cd ./bin/utils/subkey 
+    - cd ./bin/utils/subkey
     - BUILD_DUMMY_WASM_BINARY=1 time cargo build --release --verbose
     - cd -
     - mv ./target/release/subkey ./artifacts/subkey/.

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-dev", default-features = false, path = "../../primitives/std" }
 sp-phragmen = { version = "2.0.0-dev", default-features = false, path = "../../primitives/phragmen" }
-sp-io ={ path = "../../primitives/io", default-features = false , version = "2.0.0-dev"}
+sp-io ={ version = "2.0.0-dev", path = "../../primitives/io", default-features = false }
 sp-runtime = { version = "2.0.0-dev", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "2.0.0-dev", default-features = false, path = "../../primitives/staking" }
 frame-support = { version = "2.0.0-dev", default-features = false, path = "../support" }
@@ -44,7 +44,7 @@ pallet-staking-reward-curve = { version = "2.0.0-dev",  path = "../staking/rewar
 substrate-test-utils = { version = "2.0.0-dev", path = "../../test-utils" }
 frame-benchmarking = { version = "2.0.0-dev", path = "../benchmarking" }
 rand_chacha = { version = "0.2" }
-parking_lot = "0.10.0"
+parking_lot = "0.10.2"
 env_logger = "0.7.1"
 hex = "0.4"
 

--- a/frame/staking/fuzzer/src/submit_solution.rs
+++ b/frame/staking/fuzzer/src/submit_solution.rs
@@ -23,8 +23,9 @@ use pallet_staking::testing_utils::{
 	USER, get_seq_phragmen_solution, get_weak_solution, setup_chain_stakers,
 	set_validator_count, signed_account,
 };
-use frame_support::assert_ok;
+use frame_support::{assert_ok, storage::StorageValue};
 use sp_runtime::{traits::Dispatchable, DispatchError};
+use sp_core::offchain::{testing::TestOffchainExt, OffchainExt};
 
 mod mock;
 
@@ -40,8 +41,19 @@ enum Mode {
 	WeakerSubmission,
 }
 
-pub fn new_test_ext() -> Result<sp_io::TestExternalities, std::string::String> {
-	frame_system::GenesisConfig::default().build_storage::<mock::Test>().map(Into::into)
+pub fn new_test_ext(iterations: u32) -> sp_io::TestExternalities {
+	let mut ext: sp_io::TestExternalities = frame_system::GenesisConfig::default().build_storage::<mock::Test>().map(Into::into)
+		.expect("Failed to create test externalities.");
+
+	let (offchain, offchain_state) = TestOffchainExt::new();
+
+	let mut seed = [0u8; 32];
+	seed[0..4].copy_from_slice(&iterations.to_le_bytes());
+	offchain_state.write().seed = seed;
+
+	ext.register_extension(OffchainExt::new(offchain));
+
+	ext
 }
 
 fn main() {
@@ -56,7 +68,7 @@ fn main() {
 	loop {
 		fuzz!(|data: (u32, u32, u32, u32, u32)| {
 			let (mut num_validators, mut num_nominators, mut edge_per_voter, mut to_elect, mode_u32) = data;
-			let ext = new_test_ext();
+			let mut ext = new_test_ext(5);
 			let mode: Mode = unsafe { std::mem::transmute(mode_u32) };
 			num_validators = to_range(num_validators, 50, 1000);
 			num_nominators = to_range(num_nominators, 50, 2000);
@@ -73,7 +85,7 @@ fn main() {
 				to_elect,
 			);
 
-			ext.unwrap_or_default().execute_with(|| {
+			ext.execute_with(|| {
 				// initial setup
 				set_validator_count::<Test>(to_elect);
 				pallet_staking::testing_utils::init_active_era();
@@ -82,6 +94,7 @@ fn main() {
 					num_nominators,
 					edge_per_voter,
 				);
+				<pallet_staking::EraElectionStatus<Test>>::put(pallet_staking::ElectionStatus::Open(1));
 
 				println!("++ Chain setup done.");
 
@@ -140,7 +153,7 @@ fn main() {
 					Mode::WeakerSubmission => {
 						assert_eq!(
 							call.dispatch(caller.into()).unwrap_err().error,
-							DispatchError::Module { index: 0, error: 15, message: Some("PhragmenWeakSubmission") },
+							DispatchError::Module { index: 0, error: 16, message: Some("PhragmenWeakSubmission") },
 						);
 					},
 					// NOTE: so exhaustive pattern doesn't work here.. maybe some rust issue? or due to `#[repr(u32)]`?

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -50,7 +50,7 @@ pub fn random(a: u32, b: u32) -> u32 {
 pub fn set_validator_count<T: Trait>(to_elect: u32) {
 	ValidatorCount::put(to_elect);
 	MinimumValidatorCount::put(to_elect / 2);
-	<EraElectionStatus<T>>::put(ElectionStatus::Open(T::BlockNumber::from(1u32)));
+	<EraElectionStatus<T>>::put(ElectionStatus::Closed);
 }
 
 /// Build an account with the given index.


### PR DESCRIPTION
Why do we have the staking test with `std` in the first place? 