### PR TITLE
Fix wrong task name

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1023,7 +1023,7 @@ ServiceBuilder<
 				});
 
 			spawn_handle.spawn(
-				"telemetry-on-block",
+				"on-transaction-imported",
 				events,
 			);
 		}


### PR DESCRIPTION
The name of this task is totally wrong. Its role is to propagate extrinsics and send a message to the telemetry.
It has nothing to do with blocks.