### PR TITLE
Use header cache for blockchain cache

### DIFF
--- a/client/db/src/changes_tries_storage.rs
+++ b/client/db/src/changes_tries_storage.rs
@@ -24,7 +24,7 @@ use parking_lot::RwLock;
 use sp_blockchain::{Error as ClientError, Result as ClientResult};
 use sp_trie::MemoryDB;
 use sc_client_api::backend::PrunableStateChangesTrieStorage;
-use sp_blockchain::{well_known_cache_keys, Cache as BlockchainCache};
+use sp_blockchain::{well_known_cache_keys, Cache as BlockchainCache, HeaderMetadataCache};
 use sp_core::{ChangesTrieConfiguration, ChangesTrieConfigurationRange, convert_hash};
 use sp_core::storage::PrefixedStorageKey;
 use sp_database::Transaction;
@@ -114,6 +114,7 @@ impl<Block: BlockT> DbChangesTrieStorage<Block> {
 	/// Create new changes trie storage.
 	pub fn new(
 		db: Arc<dyn Database<DbHash>>,
+		header_metadata_cache: Arc<HeaderMetadataCache<Block>>,
 		meta_column: u32,
 		changes_tries_column: u32,
 		key_lookup_column: u32,
@@ -137,6 +138,7 @@ impl<Block: BlockT> DbChangesTrieStorage<Block> {
 			min_blocks_to_keep,
 			cache: DbCacheSync(RwLock::new(DbCache::new(
 				db.clone(),
+				header_metadata_cache,
 				key_lookup_column,
 				header_column,
 				cache_column,

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -368,7 +368,7 @@ pub struct BlockchainDb<Block: BlockT> {
 	db: Arc<dyn Database<DbHash>>,
 	meta: Arc<RwLock<Meta<NumberFor<Block>, Block::Hash>>>,
 	leaves: RwLock<LeafSet<Block::Hash, NumberFor<Block>>>,
-	header_metadata_cache: HeaderMetadataCache<Block>,
+	header_metadata_cache: Arc<HeaderMetadataCache<Block>>,
 }
 
 impl<Block: BlockT> BlockchainDb<Block> {
@@ -379,7 +379,7 @@ impl<Block: BlockT> BlockchainDb<Block> {
 			db,
 			leaves: RwLock::new(leaves),
 			meta: Arc::new(RwLock::new(meta)),
-			header_metadata_cache: HeaderMetadataCache::default(),
+			header_metadata_cache: Arc::new(HeaderMetadataCache::default()),
 		})
 	}
 
@@ -505,7 +505,7 @@ impl<Block: BlockT> HeaderMetadata<Block> for BlockchainDb<Block> {
 	type Error = sp_blockchain::Error;
 
 	fn header_metadata(&self, hash: Block::Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
-		self.header_metadata_cache.header_metadata(hash).or_else(|_| {
+		self.header_metadata_cache.header_metadata(hash).map_or_else(|| {
 			self.header(BlockId::hash(hash))?.map(|header| {
 				let header_metadata = CachedHeaderMetadata::from(&header);
 				self.header_metadata_cache.insert_header_metadata(
@@ -514,7 +514,7 @@ impl<Block: BlockT> HeaderMetadata<Block> for BlockchainDb<Block> {
 				);
 				header_metadata
 			}).ok_or(ClientError::UnknownBlock(format!("header not found in db: {}", hash)))
-		})
+		}, Ok)
 	}
 
 	fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {
@@ -831,6 +831,7 @@ impl<Block: BlockT> Backend<Block> {
 		let offchain_storage = offchain::LocalStorage::new(db.clone());
 		let changes_tries_storage = DbChangesTrieStorage::new(
 			db,
+			blockchain.header_metadata_cache.clone(),
 			columns::META,
 			columns::CHANGES_TRIE,
 			columns::KEY_LOOKUP,

--- a/primitives/blockchain/src/header_metadata.rs
+++ b/primitives/blockchain/src/header_metadata.rs
@@ -239,19 +239,16 @@ impl<Block: BlockT> Default for HeaderMetadataCache<Block> {
 	}
 }
 
-impl<Block: BlockT> HeaderMetadata<Block> for HeaderMetadataCache<Block> {
-	type Error = String;
-
-	fn header_metadata(&self, hash: Block::Hash) -> Result<CachedHeaderMetadata<Block>, Self::Error> {
+impl<Block: BlockT> HeaderMetadataCache<Block> {
+	pub fn header_metadata(&self, hash: Block::Hash) -> Option<CachedHeaderMetadata<Block>> {
 		self.cache.write().get(&hash).cloned()
-			.ok_or("header metadata not found in cache".to_owned())
 	}
 
-	fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {
+	pub fn insert_header_metadata(&self, hash: Block::Hash, metadata: CachedHeaderMetadata<Block>) {
 		self.cache.write().put(hash, metadata);
 	}
 
-	fn remove_header_metadata(&self, hash: Block::Hash) {
+	pub fn remove_header_metadata(&self, hash: Block::Hash) {
 		self.cache.write().pop(&hash);
 	}
 }


### PR DESCRIPTION
This removes another DB query on each block import.