### PR TITLE
Unify format of state-trace logs

### DIFF
--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -420,7 +420,7 @@ where
 		key: Vec<u8>,
 		value: Vec<u8>,
 	) {
-		trace!(target: "state", "{:04x}: Append({}) {}",
+		trace!(target: "state", "{:04x}: Append {}={}",
 			self.id,
 			HexDisplay::from(&key),
 			HexDisplay::from(&value),
@@ -444,7 +444,7 @@ where
 	fn storage_root(&mut self) -> Vec<u8> {
 		let _guard = sp_panic_handler::AbortGuard::force_abort();
 		if let Some(ref root) = self.storage_transaction_cache.transaction_storage_root {
-			trace!(target: "state", "{:04x}: Root (cached) {}",
+			trace!(target: "state", "{:04x}: Root(cached) {}",
 				self.id,
 				HexDisplay::from(&root.as_ref()),
 			);
@@ -470,7 +470,7 @@ where
 				.unwrap_or(
 					empty_child_trie_root::<Layout<H>>()
 				);
-			trace!(target: "state", "{:04x}: ChildRoot({}) (cached) {}",
+			trace!(target: "state", "{:04x}: ChildRoot({})(cached) {}",
 				self.id,
 				HexDisplay::from(&storage_key),
 				HexDisplay::from(&root.as_ref()),
@@ -518,7 +518,7 @@ where
 					.unwrap_or(
 						empty_child_trie_root::<Layout<H>>()
 					);
-				trace!(target: "state", "{:04x}: ChildRoot({}) (no change) {}",
+				trace!(target: "state", "{:04x}: ChildRoot({})(no_change) {}",
 					self.id,
 					HexDisplay::from(&storage_key.as_ref()),
 					HexDisplay::from(&root.as_ref()),


### PR DESCRIPTION
This is a really insubstantial PR that will make state-trace logs follow the same space-separated-value format so they can be easily parsed.

Basically the format is always:

```
ID: OPERATION KEY=MAYBE_VALUE
```

This small change fixes that, and anyone else who parses the state logs will thank us for this change.