### PR TITLE
Relase `wasm-builder` and `wasm-builder-runner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8259,7 +8259,7 @@ version = "2.0.0-dev"
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "atty",
  "build-helper",
@@ -8274,7 +8274,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder-runner"
-version = "1.0.5"
+version = "1.0.6"
 
 [[package]]
 name = "substrate-wasmtime"

--- a/utils/wasm-builder-runner/Cargo.toml
+++ b/utils/wasm-builder-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder-runner"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Runner for substrate-wasm-builder"
 edition = "2018"

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/5933

We are already using these versions since quite some time and I just had forgotten to release them.