### PR TITLE
Make sure `config_mut` returns a mutable reference

### DIFF
--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -248,7 +248,7 @@ impl<C: SubstrateCli> Runner<C> {
 	}
 
 	/// Get a mutable reference to the node Configuration
-	pub fn config_mut(&mut self) -> &Configuration {
+	pub fn config_mut(&mut self) -> &mut Configuration {
 		&mut self.config
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/5936