### PR TITLE
Disconnect node after sync request cancelled

### DIFF
--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -320,19 +320,10 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviourEventProcess<block_requests::Event<B
 				let ev = self.substrate.on_block_response(peer, original_request, response);
 				self.inject_event(ev);
 			}
-			block_requests::Event::RequestCancelled { peer, request_duration, .. } => {
-				// There doesn't exist any mechanism to report cancellations yet.
-				// We would normally disconnect the node, but this event happens as the result of
-				// a disconnect, so there's nothing more to do.
-				self.events.push_back(BehaviourOut::RequestFinished {
-					peer,
-					protocol: self.block_requests.protocol_name().to_vec(),
-					request_duration,
-				});
-			}
+			block_requests::Event::RequestCancelled { peer, request_duration, .. } |
 			block_requests::Event::RequestTimeout { peer, request_duration, .. } => {
-				// There doesn't exist any mechanism to report timeouts yet, so we process them by
-				// disconnecting the node.
+				// There doesn't exist any mechanism to report cancellations or timeouts yet, so
+				// we process them by disconnecting the node.
 				self.events.push_back(BehaviourOut::RequestFinished {
 					peer: peer.clone(),
 					protocol: self.block_requests.protocol_name().to_vec(),


### PR DESCRIPTION
Here is an example problematic situation:

- We have two active TCP connections to the same peer.
- The sync code starts a request. We pick one of the TCP connections and send it on it.
- That TCP connection closes. This makes the `blocks_request` code emit a `RequestCancelled` event. Because we still have the other TCP connections, the sync code doesn't get notified of the disconnect and still thinks that the request is in progress.

In my mind, a `RequestCancelled` event could only happen in case of a complete disconnect, which would also have notified the sync code, and I didn't take into account the situation where we have multiple connections.

This PR fixes that by treating a `RequestCancelled` the same way as a `RequestTimeout` and closing all the connections.

This is a hotfix, and a proper fix would be to:

- Either change the `block_requests` code to automatically restart the same request on the other TCP connection (without resetting the timeout).
- Or explicitly tell the `sync` that this specific request has failed so that it can try another node.

This should hopefully fix the sync stalling.
