### PR TITLE
weight adjustments for identity and timestamp pallets

### DIFF
--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -392,9 +392,9 @@ fn full_native_block_import_works() {
 		let events = vec![
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
-				// timestamp set call with weight 9_000_000 + 2 read + 1 write
+				// timestamp set call with weight 8_000_000 + 2 read + 1 write
 				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 9_000_000 + 2 * 25_000_000 + 1 * 100_000_000, class: DispatchClass::Mandatory, ..Default::default() }
+					DispatchInfo { weight: 8_000_000 + 2 * 25_000_000 + 1 * 100_000_000, class: DispatchClass::Mandatory, ..Default::default() }
 				)),
 				topics: vec![],
 			},

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -337,9 +337,9 @@ fn full_native_block_import_works() {
 		let events = vec![
 			EventRecord {
 				phase: Phase::ApplyExtrinsic(0),
-				// timestamp set call with weight 9_000_000 + 2 read + 1 write
+				// timestamp set call with weight 8_000_000 + 2 read + 1 write
 				event: Event::frame_system(frame_system::RawEvent::ExtrinsicSuccess(
-					DispatchInfo { weight: 9_000_000 + 2 * 25_000_000 + 1 * 100_000_000, class: DispatchClass::Mandatory, ..Default::default() }
+					DispatchInfo { weight: 8_000_000 + 2 * 25_000_000 + 1 * 100_000_000, class: DispatchClass::Mandatory, ..Default::default() }
 				)),
 				topics: vec![],
 			},

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -466,6 +466,9 @@ mod weight_for {
 	use frame_support::weights::{RuntimeDbWeight, Weight};
 
 	/// Weight calculation for `set_identity`.
+	///
+	/// Based on benchmark:
+	/// 50.64 + R * 0.215 + X * 1.424 µs (min squares analysis)
 	pub(crate) fn set_identity(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -478,6 +481,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `set_subs`.
+	///
+	/// Based on benchmark:
+	/// 36.21 + P * 2.481 + S * 3.633 µs (min squares analysis)
 	pub(crate) fn set_subs(
 		db: RuntimeDbWeight,
 		old_subs: impl Into<Weight> + Copy,
@@ -492,6 +498,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `clear_identity`.
+	///
+	/// Based on benchmark:
+	/// 43.19 + R * 0.099 + S * 2.547 + X * 0.875 µs (min squares analysis)
 	pub(crate) fn clear_identity(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -506,6 +515,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `request_judgement`.
+	///
+	/// Based on benchmark:
+	/// 51.51 + R * 0.32 + X * 1.85 µs (min squares analysis)
 	pub(crate) fn request_judgement(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -518,6 +530,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `cancel_request`.
+	///
+	/// Based on benchmark:
+	/// 40.95 + R * 0.219 + X * 1.655 µs (min squares analysis)
 	pub(crate) fn cancel_request(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -530,6 +545,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `provide_judgement`.
+	///
+	/// Based on benchmark:
+	/// 40.77 + R * 0.282 + X * 1.66 µs (min squares analysis)
 	pub(crate) fn provide_judgement(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -542,6 +560,9 @@ mod weight_for {
 	}
 
 	/// Weight calculation for `kill_identity`.
+	///
+	/// Based on benchmark:
+	/// 83.96 + R * 0.122 + S * 2.533 + X * 0.867 µs (min squares analysis)
 	pub(crate) fn kill_identity(
 		db: RuntimeDbWeight,
 		judgements: impl Into<Weight>,
@@ -639,7 +660,6 @@ decl_module! {
 		/// - One balance reserve operation.
 		/// - One storage mutation (codec-read `O(X' + R)`, codec-write `O(X + R)`).
 		/// - One event.
-		/// - Benchmark: 50.64 + R * 0.215 + X * 1.424 µs (min squares analysis)
 		/// # </weight>
 		#[weight =  weight_for::set_identity(
 			T::DbWeight::get(),
@@ -702,7 +722,6 @@ decl_module! {
 		///   - One storage read (codec complexity `O(P)`).
 		///   - One storage write (codec complexity `O(S)`).
 		///   - One storage-exists (`IdentityOf::contains_key`).
-		/// - Benchmark: 36.21 + P * 2.481 + S * 3.633 µs (min squares analysis)
 		/// # </weight>
 		#[weight = weight_for::set_subs(
 			T::DbWeight::get(),
@@ -764,7 +783,6 @@ decl_module! {
 		/// - One balance-unreserve operation.
 		/// - `2` storage reads and `S + 2` storage deletions.
 		/// - One event.
-		/// - Benchmark: 43.19 + R * 0.099 + S * 2.547 + X * 0.875 µs (min squares analysis)
 		/// # </weight>
 		#[weight = weight_for::clear_identity(
 			T::DbWeight::get(),
@@ -817,7 +835,6 @@ decl_module! {
 		/// - One balance-reserve operation.
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(X + R)`.
 		/// - One event.
-		/// - Benchmark: 51.51 + R * 0.32 + X * 1.85 µs (min squares analysis)
 		/// # </weight>
 		#[weight = weight_for::request_judgement(
 			T::DbWeight::get(),
@@ -871,8 +888,7 @@ decl_module! {
 		/// - `O(R + X)`.
 		/// - One balance-reserve operation.
 		/// - One storage mutation `O(R + X)`.
-		/// - One event.
-		/// - Benchmark: 40.95 + R * 0.219 + X * 1.655 µs (min squares analysis)
+		/// - One event
 		/// # </weight>
 		#[weight = weight_for::cancel_request(
 			T::DbWeight::get(),
@@ -1024,7 +1040,6 @@ decl_module! {
 		/// - Up to one account-lookup operation.
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(R + X)`.
 		/// - One event.
-		/// - Benchmark: 40.77 + R * 0.282 + X * 1.66 µs (min squares analysis)
 		/// # </weight>
 		#[weight = weight_for::provide_judgement(
 			T::DbWeight::get(),
@@ -1083,7 +1098,6 @@ decl_module! {
 		/// - One balance-reserve operation.
 		/// - `S + 2` storage mutations.
 		/// - One event.
-		/// - Benchmark: 83.96 + R * 0.122 + S * 2.533 + X * 0.867 µs (min squares analysis)
 		/// # </weight>
 		#[weight = weight_for::kill_identity(
 			T::DbWeight::get(),

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -463,118 +463,126 @@ decl_error! {
 
 /// Functions for calcuating the weight of dispatchables.
 mod weight_for {
-	use frame_support::weights::{RuntimeDbWeight, Weight};
+	use frame_support::{traits::Get, weights::Weight};
+	use super::Trait;
+
+	/// Weight calculation for `add_registrar`.
+	///
+	/// Based on benchmark:
+	/// 22.24 + R * 0.371 µs (min squares analysis)
+	pub(crate) fn add_registrar<T: Trait>(
+		registrars: Weight
+	) -> Weight {
+		T::DbWeight::get().reads_writes(1, 1)
+			+ 23_000_000 // constant
+			+ 380_000 * registrars // R
+	}
 
 	/// Weight calculation for `set_identity`.
 	///
 	/// Based on benchmark:
 	/// 50.64 + R * 0.215 + X * 1.424 µs (min squares analysis)
-	pub(crate) fn set_identity(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn set_identity<T: Trait>(
+		judgements: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(1, 1)
+		T::DbWeight::get().reads_writes(1, 1)
 			+ 51_000_000 // constant
-			+ 220_000 * judgements.into() // R
-			+ 1_500_000 * extra_fields.into() // X
+			+ 220_000 * judgements // R
+			+ 1_500_000 * extra_fields // X
 	}
 
 	/// Weight calculation for `set_subs`.
 	///
 	/// Based on benchmark:
 	/// 36.21 + P * 2.481 + S * 3.633 µs (min squares analysis)
-	pub(crate) fn set_subs(
-		db: RuntimeDbWeight,
-		old_subs: impl Into<Weight> + Copy,
-		subs: impl Into<Weight> + Copy
+	pub(crate) fn set_subs<T: Trait>(
+		old_subs: Weight,
+		subs: Weight
 	) -> Weight {
+		let db = T::DbWeight::get();
 		db.reads(1) // storage-exists (`IdentityOf::contains_key`)
-			.saturating_add(db.reads_writes(1, old_subs.into())) // `SubsOf::get` read + P old DB deletions
-			.saturating_add(db.writes(subs.into() + 1)) // S + 1 new DB writes
+			.saturating_add(db.reads_writes(1, old_subs)) // `SubsOf::get` read + P old DB deletions
+			.saturating_add(db.writes(subs + 1)) // S + 1 new DB writes
 			.saturating_add(37_000_000) // constant
-			.saturating_add(2_500_000 * old_subs.into()) // P
-			.saturating_add(subs.into().saturating_mul(3_700_000)) // S
+			.saturating_add(2_500_000 * old_subs) // P
+			.saturating_add(subs.saturating_mul(3_700_000)) // S
 	}
 
 	/// Weight calculation for `clear_identity`.
 	///
 	/// Based on benchmark:
 	/// 43.19 + R * 0.099 + S * 2.547 + X * 0.875 µs (min squares analysis)
-	pub(crate) fn clear_identity(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		subs: impl Into<Weight> + Copy,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn clear_identity<T: Trait>(
+		judgements: Weight,
+		subs: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(2, subs.into() + 2) // S + 2 deletions
+		T::DbWeight::get().reads_writes(2, subs + 2) // S + 2 deletions
 			+ 44_000_000 // constant
-			+ 100_000 * judgements.into() // R
-			+ 2_600_000 * subs.into() // S
-			+ 900_000 * extra_fields.into() // X
+			+ 100_000 * judgements // R
+			+ 2_600_000 * subs // S
+			+ 900_000 * extra_fields // X
 	}
 
 	/// Weight calculation for `request_judgement`.
 	///
 	/// Based on benchmark:
 	/// 51.51 + R * 0.32 + X * 1.85 µs (min squares analysis)
-	pub(crate) fn request_judgement(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn request_judgement<T: Trait>(
+		judgements: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(2, 1)
+		T::DbWeight::get().reads_writes(2, 1)
 			+ 52_000_000 // constant
-			+ 400_000 * judgements.into() // R
-			+ 1_900_000 * extra_fields.into() // X
+			+ 400_000 * judgements // R
+			+ 1_900_000 * extra_fields // X
 	}
 
 	/// Weight calculation for `cancel_request`.
 	///
 	/// Based on benchmark:
 	/// 40.95 + R * 0.219 + X * 1.655 µs (min squares analysis)
-	pub(crate) fn cancel_request(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn cancel_request<T: Trait>(
+		judgements: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(1, 1)
+		T::DbWeight::get().reads_writes(1, 1)
 			+ 41_000_000 // constant
-			+ 300_000 * judgements.into() // R
-			+ 1_700_000 * extra_fields.into() // X
+			+ 300_000 * judgements // R
+			+ 1_700_000 * extra_fields // X
 	}
 
 	/// Weight calculation for `provide_judgement`.
 	///
 	/// Based on benchmark:
 	/// 40.77 + R * 0.282 + X * 1.66 µs (min squares analysis)
-	pub(crate) fn provide_judgement(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn provide_judgement<T: Trait>(
+		judgements: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(2, 1)
+		T::DbWeight::get().reads_writes(2, 1)
 			+ 41_000_000 // constant
-			+ 300_000 * judgements.into() // R
-			+ 1_700_000 * extra_fields.into()// X
+			+ 300_000 * judgements // R
+			+ 1_700_000 * extra_fields// X
 	}
 
 	/// Weight calculation for `kill_identity`.
 	///
 	/// Based on benchmark:
 	/// 83.96 + R * 0.122 + S * 2.533 + X * 0.867 µs (min squares analysis)
-	pub(crate) fn kill_identity(
-		db: RuntimeDbWeight,
-		judgements: impl Into<Weight>,
-		subs: impl Into<Weight> + Copy,
-		extra_fields: impl Into<Weight>
+	pub(crate) fn kill_identity<T: Trait>(
+		judgements: Weight,
+		subs: Weight,
+		extra_fields: Weight
 	) -> Weight {
-		db.reads_writes(2, subs.into() + 2) // 2 `take`s + S deletions
+		let db = T::DbWeight::get();
+		db.reads_writes(2, subs + 2) // 2 `take`s + S deletions
 			+ db.reads_writes(1, 1) // balance ops
 			+ 84_000_000 // constant
-			+ 130_000 * judgements.into() // R
-			+ 2_600_000 * subs.into() // S
-			+ 900_000 * extra_fields.into() // X
+			+ 130_000 * judgements // R
+			+ 2_600_000 * subs // S
+			+ 900_000 * extra_fields // X
 	}
 }
 
@@ -619,27 +627,26 @@ decl_module! {
 		/// - `O(R)` where `R` registrar-count (governance-bounded and code-bounded).
 		/// - One storage mutation (codec `O(R)`).
 		/// - One event.
-		/// - Benchmark: 22.24 + R * 0.371 µs (min squares analysis)
 		/// # </weight>
-		#[weight = T::DbWeight::get().reads_writes(1, 1)
-			+ 23_000_000 // constant
-			+ 380_000 * T::MaxRegistrars::get() as Weight // R
-		]
+		#[weight = weight_for::add_registrar::<T>(T::MaxRegistrars::get().into()) ]
 		fn add_registrar(origin, account: T::AccountId) -> DispatchResultWithPostInfo {
 			T::RegistrarOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
 
-			let (i, registrar_count) = <Registrars<T>>::try_mutate(|registrars| -> Result<(RegistrarIndex, usize), DispatchError> {
-				ensure!((registrars.len() as u32) < T::MaxRegistrars::get(), Error::<T>::TooManyRegistrars);
-				registrars.push(Some(RegistrarInfo { account, fee: Zero::zero(), fields: Default::default() }));
-				Ok(((registrars.len() - 1) as RegistrarIndex, registrars.len()))
-			})?;
+			let (i, registrar_count) = <Registrars<T>>::try_mutate(
+				|registrars| -> Result<(RegistrarIndex, usize), DispatchError> {
+					ensure!(registrars.len() < T::MaxRegistrars::get() as usize, Error::<T>::TooManyRegistrars);
+					registrars.push(Some(RegistrarInfo {
+						account, fee: Zero::zero(), fields: Default::default()
+					}));
+					Ok(((registrars.len() - 1) as RegistrarIndex, registrars.len()))
+				}
+			)?;
 
 			Self::deposit_event(RawEvent::RegistrarAdded(i));
 
-			Ok(Some(T::DbWeight::get().reads_writes(1, 1)
-				+ 25_000_000 + 550_000 * registrar_count as Weight).into())
+			Ok(Some(weight_for::add_registrar::<T>(registrar_count as Weight)).into())
 		}
 
 		/// Set an account's identity information and reserve the appropriate deposit.
@@ -661,10 +668,9 @@ decl_module! {
 		/// - One storage mutation (codec-read `O(X' + R)`, codec-write `O(X + R)`).
 		/// - One event.
 		/// # </weight>
-		#[weight =  weight_for::set_identity(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxAdditionalFields::get() // X
+		#[weight =  weight_for::set_identity::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn set_identity(origin, info: IdentityInfo) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
@@ -695,8 +701,7 @@ decl_module! {
 			<IdentityOf<T>>::insert(&sender, id);
 			Self::deposit_event(RawEvent::IdentitySet(sender));
 
-			Ok(Some(weight_for::set_identity(
-				T::DbWeight::get(),
+			Ok(Some(weight_for::set_identity::<T>(
 				judgements, // R
 				extra_fields as Weight // X
 			)).into())
@@ -723,9 +728,8 @@ decl_module! {
 		///   - One storage write (codec complexity `O(S)`).
 		///   - One storage-exists (`IdentityOf::contains_key`).
 		/// # </weight>
-		#[weight = weight_for::set_subs(
-			T::DbWeight::get(),
-			T::MaxSubAccounts::get(), // P
+		#[weight = weight_for::set_subs::<T>(
+			T::MaxSubAccounts::get().into(), // P
 			subs.len() as Weight // S
 		)]
 		fn set_subs(origin, subs: Vec<(T::AccountId, Data)>) -> DispatchResultWithPostInfo {
@@ -759,8 +763,7 @@ decl_module! {
 				<SubsOf<T>>::insert(&sender, (new_deposit, ids));
 			}
 
-			Ok(Some(weight_for::set_subs(
-				T::DbWeight::get(),
+			Ok(Some(weight_for::set_subs::<T>(
 				old_ids.len() as Weight, // P
 				new_subs // S
 			)).into())
@@ -784,11 +787,10 @@ decl_module! {
 		/// - `2` storage reads and `S + 2` storage deletions.
 		/// - One event.
 		/// # </weight>
-		#[weight = weight_for::clear_identity(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxSubAccounts::get(), // S
-			T::MaxAdditionalFields::get() // X
+		#[weight = weight_for::clear_identity::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxSubAccounts::get().into(), // S
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn clear_identity(origin) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
@@ -805,8 +807,7 @@ decl_module! {
 
 			Self::deposit_event(RawEvent::IdentityCleared(sender, deposit));
 
-			Ok(Some(weight_for::clear_identity(
-				T::DbWeight::get(),
+			Ok(Some(weight_for::clear_identity::<T>(
 				id.judgements.len() as Weight, // R
 				sub_ids.len() as Weight, // S
 				id.info.additional.len() as Weight // X
@@ -836,10 +837,9 @@ decl_module! {
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(X + R)`.
 		/// - One event.
 		/// # </weight>
-		#[weight = weight_for::request_judgement(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxAdditionalFields::get() // X
+		#[weight = weight_for::request_judgement::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn request_judgement(origin,
 			#[compact] reg_index: RegistrarIndex,
@@ -870,7 +870,7 @@ decl_module! {
 
 			Self::deposit_event(RawEvent::JudgementRequested(sender, reg_index));
 
-			Ok(Some(weight_for::request_judgement(T::DbWeight::get(), judgements, extra_fields)).into())
+			Ok(Some(weight_for::request_judgement::<T>(judgements, extra_fields)).into())
 		}
 
 		/// Cancel a previous request.
@@ -890,10 +890,9 @@ decl_module! {
 		/// - One storage mutation `O(R + X)`.
 		/// - One event
 		/// # </weight>
-		#[weight = weight_for::cancel_request(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxAdditionalFields::get() // X
+		#[weight = weight_for::cancel_request::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn cancel_request(origin, reg_index: RegistrarIndex) -> DispatchResultWithPostInfo {
 			let sender = ensure_signed(origin)?;
@@ -914,7 +913,7 @@ decl_module! {
 
 			Self::deposit_event(RawEvent::JudgementUnrequested(sender, reg_index));
 
-			Ok(Some(weight_for::request_judgement(T::DbWeight::get(), judgements, extra_fields)).into())
+			Ok(Some(weight_for::request_judgement::<T>(judgements, extra_fields)).into())
 		}
 
 		/// Set the fee required for a judgement to be requested from a registrar.
@@ -1041,10 +1040,9 @@ decl_module! {
 		/// - Storage: 1 read `O(R)`, 1 mutate `O(R + X)`.
 		/// - One event.
 		/// # </weight>
-		#[weight = weight_for::provide_judgement(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxAdditionalFields::get() // X
+		#[weight = weight_for::provide_judgement::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn provide_judgement(origin,
 			#[compact] reg_index: RegistrarIndex,
@@ -1077,7 +1075,7 @@ decl_module! {
 			<IdentityOf<T>>::insert(&target, id);
 			Self::deposit_event(RawEvent::JudgementGiven(target, reg_index));
 
-			Ok(Some(weight_for::provide_judgement(T::DbWeight::get(), judgements, extra_fields)).into())
+			Ok(Some(weight_for::provide_judgement::<T>(judgements, extra_fields)).into())
 		}
 
 		/// Remove an account's identity and sub-account information and slash the deposits.
@@ -1099,11 +1097,10 @@ decl_module! {
 		/// - `S + 2` storage mutations.
 		/// - One event.
 		/// # </weight>
-		#[weight = weight_for::kill_identity(
-			T::DbWeight::get(),
-			T::MaxRegistrars::get(), // R
-			T::MaxSubAccounts::get(), // S
-			T::MaxAdditionalFields::get() // X
+		#[weight = weight_for::kill_identity::<T>(
+			T::MaxRegistrars::get().into(), // R
+			T::MaxSubAccounts::get().into(), // S
+			T::MaxAdditionalFields::get().into(), // X
 		)]
 		fn kill_identity(origin, target: <T::Lookup as StaticLookup>::Source) -> DispatchResultWithPostInfo {
 			T::ForceOrigin::try_origin(origin)
@@ -1124,8 +1121,7 @@ decl_module! {
 
 			Self::deposit_event(RawEvent::IdentityKilled(target, deposit));
 
-			Ok(Some(weight_for::kill_identity(
-				T::DbWeight::get(),
+			Ok(Some(weight_for::kill_identity::<T>(
 				id.judgements.len() as Weight, // R
 				sub_ids.len() as Weight, // S
 				id.info.additional.len() as Weight // X

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -152,12 +152,12 @@ decl_module! {
 		/// - `O(T)` where `T` complexity of `on_timestamp_set`
 		/// - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in `on_finalize`)
 		/// - 1 event handler `on_timestamp_set` `O(T)`.
-		/// - Benchmark: 8.523 (min squares analysis)
+		/// - Benchmark: 7.678 (min squares analysis)
 		///   - NOTE: This benchmark was done for a runtime with insignificant `on_timestamp_set` handlers.
 		///     New benchmarking is needed when adding new handlers.
 		/// # </weight>
 		#[weight = (
-			T::DbWeight::get().reads_writes(2, 1) + 9_000_000,
+			T::DbWeight::get().reads_writes(2, 1) + 8_000_000,
 			DispatchClass::Mandatory
 		)]
 		fn set(origin, #[compact] now: T::Moment) {
@@ -177,13 +177,13 @@ decl_module! {
 		/// dummy `on_initialize` to return the weight used in `on_finalize`.
 		fn on_initialize() -> Weight {
 			// weight of `on_finalize`
-			6_000_000
+			5_000_000
 		}
 
 		/// # <weight>
 		/// - `O(1)`
 		/// - 1 storage deletion (codec `O(1)`).
-		/// - Benchmark: 5.105 µs (min squares analysis)
+		/// - Benchmark: 4.928 µs (min squares analysis)
 		/// # </weight>
 		fn on_finalize() {
 			assert!(<Self as Store>::DidUpdate::take(), "Timestamp must be updated once in the block");


### PR DESCRIPTION
Make some weight adjustments to `pallet-identity` and `pallet-timestamp` based on recent benchmarking.