### PR TITLE
Bump wasmtime again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "bincode"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,18 +727,18 @@ checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a9c21f8042b9857bda93f6c1910b9f9f24100187a3d3d52f214a34e3dc5818"
+checksum = "d4425bb6c3f3d2f581c650f1a1fdd3196a975490149cf59bea9d34c3bea79eda"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7853f77a6e4a33c67a69c40f5e1bb982bd2dc5c4a22e17e67b65bbccf9b33b2e"
+checksum = "d166b289fd30062ee6de86284750fc3fe5d037c6b864b3326ce153239b0626e1"
 dependencies = [
  "byteorder 1.3.4",
  "cranelift-bforest",
@@ -741,6 +747,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "log",
+ "regalloc",
  "serde",
  "smallvec 1.3.0",
  "target-lexicon",
@@ -749,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084cd6d5fb0d1da28acd72c199471bfb09acc703ec8f3bf07b1699584272a3b9"
+checksum = "02c9fb2306a36d41c5facd4bf3400bc6c157185c43a96eaaa503471c34c5144b"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -759,24 +766,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701b599783305a58c25027a4d73f2d6b599b2d8ef3f26677275f480b4d51e05d"
+checksum = "44e0cfe9b1f97d9f836bca551618106c7d53b93b579029ecd38e73daa7eb689e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88e792b28e1ebbc0187b72ba5ba880dad083abe9231a99d19604d10c9e73f38"
+checksum = "926a73c432e5ba9c891171ff50b75e7d992cd76cd271f0a0a0ba199138077472"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518344698fa6c976d853319218415fdfb4f1bc6b42d0b2e2df652e55dff1f778"
+checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -786,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32daf082da21c0c05d93394ff4842c2ab7c4991b1f3186a1d952f8ac660edd0b"
+checksum = "488b5d481bb0996a143e55a9d1739ef425efa20d4a5e5e98c859a8573c9ead9a"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid",
@@ -797,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.59.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2aa816f554a3ef739a5d17ca3081a1f8983f04c944ea8ff60fb8d9dd8cd2d7b"
+checksum = "00aa8dde71fd9fdb1958e7b0ef8f524c1560e2c6165e4ea54bc302b40551c161"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1277,11 +1284,10 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
+checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
 dependencies = [
- "anyhow",
  "goblin",
  "indexmap",
  "log",
@@ -2724,7 +2730,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7f3f79f060864db0317cc47641b7d35276dee52a0ffa91553fbd0c153863a3"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "byteorder 1.3.4",
  "bytes 0.5.4",
  "fnv",
@@ -3865,16 +3871,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea44a4fd660ab0f38434934ca0212e90fbeaaee54126ef20a3451c30c95bafae"
+checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
 dependencies = [
  "flate2",
- "goblin",
- "parity-wasm 0.41.0",
- "scroll",
  "target-lexicon",
- "uuid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5610,6 +5613,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec 1.3.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,7 +5727,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -5752,7 +5766,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "log",
  "ring",
  "sct",
@@ -7201,7 +7215,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c9dab3f95c9ebdf3a88268c19af668f637a3c5039c2c56ff2d40b1b2d64a25b"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "bytes 0.5.4",
  "flate2",
  "futures 0.3.4",
@@ -8264,9 +8278,9 @@ version = "1.0.6"
 
 [[package]]
 name = "substrate-wasmtime"
-version = "0.13.0-threadsafe.1"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e512629525ecfe43bffe1f3d9e6bb0f08bf01155288ef27fcaae4ea086e4a9d"
+checksum = "3b8f9558e3fe7018b9aeac2aba318664dd7b15e307de11b09f58240695688a96"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -8276,20 +8290,20 @@ dependencies = [
  "region",
  "rustc-demangle",
  "substrate-wasmtime-jit",
+ "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
- "wasmtime-profiling",
  "wat",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "substrate-wasmtime-jit"
-version = "0.13.0-threadsafe.1"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20de5564886d2bcffdd351c9cd114ceb50758aa58eac3cedb14faabf7f93b91"
+checksum = "f6b681b90a8d48b9535e4287c02e5aef6c72228ff45cbb60b4d195a762cc0770"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8298,23 +8312,44 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
+ "gimli",
+ "log",
  "more-asserts",
  "region",
+ "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "thiserror",
  "wasmparser",
  "wasmtime-debug",
  "wasmtime-environ",
- "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
 [[package]]
-name = "substrate-wasmtime-runtime"
-version = "0.13.0-threadsafe.1"
+name = "substrate-wasmtime-profiling"
+version = "0.16.0-threadsafe.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d08846f04293a7fc27eeb30f06262ca2e1b4ee20f5192cec1f3ce201e08ceb8"
+checksum = "b7cb99b24e771de6c20b380fdf2d26ffc2c20701892c540830beb83af98bb3b7"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "gimli",
+ "lazy_static",
+ "libc",
+ "object",
+ "scroll",
+ "serde",
+ "substrate-wasmtime-runtime",
+ "target-lexicon",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "substrate-wasmtime-runtime"
+version = "0.16.0-threadsafe.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaccd27cc466bd2904aa14f984f642083037bf5b47e251ccaf1009aed0a2a185"
 dependencies = [
  "backtrace",
  "cc",
@@ -8327,7 +8362,6 @@ dependencies = [
  "region",
  "thiserror",
  "wasmtime-environ",
- "wasmtime-profiling",
  "winapi 0.3.8",
 ]
 
@@ -9086,12 +9120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9336,9 +9364,9 @@ checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.12.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3d007436043bf55ec252d2f4dc1d35834157b5e2f148da839ca502e611cfe1"
+checksum = "d39ba645aee700b29ff0093028b4123556dd142a74973f04ed6225eedb40e77d"
 dependencies = [
  "anyhow",
  "faerie",
@@ -9352,12 +9380,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.12.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f3dea0e60c076dd0da27fa10c821323903c9554c617ed32eaab8e7a7e36c89"
+checksum = "ed54fd9d64dfeeee7c285fd126174a6b5e6d4efc7e5a1566fdb635e60ff6a74e"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.12.0",
  "bincode",
  "cranelift-codegen",
  "cranelift-entity",
@@ -9377,22 +9405,6 @@ dependencies = [
  "wasmparser",
  "winapi 0.3.8",
  "zstd",
-]
-
-[[package]]
-name = "wasmtime-profiling"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984d29c8add3381e60d649f4e3e2a501da900fc2d2586e139502eec32fe0ebc8"
-dependencies = [
- "gimli",
- "goblin",
- "lazy_static",
- "libc",
- "object",
- "scroll",
- "serde",
- "target-lexicon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
  "log",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.51.4",
 ]
 
 [[package]]
@@ -3875,9 +3875,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5666bbb90bc4d1e5bdcb26c0afda1822d25928341e9384ab187a9b37ab69e36"
 dependencies = [
- "flate2",
  "target-lexicon",
- "wasmparser",
 ]
 
 [[package]]
@@ -8278,9 +8276,9 @@ version = "1.0.6"
 
 [[package]]
 name = "substrate-wasmtime"
-version = "0.16.0-threadsafe.1"
+version = "0.16.0-threadsafe.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8f9558e3fe7018b9aeac2aba318664dd7b15e307de11b09f58240695688a96"
+checksum = "7b40a6f3d5d3c00754e348863fead4f37763c32eedf950f5b23df87769882311"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -8293,7 +8291,7 @@ dependencies = [
  "substrate-wasmtime-profiling",
  "substrate-wasmtime-runtime",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.52.2",
  "wasmtime-environ",
  "wat",
  "winapi 0.3.8",
@@ -8301,9 +8299,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasmtime-jit"
-version = "0.16.0-threadsafe.1"
+version = "0.16.0-threadsafe.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b681b90a8d48b9535e4287c02e5aef6c72228ff45cbb60b4d195a762cc0770"
+checksum = "09712de4f56a2c2912bee7763b0877d17d72cfb2237987d63ab78956907e7692"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8320,7 +8318,7 @@ dependencies = [
  "substrate-wasmtime-runtime",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.52.2",
  "wasmtime-debug",
  "wasmtime-environ",
  "winapi 0.3.8",
@@ -8328,9 +8326,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasmtime-profiling"
-version = "0.16.0-threadsafe.1"
+version = "0.16.0-threadsafe.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cb99b24e771de6c20b380fdf2d26ffc2c20701892c540830beb83af98bb3b7"
+checksum = "31505dd221f001634a54ea51472bc0058bcbde9186eaf8dd31d0859638121385"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8347,9 +8345,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasmtime-runtime"
-version = "0.16.0-threadsafe.1"
+version = "0.16.0-threadsafe.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaccd27cc466bd2904aa14f984f642083037bf5b47e251ccaf1009aed0a2a185"
+checksum = "3708081f04d9216d4dee487abf94872065f930cf82e287bd0c5bdb57895460ba"
 dependencies = [
  "backtrace",
  "cc",
@@ -9363,6 +9361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
+name = "wasmparser"
+version = "0.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
+
+[[package]]
 name = "wasmtime-debug"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9374,7 +9378,7 @@ dependencies = [
  "more-asserts",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.51.4",
  "wasmtime-environ",
 ]
 
@@ -9402,7 +9406,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "toml",
- "wasmparser",
+ "wasmparser 0.51.4",
  "winapi 0.3.8",
  "zstd",
 ]

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -92,9 +92,8 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 					"\"Trap: Trap { kind: Host(Other(\\\"Function `missing_external` is only a stub. Calling a stub is not allowed.\\\")) }\""
 				),
 				#[cfg(feature = "wasmtime")]
-				WasmExecutionMethod::Compiled => assert_eq!(
-					&format!("{:?}", e),
-					"\"Wasm execution trapped: call to a missing function env:missing_external\""
+				WasmExecutionMethod::Compiled => assert!(
+					format!("{:?}", e).contains("Wasm execution trapped: call to a missing function env:missing_external")
 				),
 			}
 		}
@@ -121,9 +120,8 @@ fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 					"\"Trap: Trap { kind: Host(Other(\\\"Function `yet_another_missing_external` is only a stub. Calling a stub is not allowed.\\\")) }\""
 				),
 				#[cfg(feature = "wasmtime")]
-				WasmExecutionMethod::Compiled => assert_eq!(
-					&format!("{:?}", e),
-					"\"Wasm execution trapped: call to a missing function env:yet_another_missing_external\""
+				WasmExecutionMethod::Compiled => assert!(
+					format!("{:?}", e).contains("Wasm execution trapped: call to a missing function env:yet_another_missing_external")
 				),
 			}
 		}

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -21,11 +21,11 @@ sp-wasm-interface = { version = "2.0.0-dev", path = "../../../primitives/wasm-in
 sp-runtime-interface = { version = "2.0.0-dev", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-dev", path = "../../../primitives/allocator" }
-wasmtime = { package = "substrate-wasmtime", version = "0.13.0-threadsafe.1" }
-wasmtime_runtime = { package = "substrate-wasmtime-runtime", version = "0.13.0-threadsafe.1" }
-wasmtime-environ = "0.12.0"
-cranelift-wasm = "0.59.0"
-cranelift-codegen = "0.59.0"
+wasmtime = { package = "substrate-wasmtime", version = "0.16.0-threadsafe.1" }
+wasmtime-runtime = { package = "substrate-wasmtime-runtime", version = "0.16.0-threadsafe.1" }
+wasmtime-environ = "0.16"
+cranelift-wasm = "0.63"
+cranelift-codegen = "0.63"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -21,8 +21,8 @@ sp-wasm-interface = { version = "2.0.0-dev", path = "../../../primitives/wasm-in
 sp-runtime-interface = { version = "2.0.0-dev", path = "../../../primitives/runtime-interface" }
 sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
 sp-allocator = { version = "2.0.0-dev", path = "../../../primitives/allocator" }
-wasmtime = { package = "substrate-wasmtime", version = "0.16.0-threadsafe.1" }
-wasmtime-runtime = { package = "substrate-wasmtime-runtime", version = "0.16.0-threadsafe.1" }
+wasmtime = { package = "substrate-wasmtime", version = "0.16.0-threadsafe.2" }
+wasmtime-runtime = { package = "substrate-wasmtime-runtime", version = "0.16.0-threadsafe.2" }
 wasmtime-environ = "0.16"
 cranelift-wasm = "0.63"
 cranelift-codegen = "0.63"

--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -117,7 +117,7 @@ impl<'a> SandboxCapabilities for HostContext<'a> {
 					return Err("Supervisor function returned unexpected result!".into());
 				}
 			}
-			Err(err) => Err(err.message().to_string().into()),
+			Err(err) => Err(err.to_string().into()),
 		}
 	}
 }

--- a/client/executor/wasmtime/src/instance_wrapper.rs
+++ b/client/executor/wasmtime/src/instance_wrapper.rs
@@ -26,7 +26,7 @@ use sc_executor_common::{
 	util::{WasmModuleInfo, DataSegmentsSnapshot},
 };
 use sp_wasm_interface::{Pointer, WordSize, Value};
-use wasmtime::{Store, Instance, Module, Memory, Table, Val};
+use wasmtime::{Store, Instance, Module, Memory, Table, Val, Func, Extern, Global};
 
 mod globals_snapshot;
 
@@ -88,6 +88,35 @@ pub struct InstanceWrapper {
 	_not_send_nor_sync: marker::PhantomData<*const ()>,
 }
 
+fn extern_memory(extern_: &Extern) -> Option<&Memory> {
+	match extern_ {
+		Extern::Memory(mem) => Some(mem),
+		_ => None,
+	}
+}
+
+
+fn extern_global(extern_: &Extern) -> Option<&Global> {
+	match extern_ {
+		Extern::Global(glob) => Some(glob),
+		_ => None,
+	}
+}
+
+fn extern_table(extern_: &Extern) -> Option<&Table> {
+	match extern_ {
+		Extern::Table(table) => Some(table),
+		_ => None,
+	}
+}
+
+fn extern_func(extern_: &Extern) -> Option<&Func> {
+	match extern_ {
+		Extern::Func(func) => Some(func),
+		_ => None,
+	}
+}
+
 impl InstanceWrapper {
 	/// Create a new instance wrapper from the given wasm module.
 	pub fn new(module_wrapper: &ModuleWrapper, imports: &Imports, heap_pages: u32) -> Result<Self> {
@@ -96,8 +125,7 @@ impl InstanceWrapper {
 
 		let memory = match imports.memory_import_index {
 			Some(memory_idx) => {
-				imports.externs[memory_idx]
-					.memory()
+				extern_memory(&imports.externs[memory_idx])
 					.expect("only memory can be at the `memory_idx`; qed")
 					.clone()
 			}
@@ -130,8 +158,7 @@ impl InstanceWrapper {
 			.instance
 			.get_export(name)
 			.ok_or_else(|| Error::from(format!("Exported method {} is not found", name)))?;
-		let entrypoint = export
-			.func()
+		let entrypoint = extern_func(&export)
 			.ok_or_else(|| Error::from(format!("Export {} is not a function", name)))?;
 		match (entrypoint.ty().params(), entrypoint.ty().results()) {
 			(&[wasmtime::ValType::I32, wasmtime::ValType::I32], &[wasmtime::ValType::I64]) => {}
@@ -164,8 +191,7 @@ impl InstanceWrapper {
 			.get_export("__heap_base")
 			.ok_or_else(|| Error::from("__heap_base is not found"))?;
 
-		let heap_base_global = heap_base_export
-			.global()
+		let heap_base_global = extern_global(&heap_base_export)
 			.ok_or_else(|| Error::from("__heap_base is not a global"))?;
 
 		let heap_base = heap_base_global
@@ -183,7 +209,7 @@ impl InstanceWrapper {
 			None => return Ok(None),
 		};
 
-		let global = global.global().ok_or_else(|| format!("`{}` is not a global", name))?;
+		let global = extern_global(&global).ok_or_else(|| format!("`{}` is not a global", name))?;
 
 		match global.get() {
 			Val::I32(val) => Ok(Some(Value::I32(val))),
@@ -201,8 +227,7 @@ fn get_linear_memory(instance: &Instance) -> Result<Memory> {
 		.get_export("memory")
 		.ok_or_else(|| Error::from("memory is not exported under `memory` name"))?;
 
-	let memory = memory_export
-		.memory()
+	let memory = extern_memory(&memory_export)
 		.ok_or_else(|| Error::from("the `memory` export should have memory type"))?
 		.clone();
 
@@ -213,7 +238,8 @@ fn get_linear_memory(instance: &Instance) -> Result<Memory> {
 fn get_table(instance: &Instance) -> Option<Table> {
 	instance
 		.get_export("__indirect_function_table")
-		.and_then(|export| export.table())
+		.as_ref()
+		.and_then(extern_table)
 		.cloned()
 }
 

--- a/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
+++ b/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
@@ -21,6 +21,7 @@ use sc_executor_common::{
 use sp_wasm_interface::Value;
 use cranelift_codegen::ir;
 use cranelift_wasm::GlobalIndex;
+use wasmtime_runtime::{ExportGlobal, Export};
 
 /// A snapshot of a global variables values. This snapshot can be used later for restoring the
 /// values to the preserved state.
@@ -43,11 +44,9 @@ impl GlobalsSnapshot {
 
 		for global_idx in instance_wrapper.imported_globals_count..instance_wrapper.globals_count {
 			let (def, global) = match handle.lookup_by_declaration(
-				&wasmtime_environ::Export::Global(GlobalIndex::from_u32(global_idx)),
+				&wasmtime_environ::EntityIndex::Global(GlobalIndex::from_u32(global_idx)),
 			) {
-				wasmtime_runtime::Export::Global {
-					definition, global, ..
-				} => (definition, global),
+				Export::Global(ExportGlobal { definition, global, .. }) => (definition, global),
 				_ => unreachable!("only globals can be returned for a global request"),
 			};
 

--- a/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
+++ b/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
@@ -38,7 +38,7 @@ impl GlobalsSnapshot {
 	pub fn take(instance_wrapper: &InstanceWrapper) -> Result<Self> {
 		// EVIL:
 		// Usage of an undocumented function.
-		let handle = instance_wrapper.instance.handle().clone();
+		let handle = unsafe { instance_wrapper.instance.handle().clone() };
 
 		let mut preserved_mut_globals = vec![];
 

--- a/client/executor/wasmtime/src/runtime.rs
+++ b/client/executor/wasmtime/src/runtime.rs
@@ -158,7 +158,7 @@ fn perform_call(
 			Err(trap) => {
 				return Err(Error::from(format!(
 					"Wasm execution trapped: {}",
-					trap.message()
+					trap
 				)));
 			}
 		}


### PR DESCRIPTION
Brings back #5822 which should be safe to use now. 
`paritytech/wasmtime` is now up to date with upstream and the race in signatures registration is protected with a lock.