### PR TITLE
Split Operational and Normal weight

### DIFF
--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -132,11 +132,12 @@ mod tests {
 
 	// poc reference implementation.
 	fn fee_multiplier_update(block_weight: Weight, previous: Fixed128) -> Fixed128  {
-		let block_weight = block_weight as f64;
-		let v: f64 = 0.00004;
-
 		// maximum tx weight
 		let m = max() as f64;
+		// block weight always truncated to max weight
+		let block_weight = (block_weight as f64).min(m);
+		let v: f64 = 0.00004;
+
 		// Ideal saturation in terms of weight
 		let ss = target() as f64;
 		// Current saturation in terms of weight

--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -70,7 +70,7 @@ pub struct TargetedFeeAdjustment<T>(sp_std::marker::PhantomData<T>);
 
 impl<T: Get<Perquintill>> Convert<Fixed128, Fixed128> for TargetedFeeAdjustment<T> {
 	fn convert(multiplier: Fixed128) -> Fixed128 {
-		let block_weight = System::all_extrinsics_weight();
+		let block_weight = System::all_extrinsics_weight().total();
 		let max_weight = MaximumBlockWeight::get();
 		let target_weight = (T::get() * max_weight) as u128;
 		let block_weight = block_weight as u128;

--- a/bin/node/runtime/src/impls.rs
+++ b/bin/node/runtime/src/impls.rs
@@ -70,8 +70,8 @@ pub struct TargetedFeeAdjustment<T>(sp_std::marker::PhantomData<T>);
 
 impl<T: Get<Perquintill>> Convert<Fixed128, Fixed128> for TargetedFeeAdjustment<T> {
 	fn convert(multiplier: Fixed128) -> Fixed128 {
-		let block_weight = System::all_extrinsics_weight().total();
 		let max_weight = MaximumBlockWeight::get();
+		let block_weight = System::all_extrinsics_weight().total().min(max_weight);
 		let target_weight = (T::get() * max_weight) as u128;
 		let block_weight = block_weight as u128;
 

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -116,7 +116,7 @@
 
 use sp_std::{prelude::*, marker::PhantomData};
 use frame_support::{
-	storage::StorageValue, weights::{GetDispatchInfo, DispatchInfo},
+	storage::StorageValue, weights::{GetDispatchInfo, DispatchInfo, DispatchClass},
 	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade, OffchainWorker},
 };
 use sp_runtime::{
@@ -235,7 +235,7 @@ where
 			let mut weight = <frame_system::Module::<System> as OnRuntimeUpgrade>::on_runtime_upgrade();
 			weight = weight.saturating_add(COnRuntimeUpgrade::on_runtime_upgrade());
 			weight = weight.saturating_add(<AllModules as OnRuntimeUpgrade>::on_runtime_upgrade());
-			<frame_system::Module<System>>::register_extra_weight_unchecked(weight);
+			<frame_system::Module<System>>::register_extra_weight_unchecked(weight, DispatchClass::Mandatory);
 		}
 		<frame_system::Module<System>>::initialize(
 			block_number,
@@ -247,7 +247,7 @@ where
 		<frame_system::Module<System> as OnInitialize<System::BlockNumber>>::on_initialize(*block_number);
 		let weight = <AllModules as OnInitialize<System::BlockNumber>>::on_initialize(*block_number)
 			.saturating_add(<System::BlockExecutionWeight as frame_support::traits::Get<_>>::get());
-		<frame_system::Module::<System>>::register_extra_weight_unchecked(weight);
+		<frame_system::Module::<System>>::register_extra_weight_unchecked(weight, DispatchClass::Mandatory);
 
 		frame_system::Module::<System>::note_finished_initialize();
 	}

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -785,7 +785,7 @@ mod tests {
 				Digest::default(),
 			));
 			// Base block execution weight + `on_initialize` weight from the custom module.
-			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight(), base_block_weight);
+			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight().total(), base_block_weight);
 
 			for nonce in 0..=num_to_exhaust_block {
 				let xt = TestXt::new(
@@ -795,7 +795,7 @@ mod tests {
 				if nonce != num_to_exhaust_block {
 					assert!(res.is_ok());
 					assert_eq!(
-						<frame_system::Module<Runtime>>::all_extrinsics_weight(),
+						<frame_system::Module<Runtime>>::all_extrinsics_weight().total(),
 						//--------------------- on_initialize + block_execution + extrinsic_base weight
 						(encoded_len + 5) * (nonce + 1) + base_block_weight,
 					);
@@ -815,7 +815,7 @@ mod tests {
 		let len = xt.clone().encode().len() as u32;
 		let mut t = new_test_ext(1);
 		t.execute_with(|| {
-			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight(), 0);
+			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight().total(), 0);
 			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_len(), 0);
 
 			assert!(Executive::apply_extrinsic(xt.clone()).unwrap().is_ok());
@@ -824,14 +824,14 @@ mod tests {
 
 			// default weight for `TestXt` == encoded length.
 			assert_eq!(
-				<frame_system::Module<Runtime>>::all_extrinsics_weight(),
+				<frame_system::Module<Runtime>>::all_extrinsics_weight().total(),
 				3 * (len as Weight + <Runtime as frame_system::Trait>::ExtrinsicBaseWeight::get()),
 			);
 			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_len(), 3 * len);
 
 			let _ = <frame_system::Module<Runtime>>::finalize();
 
-			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight(), 0);
+			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight().total(), 0);
 			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_len(), 0);
 		});
 	}
@@ -903,7 +903,7 @@ mod tests {
 			// NOTE: might need updates over time if new weights are introduced.
 			// For now it only accounts for the base block execution weight and
 			// the `on_initialize` weight defined in the custom test module.
-			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight(), 175 + 10);
+			assert_eq!(<frame_system::Module<Runtime>>::all_extrinsics_weight().total(), 175 + 10);
 		})
 	}
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -372,14 +372,16 @@ impl ExtrinsicsWeight {
 	pub fn add(&mut self, weight: Weight, class: DispatchClass) {
 		match class {
 			DispatchClass::Operational => self.operational = self.operational.saturating_add(weight),
-			_ => self.normal = self.normal.saturating_add(weight),
+			DispatchClass::Normal => self.normal = self.normal.saturating_add(weight),
+			DispatchClass::Mandatory => self.normal = self.normal.saturating_add(weight),
 		};
 	}
 
 	pub fn checked_add(&mut self, weight: Weight, class: DispatchClass) -> Result<(), ()> {
 		match class {
 			DispatchClass::Operational => self.operational = self.operational.checked_add(weight).ok_or(())?,
-			_ => self.normal = self.normal.checked_add(weight).ok_or(())?,
+			DispatchClass::Normal => self.normal = self.normal.checked_add(weight).ok_or(())?,
+			DispatchClass::Mandatory => self.normal = self.normal.checked_add(weight).ok_or(())?,
 		}
 		Ok(())
 	}
@@ -387,21 +389,24 @@ impl ExtrinsicsWeight {
 	pub fn sub(&mut self, weight: Weight, class: DispatchClass) {
 		match class {
 			DispatchClass::Operational => self.operational = self.operational.saturating_sub(weight),
-			_ => self.normal = self.normal.saturating_sub(weight),
+			DispatchClass::Normal => self.normal = self.normal.saturating_sub(weight),
+			DispatchClass::Mandatory => self.normal = self.normal.saturating_sub(weight),
 		};
 	}
 
 	pub fn get(&self, class: DispatchClass) -> Weight {
 		match class {
 			DispatchClass::Operational => self.operational,
-			_ => self.normal,
+			DispatchClass::Normal => self.normal,
+			DispatchClass::Mandatory => self.normal,
 		}
 	}
 
 	pub fn put(&mut self, new: Weight, class: DispatchClass) {
 		match class {
 			DispatchClass::Operational => self.operational = new,
-			_ => self.normal = new,
+			DispatchClass::Normal => self.normal = new,
+			DispatchClass::Mandatory => self.normal = new,
 		};
 	}
 }

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1377,7 +1377,7 @@ impl<T: Trait + Send + Sync> CheckWeight<T> where
 					Ok(all_weight)
 				}
 			},
-			// If we have an operation dispatch, allow it if we have not used our full
+			// If we have an operational dispatch, allow it if we have not used our full
 			// "operational space" (independent of existing fullness).
 			DispatchClass::Operational => {
 				let operational_limit = Self::get_dispatch_limit_ratio(DispatchClass::Operational) * maximum_weight;

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1356,17 +1356,16 @@ impl<T: Trait + Send + Sync> CheckWeight<T> where
 		info: &DispatchInfoOf<T::Call>,
 	) -> Result<ExtrinsicsWeight, TransactionValidityError> {
 		let maximum_weight = T::MaximumBlockWeight::get();
+		let mut all_weight = Module::<T>::all_extrinsics_weight();
 		match info.class {
 			// If we have a dispatch that must be included in the block, it ignores all the limits.
 			DispatchClass::Mandatory => {
-				let mut all_weight = Module::<T>::all_extrinsics_weight();
 				let extrinsic_weight = info.weight.saturating_add(T::ExtrinsicBaseWeight::get());
 				all_weight.add(extrinsic_weight, DispatchClass::Mandatory);
 				Ok(all_weight)
 			},
 			// If we have a normal dispatch, we follow all the normal rules and limits.
 			DispatchClass::Normal => {
-				let mut all_weight = Module::<T>::all_extrinsics_weight();
 				let normal_limit = Self::get_dispatch_limit_ratio(DispatchClass::Normal) * maximum_weight;
 				let extrinsic_weight = info.weight.checked_add(T::ExtrinsicBaseWeight::get())
 					.ok_or(InvalidTransaction::ExhaustsResources)?;
@@ -1381,7 +1380,6 @@ impl<T: Trait + Send + Sync> CheckWeight<T> where
 			// If we have an operation dispatch, allow it if we have not used our full
 			// "operational space" (independent of existing fullness).
 			DispatchClass::Operational => {
-				let mut all_weight = Module::<T>::all_extrinsics_weight();
 				let operational_limit = Self::get_dispatch_limit_ratio(DispatchClass::Operational) * maximum_weight;
 				let normal_limit = Self::get_dispatch_limit_ratio(DispatchClass::Normal) * maximum_weight;
 				let operational_space = operational_limit.saturating_sub(normal_limit);


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/5758

This PR splits operational and normal weight to be tracked separately.

This means that order of inclusion will not matter for operational and transactional weights. (see the tagged issue).

On top of this, we change the logic around when an operational transaction will be included in a block.

In the case where a block is completely full with non-operational transactions (either normal transaction, mandatory inherents, or on_initialize/on_finalize), we still allow an amount of operational transactions that would normally comprise a full block (1 - available block ratio).

This is to avoid any situations where users may be locked out of the chain due to full blocks.

