### PR TITLE
Expose BlockHashCount on system metadata constants

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -481,6 +481,9 @@ decl_module! {
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 		type Error = Error<T>;
 
+		/// The maximum number of blocks to allow in mortal eras.
+		const BlockHashCount: T::BlockNumber = T::BlockHashCount::get();
+
 		/// The maximum weight of a block.
 		const MaximumBlockWeight: Weight = T::MaximumBlockWeight::get();
 


### PR DESCRIPTION
This is useful to external users, using this info they can determine the maximum number of allowed blocks when constructing mortal eras. Currently this is either hardcoded or not checked at all in APIs, in either case this could mean that an invalid period is chosen for the mortal era.