### PR TITLE
Small fix to block response completion reporting

### DIFF
--- a/client/network/src/block_requests.rs
+++ b/client/network/src/block_requests.rs
@@ -709,7 +709,7 @@ where
 				peer,
 				total_handling_time,
 			};
-			self.pending_events.push_back(NetworkBehaviourAction::GenerateEvent(ev));
+			return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev));
 		}
 
 		Poll::Pending

--- a/client/network/src/block_requests.rs
+++ b/client/network/src/block_requests.rs
@@ -704,7 +704,7 @@ where
 			}
 		}
 
-		while let Poll::Ready(Some((peer, total_handling_time))) = self.outgoing.poll_next_unpin(cx) {
+		if let Poll::Ready(Some((peer, total_handling_time))) = self.outgoing.poll_next_unpin(cx) {
 			let ev = Event::AnsweredRequest {
 				peer,
 				total_handling_time,


### PR DESCRIPTION
Report events immediately instead of en-queueing them and returning `Poll::Pending`.
This is only relevant to reporting to Prometheus how much time we took to answer requests, so it's not related to the current sync stalling issue.
