### PR TITLE
grandpa: update to finality-grandpa v0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4682570188cd105606e621b9992e580f717c15f8cd1b7d106b59f1c6e54680"
+checksum = "8feb87a63249689640ac9c011742c33139204e3c134293d3054022276869133b"
 dependencies = [
  "either",
  "futures 0.3.4",

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -42,11 +42,11 @@ sp-finality-tracker = { version = "2.0.0-dev", path = "../../primitives/finality
 sp-finality-grandpa = { version = "2.0.0-dev", path = "../../primitives/finality-grandpa" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-dev"}
 sc-block-builder = { version = "0.8.0-dev", path = "../block-builder" }
-finality-grandpa = { version = "0.12.2", features = ["derive-codec"] }
+finality-grandpa = { version = "0.12.3", features = ["derive-codec"] }
 pin-project = "0.4.6"
 
 [dev-dependencies]
-finality-grandpa = { version = "0.12.2", features = ["derive-codec", "test-helpers"] }
+finality-grandpa = { version = "0.12.3", features = ["derive-codec", "test-helpers"] }
 sc-network = { version = "0.8.0-dev", path = "../network" }
 sc-network-test = { version = "0.8.0-dev", path = "../network/test" }
 sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 
 [dependencies]
 sc-finality-grandpa = { version = "0.8.0-dev", path = "../" }
-finality-grandpa = { version = "0.12.2", features = ["derive-codec"] }
+finality-grandpa = { version = "0.12.3", features = ["derive-codec"] }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -27,7 +27,7 @@ pallet-session = { version = "2.0.0-dev", default-features = false, path = "../s
 pallet-finality-tracker = { version = "2.0.0-dev", default-features = false, path = "../finality-tracker" }
 
 [dev-dependencies]
-grandpa = { package = "finality-grandpa", version = "0.12.2", features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.12.3", features = ["derive-codec"] }
 sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 pallet-balances = { version = "2.0.0-dev", path = "../balances" }

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-application-crypto = { version = "2.0.0-dev", default-features = false, path = "../application-crypto" }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-grandpa = { package = "finality-grandpa", version = "0.12.2", default-features = false, features = ["derive-codec"] }
+grandpa = { package = "finality-grandpa", version = "0.12.3", default-features = false, features = ["derive-codec"] }
 log = { version = "0.4.8", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-api = { version = "2.0.0-dev", default-features = false, path = "../api" }


### PR DESCRIPTION
Fixes an issue with background rounds leaking (https://github.com/paritytech/finality-grandpa/pull/122).