### PR TITLE
Do not fetch every block body from transaction pool

### DIFF
--- a/client/transaction-pool/graph/src/listener.rs
+++ b/client/transaction-pool/graph/src/listener.rs
@@ -129,10 +129,11 @@ impl<H: hash::Hash + traits::Member + Serialize, C: ChainApi> Listener<H, C> {
 	}
 
 	/// Notify all watchers that transactions have been finalized
-	pub fn finalized(&mut self, block_hash: BlockHash<C>, txs: Vec<H>) {
-		self.finality_watchers.remove(&block_hash);
-		for h in txs {
-			self.fire(&h, |s| s.finalized(block_hash.clone()))
+	pub fn finalized(&mut self, block_hash: BlockHash<C>) {
+		if let Some(hashes) = self.finality_watchers.remove(&block_hash) {
+			for hash in hashes {
+				self.fire(&hash, |s| s.finalized(block_hash))
+			}
 		}
 	}
 }

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -559,15 +559,7 @@ impl<B: ChainApi> ValidatedPool<B> {
 	/// Notify all watchers that transactions in the block with hash have been finalized
 	pub async fn on_block_finalized(&self, block_hash: BlockHash<B>) -> Result<(), B::Error> {
 		debug!(target: "txpool", "Attempting to notify watchers of finalization for {}", block_hash);
-		// fetch all extrinsic hashes
-		if let Some(txs) = self.api.block_body(&BlockId::Hash(block_hash.clone())).await? {
-			let tx_hashes = txs.into_iter()
-				.map(|tx| self.api.hash_and_length(&tx).0)
-				.collect::<Vec<_>>();
-			// notify the watcher that these extrinsics have been finalized
-			self.listener.write().finalized(block_hash, tx_hashes);
-		}
-
+		self.listener.write().finalized(block_hash);
 		Ok(())
 	}
 


### PR DESCRIPTION
closes #5973 

@seunlanlege I'm not sure if I've missed something. I assume that for every 'listened' transaction that has been included into some block, we have entry in `finality_watchers` under that block hash key, right? So we actually do not need to have hashes of all block transactions to notify these listeners. At least that's how `retracted` works. So I simply changed the code to notify only registered listeners. Please check if I'm not missing anything.