### PR TITLE
Allow passing multiple --log CLI options

### DIFF
--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -396,7 +396,7 @@ macro_rules! substrate_cli_subcommands {
 				}
 			}
 
-			fn log_filters(&self) -> $crate::Result<::std::option::Option<String>> {
+			fn log_filters(&self) -> $crate::Result<String> {
 				match self {
 					$($enum::$variant(cmd) => cmd.log_filters()),*
 				}

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -473,7 +473,7 @@ pub trait CliConfiguration: Sized {
 	/// Get the filters for the logging.
 	///
 	/// This should be a list of comma-separated values.
-	/// Example: `foo=trace,bar=debug,bar=info`
+	/// Example: `foo=trace,bar=debug,baz=info`
 	///
 	/// By default this is retrieved from `SharedParams`.
 	fn log_filters(&self) -> Result<String> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -472,9 +472,12 @@ pub trait CliConfiguration: Sized {
 
 	/// Get the filters for the logging.
 	///
+	/// This should be a list of comma-separated values.
+	/// Example: `foo=trace,bar=debug,bar=info`
+	///
 	/// By default this is retrieved from `SharedParams`.
-	fn log_filters(&self) -> Result<Option<String>> {
-		Ok(self.shared_params().log_filters())
+	fn log_filters(&self) -> Result<String> {
+		Ok(self.shared_params().log_filters().join(","))
 	}
 
 	/// Initialize substrate. This must be done only once.
@@ -485,12 +488,12 @@ pub trait CliConfiguration: Sized {
 	/// 2. Raise the FD limit
 	/// 3. Initialize the logger
 	fn init<C: SubstrateCli>(&self) -> Result<()> {
-		let logger_pattern = self.log_filters()?.unwrap_or_default();
+		let logger_pattern = self.log_filters()?;
 
 		sp_panic_handler::set(C::support_url(), C::impl_version());
 
 		fdlimit::raise_fd_limit();
-		init_logger(logger_pattern.as_str());
+		init_logger(&logger_pattern);
 
 		Ok(())
 	}

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -42,7 +42,7 @@ pub struct SharedParams {
 	/// Log levels (least to most verbose) are error, warn, info, debug, and trace.
 	/// By default, all targets log `info`. The global log level can be set with -l<level>.
 	#[structopt(short = "l", long = "log", value_name = "LOG_PATTERN")]
-	pub log: Option<String>,
+	pub log: Vec<String>,
 }
 
 impl SharedParams {
@@ -71,7 +71,7 @@ impl SharedParams {
 	}
 
 	/// Get the filters for the logging
-	pub fn log_filters(&self) -> Option<String> {
-		self.log.clone()
+	pub fn log_filters(&self) -> &[String] {
+		&self.log
 	}
 }


### PR DESCRIPTION
Quality-of-life change. You can now do `./polkadot --log foo=debug --log bar=trace`.
The code will automatically put a `,` between the multiple values.
