### PR TITLE
Restore the reputation penalty for timeouts

### DIFF
--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -329,7 +329,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviourEventProcess<block_requests::Event<B
 					protocol: self.block_requests.protocol_name().to_vec(),
 					request_duration,
 				});
-				self.substrate.disconnect_peer(&peer);
+				self.substrate.on_block_request_failed(&peer);
 			}
 		}
 	}


### PR DESCRIPTION
The reputation penalty for timing out a block request was accidentally removed. This restores it.

This should hopefully prevent the PSM from connecting again to the same node we just had a timeout with.