### PR TITLE
WIP Make ChangeMembers trait fallible

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -90,7 +90,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 247,
+	spec_version: 248,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -377,6 +377,7 @@ impl pallet_democracy::Trait for Runtime {
 
 parameter_types! {
 	pub const CouncilMotionDuration: BlockNumber = 5 * DAYS;
+	pub const DesiredMembers: u32 = 13;
 }
 
 type CouncilCollective = pallet_collective::Instance1;
@@ -385,13 +386,13 @@ impl pallet_collective::Trait<CouncilCollective> for Runtime {
 	type Proposal = Call;
 	type Event = Event;
 	type MotionDuration = CouncilMotionDuration;
+	type MaxMembers = DesiredMembers;
 }
 
 parameter_types! {
 	pub const CandidacyBond: Balance = 10 * DOLLARS;
 	pub const VotingBond: Balance = 1 * DOLLARS;
 	pub const TermDuration: BlockNumber = 7 * DAYS;
-	pub const DesiredMembers: u32 = 13;
 	pub const DesiredRunnersUp: u32 = 7;
 	pub const ElectionsPhragmenModuleId: LockIdentifier = *b"phrelect";
 }
@@ -417,6 +418,7 @@ impl pallet_elections_phragmen::Trait for Runtime {
 
 parameter_types! {
 	pub const TechnicalMotionDuration: BlockNumber = 5 * DAYS;
+	pub const TechnicalMaxMembers: u32 = 100;
 }
 
 type TechnicalCollective = pallet_collective::Instance2;
@@ -425,6 +427,7 @@ impl pallet_collective::Trait<TechnicalCollective> for Runtime {
 	type Proposal = Call;
 	type Event = Event;
 	type MotionDuration = TechnicalMotionDuration;
+	type MaxMembers = TechnicalMaxMembers;
 }
 
 impl pallet_membership::Trait<pallet_membership::Instance1> for Runtime {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -383,7 +383,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		_incoming: &[T::AccountId],
 		outgoing: &[T::AccountId],
 		new: &[T::AccountId],
-	) {
+	) -> usize {
 		// remove accounts from all current voting in motions.
 		let mut outgoing = outgoing.to_vec();
 		outgoing.sort_unstable();
@@ -402,7 +402,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		}
 		Members::<T, I>::put(new);
 		Prime::<T, I>::kill();
-		length
+		new.len()
 	}
 
 	fn set_prime(prime: Option<T::AccountId>) {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -203,7 +203,7 @@ decl_module! {
 			let mut new_members = new_members;
 			new_members.sort();
 			// We can drop the members count from `ChangeMembers` because we used the ensure above.
-			let _ = <Self as ChangeMembers<T::AccountId>>::set_members_sorted(&new_members, &old);
+			<Self as ChangeMembers<T::AccountId>>::set_members_sorted(&new_members, &old);
 			Prime::<T, I>::set(prime);
 		}
 

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -404,7 +404,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		_incoming: &[T::AccountId],
 		outgoing: &[T::AccountId],
 		new: &[T::AccountId],
-	) -> usize {
+	) -> Vec<T::AccountId> {
 		// limit members to `MaxMembers`
 		let length = new.len().min(T::MaxMembers::get() as usize);
 		if length != new.len() {
@@ -433,7 +433,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		}
 		Members::<T, I>::put(new);
 		Prime::<T, I>::kill();
-		length
+		new.to_vec()
 	}
 
 	fn set_prime(prime: Option<T::AccountId>) {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -402,6 +402,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		}
 		Members::<T, I>::put(new);
 		Prime::<T, I>::kill();
+		length
 	}
 
 	fn set_prime(prime: Option<T::AccountId>) {
@@ -523,7 +524,7 @@ impl<
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use frame_support::{Hashable, assert_ok, assert_noop, parameter_types, weights::Weight};
+	use frame_support::{Hashable, assert_err, assert_ok, assert_noop, parameter_types, weights::Weight};
 	use frame_system::{self as system, EventRecord, Phase};
 	use hex_literal::hex;
 	use sp_core::H256;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -551,7 +551,6 @@ impl<T: Trait> Module<T> {
 			let old = [who.clone()];
 			// We don't need to check the actual new members length because it will be the same
 			// as before or one less.
-			// TODO: Is this safe without ensure_can_change_members?
 			let _ = match maybe_replacement {
 				Some(new) => T::ChangeMembers::change_members_sorted(&[new], &old, &members),
 				None => T::ChangeMembers::change_members_sorted(&[], &old, &members),

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -551,7 +551,7 @@ impl<T: Trait> Module<T> {
 			let old = [who.clone()];
 			// We don't need to check the actual new members length because it will be the same
 			// as before or one less.
-			let _ = match maybe_replacement {
+			match maybe_replacement {
 				Some(new) => T::ChangeMembers::change_members_sorted(&[new], &old, &members),
 				None => T::ChangeMembers::change_members_sorted(&[], &old, &members),
 			};

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -975,7 +975,7 @@ mod tests {
 
 	pub struct TestChangeMembers;
 	impl ChangeMembers<u64> for TestChangeMembers {
-		fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
+		fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> Vec<u64> {
 			// new, incoming, outgoing must be sorted.
 			let mut new_sorted = new.to_vec();
 			new_sorted.sort();
@@ -1007,7 +1007,7 @@ mod tests {
 			MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
 			PRIME.with(|p| *p.borrow_mut() = None);
 
-			new.len()
+			new.to_vec()
 		}
 
 		fn set_prime(who: Option<u64>) {

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -682,6 +682,7 @@ decl_module! {
 				.collect();
 			<Members<T>>::put(&new_set);
 			let new_set = new_set.into_iter().map(|x| x.0).collect::<Vec<_>>();
+			// This is save to just call because we are removing members, not adding any.
 			T::ChangeMembers::change_members(&[], &[who], new_set);
 		}
 

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -111,7 +111,7 @@ impl Get<u32> for DecayRatio {
 
 pub struct TestChangeMembers;
 impl ChangeMembers<u64> for TestChangeMembers {
-	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
+	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> Vec<u64> {
 		let mut old_plus_incoming = MEMBERS.with(|m| m.borrow().to_vec());
 		old_plus_incoming.extend_from_slice(incoming);
 		old_plus_incoming.sort();
@@ -121,7 +121,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 		assert_eq!(old_plus_incoming, new_plus_outgoing);
 
 		MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
-		new.len()
+		new.to_vec()
 	}
 }
 

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -111,7 +111,7 @@ impl Get<u32> for DecayRatio {
 
 pub struct TestChangeMembers;
 impl ChangeMembers<u64> for TestChangeMembers {
-	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) {
+	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
 		let mut old_plus_incoming = MEMBERS.with(|m| m.borrow().to_vec());
 		old_plus_incoming.extend_from_slice(incoming);
 		old_plus_incoming.sort();
@@ -121,6 +121,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 		assert_eq!(old_plus_incoming, new_plus_outgoing);
 
 		MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
+		new.len()
 	}
 }
 

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -130,8 +130,7 @@ decl_module! {
 			T::MembershipChanged::ensure_can_change_members(&members, &old)?;
 			<Members<T, I>>::put(&members);
 
-			// Safe to ignore the length of the new members here because of `ensure_can_change_members`.
-			let _ = T::MembershipChanged::change_members_sorted(&[who], &[], &members[..]);
+			T::MembershipChanged::change_members_sorted(&[who], &[], &members[..]);
 
 			Self::deposit_event(RawEvent::MemberAdded);
 		}

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -343,7 +343,7 @@ mod tests {
 
 	pub struct TestChangeMembers;
 	impl ChangeMembers<u64> for TestChangeMembers {
-		fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
+		fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> Vec<u64> {
 			let mut old_plus_incoming = MEMBERS.with(|m| m.borrow().to_vec());
 			old_plus_incoming.extend_from_slice(incoming);
 			old_plus_incoming.sort();
@@ -354,7 +354,7 @@ mod tests {
 
 			MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
 			PRIME.with(|p| *p.borrow_mut() = None);
-			new.len()
+			new.to_vec()
 		}
 
 		fn set_prime(who: Option<u64>) {

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -416,7 +416,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 				T::MembershipInitialized::initialize_members(&new_members),
 			ChangeReceiver::MembershipChanged => {
 				// TODO: Is this safe?
-				let _ = T::MembershipChanged::set_members_sorted(
+				T::MembershipChanged::set_members_sorted(
 					&new_members[..],
 					&old_members[..],
 				);

--- a/frame/scored-pool/src/lib.rs
+++ b/frame/scored-pool/src/lib.rs
@@ -40,6 +40,9 @@
 //! - [`Call`](./enum.Call.html)
 //! - [`Module`](./struct.Module.html)
 //!
+//! NOTE: This pallet does not provide proper weights for its functions, yet.
+//!       Benchmark and adjust the weights before using in production.
+//!
 //! ## Interface
 //!
 //! ### Public Functions
@@ -407,21 +410,20 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 		new_members.sort();
 
 		let old_members = <Members<T, I>>::get();
-		// TODO: What to do in case of error?
-		let _ = T::MembershipChanged::ensure_can_change_members(&new_members, &old_members);
 		<Members<T, I>>::put(&new_members);
 
 		match notify {
 			ChangeReceiver::MembershipInitialized =>
 				T::MembershipInitialized::initialize_members(&new_members),
 			ChangeReceiver::MembershipChanged => {
-				// TODO: Is this safe?
+				// TODO: This is not safe as members might be truncated.
 				T::MembershipChanged::set_members_sorted(
 					&new_members[..],
 					&old_members[..],
 				);
 			},
 		}
+		
 	}
 
 	/// Removes an entity `remove` at `index` from the `Pool`.

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -92,7 +92,7 @@ thread_local! {
 
 pub struct TestChangeMembers;
 impl ChangeMembers<u64> for TestChangeMembers {
-	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) {
+	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
 		let mut old_plus_incoming = MEMBERS.with(|m| m.borrow().to_vec());
 		old_plus_incoming.extend_from_slice(incoming);
 		old_plus_incoming.sort();
@@ -104,6 +104,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 		assert_eq!(old_plus_incoming, new_plus_outgoing);
 
 		MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
+		new.len()
 	}
 }
 

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -92,7 +92,7 @@ thread_local! {
 
 pub struct TestChangeMembers;
 impl ChangeMembers<u64> for TestChangeMembers {
-	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> usize {
+	fn change_members_sorted(incoming: &[u64], outgoing: &[u64], new: &[u64]) -> Vec<u64> {
 		let mut old_plus_incoming = MEMBERS.with(|m| m.borrow().to_vec());
 		old_plus_incoming.extend_from_slice(incoming);
 		old_plus_incoming.sort();
@@ -104,7 +104,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 		assert_eq!(old_plus_incoming, new_plus_outgoing);
 
 		MEMBERS.with(|m| *m.borrow_mut() = new.to_vec());
-		new.len()
+		new.to_vec()
 	}
 }
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -956,7 +956,7 @@ pub trait ChangeMembers<AccountId: Clone + Ord, MembersCount = usize> {
 	///
 	/// This resets any previous value of prime.
 	///
-	/// Returns the actual number of members set. This may differ from `new.len()` for example
+	/// Returns the actual number of members set. This may differ from `new.len()`
 	/// if there are errors. Use `ensure_can_change_members` to check for those beforehand.
 	fn change_members(
 		incoming: &[AccountId],
@@ -975,7 +975,7 @@ pub trait ChangeMembers<AccountId: Clone + Ord, MembersCount = usize> {
 	///
 	/// This resets any previous value of prime.
 	///
-	/// Returns the actual number of members set. This may differ from `new.len()` for example
+	/// Returns the actual number of members set. This may differ from `sorted_new.len()`
 	/// if there are errors. Use `ensure_can_change_members` to check for those beforehand.
 	fn change_members_sorted(
 		incoming: &[AccountId],
@@ -988,7 +988,7 @@ pub trait ChangeMembers<AccountId: Clone + Ord, MembersCount = usize> {
 	///
 	/// This resets any previous value of prime.
 	///
-	/// Returns the actual number of members set. This may differ from `new.len()` for example
+	/// Returns the actual number of members set. This may differ from `new_members.len()`
 	/// if there are errors. Use `ensure_can_change_members` to check for those beforehand.
 	fn set_members_sorted(
 		new_members: &[AccountId],


### PR DESCRIPTION
This PR changes the `ChangeMembers` trait to be fallible.
`change_members`, `change_members_sorted` and `set_members_sorted` are no longer guaranteed to set all members successfully.
Instead they return the new number of members after the operation. There is also a new `ensure_can_change_members` function that is meant to allow checking whether a member change will execute without errors.

Preparation for #5802 as it uses the member limit to estimate weights in `pallet-collective` (an implementor of `ChangeMembers`).

✄ -----------------------------------------------------------------------------
- [ ] You labeled the PR with appropriate labels if you have permissions to do so.
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?