### PR TITLE
Monitor transactions rejected from the pool as invalid

### DIFF
--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -296,7 +296,9 @@ impl<PoolApi, Block> TransactionPool for BasicPool<PoolApi, Block>
 	}
 
 	fn remove_invalid(&self, hashes: &[TxHash<Self>]) -> Vec<Arc<Self::InPoolTransaction>> {
-		self.pool.validated_pool().remove_invalid(hashes)
+		let removed = self.pool.validated_pool().remove_invalid(hashes);
+		self.metrics.report(|metrics| metrics.validations_invalid.inc_by(removed.len() as u64));
+		removed
 	}
 
 	fn status(&self) -> PoolStatus {

--- a/client/transaction-pool/src/metrics.rs
+++ b/client/transaction-pool/src/metrics.rs
@@ -45,6 +45,7 @@ impl MetricsLink {
 pub struct Metrics {
 	pub validations_scheduled: Counter<U64>,
 	pub validations_finished: Counter<U64>,
+	pub validations_invalid: Counter<U64>,
 }
 
 impl Metrics {
@@ -61,6 +62,13 @@ impl Metrics {
 				Counter::new(
 					"sub_txpool_validations_finished",
 					"Total number of transactions that finished validation",
+				)?,
+				registry,
+			)?,
+			validations_invalid: register(
+				Counter::new(
+					"sub_txpool_validations_invalid",
+					"Total number of transactions that were removed from the pool as invalid",
 				)?,
 				registry,
 			)?,


### PR DESCRIPTION
Adds a Prometheus metric counting transactions rejected from the pool as invalid. Fixes https://github.com/paritytech/substrate/issues/5991