### PR TITLE
Fix gitlab line-width CI check

### DIFF
--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -9,7 +9,7 @@ BASE_ORIGIN="origin"
 BASE_BRANCH_NAME="master"
 LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
-BASE_BRANCH="${BASE_ORIGN}/${BASE_BRANCH_NAME}"
+BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
 
 git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME}
 git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} -- \*.rs | ( while read file

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -2,7 +2,7 @@
 #
 # check if line width of rust source files is not beyond x characters
 #
-
+set -e
 
 BASE_BRANCH="origin/master"
 LINE_WIDTH="121"

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -12,12 +12,12 @@ GOOD_LINE_WIDTH="100"
 BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
 
 git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME}
-git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} -- \*.rs | ( while read file
+git diff --name-only ${BASE_BRANCH} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];
   then
 	echo "Skipping removed file."
-  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
+  elif git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
   then
     if [ -z "${FAIL}" ]
     then
@@ -29,11 +29,11 @@ do
       FAIL="true"
     fi
     echo "| file: ${file}"
-    git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
+    git diff ${BASE_BRANCH} -- ${file} \
       | grep -n "^+.\{$(( $LINE_WIDTH + 1))\}"
     echo "|"
   else
-    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+    if git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
     then
       if [ -z "${FAIL}" ]
       then
@@ -44,8 +44,7 @@ do
         echo "|"
       fi
       echo "| file: ${file}"
-      git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
-        | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+      git diff ${BASE_BRANCH} -- ${file} | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
       echo "|"
     fi
   fi

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -9,28 +9,28 @@ LINE_WIDTH="121"
 GOOD_LINE_WIDTH="101"
 
 
-git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} \*.rs | ( while read file
+git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];
   then
 	echo "Skipping removed file."
-  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} | grep -q "^+.\{${LINE_WIDTH}\}"
+  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{${LINE_WIDTH}\}"
   then
     if [ -z "${FAIL}" ]
     then
-      echo "| warning!"
-      echo "| Lines should not be longer than 120 characters."
+      echo "| error!"
+      echo "| Lines must not be longer than 120 characters."
       echo "| "
       echo "| see more https://wiki.parity.io/Substrate-Style-Guide"
       echo "|"
       FAIL="true"
     fi
     echo "| file: ${file}"
-    git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} \
+    git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
       | grep -n "^+.\{${LINE_WIDTH}\}"
     echo "|"
   else
-    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} | grep -q "^+.\{${GOOD_LINE_WIDTH}\}"
+    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{${GOOD_LINE_WIDTH}\}"
     then
       if [ -z "${FAIL}" ]
       then
@@ -41,7 +41,7 @@ do
         echo "|"
       fi
       echo "| file: ${file}"
-      git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} ${file} \
+      git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
         | grep -n "^+.\{${LINE_WIDTH}\}"
       echo "|"
     fi

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -4,10 +4,13 @@
 #
 set -e
 
-BASE_BRANCH="origin/master"
+BASE_ORIGIN="origin"
+BASE_BRANCH_NAME="master"
 LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
+BASE_BRANCH="${BASE_ORIGN}/${BASE_BRANCH_NAME}"
 
+git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME}
 git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -3,6 +3,7 @@
 # check if line width of rust source files is not beyond x characters
 #
 set -e
+set -o pipefail
 
 BASE_ORIGIN="origin"
 BASE_BRANCH_NAME="master"

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -42,7 +42,7 @@ do
       fi
       echo "| file: ${file}"
       git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
-        | grep -n "^+.\{${LINE_WIDTH}\}"
+        | grep -n "^+.\{${GOOD_LINE_WIDTH}\}"
       echo "|"
     fi
   fi

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -11,7 +11,7 @@ LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
 BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
 
-git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME}
+git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth ${GIT_DEPTH}
 git diff --name-only ${BASE_BRANCH} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -5,21 +5,20 @@
 set -e
 
 BASE_BRANCH="origin/master"
-LINE_WIDTH="121"
-GOOD_LINE_WIDTH="101"
-
+LINE_WIDTH="120"
+GOOD_LINE_WIDTH="100"
 
 git diff --name-only ${BASE_BRANCH}...${CI_COMMIT_SHA} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];
   then
 	echo "Skipping removed file."
-  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{${LINE_WIDTH}\}"
+  elif git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
   then
     if [ -z "${FAIL}" ]
     then
       echo "| error!"
-      echo "| Lines must not be longer than 120 characters."
+      echo "| Lines must not be longer than ${LINE_WIDTH} characters."
       echo "| "
       echo "| see more https://wiki.parity.io/Substrate-Style-Guide"
       echo "|"
@@ -27,22 +26,22 @@ do
     fi
     echo "| file: ${file}"
     git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
-      | grep -n "^+.\{${LINE_WIDTH}\}"
+      | grep -n "^+.\{$(( $LINE_WIDTH + 1))\}"
     echo "|"
   else
-    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{${GOOD_LINE_WIDTH}\}"
+    if git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
     then
       if [ -z "${FAIL}" ]
       then
         echo "| warning!"
-        echo "| Lines should be longer than 100 characters only in exceptional circumstances!"
+        echo "| Lines should be longer than ${GOOD_LINE_WIDTH} characters only in exceptional circumstances!"
         echo "| "
         echo "| see more https://wiki.parity.io/Substrate-Style-Guide"
         echo "|"
       fi
       echo "| file: ${file}"
       git diff ${BASE_BRANCH}...${CI_COMMIT_SHA} -- ${file} \
-        | grep -n "^+.\{${GOOD_LINE_WIDTH}\}"
+        | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
       echo "|"
     fi
   fi

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -11,7 +11,7 @@ LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
 BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
 
-git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth ${GIT_DEPTH}
+git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth 1
 git diff --name-only ${BASE_BRANCH} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];


### PR DESCRIPTION
The gitlab line width check test is broken (it fails with some shell error). Nobody noticed because the script returns success.

The problem here was that it was checking the changes against `origin/master` which was never fetched by the CI. I added the necessary fetch command and also enabled shell strict mode in order to detect such errors in the future.

Example output of the broken script:
```
$ ./.maintain/gitlab/check_line_width.sh
00:00
fatal: ambiguous argument 'origin/master...8ec43ae8cc7dd5dd53bf66ece1a63e3337c7aa45': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Job succeeded
```