### PR TITLE
Fix minor typos in im-online documentation

### DIFF
--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -166,7 +166,7 @@ impl<BlockNumber: PartialEq + AtLeast32Bit + Copy> HeartbeatStatus<BlockNumber> 
 	/// `session_index` - index of current session.
 	/// `now` - block at which the offchain worker is running.
 	///
-	/// This function will return `true` if:
+	/// This function will return `true` iff:
 	/// 1. the session index is the same (we don't care if it went up or down)
 	/// 2. the heartbeat has been sent recently (within the threshold)
 	///

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -166,7 +166,7 @@ impl<BlockNumber: PartialEq + AtLeast32Bit + Copy> HeartbeatStatus<BlockNumber> 
 	/// `session_index` - index of current session.
 	/// `now` - block at which the offchain worker is running.
 	///
-	/// This function will return `true` iff:
+	/// This function will return `true` if:
 	/// 1. the session index is the same (we don't care if it went up or down)
 	/// 2. the heartbeat has been sent recently (within the threshold)
 	///
@@ -264,7 +264,7 @@ decl_event!(
 		HeartbeatReceived(AuthorityId),
 		/// At the end of the session, no offence was committed.
 		AllGood,
-		/// At the end of the session, at least once validator was found to be offline.
+		/// At the end of the session, at least one validator was found to be offline.
 		SomeOffline(Vec<IdentificationTuple>),
 	}
 );


### PR DESCRIPTION
# Description
I'm quite sure there's a misleading typo in `SomeOffline` event documentation.

It was stated as:
_At the end of the session, at least **once** validator was found to be offline._

It should be:
_At the end of the session, at least **one** validator was found to be offline._

I also fixed another minor typo `iff -> if`

# Rationale
That description was a bit confusing to me because I wanted to understand if there's a way to find out if a validator was online when a specific block was created. 
So I checked [when this event is published](https://github.com/paritytech/substrate/blob/9b23e35e677608bcab5972052e7ebb14b0cae097/frame/im-online/src/lib.rs#L660) and I understood that a this event is being sent if a validator did not create a block and did not send a heartbeat (which is sent once per session, roughly in the middle of session).

This event then states that Some **validators** were Offline during a session, not that at **least once a validator** was found to be offline. Which is confusing because I thought that validators could be offline multiple times per session, and this event informed that validator was offline at least once.
