### PR TITLE
Turn an error! into a debug!

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -810,7 +810,7 @@ impl GenericProto {
 		};
 
 		if !incoming.alive {
-			error!(target: "sub-libp2p", "PSM => Reject({:?}, {:?}): Obsolete incoming, \
+			debug!(target: "sub-libp2p", "PSM => Reject({:?}, {:?}): Obsolete incoming, \
 				ignoring", index, incoming.peer_id);
 			return
 		}


### PR DESCRIPTION
This error is frequently triggered on our production nodes.

I've reviewed the code to make sure, and it's a totally normal situation that happens if we get an incoming connection but dropped it before the PSM refused it.
