### PR TITLE
Add CRYPTO_ID to AppKey

### DIFF
--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -54,11 +54,11 @@ pub use traits::*;
 #[macro_export]
 macro_rules! app_crypto {
 	($module:ident, $key_type:expr) => {
-		$crate::app_crypto_public_full_crypto!($module::Public, $key_type);
+		$crate::app_crypto_public_full_crypto!($module::Public, $key_type, $module::CRYPTO_ID);
 		$crate::app_crypto_public_common!($module::Public, $module::Signature, $key_type, $module::CRYPTO_ID);
-		$crate::app_crypto_signature_full_crypto!($module::Signature, $key_type);
+		$crate::app_crypto_signature_full_crypto!($module::Signature, $key_type, $module::CRYPTO_ID);
 		$crate::app_crypto_signature_common!($module::Signature, $key_type);
-		$crate::app_crypto_pair!($module::Pair, $key_type);
+		$crate::app_crypto_pair!($module::Pair, $key_type, $module::CRYPTO_ID);
 	};
 }
 
@@ -75,9 +75,9 @@ macro_rules! app_crypto {
 #[macro_export]
 macro_rules! app_crypto {
 	($module:ident, $key_type:expr) => {
-		$crate::app_crypto_public_not_full_crypto!($module::Public, $key_type);
+		$crate::app_crypto_public_not_full_crypto!($module::Public, $key_type, $module::CRYPTO_ID);
 		$crate::app_crypto_public_common!($module::Public, $module::Signature, $key_type, $module::CRYPTO_ID);
-		$crate::app_crypto_signature_not_full_crypto!($module::Signature, $key_type);
+		$crate::app_crypto_signature_not_full_crypto!($module::Signature, $key_type, $module::CRYPTO_ID);
 		$crate::app_crypto_signature_common!($module::Signature, $key_type);
 	};
 }
@@ -86,7 +86,7 @@ macro_rules! app_crypto {
 /// Application-specific type whose identifier is `$key_type`.
 #[macro_export]
 macro_rules! app_crypto_pair {
-	($pair:ty, $key_type:expr) => {
+	($pair:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap!{
 			/// A generic `AppPublic` wrapper type over $pair crypto; this has no specific App.
 			#[derive(Clone)]
@@ -141,6 +141,7 @@ macro_rules! app_crypto_pair {
 			type Pair = Pair;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
+			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
 		}
 
 		impl $crate::AppPair for Pair {
@@ -183,7 +184,7 @@ macro_rules! app_crypto_pair_functions_if_std {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_public_full_crypto {
-	($public:ty, $key_type:expr) => {
+	($public:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap!{
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
 			#[derive(
@@ -206,6 +207,7 @@ macro_rules! app_crypto_public_full_crypto {
 			type Pair = Pair;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
+			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
 		}
 	}
 }
@@ -217,7 +219,7 @@ macro_rules! app_crypto_public_full_crypto {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_public_not_full_crypto {
-	($public:ty, $key_type:expr) => {
+	($public:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap!{
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
 			#[derive(
@@ -236,6 +238,7 @@ macro_rules! app_crypto_public_not_full_crypto {
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
+			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
 		}
 	}
 }
@@ -357,7 +360,7 @@ macro_rules! app_crypto_public_common_if_std {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_signature_full_crypto {
-	($sig:ty, $key_type:expr) => {
+	($sig:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
 			#[derive(Clone, Default, Eq, PartialEq,
@@ -379,6 +382,7 @@ macro_rules! app_crypto_signature_full_crypto {
 			type Pair = Pair;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
+			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
 		}
 	}
 }
@@ -390,7 +394,7 @@ macro_rules! app_crypto_signature_full_crypto {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_signature_not_full_crypto {
-	($sig:ty, $key_type:expr) => {
+	($sig:ty, $key_type:expr, $crypto_type:expr) => {
 		$crate::wrap! {
 			/// A generic `AppPublic` wrapper type over $public crypto; this has no specific App.
 			#[derive(Clone, Default, Eq, PartialEq,
@@ -408,6 +412,7 @@ macro_rules! app_crypto_signature_not_full_crypto {
 			type Public = Public;
 			type Signature = Signature;
 			const ID: $crate::KeyTypeId = $key_type;
+			const CRYPTO_ID: $crate::CryptoTypeId = $crypto_type;
 		}
 	}
 }

--- a/primitives/application-crypto/src/traits.rs
+++ b/primitives/application-crypto/src/traits.rs
@@ -38,6 +38,8 @@ pub trait AppKey: 'static + Send + Sync + Sized + CryptoType + Clone {
 
 	/// An identifier for this application-specific key type.
 	const ID: KeyTypeId;
+	/// The identifier of the crypto type of this application-specific key type.
+	const CRYPTO_ID: CryptoTypeId;
 }
 
 /// Type which implements Hash in std, not when no-std (std variant).


### PR DESCRIPTION
This has already been done for `RuntimeAppPublic` previously in #5965  under the assumption it can be used in client/consensus crate. However, as this comment suggests: https://github.com/paritytech/substrate/pull/6008#discussion_r424350273 `AppKey` should be the trait used in consensus and therefore, this change is required.