### PR TITLE
Fix potential state mismatch in behaviour.rs

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -1123,6 +1123,10 @@ impl NetworkBehaviour for GenericProto {
 							);
 						}
 
+						// TODO: We switch the entire peer state to "disabled" because of possible
+						// race conditions involving the legacy substream.
+						// Once https://github.com/paritytech/substrate/issues/5670 is done, this
+						// should be changed to stay in the `Enabled` state.
 						debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", source);
 						debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", source);
 						self.peerset.dropped(source.clone());

--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -1124,24 +1124,20 @@ impl NetworkBehaviour for GenericProto {
 						}
 
 						debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", source);
+						debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", source);
+						self.peerset.dropped(source.clone());
 						self.events.push(NetworkBehaviourAction::NotifyHandler {
 							peer_id: source.clone(),
-							handler: NotifyHandler::One(connection),
+							handler: NotifyHandler::All,
 							event: NotifsHandlerIn::Disable,
 						});
 
 						let last = open.is_empty();
 
-						if last {
-							debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", source);
-							self.peerset.dropped(source.clone());
-							*entry.into_mut() = PeerState::Disabled {
-								open,
-								banned_until: None
-							};
-						} else {
-							*entry.into_mut() = PeerState::Enabled { open };
-						}
+						*entry.into_mut() = PeerState::Disabled {
+							open,
+							banned_until: None
+						};
 
 						last
 					},


### PR DESCRIPTION
When multiple connections to the same peer are involved, the code in `behaviour.rs` works under the assumption that all the handlers are in the same state: either enabled or disabled.

This, however, isn't the case when the remote closes the substream on one of the two connections while the second one is in an enabled+closed state. When that happens, we switch that first connection to disabled, keep the other as enabled, and switch the entire peer state to disabled.

The problem is that this other connection, still enabled, will then open (or stay open) and can communicate with the sync/grandpa/etc. codes. Meanwhile, the behaviour sees the peer as disabled. Since disabled implies "is going to close soon", the behaviour ignores all disconnect requests sent by the sync code or others.
