### PR TITLE
Convert `Public` to `CryptoTypePublicPair`

### DIFF
--- a/primitives/application-crypto/src/ed25519.rs
+++ b/primitives/application-crypto/src/ed25519.rs
@@ -23,26 +23,12 @@ use sp_std::vec::Vec;
 pub use sp_core::ed25519::*;
 
 mod app {
-	use sp_core::crypto::{CryptoTypePublicPair, Public as TraitPublic};
 	use sp_core::testing::ED25519;
-	use sp_core::ed25519::CRYPTO_ID;
 
 	crate::app_crypto!(super, ED25519);
 
 	impl crate::traits::BoundToRuntimeAppPublic for Public {
 		type Public = Self;
-	}
-
-	impl From<Public> for CryptoTypePublicPair {
-		fn from(key: Public) -> Self {
-			(&key).into()
-		}
-	}
-
-	impl From<&Public> for CryptoTypePublicPair {
-		fn from(key: &Public) -> Self {
-			CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
-		}
 	}
 }
 

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -262,6 +262,10 @@ macro_rules! app_crypto_public_common {
 
 		impl $crate::Public for Public {
 			fn from_slice(x: &[u8]) -> Self { Self(<$public>::from_slice(x)) }
+
+			fn to_public_crypto_pair(&self) -> $crate::CryptoTypePublicPair {
+				$crate::CryptoTypePublicPair($crypto_type, self.to_raw_vec())
+			}
 		}
 
 		impl $crate::AppPublic for Public {

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -298,6 +298,21 @@ macro_rules! app_crypto_public_common {
 				<$public as $crate::RuntimePublic>::to_raw_vec(&self.0)
 			}
 		}
+
+		impl From<Public> for $crate::CryptoTypePublicPair {
+			fn from(key: Public) -> Self {
+				(&key).into()
+			}
+		}
+
+		impl From<&Public> for $crate::CryptoTypePublicPair {
+			fn from(key: &Public) -> Self {
+				$crate::CryptoTypePublicPair(
+					$crypto_type,
+					$crate::Public::to_raw_vec(key),
+				)
+			}
+		}
 	}
 }
 

--- a/primitives/application-crypto/src/sr25519.rs
+++ b/primitives/application-crypto/src/sr25519.rs
@@ -23,26 +23,12 @@ use sp_std::vec::Vec;
 pub use sp_core::sr25519::*;
 
 mod app {
-	use sp_core::crypto::{CryptoTypePublicPair, Public as TraitPublic};
 	use sp_core::testing::SR25519;
-	use sp_core::sr25519::CRYPTO_ID;
 
 	crate::app_crypto!(super, SR25519);
 
 	impl crate::traits::BoundToRuntimeAppPublic for Public {
 		type Public = Self;
-	}
-
-	impl From<Public> for CryptoTypePublicPair {
-		fn from(key: Public) -> Self {
-			(&key).into()
-		}
-	}
-
-	impl From<&Public> for CryptoTypePublicPair {
-		fn from(key: &Public) -> Self {
-			CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
-		}
 	}
 }
 

--- a/primitives/authority-discovery/src/lib.rs
+++ b/primitives/authority-discovery/src/lib.rs
@@ -22,24 +22,11 @@ use sp_std::vec::Vec;
 
 mod app {
 	use sp_application_crypto::{
-		CryptoTypePublicPair,
 		key_types::AUTHORITY_DISCOVERY,
-		Public as _,
 		app_crypto,
-		sr25519};
+		sr25519,
+	};
 	app_crypto!(sr25519, AUTHORITY_DISCOVERY);
-
-	impl From<Public> for CryptoTypePublicPair {
-		fn from(key: Public) -> Self {
-			(&key).into()
-		}
-	}
-
-	impl From<&Public> for CryptoTypePublicPair {
-		fn from(key: &Public) -> Self {
-			CryptoTypePublicPair(sr25519::CRYPTO_ID, key.to_raw_vec())
-		}
-	}
 }
 
 sp_application_crypto::with_pair! {

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -1068,6 +1068,11 @@ mod tests {
 		fn to_raw_vec(&self) -> Vec<u8> {
 			vec![]
 		}
+		fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
+			CryptoTypePublicPair(
+				CryptoTypeId(*b"dumm"), self.to_raw_vec(),
+			)
+		}
 	}
 	impl Pair for TestPair {
 		type Public = TestPublic;

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -559,6 +559,8 @@ pub trait Public:
 
 	/// Return a slice filled with raw data.
 	fn as_slice(&self) -> &[u8] { self.as_ref() }
+	/// Return `CryptoTypePublicPair` from public key.
+	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair;
 }
 
 /// An opaque 32-byte cryptographic identifier.
@@ -706,6 +708,11 @@ mod dummy {
 		#[cfg(feature = "std")]
 		fn to_raw_vec(&self) -> Vec<u8> { vec![] }
 		fn as_slice(&self) -> &[u8] { b"" }
+		fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
+			CryptoTypePublicPair(
+				CryptoTypeId(*b"dumm"), Public::to_raw_vec(self)
+			)
+		}
 	}
 
 	impl Pair for Dummy {

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -36,7 +36,7 @@ use crate::{hashing::blake2_256, crypto::{Pair as TraitPair, DeriveJunction, Sec
 use crate::crypto::Ss58Codec;
 #[cfg(feature = "std")]
 use serde::{de, Serializer, Serialize, Deserializer, Deserialize};
-use crate::crypto::{Public as TraitPublic, UncheckedFrom, CryptoType, Derive, CryptoTypeId};
+use crate::crypto::{Public as TraitPublic, CryptoTypePublicPair, UncheckedFrom, CryptoType, Derive, CryptoTypeId};
 #[cfg(feature = "full_crypto")]
 use secp256k1::{PublicKey, SecretKey};
 
@@ -117,6 +117,10 @@ impl TraitPublic for Public {
 		let mut r = [0u8; 33];
 		r.copy_from_slice(data);
 		Self(r)
+	}
+
+	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
+		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
 	}
 }
 

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -382,15 +382,15 @@ impl TraitPublic for Public {
 impl Derive for Public {}
 
 impl From<Public> for CryptoTypePublicPair {
-    fn from(key: Public) -> Self {
-        (&key).into()
-    }
+	fn from(key: Public) -> Self {
+		(&key).into()
+	}
 }
 
 impl From<&Public> for CryptoTypePublicPair {
-    fn from(key: &Public) -> Self {
-        CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
-    }
+	fn from(key: &Public) -> Self {
+		CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
+	}
 }
 
 /// Derive a single hard junction.

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -377,6 +377,10 @@ impl TraitPublic for Public {
 		r.copy_from_slice(data);
 		Public(r)
 	}
+
+	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
+		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
+	}
 }
 
 impl Derive for Public {}

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -391,6 +391,10 @@ impl TraitPublic for Public {
 		r.copy_from_slice(data);
 		Public(r)
 	}
+
+	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
+		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
+	}
 }
 
 impl From<Public> for CryptoTypePublicPair {


### PR DESCRIPTION
This PR does 2 things:

1. Introduce `to_public_crypto_pair` to facilitate convering `sp_core::crypto::Public` to `CryptoTypePublicPair`
2. Implement `From<sp_app_crypto::Public> for CryptoTypePublicPair` so that application-specific keys can be converted easily into the target type required for signing.

This PR is a dependency for #6008 