### PR TITLE
[CI] Fix a few issues with .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ check-signed-tag:
   image:                           parity/tools:latest
   <<:                              *kubernetes-build
   only:
-    - tags
+    - /^ci-release-.*$/
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/gitlab/check_signed.sh
@@ -581,7 +581,7 @@ publish-draft-release:
   stage:                           publish
   image:                           parity/tools:latest
   only:
-    - tags
+    - /^ci-release-.*$/
     - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/gitlab/publish_draft_release.sh
@@ -592,8 +592,8 @@ publish-to-crates-io:
   stage:                           publish
   <<:                              *docker-env
   only:
-    - tags
     - /^ci-release-.*$/
+    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check ${CARGO_UNLEASH_PKG_DEF}


### PR DESCRIPTION
When the edited scripts were made, I erroneously thought the 'only:' conditionals were logical ANDs, but they're ORs. Get rid of the pointless `- tags`.

Fixes #5910  - where the updating of the rolling `release` tag erroneously triggered a check_signed_tag job, and thus caused an error.

Also edits it to capture the `ci-release` tag since this is our 'dry run' tag pattern.