### PR TITLE
bump kvdb-* versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,12 +2281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65877bf7d44897a473350b1046277941cee20b263397e90869c50b6e766088b"
 
 [[package]]
-name = "interleaved-ordered"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141340095b15ed7491bd3d4ced9d20cebfb826174b6bb03386381f62b01e3d77"
-
-[[package]]
 name = "intervalier"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad096c6849b2ef027fabe35c4aed356d0e3d3f586d0a8361e5e17f1e50a7ce5"
+checksum = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
 dependencies = [
  "parity-util-mem",
  "smallvec 1.3.0",
@@ -2506,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa954d12cfac958822dfd77aab34f3eec71f103b918c4ab79ab59a36ee594ea"
+checksum = "73027d5e228de6f503b5b7335d530404fc26230a6ae3e09b33ec6e45408509a4"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -2517,12 +2511,11 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f14c3a10c8894d26175e57e9e26032e6d6c49c30cbe2468c5bf5f6b64bb0be"
+checksum = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
 dependencies = [
  "fs-swap",
- "interleaved-ordered",
  "kvdb",
  "log",
  "num_cpus",
@@ -2536,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-web"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f96eec962af83cdf7c83036b3dbb0ae6a1249ddab746820618e2567ca8ebcd"
+checksum = "6c7f36acb1841d4c701d30ae1f2cfd242e805991443f75f6935479ed3de64903"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
@@ -3020,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.6.4"
+version = "6.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3b727e2dd20ec2fb7ed93f23d9fd5328a0871185485ebdaff007b47d3e27e4"
+checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
@@ -5701,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12069b106981c6103d3eab7dd1c86751482d0779a520b7c14954c8b586c1e643"
+checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -20,8 +20,8 @@ serde = "1.0.101"
 serde_json = "1.0.41"
 structopt = "0.3"
 derive_more = "0.99.2"
-kvdb = "0.5"
-kvdb-rocksdb = "0.7"
+kvdb = "0.6"
+kvdb-rocksdb = "0.8"
 sp-trie = { version = "2.0.0-dev", path = "../../../primitives/trie" }
 sp-core = { version = "2.0.0-dev", path = "../../../primitives/core" }
 hash-db = "0.15.2"

--- a/bin/node/bench/src/tempdb.rs
+++ b/bin/node/bench/src/tempdb.rs
@@ -46,6 +46,7 @@ impl KeyValueDB for ParityDbWrapper {
 			transaction.ops.iter().map(|op| match op {
 				kvdb::DBOp::Insert { col, key, value } => (*col as u8, &key[key.len() - 32..], Some(value.to_vec())),
 				kvdb::DBOp::Delete { col, key } => (*col as u8, &key[key.len() - 32..], None),
+				kvdb::DBOp::DeletePrefix { col: _, prefix: _ } => unimplemented!()
 			})
 		).expect("db error");
 		Ok(())

--- a/bin/node/bench/src/tempdb.rs
+++ b/bin/node/bench/src/tempdb.rs
@@ -41,17 +41,13 @@ impl KeyValueDB for ParityDbWrapper {
 	}
 
 	/// Write a transaction of changes to the buffer.
-	fn write_buffered(&self, transaction: DBTransaction) {
+	fn write(&self, transaction: DBTransaction) -> io::Result<()> {
 		self.0.commit(
 			transaction.ops.iter().map(|op| match op {
 				kvdb::DBOp::Insert { col, key, value } => (*col as u8, &key[key.len() - 32..], Some(value.to_vec())),
 				kvdb::DBOp::Delete { col, key } => (*col as u8, &key[key.len() - 32..], None),
 			})
 		).expect("db error");
-	}
-
-	/// Flush all buffered data.
-	fn flush(&self) -> io::Result<()> {
 		Ok(())
 	}
 
@@ -61,7 +57,7 @@ impl KeyValueDB for ParityDbWrapper {
 	}
 
 	/// Iterate over flushed data for a given column, starting from a given prefix.
-	fn iter_from_prefix<'a>(
+	fn iter_with_prefix<'a>(
 		&'a self,
 		_col: u32,
 		_prefix: &'a [u8],

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -25,7 +25,7 @@ sp-blockchain = { version = "2.0.0-dev", path = "../../primitives/blockchain" }
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0-dev", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
-kvdb = "0.5.0"
+kvdb = "0.6.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
 lazy_static =  "1.4.0"
@@ -44,6 +44,6 @@ sp-transaction-pool = { version = "2.0.0-dev", path = "../../primitives/transact
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0-dev", path = "../../utils/prometheus" }
 
 [dev-dependencies]
-kvdb-memorydb = "0.5.0"
+kvdb-memorydb = "0.6.0"
 sp-test-primitives = { version = "2.0.0-dev", path = "../../primitives/test-primitives" }
 substrate-test-runtime = { version = "2.0.0-dev", path = "../../test-utils/runtime"  }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parking_lot = "0.10.0"
 log = "0.4.8"
-kvdb = "0.5.0"
-kvdb-rocksdb = { version = "0.7", optional = true }
-kvdb-memorydb = "0.5.0"
+kvdb = "0.6.0"
+kvdb-rocksdb = { version = "0.8", optional = true }
+kvdb-memorydb = "0.6.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
 parity-util-mem = { version = "0.6.1", default-features = false, features = ["std"] }
@@ -41,7 +41,7 @@ sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 quickcheck = "0.9"
-kvdb-rocksdb = "0.7"
+kvdb-rocksdb = "0.8"
 tempfile = "3"
 
 [features]

--- a/primitives/database/Cargo.toml
+++ b/primitives/database/Cargo.toml
@@ -11,4 +11,4 @@ documentation = "https://docs.rs/sp-database"
 
 [dependencies]
 parking_lot = "0.10.0"
-kvdb = "0.5.0"
+kvdb = "0.6.0"

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -21,7 +21,7 @@ console_log = "0.1.2"
 js-sys = "0.3.34"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.7"
-kvdb-web = "0.5"
+kvdb-web = "0.6"
 sp-database = { version = "2.0.0-dev", path = "../../primitives/database" }
 sc-informant = { version = "0.8.0-dev", path = "../../client/informant" }
 sc-service = { version = "0.8.0-dev", path = "../../client/service", default-features = false }


### PR DESCRIPTION
updates kvdb:
- kvdb: 0.5 -> 0.6
- kvdb-rocksdb: 0.7 -> 0.8
- kvdb-memorydb: 0.5 -> 0.6
- kvdb-web: 0.5 -> 0.6

this version of KVDB updates to librocksdb 6.7.3 and updates to a new kvdb interface


