### PR TITLE
Fix RPC tests for machines with a high number of cores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,6 +6611,7 @@ dependencies = [
  "hash-db",
  "jsonrpc-core",
  "jsonrpc-pubsub",
+ "lazy_static",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -46,3 +46,4 @@ sp-io = { version = "2.0.0-dev", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0-dev", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"
 sc-transaction-pool = { version = "2.0.0-dev", path = "../transaction-pool" }
+lazy_static = "1.4.0"

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -31,3 +31,5 @@ pub mod chain;
 pub mod offchain;
 pub mod state;
 pub mod system;
+#[cfg(test)]
+mod testing;

--- a/client/rpc/src/testing.rs
+++ b/client/rpc/src/testing.rs
@@ -1,0 +1,42 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Testing utils used by the RPC tests.
+
+use rpc::futures::future as future01;
+use futures::{executor, compat::Future01CompatExt, FutureExt};
+
+// Executor shared by all tests.
+//
+// This shared executor is used to prevent `Too many open files` errors
+// on systems with a lot of cores.
+lazy_static::lazy_static! {
+	static ref EXECUTOR: executor::ThreadPool = executor::ThreadPool::new()
+		.expect("Failed to create thread pool executor for tests");
+}
+
+type Boxed01Future01 = Box<dyn future01::Future<Item = (), Error = ()> + Send + 'static>;
+
+pub struct TaskExecutor;
+impl future01::Executor<Boxed01Future01> for TaskExecutor {
+	fn execute(
+		&self,
+		future: Boxed01Future01,
+	) -> std::result::Result<(), future01::ExecuteError<Boxed01Future01>>{
+		EXECUTOR.spawn_ok(future.compat().map(drop));
+		Ok(())
+	}
+}


### PR DESCRIPTION
This fixes the RPC tests on machines with a high number of cores e.g. a
3900x. Without this fix the tests are almost fail with `Too many files
open`. This problem is fixed by using one executor for all tests.
