### PR TITLE
Added RuntimePublic for ecdsa public key.

### DIFF
--- a/primitives/application-crypto/src/ecdsa.rs
+++ b/primitives/application-crypto/src/ecdsa.rs
@@ -1,0 +1,61 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Ed25519 crypto types.
+
+use crate::{RuntimePublic, KeyTypeId};
+
+use sp_std::vec::Vec;
+
+pub use sp_core::ed25519::*;
+
+mod app {
+	use sp_core::testing::ED25519;
+
+	crate::app_crypto!(super, ED25519);
+
+	impl crate::traits::BoundToRuntimeAppPublic for Public {
+		type Public = Self;
+	}
+}
+
+pub use app::{Public as AppPublic, Signature as AppSignature};
+#[cfg(feature = "full_crypto")]
+pub use app::Pair as AppPair;
+
+impl RuntimePublic for Public {
+	type Signature = Signature;
+
+	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
+		sp_io::crypto::ed25519_public_keys(key_type)
+	}
+
+	fn generate_pair(key_type: KeyTypeId, seed: Option<Vec<u8>>) -> Self {
+		sp_io::crypto::ed25519_generate(key_type, seed)
+	}
+
+	fn sign<M: AsRef<[u8]>>(&self, key_type: KeyTypeId, msg: &M) -> Option<Self::Signature> {
+		sp_io::crypto::ed25519_sign(key_type, self, msg.as_ref())
+	}
+
+	fn verify<M: AsRef<[u8]>>(&self, msg: &M, signature: &Self::Signature) -> bool {
+		sp_io::crypto::ed25519_verify(&signature, msg.as_ref(), self)
+	}
+
+	fn to_raw_vec(&self) -> Vec<u8> {
+		sp_core::crypto::Public::to_raw_vec(self)
+	}
+}

--- a/primitives/application-crypto/src/ecdsa.rs
+++ b/primitives/application-crypto/src/ecdsa.rs
@@ -14,18 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Ed25519 crypto types.
+//! Ecdsa crypto types.
 
 use crate::{RuntimePublic, KeyTypeId};
 
 use sp_std::vec::Vec;
 
-pub use sp_core::ed25519::*;
+pub use sp_core::ecdsa::*;
 
 mod app {
-	use sp_core::testing::ED25519;
+	use sp_core::testing::ECDSA;
 
-	crate::app_crypto!(super, ED25519);
+	crate::app_crypto!(super, ECDSA);
 
 	impl crate::traits::BoundToRuntimeAppPublic for Public {
 		type Public = Self;
@@ -40,19 +40,19 @@ impl RuntimePublic for Public {
 	type Signature = Signature;
 
 	fn all(key_type: KeyTypeId) -> crate::Vec<Self> {
-		sp_io::crypto::ed25519_public_keys(key_type)
+		sp_io::crypto::ecdsa_public_keys(key_type)
 	}
 
 	fn generate_pair(key_type: KeyTypeId, seed: Option<Vec<u8>>) -> Self {
-		sp_io::crypto::ed25519_generate(key_type, seed)
+		sp_io::crypto::ecdsa_generate(key_type, seed)
 	}
 
 	fn sign<M: AsRef<[u8]>>(&self, key_type: KeyTypeId, msg: &M) -> Option<Self::Signature> {
-		sp_io::crypto::ed25519_sign(key_type, self, msg.as_ref())
+		sp_io::crypto::ecdsa_sign(key_type, self, msg.as_ref())
 	}
 
 	fn verify<M: AsRef<[u8]>>(&self, msg: &M, signature: &Self::Signature) -> bool {
-		sp_io::crypto::ed25519_verify(&signature, msg.as_ref(), self)
+		sp_io::crypto::ecdsa_verify(&signature, msg.as_ref(), self)
 	}
 
 	fn to_raw_vec(&self) -> Vec<u8> {

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -37,6 +37,7 @@ pub use sp_std::{ops::Deref, vec::Vec};
 
 pub mod ed25519;
 pub mod sr25519;
+pub mod ecdsa;
 mod traits;
 
 pub use traits::*;

--- a/primitives/application-crypto/test/src/ecdsa.rs
+++ b/primitives/application-crypto/test/src/ecdsa.rs
@@ -1,0 +1,42 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Integration tests for ed25519
+
+use sp_runtime::generic::BlockId;
+use sp_core::{
+	crypto::Pair,
+	testing::{KeyStore, ED25519},
+};
+use substrate_test_runtime_client::{
+	TestClientBuilder, DefaultTestClientBuilderExt, TestClientBuilderExt,
+	runtime::TestAPI,
+};
+use sp_api::ProvideRuntimeApi;
+use sp_application_crypto::ed25519::{AppPair, AppPublic};
+
+#[test]
+fn ed25519_works_in_runtime() {
+	let keystore = KeyStore::new();
+	let test_client = TestClientBuilder::new().set_keystore(keystore.clone()).build();
+	let (signature, public) = test_client.runtime_api()
+		.test_ed25519_crypto(&BlockId::Number(0))
+		.expect("Tests `ed25519` crypto.");
+
+	let supported_keys = keystore.read().keys(ED25519).unwrap();
+	assert!(supported_keys.contains(&public.clone().into()));
+	assert!(AppPair::verify(&signature, "ed25519", &AppPublic::from(public)));
+}

--- a/primitives/application-crypto/test/src/ecdsa.rs
+++ b/primitives/application-crypto/test/src/ecdsa.rs
@@ -14,29 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Integration tests for ed25519
+//! Integration tests for ecdsa
 
 use sp_runtime::generic::BlockId;
 use sp_core::{
 	crypto::Pair,
-	testing::{KeyStore, ED25519},
+	testing::{KeyStore, ECDSA},
 };
 use substrate_test_runtime_client::{
 	TestClientBuilder, DefaultTestClientBuilderExt, TestClientBuilderExt,
 	runtime::TestAPI,
 };
 use sp_api::ProvideRuntimeApi;
-use sp_application_crypto::ed25519::{AppPair, AppPublic};
+use sp_application_crypto::ecdsa::{AppPair, AppPublic};
 
 #[test]
-fn ed25519_works_in_runtime() {
+fn ecdsa_works_in_runtime() {
 	let keystore = KeyStore::new();
 	let test_client = TestClientBuilder::new().set_keystore(keystore.clone()).build();
 	let (signature, public) = test_client.runtime_api()
-		.test_ed25519_crypto(&BlockId::Number(0))
-		.expect("Tests `ed25519` crypto.");
+		.test_ecdsa_crypto(&BlockId::Number(0))
+		.expect("Tests `ecdsa` crypto.");
 
-	let supported_keys = keystore.read().keys(ED25519).unwrap();
+	let supported_keys = keystore.read().keys(ECDSA).unwrap();
 	assert!(supported_keys.contains(&public.clone().into()));
-	assert!(AppPair::verify(&signature, "ed25519", &AppPublic::from(public)));
+	assert!(AppPair::verify(&signature, "ecdsa", &AppPublic::from(public)));
 }

--- a/primitives/application-crypto/test/src/lib.rs
+++ b/primitives/application-crypto/test/src/lib.rs
@@ -20,3 +20,5 @@
 mod ed25519;
 #[cfg(test)]
 mod sr25519;
+#[cfg(test)]
+mod ecdsa;

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -190,11 +190,16 @@ impl std::fmt::Display for Public {
 	}
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Debug for Public {
+impl sp_std::fmt::Debug for Public {
+	#[cfg(feature = "std")]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		let s = self.to_ss58check();
 		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.as_ref()), &s[0..8])
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
 	}
 }
 
@@ -301,10 +306,15 @@ impl AsMut<[u8]> for Signature {
 	}
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Debug for Signature {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl sp_std::fmt::Debug for Signature {
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "{}", crate::hexdisplay::HexDisplay::from(&self.0))
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+		Ok(())
 	}
 }
 

--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -37,6 +37,7 @@ use crate::crypto::Ss58Codec;
 #[cfg(feature = "std")]
 use serde::{de, Serializer, Serialize, Deserializer, Deserialize};
 use crate::crypto::{Public as TraitPublic, CryptoTypePublicPair, UncheckedFrom, CryptoType, Derive, CryptoTypeId};
+use sp_runtime_interface::pass_by::PassByInner;
 #[cfg(feature = "full_crypto")]
 use secp256k1::{PublicKey, SecretKey};
 
@@ -50,7 +51,7 @@ pub const CRYPTO_ID: CryptoTypeId = CryptoTypeId(*b"ecds");
 type Seed = [u8; 32];
 
 /// The ECDSA compressed public key.
-#[derive(Clone, Encode, Decode)]
+#[derive(Clone, Encode, Decode, PassByInner)]
 pub struct Public([u8; 33]);
 
 impl PartialOrd for Public {
@@ -121,6 +122,18 @@ impl TraitPublic for Public {
 
 	fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
 		CryptoTypePublicPair(CRYPTO_ID, self.to_raw_vec())
+	}
+}
+
+impl From<Public> for CryptoTypePublicPair {
+	fn from(key: Public) -> Self {
+		(&key).into()
+	}
+}
+
+impl From<&Public> for CryptoTypePublicPair {
+	fn from(key: &Public) -> Self {
+		CryptoTypePublicPair(CRYPTO_ID, key.to_raw_vec())
 	}
 }
 
@@ -208,7 +221,7 @@ impl sp_std::hash::Hash for Public {
 }
 
 /// A signature (a 512-bit value, plus 8 bits for recovery ID).
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, PassByInner)]
 pub struct Signature([u8; 65]);
 
 impl sp_std::convert::TryFrom<&[u8]> for Signature {

--- a/primitives/core/src/traits.rs
+++ b/primitives/core/src/traits.rs
@@ -18,7 +18,7 @@
 
 use crate::{
 	crypto::{KeyTypeId, CryptoTypePublicPair},
-	ed25519, sr25519,
+	ed25519, sr25519, ecdsa,
 };
 
 use std::{
@@ -71,6 +71,18 @@ pub trait BareCryptoStore: Send + Sync {
 		id: KeyTypeId,
 		seed: Option<&str>,
 	) -> Result<ed25519::Public, BareCryptoStoreError>;
+	/// Returns all ecdsa public keys for the given key type.
+	fn ecdsa_public_keys(&self, id: KeyTypeId) -> Vec<ecdsa::Public>;
+	/// Generate a new ecdsa key pair for the given key type and an optional seed.
+	///
+	/// If the given seed is `Some(_)`, the key pair will only be stored in memory.
+	///
+	/// Returns the public key of the generated key pair.
+	fn ecdsa_generate_new(
+		&mut self,
+		id: KeyTypeId,
+		seed: Option<&str>,
+	) -> Result<ecdsa::Public, BareCryptoStoreError>;
 
 	/// Insert a new key. This doesn't require any known of the crypto; but a public key must be
 	/// manually provided.

--- a/primitives/io/src/batch_verifier.rs
+++ b/primitives/io/src/batch_verifier.rs
@@ -16,7 +16,7 @@
 
 //! Batch/parallel verification.
 
-use sp_core::{ed25519, sr25519, crypto::Pair, traits::CloneableSpawn};
+use sp_core::{ed25519, sr25519, ecdsa, crypto::Pair, traits::CloneableSpawn};
 use std::sync::{Arc, atomic::{AtomicBool, Ordering as AtomicOrdering}};
 use futures::{future::FutureExt, task::FutureObj, channel::oneshot};
 
@@ -120,6 +120,29 @@ impl BatchVerifier {
 			}
 		}
 
+		true
+	}
+
+	/// Push ecdsa signature to verify.
+	///
+	/// Returns false if some of the pushed signatures before already failed the check
+	/// (in this case it won't verify anything else)
+	pub fn push_ecdsa(
+		&mut self,
+		signature: ecdsa::Signature,
+		pub_key: ecdsa::Public,
+		message: Vec<u8>,
+	) -> bool {
+		if self.invalid.load(AtomicOrdering::Relaxed) { return false; }
+
+		if self.spawn_verification_task(move || ecdsa::Pair::verify(&signature, &message, &pub_key)).is_err() {
+			log::debug!(
+				target: "runtime",
+				"Batch-verification returns false because failed to spawn background task.",
+			);
+
+			return false;
+		}
 		true
 	}
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -41,7 +41,7 @@ use sp_core::{
 };
 
 use sp_core::{
-	crypto::KeyTypeId, ed25519, sr25519, H256, LogLevel,
+	crypto::KeyTypeId, ed25519, sr25519, ecdsa, H256, LogLevel,
 	offchain::{
 		Timestamp, HttpRequestId, HttpRequestStatus, HttpError, StorageKind, OpaqueNetworkState,
 	},
@@ -542,6 +542,80 @@ pub trait Crypto {
 	/// signature version.
 	fn sr25519_verify(sig: &sr25519::Signature, msg: &[u8], pubkey: &sr25519::Public) -> bool {
 		sr25519::Pair::verify_deprecated(sig, msg, pubkey)
+	}
+
+	/// Returns all `ecdsa` public keys for the given key id from the keystore.
+	fn ecdsa_public_keys(&mut self, id: KeyTypeId) -> Vec<ecdsa::Public> {
+		self.extension::<KeystoreExt>()
+			.expect("No `keystore` associated for the current context!")
+			.read()
+			.ecdsa_public_keys(id)
+	}
+
+	/// Generate an `ecdsa` key for the given key type using an optional `seed` and
+	/// store it in the keystore.
+	///
+	/// The `seed` needs to be a valid utf8.
+	///
+	/// Returns the public key.
+	fn ecdsa_generate(&mut self, id: KeyTypeId, seed: Option<Vec<u8>>) -> ecdsa::Public {
+		let seed = seed.as_ref().map(|s| std::str::from_utf8(&s).expect("Seed is valid utf8!"));
+		self.extension::<KeystoreExt>()
+			.expect("No `keystore` associated for the current context!")
+			.write()
+			.ecdsa_generate_new(id, seed)
+			.expect("`ecdsa_generate` failed")
+	}
+
+	/// Sign the given `msg` with the `ecdsa` key that corresponds to the given public key and
+	/// key type in the keystore.
+	///
+	/// Returns the signature.
+	fn ecdsa_sign(
+		&mut self,
+		id: KeyTypeId,
+		pub_key: &ecdsa::Public,
+		msg: &[u8],
+	) -> Option<ecdsa::Signature> {
+		self.extension::<KeystoreExt>()
+			.expect("No `keystore` associated for the current context!")
+			.read()
+			.sign_with(id, &pub_key.into(), msg)
+			.map(|sig| ecdsa::Signature::from_slice(sig.as_slice()))
+			.ok()
+	}
+
+	/// Verify `ecdsa` signature.
+	///
+	/// Returns `true` when the verification is either successful or batched.
+	/// If no batching verification extension registered, this will return the result
+	/// of verification immediately. If batching verification extension is registered
+	/// caller should call `crypto::finish_batch_verify` to actualy check all submitted
+	/// signatures.
+	fn ecdsa_verify(
+		sig: &ecdsa::Signature,
+		msg: &[u8],
+		pub_key: &ecdsa::Public,
+	) -> bool {
+		// TODO: see #5554, this is used outside of externalities context/runtime, thus this manual
+		// `with_externalities`.
+		//
+		// This `with_externalities(..)` block returns Some(Some(result)) if signature verification was successfully
+		// batched, everything else (Some(None)/None) means it was not batched and needs to be verified.
+		let evaluated = sp_externalities::with_externalities(|mut instance|
+			instance.extension::<VerificationExt>().map(
+				|extension| extension.push_ecdsa(
+					sig.clone(),
+					pub_key.clone(),
+					msg.to_vec(),
+				)
+			)
+		);
+
+		match evaluated {
+			Some(Some(val)) => val,
+			_ => ecdsa::Pair::verify(sig, msg, pub_key),
+		}
 	}
 
 	/// Verify and recover a SECP256k1 ECDSA signature.

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -304,6 +304,10 @@ cfg_if! {
 				///
 				/// Returns the signature generated for the message `sr25519`.
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic);
+				/// Test that `ecdsa` crypto works in the runtime.
+				///
+				/// Returns the signature generated for the message `ecdsa`.
+				fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic);
 				/// Run various tests against storage.
 				fn test_storage();
 			}
@@ -346,6 +350,10 @@ cfg_if! {
 				///
 				/// Returns the signature generated for the message `sr25519`.
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic);
+				/// Test that `ecdsa` crypto works in the runtime.
+				///
+				/// Returns the signature generated for the message `ecdsa`.
+				fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic);
 				/// Run various tests against storage.
 				fn test_storage();
 			}
@@ -484,6 +492,7 @@ impl_opaque_keys! {
 	pub struct SessionKeys {
 		pub ed25519: ed25519::AppPublic,
 		pub sr25519: sr25519::AppPublic,
+		pub ecdsa: ecdsa::AppPublic,
 	}
 }
 
@@ -617,6 +626,10 @@ cfg_if! {
 
 				fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 					test_sr25519_crypto()
+				}
+
+				fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic) {
+					test_ecdsa_crypto()
 				}
 
 				fn test_storage() {
@@ -836,6 +849,10 @@ cfg_if! {
 					test_sr25519_crypto()
 				}
 
+				fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic) {
+					test_ecdsa_crypto()
+				}
+
 				fn test_storage() {
 					test_read_storage();
 					test_read_child_storage();
@@ -925,6 +942,21 @@ fn test_sr25519_crypto() -> (sr25519::AppSignature, sr25519::AppPublic) {
 
 	let signature = public0.sign(&"sr25519").expect("Generates a valid `sr25519` signature.");
 	assert!(public0.verify(&"sr25519", &signature));
+	(signature, public0)
+}
+
+fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic) {
+	let public0 = ecdsa::AppPublic::generate_pair(None);
+	let public1 = ecdsa::AppPublic::generate_pair(None);
+	let public2 = ecdsa::AppPublic::generate_pair(None);
+
+	let all = ecdsa::AppPublic::all();
+	assert!(all.contains(&public0));
+	assert!(all.contains(&public1));
+	assert!(all.contains(&public2));
+
+	let signature = public0.sign(&"ecdsa").expect("Generates a valid `ecdsa` signature.");
+	assert!(public0.verify(&"ecdsa", &signature));
 	(signature, public0)
 }
 

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -26,7 +26,7 @@ use sp_std::{prelude::*, marker::PhantomData};
 use codec::{Encode, Decode, Input, Error};
 
 use sp_core::{OpaqueMetadata, RuntimeDebug, ChangesTrieConfiguration};
-use sp_application_crypto::{ed25519, sr25519, RuntimeAppPublic};
+use sp_application_crypto::{ed25519, sr25519, ecdsa, RuntimeAppPublic};
 use trie_db::{TrieMut, Trie};
 use sp_trie::PrefixedMemoryDB;
 use sp_trie::trie_types::{TrieDB, TrieDBMut};
@@ -956,6 +956,7 @@ fn test_ecdsa_crypto() -> (ecdsa::AppSignature, ecdsa::AppPublic) {
 	assert!(all.contains(&public2));
 
 	let signature = public0.sign(&"ecdsa").expect("Generates a valid `ecdsa` signature.");
+
 	assert!(public0.verify(&"ecdsa", &signature));
 	(signature, public0)
 }


### PR DESCRIPTION
`RuntimePublic` implementation of ECDSA on `application-crypto`.
https://github.com/paritytech/substrate/tree/master/primitives/application-crypto/src

`client/keystore` and `primitves/sr_io` and `primitives/core/crypto/ecdsa` was changed.