### PR TITLE
Don't log the yamux errors by default

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -217,6 +217,7 @@ pub fn init_logger(pattern: &str) {
 	let mut builder = env_logger::Builder::new();
 	// Disable info logging by default for some modules:
 	builder.filter(Some("ws"), log::LevelFilter::Off);
+	builder.filter(Some("yamux"), log::LevelFilter::Off);
 	builder.filter(Some("hyper"), log::LevelFilter::Warn);
 	builder.filter(Some("cranelift_wasm"), log::LevelFilter::Warn);
 	// Always log the special target `sc_tracing`, overrides global level


### PR DESCRIPTION
The `yamux` crate generates errors if the connection misbehaves, while Substrate in general assumes that errors represent internal errors within our code.