### PR TITLE
Add Slashing Spans to Staking Benchmarks

### DIFF
--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -231,6 +231,7 @@ benchmarks! {
 		// Slashing Spans
 		let s in 0 .. MAX_SPANS;
 		let (stash, controller) = create_stash_controller::<T>(0)?;
+		add_slashing_spans::<T>(&stash, s);
 		let amount = T::Currency::minimum_balance() * 10.into();
 		Staking::<T>::unbond(RawOrigin::Signed(controller.clone()).into(), amount)?;
 		CurrentEra::put(EraIndex::max_value());

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -543,7 +543,6 @@ mod tests {
 			for i in 0 .. num_of_slashing_spans {
 				assert!(!SpanSlash::<Test>::contains_key((&validator_stash, i)));
 			}
-
 		});
 	}
 

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -539,7 +539,7 @@ mod tests {
 			}
 
 			// Test everything is cleaned up
-			assert_ok!(Staking::kill_stash(&validator_stash, 20));
+			assert_ok!(Staking::kill_stash(&validator_stash, num_of_slashing_spans));
 			assert!(SlashingSpans::<Test>::get(&validator_stash).is_none());
 			for i in 0 .. num_of_slashing_spans {
 				assert!(!SpanSlash::<Test>::contains_key((&validator_stash, i)));

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -305,7 +305,7 @@ benchmarks! {
 	force_unstake {
 		let u in ...;
 		let (stash, controller) = create_stash_controller::<T>(u)?;
-	}: _(RawOrigin::Root, stash)
+	}: _(RawOrigin::Root, stash, u32::max_value())
 	verify {
 		assert!(!Ledger::<T>::contains_key(&controller));
 	}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1732,11 +1732,16 @@ decl_module! {
 		/// The dispatch origin must be Root.
 		///
 		/// # <weight>
+		/// O(S) where S is the number of slashing spans to be removed
 		/// Base Weight: 47.68 µs
 		/// Reads: Bonded, Slashing Spans, Account, Locks
 		/// Writes: Bonded, Ledger, Payee, Validators, Nominators, Account, Locks
+		/// Writes Each: SlashingSpans * S
 		/// # </weight>
-		#[weight = 48 * WEIGHT_PER_MICROS + T::DbWeight::get().reads_writes(4, 7)]
+		#[weight = T::DbWeight::get().reads_writes(4, 7)
+			.saturating_add(48 * WEIGHT_PER_MICROS)
+			.saturating_add(T::DbWeight::get().writes(Weight::from(*num_slashing_spans)))
+		]
 		fn force_unstake(origin, stash: T::AccountId, num_slashing_spans: u32) {
 			ensure_root(origin)?;
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -763,6 +763,18 @@ pub(crate) fn on_offence_now(
 	on_offence_in_era(offenders, slash_fraction, now)
 }
 
+pub(crate) fn add_slash(who: &AccountId) {
+	on_offence_now(
+		&[
+			OffenceDetails {
+				offender: (who.clone(), Staking::eras_stakers(Staking::active_era().unwrap().index, who.clone())),
+				reporters: vec![],
+			},
+		],
+		&[Perbill::from_percent(10)],
+	);
+}
+
 // winners will be chosen by simply their unweighted total backing stake. Nominator stake is
 // distributed evenly.
 pub(crate) fn horrible_phragmen_with_post_processing(

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -50,11 +50,11 @@
 
 use super::{
 	EraIndex, Trait, Module, Store, BalanceOf, Exposure, Perbill, SessionInterface,
-	NegativeImbalanceOf, UnappliedSlash,
+	NegativeImbalanceOf, UnappliedSlash, Error,
 };
-use sp_runtime::{traits::{Zero, Saturating}, RuntimeDebug};
+use sp_runtime::{traits::{Zero, Saturating}, RuntimeDebug, DispatchResult};
 use frame_support::{
-	StorageMap, StorageDoubleMap,
+	StorageMap, StorageDoubleMap, ensure,
 	traits::{Currency, OnUnbalanced, Imbalance},
 };
 use sp_std::vec::Vec;
@@ -547,11 +547,18 @@ pub(crate) fn clear_era_metadata<T: Trait>(obsolete_era: EraIndex) {
 }
 
 /// Clear slashing metadata for a dead account.
-pub(crate) fn clear_stash_metadata<T: Trait>(stash: &T::AccountId) {
-	let spans = match <Module<T> as Store>::SlashingSpans::take(stash) {
-		None => return,
+pub(crate) fn clear_stash_metadata<T: Trait>(
+	stash: &T::AccountId,
+	num_slashing_spans: u32,
+) -> DispatchResult {
+	let spans = match <Module<T> as Store>::SlashingSpans::get(stash) {
+		None => return Ok(()),
 		Some(s) => s,
 	};
+
+	ensure!(num_slashing_spans as usize >= spans.iter().count(), Error::<T>::IncorrectSlashingSpans);
+
+	<Module<T> as Store>::SlashingSpans::remove(stash);
 
 	// kill slashing-span metadata for account.
 	//
@@ -561,6 +568,8 @@ pub(crate) fn clear_stash_metadata<T: Trait>(stash: &T::AccountId) {
 	for span in spans.iter() {
 		<Module<T> as Store>::SpanSlash::remove(&(stash.clone(), span.index));
 	}
+
+	Ok(())
 }
 
 // apply the slash to a stash account, deducting any missing funds from the reward

--- a/frame/staking/src/slashing.rs
+++ b/frame/staking/src/slashing.rs
@@ -100,7 +100,7 @@ pub struct SlashingSpans {
 impl SlashingSpans {
 	// creates a new record of slashing spans for a stash, starting at the beginning
 	// of the bonding period, relative to now.
-	fn new(window_start: EraIndex) -> Self {
+	pub(crate) fn new(window_start: EraIndex) -> Self {
 		SlashingSpans {
 			span_index: 0,
 			last_start: window_start,
@@ -115,7 +115,7 @@ impl SlashingSpans {
 	// update the slashing spans to reflect the start of a new span at the era after `now`
 	// returns `true` if a new span was started, `false` otherwise. `false` indicates
 	// that internal state is unchanged.
-	fn end_span(&mut self, now: EraIndex) -> bool {
+	pub(crate) fn end_span(&mut self, now: EraIndex) -> bool {
 		let next_start = now + 1;
 		if next_start <= self.last_start { return false }
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -1060,7 +1060,7 @@ fn bond_extra_and_withdraw_unbonded_works() {
 		);
 
 		// Attempting to free the balances now will fail. 2 eras need to pass.
-		Staking::withdraw_unbonded(Origin::signed(10)).unwrap();
+		Staking::withdraw_unbonded(Origin::signed(10), u32::max_value()).unwrap();
 		assert_eq!(Staking::ledger(&10), Some(StakingLedger {
 			stash: 11, total: 1000 + 100, active: 100, unlocking: vec![UnlockChunk{ value: 1000, era: 2 + 3}], claimed_rewards: vec![] }));
 
@@ -1068,14 +1068,14 @@ fn bond_extra_and_withdraw_unbonded_works() {
 		mock::start_era(3);
 
 		// nothing yet
-		Staking::withdraw_unbonded(Origin::signed(10)).unwrap();
+		Staking::withdraw_unbonded(Origin::signed(10), u32::max_value()).unwrap();
 		assert_eq!(Staking::ledger(&10), Some(StakingLedger {
 			stash: 11, total: 1000 + 100, active: 100, unlocking: vec![UnlockChunk{ value: 1000, era: 2 + 3}], claimed_rewards: vec![] }));
 
 		// trigger next era.
 		mock::start_era(5);
 
-		Staking::withdraw_unbonded(Origin::signed(10)).unwrap();
+		Staking::withdraw_unbonded(Origin::signed(10), u32::max_value()).unwrap();
 		// Now the value is free and the staking ledger is updated.
 		assert_eq!(Staking::ledger(&10), Some(StakingLedger {
 			stash: 11, total: 100, active: 100, unlocking: vec![], claimed_rewards: vec![] }));
@@ -1101,7 +1101,7 @@ fn too_many_unbond_calls_should_not_work() {
 
 		assert_noop!(Staking::unbond(Origin::signed(10), 1), Error::<Test>::NoMoreChunks);
 		// free up.
-		assert_ok!(Staking::withdraw_unbonded(Origin::signed(10)));
+		assert_ok!(Staking::withdraw_unbonded(Origin::signed(10), u32::max_value()));
 
 		// Can add again.
 		assert_ok!(Staking::unbond(Origin::signed(10), 1));
@@ -1449,7 +1449,7 @@ fn on_free_balance_zero_stash_removes_validator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Reap the stash
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11));
+		assert_ok!(Staking::reap_stash(Origin::NONE, 11, u32::max_value()));
 
 		// Check storage items do not exist
 		assert!(!<Ledger<Test>>::contains_key(&10));
@@ -1505,7 +1505,7 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Reap the stash
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11));
+		assert_ok!(Staking::reap_stash(Origin::NONE, 11, u32::max_value()));
 
 		// Check storage items do not exist
 		assert!(!<Ledger<Test>>::contains_key(&10));
@@ -1619,14 +1619,14 @@ fn bond_with_no_staked_value() {
 			mock::start_era(2);
 
 			// not yet removed.
-			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
+			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2), u32::max_value()));
 			assert!(Staking::ledger(2).is_some());
 			assert_eq!(Balances::locks(&1)[0].amount, 5);
 
 			mock::start_era(3);
 
 			// poof. Account 1 is removed from the staking system.
-			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2)));
+			assert_ok!(Staking::withdraw_unbonded(Origin::signed(2), u32::max_value()));
 			assert!(Staking::ledger(2).is_none());
 			assert_eq!(Balances::locks(&1).len(), 0);
 		});
@@ -2270,7 +2270,7 @@ fn garbage_collection_after_slashing() {
 		assert_eq!(Balances::free_balance(11), 0);
 		assert_eq!(Balances::total_balance(&11), 0);
 
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11));
+		assert_ok!(Staking::reap_stash(Origin::NONE, 11, u32::max_value()));
 
 		assert!(<Staking as crate::Store>::SlashingSpans::get(&11).is_none());
 		assert_eq!(<Staking as crate::Store>::SpanSlash::get(&(11, 0)).amount_slashed(), &0);

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -40,9 +40,9 @@ fn force_unstake_works() {
 			BalancesError::<Test, _>::LiquidityRestrictions
 		);
 		// Force unstake requires root.
-		assert_noop!(Staking::force_unstake(Origin::signed(11), 11), BadOrigin);
+		assert_noop!(Staking::force_unstake(Origin::signed(11), 11, u32::max_value()), BadOrigin);
 		// We now force them to unstake
-		assert_ok!(Staking::force_unstake(Origin::ROOT, 11));
+		assert_ok!(Staking::force_unstake(Origin::ROOT, 11, u32::max_value()));
 		// No longer bonded.
 		assert_eq!(Staking::bonded(&11), None);
 		// Transfer works.

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -2270,7 +2270,12 @@ fn garbage_collection_after_slashing() {
 		assert_eq!(Balances::free_balance(11), 0);
 		assert_eq!(Balances::total_balance(&11), 0);
 
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11, u32::max_value()));
+		let slashing_spans = <Staking as crate::Store>::SlashingSpans::get(&11).unwrap();
+		assert_eq!(slashing_spans.iter().count(), 2);
+
+		// reap_stash respects num_slashing_spans so that weight is accurate
+		assert_noop!(Staking::reap_stash(Origin::NONE, 11, 0), Error::<Test>::IncorrectSlashingSpans);
+		assert_ok!(Staking::reap_stash(Origin::NONE, 11, 2));
 
 		assert!(<Staking as crate::Store>::SlashingSpans::get(&11).is_none());
 		assert_eq!(<Staking as crate::Store>::SpanSlash::get(&(11, 0)).amount_slashed(), &0);


### PR DESCRIPTION
This adds slashing spans to any situation where the account could be killed, and this storage needs to be cleaned up.

TODO:
* [x] Add a test on `kill_stash` for this