### PR TITLE
Updates the license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Substrate &middot; [![GitHub license](https://img.shields.io/github/license/paritytech/substrate)](LICENSE) [![GitLab Status](https://gitlab.parity.io/parity/substrate/badges/master/pipeline.svg)](https://gitlab.parity.io/parity/substrate/pipelines) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](docs/CONTRIBUTING.adoc)
+# Substrate &middot; [![GitHub license](https://img.shields.io/badge/license-GPL3%2FApache2-blue)](LICENSE) [![GitLab Status](https://gitlab.parity.io/parity/substrate/badges/master/pipeline.svg)](https://gitlab.parity.io/parity/substrate/pipelines) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](docs/CONTRIBUTING.adoc)
 
 <p align="center">
   <img src="/docs/media/sub.gif">


### PR DESCRIPTION
The current license badge is not identifiable by github

[![GitHub license](https://img.shields.io/github/license/paritytech/substrate)](LICENSE)

```
[![GitHub license](https://img.shields.io/github/license/paritytech/substrate)](LICENSE)
```

Updates a new one contains both `GPL3` and `Apache2`

[![GitHub license](https://img.shields.io/badge/license-GPL3%2FApache2-blue)](LICENSE)

```
[![GitHub license](https://img.shields.io/badge/license-GPL3%2FApache2-blue)](LICENSE)
```

✄ ----------------------------------------------------------------------------------------

Preview the modification at [clearloop/substrate:badge][0].

[0]: https://github.com/clearloop/substrate/tree/badge
