### PR TITLE
Upgrade to libp2p v0.19 - Changes the default PeerId representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,39 +2599,103 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "libp2p"
 version = "0.18.1"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "bytes 0.5.4",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core-derive 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-dns 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-identify 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-kad 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-mdns 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-mplex 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-noise 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-ping 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-secio 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-tcp 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-wasm-ext 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-websocket 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-yamux 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "multihash 0.11.1",
+ "parity-multiaddr 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "smallvec 1.3.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
- "libp2p-core-derive",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core-derive 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-deflate",
- "libp2p-dns",
+ "libp2p-dns 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-floodsub",
  "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-mplex",
- "libp2p-noise",
- "libp2p-ping",
+ "libp2p-identify 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-kad 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-mdns 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-mplex 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-noise 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-ping 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-plaintext",
  "libp2p-pnet",
- "libp2p-secio",
- "libp2p-swarm",
- "libp2p-tcp",
+ "libp2p-secio 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-tcp 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-uds",
- "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux",
- "multihash",
- "parity-multiaddr 0.8.0",
+ "libp2p-wasm-ext 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-websocket 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-yamux 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multihash 0.10.1",
+ "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.3.0",
  "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.4",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "multihash 0.11.1",
+ "multistream-select 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "parity-multiaddr 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "smallvec 1.3.0",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
 ]
 
 [[package]]
@@ -2650,9 +2714,9 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multihash",
- "multistream-select",
- "parity-multiaddr 0.8.0",
+ "multihash 0.10.1",
+ "multistream-select 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2666,6 +2730,15 @@ dependencies = [
  "unsigned-varint",
  "void",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-core-derive"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "quote 1.0.3",
+ "syn 1.0.17",
 ]
 
 [[package]]
@@ -2686,7 +2759,17 @@ checksum = "4ad32b006ea922da8cc66e537cf2df4b0fad8ebaa467d2a8c63d7784ac252ec6"
 dependencies = [
  "flate2",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
 ]
 
 [[package]]
@@ -2696,7 +2779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d0993481203d68e5ce2f787d033fb0cac6b850659ed6c784612db678977c71"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
 ]
 
@@ -2709,8 +2792,8 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2729,8 +2812,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "lru",
  "prost",
@@ -2745,16 +2828,57 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "prost",
  "prost-build",
  "smallvec 1.3.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "prost",
+ "prost-build",
+ "smallvec 1.3.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "arrayvec 0.5.1",
+ "bytes 0.5.4",
+ "either",
+ "fnv",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "multihash 0.11.1",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "smallvec 1.3.0",
+ "uint",
+ "unsigned-varint",
+ "void",
  "wasm-timer",
 ]
 
@@ -2770,10 +2894,10 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
- "multihash",
+ "multihash 0.10.1",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2781,6 +2905,27 @@ dependencies = [
  "smallvec 1.3.0",
  "uint",
  "unsigned-varint",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "async-std",
+ "data-encoding",
+ "dns-parser",
+ "either",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "net2",
+ "rand 0.7.3",
+ "smallvec 1.3.0",
  "void",
  "wasm-timer",
 ]
@@ -2797,14 +2942,29 @@ dependencies = [
  "either",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "net2",
  "rand 0.7.3",
  "smallvec 1.3.0",
  "void",
  "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv",
+ "futures 0.3.4",
+ "futures_codec",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "parking_lot 0.10.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2817,10 +2977,30 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "parking_lot 0.10.2",
  "unsigned-varint",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "curve25519-dalek",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -2832,7 +3012,7 @@ dependencies = [
  "curve25519-dalek",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "prost",
  "prost-build",
@@ -2847,12 +3027,26 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "rand 0.7.3",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9bfbf87eebb492d040f9899c5c81c9738730465ac5e78d9b7a7d086d0f07230"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "rand 0.7.3",
  "void",
@@ -2868,7 +3062,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "prost",
  "prost-build",
@@ -2894,6 +3088,35 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "aes-ctr",
+ "ctr",
+ "futures 0.3.4",
+ "hmac",
+ "js-sys",
+ "lazy_static",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "parity-send-wrapper",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "quicksink",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "static_assertions",
+ "twofish",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "libp2p-secio"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a0509a7e47245259954fef58b85b81bf4d29ae33a4365e38d718a866698774"
 dependencies = [
@@ -2903,7 +3126,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "parity-send-wrapper",
  "pin-project",
@@ -2924,16 +3147,45 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "rand 0.7.3",
  "smallvec 1.3.0",
  "void",
  "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "rand 0.7.3",
+ "smallvec 1.3.0",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "async-std",
+ "futures 0.3.4",
+ "futures-timer 3.0.2",
+ "get_if_addrs",
+ "ipnet",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "socket2",
 ]
 
 [[package]]
@@ -2947,7 +3199,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
 ]
 
@@ -2959,8 +3211,21 @@ checksum = "281c18ea2faacb9c8a6ff76c4405df5918d9a263770e3847bf03f099abadc010"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "futures 0.3.4",
+ "js-sys",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "parity-send-wrapper",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2971,10 +3236,30 @@ checksum = "e3ac7dbde0f88cad191dcdfd073b8bae28d01823e8ca313f117b6ecb914160c3"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "async-tls",
+ "bytes 0.5.4",
+ "either",
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "log",
+ "quicksink",
+ "rustls",
+ "rw-stream-sink",
+ "soketto",
+ "url 2.1.1",
+ "webpki",
+ "webpki-roots 0.18.0",
 ]
 
 [[package]]
@@ -2987,7 +3272,7 @@ dependencies = [
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "quicksink",
  "rustls",
@@ -3001,11 +3286,23 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.18.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "parking_lot 0.10.2",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02f91aea50f6571e0bc6c058dc0e9b270afd41ec28dd94e9e4bf607e78b9ab87"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core",
+ "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3283,10 +3580,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae32179a9904ccc6e063de8beee7f5dd55fae85ecb851ca923d55722bc28cf5d"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+
+[[package]]
+name = "multistream-select"
+version = "0.8.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "bytes 0.5.4",
+ "futures 0.3.4",
+ "log",
+ "pin-project",
+ "smallvec 1.3.0",
+ "unsigned-varint",
+]
 
 [[package]]
 name = "multistream-select"
@@ -3402,7 +3727,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "node-cli",
  "sc-rpc-api",
  "serde",
@@ -4774,6 +5099,23 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.8.0"
+source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder 1.3.4",
+ "data-encoding",
+ "multihash 0.11.1",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4db35e222f783ef4e6661873f6c165c4eb7b65e0c408349818517d5705c2d7d3"
 dependencies = [
@@ -4781,7 +5123,7 @@ dependencies = [
  "bs58",
  "byteorder 1.3.4",
  "data-encoding",
- "multihash",
+ "multihash 0.10.1",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
@@ -5853,7 +6195,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "parity-scale-codec",
  "prost",
@@ -6471,7 +6813,7 @@ dependencies = [
  "futures_codec",
  "hex",
  "ip_network",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6518,7 +6860,7 @@ dependencies = [
  "async-std",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "lru",
  "quickcheck",
@@ -6536,7 +6878,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -6593,7 +6935,7 @@ name = "sc-peerset"
 version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "rand 0.7.3",
  "serde_json",
@@ -6807,7 +7149,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "parking_lot 0.10.2",
  "pin-project",
@@ -7209,6 +7551,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "soketto"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7395,7 +7749,7 @@ dependencies = [
  "derive_more",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8043,7 +8397,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
- "libp2p",
+ "libp2p 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "node-primitives",
  "node-runtime",
  "pallet-balances",
@@ -8085,7 +8439,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "js-sys",
  "kvdb-web",
- "libp2p-wasm-ext",
+ "libp2p-wasm-ext 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
  "log",
  "rand 0.6.5",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,28 +2599,35 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "libp2p"
 version = "0.18.1"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-core-derive 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-dns 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-identify 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-kad 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-mdns 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-mplex 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-noise 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-ping 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-secio 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-tcp 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-wasm-ext 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-websocket 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-yamux 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "multihash 0.11.1",
- "parity-multiaddr 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
+ "libp2p-core-derive 0.18.0",
+ "libp2p-deflate",
+ "libp2p-dns 0.18.0",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
+ "libp2p-identify 0.18.0",
+ "libp2p-kad 0.18.0",
+ "libp2p-mdns 0.18.0",
+ "libp2p-mplex 0.18.0",
+ "libp2p-noise 0.18.0",
+ "libp2p-ping 0.18.0",
+ "libp2p-plaintext",
+ "libp2p-pnet",
+ "libp2p-secio 0.18.0",
+ "libp2p-swarm 0.18.1",
+ "libp2p-tcp 0.18.0",
+ "libp2p-uds",
+ "libp2p-wasm-ext 0.18.0",
+ "libp2p-websocket 0.18.0",
+ "libp2p-yamux 0.18.0",
+ "multihash 0.10.1",
+ "parity-multiaddr 0.8.0",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.3.0",
@@ -2629,73 +2636,34 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
+checksum = "3ec214d189b57e4412f079ac5a1442578d06b12ca7282ba4696104cc92ab96c1"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core-derive 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-deflate",
- "libp2p-dns 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-floodsub",
- "libp2p-gossipsub",
- "libp2p-identify 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-kad 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mdns 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-mplex 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-noise 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-ping 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-plaintext",
- "libp2p-pnet",
- "libp2p-secio 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-tcp 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-uds",
- "libp2p-wasm-ext 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-websocket 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-yamux 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "multihash 0.10.1",
- "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
+ "libp2p-core-derive 0.19.0",
+ "libp2p-dns 0.19.0",
+ "libp2p-identify 0.19.0",
+ "libp2p-kad 0.19.0",
+ "libp2p-mdns 0.19.0",
+ "libp2p-mplex 0.19.0",
+ "libp2p-noise 0.19.0",
+ "libp2p-ping 0.19.0",
+ "libp2p-secio 0.19.0",
+ "libp2p-swarm 0.19.0",
+ "libp2p-tcp 0.19.0",
+ "libp2p-wasm-ext 0.19.0",
+ "libp2p-websocket 0.19.0",
+ "libp2p-yamux 0.19.0",
+ "multihash 0.11.1",
+ "parity-multiaddr 0.9.0",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.3.0",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures 0.3.4",
- "futures-timer 3.0.2",
- "lazy_static",
- "libsecp256k1",
- "log",
- "multihash 0.11.1",
- "multistream-select 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
- "parity-multiaddr 0.8.0 (git+https://github.com/libp2p/rust-libp2p)",
- "parking_lot 0.10.2",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "smallvec 1.3.0",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -2715,8 +2683,42 @@ dependencies = [
  "libsecp256k1",
  "log",
  "multihash 0.10.1",
- "multistream-select 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
+ "parity-multiaddr 0.8.0",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2",
+ "smallvec 1.3.0",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a6000296bdbff540b6c00ef82108ef23aa68d195b9333823ea491562c338d7"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.4",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "multihash 0.11.1",
+ "multistream-select",
+ "parity-multiaddr 0.9.0",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2735,7 +2737,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
 dependencies = [
  "quote 1.0.3",
  "syn 1.0.17",
@@ -2743,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
+checksum = "67f0d915bee5d457a6d113377101e1f06e86a4286778aa4c6939553e9a4d7033"
 dependencies = [
  "quote 1.0.3",
  "syn 1.0.17",
@@ -2759,17 +2762,7 @@ checksum = "4ad32b006ea922da8cc66e537cf2df4b0fad8ebaa467d2a8c63d7784ac252ec6"
 dependencies = [
  "flate2",
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "log",
+ "libp2p-core 0.18.0",
 ]
 
 [[package]]
@@ -2779,7 +2772,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d0993481203d68e5ce2f787d033fb0cac6b850659ed6c784612db678977c71"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "log",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc186d9a941fd0207cf8f08ef225a735e2d7296258f570155e525f6ee732f87"
+dependencies = [
+ "futures 0.3.4",
+ "libp2p-core 0.19.0",
  "log",
 ]
 
@@ -2792,8 +2796,8 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2812,8 +2816,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "log",
  "lru",
  "prost",
@@ -2828,11 +2832,12 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "log",
  "prost",
  "prost-build",
@@ -2842,43 +2847,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
+checksum = "6a455af71c59473444eba05e83dbaa20262bdbd9b4154f22389510fbac16f201"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
+ "libp2p-swarm 0.19.0",
  "log",
  "prost",
  "prost-build",
  "smallvec 1.3.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "arrayvec 0.5.1",
- "bytes 0.5.4",
- "either",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
- "log",
- "multihash 0.11.1",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "smallvec 1.3.0",
- "uint",
- "unsigned-varint",
- "void",
  "wasm-timer",
 ]
 
@@ -2894,8 +2873,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "log",
  "multihash 0.10.1",
  "prost",
@@ -2910,22 +2889,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-mdns"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+name = "libp2p-kad"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d6c1d5100973527ae70d82687465b17049c1b717a7964de38b8e65000878ff"
 dependencies = [
- "async-std",
- "data-encoding",
- "dns-parser",
+ "arrayvec 0.5.1",
+ "bytes 0.5.4",
  "either",
+ "fnv",
  "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "futures_codec",
+ "libp2p-core 0.19.0",
+ "libp2p-swarm 0.19.0",
  "log",
- "net2",
+ "multihash 0.11.1",
+ "prost",
+ "prost-build",
  "rand 0.7.3",
+ "sha2",
  "smallvec 1.3.0",
+ "uint",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -2942,8 +2927,8 @@ dependencies = [
  "either",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "log",
  "net2",
  "rand 0.7.3",
@@ -2953,18 +2938,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+name = "libp2p-mdns"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5bc788d92111802cb0c92d2e032fa6f46333aaeb5650c2f37b5d3eba78cabe6"
 dependencies = [
- "bytes 0.5.4",
- "fnv",
+ "async-std",
+ "data-encoding",
+ "dns-parser",
+ "either",
  "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "lazy_static",
+ "libp2p-core 0.19.0",
+ "libp2p-swarm 0.19.0",
  "log",
- "parking_lot 0.10.2",
- "unsigned-varint",
+ "net2",
+ "rand 0.7.3",
+ "smallvec 1.3.0",
+ "void",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -2977,30 +2969,26 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
  "log",
  "parking_lot 0.10.2",
  "unsigned-varint",
 ]
 
 [[package]]
-name = "libp2p-noise"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+name = "libp2p-mplex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4095bce2100f840883f1f75dbd010c966ee4ad323ae9f82026396da5cf6cce68"
 dependencies = [
- "curve25519-dalek",
+ "bytes 0.5.4",
+ "fnv",
  "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "futures_codec",
+ "libp2p-core 0.19.0",
  "log",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "snow",
- "static_assertions",
- "x25519-dalek",
- "zeroize",
+ "parking_lot 0.10.2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3012,7 +3000,28 @@ dependencies = [
  "curve25519-dalek",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd504e27b0eadd451e06b67694ef714bd8374044e7db339bb0cdb83755ddf4"
+dependencies = [
+ "curve25519-dalek",
+ "futures 0.3.4",
+ "lazy_static",
+ "libp2p-core 0.19.0",
  "log",
  "prost",
  "prost-build",
@@ -3027,11 +3036,12 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9bfbf87eebb492d040f9899c5c81c9738730465ac5e78d9b7a7d086d0f07230"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "libp2p-swarm 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
+ "libp2p-swarm 0.18.1",
  "log",
  "rand 0.7.3",
  "void",
@@ -3040,13 +3050,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bfbf87eebb492d040f9899c5c81c9738730465ac5e78d9b7a7d086d0f07230"
+checksum = "82930c36490008b1ef2f26c237a2c205c38ef6edc263738d0528b842740ab09f"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
+ "libp2p-swarm 0.19.0",
  "log",
  "rand 0.7.3",
  "void",
@@ -3062,7 +3072,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
  "log",
  "prost",
  "prost-build",
@@ -3088,7 +3098,8 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a0509a7e47245259954fef58b85b81bf4d29ae33a4365e38d718a866698774"
 dependencies = [
  "aes-ctr",
  "ctr",
@@ -3096,7 +3107,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
  "log",
  "parity-send-wrapper",
  "pin-project",
@@ -3116,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-secio"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a0509a7e47245259954fef58b85b81bf4d29ae33a4365e38d718a866698774"
+checksum = "22e30b873276846181fa9c04126653678c2797cb1556361d01b7b7fd6bf24682"
 dependencies = [
  "aes-ctr",
  "ctr",
@@ -3126,7 +3137,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
  "log",
  "parity-send-wrapper",
  "pin-project",
@@ -3147,10 +3158,11 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.18.1"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
  "log",
  "rand 0.7.3",
  "smallvec 1.3.0",
@@ -3160,32 +3172,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
+checksum = "b4a8101a0e0d5f04562137a476bf5f5423cd5bdab2f7e43a75909668e63cb102"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
  "log",
  "rand 0.7.3",
  "smallvec 1.3.0",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "async-std",
- "futures 0.3.4",
- "futures-timer 3.0.2",
- "get_if_addrs",
- "ipnet",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "log",
- "socket2",
 ]
 
 [[package]]
@@ -3199,8 +3196,24 @@ dependencies = [
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
  "log",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4462bd96b97cac3f3a83b1b343ad3c3460cebbc8d929c040b1520c30e3611e08"
+dependencies = [
+ "async-std",
+ "futures 0.3.4",
+ "futures-timer 3.0.2",
+ "get_if_addrs",
+ "ipnet",
+ "libp2p-core 0.19.0",
+ "log",
+ "socket2",
 ]
 
 [[package]]
@@ -3211,21 +3224,8 @@ checksum = "281c18ea2faacb9c8a6ff76c4405df5918d9a263770e3847bf03f099abadc010"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
  "log",
-]
-
-[[package]]
-name = "libp2p-wasm-ext"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "futures 0.3.4",
- "js-sys",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "parity-send-wrapper",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3236,30 +3236,24 @@ checksum = "e3ac7dbde0f88cad191dcdfd073b8bae28d01823e8ca313f117b6ecb914160c3"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
-name = "libp2p-websocket"
-version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+name = "libp2p-wasm-ext"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59fdbb5706f2723ca108c088b1c7a37f735a8c328021f0508007162627e9885"
 dependencies = [
- "async-tls",
- "bytes 0.5.4",
- "either",
  "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
- "log",
- "quicksink",
- "rustls",
- "rw-stream-sink",
- "soketto",
- "url 2.1.1",
- "webpki",
- "webpki-roots 0.18.0",
+ "js-sys",
+ "libp2p-core 0.19.0",
+ "parity-send-wrapper",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3272,7 +3266,28 @@ dependencies = [
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.18.0",
+ "log",
+ "quicksink",
+ "rustls",
+ "rw-stream-sink",
+ "soketto",
+ "url 2.1.1",
+ "webpki",
+ "webpki-roots 0.18.0",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085fbe4c05c4116c2164ab4d5a521eb6e00516c444f61b3ee9f68c7b1e53580b"
+dependencies = [
+ "async-tls",
+ "bytes 0.5.4",
+ "either",
+ "futures 0.3.4",
+ "libp2p-core 0.19.0",
  "log",
  "quicksink",
  "rustls",
@@ -3286,10 +3301,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.18.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f91aea50f6571e0bc6c058dc0e9b270afd41ec28dd94e9e4bf607e78b9ab87"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-core 0.18.0",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3297,12 +3313,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f91aea50f6571e0bc6c058dc0e9b270afd41ec28dd94e9e4bf607e78b9ab87"
+checksum = "0b305d3a8981e68f11c0e17f2d11d5c52fae95e0d7c283f9e462b5b2dab413b2"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.19.0",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3603,19 +3619,6 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.8.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
-dependencies = [
- "bytes 0.5.4",
- "futures 0.3.4",
- "log",
- "pin-project",
- "smallvec 1.3.0",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74cdcf7cfb3402881e15a1f95116cb033d69b33c83d481e1234777f5ef0c3d2c"
 dependencies = [
@@ -3727,7 +3730,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "node-cli",
  "sc-rpc-api",
  "serde",
@@ -5099,13 +5102,14 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.8.0"
-source = "git+https://github.com/libp2p/rust-libp2p#162a0be0c2dd08be76f8fbf5a58d12ac45267339"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db35e222f783ef4e6661873f6c165c4eb7b65e0c408349818517d5705c2d7d3"
 dependencies = [
  "arrayref",
  "bs58",
  "byteorder 1.3.4",
  "data-encoding",
- "multihash 0.11.1",
+ "multihash 0.10.1",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
@@ -5115,15 +5119,15 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db35e222f783ef4e6661873f6c165c4eb7b65e0c408349818517d5705c2d7d3"
+checksum = "12ca96399f4a01aa89c59220c4f52ac371940eb4e53e3ce990da796f364bdf69"
 dependencies = [
  "arrayref",
  "bs58",
  "byteorder 1.3.4",
  "data-encoding",
- "multihash 0.10.1",
+ "multihash 0.11.1",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
@@ -6195,7 +6199,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "parity-scale-codec",
  "prost",
@@ -6814,7 +6818,7 @@ dependencies = [
  "futures_codec",
  "hex",
  "ip_network",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6861,7 +6865,7 @@ dependencies = [
  "async-std",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "lru",
  "quickcheck",
@@ -6879,7 +6883,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -6936,7 +6940,7 @@ name = "sc-peerset"
 version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "rand 0.7.3",
  "serde_json",
@@ -7150,7 +7154,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "parking_lot 0.10.2",
  "pin-project",
@@ -7750,7 +7754,7 @@ dependencies = [
  "derive_more",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.18.1 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p 0.19.0",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8398,7 +8402,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
- "libp2p 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p 0.18.1",
  "node-primitives",
  "node-runtime",
  "pallet-balances",
@@ -8440,7 +8444,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "js-sys",
  "kvdb-web",
- "libp2p-wasm-ext 0.18.0 (git+https://github.com/libp2p/rust-libp2p)",
+ "libp2p-wasm-ext 0.19.0",
  "log",
  "rand 0.6.5",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
+checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 
 [[package]]
 name = "bstr"
@@ -6801,6 +6801,7 @@ dependencies = [
  "assert_matches",
  "async-std",
  "bitflags",
+ "bs58",
  "bytes 0.5.4",
  "derive_more",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,44 +2598,6 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ea742c86405b659c358223a8f0f9f5a9eb27bb6083894c6340959b05269662"
-dependencies = [
- "bytes 0.5.4",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.18.0",
- "libp2p-core-derive 0.18.0",
- "libp2p-deflate",
- "libp2p-dns 0.18.0",
- "libp2p-floodsub",
- "libp2p-gossipsub",
- "libp2p-identify 0.18.0",
- "libp2p-kad 0.18.0",
- "libp2p-mdns 0.18.0",
- "libp2p-mplex 0.18.0",
- "libp2p-noise 0.18.0",
- "libp2p-ping 0.18.0",
- "libp2p-plaintext",
- "libp2p-pnet",
- "libp2p-secio 0.18.0",
- "libp2p-swarm 0.18.1",
- "libp2p-tcp 0.18.0",
- "libp2p-uds",
- "libp2p-wasm-ext 0.18.0",
- "libp2p-websocket 0.18.0",
- "libp2p-yamux 0.18.0",
- "multihash 0.10.1",
- "parity-multiaddr 0.8.0",
- "parking_lot 0.10.2",
- "pin-project",
- "smallvec 1.3.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec214d189b57e4412f079ac5a1442578d06b12ca7282ba4696104cc92ab96c1"
@@ -2643,61 +2605,33 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.19.0",
- "libp2p-core-derive 0.19.0",
- "libp2p-dns 0.19.0",
- "libp2p-identify 0.19.0",
- "libp2p-kad 0.19.0",
- "libp2p-mdns 0.19.0",
- "libp2p-mplex 0.19.0",
- "libp2p-noise 0.19.0",
- "libp2p-ping 0.19.0",
- "libp2p-secio 0.19.0",
- "libp2p-swarm 0.19.0",
- "libp2p-tcp 0.19.0",
- "libp2p-wasm-ext 0.19.0",
- "libp2p-websocket 0.19.0",
- "libp2p-yamux 0.19.0",
- "multihash 0.11.1",
+ "libp2p-core",
+ "libp2p-core-derive",
+ "libp2p-deflate",
+ "libp2p-dns",
+ "libp2p-floodsub",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-mplex",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-plaintext",
+ "libp2p-pnet",
+ "libp2p-secio",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-uds",
+ "libp2p-wasm-ext",
+ "libp2p-websocket",
+ "libp2p-yamux",
+ "multihash",
  "parity-multiaddr 0.9.0",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.3.0",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d2c17158c4dca984a77a5927aac6f0862d7f50c013470a415f93be498b5739"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures 0.3.4",
- "futures-timer 3.0.2",
- "lazy_static",
- "libsecp256k1",
- "log",
- "multihash 0.10.1",
- "multistream-select",
- "parity-multiaddr 0.8.0",
- "parking_lot 0.10.2",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "smallvec 1.3.0",
- "thiserror",
- "unsigned-varint",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -2716,7 +2650,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multihash 0.11.1",
+ "multihash",
  "multistream-select",
  "parity-multiaddr 0.9.0",
  "parking_lot 0.10.2",
@@ -2736,16 +2670,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329127858e4728db5ab60c33d5ae352a999325fdf190ed022ec7d3a4685ae2e6"
-dependencies = [
- "quote 1.0.3",
- "syn 1.0.17",
-]
-
-[[package]]
-name = "libp2p-core-derive"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67f0d915bee5d457a6d113377101e1f06e86a4286778aa4c6939553e9a4d7033"
@@ -2756,24 +2680,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad32b006ea922da8cc66e537cf2df4b0fad8ebaa467d2a8c63d7784ac252ec6"
+checksum = "975c847575ef9b3d63f9c11d465e9a9b0ea940cfa408b93cc6981bbc3b1bac40"
 dependencies = [
  "flate2",
  "futures 0.3.4",
- "libp2p-core 0.18.0",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d0993481203d68e5ce2f787d033fb0cac6b850659ed6c784612db678977c71"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "log",
+ "libp2p-core",
 ]
 
 [[package]]
@@ -2783,21 +2696,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc186d9a941fd0207cf8f08ef225a735e2d7296258f570155e525f6ee732f87"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
 ]
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3673153ca967c179d745fadf047d069355d6669ecf7f261b450fbaebf1bffd3d"
+checksum = "c6dd8cc558e0edde2d4a423d017efd6b36c1b6bf97f4304c83076895c5edaed8"
 dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.4",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2806,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7f3f79f060864db0317cc47641b7d35276dee52a0ffa91553fbd0c153863a3"
+checksum = "ce48659363fe765c09d77eb5b2248e04362557b11bba3701f05879ad34919ccd"
 dependencies = [
  "base64 0.11.0",
  "byteorder 1.3.4",
@@ -2816,8 +2729,8 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "lru",
  "prost",
@@ -2831,60 +2744,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38ca3eb807789e26f41c82ca7cd2b3843c66c5587b8b5f709a2f421f3061414"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
- "log",
- "prost",
- "prost-build",
- "smallvec 1.3.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-identify"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a455af71c59473444eba05e83dbaa20262bdbd9b4154f22389510fbac16f201"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.19.0",
- "libp2p-swarm 0.19.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "prost",
  "prost-build",
  "smallvec 1.3.0",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92cda1fb8149ea64d092a2b99d2bd7a2c309eee38ea322d02e4480bd6ee1759"
-dependencies = [
- "arrayvec 0.5.1",
- "bytes 0.5.4",
- "either",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
- "log",
- "multihash 0.10.1",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "smallvec 1.3.0",
- "uint",
- "unsigned-varint",
- "void",
  "wasm-timer",
 ]
 
@@ -2900,10 +2770,10 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.19.0",
- "libp2p-swarm 0.19.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
- "multihash 0.11.1",
+ "multihash",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2911,28 +2781,6 @@ dependencies = [
  "smallvec 1.3.0",
  "uint",
  "unsigned-varint",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e908d2aaf8ff0ec6ad1f02fe1844fd777fb0b03a68a226423630750ab99471"
-dependencies = [
- "async-std",
- "data-encoding",
- "dns-parser",
- "either",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
- "log",
- "net2",
- "rand 0.7.3",
- "smallvec 1.3.0",
  "void",
  "wasm-timer",
 ]
@@ -2949,30 +2797,14 @@ dependencies = [
  "either",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.19.0",
- "libp2p-swarm 0.19.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "net2",
  "rand 0.7.3",
  "smallvec 1.3.0",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-mplex"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0832882b06619b2e81d74e71447753ea3c068164a0bca67847d272e856a04a02"
-dependencies = [
- "bytes 0.5.4",
- "fnv",
- "futures 0.3.4",
- "futures_codec",
- "libp2p-core 0.18.0",
- "log",
- "parking_lot 0.10.2",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -2985,31 +2817,10 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "parking_lot 0.10.2",
  "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918e94a649e1139c24ee9f1f8c1f2adaba6d157b9471af787f2d9beac8c29c77"
-dependencies = [
- "curve25519-dalek",
- "futures 0.3.4",
- "lazy_static",
- "libp2p-core 0.18.0",
- "log",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "sha2",
- "snow",
- "static_assertions",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -3021,7 +2832,7 @@ dependencies = [
  "curve25519-dalek",
  "futures 0.3.4",
  "lazy_static",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "prost",
  "prost-build",
@@ -3035,28 +2846,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bfbf87eebb492d040f9899c5c81c9738730465ac5e78d9b7a7d086d0f07230"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "libp2p-swarm 0.18.1",
- "log",
- "rand 0.7.3",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-ping"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82930c36490008b1ef2f26c237a2c205c38ef6edc263738d0528b842740ab09f"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.19.0",
- "libp2p-swarm 0.19.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "log",
  "rand 0.7.3",
  "void",
@@ -3065,14 +2861,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-plaintext"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabb00553a49bf6d4a8ce362f6eefac410227a14d03c3acffbb8cc3f022ea019"
+checksum = "ad28fe7beaa3e516ee8ba2af8c4f6820f269afa60d661831e879f2afea64f4a0"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures_codec",
- "libp2p-core 0.18.0",
+ "libp2p-core",
  "log",
  "prost",
  "prost-build",
@@ -3083,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-pnet"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f81b8b37ff529e1f51c20c396dac657def2108da174c1d27e57e72c9fe2d411"
+checksum = "dabaa2194e1ce3c51cd78d734dd4c81dc5c7b150b309cbf9029df044034ac261"
 dependencies = [
  "futures 0.3.4",
  "log",
@@ -3093,36 +2889,6 @@ dependencies = [
  "rand 0.7.3",
  "salsa20",
  "sha3",
-]
-
-[[package]]
-name = "libp2p-secio"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a0509a7e47245259954fef58b85b81bf4d29ae33a4365e38d718a866698774"
-dependencies = [
- "aes-ctr",
- "ctr",
- "futures 0.3.4",
- "hmac",
- "js-sys",
- "lazy_static",
- "libp2p-core 0.18.0",
- "log",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -3137,7 +2903,7 @@ dependencies = [
  "hmac",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "parity-send-wrapper",
  "pin-project",
@@ -3157,47 +2923,17 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ab289ae44cc691da0a6fe96aefa43f26c86c6c7813998e203f6d80f1860f18"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "log",
- "rand 0.7.3",
- "smallvec 1.3.0",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-swarm"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a8101a0e0d5f04562137a476bf5f5423cd5bdab2f7e43a75909668e63cb102"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "rand 0.7.3",
  "smallvec 1.3.0",
  "void",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ea44823d3ed223e4605da94b50177bc520f05ae2452286700549a32d81669"
-dependencies = [
- "async-std",
- "futures 0.3.4",
- "futures-timer 3.0.2",
- "get_if_addrs",
- "ipnet",
- "libp2p-core 0.18.0",
- "log",
 ]
 
 [[package]]
@@ -3211,35 +2947,21 @@ dependencies = [
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "socket2",
 ]
 
 [[package]]
 name = "libp2p-uds"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c18ea2faacb9c8a6ff76c4405df5918d9a263770e3847bf03f099abadc010"
+checksum = "69660d235449bb2d99333b9892c9176d06fd2b380490cb8213feb5b015678cf1"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "libp2p-core 0.18.0",
+ "libp2p-core",
  "log",
-]
-
-[[package]]
-name = "libp2p-wasm-ext"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ac7dbde0f88cad191dcdfd073b8bae28d01823e8ca313f117b6ecb914160c3"
-dependencies = [
- "futures 0.3.4",
- "js-sys",
- "libp2p-core 0.18.0",
- "parity-send-wrapper",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3250,31 +2972,10 @@ checksum = "f59fdbb5706f2723ca108c088b1c7a37f735a8c328021f0508007162627e9885"
 dependencies = [
  "futures 0.3.4",
  "js-sys",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "libp2p-websocket"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6874c9069ce93d899df9dc7b29f129c706b2a0fdc048f11d878935352b580190"
-dependencies = [
- "async-tls",
- "bytes 0.5.4",
- "either",
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "log",
- "quicksink",
- "rustls",
- "rw-stream-sink",
- "soketto",
- "url 2.1.1",
- "webpki",
- "webpki-roots 0.18.0",
 ]
 
 [[package]]
@@ -3287,7 +2988,7 @@ dependencies = [
  "bytes 0.5.4",
  "either",
  "futures 0.3.4",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "log",
  "quicksink",
  "rustls",
@@ -3300,25 +3001,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f91aea50f6571e0bc6c058dc0e9b270afd41ec28dd94e9e4bf607e78b9ab87"
-dependencies = [
- "futures 0.3.4",
- "libp2p-core 0.18.0",
- "parking_lot 0.10.2",
- "thiserror",
- "yamux",
-]
-
-[[package]]
-name = "libp2p-yamux"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b305d3a8981e68f11c0e17f2d11d5c52fae95e0d7c283f9e462b5b2dab413b2"
 dependencies = [
  "futures 0.3.4",
- "libp2p-core 0.19.0",
+ "libp2p-core",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3582,21 +3270,6 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "multihash"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fbc227f7e2b1cb701f95404579ecb2668abbdd3c7ef7a6cbb3cc0d3b236869"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "digest",
- "sha-1",
- "sha2",
- "sha3",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae32179a9904ccc6e063de8beee7f5dd55fae85ecb851ca923d55722bc28cf5d"
@@ -3730,7 +3403,7 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p 0.19.0",
+ "libp2p",
  "node-cli",
  "sc-rpc-api",
  "serde",
@@ -5101,24 +4774,6 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db35e222f783ef4e6661873f6c165c4eb7b65e0c408349818517d5705c2d7d3"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder 1.3.4",
- "data-encoding",
- "multihash 0.10.1",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint",
- "url 2.1.1",
-]
-
-[[package]]
-name = "parity-multiaddr"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ca96399f4a01aa89c59220c4f52ac371940eb4e53e3ce990da796f364bdf69"
@@ -5127,7 +4782,7 @@ dependencies = [
  "bs58",
  "byteorder 1.3.4",
  "data-encoding",
- "multihash 0.11.1",
+ "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
@@ -6199,7 +5854,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "parity-scale-codec",
  "prost",
@@ -6818,7 +6473,7 @@ dependencies = [
  "futures_codec",
  "hex",
  "ip_network",
- "libp2p 0.19.0",
+ "libp2p",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -6865,7 +6520,7 @@ dependencies = [
  "async-std",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "lru",
  "quickcheck",
@@ -6883,7 +6538,7 @@ dependencies = [
  "env_logger 0.7.1",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "parking_lot 0.10.2",
  "rand 0.7.3",
@@ -6940,7 +6595,7 @@ name = "sc-peerset"
 version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.4",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "rand 0.7.3",
  "serde_json",
@@ -7154,7 +6809,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "parking_lot 0.10.2",
  "pin-project",
@@ -7754,7 +7409,7 @@ dependencies = [
  "derive_more",
  "futures 0.3.4",
  "futures-timer 3.0.2",
- "libp2p 0.19.0",
+ "libp2p",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -8402,7 +8057,7 @@ dependencies = [
  "hyper 0.12.35",
  "itertools",
  "jsonrpc-core-client",
- "libp2p 0.18.1",
+ "libp2p",
  "node-primitives",
  "node-runtime",
  "pallet-balances",
@@ -8444,7 +8099,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "js-sys",
  "kvdb-web",
- "libp2p-wasm-ext 0.19.0",
+ "libp2p-wasm-ext",
  "log",
  "rand 0.6.5",
  "rand 0.7.3",

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures-timer = "3.0.2"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
+libp2p = { version = "0.19.0", default-features = false }
 jsonrpc-core = "14.0.5"
 serde = "1.0.106"
 serde_json = "1.0.48"

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures-timer = "3.0.2"
-libp2p = { version = "0.18.0", default-features = false }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
 jsonrpc-core = "14.0.5"
 serde = "1.0.106"
 serde_json = "1.0.48"

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -33,7 +33,7 @@ derive_more = { version = "0.99.2" }
 sc-rpc = { version = "2.0.0-dev", path = "../../../client/rpc" }
 jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
-libp2p = "0.18.1"
+libp2p = "0.19.0"
 serde_json = "1.0"
 
 [features]

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", default-features = false, version = "1
 derive_more = "0.99.2"
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
+libp2p = { version = "0.19.0", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-dev"}
 prost = "0.6.1"

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", default-features = false, version = "1
 derive_more = "0.99.2"
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { version = "0.18.1", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["secp256k1", "libp2p-websocket"] }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-dev"}
 prost = "0.6.1"

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -5,7 +5,7 @@
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or 
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
@@ -123,6 +123,9 @@ impl NetworkParams {
 
 		let listen_addresses = if self.listen_addr.is_empty() {
 			vec![
+				Multiaddr::empty()
+					.with(Protocol::Ip6([0, 0, 0, 0, 0, 0, 0, 0].into()))
+					.with(Protocol::Tcp(port)),
 				Multiaddr::empty()
 					.with(Protocol::Ip4([0, 0, 0, 0].into()))
 					.with(Protocol::Tcp(port)),

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { version = "0.18.1", default-features = false, features = ["websocket"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["websocket"] }
 log = "0.4.8"
 lru = "0.4.3"
 sc-network = { version = "0.8.0-dev", path = "../network" }

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["websocket"] }
+libp2p = { version = "0.19.0", default-features = false, features = ["websocket"] }
 log = "0.4.8"
 lru = "0.4.3"
 sc-network = { version = "0.8.0-dev", path = "../network" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -63,7 +63,7 @@ wasm-timer = "0.2"
 zeroize = "1.0.0"
 
 [dependencies.libp2p]
-git = "https://github.com/libp2p/rust-libp2p"
+version = "0.19.0"
 default-features = false
 features = ["websocket", "kad", "mdns", "ping", "identify", "mplex", "yamux", "noise", "tcp-async-std"]
 
@@ -71,7 +71,7 @@ features = ["websocket", "kad", "mdns", "ping", "identify", "mplex", "yamux", "n
 async-std = "1.5"
 assert_matches = "1.3"
 env_logger = "0.7.0"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["secio"] }
+libp2p = { version = "0.19.0", default-features = false, features = ["secio"] }
 quickcheck = "0.9.0"
 rand = "0.7.2"
 sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -62,15 +62,15 @@ wasm-timer = "0.2"
 zeroize = "1.0.0"
 
 [dependencies.libp2p]
-version = "0.18.1"
+git = "https://github.com/libp2p/rust-libp2p"
 default-features = false
-features = ["websocket", "kad", "mdns", "ping", "identify", "mplex", "yamux", "noise"]
+features = ["websocket", "kad", "mdns", "ping", "identify", "mplex", "yamux", "noise", "tcp-async-std"]
 
 [dev-dependencies]
 async-std = "1.5"
 assert_matches = "1.3"
 env_logger = "0.7.0"
-libp2p = { version = "0.18.1", default-features = false, features = ["secio"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["secio"] }
 quickcheck = "0.9.0"
 rand = "0.7.2"
 sp-keyring = { version = "2.0.0-dev", path = "../../primitives/keyring" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -19,6 +19,7 @@ prost-build = "0.6.1"
 
 [dependencies]
 bitflags = "1.2.0"
+bs58 = "0.3.1"
 bytes = "0.5.0"
 codec = { package = "parity-scale-codec", version = "1.3.0", features = ["derive"] }
 derive_more = "0.99.2"

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -59,7 +59,7 @@ use sp_runtime::{
 };
 use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use std::{
-	borrow::Cow,
+	borrow::{Borrow, Cow},
 	collections::HashSet,
 	fs, io,
 	marker::PhantomData,
@@ -186,7 +186,13 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		let local_identity = params.network_config.node_key.clone().into_keypair()?;
 		let local_public = local_identity.public();
 		let local_peer_id = local_public.clone().into_peer_id();
-		info!(target: "sub-libp2p", "🏷  Local node identity is: {}", local_peer_id.to_base58());
+		let local_peer_id_legacy = bs58::encode(Borrow::<[u8]>::borrow(&local_peer_id)).into_string();
+		info!(
+			target: "sub-libp2p",
+			"🏷  Local node identity is: {} (legacy representation: {})",
+			local_peer_id.to_base58(),
+			local_peer_id_legacy
+		);
 
 		// Initialize the metrics.
 		let metrics = match &params.metrics_registry {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -5,7 +5,7 @@
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or 
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
@@ -63,6 +63,7 @@ use std::{
 	collections::HashSet,
 	fs, io,
 	marker::PhantomData,
+	num:: NonZeroUsize,
 	pin::Pin,
 	str,
 	sync::{
@@ -286,7 +287,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				transport::build_transport(local_identity, config_mem, config_wasm, flowctrl)
 			};
 			let mut builder = SwarmBuilder::new(transport, behaviour, local_peer_id.clone())
-				.peer_connection_limit(crate::MAX_CONNECTIONS_PER_PEER);
+				.peer_connection_limit(crate::MAX_CONNECTIONS_PER_PEER)
+				.notify_handler_buffer_size(NonZeroUsize::new(16).expect("16 != 0; qed"))
+				.connection_event_buffer_size(128);
 			if let Some(spawner) = params.executor {
 				struct SpawnImpl<F>(F);
 				impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> Executor for SpawnImpl<F> {

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -18,14 +18,14 @@
 use futures::prelude::*;
 use libp2p::{
 	InboundUpgradeExt, OutboundUpgradeExt, PeerId, Transport,
-	core::either::{EitherError, EitherOutput},
+	core::{
+		self, either::{EitherError, EitherOutput}, muxing::StreamMuxerBox,
+		transport::{boxed::Boxed, OptionalTransport}, upgrade
+	},
 	mplex, identity, bandwidth, wasm_ext, noise
 };
 #[cfg(not(target_os = "unknown"))]
-use libp2p::{
-	core::{self, muxing::StreamMuxerBox, transport::{boxed::Boxed, OptionalTransport}, upgrade},
-	tcp, dns, websocket
-};
+use libp2p::{tcp, dns, websocket};
 use std::{io, sync::Arc, time::Duration, usize};
 
 pub use self::bandwidth::BandwidthSinks;

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -18,11 +18,14 @@
 use futures::prelude::*;
 use libp2p::{
 	InboundUpgradeExt, OutboundUpgradeExt, PeerId, Transport,
+	core::either::{EitherError, EitherOutput},
 	mplex, identity, bandwidth, wasm_ext, noise
 };
 #[cfg(not(target_os = "unknown"))]
-use libp2p::{tcp, dns, websocket};
-use libp2p::core::{self, either::{EitherError, EitherOutput}, upgrade, transport::boxed::Boxed, transport::OptionalTransport, muxing::StreamMuxerBox};
+use libp2p::{
+	core::{self, muxing::StreamMuxerBox, transport::{boxed::Boxed, OptionalTransport}, upgrade},
+	tcp, dns, websocket
+};
 use std::{io, sync::Arc, time::Duration, usize};
 
 pub use self::bandwidth::BandwidthSinks;

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -5,7 +5,7 @@
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or 
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
@@ -42,7 +42,7 @@ pub fn build_transport(
 ) -> (Boxed<(PeerId, StreamMuxerBox), io::Error>, Arc<bandwidth::BandwidthSinks>) {
 	// Build configuration objects for encryption mechanisms.
 	let noise_config = {
-		let noise_keypair = noise::Keypair::new().into_authentic(&keypair)
+		let noise_keypair = noise::Keypair::<noise::X25519>::new().into_authentic(&keypair)
 			// For more information about this panic, see in "On the Importance of Checking
 			// Cryptographic Protocols for Faults" by Dan Boneh, Richard A. DeMillo,
 			// and Richard J. Lipton.

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -22,7 +22,7 @@ use libp2p::{
 };
 #[cfg(not(target_os = "unknown"))]
 use libp2p::{tcp, dns, websocket};
-use libp2p::core::{self, upgrade, transport::boxed::Boxed, transport::OptionalTransport, muxing::StreamMuxerBox};
+use libp2p::core::{self, either::{EitherError, EitherOutput}, upgrade, transport::boxed::Boxed, transport::OptionalTransport, muxing::StreamMuxerBox};
 use std::{io, sync::Arc, time::Duration, usize};
 
 pub use self::bandwidth::BandwidthSinks;
@@ -42,14 +42,22 @@ pub fn build_transport(
 ) -> (Boxed<(PeerId, StreamMuxerBox), io::Error>, Arc<bandwidth::BandwidthSinks>) {
 	// Build configuration objects for encryption mechanisms.
 	let noise_config = {
-		let noise_keypair = noise::Keypair::<noise::X25519>::new().into_authentic(&keypair)
-			// For more information about this panic, see in "On the Importance of Checking
-			// Cryptographic Protocols for Faults" by Dan Boneh, Richard A. DeMillo,
-			// and Richard J. Lipton.
+		// For more information about these two panics, see in "On the Importance of
+		// Checking Cryptographic Protocols for Faults" by Dan Boneh, Richard A. DeMillo,
+		// and Richard J. Lipton.
+		let noise_keypair_legacy = noise::Keypair::<noise::X25519>::new().into_authentic(&keypair)
 			.expect("can only fail in case of a hardware bug; since this signing is performed only \
 				once and at initialization, we're taking the bet that the inconvenience of a very \
 				rare panic here is basically zero");
-		noise::NoiseConfig::ix(noise_keypair)
+		let noise_keypair_spec = noise::Keypair::<noise::X25519Spec>::new().into_authentic(&keypair)
+			.expect("can only fail in case of a hardware bug; since this signing is performed only \
+				once and at initialization, we're taking the bet that the inconvenience of a very \
+				rare panic here is basically zero");
+
+		core::upgrade::SelectUpgrade::new(
+			noise::NoiseConfig::ix(noise_keypair_legacy),
+			noise::NoiseConfig::xx(noise_keypair_spec)
+		)
 	};
 
 	// Build configuration objects for multiplexing mechanisms.
@@ -97,10 +105,21 @@ pub fn build_transport(
 	// Encryption
 	let transport = transport.and_then(move |stream, endpoint| {
 		core::upgrade::apply(stream, noise_config, endpoint, upgrade::Version::V1)
-			.and_then(|(remote_id, out)| async move {
-				let remote_key = match remote_id {
-					noise::RemoteIdentity::IdentityKey(key) => key,
+			.map_err(|err|
+				err.map_err(|err| match err {
+					EitherError::A(err) => err,
+					EitherError::B(err) => err,
+				})
+			)
+			.and_then(|result| async move {
+				let remote_key = match &result {
+					EitherOutput::First((noise::RemoteIdentity::IdentityKey(key), _)) => key.clone(),
+					EitherOutput::Second((noise::RemoteIdentity::IdentityKey(key), _)) => key.clone(),
 					_ => return Err(upgrade::UpgradeError::Apply(noise::NoiseError::InvalidKey))
+				};
+				let out = match result {
+					EitherOutput::First((_, o)) => o,
+					EitherOutput::Second((_, o)) => o,
 				};
 				Ok((out, remote_key.into_peer_id()))
 			})

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -55,8 +55,8 @@ pub fn build_transport(
 				rare panic here is basically zero");
 
 		core::upgrade::SelectUpgrade::new(
-			noise::NoiseConfig::ix(noise_keypair_legacy),
-			noise::NoiseConfig::xx(noise_keypair_spec)
+			noise::NoiseConfig::xx(noise_keypair_spec),
+			noise::NoiseConfig::ix(noise_keypair_legacy)
 		)
 	};
 

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { version = "0.19.0", default-features = false, features = ["libp2p-websocket"] }
 sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.8.0-dev", path = "../../../client/consensus/common" }
 sc-client-api = { version = "2.0.0-dev", path = "../../api" }

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.18.1", default-features = false, features = ["libp2p-websocket"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["libp2p-websocket"] }
 sp-consensus = { version = "0.8.0-dev", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.8.0-dev", path = "../../../client/consensus/common" }
 sc-client-api = { version = "2.0.0-dev", path = "../../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.3.4"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
+libp2p = { version = "0.19.0", default-features = false }
 sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils"}
 log = "0.4.8"
 serde_json = "1.0.41"

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.3.4"
-libp2p = { version = "0.18.1", default-features = false }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
 sp-utils = { version = "2.0.0-dev", path = "../../primitives/utils"}
 log = "0.4.8"
 serde_json = "1.0.41"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 wasm-timer = "0.2.0"
-libp2p = { version = "0.18.1", default-features = false, features = ["websocket", "wasm-ext", "tcp", "dns"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["websocket", "wasm-ext", "tcp-async-std", "dns"] }
 log = "0.4.8"
 pin-project = "0.4.6"
 rand = "0.7.2"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 wasm-timer = "0.2.0"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false, features = ["websocket", "wasm-ext", "tcp-async-std", "dns"] }
+libp2p = { version = "0.19.0", default-features = false, features = ["websocket", "wasm-ext", "tcp-async-std", "dns"] }
 log = "0.4.8"
 pin-project = "0.4.6"
 rand = "0.7.2"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
+libp2p = { version = "0.19.0", default-features = false }
 log = "0.4.8"
 sp-core = { path= "../../core", version = "2.0.0-dev"}
 sp-inherents = { version = "2.0.0-dev", path = "../../inherents" }

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
-libp2p = { version = "0.18.1", default-features = false }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", default-features = false }
 log = "0.4.8"
 sp-core = { path= "../../core", version = "2.0.0-dev"}
 sp-inherents = { version = "2.0.0-dev", path = "../../inherents" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
-libp2p-wasm-ext = { git = "https://github.com/libp2p/rust-libp2p", features = ["websocket"] }
+libp2p-wasm-ext = { version = "0.19.0", features = ["websocket"] }
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 js-sys = "0.3.34"

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 futures = { version = "0.3", features = ["compat"] }
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
-libp2p-wasm-ext = { version = "0.18.0", features = ["websocket"] }
+libp2p-wasm-ext = { git = "https://github.com/libp2p/rust-libp2p", features = ["websocket"] }
 console_error_panic_hook = "0.1.6"
 console_log = "0.1.2"
 js-sys = "0.3.34"


### PR DESCRIPTION
Libp2p 0.19 isn't published yet, so this is only a draft and I've temporarily replaced the crates.io dependencies with git dependencies.

- The first commit just does the upgrade without any additional change. I've had to replace `KademliaBehaviour::discoveries` with `pending_events` in order to accommodate for `put_record` now returning a result.

- The second commit makes us listen on IPv6 by default. (#5691)

- The third commit increases the number of elements in bounded channels (#6009). While the numbers chosen are mostly a random guess, I would at least try see if it results in any difference on the CPU profile of our nodes and maybe continue adjusting later.

- The fourth commit adds support for the libp2p-specs-compliant Noise transport-level protocol while maintaining the former protocol as a fallback for backwards compatibility.

- The fifth commit shows the legacy `PeerId` representation when the node starts (I've made sure that the legacy representation matches the one that is currently shown on the master branch).

Importantly, this change brings in https://github.com/libp2p/rust-libp2p/pull/1576, which means that `PeerId`s will be printed with their correct representation, prefixed with `1...` rather than `Qm...`.
Consequently, all bootnode IDs and reserved node IDs should be updated everywhere.
Backwards compatibility will be maintained for a little while (in other words `PeerId`s that start with `Qm...` will continue to work), but this shall eventually be removed.

cc @wpank

cc https://github.com/paritytech/substrate/issues/5235 
cc #6044
fix https://github.com/paritytech/substrate/issues/5691
fix #6009 