### PR TITLE
Make decl_storage generated code respect clippy

### DIFF
--- a/frame/support/procedural/src/storage/genesis_config/builder_def.rs
+++ b/frame/support/procedural/src/storage/genesis_config/builder_def.rs
@@ -55,10 +55,16 @@ impl BuilderDef {
 				data = Some(match &line.storage_type {
 					StorageLineTypeDef::Simple(_) if line.is_option =>
 						quote_spanned!(builder.span() =>
-							let data = (#builder)(self);
+							// NOTE: the type of `data` is specified when used later in the code
+							let builder: fn(&Self) -> _ = #builder;
+							let data = builder(self);
 							let data = Option::as_ref(&data);
 						),
-					_ => quote_spanned!(builder.span() => let data = &(#builder)(self); ),
+					_ => quote_spanned!(builder.span() =>
+						// NOTE: the type of `data` is specified when used later in the code
+						let builder: fn(&Self) -> _ = #builder;
+						let data = &builder(self);
+					),
 				});
 			} else if let Some(config) = &line.config {
 				is_generic |= line.is_generic;

--- a/frame/support/procedural/src/storage/storage_struct.rs
+++ b/frame/support/procedural/src/storage/storage_struct.rs
@@ -86,7 +86,10 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 			Ident::new(INHERENT_INSTANCE_NAME, Span::call_site())
 		};
 
-		let storage_name_str = syn::LitStr::new(&line.name.to_string(), line.name.span());
+		let storage_name_bstr = syn::LitByteStr::new(
+			&line.name.to_string().into_bytes()[..],
+			line.name.span()
+		);
 
 		let storage_generator_trait = &line.storage_generator_trait;
 		let storage_struct = &line.storage_struct;
@@ -107,7 +110,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 						}
 
 						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
+							#storage_name_bstr
 						}
 
 						fn from_optional_value_to_query(v: Option<#value_type>) -> Self::Query {
@@ -131,7 +134,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 						}
 
 						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
+							#storage_name_bstr
 						}
 					}
 
@@ -146,7 +149,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 						}
 
 						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
+							#storage_name_bstr
 						}
 
 						fn from_optional_value_to_query(v: Option<#value_type>) -> Self::Query {
@@ -171,7 +174,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 						}
 
 						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
+							#storage_name_bstr
 						}
 					}
 
@@ -189,7 +192,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 						}
 
 						fn storage_prefix() -> &'static [u8] {
-							#storage_name_str.as_bytes()
+							#storage_name_bstr
 						}
 
 						fn from_optional_value_to_query(v: Option<#value_type>) -> Self::Query {

--- a/frame/support/procedural/src/storage/storage_struct.rs
+++ b/frame/support/procedural/src/storage/storage_struct.rs
@@ -87,7 +87,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 		};
 
 		let storage_name_bstr = syn::LitByteStr::new(
-			&line.name.to_string().into_bytes()[..],
+			line.name.to_string().as_ref(),
 			line.name.span()
 		);
 


### PR DESCRIPTION
As some user use clippy for their code, better to have decl_storage respecting clippy.

related to https://github.com/open-web3-stack/open-runtime-module-library/pull/162/files/2be2da8363c27c520e95c7cccf7b026bcf5cfecf..5175f0ee38b4b619cf44787fa32829a4b608acb4#r426129576