### PR TITLE
Make GrandpaBlockImport public

### DIFF
--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -118,6 +118,7 @@ mod voting_rule;
 
 pub use authorities::SharedAuthoritySet;
 pub use finality_proof::{FinalityProofProvider, StorageAndProofProvider};
+pub use import::GrandpaBlockImport;
 pub use justification::GrandpaJustification;
 pub use light_import::light_block_import;
 pub use voting_rule::{
@@ -127,7 +128,6 @@ pub use finality_grandpa::voter::report;
 
 use aux_schema::PersistentData;
 use environment::{Environment, VoterSetState};
-use import::GrandpaBlockImport;
 use until_imported::UntilGlobalMessageBlocksImported;
 use communication::{NetworkBridge, Network as NetworkT};
 use sp_finality_grandpa::{AuthorityList, AuthorityPair, AuthoritySignature, SetId};


### PR DESCRIPTION
This PR makes the `GrandpaBlockImport` struct public in the `sc-finality-grandpa` crate.

I believe this change is correct because:
1. It makes `GrandpaBlockImport` consistent with `PowBlockImport`, `AuraBlockImport`, etc
2. The `service.rs` files in both the `bin/node` and the node template hold a reference to an instance of `GrandpaBlockImport`

quoting @tomaka from riot:
> It's always a bug in the code to have private types in your public API. Unfortunately Rust doesn't really enforce that. If GrandpaBlockImport wasn't marked pub at all, Rust would complain for this specific reason. But if it's marked pub and not publicly-visible where it should be (like is the case here), Rust can't detect that.