### PR TITLE
Increase network buffer sizes even more

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -298,8 +298,8 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 			};
 			let mut builder = SwarmBuilder::new(transport, behaviour, local_peer_id.clone())
 				.peer_connection_limit(crate::MAX_CONNECTIONS_PER_PEER)
-				.notify_handler_buffer_size(NonZeroUsize::new(16).expect("16 != 0; qed"))
-				.connection_event_buffer_size(128);
+				.notify_handler_buffer_size(NonZeroUsize::new(32).expect("32 != 0; qed"))
+				.connection_event_buffer_size(1024);
 			if let Some(spawner) = params.executor {
 				struct SpawnImpl<F>(F);
 				impl<F: Fn(Pin<Box<dyn Future<Output = ()> + Send>>)> Executor for SpawnImpl<F> {


### PR DESCRIPTION
cc https://github.com/paritytech/substrate/issues/6009

After https://github.com/paritytech/substrate/pull/6064, it's pretty clear that the spikes in the network worker taking a long time are caused by the fact that the network worker is sleeping while waiting for a libp2p node task to empty the messages in its channel, and that during this sleep the events accumulate in the queues.

We still have spikes, so this PR increases these channel sizes even more, allowing for more parallelism between the network worker and the node tasks.
