### PR TITLE
evm: allow setting pre-defined accounts in genesis

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -93,8 +93,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 249,
-	impl_version: 1,
+	spec_version: 250,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -24,10 +24,11 @@ mod backend;
 
 pub use crate::backend::{Account, Log, Vicinity, Backend};
 
-use sp_std::{vec::Vec, marker::PhantomData, collections::btree_map::BTreeMap};
+use sp_std::{vec::Vec, marker::PhantomData};
+#[cfg(feature = "std")]
+use codec::{Encode, Decode};
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
-use codec::{Encode, Decode};
 use frame_support::{ensure, decl_module, decl_storage, decl_event, decl_error};
 use frame_support::weights::{Weight, DispatchClass, FunctionOf, Pays};
 use frame_support::traits::{Currency, WithdrawReason, ExistenceRequirement, Get};
@@ -140,8 +141,8 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
 	}
 }
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+#[cfg(feature = "std")]
+#[derive(Clone, Eq, PartialEq, Encode, Decode, Debug, Serialize, Deserialize)]
 /// Account definition used for genesis block construction.
 pub struct GenesisAccount {
 	/// Account nonce.
@@ -149,7 +150,7 @@ pub struct GenesisAccount {
 	/// Account balance.
 	pub balance: U256,
 	/// Full account storage.
-	pub storage: BTreeMap<H256, H256>,
+	pub storage: std::collections::BTreeMap<H256, H256>,
 	/// Account code.
 	pub code: Vec<u8>,
 }
@@ -162,7 +163,7 @@ decl_storage! {
 	}
 
 	add_extra_genesis {
-		config(accounts): BTreeMap<H160, GenesisAccount>;
+		config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
 		build(|config: &GenesisConfig| {
 			for (address, account) in &config.accounts {
 				Accounts::insert(address, Account {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -24,7 +24,10 @@ mod backend;
 
 pub use crate::backend::{Account, Log, Vicinity, Backend};
 
-use sp_std::{vec::Vec, marker::PhantomData};
+use sp_std::{vec::Vec, marker::PhantomData, collections::btree_map::BTreeMap};
+#[cfg(feature = "std")]
+use serde::{Serialize, Deserialize};
+use codec::{Encode, Decode};
 use frame_support::{ensure, decl_module, decl_storage, decl_event, decl_error};
 use frame_support::weights::{Weight, DispatchClass, FunctionOf, Pays};
 use frame_support::traits::{Currency, WithdrawReason, ExistenceRequirement, Get};
@@ -137,11 +140,42 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
 	}
 }
 
+#[derive(Clone, Eq, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
+/// Account definition used for genesis block construction.
+pub struct GenesisAccount {
+	/// Account nonce.
+	pub nonce: U256,
+	/// Account balance.
+	pub balance: U256,
+	/// Full account storage.
+	pub storage: BTreeMap<H256, H256>,
+	/// Account code.
+	pub code: Vec<u8>,
+}
+
 decl_storage! {
 	trait Store for Module<T: Trait> as EVM {
-		Accounts get(fn accounts) config(): map hasher(blake2_128_concat) H160 => Account;
+		Accounts get(fn accounts): map hasher(blake2_128_concat) H160 => Account;
 		AccountCodes: map hasher(blake2_128_concat) H160 => Vec<u8>;
 		AccountStorages: double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
+	}
+
+	add_extra_genesis {
+		config(accounts): BTreeMap<H160, GenesisAccount>;
+		build(|config: &GenesisConfig| {
+			for (address, account) in &config.accounts {
+				Accounts::insert(address, Account {
+					balance: account.balance,
+					nonce: account.nonce,
+				});
+				AccountCodes::insert(address, &account.code);
+
+				for (index, value) in &account.storage {
+					AccountStorages::insert(address, index, value);
+				}
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
This adds the genesis config `accounts` that allows setting the full values of pre-defined accounts with code and storage.