### PR TITLE
Restore the empty line after the license

### DIFF
--- a/client/api/src/call_executor.rs
+++ b/client/api/src/call_executor.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A method call executor interface.
 
 use std::{panic::UnwindSafe, result, cell::RefCell};

--- a/client/api/src/cht.rs
+++ b/client/api/src/cht.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Canonical hash trie definitions and helper functions.
 //!
 //! Each CHT is a trie mapping block numbers to canonical hash.

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! In memory client backend
 
 use std::collections::HashMap;

--- a/client/api/src/leaves.rs
+++ b/client/api/src/leaves.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Helper for managing the set of available leaves in the chain for DB implementations.
 
 use std::collections::BTreeMap;

--- a/client/api/src/notifications.rs
+++ b/client/api/src/notifications.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Storage notifications
 
 use std::{

--- a/client/authority-discovery/src/tests.rs
+++ b/client/authority-discovery/src/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{iter::FromIterator, sync::{Arc, Mutex}};
 
 use futures::channel::mpsc::channel;

--- a/client/basic-authorship/src/lib.rs
+++ b/client/basic-authorship/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Basic implementation of block-authoring logic.
 //!
 //! # Example

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate block builder
 //!
 //! This crate provides the [`BlockBuilder`] utility and the corresponding runtime api

--- a/client/chain-spec/src/chain_spec.rs
+++ b/client/chain-spec/src/chain_spec.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate chain configurations.
 
 use std::{borrow::Cow, fs::File, path::PathBuf, sync::Arc, collections::HashMap};

--- a/client/cli/src/commands/build_spec_cmd.rs
+++ b/client/cli/src/commands/build_spec_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use crate::params::NodeKeyParams;
 use crate::params::SharedParams;

--- a/client/cli/src/commands/check_block_cmd.rs
+++ b/client/cli/src/commands/check_block_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{
 	CliConfiguration, error, params::{ImportParams, SharedParams, BlockNumberOrHash},
 };

--- a/client/cli/src/commands/export_blocks_cmd.rs
+++ b/client/cli/src/commands/export_blocks_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use crate::params::{BlockNumber, DatabaseParams, PruningParams, SharedParams};
 use crate::CliConfiguration;

--- a/client/cli/src/commands/export_state_cmd.rs
+++ b/client/cli/src/commands/export_state_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{
 	CliConfiguration, error, params::{PruningParams, SharedParams, BlockNumberOrHash},
 };

--- a/client/cli/src/commands/import_blocks_cmd.rs
+++ b/client/cli/src/commands/import_blocks_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use crate::params::ImportParams;
 use crate::params::SharedParams;

--- a/client/cli/src/commands/purge_chain_cmd.rs
+++ b/client/cli/src/commands/purge_chain_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use crate::params::{DatabaseParams, SharedParams};
 use crate::CliConfiguration;

--- a/client/cli/src/commands/revert_cmd.rs
+++ b/client/cli/src/commands/revert_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use crate::params::{BlockNumber, PruningParams, SharedParams};
 use crate::CliConfiguration;

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::arg_enums::RpcMethods;
 use crate::error::{Error, Result};
 use crate::params::ImportParams;

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Configuration trait for a CLI based on substrate
 
 use crate::arg_enums::Database;

--- a/client/cli/src/error.rs
+++ b/client/cli/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Initialization errors.
 
 /// Result type alias for the CLI.

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate CLI library.
 
 #![warn(missing_docs)]

--- a/client/cli/src/params/database_params.rs
+++ b/client/cli/src/params/database_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::arg_enums::Database;
 use structopt::StructOpt;
 

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::arg_enums::{
 	ExecutionStrategy, TracingReceiver, WasmExecutionMethod,
 	DEFAULT_EXECUTION_BLOCK_CONSTRUCTION, DEFAULT_EXECUTION_IMPORT_BLOCK,

--- a/client/cli/src/params/keystore_params.rs
+++ b/client/cli/src/params/keystore_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error::Result;
 use sc_service::config::KeystoreConfig;
 use std::fs;

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::params::node_key_params::NodeKeyParams;
 use sc_network::{
 	config::{NetworkConfiguration, NodeKeyConfig, NonReservedPeerMode, TransportConfig},

--- a/client/cli/src/params/node_key_params.rs
+++ b/client/cli/src/params/node_key_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sc_network::config::NodeKeyConfig;
 use sp_core::H256;
 use std::{path::PathBuf, str::FromStr};

--- a/client/cli/src/params/pruning_params.rs
+++ b/client/cli/src/params/pruning_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::error;
 use sc_service::{PruningMode, Role};
 use structopt::StructOpt;

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/client/cli/src/params/transaction_pool_params.rs
+++ b/client/cli/src/params/transaction_pool_params.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sc_service::config::TransactionPoolOptions;
 use structopt::StructOpt;
 

--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::CliConfiguration;
 use crate::Result;
 use crate::SubstrateCli;

--- a/client/consensus/aura/src/digests.rs
+++ b/client/consensus/aura/src/digests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Aura (Authority-Round) digests
 //!
 //! This implements the digests for AuRa, to allow the private

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! RPC api for babe.
 
 use sc_consensus_babe::{Epoch, authorship, Config};

--- a/client/consensus/manual-seal/src/error.rs
+++ b/client/consensus/manual-seal/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
 //! This is suitable for a testing environment.
 use sp_consensus::{Error as ConsensusError, ImportResult};

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A manual sealing engine: the engine listens for rpc calls to seal blocks and create forks.
 //! This is suitable for a testing environment.
 

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Proof of work consensus for Substrate.
 //!
 //! To use this engine, you can need to have a struct that implements

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! State backend that's useful for benchmarking
 
 use std::sync::Arc;

--- a/client/db/src/cache/list_cache.rs
+++ b/client/db/src/cache/list_cache.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! List-based cache.
 //!
 //! Maintains several lists, containing nodes that are inserted whenever

--- a/client/db/src/cache/list_entry.rs
+++ b/client/db/src/cache/list_entry.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! List-cache storage entries.
 
 use sp_blockchain::Result as ClientResult;

--- a/client/db/src/cache/list_storage.rs
+++ b/client/db/src/cache/list_storage.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! List-cache storage definition and implementation.
 
 use std::sync::Arc;

--- a/client/db/src/cache/mod.rs
+++ b/client/db/src/cache/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! DB-backed cache of blockchain data.
 
 use std::{sync::Arc, collections::{HashMap, hash_map::Entry}};

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Client backend that is backed by a database.
 //!
 //! # Canonicality vs. Finality

--- a/client/db/src/light.rs
+++ b/client/db/src/light.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! RocksDB-based light client blockchain storage.
 
 use std::{sync::Arc, collections::HashMap};

--- a/client/db/src/offchain.rs
+++ b/client/db/src/offchain.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! RocksDB-based offchain workers local storage.
 
 use std::{

--- a/client/db/src/stats.rs
+++ b/client/db/src/stats.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Database usage statistics
 
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Db-based backend utility structures and functions, used by both
 //! full and light storages.
 

--- a/client/executor/common/src/error.rs
+++ b/client/executor/common/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Rust executor possible errors.
 
 use sp_serializer;

--- a/client/executor/common/src/sandbox.rs
+++ b/client/executor/common/src/sandbox.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! This module implements sandboxing support in the runtime.
 //!
 //! Sandboxing is baked by wasmi at the moment. In future, however, we would like to add/switch to

--- a/client/executor/common/src/util.rs
+++ b/client/executor/common/src/util.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A set of utilities for resetting a wasm instance to its initial state.
 
 use crate::error::{self, Error};

--- a/client/executor/src/integration_tests/sandbox.rs
+++ b/client/executor/src/integration_tests/sandbox.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::{TestExternalities, call_in_wasm};
 use crate::WasmExecutionMethod;
 

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A crate that provides means of executing/dispatching calls into the runtime.
 //!
 //! There are a few responsibilities of this crate at the moment:

--- a/client/executor/src/native_executor.rs
+++ b/client/executor/src/native_executor.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{
 	RuntimeInfo, error::{Error, Result},
 	wasm_runtime::{RuntimeCache, WasmExecutionMethod},

--- a/client/executor/wasmtime/src/imports.rs
+++ b/client/executor/wasmtime/src/imports.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::state_holder;
 use sc_executor_common::error::WasmError;
 use sp_wasm_interface::{Function, Value, ValueType};

--- a/client/executor/wasmtime/src/instance_wrapper.rs
+++ b/client/executor/wasmtime/src/instance_wrapper.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Defines data and logic needed for interaction with an WebAssembly instance of a substrate
 //! runtime module.
 

--- a/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
+++ b/client/executor/wasmtime/src/instance_wrapper/globals_snapshot.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::InstanceWrapper;
 use sc_executor_common::{
 	error::{Error, Result},

--- a/client/executor/wasmtime/src/state_holder.rs
+++ b/client/executor/wasmtime/src/state_holder.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::host::{HostContext, HostState};
 
 scoped_tls::scoped_thread_local!(static HOST_STATE: HostState);

--- a/client/finality-grandpa/rpc/src/error.rs
+++ b/client/finality-grandpa/rpc/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::NOT_READY_ERROR_CODE;
 
 #[derive(derive_more::Display, derive_more::From)]

--- a/client/finality-grandpa/rpc/src/lib.rs
+++ b/client/finality-grandpa/rpc/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! RPC API for GRANDPA.
 #![warn(missing_docs)]
 

--- a/client/finality-grandpa/rpc/src/report.rs
+++ b/client/finality-grandpa/rpc/src/report.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	collections::{BTreeSet, HashSet},
 	fmt::Debug,

--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Utilities for dealing with authorities, authority sets, and handoffs.
 
 use fork_tree::ForkTree;

--- a/client/finality-grandpa/src/communication/mod.rs
+++ b/client/finality-grandpa/src/communication/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Communication streams for the polite-grandpa networking protocol.
 //!
 //! GRANDPA nodes communicate over a gossip network, where messages are not sent to

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use std::pin::Pin;

--- a/client/finality-grandpa/src/finality_proof.rs
+++ b/client/finality-grandpa/src/finality_proof.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! GRANDPA block finality proof generation and check.
 //!
 //! Finality of block B is proved by providing:

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{sync::Arc, collections::HashMap};
 
 use log::{debug, trace};

--- a/client/finality-grandpa/src/justification.rs
+++ b/client/finality-grandpa/src/justification.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Integration of the GRANDPA finality gadget into substrate.
 //!
 //! This crate is unstable and the API and usage may change.

--- a/client/finality-grandpa/src/observer.rs
+++ b/client/finality-grandpa/src/observer.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Tests and test helpers for GRANDPA.
 
 use super::*;

--- a/client/finality-grandpa/src/until_imported.rs
+++ b/client/finality-grandpa/src/until_imported.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Helper stream for waiting until one or more blocks are imported before
 //! passing through inner items. This is done in a generic way to support
 //! many different kinds of items.

--- a/client/finality-grandpa/src/voting_rule.rs
+++ b/client/finality-grandpa/src/voting_rule.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Handling custom voting rules for GRANDPA.
 //!
 //! This exposes the `VotingRule` trait used to implement arbitrary voting

--- a/client/informant/src/lib.rs
+++ b/client/informant/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Console informant. Prints sync progress and block events. Runs on the calling thread.
 
 use ansi_term::Colour;

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{Network, MessageIntent, Validator, ValidatorContext, ValidationResult};
 
 use std::collections::{HashMap, HashSet};

--- a/client/network-gossip/src/validator.rs
+++ b/client/network-gossip/src/validator.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sc_network::{ObservedRole, PeerId};
 use sp_runtime::traits::Block as BlockT;
 

--- a/client/network/src/chain.rs
+++ b/client/network/src/chain.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Blockchain access trait
 
 use sp_blockchain::{Error, HeaderBackend, HeaderMetadata};

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Configuration of the networking layer.
 //!
 //! The [`Params`] struct is the struct that must be passed in order to initialize the networking.

--- a/client/network/src/error.rs
+++ b/client/network/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate network possible errors.
 
 use libp2p::{PeerId, Multiaddr};

--- a/client/network/src/network_state.rs
+++ b/client/network/src/network_state.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Information about the networking, for diagnostic purposes.
 //!
 //! **Warning**: These APIs are not stable.

--- a/client/network/src/on_demand_layer.rs
+++ b/client/network/src/on_demand_layer.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! On-demand requests service.
 
 use crate::light_client_handler;

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{
 	ExHashT,
 	chain::{Client, FinalityProofProvider},

--- a/client/network/src/protocol/generic_proto/handler/notif_in.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_in.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Implementations of the `IntoProtocolsHandler` and `ProtocolsHandler` traits for ingoing
 //! substreams for a single gossiping protocol.
 //!

--- a/client/network/src/protocol/generic_proto/upgrade/legacy.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/legacy.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::config::ProtocolId;
 use bytes::BytesMut;
 use futures::prelude::*;

--- a/client/network/src/protocol/message.rs
+++ b/client/network/src/protocol/message.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Network packet message types. These get serialized and put into the lower level protocol payload.
 
 use bitflags::bitflags;

--- a/client/network/src/protocol/sync/blocks.rs
+++ b/client/network/src/protocol/sync/blocks.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::cmp;
 use std::ops::Range;
 use std::collections::{HashMap, BTreeMap};

--- a/client/network/src/protocol/sync/extra_requests.rs
+++ b/client/network/src/protocol/sync/extra_requests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sp_blockchain::Error as ClientError;
 use crate::protocol::sync::{PeerSync, PeerSyncState};
 use fork_tree::ForkTree;

--- a/client/network/src/schema.rs
+++ b/client/network/src/schema.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Include sources generated from protobuf definitions.
 
 pub mod v1 {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Main entry point of the sc-network crate.
 //!
 //! There are two main structs in this module: [`NetworkWorker`] and [`NetworkService`].

--- a/client/network/src/service/out_events.rs
+++ b/client/network/src/service/out_events.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Registering events streams.
 //!
 //! This code holds the logic that is used for the network service to inform other parts of

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{config, Event, NetworkService, NetworkWorker};
 
 use futures::prelude::*;

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use futures::prelude::*;
 use libp2p::{
 	InboundUpgradeExt, OutboundUpgradeExt, PeerId, Transport,

--- a/client/network/test/src/block_import.rs
+++ b/client/network/test/src/block_import.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Testing block import logic.
 
 use sp_consensus::ImportedAux;

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sp_consensus::BlockOrigin;
 use std::time::Duration;
 use futures::executor::block_on;

--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Peer Set Manager (PSM). Contains the strategy for choosing which nodes the network should be
 //! connected to.
 

--- a/client/peerset/tests/fuzz.rs
+++ b/client/peerset/tests/fuzz.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use futures::prelude::*;
 use libp2p::PeerId;
 use rand::distributions::{Distribution, Uniform, WeightedIndex};

--- a/client/rpc-api/src/author/error.rs
+++ b/client/rpc-api/src/author/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Authoring RPC module errors.
 
 use crate::errors;

--- a/client/rpc-api/src/author/mod.rs
+++ b/client/rpc-api/src/author/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate block-author/full-node API.
 
 pub mod error;

--- a/client/rpc-api/src/chain/mod.rs
+++ b/client/rpc-api/src/chain/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate blockchain API.
 
 pub mod error;

--- a/client/rpc-api/src/child_state/mod.rs
+++ b/client/rpc-api/src/child_state/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate state API.
 
 use jsonrpc_derive::rpc;

--- a/client/rpc-api/src/errors.rs
+++ b/client/rpc-api/src/errors.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use log::warn;
 
 pub fn internal<E: ::std::fmt::Debug>(e: E) -> jsonrpc_core::Error {

--- a/client/rpc-api/src/helpers.rs
+++ b/client/rpc-api/src/helpers.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use jsonrpc_core::futures::prelude::*;
 use futures::{channel::oneshot, compat::Compat};
 

--- a/client/rpc-api/src/offchain/error.rs
+++ b/client/rpc-api/src/offchain/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Offchain RPC errors.
 
 use jsonrpc_core as rpc;

--- a/client/rpc-api/src/offchain/mod.rs
+++ b/client/rpc-api/src/offchain/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate offchain API.
 
 pub mod error;

--- a/client/rpc-api/src/policy.rs
+++ b/client/rpc-api/src/policy.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Policy-related types.
 //!
 //! Contains a `DenyUnsafe` type that can be used to deny potentially unsafe

--- a/client/rpc-api/src/state/error.rs
+++ b/client/rpc-api/src/state/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! State RPC errors.
 
 use crate::errors;

--- a/client/rpc-api/src/state/helpers.rs
+++ b/client/rpc-api/src/state/helpers.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate state API helpers.
 
 use sp_core::Bytes;

--- a/client/rpc-api/src/state/mod.rs
+++ b/client/rpc-api/src/state/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate state API.
 
 pub mod error;

--- a/client/rpc-api/src/subscriptions.rs
+++ b/client/rpc-api/src/subscriptions.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::{self, AtomicUsize}};
 

--- a/client/rpc-api/src/system/error.rs
+++ b/client/rpc-api/src/system/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! System RPC module errors.
 
 use crate::system::helpers::Health;

--- a/client/rpc-api/src/system/helpers.rs
+++ b/client/rpc-api/src/system/helpers.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate system API helpers.
 
 use std::fmt;

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate system API.
 
 pub mod error;

--- a/client/rpc-servers/src/lib.rs
+++ b/client/rpc-servers/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate RPC servers.
 
 #![warn(missing_docs)]

--- a/client/rpc/src/author/mod.rs
+++ b/client/rpc/src/author/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate block-author/full-node API.
 
 #[cfg(test)]

--- a/client/rpc/src/author/tests.rs
+++ b/client/rpc/src/author/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::*;
 
 use std::{mem, sync::Arc};

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate blockchain API.
 
 mod chain_full;

--- a/client/rpc/src/chain/tests.rs
+++ b/client/rpc/src/chain/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::*;
 use assert_matches::assert_matches;
 use substrate_test_runtime_client::{

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate RPC implementation.
 //!
 //! A core implementation of Substrate RPC interfaces.

--- a/client/rpc/src/metadata.rs
+++ b/client/rpc/src/metadata.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! RPC Metadata
 use std::sync::Arc;
 

--- a/client/rpc/src/offchain/mod.rs
+++ b/client/rpc/src/offchain/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate offchain API.
 
 #[cfg(test)]

--- a/client/rpc/src/offchain/tests.rs
+++ b/client/rpc/src/offchain/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::*;
 use assert_matches::assert_matches;
 use sp_core::{Bytes, offchain::storage::InMemOffchainStorage};

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate state API.
 
 mod state_full;

--- a/client/rpc/src/state/tests.rs
+++ b/client/rpc/src/state/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::*;
 use super::state_full::split_range;
 use self::error::Error;

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate system API.
 
 #[cfg(test)]

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use super::*;
 
 use sc_network::{self, PeerId};

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::{Service, NetworkStatus, NetworkState, error::Error, DEFAULT_PROTOCOL_ID, MallocSizeOfWasm};
 use crate::{start_rpc_servers, build_network_future, TransactionPoolAdapter, TaskManager, SpawnTaskHandle};
 use crate::status_sinks;

--- a/client/service/src/chain_ops.rs
+++ b/client/service/src/chain_ops.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Chain utilities.
 
 use crate::error;

--- a/client/service/src/client/block_rules.rs
+++ b/client/service/src/client/block_rules.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Client fixed chain specification rules
 
 use std::collections::{HashMap, HashSet};

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{sync::Arc, panic::UnwindSafe, result, cell::RefCell};
 use codec::{Encode, Decode};
 use sp_runtime::{

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate Client
 
 use std::{

--- a/client/service/src/client/genesis.rs
+++ b/client/service/src/client/genesis.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Tool for creating the genesis block.
 
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, Hash as HashT, Zero};

--- a/client/service/src/client/light/blockchain.rs
+++ b/client/service/src/client/light/blockchain.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Light client blockchain backend. Only stores headers and justifications of recent
 //! blocks. CHT roots are stored for headers of ancient blocks.
 

--- a/client/service/src/client/light/call_executor.rs
+++ b/client/service/src/client/light/call_executor.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Methods that light client could use to execute runtime calls.
 
 use std::{

--- a/client/service/src/client/light/fetcher.rs
+++ b/client/service/src/client/light/fetcher.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Light client data fetcher. Fetches requested data from remote full nodes.
 
 use std::sync::Arc;

--- a/client/service/src/client/light/mod.rs
+++ b/client/service/src/client/light/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Light client components.
 
 pub mod backend;

--- a/client/service/src/client/mod.rs
+++ b/client/service/src/client/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate Client and associated logic.
 //!
 //! The [`Client`] is one of the most important components of Substrate. It mainly comprises two

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Service configuration.
 
 pub use sc_client_db::{Database, PruningMode, DatabaseSettingsSrc as DatabaseConfig};

--- a/client/service/src/error.rs
+++ b/client/service/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Errors that can occur during the service operation.
 
 use sc_network;

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate service. Starts a thread that spins up the network, client, and extrinsic pool.
 //! Manages communication between them.
 

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::convert::TryFrom;
 
 use crate::NetworkStatus;

--- a/client/service/test/src/client/db.rs
+++ b/client/service/test/src/client/db.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use sp_core::offchain::{OffchainStorage, storage::InMemOffchainStorage};
 use std::sync::Arc;
 

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use parity_scale_codec::{Encode, Decode, Joiner};
 use sc_executor::native_executor_instance;
 use sp_state_machine::{StateMachine, OverlayedChanges, ExecutionStrategy, InMemoryBackend};

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Service integration test utils.
 
 use std::iter;

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! State database maintenance. Handles canonicalization and pruning in the database. The input to
 //! this module is a `ChangeSet` which is basically a list of key-value pairs (trie nodes) that
 //! were added or deleted during block execution.

--- a/client/state-db/src/noncanonical.rs
+++ b/client/state-db/src/noncanonical.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Canonicalization window.
 //! Maintains trees of block overlays and allows discarding trees/roots
 //! The overlays are added in `insert` and removed in `canonicalize`.

--- a/client/state-db/src/pruning.rs
+++ b/client/state-db/src/pruning.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Pruning window.
 //!
 //! For each block we maintain a list of nodes pending deletion.

--- a/client/state-db/src/test.rs
+++ b/client/state-db/src/test.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Test utils
 
 use std::collections::HashMap;

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Telemetry utilities.
 //!
 //! Calling `init_telemetry` registers a global `slog` logger using `slog_scope::set_global_logger`.

--- a/client/telemetry/src/worker.rs
+++ b/client/telemetry/src/worker.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Contains the object that makes the telemetry work.
 //!
 //! # Usage

--- a/client/telemetry/src/worker/node.rs
+++ b/client/telemetry/src/worker/node.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Contains the `Node` struct, which handles communications with a single telemetry endpoint.
 
 use bytes::BytesMut;

--- a/client/transaction-pool/graph/benches/basics.rs
+++ b/client/transaction-pool/graph/benches/basics.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use futures::{future::{ready, Ready}, executor::block_on};

--- a/client/transaction-pool/graph/src/base_pool.rs
+++ b/client/transaction-pool/graph/src/base_pool.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! A basic version of the dependency graph.
 //!
 //! For a more full-featured pool, have a look at the `pool` module.

--- a/client/transaction-pool/graph/src/error.rs
+++ b/client/transaction-pool/graph/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Transaction pool errors.
 
 use sp_runtime::transaction_validity::{

--- a/client/transaction-pool/graph/src/future.rs
+++ b/client/transaction-pool/graph/src/future.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	collections::{HashMap, HashSet},
 	fmt,

--- a/client/transaction-pool/graph/src/lib.rs
+++ b/client/transaction-pool/graph/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Generic Transaction Pool
 //!
 //! The pool is based on dependency graph between transactions

--- a/client/transaction-pool/graph/src/listener.rs
+++ b/client/transaction-pool/graph/src/listener.rs
@@ -16,6 +16,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	collections::HashMap, hash,
 };

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	hash,
 	collections::HashMap,

--- a/client/transaction-pool/graph/src/ready.rs
+++ b/client/transaction-pool/graph/src/ready.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	collections::{HashMap, HashSet, BTreeSet},
 	cmp,

--- a/client/transaction-pool/graph/src/rotator.rs
+++ b/client/transaction-pool/graph/src/rotator.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Rotate extrinsic inside the pool.
 //!
 //! Keeps only recent extrinsic and discard the ones kept for a significant amount of time.

--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use std::{
 	collections::{HashSet, HashMap},
 	hash,

--- a/client/transaction-pool/graph/src/watcher.rs
+++ b/client/transaction-pool/graph/src/watcher.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Extrinsics status updates.
 
 use futures::Stream;

--- a/client/transaction-pool/src/api.rs
+++ b/client/transaction-pool/src/api.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Chain api required for the transaction pool.
 
 use std::{marker::PhantomData, pin::Pin, sync::Arc};

--- a/client/transaction-pool/src/error.rs
+++ b/client/transaction-pool/src/error.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Transaction pool error.
 
 use sp_transaction_pool::error::Error as TxPoolError;

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Substrate transaction pool implementation.
 
 #![recursion_limit="256"]

--- a/client/transaction-pool/src/metrics.rs
+++ b/client/transaction-pool/src/metrics.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Transaction pool Prometheus metrics.
 
 use std::sync::Arc;

--- a/client/transaction-pool/src/revalidation.rs
+++ b/client/transaction-pool/src/revalidation.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Pool periodic revalidation.
 
 use std::{sync::Arc, pin::Pin, collections::{HashMap, HashSet, BTreeMap}};

--- a/client/transaction-pool/src/testing/mod.rs
+++ b/client/transaction-pool/src/testing/mod.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 //! Tests for top-level transaction pool api
 
 mod pool;

--- a/client/transaction-pool/src/testing/pool.rs
+++ b/client/transaction-pool/src/testing/pool.rs
@@ -15,6 +15,7 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use crate::*;
 use sp_transaction_pool::TransactionStatus;
 use futures::executor::block_on;


### PR DESCRIPTION
Restores the empty line between the license header and the doc-comment or the first line of code.

I assume that was an accident in https://github.com/paritytech/substrate/pull/5947
