### PR TITLE
Turn a SmallVec into VecDeque for performances

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -34,7 +34,7 @@ use prometheus_endpoint::HistogramVec;
 use rand::distributions::{Distribution as _, Uniform};
 use smallvec::SmallVec;
 use std::task::{Context, Poll};
-use std::{borrow::Cow, cmp, collections::hash_map::Entry};
+use std::{borrow::Cow, cmp, collections::{hash_map::Entry, VecDeque}};
 use std::{error, mem, pin::Pin, str, time::Duration};
 use wasm_timer::Instant;
 
@@ -135,7 +135,7 @@ pub struct GenericProto {
 	next_incoming_index: sc_peerset::IncomingIndex,
 
 	/// Events to produce from `poll()`.
-	events: SmallVec<[NetworkBehaviourAction<NotifsHandlerIn, GenericProtoOut>; 4]>,
+	events: VecDeque<NetworkBehaviourAction<NotifsHandlerIn, GenericProtoOut>>,
 
 	/// If `Some`, report the message queue sizes on this `Histogram`.
 	queue_size_report: Option<HistogramVec>,
@@ -340,7 +340,7 @@ impl GenericProto {
 			peers: FnvHashMap::default(),
 			incoming: SmallVec::new(),
 			next_incoming_index: sc_peerset::IncomingIndex(0),
-			events: SmallVec::new(),
+			events: VecDeque::new(),
 			queue_size_report,
 		}
 	}
@@ -374,7 +374,7 @@ impl GenericProto {
 
 		// Send an event to all the peers we're connected to, updating the handshake message.
 		for (peer_id, _) in self.peers.iter().filter(|(_, state)| state.is_connected()) {
-			self.events.push(NetworkBehaviourAction::NotifyHandler {
+			self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 				peer_id: peer_id.clone(),
 				handler: NotifyHandler::All,
 				event: NotifsHandlerIn::UpdateHandshake {
@@ -446,7 +446,7 @@ impl GenericProto {
 				debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", peer_id);
 				self.peerset.dropped(peer_id.clone());
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", peer_id);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Disable,
@@ -471,7 +471,7 @@ impl GenericProto {
 
 				inc.alive = false;
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", peer_id);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Disable,
@@ -562,7 +562,7 @@ impl GenericProto {
 		);
 		trace!(target: "sub-libp2p", "Handler({:?}) <= Packet", target);
 
-		self.events.push(NetworkBehaviourAction::NotifyHandler {
+		self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 			peer_id: target.clone(),
 			handler: NotifyHandler::One(conn),
 			event: NotifsHandlerIn::SendNotification {
@@ -592,7 +592,7 @@ impl GenericProto {
 
 		trace!(target: "sub-libp2p", "External API => Packet for {:?}", target);
 		trace!(target: "sub-libp2p", "Handler({:?}) <= Packet", target);
-		self.events.push(NetworkBehaviourAction::NotifyHandler {
+		self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 			peer_id: target.clone(),
 			handler: NotifyHandler::One(conn),
 			event: NotifsHandlerIn::SendLegacy {
@@ -614,7 +614,7 @@ impl GenericProto {
 				// If there's no entry in `self.peers`, start dialing.
 				debug!(target: "sub-libp2p", "PSM => Connect({:?}): Starting to connect", entry.key());
 				debug!(target: "sub-libp2p", "Libp2p <= Dial {:?}", entry.key());
-				self.events.push(NetworkBehaviourAction::DialPeer {
+				self.events.push_back(NetworkBehaviourAction::DialPeer {
 					peer_id: entry.key().clone(),
 					condition: DialPeerCondition::Disconnected
 				});
@@ -638,7 +638,7 @@ impl GenericProto {
 			PeerState::Banned { .. } => {
 				debug!(target: "sub-libp2p", "PSM => Connect({:?}): Starting to connect", occ_entry.key());
 				debug!(target: "sub-libp2p", "Libp2p <= Dial {:?}", occ_entry.key());
-				self.events.push(NetworkBehaviourAction::DialPeer {
+				self.events.push_back(NetworkBehaviourAction::DialPeer {
 					peer_id: occ_entry.key().clone(),
 					condition: DialPeerCondition::Disconnected
 				});
@@ -662,7 +662,7 @@ impl GenericProto {
 				debug!(target: "sub-libp2p", "PSM => Connect({:?}): Enabling connections.",
 					occ_entry.key());
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", occ_entry.key());
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: occ_entry.key().clone(),
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Enable,
@@ -681,7 +681,7 @@ impl GenericProto {
 						incoming for incoming peer")
 				}
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", occ_entry.key());
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: occ_entry.key().clone(),
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Enable,
@@ -746,7 +746,7 @@ impl GenericProto {
 			PeerState::Enabled { open } => {
 				debug!(target: "sub-libp2p", "PSM => Drop({:?}): Disabling connections.", entry.key());
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", entry.key());
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: entry.key().clone(),
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Disable,
@@ -801,7 +801,7 @@ impl GenericProto {
 				debug!(target: "sub-libp2p", "PSM => Accept({:?}, {:?}): Enabling connections.",
 					index, incoming.peer_id);
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Enable", incoming.peer_id);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: incoming.peer_id,
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Enable,
@@ -834,7 +834,7 @@ impl GenericProto {
 				debug!(target: "sub-libp2p", "PSM => Reject({:?}, {:?}): Rejecting connections.",
 					index, incoming.peer_id);
 				debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", incoming.peer_id);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: incoming.peer_id,
 					handler: NotifyHandler::All,
 					event: NotifsHandlerIn::Disable,
@@ -881,7 +881,7 @@ impl NetworkBehaviour for GenericProto {
 					peer_id, endpoint
 				);
 				*st = PeerState::Enabled { open: SmallVec::new() };
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::One(*conn),
 					event: NotifsHandlerIn::Enable
@@ -925,7 +925,7 @@ impl NetworkBehaviour for GenericProto {
 					"Libp2p => Connected({},{:?}): Not requested by PSM, disabling.",
 					peer_id, endpoint);
 				*st = PeerState::Disabled { open: SmallVec::new(), banned_until };
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::One(*conn),
 					event: NotifsHandlerIn::Disable
@@ -941,7 +941,7 @@ impl NetworkBehaviour for GenericProto {
 			(PeerState::Enabled { .. }, _) => {
 				debug!(target: "sub-libp2p", "Handler({},{:?}) <= Enable secondary connection",
 					peer_id, conn);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::One(*conn),
 					event: NotifsHandlerIn::Enable
@@ -951,7 +951,7 @@ impl NetworkBehaviour for GenericProto {
 			(PeerState::Disabled { .. }, _) | (PeerState::DisabledPendingEnable { .. }, _) => {
 				debug!(target: "sub-libp2p", "Handler({},{:?}) <= Disable secondary connection",
 					peer_id, conn);
-				self.events.push(NetworkBehaviourAction::NotifyHandler {
+				self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 					peer_id: peer_id.clone(),
 					handler: NotifyHandler::One(*conn),
 					event: NotifsHandlerIn::Disable
@@ -979,7 +979,7 @@ impl NetworkBehaviour for GenericProto {
 						reason: "Disconnected by libp2p".into(),
 					};
 
-					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+					self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
 				}
 			}
 			_ => {}
@@ -1144,7 +1144,7 @@ impl NetworkBehaviour for GenericProto {
 						debug!(target: "sub-libp2p", "Handler({:?}) <= Disable", source);
 						debug!(target: "sub-libp2p", "PSM <= Dropped({:?})", source);
 						self.peerset.dropped(source.clone());
-						self.events.push(NetworkBehaviourAction::NotifyHandler {
+						self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 							peer_id: source.clone(),
 							handler: NotifyHandler::All,
 							event: NotifsHandlerIn::Disable,
@@ -1216,7 +1216,7 @@ impl NetworkBehaviour for GenericProto {
 						reason,
 						peer_id: source,
 					};
-					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+					self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
 				} else {
 					debug!(target: "sub-libp2p", "Secondary connection closed custom protocol.");
 				}
@@ -1254,7 +1254,7 @@ impl NetworkBehaviour for GenericProto {
 				if first {
 					debug!(target: "sub-libp2p", "External API <= Open({:?})", source);
 					let event = GenericProtoOut::CustomProtocolOpen { peer_id: source };
-					self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+					self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
 				} else {
 					debug!(target: "sub-libp2p", "Secondary connection opened custom protocol.");
 				}
@@ -1269,7 +1269,7 @@ impl NetworkBehaviour for GenericProto {
 					message,
 				};
 
-				self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+				self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
 			}
 
 			NotifsHandlerOut::Notification { protocol_name, message } => {
@@ -1287,7 +1287,7 @@ impl NetworkBehaviour for GenericProto {
 					message,
 				};
 
-				self.events.push(NetworkBehaviourAction::GenerateEvent(event));
+				self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
 			}
 
 			NotifsHandlerOut::Clogged { messages } => {
@@ -1296,7 +1296,7 @@ impl NetworkBehaviour for GenericProto {
 				trace!(target: "sub-libp2p", "External API <= Clogged({:?})", source);
 				warn!(target: "sub-libp2p", "Queue of packets to send to {:?} is \
 					pretty large", source);
-				self.events.push(NetworkBehaviourAction::GenerateEvent(GenericProtoOut::Clogged {
+				self.events.push_back(NetworkBehaviourAction::GenerateEvent(GenericProtoOut::Clogged {
 					peer_id: source,
 					messages,
 				}));
@@ -1335,6 +1335,10 @@ impl NetworkBehaviour for GenericProto {
 			Self::OutEvent,
 		>,
 	> {
+		if let Some(event) = self.events.pop_front() {
+			return Poll::Ready(event);
+		}
+
 		// Poll for instructions from the peerset.
 		// Note that the peerset is a *best effort* crate, and we have to use defensive programming.
 		loop {
@@ -1368,7 +1372,7 @@ impl NetworkBehaviour for GenericProto {
 					}
 
 					debug!(target: "sub-libp2p", "Libp2p <= Dial {:?} now that ban has expired", peer_id);
-					self.events.push(NetworkBehaviourAction::DialPeer {
+					self.events.push_back(NetworkBehaviourAction::DialPeer {
 						peer_id: peer_id.clone(),
 						condition: DialPeerCondition::Disconnected
 					});
@@ -1390,7 +1394,7 @@ impl NetworkBehaviour for GenericProto {
 					}
 
 					debug!(target: "sub-libp2p", "Handler({:?}) <= Enable (ban expired)", peer_id);
-					self.events.push(NetworkBehaviourAction::NotifyHandler {
+					self.events.push_back(NetworkBehaviourAction::NotifyHandler {
 						peer_id: peer_id.clone(),
 						handler: NotifyHandler::All,
 						event: NotifsHandlerIn::Enable,
@@ -1402,8 +1406,8 @@ impl NetworkBehaviour for GenericProto {
 			}
 		}
 
-		if !self.events.is_empty() {
-			return Poll::Ready(self.events.remove(0))
+		if let Some(event) = self.events.pop_front() {
+			return Poll::Ready(event);
 		}
 
 		Poll::Pending

--- a/client/network/src/protocol/generic_proto/handler/notif_in.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_in.rs
@@ -36,8 +36,7 @@ use libp2p::swarm::{
 	NegotiatedSubstream,
 };
 use log::{error, warn};
-use smallvec::SmallVec;
-use std::{borrow::Cow, fmt, pin::Pin, task::{Context, Poll}};
+use std::{borrow::Cow, collections::VecDeque, fmt, pin::Pin, task::{Context, Poll}};
 
 /// Implements the `IntoProtocolsHandler` trait of libp2p.
 ///
@@ -69,7 +68,7 @@ pub struct NotifsInHandler {
 	///
 	/// This queue is only ever modified to insert elements at the back, or remove the first
 	/// element.
-	events_queue: SmallVec<[ProtocolsHandlerEvent<DeniedUpgrade, (), NotifsInHandlerOut, void::Void>; 16]>,
+	events_queue: VecDeque<ProtocolsHandlerEvent<DeniedUpgrade, (), NotifsInHandlerOut, void::Void>>,
 }
 
 /// Event that can be received by a `NotifsInHandler`.
@@ -129,7 +128,7 @@ impl IntoProtocolsHandler for NotifsInHandlerProto {
 			in_protocol: self.in_protocol,
 			substream: None,
 			pending_accept_refuses: 0,
-			events_queue: SmallVec::new(),
+			events_queue: VecDeque::new(),
 		}
 	}
 }
@@ -159,7 +158,7 @@ impl ProtocolsHandler for NotifsInHandler {
 	) {
 		// If a substream already exists, we drop it and replace it with the new incoming one.
 		if self.substream.is_some() {
-			self.events_queue.push(ProtocolsHandlerEvent::Custom(NotifsInHandlerOut::Closed));
+			self.events_queue.push_back(ProtocolsHandlerEvent::Custom(NotifsInHandlerOut::Closed));
 		}
 
 		// Note that we drop the existing substream, which will send an equivalent to a TCP "RST"
@@ -170,7 +169,7 @@ impl ProtocolsHandler for NotifsInHandler {
 		// and we can't close "more" than that anyway.
 		self.substream = Some(proto);
 
-		self.events_queue.push(ProtocolsHandlerEvent::Custom(NotifsInHandlerOut::OpenRequest(msg)));
+		self.events_queue.push_back(ProtocolsHandlerEvent::Custom(NotifsInHandlerOut::OpenRequest(msg)));
 		self.pending_accept_refuses = self.pending_accept_refuses
 			.checked_add(1)
 			.unwrap_or_else(|| {
@@ -232,8 +231,7 @@ impl ProtocolsHandler for NotifsInHandler {
 		ProtocolsHandlerEvent<Self::OutboundProtocol, Self::OutboundOpenInfo, Self::OutEvent, Self::Error>
 	> {
 		// Flush the events queue if necessary.
-		if !self.events_queue.is_empty() {
-			let event = self.events_queue.remove(0);
+		if let Some(event) = self.events_queue.pop_front() {
 			return Poll::Ready(event)
 		}
 


### PR DESCRIPTION
Fixes some quadratic explosion if there's a large number of events.

If I'm not mistaken, there's no `Vec<Event>` or `SmallVec<[Event; _]>` after this PR anymore.
