### PR TITLE
Add Keccak hasher

### DIFF
--- a/primitives/core/src/hasher.rs
+++ b/primitives/core/src/hasher.rs
@@ -36,3 +36,23 @@ pub mod blake2 {
 		}
 	}
 }
+
+pub mod keccak {
+	use hash_db::Hasher;
+	use hash256_std_hasher::Hash256StdHasher;
+	use crate::hash::H256;
+
+	/// Concrete implementation of Hasher using Blake2b 256-bit hashes
+	#[derive(Debug)]
+	pub struct KeccakHasher;
+
+	impl Hasher for KeccakHasher {
+		type Out = H256;
+		type StdHasher = Hash256StdHasher;
+		const LENGTH: usize = 32;
+
+		fn hash(x: &[u8]) -> Self::Out {
+			crate::hashing::keccak_256(x).into()
+		}
+	}
+}

--- a/primitives/core/src/hasher.rs
+++ b/primitives/core/src/hasher.rs
@@ -42,7 +42,7 @@ pub mod keccak {
 	use hash256_std_hasher::Hash256StdHasher;
 	use crate::hash::H256;
 
-	/// Concrete implementation of Hasher using Blake2b 256-bit hashes
+	/// Concrete implementation of Hasher using Keccak 256-bit hashes
 	#[derive(Debug)]
 	pub struct KeccakHasher;
 

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -83,6 +83,8 @@ pub use crypto::{DeriveJunction, Pair, Public};
 pub use hash_db::Hasher;
 #[cfg(feature = "std")]
 pub use self::hasher::blake2::Blake2Hasher;
+#[cfg(feature = "std")]
+pub use self::hasher::keccak::KeccakHasher;
 
 pub use sp_storage as storage;
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -300,6 +300,16 @@ pub trait Trie {
 	fn blake2_256_ordered_root(input: Vec<Vec<u8>>) -> H256 {
 		Layout::<sp_core::Blake2Hasher>::ordered_trie_root(input)
 	}
+
+	/// A trie root formed from the iterated items.
+	fn keccak_256_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> H256 {
+		Layout::<sp_core::KeccakHasher>::trie_root(input)
+	}
+
+	/// A trie root formed from the enumerated items.
+	fn keccak_256_ordered_root(input: Vec<Vec<u8>>) -> H256 {
+		Layout::<sp_core::KeccakHasher>::ordered_trie_root(input)
+	}
 }
 
 /// Interface that provides miscellaneous functions for communicating between the runtime and the node.

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -376,6 +376,33 @@ impl Hash for BlakeTwo256 {
 	}
 }
 
+/// Keccak-256 Hash implementation.
+#[derive(PartialEq, Eq, Clone, RuntimeDebug)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct Keccak256;
+
+impl Hasher for Keccak256 {
+	type Out = sp_core::H256;
+	type StdHasher = hash256_std_hasher::Hash256StdHasher;
+	const LENGTH: usize = 32;
+
+	fn hash(s: &[u8]) -> Self::Out {
+		sp_io::hashing::keccak_256(s).into()
+	}
+}
+
+impl Hash for Keccak256 {
+	type Output = sp_core::H256;
+
+	fn trie_root(input: Vec<(Vec<u8>, Vec<u8>)>) -> Self::Output {
+		sp_io::trie::keccak_256_root(input)
+	}
+
+	fn ordered_trie_root(input: Vec<Vec<u8>>) -> Self::Output {
+		sp_io::trie::keccak_256_ordered_root(input)
+	}
+}
+
 /// Something that can be checked for equality and printed out to a debug channel if bad.
 pub trait CheckEqual {
 	/// Perform the equality check.


### PR DESCRIPTION
Added Hasher trait to Keccak hash algorithm.
You can now select `type Hashing = Keccak;`.

Please let us know if you have any problems with adding tests or making this change.