### PR TITLE
chore(client): remove the unnecessary clap dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,7 +5954,6 @@ dependencies = [
  "app_dirs",
  "atty",
  "chrono",
- "clap",
  "derive_more",
  "env_logger 0.7.1",
  "fdlimit",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-clap = "2.33.0"
 derive_more = "0.99.2"
 env_logger = "0.7.0"
 log = "0.4.8"

--- a/client/cli/src/error.rs
+++ b/client/cli/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
 	/// Io error
 	Io(std::io::Error),
 	/// Cli error
-	Cli(clap::Error),
+	Cli(structopt::clap::Error),
 	/// Service error
 	Service(sc_service::Error),
 	/// Client error


### PR DESCRIPTION
## Desc

We already have `structopt` which re-exports `clap` in `client/cli`.

✄ -----------------------------------------------------------------------------

btw, is there any standard `rustfmt.toml` substrate has? I modified some `.rs` files last night, and my emacs just re-formatted every one of them...it's a hard day's night. #5456

