### PR TITLE
Make pallet-membership dispatchables public

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 250,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -119,7 +119,7 @@ decl_module! {
 		///
 		/// May only be called from `AddOrigin` or root.
 		#[weight = 50_000_000]
-		fn add_member(origin, who: T::AccountId) {
+		pub fn add_member(origin, who: T::AccountId) {
 			T::AddOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
@@ -138,7 +138,7 @@ decl_module! {
 		///
 		/// May only be called from `RemoveOrigin` or root.
 		#[weight = 50_000_000]
-		fn remove_member(origin, who: T::AccountId) {
+		pub fn remove_member(origin, who: T::AccountId) {
 			T::RemoveOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
@@ -160,7 +160,7 @@ decl_module! {
 		///
 		/// Prime membership is *not* passed from `remove` to `add`, if extant.
 		#[weight = 50_000_000]
-		fn swap_member(origin, remove: T::AccountId, add: T::AccountId) {
+		pub fn swap_member(origin, remove: T::AccountId, add: T::AccountId) {
 			T::SwapOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
@@ -189,7 +189,7 @@ decl_module! {
 		///
 		/// May only be called from `ResetOrigin` or root.
 		#[weight = 50_000_000]
-		fn reset_members(origin, members: Vec<T::AccountId>) {
+		pub fn reset_members(origin, members: Vec<T::AccountId>) {
 			T::ResetOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
@@ -212,7 +212,7 @@ decl_module! {
 		///
 		/// Prime membership is passed from the origin account to `new`, if extant.
 		#[weight = 50_000_000]
-		fn change_key(origin, new: T::AccountId) {
+		pub fn change_key(origin, new: T::AccountId) {
 			let remove = ensure_signed(origin)?;
 
 			if remove != new {
@@ -240,7 +240,7 @@ decl_module! {
 
 		/// Set the prime member. Must be a current member.
 		#[weight = 50_000_000]
-		fn set_prime(origin, who: T::AccountId) {
+		pub fn set_prime(origin, who: T::AccountId) {
 			T::PrimeOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;
@@ -251,7 +251,7 @@ decl_module! {
 
 		/// Remove the prime member if it exists.
 		#[weight = 50_000_000]
-		fn clear_prime(origin) {
+		pub fn clear_prime(origin) {
 			T::PrimeOrigin::try_origin(origin)
 				.map(|_| ())
 				.or_else(ensure_root)?;


### PR DESCRIPTION
We would like to call those method directly from our integration test. I don't see why those dispatchable calls needs to be private.