### PR TITLE
Put democracy max votes into metadata

### DIFF
--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -652,6 +652,9 @@ decl_module! {
 		/// The amount of balance that must be deposited per byte of preimage stored.
 		const PreimageByteDeposit: BalanceOf<T> = T::PreimageByteDeposit::get();
 
+		/// The maximum number of votes for an account.
+		const MaxVotes: u32 = T::MaxVotes::get();
+
 		fn deposit_event() = default;
 
 		fn on_runtime_upgrade() -> Weight {


### PR DESCRIPTION
I forgot to put The maximum number of votes for an account in democracy into metadata.

@jacogr that also might interest you if you want to provide more informationto user.

If this max votes is exceeded any subsequent vote will fail with `MaxVotesReached` until some votes are removed with remove_vote.