### PR TITLE
Events and better log for staking.

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1173,8 +1173,8 @@ decl_event!(
 		OldSlashingReportDiscarded(SessionIndex),
 		/// A new set of stakers was elected with the given computation method.
 		StakingElection(ElectionCompute),
-		/// A bew solution for the election has been stored.
-		SolutionStored(ElectionCompute)
+		/// A bew solution for the upcoming election has been stored.
+		SolutionStored(ElectionCompute),
 		/// An account has bonded this amount.
 		///
 		/// NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,
@@ -2792,7 +2792,7 @@ impl<T: Trait> Module<T> {
 		QueuedScore::put(submitted_score);
 
 		// emit event.
-		Self::deposit_event(RawEvent::SolutionStored(compute);
+		Self::deposit_event(RawEvent::SolutionStored(compute));
 
 		Ok(Some(adjusted_weight).into())
 	}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -290,7 +290,7 @@ use sp_std::{
 };
 use codec::{HasCompact, Encode, Decode};
 use frame_support::{
-	decl_module, decl_event, decl_storage, ensure, decl_error, debug,
+	decl_module, decl_event, decl_storage, ensure, decl_error,
 	weights::{Weight, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
 	storage::IterableStorageMap,
 	dispatch::{IsSubType, DispatchResult, DispatchResultWithPostInfo, WithPostDispatchInfo},
@@ -332,13 +332,14 @@ const STAKING_ID: LockIdentifier = *b"staking ";
 pub const MAX_UNLOCKING_CHUNKS: usize = 32;
 pub const MAX_NOMINATIONS: usize = <CompactAssignments as VotingLimit>::LIMIT;
 
-// syntactic sugar for logging
-#[cfg(feature = "std")]
-const LOG_TARGET: &'static str = "staking";
+pub(crate) const LOG_TARGET: &'static str = "staking";
+
+// syntactic sugar for logging.
+#[macro_export]
 macro_rules! log {
 	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
-		debug::native::$level!(
-			target: LOG_TARGET,
+		frame_support::debug::$level!(
+			target: crate::LOG_TARGET,
 			$patter $(, $values)*
 		)
 	};
@@ -372,7 +373,7 @@ generate_compact_solution_type!(pub GenericCompactAssignments, 16);
 pub struct ActiveEraInfo {
 	/// Index of era.
 	pub index: EraIndex,
-	/// Moment of start expresed as millisecond from `$UNIX_EPOCH`.
+	/// Moment of start expressed as millisecond from `$UNIX_EPOCH`.
 	///
 	/// Start can be none if start hasn't been set for the era yet,
 	/// Start is set on the first on_finalize of the era to guarantee usage of `Time`.
@@ -1172,6 +1173,8 @@ decl_event!(
 		OldSlashingReportDiscarded(SessionIndex),
 		/// A new set of stakers was elected with the given computation method.
 		StakingElection(ElectionCompute),
+		/// A bew solution for the election has been stored.
+		SolutionStored(ElectionCompute)
 		/// An account has bonded this amount.
 		///
 		/// NOTE: This event is only emitted when funds are bonded via a dispatchable. Notably,
@@ -1327,7 +1330,7 @@ decl_module! {
 					log!(debug, "skipping offchain worker in open election window due to [{}]", why);
 				} else {
 					if let Err(e) = compute_offchain_election::<T>() {
-						log!(warn, "💸 Error in phragmen offchain worker: {:?}", e);
+						log!(error, "💸 Error in phragmen offchain worker: {:?}", e);
 					} else {
 						log!(debug, "Executed offchain worker thread without errors.");
 					}
@@ -2787,6 +2790,9 @@ impl<T: Trait> Module<T> {
 			exposures,
 		});
 		QueuedScore::put(submitted_score);
+
+		// emit event.
+		Self::deposit_event(RawEvent::SolutionStored(compute);
 
 		Ok(Some(adjusted_weight).into())
 	}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1173,7 +1173,7 @@ decl_event!(
 		OldSlashingReportDiscarded(SessionIndex),
 		/// A new set of stakers was elected with the given computation method.
 		StakingElection(ElectionCompute),
-		/// A bew solution for the upcoming election has been stored.
+		/// A new solution for the upcoming election has been stored.
 		SolutionStored(ElectionCompute),
 		/// An account has bonded this amount.
 		///

--- a/frame/staking/src/offchain_election.rs
+++ b/frame/staking/src/offchain_election.rs
@@ -29,7 +29,7 @@ use sp_phragmen::{
 };
 use sp_runtime::offchain::storage::StorageValueRef;
 use sp_runtime::{PerThing, RuntimeDebug, traits::{TrailingZeroInput, Zero}};
-use frame_support::{debug, traits::Get};
+use frame_support::traits::Get;
 use sp_std::{convert::TryInto, prelude::*};
 
 /// Error types related to the offchain election machinery.
@@ -249,8 +249,8 @@ pub fn prepare_submission<T: Trait>(
 		nominators: snapshot_nominators.len() as NominatorIndex,
 	};
 
-	debug::native::debug!(
-		target: "staking",
+	crate::log!(
+		info,
 		"prepared solution after {} equalization iterations with score {:?}",
 		iterations_executed,
 		score,

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -3031,6 +3031,21 @@ mod offchain_phragmen {
 
 				let queued_result = Staking::queued_elected().unwrap();
 				assert_eq!(queued_result.compute, ElectionCompute::Signed);
+				assert_eq!(
+					System::events()
+						.into_iter()
+						.map(|r| r.event)
+						.filter_map(|e| {
+							if let MetaEvent::staking(inner) = e {
+								Some(inner)
+							} else {
+								None
+							}
+						})
+						.last()
+						.unwrap(),
+					RawEvent::SolutionStored(ElectionCompute::Signed),
+				);
 
 				run_to_block(15);
 				assert_eq!(Staking::era_election_status(), ElectionStatus::Closed);


### PR DESCRIPTION
Currently there is no way to trace the submission of a solution in staking other than `System::ExtrinsicSuccess` and matching the weight, or if you are lucky and we are running in native, tracing the logs. The former is cumbersome and the latter is unreliable. While I am an advocate of "don't sprinkle events in your pallet", unless if someone objects I want to add this handy event to staking to show all the new submissions. Since this is a very important operation I think it will be worthwhile to have. 

An example of where this can be used: https://github.com/paritytech/substrate/issues/6106