### PR TITLE
Fix default base path on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,18 +113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2494382e9ba43995f3c56359e518641f450f5c36feeb4632a75cde2ec297c867"
 
 [[package]]
-name = "app_dirs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
-dependencies = [
- "ole32-sys",
- "shell32-sys",
- "winapi 0.2.8",
- "xdg",
-]
-
-[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,16 +3895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
-name = "ole32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5980,10 +5958,10 @@ name = "sc-cli"
 version = "0.8.0-dev"
 dependencies = [
  "ansi_term 0.12.1",
- "app_dirs",
  "atty",
  "chrono",
  "derive_more",
+ "directories",
  "env_logger 0.7.1",
  "fdlimit",
  "futures 0.3.5",
@@ -7143,16 +7121,6 @@ dependencies = [
  "digest",
  "keccak",
  "opaque-debug",
-]
-
-[[package]]
-name = "shell32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -9617,12 +9585,6 @@ dependencies = [
  "rand_core 0.5.1",
  "zeroize",
 ]
-
-[[package]]
-name = "xdg"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 
 [[package]]
 name = "yamux"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.3.1"
 time = "0.1.42"
 ansi_term = "0.12.1"
 lazy_static = "1.4.0"
-app_dirs = "1.2.1"
+directories = "2.0.2"
 tokio = { version = "0.2.9", features = [ "signal", "rt-core", "rt-threaded" ] }
 futures = "0.3.4"
 fdlimit = "0.1.4"

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -407,7 +407,7 @@ pub trait CliConfiguration: Sized {
 			.unwrap_or_else(|| {
 				directories::ProjectDirs::from("", "", C::executable_name())
 					.expect("app directories exist on all supported platforms; qed")
-					.data_dir()
+					.data_local_dir()
 					.into()
 			})
 			.join("chains")

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -24,7 +24,6 @@ use crate::{
 	init_logger, DatabaseParams, ImportParams, KeystoreParams, NetworkParams, NodeKeyParams,
 	OffchainWorkerParams, PruningParams, SharedParams, SubstrateCli,
 };
-use app_dirs::{AppDataType, AppInfo};
 use names::{Generator, Name};
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use sc_service::config::{
@@ -406,14 +405,10 @@ pub trait CliConfiguration: Sized {
 		let config_dir = self
 			.base_path()?
 			.unwrap_or_else(|| {
-				app_dirs::get_app_root(
-					AppDataType::UserData,
-					&AppInfo {
-						name: C::executable_name(),
-						author: C::author(),
-					},
-				)
-				.expect("app directories exist on all supported platforms; qed")
+				directories::ProjectDirs::from("", "", C::executable_name())
+					.expect("app directories exist on all supported platforms; qed")
+					.data_dir()
+					.into()
 			})
 			.join("chains")
 			.join(chain_spec.id());


### PR DESCRIPTION
Default data dir on windows is set to use `author` field from Cargo.toml, which contains an e-mail and therefore does not really work as a directory name.
This PR switches from `app_dirs` to `directories` crate as it allows setting empty org name for windows. Paths for linux and mac stay the same, as these do not use organization name.