### PR TITLE
Make Get<T> const friendly + Clean the runtime files a bit.

### DIFF
--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -128,7 +128,7 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	/// Assume 10% of weight for average on_initialize calls.
-	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
 		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -65,11 +65,11 @@ use static_assertions::const_assert;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-pub use pallet_timestamp::Call as TimestampCall;
+#[cfg(any(feature = "std", test))]
 pub use pallet_balances::Call as BalancesCall;
+#[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;
-pub use pallet_contracts::Gas;
-pub use frame_support::StorageValue;
+#[cfg(any(feature = "std", test))]
 pub use pallet_staking::StakerStatus;
 
 /// Implementations of some helper traits passed into runtime modules as associated types.
@@ -126,6 +126,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	}
 }
 
+const AVERAGE_ON_INITIALIZE_WEIGHT: Perbill = Perbill::from_percent(10);
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
@@ -133,13 +134,13 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	/// Assume 10% of weight for average on_initialize calls.
 	pub MaximumExtrinsicWeight: Weight =
-		AvailableBlockRatio::get().saturating_sub(Perbill::from_percent(10))
+		AvailableBlockRatio::get().saturating_sub(AVERAGE_ON_INITIALIZE_WEIGHT)
 		* MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
 
-const_assert!(AvailableBlockRatio::get().deconstruct() >= Perbill::from_percent(10).deconstruct());
+const_assert!(AvailableBlockRatio::get().deconstruct() >= AVERAGE_ON_INITIALIZE_WEIGHT.deconstruct());
 
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -139,7 +139,7 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 }
 
-const_assert!(AvailableBlockRatio::get_const().deconstruct() >= Perbill::from_percent(10).deconstruct());
+const_assert!(AvailableBlockRatio::get().deconstruct() >= Perbill::from_percent(10).deconstruct());
 
 impl frame_system::Trait for Runtime {
 	type Origin = Origin;
@@ -237,8 +237,8 @@ parameter_types! {
 
 // for a sane configuration, this should always be less than `AvailableBlockRatio`.
 const_assert!(
-	TargetBlockFullness::get_const().deconstruct() <
-	(AvailableBlockRatio::get_const().deconstruct() as <Perquintill as PerThing>::Inner)
+	TargetBlockFullness::get().deconstruct() <
+	(AvailableBlockRatio::get().deconstruct() as <Perquintill as PerThing>::Inner)
 		* (<Perquintill as PerThing>::ACCURACY / <Perbill as PerThing>::ACCURACY as <Perquintill as PerThing>::Inner)
 );
 
@@ -418,7 +418,7 @@ parameter_types! {
 }
 
 // Make sure that there are no more than `MAX_MEMBERS` members elected via phragmen.
-const_assert!(DesiredMembers::get_const() <= pallet_collective::MAX_MEMBERS);
+const_assert!(DesiredMembers::get() <= pallet_collective::MAX_MEMBERS);
 
 impl pallet_elections_phragmen::Trait for Runtime {
 	type ModuleId = ElectionsPhragmenModuleId;

--- a/bin/node/testing/src/genesis.rs
+++ b/bin/node/testing/src/genesis.rs
@@ -23,7 +23,7 @@ use sp_keyring::{Ed25519Keyring, Sr25519Keyring};
 use node_runtime::{
 	GenesisConfig, BalancesConfig, SessionConfig, StakingConfig, SystemConfig,
 	GrandpaConfig, IndicesConfig, ContractsConfig, SocietyConfig, WASM_BINARY,
-	AccountId,
+	AccountId, StakerStatus,
 };
 use node_runtime::constants::currency::*;
 use sp_core::ChangesTrieConfiguration;
@@ -87,9 +87,9 @@ pub fn config_endowed(
 		}),
 		pallet_staking: Some(StakingConfig {
 			stakers: vec![
-				(dave(), alice(), 111 * DOLLARS, pallet_staking::StakerStatus::Validator),
-				(eve(), bob(), 100 * DOLLARS, pallet_staking::StakerStatus::Validator),
-				(ferdie(), charlie(), 100 * DOLLARS, pallet_staking::StakerStatus::Validator)
+				(dave(), alice(), 111 * DOLLARS, StakerStatus::Validator),
+				(eve(), bob(), 100 * DOLLARS, StakerStatus::Validator),
+				(ferdie(), charlie(), 100 * DOLLARS, StakerStatus::Validator)
 			],
 			validator_count: 3,
 			minimum_validator_count: 0,

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -110,7 +110,7 @@ impl frame_system::Trait for Test {
 	type OnKilledAccount = ();
 }
 parameter_types! {
-	pub const MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * MaximumBlockWeight::get();
+	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * MaximumBlockWeight::get();
 }
 impl pallet_scheduler::Trait for Test {
 	type Event = Event;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -232,7 +232,7 @@ impl staking::Trait for Test {
 }
 
 parameter_types! {
-	pub const OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
+	pub OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
 }
 
 impl offences::Trait for Test {

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -187,7 +187,7 @@ impl pallet_im_online::Trait for Test {
 }
 
 parameter_types! {
-	pub const OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
+	pub OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
 }
 
 impl pallet_offences::Trait for Test {

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -122,7 +122,7 @@ impl frame_system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
+	pub OffencesWeightSoftLimit: Weight = Perbill::from_percent(60) * MaximumBlockWeight::get();
 }
 
 impl Trait for Runtime {

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -515,7 +515,7 @@ mod tests {
 		type Event = ();
 	}
 	parameter_types! {
-		pub const MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * MaximumBlockWeight::get();
+		pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * MaximumBlockWeight::get();
 	}
 	impl Trait for Test {
 		type Event = ();

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -87,19 +87,43 @@ pub enum Never {}
 /// Macro for easily creating a new implementation of the `Get` trait. If `const` token is used, the
 /// rhs of the expression must be `const`-only, and get is implemented as `const`:
 ///
-/// ```no_compile
+/// ```
+/// # use frame_support::traits::Get;
+/// # use frame_support::parameter_types;
+/// // This function cannot be used in a const context.
+/// fn non_const_expression() -> u64 { 99 }
+///
+/// const FIXED_VALUE: u64 = 10;
 /// parameter_types! {
-///   pub const Argument: u64 = 42;
-///   pub OtherArg: u63 = non_const_expression();
+///   pub const Argument: u64 = 42 + FIXED_VALUE;
+///   pub OtherArgument: u64 = non_const_expression();
 /// }
+///
 /// trait Config {
 ///   type Parameter: Get<u64>;
+///   type OtherParameter: Get<u64>;
 /// }
+///
 /// struct Runtime;
 /// impl Config for Runtime {
 ///   type Parameter = Argument;
+///   type OtherParameter = OtherArgument;
 /// }
 /// ```
+///
+/// Invalid example:
+///
+/// ```compile_fail
+/// # use frame_support::traits::Get;
+/// # use frame_support::parameter_types;
+/// // This function cannot be used in a const context.
+/// fn non_const_expression() -> u64 { 99 }
+///
+/// parameter_types! {
+///   pub const Argument: u64 = non_const_expression();
+/// }
+/// ```
+
 #[macro_export]
 macro_rules! parameter_types {
 	(

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -108,10 +108,35 @@ macro_rules! parameter_types {
 	) => (
 		$( #[ $attr ] )*
 		$vis struct $name;
+		$crate::parameter_types!{IMPL_CONST $name , $type , $value}
+		$crate::parameter_types!{ $( $rest )* }
+	);
+	(
+		$( #[ $attr:meta ] )*
+		$vis:vis $name:ident: $type:ty = $value:expr;
+		$( $rest:tt )*
+	) => (
+		$( #[ $attr ] )*
+		$vis struct $name;
 		$crate::parameter_types!{IMPL $name , $type , $value}
 		$crate::parameter_types!{ $( $rest )* }
 	);
 	() => ();
+	(IMPL_CONST $name:ident , $type:ty , $value:expr) => {
+		impl $name {
+			pub fn get() -> $type {
+				$value
+			}
+			pub const fn get_const() -> $type {
+				$value
+			}
+		}
+		impl<I: From<$type>> $crate::traits::Get<I> for $name {
+			fn get() -> I {
+				I::from($value)
+			}
+		}
+	};
 	(IMPL $name:ident , $type:ty , $value:expr) => {
 		impl $name {
 			pub fn get() -> $type {

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -84,12 +84,14 @@ pub use sp_runtime::{self, ConsensusEngineId, print, traits::Printable};
 #[derive(Debug)]
 pub enum Never {}
 
-/// Macro for easily creating a new implementation of the `Get` trait. Use similarly to
-/// how you would declare a `const`:
+/// Macro for easily creating a new implementation of the `Get` trait. If `const` token is used, the
+/// rhs of the expression must be `const`-only, and an additional `get_const` for it is implemented,
+/// else only `Get` is implemented and the rhs can be any expression:
 ///
 /// ```no_compile
 /// parameter_types! {
 ///   pub const Argument: u64 = 42;
+///   pub OtherArg: u63 = non_const_expression();
 /// }
 /// trait Config {
 ///   type Parameter: Get<u64>;

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -85,8 +85,7 @@ pub use sp_runtime::{self, ConsensusEngineId, print, traits::Printable};
 pub enum Never {}
 
 /// Macro for easily creating a new implementation of the `Get` trait. If `const` token is used, the
-/// rhs of the expression must be `const`-only, and an additional `get_const` for it is implemented,
-/// else only `Get` is implemented and the rhs can be any expression:
+/// rhs of the expression must be `const`-only, and get is implemented as `const`:
 ///
 /// ```no_compile
 /// parameter_types! {
@@ -126,10 +125,7 @@ macro_rules! parameter_types {
 	() => ();
 	(IMPL_CONST $name:ident , $type:ty , $value:expr) => {
 		impl $name {
-			pub fn get() -> $type {
-				$value
-			}
-			pub const fn get_const() -> $type {
+			pub const fn get() -> $type {
 				$value
 			}
 		}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1877,7 +1877,7 @@ pub(crate) mod tests {
 		pub const MaximumExtrinsicWeight: Weight = 768;
 		pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 		pub const MaximumBlockLength: u32 = 1024;
-		pub const Version: RuntimeVersion = RuntimeVersion {
+		pub Version: RuntimeVersion = RuntimeVersion {
 			spec_name: sp_version::create_runtime_str!("test"),
 			impl_name: sp_version::create_runtime_str!("system-test"),
 			authoring_version: 1,

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -383,7 +383,6 @@ macro_rules! implement_per_thing {
 		impl $name {
 			/// From an explicitly defined number of parts per maximum of the type.
 			///
-			/// This can be called at compile time.
 			// needed only for peru16. Since peru16 is the only type in which $max ==
 			// $type::max_value(), rustc is being a smart-a** here by warning that the comparison
 			// is not needed.
@@ -400,8 +399,6 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::one`]
-			///
-			/// This can be called at compile time.
 			pub const fn one() -> Self {
 				Self::from_parts($max)
 			}
@@ -412,8 +409,6 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::zero`].
-			///
-			/// This can be called at compile time.
 			pub const fn zero() -> Self {
 				Self::from_parts(0)
 			}
@@ -424,8 +419,6 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::deconstruct`].
-			///
-			/// This can be called at compile time.
 			pub const fn deconstruct(self) -> $type {
 				self.0
 			}

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -399,9 +399,11 @@ macro_rules! implement_per_thing {
 				Self(([x, 100][(x > 100) as usize] as $upper_type * $max as $upper_type / 100) as $type)
 			}
 
-			/// See [`PerThing::one`].
-			pub fn one() -> Self {
-				<Self as PerThing>::one()
+			/// See [`PerThing::one`]
+			///
+			/// This can be called at compile time.
+			pub const fn one() -> Self {
+				Self::from_parts($max)
 			}
 
 			/// See [`PerThing::is_one`].
@@ -410,8 +412,10 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::zero`].
-			pub fn zero() -> Self {
-				<Self as PerThing>::zero()
+			///
+			/// This can be called at compile time.
+			pub const fn zero() -> Self {
+				Self::from_parts(0)
 			}
 
 			/// See [`PerThing::is_zero`].
@@ -420,8 +424,10 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::deconstruct`].
-			pub fn deconstruct(self) -> $type {
-				PerThing::deconstruct(self)
+			///
+			/// This can be called at compile time.
+			pub const fn deconstruct(self) -> $type {
+				self.0
 			}
 
 			/// See [`PerThing::square`].
@@ -1129,6 +1135,18 @@ macro_rules! implement_per_thing {
 					),
 					1,
 				);
+			}
+
+			#[test]
+			#[allow(unused)]
+			fn const_fns_work() {
+				const C1: $name = $name::from_percent(50);
+				const C2: $name = $name::one();
+				const C3: $name = $name::zero();
+				const C4: $name = $name::from_parts(1);
+
+				// deconstruct is also const, hence it can be called in const rhs.
+				const C5: bool = C1.deconstruct() == 0;
 			}
 		}
 	};


### PR DESCRIPTION
Currently the `const` token in `parameter_types` is not doing anything. Henceforth, if `const` token exists, it will implement a `get_const()` as well that can be used in const context, such as `const_assert!`.

In `per_thing` we defined one `fn one` on the trait and one `const fn one` on the `impl` and the compiler was smart enough to know which one is which. I cannot do the same, here, hence named `get_const()`.  

Related to https://github.com/paritytech/substrate/issues/5570 but not really solving it yet. I don't think this is a good approach to sprinkle some `const_asserts` here and copy them to polkadot and hope that they maintain in sync all the time. If an inter-pallet assertion must always hold, then `construct_runtime!` should somehow enforce them. 

polkadot-companion: https://github.com/paritytech/polkadot/pull/1159