### PR TITLE
Don't iterate over peers in generic_proto::behaviour::poll

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -129,7 +129,10 @@ pub struct GenericProto {
 	/// `peers` occasionally contains a few `Delay` objects that we would normally have to be
 	/// polled one by one. In order to avoid doing so, as an optimization, every `Delay` is
 	/// duplicated in `peers_check_after`. This stream yields `PeerId`s whose `Delay` is
-	/// potentially ready to be checked.
+	/// potentially ready.
+	///
+	/// By design, we never remove elements from this list. Elements are removed only when the
+	/// `Delay` triggers. As such, this stream may produce obsolete elements.
 	peers_check_after: stream::FuturesUnordered<Pin<Box<dyn Future<Output = PeerId> + Send>>>,
 
 	/// List of incoming messages we have sent to the peer set manager and that are waiting for an


### PR DESCRIPTION
At the moment, every single call to `GenericProto::poll` leads to iterating every single peer we are connected to (including the ones for which we are connected only for Kademlia-related purposes).

This PR optimizes this a bit.

The only reason why we need to iterate is to query the various `Delay`s. After this PR, we would now duplicate all these `Delay`s and push these duplicates in a `FuturesUnordered`.

Polling a `FuturesUnordered` is `O(1)` over the number of elements that it contains because it tracks which child futures have woken up and which haven't.

By design, we never remove elements from `peers_check_after`, as the `FuturesUnordered` struct doesn't allow removing elements anyway. As such, these duplicate `Delay`s will trigger even when there's nothing to do. This should be negligible.
