### PR TITLE
Fixes `wasm-builder` rerun if changed logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cargo_metadata"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
+checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
 dependencies = [
  "semver 0.9.0",
  "serde",
@@ -7021,18 +7021,18 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
  "proc-macro2",
  "quote 1.0.3",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -14,10 +14,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 build-helper = "0.1.1"
-cargo_metadata = "0.9.0"
+cargo_metadata = "0.10.0"
 tempfile = "3.1.0"
 toml = "0.5.4"
-walkdir = "2.2.9"
+walkdir = "2.3.1"
 fs2 = "0.4.3"
 wasm-gc-api = "0.1.11"
 atty = "0.2.13"


### PR DESCRIPTION
There was a bug which related in required files not being tracked of
being modified. This pr fixes this bug by making sure we ignore version
requirements for path dependencies and git dependencies. This also
ensures that we only track `.rs` or `.toml` files. Another improvement
is that we only include paths which don't contain a `Cargo.toml` if this
`Cargo.toml` does not belongs to the package being processed. This
prevents that sub-crates are added to the tracked files, while not being
part of the dependencies.
