### PR TITLE
CLI: Make `--dev` conflict with `--chain`

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -65,7 +65,7 @@ pub struct RunCmd {
 	pub sentry: Vec<MultiaddrWithPeerId>,
 
 	/// Disable GRANDPA voter when running in validator mode, otherwise disable the GRANDPA observer.
-	#[structopt(long = "no-grandpa")]
+	#[structopt(long)]
 	pub no_grandpa: bool,
 
 	/// Experimental: Run in light client mode.

--- a/client/cli/src/params/shared_params.rs
+++ b/client/cli/src/params/shared_params.rs
@@ -23,16 +23,16 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt, Clone)]
 pub struct SharedParams {
 	/// Specify the chain specification (one of dev, local, or staging).
-	#[structopt(long = "chain", value_name = "CHAIN_SPEC")]
+	#[structopt(long, value_name = "CHAIN_SPEC")]
 	pub chain: Option<String>,
 
 	/// Specify the development chain.
-	#[structopt(long = "dev")]
+	#[structopt(long, conflicts_with_all = &["chain"])]
 	pub dev: bool,
 
 	/// Specify custom base path.
 	#[structopt(
-		long = "base-path",
+		long,
 		short = "d",
 		value_name = "PATH",
 		parse(from_os_str)
@@ -43,7 +43,7 @@ pub struct SharedParams {
 	///
 	/// Log levels (least to most verbose) are error, warn, info, debug, and trace.
 	/// By default, all targets log `info`. The global log level can be set with -l<level>.
-	#[structopt(short = "l", long = "log", value_name = "LOG_PATTERN")]
+	#[structopt(short = "l", long, value_name = "LOG_PATTERN")]
 	pub log: Vec<String>,
 }
 


### PR DESCRIPTION
If we are running `--dev` chain, we should forbid the `--chain`
argument. The `--dev` chain is always special by only having one
authority etc and some other chain spec is probably not setup for this
correctly. In the end `--dev` is just a shortcut for `--validator --alice`.
