### PR TITLE
pallet-contracts: State rent fixes

### DIFF
--- a/frame/contracts/fixtures/set_empty_storage.wat
+++ b/frame/contracts/fixtures/set_empty_storage.wat
@@ -1,0 +1,15 @@
+;; This module stores a KV pair into the storage
+(module
+	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
+	(import "env" "memory" (memory 16 16))
+
+	(func (export "call")
+	)
+	(func (export "deploy")
+		(call $ext_set_storage
+			(i32.const 0)				;; Pointer to storage key
+			(i32.const 0)				;; Pointer to value
+			(i32.load (i32.const 0))	;; Size of value
+		)
+	)
+)

--- a/frame/contracts/src/account_db.rs
+++ b/frame/contracts/src/account_db.rs
@@ -176,7 +176,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 						child::kill_storage(&info.child_trie_info());
 						AliveContractInfo::<T> {
 							code_hash,
-							storage_size: T::StorageSizeOffset::get(),
+							storage_size: 0,
 							trie_id: <T as Trait>::TrieIdGenerator::trie_id(&address),
 							deduct_block: <frame_system::Module<T>>::block_number(),
 							rent_allowance: <BalanceOf<T>>::max_value(),
@@ -187,7 +187,7 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 					(_, None, Some(code_hash)) => {
 						AliveContractInfo::<T> {
 							code_hash,
-							storage_size: T::StorageSizeOffset::get(),
+							storage_size: 0,
 							trie_id: <T as Trait>::TrieIdGenerator::trie_id(&address),
 							deduct_block: <frame_system::Module<T>>::block_number(),
 							rent_allowance: <BalanceOf<T>>::max_value(),

--- a/frame/contracts/src/account_db.rs
+++ b/frame/contracts/src/account_db.rs
@@ -26,7 +26,7 @@ use sp_std::collections::btree_map::{BTreeMap, Entry};
 use sp_std::prelude::*;
 use sp_io::hashing::blake2_256;
 use sp_runtime::traits::{Bounded, Zero};
-use frame_support::traits::{Currency, Get, Imbalance, SignedImbalance};
+use frame_support::traits::{Currency, Imbalance, SignedImbalance};
 use frame_support::{storage::child, StorageMap};
 use frame_system;
 
@@ -108,7 +108,12 @@ pub trait AccountDb<T: Trait> {
 	///
 	/// Trie id is None iff account doesn't have an associated trie id in <ContractInfoOf<T>>.
 	/// Because DirectAccountDb bypass the lookup for this association.
-	fn get_storage(&self, account: &T::AccountId, trie_id: Option<&TrieId>, location: &StorageKey) -> Option<Vec<u8>>;
+	fn get_storage(
+		&self,
+		account: &T::AccountId,
+		trie_id: Option<&TrieId>,
+		location: &StorageKey,
+	) -> Option<Vec<u8>>;
 	/// If account has an alive contract then return the code hash associated.
 	fn get_code_hash(&self, account: &T::AccountId) -> Option<CodeHash<T>>;
 	/// If account has an alive contract then return the rent allowance associated.
@@ -126,9 +131,10 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 		&self,
 		_account: &T::AccountId,
 		trie_id: Option<&TrieId>,
-		location: &StorageKey
+		location: &StorageKey,
 	) -> Option<Vec<u8>> {
-		trie_id.and_then(|id| child::get_raw(&crate::child_trie_info(&id[..]), &blake2_256(location)))
+		trie_id
+			.and_then(|id| child::get_raw(&crate::child_trie_info(&id[..]), &blake2_256(location)))
 	}
 	fn get_code_hash(&self, account: &T::AccountId) -> Option<CodeHash<T>> {
 		<ContractInfoOf<T>>::get(account).and_then(|i| i.as_alive().map(|i| i.code_hash))
@@ -184,16 +190,14 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 						}
 					}
 					// New contract is being instantiated.
-					(_, None, Some(code_hash)) => {
-						AliveContractInfo::<T> {
-							code_hash,
-							storage_size: 0,
-							trie_id: <T as Trait>::TrieIdGenerator::trie_id(&address),
-							deduct_block: <frame_system::Module<T>>::block_number(),
-							rent_allowance: <BalanceOf<T>>::max_value(),
-							last_write: None,
-						}
-					}
+					(_, None, Some(code_hash)) => AliveContractInfo::<T> {
+						code_hash,
+						storage_size: 0,
+						trie_id: <T as Trait>::TrieIdGenerator::trie_id(&address),
+						deduct_block: <frame_system::Module<T>>::block_number(),
+						rent_allowance: <BalanceOf<T>>::max_value(),
+						last_write: None,
+					},
 					// There is no existing at the address nor a new one to be instantiated.
 					(_, None, None) => continue,
 				};
@@ -210,18 +214,39 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 					new_info.last_write = Some(<frame_system::Module<T>>::block_number());
 				}
 
-				for (k, v) in changed.storage.into_iter() {
-					if let Some(value) = child::get_raw(
-						&new_info.child_trie_info(),
-						&blake2_256(&k),
-					) {
-						new_info.storage_size -= value.len() as u32;
-					}
-					if let Some(value) = v {
-						new_info.storage_size += value.len() as u32;
-						child::put_raw(&new_info.child_trie_info(), &blake2_256(&k), &value[..]);
-					} else {
-						child::kill(&new_info.child_trie_info(), &blake2_256(&k));
+				// NB: this call allocates internally. To keep allocations to the minimum we cache
+				// the child trie info here.
+				let child_trie_info = new_info.child_trie_info();
+
+				// Here we iterate over all storage key-value pairs that were changed throughout the
+				// execution of a contract and apply them to the substrate storage.
+				for (key, opt_new_value) in changed.storage.into_iter() {
+					let hashed_key = blake2_256(&key);
+
+					// In order to correctly update the storage size we need to fetch the previous
+					// value of the key-value pair.
+					//
+					// It might be a bit more clean if we had an API that supported getting the size
+					// of the value without going through the loading of it. But at the moment of
+					// writing, there is no such API.
+					//
+					// That's not a show stopper in any case, since the performance cost is
+					// dominated by the trie traversal anyway.
+					let prev_value_len = child::get_raw(&child_trie_info, &hashed_key)
+						.map(|prev_value| prev_value.len() as u32)
+						.unwrap_or(0);
+					let new_value_len = opt_new_value
+						.as_ref()
+						.map(|new_value| new_value.len() as u32)
+						.unwrap_or(0);
+					new_info.storage_size = new_info
+						.storage_size
+						.saturating_sub(prev_value_len)
+						.saturating_add(new_value_len);
+
+					match opt_new_value {
+						Some(new_value) => child::put_raw(&child_trie_info, &hashed_key, &new_value[..]),
+						None => child::kill(&child_trie_info, &hashed_key),
 					}
 				}
 
@@ -239,8 +264,9 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 			// then it's indicative of a buggy contracts system.
 			// Panicking is far from ideal as it opens up a DoS attack on block validators, however
 			// it's a less bad option than allowing arbitrary value to be created.
-			SignedImbalance::Positive(ref p) if !p.peek().is_zero() =>
-				panic!("contract subsystem resulting in positive imbalance!"),
+			SignedImbalance::Positive(ref p) if !p.peek().is_zero() => {
+				panic!("contract subsystem resulting in positive imbalance!")
+			}
 			_ => {}
 		}
 	}
@@ -267,7 +293,8 @@ impl<'a, T: Trait> OverlayAccountDb<'a, T> {
 		location: StorageKey,
 		value: Option<Vec<u8>>,
 	) {
-		self.local.borrow_mut()
+		self.local
+			.borrow_mut()
 			.entry(account.clone())
 			.or_insert(Default::default())
 			.storage
@@ -285,7 +312,9 @@ impl<'a, T: Trait> OverlayAccountDb<'a, T> {
 		}
 
 		let mut local = self.local.borrow_mut();
-		let contract = local.entry(account.clone()).or_insert_with(|| Default::default());
+		let contract = local
+			.entry(account.clone())
+			.or_insert_with(|| Default::default());
 
 		contract.code_hash = Some(code_hash);
 		contract.rent_allowance = Some(<BalanceOf<T>>::max_value());
@@ -301,7 +330,7 @@ impl<'a, T: Trait> OverlayAccountDb<'a, T> {
 			ChangeEntry {
 				reset: true,
 				..Default::default()
-			}
+			},
 		);
 	}
 
@@ -327,7 +356,7 @@ impl<'a, T: Trait> AccountDb<T> for OverlayAccountDb<'a, T> {
 		&self,
 		account: &T::AccountId,
 		trie_id: Option<&TrieId>,
-		location: &StorageKey
+		location: &StorageKey,
 	) -> Option<Vec<u8>> {
 		self.local
 			.borrow()

--- a/frame/contracts/src/account_db.rs
+++ b/frame/contracts/src/account_db.rs
@@ -348,9 +348,7 @@ impl<'a, T: Trait> OverlayAccountDb<'a, T> {
 		}
 
 		let mut local = self.local.borrow_mut();
-		let contract = local
-			.entry(account.clone())
-			.or_insert_with(|| Default::default());
+		let contract = local.entry(account.clone()).or_default();
 
 		contract.code_hash = Some(code_hash);
 		contract.rent_allowance = Some(<BalanceOf<T>>::max_value());

--- a/frame/contracts/src/account_db.rs
+++ b/frame/contracts/src/account_db.rs
@@ -274,9 +274,8 @@ impl<T: Trait> AccountDb<T> for DirectAccountDb {
 						.unwrap_or(0);
 					new_info.storage_size = new_info
 						.storage_size
-						.saturating_sub(prev_value_len)
-						.saturating_add(new_value_len);
-
+						.saturating_add(new_value_len)
+						.saturating_sub(prev_value_len);
 
 					// Finally, perform the change on the storage.
 					match opt_new_value {

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -203,7 +203,7 @@ pub type AliveContractInfo<T> =
 pub struct RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
 	/// Unique ID for the subtree encoded as a bytes vector.
 	pub trie_id: TrieId,
-	/// The size of stored value in octet.
+	/// The size of stored value in bytes.
 	pub storage_size: u32,
 	/// The code associated with a given account.
 	pub code_hash: CodeHash,
@@ -338,8 +338,10 @@ pub trait Trait: frame_system::Trait + pallet_transaction_payment::Trait {
 	/// The minimum amount required to generate a tombstone.
 	type TombstoneDeposit: Get<BalanceOf<Self>>;
 
-	/// Size of a contract at the time of instantiation. This is a simple way to ensure
-	/// that empty contracts eventually gets deleted.
+	/// A size offset for an contract. A just created account with untouched storage will have that
+	/// much of storage from the perspective of the state rent.
+	///
+	/// This is a simple way to ensure that empty contracts eventually gets deleted.
 	type StorageSizeOffset: Get<u32>;
 
 	/// Price of a byte of storage per one block interval. Should be greater than 0.
@@ -420,8 +422,10 @@ decl_module! {
 		/// The minimum amount required to generate a tombstone.
 		const TombstoneDeposit: BalanceOf<T> = T::TombstoneDeposit::get();
 
-		/// Size of a contract at the time of instantiation. This is a simple way to ensure that
-		/// empty contracts eventually gets deleted.
+		/// A size offset for an contract. A just created account with untouched storage will have that
+		/// much of storage from the perspective of the state rent.
+		///
+		/// This is a simple way to ensure that empty contracts eventually gets deleted.
 		const StorageSizeOffset: u32 = T::StorageSizeOffset::get();
 
 		/// Price of a byte of storage per one block interval. Should be greater than 0.

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -348,7 +348,8 @@ pub trait Trait: frame_system::Trait + pallet_transaction_payment::Trait {
 	/// A size offset for an contract. A just created account with untouched storage will have that
 	/// much of storage from the perspective of the state rent.
 	///
-	/// This is a simple way to ensure that empty contracts eventually gets deleted.
+	/// This is a simple way to ensure that contracts with empty storage eventually get deleted by
+	/// making them pay rent. This creates an incentive to remove them early in order to save rent.
 	type StorageSizeOffset: Get<u32>;
 
 	/// Price of a byte of storage per one block interval. Should be greater than 0.
@@ -432,7 +433,9 @@ decl_module! {
 		/// A size offset for an contract. A just created account with untouched storage will have that
 		/// much of storage from the perspective of the state rent.
 		///
-		/// This is a simple way to ensure that empty contracts eventually gets deleted.
+		/// This is a simple way to ensure that contracts with empty storage eventually get deleted
+		/// by making them pay rent. This creates an incentive to remove them early in order to save
+		/// rent.
 		const StorageSizeOffset: u32 = T::StorageSizeOffset::get();
 
 		/// Price of a byte of storage per one block interval. Should be greater than 0.

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -93,7 +93,8 @@ fn compute_fee_per_block<T: Trait>(
 		.unwrap_or_else(Zero::zero);
 
 	let effective_storage_size =
-		<BalanceOf<T>>::from(contract.storage_size).saturating_sub(free_storage);
+		<BalanceOf<T>>::from(contract.storage_size + T::StorageSizeOffset::get())
+			.saturating_sub(free_storage);
 
 	effective_storage_size
 		.checked_mul(&T::RentByteFee::get())

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -92,9 +92,13 @@ fn compute_fee_per_block<T: Trait>(
 		.checked_div(&T::RentDepositOffset::get())
 		.unwrap_or_else(Zero::zero);
 
-	let effective_storage_size =
-		<BalanceOf<T>>::from(contract.storage_size + T::StorageSizeOffset::get())
-			.saturating_sub(free_storage);
+	// For now, we treat every empty KV pair as if it was one byte long.
+	let empty_pairs_equivalent = contract.empty_pair_count;
+
+	let effective_storage_size = <BalanceOf<T>>::from(
+		contract.storage_size + T::StorageSizeOffset::get() + empty_pairs_equivalent,
+	)
+	.saturating_sub(free_storage);
 
 	effective_storage_size
 		.checked_mul(&T::RentByteFee::get())

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -752,7 +752,7 @@ fn storage_size() {
 				.unwrap();
 			assert_eq!(
 				bob_contract.storage_size,
-				<Test as Trait>::StorageSizeOffset::get() + 4
+				4
 			);
 
 			assert_ok!(Contracts::call(
@@ -768,7 +768,7 @@ fn storage_size() {
 				.unwrap();
 			assert_eq!(
 				bob_contract.storage_size,
-				<Test as Trait>::StorageSizeOffset::get() + 4 + 4
+				4 + 4
 			);
 
 			assert_ok!(Contracts::call(
@@ -784,7 +784,7 @@ fn storage_size() {
 				.unwrap();
 			assert_eq!(
 				bob_contract.storage_size,
-				<Test as Trait>::StorageSizeOffset::get() + 4
+				4
 			);
 		});
 }
@@ -1316,7 +1316,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 				assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
 				let django_contract = ContractInfoOf::<Test>::get(DJANGO).unwrap()
 					.get_alive().unwrap();
-				assert_eq!(django_contract.storage_size, 16);
+				assert_eq!(django_contract.storage_size, 8);
 				assert_eq!(django_contract.trie_id, django_trie_id);
 				assert_eq!(django_contract.deduct_block, System::block_number());
 				match (test_different_storage, test_restore_to_with_dirty_storage) {
@@ -1390,7 +1390,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 				let bob_contract = ContractInfoOf::<Test>::get(BOB).unwrap()
 					.get_alive().unwrap();
 				assert_eq!(bob_contract.rent_allowance, 50);
-				assert_eq!(bob_contract.storage_size, 12);
+				assert_eq!(bob_contract.storage_size, 4);
 				assert_eq!(bob_contract.trie_id, django_trie_id);
 				assert_eq!(bob_contract.deduct_block, System::block_number());
 				assert!(ContractInfoOf::<Test>::get(DJANGO).is_none());

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -290,7 +290,7 @@ fn account_removal_does_not_remove_storage() {
 			let _ = Balances::deposit_creating(&1, 110);
 			ContractInfoOf::<Test>::insert(1, &ContractInfo::Alive(RawAliveContractInfo {
 				trie_id: trie_id1.clone(),
-				storage_size: <Test as Trait>::StorageSizeOffset::get(),
+				storage_size: 0,
 				deduct_block: System::block_number(),
 				code_hash: H256::repeat_byte(1),
 				rent_allowance: 40,
@@ -305,7 +305,7 @@ fn account_removal_does_not_remove_storage() {
 			let _ = Balances::deposit_creating(&2, 110);
 			ContractInfoOf::<Test>::insert(2, &ContractInfo::Alive(RawAliveContractInfo {
 				trie_id: trie_id2.clone(),
-				storage_size: <Test as Trait>::StorageSizeOffset::get(),
+				storage_size: 0,
 				deduct_block: System::block_number(),
 				code_hash: H256::repeat_byte(2),
 				rent_allowance: 40,


### PR DESCRIPTION
This PR basically fixes two things:

This a long standing annoyance that `T::StorageOffsetSize` was assigned at a contract creation time. If we were to change this parameter it would have been a nightmare since we would have to alter each storage item. With this PR, the `storage_size` reflects the actual sum of all KV pairs and `T::StorageOffsetSize` is only accounted for during computing the fees for state rent.

Apart from that

Fixes #5107 
