### PR TITLE
Improve the log messages printed when a listener closes

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -488,7 +488,6 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 	}
 
 	fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
-		info!(target: "sub-libp2p", "📪 No longer listening on {}", addr);
 		for k in self.kademlias.values_mut() {
 			NetworkBehaviour::inject_expired_listen_addr(k, addr)
 		}

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -62,7 +62,7 @@ use libp2p::swarm::toggle::Toggle;
 #[cfg(not(target_os = "unknown"))]
 use libp2p::mdns::{Mdns, MdnsEvent};
 use libp2p::multiaddr::Protocol;
-use log::{debug, info, trace, warn, error};
+use log::{debug, info, trace, warn};
 use std::{cmp, collections::{HashMap, HashSet, VecDeque}, io, time::Duration};
 use std::task::{Context, Poll};
 use sp_core::hexdisplay::HexDisplay;
@@ -488,7 +488,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 	}
 
 	fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
-		info!(target: "sub-libp2p", "No longer listening on {}", addr);
+		info!(target: "sub-libp2p", "📪 No longer listening on {}", addr);
 		for k in self.kademlias.values_mut() {
 			NetworkBehaviour::inject_expired_listen_addr(k, addr)
 		}
@@ -507,14 +507,12 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 	}
 
 	fn inject_listener_error(&mut self, id: ListenerId, err: &(dyn std::error::Error + 'static)) {
-		error!(target: "sub-libp2p", "Error on libp2p listener {:?}: {}", id, err);
 		for k in self.kademlias.values_mut() {
 			NetworkBehaviour::inject_listener_error(k, id, err)
 		}
 	}
 
 	fn inject_listener_closed(&mut self, id: ListenerId, reason: Result<(), &io::Error>) {
-		error!(target: "sub-libp2p", "Libp2p listener {:?} closed", id);
 		for k in self.kademlias.values_mut() {
 			NetworkBehaviour::inject_listener_closed(k, id, reason)
 		}

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1281,9 +1281,22 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 					trace!(target: "sub-libp2p", "Libp2p => UnknownPeerUnreachableAddr({}): {}",
 						address, error),
 				Poll::Ready(SwarmEvent::ListenerClosed { reason, addresses }) => {
-					warn!(target: "sub-libp2p", "Libp2p => ListenerClosed: {:?}", reason);
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_local_addresses.sub(addresses.len() as u64);
+					}
+					let addrs = addresses.into_iter().map(|a| a.to_string())
+						.collect::<Vec<_>>().join(", ");
+					match reason {
+						Ok(()) => error!(
+							target: "sub-libp2p",
+							"📪 Libp2p listener ({}) closed gracefully",
+							addrs
+						),
+						Err(e) => error!(
+							target: "sub-libp2p",
+							"📪 Libp2p listener ({}) closed: {}",
+							addrs, e
+						),
 					}
 				},
 				Poll::Ready(SwarmEvent::ListenerError { error }) => {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1213,7 +1213,7 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 					}
 				},
 				Poll::Ready(SwarmEvent::ExpiredListenAddr(addr)) => {
-					trace!(target: "sub-libp2p", "Libp2p => ExpiredListenAddr({})", addr);
+					info!(target: "sub-libp2p", "📪 No longer listening on {}", addr);
 					if let Some(metrics) = this.metrics.as_ref() {
 						metrics.listeners_local_addresses.dec();
 					}


### PR DESCRIPTION
Right now we print something at two different places, so I removed the reporting from `discovery.rs`. These messages have nothing to do with the discovery mechanism, and were there purely because it was the most convenient place to them at the time.

This also improves the log message itself.