### PR TITLE
Make post dispatch fee consistent with a direct calculation

### DIFF
--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -272,14 +272,15 @@ pub struct PostDispatchInfo {
 impl PostDispatchInfo {
 	/// Calculate how much (if any) weight was not used by the `Dispatchable`.
 	pub fn calc_unspent(&self, info: &DispatchInfo) -> Weight {
+		info.weight - self.calc_actual_weight(info)
+	}
+
+	/// Calculate how much weight was actually spent by the `Dispatchable`.
+	pub fn calc_actual_weight(&self, info: &DispatchInfo) -> Weight {
 		if let Some(actual_weight) = self.actual_weight {
-			if actual_weight >= info.weight {
-				0
-			} else {
-				info.weight - actual_weight
-			}
+			actual_weight.min(info.weight)
 		} else {
-			0
+			info.weight
 		}
 	}
 }
@@ -287,9 +288,9 @@ impl PostDispatchInfo {
 /// Extract the actual weight from a dispatch result if any or fall back to the default weight.
 pub fn extract_actual_weight(result: &DispatchResultWithPostInfo, info: &DispatchInfo) -> Weight {
 	match result {
-		Ok(post_info) => &post_info.actual_weight,
-		Err(err) => &err.post_info.actual_weight,
-	}.unwrap_or_else(|| info.weight).min(info.weight)
+		Ok(post_info) => &post_info,
+		Err(err) => &err.post_info,
+	}.calc_actual_weight(info)
 }
 
 impl From<Option<Weight>> for PostDispatchInfo {

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -853,7 +853,7 @@ mod tests {
 			// 123 weight, 456 length, 100 base
 			// adjustable fee = (123 * 1) + (456 * 10) = 4683
 			// adjusted fee = 4683 - (4683 * -.5)  = 4683 - 2341.5 = 4683 - 2341 = 2342
-			// final fee = 100 + 2342 + 789 tip = 3239
+			// final fee = 100 + 2342 + 789 tip = 3231
 			assert_eq!(Module::<Runtime>::compute_fee(456, &dispatch_info, 789), 3231);
 		});
 	}
@@ -1000,10 +1000,16 @@ mod tests {
 				::post_dispatch(pre, &info, &post_info, len, &Ok(()))
 				.unwrap();
 
-			assert_eq!(
-				prev_balance - Balances::free_balance(2),
-				Module::<Runtime>::compute_actual_fee(len as u32, &info, &post_info, tip),
-			);
+			let refund_based_fee = prev_balance - Balances::free_balance(2);
+			let actual_fee = Module::<Runtime>
+				::compute_actual_fee(len as u32, &info, &post_info, tip);
+
+			// 33 weight, 10 length, 7 base
+			// adjustable fee = (33 * 1) + (10 * 1) = 43
+			// adjusted fee = 43 + (43 * .25)  = 43 + 10.75 = 43 + 10 = 53
+			// final fee = 7 + 53 + 5 tip = 65
+			assert_eq!(actual_fee, 65);
+			assert_eq!(refund_based_fee, actual_fee);
 		});
 	}
 }

--- a/primitives/arithmetic/src/lib.rs
+++ b/primitives/arithmetic/src/lib.rs
@@ -40,7 +40,7 @@ mod per_things;
 mod fixed;
 mod rational128;
 
-pub use fixed::{FixedPointNumber, Fixed64, Fixed128};
+pub use fixed::{FixedPointNumber, Fixed64, Fixed128, FixedPointOperand};
 pub use per_things::{PerThing, Percent, PerU16, Permill, Perbill, Perquintill};
 pub use rational128::Rational128;
 

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -72,7 +72,7 @@ pub use sp_core::RuntimeDebug;
 /// Re-export top-level arithmetic stuff.
 pub use sp_arithmetic::{
 	Perquintill, Perbill, Permill, Percent, PerU16, Rational128, Fixed64, Fixed128,
-	PerThing, traits::SaturatedConversion, FixedPointNumber,
+	PerThing, traits::SaturatedConversion, FixedPointNumber, FixedPointOperand,
 };
 /// Re-export 128 bit helpers.
 pub use sp_arithmetic::helpers_128bit;


### PR DESCRIPTION
Currently, the post dispatch fee refund is calculated as
```
refund = weight_to_fee(unspent_weight)
```

This means substrate calculates the actual_fee as
```
actual_fee = pre_dispatch_fee - weight_to_fee(unspent_weight)
```

Because of limited precision of the fixed point multiplication happening in `weight_to_fee` this is different from the desired :
```
actual_fee = weight_to_fee(actual_weight)
```

This PR fixes this disparity by calculating the refund in the following way:
```
refund = pre_dispatch_fee - weight_to_fee(actual_weight)
```

This problem became apparent when trying to [calculate the fee of an extrinsic off-chain](https://github.com/paritytech/substrate-api-sidecar/pull/50#pullrequestreview-419350084) as
```
fee = weight_to_fee(actual_weight)
```