### PR TITLE
Accept new Phragmén solutions if they are epsilon better + Better pre-inclusion checks.

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -320,9 +320,10 @@ parameter_types! {
 	pub const BondingDuration: pallet_staking::EraIndex = 24 * 28;
 	pub const SlashDeferDuration: pallet_staking::EraIndex = 24 * 7; // 1/4 the bonding duration.
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
-	pub const MaxIterations: u32 = 5;
+	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
+	pub const MaxIterations: u32 = 10;
+	pub SolutionImprovementThreshold: Perbill = Perbill::from_parts(Perbill::from_percent(1).deconstruct() / 10);
 }
 
 impl pallet_staking::Trait for Runtime {
@@ -344,6 +345,7 @@ impl pallet_staking::Trait for Runtime {
 	type ElectionLookahead = ElectionLookahead;
 	type Call = Call;
 	type MaxIterations = MaxIterations;
+	type SolutionImprovementThreshold = SolutionImprovementThreshold;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = StakingUnsignedPriority;
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -323,7 +323,8 @@ parameter_types! {
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const MaxIterations: u32 = 10;
-	pub SolutionImprovementThreshold: Perbill = Perbill::from_parts(Perbill::from_percent(1).deconstruct() / 10);
+	// 0.05%. The higher the value, the more strict solution acceptance becomes.
+	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
 }
 
 impl pallet_staking::Trait for Runtime {
@@ -345,7 +346,7 @@ impl pallet_staking::Trait for Runtime {
 	type ElectionLookahead = ElectionLookahead;
 	type Call = Call;
 	type MaxIterations = MaxIterations;
-	type SolutionImprovementThreshold = SolutionImprovementThreshold;
+	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = StakingUnsignedPriority;
 }

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -229,6 +229,7 @@ impl staking::Trait for Test {
 	type Call = Call;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
+	type SolutionImprovementThreshold = ();
 }
 
 parameter_types! {

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -229,7 +229,7 @@ impl staking::Trait for Test {
 	type Call = Call;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
-	type SolutionImprovementThreshold = ();
+	type MinSolutionScoreBump = ();
 }
 
 parameter_types! {

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -176,7 +176,7 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
 	type MaxIterations = ();
-	type SolutionImprovementThreshold = ();
+	type MinSolutionScoreBump = ();
 }
 
 impl pallet_im_online::Trait for Test {

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -176,6 +176,7 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
 	type MaxIterations = ();
+	type SolutionImprovementThreshold = ();
 }
 
 impl pallet_im_online::Trait for Test {

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -183,7 +183,7 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
 	type MaxIterations = ();
-	type SolutionImprovementThreshold = ();
+	type MinSolutionScoreBump = ();
 }
 
 impl crate::Trait for Test {}

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -183,6 +183,7 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
 	type MaxIterations = ();
+	type SolutionImprovementThreshold = ();
 }
 
 impl crate::Trait for Test {}

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -185,6 +185,7 @@ impl pallet_staking::Trait for Test {
 	type ElectionLookahead = ();
 	type Call = Call;
 	type MaxIterations = MaxIterations;
+	type SolutionImprovementThreshold = ();
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
 }

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -185,7 +185,7 @@ impl pallet_staking::Trait for Test {
 	type ElectionLookahead = ();
 	type Call = Call;
 	type MaxIterations = MaxIterations;
-	type SolutionImprovementThreshold = ();
+	type MinSolutionScoreBump = ();
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -891,6 +891,10 @@ pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// equalize will not be executed at all.
 	type MaxIterations: Get<u32>;
 
+	/// The threshold of improvement that should be provided for a new solution to be accepted.
+	// TODO: fancy a shorter name? my fingers do not like this.
+	type SolutionImprovementThreshold: Get<Perbill>;
+
 	/// The maximum number of nominator rewarded for each validator.
 	///
 	/// For each validator only the `$MaxNominatorRewardedPerValidator` biggest stakers can claim
@@ -2611,7 +2615,7 @@ impl<T: Trait> Module<T> {
 		// assume the given score is valid. Is it better than what we have on-chain, if we have any?
 		if let Some(queued_score) = Self::queued_score() {
 			ensure!(
-				is_score_better(queued_score, score),
+				is_score_better(score, queued_score, T::SolutionImprovementThreshold::get()),
 				Error::<T>::PhragmenWeakSubmission.with_weight(T::DbWeight::get().reads(3)),
 			)
 		}

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -286,7 +286,7 @@ parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const UnsignedPriority: u64 = 1 << 20;
-	pub const SolutionImprovementThreshold: Perbill = Perbill::zero();
+	pub const MinSolutionScoreBump: Perbill = Perbill::zero();
 }
 
 thread_local! {
@@ -322,7 +322,7 @@ impl Trait for Test {
 	type ElectionLookahead = ElectionLookahead;
 	type Call = Call;
 	type MaxIterations = MaxIterations;
-	type SolutionImprovementThreshold = SolutionImprovementThreshold;
+	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
 }
@@ -858,7 +858,7 @@ pub(crate) fn horrible_phragmen_with_post_processing(
 		assert!(sp_phragmen::is_score_better::<Perbill>(
 			better_score,
 			score,
-			SolutionImprovementThreshold::get(),
+			MinSolutionScoreBump::get(),
 		));
 
 		score

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -286,6 +286,7 @@ parameter_types! {
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &I_NPOS;
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const UnsignedPriority: u64 = 1 << 20;
+	pub const SolutionImprovementThreshold: Perbill = Perbill::zero();
 }
 
 thread_local! {
@@ -321,6 +322,7 @@ impl Trait for Test {
 	type ElectionLookahead = ElectionLookahead;
 	type Call = Call;
 	type MaxIterations = MaxIterations;
+	type SolutionImprovementThreshold = SolutionImprovementThreshold;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
 }
@@ -853,7 +855,11 @@ pub(crate) fn horrible_phragmen_with_post_processing(
 		let support = build_support_map::<AccountId>(&winners, &staked_assignment).0;
 		let score = evaluate_support(&support);
 
-		assert!(sp_phragmen::is_score_better(score, better_score));
+		assert!(sp_phragmen::is_score_better::<Perbill>(
+			better_score,
+			score,
+			SolutionImprovementThreshold::get(),
+		));
 
 		score
 	};

--- a/primitives/arithmetic/src/lib.rs
+++ b/primitives/arithmetic/src/lib.rs
@@ -41,7 +41,7 @@ mod fixed;
 mod rational128;
 
 pub use fixed::{FixedPointNumber, Fixed64, Fixed128, FixedPointOperand};
-pub use per_things::{PerThing, Percent, PerU16, Permill, Perbill, Perquintill};
+pub use per_things::{PerThing, InnerOf, Percent, PerU16, Permill, Perbill, Perquintill};
 pub use rational128::Rational128;
 
 use sp_std::cmp::Ordering;

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -25,6 +25,9 @@ use crate::traits::{
 };
 use sp_debug_derive::RuntimeDebug;
 
+/// Get the inner type of a `PerThing`.
+pub type InnerOf<P> = <P as PerThing>::Inner;
+
 /// Something that implements a fixed point ration with an arbitrary granularity `X`, as _parts per
 /// `X`_.
 pub trait PerThing:
@@ -312,8 +315,7 @@ macro_rules! implement_per_thing {
 		///
 		#[doc = $title]
 		#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-		#[derive(Encode, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord,
-				 RuntimeDebug, CompactAs)]
+		#[derive(Encode, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RuntimeDebug, CompactAs)]
 		pub struct $name($type);
 
 		impl PerThing for $name {
@@ -563,6 +565,12 @@ macro_rules! implement_per_thing {
 				let p = self.0;
 				let q = rhs.0;
 				Self::from_rational_approximation(p, q)
+			}
+		}
+
+		impl Default for $name {
+			fn default() -> Self {
+				<Self as PerThing>::zero()
 			}
 		}
 

--- a/primitives/phragmen/fuzzer/src/common.rs
+++ b/primitives/phragmen/fuzzer/src/common.rs
@@ -19,8 +19,8 @@
 
 /// converts x into the range [a, b] in a pseudo-fair way.
 pub fn to_range(x: usize, a: usize, b: usize) -> usize {
-	// does not work correctly if b < 2*a
-	assert!(b > 2 * a);
+	// does not work correctly if b < 2 * a
+	assert!(b >= 2 * a);
 	let collapsed = x % b;
 	if collapsed >= a {
 		collapsed

--- a/primitives/phragmen/fuzzer/src/equalize.rs
+++ b/primitives/phragmen/fuzzer/src/equalize.rs
@@ -131,7 +131,7 @@ fn main() {
 				return;
 			}
 
-			let enhance = is_score_better(initial_score, final_score);
+			let enhance = is_score_better(final_score, initial_score, Perbill::zero());
 
 			println!(
 				"iter = {} // {:?} -> {:?} [{}]",
@@ -140,6 +140,7 @@ fn main() {
 				final_score,
 				enhance,
 			);
+
 			// if more than one iteration has been done, or they must be equal.
 			assert!(enhance || initial_score == final_score || i == 0)
 		});

--- a/primitives/phragmen/src/lib.rs
+++ b/primitives/phragmen/src/lib.rs
@@ -36,7 +36,7 @@
 
 use sp_std::{prelude::*, collections::btree_map::BTreeMap, fmt::Debug, cmp::Ordering, convert::TryFrom};
 use sp_arithmetic::{
-	PerThing, Rational128, EpsilonOrd,
+	PerThing, Rational128, ThresholdOrd,
 	helpers_128bit::multiply_by_rational,
 	traits::{Zero, Saturating, Bounded, SaturatedConversion},
 };
@@ -627,7 +627,10 @@ pub fn is_score_better<P: PerThing>(this: PhragmenScore, that: PhragmenScore, ep
 	match this
 		.iter()
 		.enumerate()
-		.map(|(i, e)| (e.ge(&that[i]), e.ecmp(&that[i], epsilon)))
+		.map(|(i, e)| (
+			e.ge(&that[i]),
+			e.tcmp(&that[i], epsilon.mul_ceil(that[i])),
+		))
 		.collect::<Vec<(bool, Ordering)>>()
 		.as_slice()
 	{

--- a/primitives/phragmen/src/lib.rs
+++ b/primitives/phragmen/src/lib.rs
@@ -36,7 +36,7 @@
 
 use sp_std::{prelude::*, collections::btree_map::BTreeMap, fmt::Debug, cmp::Ordering, convert::TryFrom};
 use sp_arithmetic::{
-	PerThing, Rational128,
+	PerThing, Rational128, EpsilonOrd,
 	helpers_128bit::multiply_by_rational,
 	traits::{Zero, Saturating, Bounded, SaturatedConversion},
 };
@@ -614,23 +614,33 @@ pub fn evaluate_support<AccountId>(
 	[min_support, sum, sum_squared]
 }
 
-/// Compares two sets of phragmen scores based on desirability and returns true if `that` is
-/// better than `this`.
+/// Compares two sets of phragmen scores based on desirability and returns true if `this` is
+/// better than `that`.
 ///
-/// Evaluation is done in a lexicographic manner.
+/// Evaluation is done in a lexicographic manner, and if each element of `this` is `that * epsilon`
+/// greater or less than `that`.
 ///
 /// Note that the third component should be minimized.
-pub fn is_score_better(this: PhragmenScore, that: PhragmenScore) -> bool {
-	match that
+pub fn is_score_better<P: PerThing>(this: PhragmenScore, that: PhragmenScore, epsilon: P) -> bool
+	where ExtendedBalance: From<sp_arithmetic::InnerOf<P>>
+{
+	match this
 		.iter()
 		.enumerate()
-		.map(|(i, e)| e.cmp(&this[i]))
-		.collect::<Vec<Ordering>>()
+		.map(|(i, e)| (e.ge(&that[i]), e.ecmp(&that[i], epsilon)))
+		.collect::<Vec<(bool, Ordering)>>()
 		.as_slice()
 	{
-		[Ordering::Greater, _, _] => true,
-		[Ordering::Equal, Ordering::Greater, _] => true,
-		[Ordering::Equal, Ordering::Equal, Ordering::Less] => true,
+		// epsilon better in the score[0], accept.
+		[(_, Ordering::Greater), _, _] => true,
+
+		// less than epsilon better in score[0], but more than epsilon better in the second.
+		[(true, Ordering::Equal), (_, Ordering::Greater), _] => true,
+
+		// less than epsilon better in score[0, 1], but more than epsilon better in the third
+		[(true, Ordering::Equal), (true, Ordering::Equal), (_, Ordering::Less)] => true,
+
+		// anything else is not a good score.
 		_ => false,
 	}
 }

--- a/primitives/phragmen/src/reduce.rs
+++ b/primitives/phragmen/src/reduce.rs
@@ -640,8 +640,8 @@ fn reduce_all<A: IdentifierT>(assignments: &mut Vec<StakedAssignment<A>>) -> u32
 	num_changed
 }
 
-/// Reduce the given [`Vec<StakedAssignment<IdentifierT>>`]. This removes redundant edges from without changing the
-/// overall backing of any of the elected candidates.
+/// Reduce the given [`Vec<StakedAssignment<IdentifierT>>`]. This removes redundant edges from
+/// without changing the overall backing of any of the elected candidates.
 ///
 /// Returns the number of edges removed.
 ///

--- a/primitives/phragmen/src/tests.rs
+++ b/primitives/phragmen/src/tests.rs
@@ -616,30 +616,101 @@ fn assignment_convert_works() {
 }
 
 #[test]
-fn score_comparison_is_lexicographical() {
+fn score_comparison_is_lexicographical_no_epsilon() {
+	let epsilon = Perbill::zero();
 	// only better in the fist parameter, worse in the other two ✅
 	assert_eq!(
-		is_score_better([10, 20, 30], [12, 10, 35]),
+		is_score_better([12, 10, 35], [10, 20, 30], epsilon),
 		true,
 	);
 
 	// worse in the first, better in the other two ❌
 	assert_eq!(
-		is_score_better([10, 20, 30], [9, 30, 10]),
+		is_score_better([9, 30, 10], [10, 20, 30], epsilon),
 		false,
 	);
 
 	// equal in the first, the second one dictates.
 	assert_eq!(
-		is_score_better([10, 20, 30], [10, 25, 40]),
+		is_score_better([10, 25, 40], [10, 20, 30], epsilon),
 		true,
 	);
 
 	// equal in the first two, the last one dictates.
 	assert_eq!(
-		is_score_better([10, 20, 30], [10, 20, 40]),
+		is_score_better([10, 20, 40], [10, 20, 30], epsilon),
 		false,
 	);
+}
+
+#[test]
+fn score_comparison_with_epsilon() {
+	let epsilon = Perbill::from_percent(1);
+
+	{
+		// no more than 1 percent (10) better in the first param.
+		assert_eq!(
+			is_score_better([1009, 5000, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		// now equal, still not better.
+		assert_eq!(
+			is_score_better([1010, 5000, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		// now it is.
+		assert_eq!(
+			is_score_better([1011, 5000, 100000], [1000, 5000, 100000], epsilon),
+			true,
+		);
+	}
+
+	{
+		// First score score is epsilon better, but first score is no longer `ge`. Then this is
+		// still not a good solution.
+		assert_eq!(
+			is_score_better([999, 6000, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+	}
+
+	{
+		// first score is equal or better, but not epsilon. Then second one is the determinant.
+		assert_eq!(
+			is_score_better([1005, 5000, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		assert_eq!(
+			is_score_better([1005, 5050, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		assert_eq!(
+			is_score_better([1005, 5051, 100000], [1000, 5000, 100000], epsilon),
+			true,
+		);
+	}
+
+	{
+		// first score and second are equal or less than epsilon more, third is determinant.
+		assert_eq!(
+			is_score_better([1005, 5025, 100000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		assert_eq!(
+			is_score_better([1005, 5025, 99_000], [1000, 5000, 100000], epsilon),
+			false,
+		);
+
+		assert_eq!(
+			is_score_better([1005, 5025, 98_999], [1000, 5000, 100000], epsilon),
+			true,
+		);
+	}
 }
 
 mod compact {

--- a/primitives/phragmen/src/tests.rs
+++ b/primitives/phragmen/src/tests.rs
@@ -713,6 +713,60 @@ fn score_comparison_with_epsilon() {
 	}
 }
 
+#[test]
+fn score_comparison_large_value() {
+	// some random value taken from eras in kusama.
+	let initial = [12488167277027543u128, 5559266368032409496, 118749283262079244270992278287436446];
+	// this claim is 0.04090% better in the third component. It should be accepted as better if
+	// epsilon is smaller than 5/10_0000
+	let claim = [12488167277027543u128, 5559266368032409496, 118700736389524721358337889258988054];
+
+	assert_eq!(
+		is_score_better(
+			claim.clone(),
+			initial.clone(),
+			Perbill::from_rational_approximation(1u32, 10_000),
+		),
+		true,
+	);
+
+	assert_eq!(
+		is_score_better(
+			claim.clone(),
+			initial.clone(),
+			Perbill::from_rational_approximation(2u32, 10_000),
+		),
+		true,
+	);
+
+	assert_eq!(
+		is_score_better(
+			claim.clone(),
+			initial.clone(),
+			Perbill::from_rational_approximation(3u32, 10_000),
+		),
+		true,
+	);
+
+	assert_eq!(
+		is_score_better(
+			claim.clone(),
+			initial.clone(),
+			Perbill::from_rational_approximation(4u32, 10_000),
+		),
+		true,
+	);
+
+	assert_eq!(
+		is_score_better(
+			claim.clone(),
+			initial.clone(),
+			Perbill::from_rational_approximation(5u32, 10_000),
+		),
+		false,
+	);
+}
+
 mod compact {
 	use codec::{Decode, Encode};
 	use crate::{generate_compact_solution_type, VoteWeight};


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/6106

- [x] Part1: Only accept solutions that are epsilon better. See the new `EpsilonOrd` trait tests and tests for `is_solution_better` for more detail. I also swapped the order of operands of this function to make it better. 

- [x] Fix `pre_dispatch` as explained [here](https://github.com/paritytech/substrate/issues/6106#issuecomment-633958783).

- companion: https://github.com/paritytech/polkadot/pull/1184