### PR TITLE
Make `Proposer` consume its reference on `propose`

### DIFF
--- a/client/basic-authorship/src/lib.rs
+++ b/client/basic-authorship/src/lib.rs
@@ -38,7 +38,7 @@
 //! );
 //!
 //! // The proposer is created asynchronously.
-//! let mut proposer = futures::executor::block_on(proposer).unwrap();
+//! let proposer = futures::executor::block_on(proposer).unwrap();
 //!
 //! // This `Proposer` allows us to create a block proposition.
 //! // The proposer will grab transactions from the transaction pool, and put them into the block.

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -904,7 +904,7 @@ mod tests {
 		type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction>, Error>>;
 
 		fn propose(
-			&mut self,
+			self,
 			_: InherentData,
 			digests: DigestFor<TestBlock>,
 			_: Duration,

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -159,7 +159,7 @@ impl Proposer<TestBlock> for DummyProposer {
 	type Proposal = future::Ready<Result<Proposal<TestBlock, Self::Transaction>, Error>>;
 
 	fn propose(
-		&mut self,
+		mut self,
 		_: InherentData,
 		pre_digests: DigestFor<TestBlock>,
 		_: Duration,

--- a/client/consensus/manual-seal/src/seal_new_block.rs
+++ b/client/consensus/manual-seal/src/seal_new_block.rs
@@ -108,7 +108,7 @@ pub async fn seal_new_block<B, SC, HB, E, T, P>(
 			None => select_chain.best_chain()?
 		};
 
-		let mut proposer = env.init(&header)
+		let proposer = env.init(&header)
 			.map_err(|err| Error::StringError(format!("{}", err))).await?;
 		let id = inherent_data_provider.create_inherent_data()?;
 		let inherents_len = id.len();

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -610,7 +610,7 @@ fn mine_loop<B: BlockT, C, Algorithm, E, SO, S, CAW>(
 			continue 'outer
 		}
 
-		let mut proposer = futures::executor::block_on(env.init(&best_header))
+		let proposer = futures::executor::block_on(env.init(&best_header))
 			.map_err(|e| Error::Environment(format!("{:?}", e)))?;
 
 		let inherent_data = inherent_data_providers

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -239,7 +239,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 		let logs = self.pre_digest_data(slot_number, &claim);
 
 		// deadline our production to approx. the end of the slot
-		let proposing = awaiting_proposer.and_then(move |mut proposer| proposer.propose(
+		let proposing = awaiting_proposer.and_then(move |proposer| proposer.propose(
 			slot_info.inherent_data,
 			sp_runtime::generic::Digest {
 				logs,

--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -157,7 +157,7 @@ pub trait Proposer<B: BlockT> {
 	///
 	/// Returns a future that resolves to a [`Proposal`] or to [`Error`].
 	fn propose(
-		&mut self,
+		self,
 		inherent_data: InherentData,
 		inherent_digests: DigestFor<B>,
 		max_duration: Duration,


### PR DESCRIPTION
A proposer must be created per new round, so it makes sense to have the
proposer consume its own reference.
