### PR TITLE
impl FindAuthor<T::AuthorityId> for Aura

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -162,6 +162,9 @@ impl<T: Trait> FindAuthor<u32> for Module<T> {
 	}
 }
 
+/// We can not implement `FindAuthor` twice, because the compiler does not know if 
+/// `u32 == T::AuthorityId` and thus, prevents us to implement the trait twice.
+#[doc(hidden)]
 pub struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
 
 impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -145,6 +145,7 @@ impl<T: Trait> pallet_session::OneSessionHandler<T::AccountId> for Module<T> {
 	}
 }
 
+/// Find the index of the Aura authority who authored the current block.
 impl<T: Trait> FindAuthor<u32> for Module<T> {
 	fn find_author<'a, I>(digests: I) -> Option<u32> where
 		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
@@ -162,10 +163,7 @@ impl<T: Trait> FindAuthor<u32> for Module<T> {
 	}
 }
 
-/// Wraps the author-scraping logic for consensus engines that can recover
-/// the canonical index of an author. This then transforms it into the
-/// actual Aura authority Id
-pub struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
+struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
 
 impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>
 	for FindAccountFromAuthorIndex<T, Inner>
@@ -180,6 +178,7 @@ impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>
 	}
 }
 
+/// Find the authority ID of the Aura authority who authored the current block.
 pub type AuraAuthorId<T> = FindAccountFromAuthorIndex<T, Module<T>>;
 
 impl<T: Trait> IsMember<T::AuthorityId> for Module<T> {

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -163,7 +163,7 @@ impl<T: Trait> FindAuthor<u32> for Module<T> {
 	}
 }
 
-struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
+pub struct FindAccountFromAuthorIndex<T, Inner>(sp_std::marker::PhantomData<(T, Inner)>);
 
 impl<T: Trait, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>
 	for FindAccountFromAuthorIndex<T, Inner>

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -145,7 +145,6 @@ impl<T: Trait> pallet_session::OneSessionHandler<T::AccountId> for Module<T> {
 	}
 }
 
-/// Find the index of the Aura authority who authored the current block.
 impl<T: Trait> FindAuthor<u32> for Module<T> {
 	fn find_author<'a, I>(digests: I) -> Option<u32> where
 		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -145,15 +145,32 @@ impl<T: Trait> pallet_session::OneSessionHandler<T::AccountId> for Module<T> {
 	}
 }
 
-impl<T: Trait> FindAuthor<u32> for Module<T> {
-	fn find_author<'a, I>(digests: I) -> Option<u32> where
+// impl<T: Trait> FindAuthor<u32> for Module<T> {
+// 	fn find_author<'a, I>(digests: I) -> Option<u32> where
+// 		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
+// 	{
+// 		for (id, mut data) in digests.into_iter() {
+// 			if id == AURA_ENGINE_ID {
+// 				if let Ok(slot_num) = u64::decode(&mut data) {
+// 					let author_index = slot_num % Self::authorities().len() as u64;
+// 					return Some(author_index as u32)
+// 				}
+// 			}
+// 		}
+//
+// 		None
+// 	}
+// }
+
+impl<T: Trait> FindAuthor<T::AuthorityId> for Module<T> {
+	fn find_author<'a, I>(digests: I) -> Option<T::AuthorityId> where
 		I: 'a + IntoIterator<Item=(ConsensusEngineId, &'a [u8])>
 	{
 		for (id, mut data) in digests.into_iter() {
 			if id == AURA_ENGINE_ID {
 				if let Ok(slot_num) = u64::decode(&mut data) {
 					let author_index = slot_num % Self::authorities().len() as u64;
-					return Some(author_index as u32)
+					return Some(Self::authorities()[author_index as usize].clone())
 				}
 			}
 		}


### PR DESCRIPTION
Users of the node template and other devhub products occasionally ask, "How can I reward the authority who authored a block?". (e.g. [here](https://github.com/substrate-developer-hub/substrate-node-template/issues/51))

The standard answer is to look a the [`FindAuthor` trait](https://crates.parity.io/frame_support/traits/trait.FindAuthor.html) and the [Authorship pallet](https://crates.parity.io/pallet_authorship/index.html). The only problem is that Aura (and Babe) only implement `FindAuthor<u32>` which returns a validator _index_ rather than an account id that can receive a token reward. In the `bin/node` this [gap is filled](https://github.com/paritytech/substrate/blob/4c29f1ce5b2ca0fe21f24e3dffe4763ced32cab5/bin/node/runtime/src/lib.rs#L271) by requesting the session pallet to convert the index to an actual account Id. But in chains that do not use the session pallet (e.g. the node template) users are stuck.

**This PR adds a `pub type AuraAuthorId<T>` that implements `FindAuthor<T::AuthorityId>`.**

This was not as straightforward as I initially expected, and I would appreciate feedback on my design. I had initially hoped that just add a `impl<T: Trait> FindAuthor<T::AuthorityId> for Module<T>`, but this implementation conflicted with the existing `impl<T: Trait> FindAuthor<u32> for Module<T>` for reasons that I do not fully understand.