### PR TITLE
Fix Rustdoc Build

### DIFF
--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -222,7 +222,7 @@ impl CloneableSpawn for TaskExecutor {
 impl BenchDb {
 	/// New immutable benchmarking database.
 	///
-	/// See [`new`] method documentation for more information about the purpose
+	/// See [`BenchDb::new`] method documentation for more information about the purpose
 	/// of this structure.
 	pub fn with_key_types(
 		database_type: DatabaseType,

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -165,9 +165,9 @@ pub trait SubstrateCli: Sized {
 	/// Print the error message and quit the program in case of failure.
 	///
 	/// **NOTE:** This method WILL NOT exit when `--help` or `--version` (or short versions) are
-	/// used. It will return a [`clap::Error`], where the [`kind`] is a
-	/// [`ErrorKind::HelpDisplayed`] or [`ErrorKind::VersionDisplayed`] respectively. You must call
-	/// [`Error::exit`] or perform a [`std::process::exit`].
+	/// used. It will return a [`clap::Error`], where the [`clap::Error::kind`] is a
+	/// [`clap::ErrorKind::HelpDisplayed`] or [`clap::ErrorKind::VersionDisplayed`] respectively.
+	/// You must call [`clap::Error::exit`] or perform a [`std::process::exit`].
 	fn try_from_iter<I>(iter: I) -> clap::Result<Self>
 	where
 		Self: StructOpt + Sized,

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -20,7 +20,6 @@
 //! time during which certain events can and/or must occur.  This crate
 //! provides generic functionality for slots.
 
-#![deny(warnings)]
 #![forbid(unsafe_code, missing_docs)]
 
 mod slots;

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -219,7 +219,7 @@ pub trait SessionHandler<ValidatorId> {
 	/// All the key type ids this session handler can process.
 	///
 	/// The order must be the same as it expects them in
-	/// [`on_new_session`](Self::on_new_session) and [`on_genesis_session`](Self::on_genesis_session).
+	/// [`on_new_session`](Self::on_new_session<Ks>) and [`on_genesis_session`](Self::on_genesis_session<Ks>).
 	const KEY_TYPE_IDS: &'static [KeyTypeId];
 
 	/// The given validator set will be used for the genesis session.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -108,7 +108,7 @@
 //! Rewards must be claimed for each era before it gets too old by `$HISTORY_DEPTH` using the
 //! `payout_stakers` call. Any account can call `payout_stakers`, which pays the reward to
 //! the validator as well as its nominators.
-//! Only the [`T::MaxNominatorRewardedPerValidator`] biggest stakers can claim their reward. This
+//! Only the [`Trait::MaxNominatorRewardedPerValidator`] biggest stakers can claim their reward. This
 //! is to limit the i/o cost to mutate storage for each nominator's account.
 //!
 //! Slashing can occur at any point in time, once misbehavior is reported. Once slashing is

--- a/primitives/runtime/src/offchain/storage_lock.rs
+++ b/primitives/runtime/src/offchain/storage_lock.rs
@@ -241,7 +241,7 @@ impl<B: BlockNumberProvider> Lockable for BlockAndTime<B> {
 ///
 /// A lock that is persisted in the DB and provides the ability to guard against
 /// concurrent access in an off-chain worker, with a defined expiry deadline
-/// based on the concrete [`Lockable`](Self::Lockable) implementation.
+/// based on the concrete [`Lockable`](Lockable) implementation.
 pub struct StorageLock<'a, L = Time> {
 	// A storage value ref which defines the DB entry representing the lock.
 	value_ref: StorageValueRef<'a>,
@@ -396,7 +396,7 @@ where
 }
 
 /// Bound for a block number source
-/// used with [`BlockAndTime<BlockNumberProvider>`](Self::BlockAndTime).
+/// used with [`BlockAndTime<BlockNumberProvider>`](BlockAndTime).
 pub trait BlockNumberProvider {
 	/// Type of `BlockNumber` to provide.
 	type BlockNumber: Codec + Clone + Ord + Eq + AtLeast32Bit;


### PR DESCRIPTION
Closes #6206
Note that there are still many warnings appearing, but they all emanate from the `async-std-1.5.0` dependency.