### PR TITLE
Remove ReportHandle

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -285,26 +285,6 @@ pub trait ExHashT: std::hash::Hash + Eq + std::fmt::Debug + Clone + Send + Sync 
 impl<T> ExHashT for T where T: std::hash::Hash + Eq + std::fmt::Debug + Clone + Send + Sync + 'static
 {}
 
-/// A cloneable handle for reporting cost/benefits of peers.
-#[derive(Clone)]
-pub struct ReportHandle {
-	inner: sc_peerset::PeersetHandle, // wraps it so we don't have to worry about breaking API.
-}
-
-impl From<sc_peerset::PeersetHandle> for ReportHandle {
-	fn from(peerset_handle: sc_peerset::PeersetHandle) -> Self {
-		ReportHandle { inner: peerset_handle }
-	}
-}
-
-impl ReportHandle {
-	/// Report a given peer as either beneficial (+) or costly (-) according to the
-	/// given scalar.
-	pub fn report_peer(&self, who: PeerId, cost_benefit: ReputationChange) {
-		self.inner.report_peer(who, cost_benefit);
-	}
-}
-
 /// Trait for providing information about the local network state
 pub trait NetworkStateInfo {
 	/// Returns the local external addresses.


### PR DESCRIPTION
Nothing in Substrate and Polkadot uses this type, and we also don't create it anywhere, which means it's unusable anyway. It's both unusable and unused.