### PR TITLE
Make dev profile faster by compiling deps with opt-level=3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,6 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.snow]
 opt-level = 3
-[profile.dev.package.soketto]
-opt-level = 3
 [profile.dev.package.twox-hash]
 opt-level = 3
 [profile.dev.package.uint]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,114 +195,61 @@ members = [
 # probably concerns this list.
 #
 # This list is ordered alphabetically.
-[profile.dev.package.aes-ctr]
-opt-level = 3
-[profile.dev.package.aes-soft]
-opt-level = 3
-[profile.dev.package.aesni]
-opt-level = 3
-[profile.dev.package.blake2]
-opt-level = 3
-[profile.dev.package.blake2-rfc]
-opt-level = 3
-[profile.dev.package.blake2b_simd]
-opt-level = 3
-[profile.dev.package.blake2s_simd]
-opt-level = 3
-[profile.dev.package.chacha20-poly1305-aead]
-opt-level = 3
-[profile.dev.package.cranelift-codegen]
-opt-level = 3
-[profile.dev.package.cranelift-wasm]
-opt-level = 3
-[profile.dev.package.crc32fast]
-opt-level = 3
-[profile.dev.package.crossbeam-deque]
-opt-level = 3
-[profile.dev.package.crossbeam-queue]
-opt-level = 3
-[profile.dev.package.crypto-mac]
-opt-level = 3
-[profile.dev.package.ctr]
-opt-level = 3
-[profile.dev.package.cuckoofilter]
-opt-level = 3
-[profile.dev.package.curve25519-dalek]
-opt-level = 3
-[profile.dev.package.ed25519-dalek]
-opt-level = 3
-[profile.dev.package.evm-core]
-opt-level = 3
-[profile.dev.package.evm-runtime]
-opt-level = 3
-[profile.dev.package.flate2]
-opt-level = 3
-[profile.dev.package.futures-channel]
-opt-level = 3
-[profile.dev.package.hashbrown]
-opt-level = 3
-[profile.dev.package.h2]
-opt-level = 3
-[profile.dev.package.hash-db]
-opt-level = 3
-[profile.dev.package.hmac]
-opt-level = 3
-[profile.dev.package.httparse]
-opt-level = 3
-[profile.dev.package.integer-sqrt]
-opt-level = 3
-[profile.dev.package.keccak]
-opt-level = 3
-[profile.dev.package.libm]
-opt-level = 3
-[profile.dev.package.librocksdb-sys]
-opt-level = 3
-[profile.dev.package.libsecp256k1]
-opt-level = 3
-[profile.dev.package.libz-sys]
-opt-level = 3
-[profile.dev.package.mio]
-opt-level = 3
-[profile.dev.package.nalgebra]
-opt-level = 3
-[profile.dev.package.num-bigint]
-opt-level = 3
-[profile.dev.package.parking_lot]
-opt-level = 3
-[profile.dev.package.parking_lot_core]
-opt-level = 3
-[profile.dev.package.percent-encoding]
-opt-level = 3
-[profile.dev.package.primitive-types]
-opt-level = 3
-[profile.dev.package.ring]
-opt-level = 3
-[profile.dev.package.rustls]
-opt-level = 3
-[profile.dev.package.salsa20]
-opt-level = 3
-[profile.dev.package.salsa20-core]
-opt-level = 3
-[profile.dev.package.sha2]
-opt-level = 3
-[profile.dev.package.sha3]
-opt-level = 3
-[profile.dev.package.smallvec]
-opt-level = 3
-[profile.dev.package.snow]
-opt-level = 3
-[profile.dev.package.twox-hash]
-opt-level = 3
-[profile.dev.package.uint]
-opt-level = 3
-[profile.dev.package.wasmi]
-opt-level = 3
-[profile.dev.package.x25519-dalek]
-opt-level = 3
-[profile.dev.package.yamux]
-opt-level = 3
-[profile.dev.package.zeroize]
-opt-level = 3
+[profile.dev.package]
+aes-ctr = { opt-level = 3 }
+aes-soft = { opt-level = 3 }
+aesni = { opt-level = 3 }
+blake2 = { opt-level = 3 }
+blake2-rfc = { opt-level = 3 }
+blake2b_simd = { opt-level = 3 }
+blake2s_simd = { opt-level = 3 }
+chacha20-poly1305-aead = { opt-level = 3 }
+cranelift-codegen = { opt-level = 3 }
+cranelift-wasm = { opt-level = 3 }
+crc32fast = { opt-level = 3 }
+crossbeam-deque = { opt-level = 3 }
+crossbeam-queue = { opt-level = 3 }
+crypto-mac = { opt-level = 3 }
+ctr = { opt-level = 3 }
+cuckoofilter = { opt-level = 3 }
+curve25519-dalek = { opt-level = 3 }
+ed25519-dalek = { opt-level = 3 }
+evm-core = { opt-level = 3 }
+evm-runtime = { opt-level = 3 }
+flate2 = { opt-level = 3 }
+futures-channel = { opt-level = 3 }
+hashbrown = { opt-level = 3 }
+h2 = { opt-level = 3 }
+hash-db = { opt-level = 3 }
+hmac = { opt-level = 3 }
+httparse = { opt-level = 3 }
+integer-sqrt = { opt-level = 3 }
+keccak = { opt-level = 3 }
+libm = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
+libsecp256k1 = { opt-level = 3 }
+libz-sys = { opt-level = 3 }
+mio = { opt-level = 3 }
+nalgebra = { opt-level = 3 }
+num-bigint = { opt-level = 3 }
+parking_lot = { opt-level = 3 }
+parking_lot_core = { opt-level = 3 }
+percent-encoding = { opt-level = 3 }
+primitive-types = { opt-level = 3 }
+ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
+salsa20 = { opt-level = 3 }
+salsa20-core = { opt-level = 3 }
+sha2 = { opt-level = 3 }
+sha3 = { opt-level = 3 }
+smallvec = { opt-level = 3 }
+snow = { opt-level = 3 }
+twox-hash = { opt-level = 3 }
+uint = { opt-level = 3 }
+wasmi = { opt-level = 3 }
+x25519-dalek = { opt-level = 3 }
+yamux = { opt-level = 3 }
+zeroize = { opt-level = 3 }
 
 [profile.release]
 # Substrate runtime requires unwinding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,10 +181,10 @@ members = [
 ]
 
 # The list of dependencies below (which can be both direct and indirect dependencies) are crates
-# that do that are suspected to be CPU-intensive and that are unlikely to require debugging (as
-# some of their debug info might be missing) or to require to be frequently recompiled. We compile
-# these dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more
-# usable.
+# that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of
+# their debug info might be missing) or to require to be frequently recompiled. We compile these
+# dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more usable.
+# The majority of these crates are cryptographic libraries.
 #
 # Note that this does **not** affect crates that depend on Substrate. In other words, if you add
 # a dependency on Substrate, you have to copy-paste this list in your own `Cargo.toml` (assuming

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,127 @@ members = [
 	"utils/wasm-builder",
 ]
 
+# The list of dependencies below (which can be both direct and indirect dependencies) are crates
+# that do that are suspected to be CPU-intensive and that are unlikely to require debugging (as
+# some of their debug info might be missing) or to require to be frequently recompiled. We compile
+# these dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more
+# usable.
+#
+# If you see an error mentioning "profile package spec ... did not match any packages", it
+# probably concerns this list.
+#
+# Note: this list is ordered alphabetically.
+[profile.dev.package.aes-ctr]
+opt-level = 3
+[profile.dev.package.aes-soft]
+opt-level = 3
+[profile.dev.package.aesni]
+opt-level = 3
+[profile.dev.package.blake2]
+opt-level = 3
+[profile.dev.package.blake2-rfc]
+opt-level = 3
+[profile.dev.package.blake2b_simd]
+opt-level = 3
+[profile.dev.package.blake2s_simd]
+opt-level = 3
+[profile.dev.package.chacha20-poly1305-aead]
+opt-level = 3
+[profile.dev.package.cranelift-codegen]
+opt-level = 3
+[profile.dev.package.cranelift-wasm]
+opt-level = 3
+[profile.dev.package.crc32fast]
+opt-level = 3
+[profile.dev.package.crossbeam-deque]
+opt-level = 3
+[profile.dev.package.crossbeam-queue]
+opt-level = 3
+[profile.dev.package.crypto-mac]
+opt-level = 3
+[profile.dev.package.ctr]
+opt-level = 3
+[profile.dev.package.cuckoofilter]
+opt-level = 3
+[profile.dev.package.curve25519-dalek]
+opt-level = 3
+[profile.dev.package.ed25519-dalek]
+opt-level = 3
+[profile.dev.package.evm-core]
+opt-level = 3
+[profile.dev.package.evm-runtime]
+opt-level = 3
+[profile.dev.package.flate2]
+opt-level = 3
+[profile.dev.package.futures-channel]
+opt-level = 3
+[profile.dev.package.hashbrown]
+opt-level = 3
+[profile.dev.package.h2]
+opt-level = 3
+[profile.dev.package.hash-db]
+opt-level = 3
+[profile.dev.package.hmac]
+opt-level = 3
+[profile.dev.package.httparse]
+opt-level = 3
+[profile.dev.package.integer-sqrt]
+opt-level = 3
+[profile.dev.package.keccak]
+opt-level = 3
+[profile.dev.package.libm]
+opt-level = 3
+[profile.dev.package.librocksdb-sys]
+opt-level = 3
+[profile.dev.package.libsecp256k1]
+opt-level = 3
+[profile.dev.package.libz-sys]
+opt-level = 3
+[profile.dev.package.mio]
+opt-level = 3
+[profile.dev.package.nalgebra]
+opt-level = 3
+[profile.dev.package.num-bigint]
+opt-level = 3
+[profile.dev.package.parking_lot]
+opt-level = 3
+[profile.dev.package.parking_lot_core]
+opt-level = 3
+[profile.dev.package.percent-encoding]
+opt-level = 3
+[profile.dev.package.primitive-types]
+opt-level = 3
+[profile.dev.package.ring]
+opt-level = 3
+[profile.dev.package.rustls]
+opt-level = 3
+[profile.dev.package.salsa20]
+opt-level = 3
+[profile.dev.package.salsa20-core]
+opt-level = 3
+[profile.dev.package.sha2]
+opt-level = 3
+[profile.dev.package.sha3]
+opt-level = 3
+[profile.dev.package.smallvec]
+opt-level = 3
+[profile.dev.package.snow]
+opt-level = 3
+[profile.dev.package.soketto]
+opt-level = 3
+[profile.dev.package.twox-hash]
+opt-level = 3
+[profile.dev.package.uint]
+opt-level = 3
+[profile.dev.package.wasmi]
+opt-level = 3
+[profile.dev.package.x25519-dalek]
+opt-level = 3
+[profile.dev.package.yamux]
+opt-level = 3
+[profile.dev.package.zeroize]
+opt-level = 3
+
 [profile.release]
 # Substrate runtime requires unwinding.
 panic = "unwind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,10 +186,15 @@ members = [
 # these dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more
 # usable.
 #
+# Note that this does **not** affect crates that depend on Substrate. In other words, if you add
+# a dependency on Substrate, you have to copy-paste this list in your own `Cargo.toml` (assuming
+# that you want the same list). This list is only relevant when running `cargo build` from within
+# the Substrate workspace.
+#
 # If you see an error mentioning "profile package spec ... did not match any packages", it
 # probably concerns this list.
 #
-# Note: this list is ordered alphabetically.
+# This list is ordered alphabetically.
 [profile.dev.package.aes-ctr]
 opt-level = 3
 [profile.dev.package.aes-soft]


### PR DESCRIPTION
As the code explains it, this is a list of dependencies that we compile with `opt-level=3` when doing a plain `cargo build`.
