### PR TITLE
Use number of downloaded blocks for test

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -533,9 +533,9 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		self.sync.status().queued_blocks
 	}
 
-	/// Number of processed blocks.
-	pub fn num_processed_blocks(&self) -> usize {
-		self.sync.num_processed_blocks()
+	/// Number of downloaded blocks.
+	pub fn num_downloaded_blocks(&self) -> usize {
+		self.sync.num_downloaded_blocks()
 	}
 
 	/// Number of active sync requests.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -390,9 +390,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		self.network_service.user_protocol().num_queued_blocks()
 	}
 
-	/// Returns the number of processed blocks.
-	pub fn num_processed_blocks(&self) -> usize {
-		self.network_service.user_protocol().num_processed_blocks()
+	/// Returns the number of downloaded blocks.
+	pub fn num_downloaded_blocks(&self) -> usize {
+		self.network_service.user_protocol().num_downloaded_blocks()
 	}
 
 	/// Number of active sync requests.

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -221,9 +221,9 @@ impl<D> Peer<D> {
 		self.network.num_connected_peers()
 	}
 
-	/// Returns the number of processed blocks.
-	pub fn num_processed_blocks(&self) -> usize {
-		self.network.num_processed_blocks()
+	/// Returns the number of downloaded blocks.
+	pub fn num_downloaded_blocks(&self) -> usize {
+		self.network.num_downloaded_blocks()
 	}
 
 	/// Returns true if we have no peer.

--- a/client/network/test/src/sync.rs
+++ b/client/network/test/src/sync.rs
@@ -673,12 +673,12 @@ fn imports_stale_once() {
 	// check that NEW block is imported from announce message
 	let new_hash = net.peer(0).push_blocks(1, false);
 	import_with_announce(&mut net, new_hash);
-	assert_eq!(net.peer(1).num_processed_blocks(), 1);
+	assert_eq!(net.peer(1).num_downloaded_blocks(), 1);
 
 	// check that KNOWN STALE block is imported from announce message
 	let known_stale_hash = net.peer(0).push_blocks_at(BlockId::Number(0), 1, true);
 	import_with_announce(&mut net, known_stale_hash);
-	assert_eq!(net.peer(1).num_processed_blocks(), 2);
+	assert_eq!(net.peer(1).num_downloaded_blocks(), 2);
 }
 
 #[test]


### PR DESCRIPTION
Instead of checking number of blocks processed by the import queue, which is racey, tests now simply check the number of downloaded blocks.
Only touches test code.

Closes #5518