### PR TITLE
Allow "anonymous" proxied accounts

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -808,7 +808,7 @@ construct_runtime!(
 		Recovery: pallet_recovery::{Module, Call, Storage, Event<T>},
 		Vesting: pallet_vesting::{Module, Call, Storage, Event<T>, Config<T>},
 		Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},
-		Proxy: pallet_proxy::{Module, Call, Storage, Event},
+		Proxy: pallet_proxy::{Module, Call, Storage, Event<T>},
 	}
 );
 

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -30,7 +30,6 @@ use sp_runtime::traits::{Bounded, One};
 use crate::Module as Democracy;
 
 const SEED: u32 = 0;
-const MAX_USERS: u32 = 1000;
 const MAX_REFERENDUMS: u32 = 100;
 const MAX_PROPOSALS: u32 = 100;
 const MAX_SECONDERS: u32 = 100;

--- a/frame/proxy/Cargo.toml
+++ b/frame/proxy/Cargo.toml
@@ -17,6 +17,7 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 frame-support = { version = "2.0.0-rc2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc2", default-features = false, path = "../system" }
 sp-core = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/core" }
+sp-io = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/std" }
 
@@ -25,7 +26,6 @@ frame-benchmarking = { version = "2.0.0-rc2", default-features = false, path = "
 [dev-dependencies]
 sp-core = { version = "2.0.0-rc2", path = "../../primitives/core" }
 pallet-balances = { version = "2.0.0-rc2", path = "../balances" }
-sp-io = { version = "2.0.0-rc2", path = "../../primitives/io" }
 
 [features]
 default = ["std"]
@@ -35,7 +35,8 @@ std = [
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",
-	"sp-std/std"
+	"sp-std/std",
+	"sp-io/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -69,12 +69,15 @@ benchmarks! {
 		let caller: T::AccountId = account("caller", 0, SEED);
 	}: _(RawOrigin::Signed(caller))
 
-	anonymous {}: _(RawOrigin::Signed(account("caller", 0, SEED)), T::ProxyType::default(), 0)
+	anonymous {
+		let p in ...;
+	}: _(RawOrigin::Signed(account("caller", 0, SEED)), T::ProxyType::default(), 0)
 
 	kill_anonymous {
 		let p in 0 .. (T::MaxProxies::get() - 2).into();
 
 		let caller: T::AccountId = account("caller", 0, SEED);
+		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		Module::<T>::anonymous(RawOrigin::Signed(account("caller", 0, SEED)).into(), T::ProxyType::default(), 0)?;
 		let height = system::Module::<T>::block_number();
 		let ext_index = system::Module::<T>::extrinsic_index().unwrap_or(0);
@@ -98,6 +101,8 @@ mod tests {
 			assert_ok!(test_benchmark_add_proxy::<Test>());
 			assert_ok!(test_benchmark_remove_proxy::<Test>());
 			assert_ok!(test_benchmark_remove_proxies::<Test>());
+			assert_ok!(test_benchmark_anonymous::<Test>());
+			assert_ok!(test_benchmark_kill_anonymous::<Test>());
 		});
 	}
 }

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -27,8 +27,8 @@ use crate::Module as Proxy;
 
 const SEED: u32 = 0;
 
-fn add_proxies<T: Trait>(n: u32) -> Result<(), &'static str> {
-	let caller: T::AccountId = account("caller", 0, SEED);
+fn add_proxies<T: Trait>(n: u32, maybe_who: Option<T::AccountId>) -> Result<(), &'static str> {
+	let caller = maybe_who.unwrap_or_else(|| account("caller", 0, SEED));
 	T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	for i in 0..n {
 		Proxy::<T>::add_proxy(
@@ -42,7 +42,7 @@ fn add_proxies<T: Trait>(n: u32) -> Result<(), &'static str> {
 
 benchmarks! {
 	_ {
-		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p)?;
+		let p in 1 .. (T::MaxProxies::get() - 1).into() => add_proxies::<T>(p, None)?;
 	}
 
 	proxy {
@@ -68,6 +68,21 @@ benchmarks! {
 		let p in ...;
 		let caller: T::AccountId = account("caller", 0, SEED);
 	}: _(RawOrigin::Signed(caller))
+
+	anonymous {}: _(RawOrigin::Signed(account("caller", 0, SEED)), T::ProxyType::default(), 0)
+
+	kill_anonymous {
+		let p in 0 .. (T::MaxProxies::get() - 2).into();
+
+		let caller: T::AccountId = account("caller", 0, SEED);
+		Module::<T>::anonymous(RawOrigin::Signed(account("caller", 0, SEED)).into(), T::ProxyType::default(), 0)?;
+		let height = system::Module::<T>::block_number();
+		let ext_index = system::Module::<T>::extrinsic_index().unwrap_or(0);
+		let anon = Module::<T>::anonymous_account(&caller, &T::ProxyType::default(), 0, None);
+
+		add_proxies::<T>(p, Some(anon.clone()))?;
+
+	}: _(RawOrigin::Signed(anon), caller, T::ProxyType::default(), 0, height, ext_index)
 }
 
 #[cfg(test)]

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -235,7 +235,7 @@ decl_module! {
 			spawner: T::AccountId,
 			proxy_type: T::ProxyType,
 			index: u16,
-			height: T::BlockNumber,
+			#[compact] height: T::BlockNumber,
 			#[compact] ext_index: u32,
 		) {
 			let who = ensure_signed(origin)?;

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -295,9 +295,15 @@ decl_module! {
 		/// same sender, with the same parameters.
 		///
 		/// Fails if there are insufficient funds to pay for deposit.
+		///
+		/// # <weight>
+		/// P is the number of proxies the user has
+		/// - Base weight: 36.48 + .039 * P µs
+		/// - DB weight: 1 storage read and write.
+		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1)
-			.saturating_add(18 * WEIGHT_PER_MICROS)
-			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+			.saturating_add(36 * WEIGHT_PER_MICROS)
+			.saturating_add((40 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn anonymous(origin, proxy_type: T::ProxyType, index: u16) {
 			let who = ensure_signed(origin)?;
@@ -326,9 +332,15 @@ decl_module! {
 		///
 		/// Fails with `NoPermission` in case the caller is not a previously created anonymous
 		/// account whose `anonymous` call has corresponding parameters.
+		///
+		/// # <weight>
+		/// P is the number of proxies the user has
+		/// - Base weight: 15.65 + .137 * P µs
+		/// - DB weight: 1 storage read and write.
+		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1)
-			.saturating_add(18 * WEIGHT_PER_MICROS)
-			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+			.saturating_add(15 * WEIGHT_PER_MICROS)
+			.saturating_add((140 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn kill_anonymous(origin,
 			spawner: T::AccountId,

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -35,15 +35,17 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use sp_std::prelude::*;
-use frame_support::{decl_module, decl_event, decl_error, decl_storage, Parameter, ensure};
+use codec::{Encode, Decode};
+use sp_core::blake2_256;
+use sp_runtime::{DispatchResult, traits::{Dispatchable, Zero}};
+use sp_runtime::traits::Member;
 use frame_support::{
+	decl_module, decl_event, decl_error, decl_storage, Parameter, ensure,
 	traits::{Get, ReservableCurrency, Currency, Filter, InstanceFilter},
 	weights::{GetDispatchInfo, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
 	dispatch::{PostDispatchInfo, IsSubType},
 };
 use frame_system::{self as system, ensure_signed};
-use sp_runtime::{DispatchResult, traits::{Dispatchable, Zero}};
-use sp_runtime::traits::Member;
 
 mod tests;
 mod benchmarking;
@@ -53,7 +55,7 @@ type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trai
 /// Configuration trait.
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
-	type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
+	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
 	/// The overarching call type.
 	type Call: Parameter + Dispatchable<Origin=Self::Origin, PostInfo=PostDispatchInfo>
@@ -115,9 +117,15 @@ decl_error! {
 
 decl_event! {
 	/// Events type.
-	pub enum Event {
+	pub enum Event<T> where
+		AccountId = <T as frame_system::Trait>::AccountId,
+		ProxyType = <T as Trait>::ProxyType
+	{
 		/// A proxy was executed correctly, with the given result.
 		ProxyExecuted(DispatchResult),
+		/// Anonymous account (first parameter) has been created by new proxy (second) with given
+		/// disambiguation index and proxy type.
+		AnonymousCreated(AccountId, AccountId, ProxyType, u16),
 	}
 }
 
@@ -164,12 +172,80 @@ decl_module! {
 				.ok_or(Error::<T>::NotProxy)?;
 			match call.is_sub_type() {
 				Some(Call::add_proxy(_, ref pt)) | Some(Call::remove_proxy(_, ref pt)) =>
-					ensure!(&proxy_type == pt, Error::<T>::NoPermission),
+					ensure!(pt.is_no_more_permissive(&proxy_type), Error::<T>::NoPermission),
 				_ => (),
 			}
 			ensure!(proxy_type.filter(&call), Error::<T>::Unproxyable);
 			let e = call.dispatch(frame_system::RawOrigin::Signed(real).into());
-			Self::deposit_event(Event::ProxyExecuted(e.map(|_| ()).map_err(|e| e.error)));
+			Self::deposit_event(RawEvent::ProxyExecuted(e.map(|_| ()).map_err(|e| e.error)));
+		}
+
+		/// Spawn a fresh new account that is guaranteed to be otherwise inaccessible, and
+		/// initialize it with a proxy of `proxy_type` for `origin` sender.
+		///
+		/// Requires a `Signed` origin.
+		///
+		/// - `proxy_type`: The type of the proxy that the sender will be registered as over the
+		/// new account. This will almost always be the most permissive `ProxyType` possible to
+		/// allow for maximum flexibility.
+		/// - `index`: A disambiguation index, in case this is called multiple times in the same
+		/// transaction (e.g. with `utility::batch`). Unless you're using `batch` you probably just
+		/// want to use `0`.
+		///
+		/// Fails with `Duplicate` if this has already been called in this transaction, from the
+		/// same sender, with the same parameters.
+		///
+		/// Fails if there are insufficient funds to pay for deposit.
+		#[weight = T::DbWeight::get().reads_writes(1, 1)
+			.saturating_add(18 * WEIGHT_PER_MICROS)
+			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+		]
+		fn anonymous(origin, proxy_type: T::ProxyType, index: u16) {
+			let who = ensure_signed(origin)?;
+
+			let anonymous = Self::anonymous_account(&who, &proxy_type, index, None);
+			ensure!(!Proxies::<T>::contains_key(&anonymous), Error::<T>::Duplicate);
+			let deposit = T::ProxyDepositBase::get() + T::ProxyDepositFactor::get();
+			T::Currency::reserve(&who, deposit)?;
+			Proxies::<T>::insert(&anonymous, (vec![(who.clone(), proxy_type.clone())], deposit));
+			Self::deposit_event(RawEvent::AnonymousCreated(anonymous, who, proxy_type, index));
+		}
+
+		/// Removes a previously spawned anonymous proxy.
+		///
+		/// WARNING: **All access to this account will be lost.** Any funds held in it will be
+		/// inaccessible.
+		///
+		/// Requires a `Signed` origin, and the sender account must have been created by a call to
+		/// `anonymous` with corresponding parameters.
+		///
+		/// - `spawner`: The account that originally called `anonymous` to create this account.
+		/// - `index`: The disambiguation index originally passed to `anonymous`. Probably `0`.
+		/// - `proxy_type`: The proxy type originally passed to `anonymous`.
+		/// - `height`: The height of the chain when the call to `anonymous` was processed.
+		/// - `ext_index`: The extrinsic index in which the call to `anonymous` was processed.
+		///
+		/// Fails with `NoPermission` in case the caller is not a previously created anonymous
+		/// account whose `anonymous` call has corresponding parameters.
+		#[weight = T::DbWeight::get().reads_writes(1, 1)
+			.saturating_add(18 * WEIGHT_PER_MICROS)
+			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+		]
+		fn kill_anonymous(origin,
+			spawner: T::AccountId,
+			proxy_type: T::ProxyType,
+			index: u16,
+			height: T::BlockNumber,
+			#[compact] ext_index: u32,
+		) {
+			let who = ensure_signed(origin)?;
+
+			let when = (height, ext_index);
+			let proxy = Self::anonymous_account(&spawner, &proxy_type, index, Some(when));
+			ensure!(proxy == who, Error::<T>::NoPermission);
+
+			let (_, deposit) = Proxies::<T>::take(&who);
+			T::Currency::unreserve(&spawner, deposit);
 		}
 
 		/// Register a proxy account for the sender that is able to make calls on its behalf.
@@ -186,8 +262,8 @@ decl_module! {
 		/// - DB weight: 1 storage read and write.
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1)
-				.saturating_add(18 * WEIGHT_PER_MICROS)
-				.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+			.saturating_add(18 * WEIGHT_PER_MICROS)
+			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn add_proxy(origin, proxy: T::AccountId, proxy_type: T::ProxyType) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -222,8 +298,8 @@ decl_module! {
 		/// - DB weight: 1 storage read and write.
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1)
-				.saturating_add(14 * WEIGHT_PER_MICROS)
-				.saturating_add((160 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+			.saturating_add(14 * WEIGHT_PER_MICROS)
+			.saturating_add((160 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn remove_proxy(origin, proxy: T::AccountId, proxy_type: T::ProxyType) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -253,19 +329,39 @@ decl_module! {
 		///
 		/// The dispatch origin for this call must be _Signed_.
 		///
+		/// WARNING: This may be called on accounts created by `anonymous`, however if done, then
+		/// the unreserved fees will be inaccessible. **All access to this account will be lost.**
+		///
 		/// # <weight>
 		/// P is the number of proxies the user has
 		/// - Base weight: 13.73 + .129 * P µs
 		/// - DB weight: 1 storage read and write.
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(1, 1)
-				.saturating_add(14 * WEIGHT_PER_MICROS)
-				.saturating_add((130 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
+			.saturating_add(14 * WEIGHT_PER_MICROS)
+			.saturating_add((130 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn remove_proxies(origin) {
 			let who = ensure_signed(origin)?;
 			let (_, old_deposit) = Proxies::<T>::take(&who);
 			T::Currency::unreserve(&who, old_deposit);
 		}
+	}
+}
+
+impl<T: Trait> Module<T> {
+	pub fn anonymous_account(
+		who: &T::AccountId,
+		proxy_type: &T::ProxyType,
+		index: u16,
+		maybe_when: Option<(T::BlockNumber, u32)>,
+	) -> T::AccountId {
+		let (height, ext_index) = maybe_when.unwrap_or_else(|| (
+			system::Module::<T>::block_number(),
+			system::Module::<T>::extrinsic_index().unwrap_or_default()
+		));
+		let entropy = (b"modlpy/proxy____", who, height, ext_index, proxy_type, index)
+			.using_encoded(blake2_256);
+		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}
 }

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -36,7 +36,7 @@
 
 use sp_std::prelude::*;
 use codec::{Encode, Decode};
-use sp_core::blake2_256;
+use sp_io::hashing::blake2_256;
 use sp_runtime::{DispatchResult, traits::{Dispatchable, Zero}};
 use sp_runtime::traits::Member;
 use frame_support::{

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -120,6 +120,8 @@ pub struct TestIsCallable;
 impl Filter<Call> for TestIsCallable {
 	fn filter(c: &Call) -> bool {
 		match *c {
+			// Remark is used as a no-op call in the benchmarking
+			Call::System(SystemCall::remark(_)) => true,
 			Call::System(_) => false,
 			_ => true,
 		}
@@ -209,7 +211,7 @@ fn proxying_works() {
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_eq!(Balances::free_balance(6), 1);
 
-		let call = Box::new(Call::System(SystemCall::remark(vec![])));
+		let call = Box::new(Call::System(SystemCall::set_code(vec![])));
 		assert_noop!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()), Error::<Test>::Uncallable);
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer_keep_alive(6, 1)));

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -206,7 +206,10 @@ fn proxying_works() {
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 1)));
 		assert_noop!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()), Error::<Test>::NotProxy);
-		assert_noop!(Proxy::proxy(Origin::signed(2), 1, Some(ProxyType::Any), call.clone()), Error::<Test>::NotProxy);
+		assert_noop!(
+			Proxy::proxy(Origin::signed(2), 1, Some(ProxyType::Any), call.clone()),
+			Error::<Test>::NotProxy
+		);
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_eq!(Balances::free_balance(6), 1);
@@ -251,7 +254,10 @@ fn anonymous_works() {
 		assert_ok!(Proxy::proxy(Origin::signed(2), anon2, None, call.clone()));
 		let de = DispatchError::from(Error::<Test>::NoPermission).stripped();
 		expect_event(RawEvent::ProxyExecuted(Err(de)));
-		assert_noop!(Proxy::kill_anonymous(Origin::signed(1), 1, ProxyType::Any, 0, 1, 0), Error::<Test>::NoPermission);
+		assert_noop!(
+			Proxy::kill_anonymous(Origin::signed(1), 1, ProxyType::Any, 0, 1, 0),
+			Error::<Test>::NoPermission
+		);
 		assert_eq!(Balances::free_balance(1), 0);
 		assert_ok!(Proxy::proxy(Origin::signed(1), anon, None, call.clone()));
 		assert_eq!(Balances::free_balance(1), 2);

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -47,10 +47,25 @@ impl<T> Filter<T> for () {
 pub trait InstanceFilter<T> {
 	/// Determine if a given value should be allowed through the filter (returns `true`) or not.
 	fn filter(&self, _: &T) -> bool;
+
+	/// Determines whether `self` matches at least all items that `o` does.
+	fn is_no_less_permissive(&self, o: &Self) -> bool { !self.is_less_permissive(o) }
+
+	/// Determines whether `self` matches at most only the items that `o` does.
+	fn is_no_more_permissive(&self, o: &Self) -> bool { !o.is_less_permissive(&self) }
+
+	/// Determines whether `self` matches all the items that `o` does and others.
+	fn is_more_permissive(&self, o: &Self) -> bool { o.is_less_permissive(self) }
+
+	/// Determines whether `self` does not match all the items that `_o` does, nor any others.
+	///
+	/// NOTE: This is the only `*permissive` function that needs to be reimplemented.
+	fn is_less_permissive(&self, _o: &Self) -> bool { true }
 }
 
 impl<T> InstanceFilter<T> for () {
 	fn filter(&self, _: &T) -> bool { true }
+	fn is_less_permissive(&self, _o: &Self) -> bool { false }
 }
 
 /// An abstraction of a value stored within storage, but possibly as part of a larger composite


### PR DESCRIPTION
Feature in `proxy` module to create usable accounts that have no assicated secret key. Instead, they begin life with the creator (origin) account as a registered proxy for them. This can then be altered as desired. This open up a bunch of interesting use cases for proxies, in particular when combined with multisigs.

TODO: 
- [x] Weights
- [x] A few more tests