### PR TITLE
The link to getting-started was obsolete.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Substrate is a next-generation framework for blockchain innovation 🚀.
 
 ## Trying it out
 
-Simply go to [substrate.dev](https://substrate.dev) and follow the [getting started](https://substrate.dev/docs/en/overview/getting-started/) instructions.
+Simply go to [substrate.dev](https://substrate.dev) and follow the [getting started](https://substrate.dev/en/tutorials) instructions.
 
 ## Contributions & Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Substrate is a next-generation framework for blockchain innovation 🚀.
 
 ## Trying it out
 
-Simply go to [substrate.dev](https://substrate.dev) and follow the [getting started](https://substrate.dev/en/tutorials) instructions.
+Simply go to [substrate.dev](https://substrate.dev) and follow the 
+[installation](https://substrate.dev/docs/en/knowledgebase/getting-started/) instructions. You can 
+also try out one of the [tutorials](https://substrate.dev/en/tutorials).
 
 ## Contributions & Code of Conduct
 


### PR DESCRIPTION
This is a super simple PR so I'm not going to check all the boxes. All I'd like to say is that this repo is currently trending on github so if you stumble onto it and click the getting started link and it leads to 404 then it's kind of not nice.