### PR TITLE
Sentry nodes and validator nodes also imply reserved

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -157,12 +157,14 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				Role::Sentry { validators } => {
 					for validator in validators {
 						sentries_and_validators.insert(validator.peer_id.clone());
+						reserved_nodes.insert(validator.peer_id.clone());
 						known_addresses.push((validator.peer_id.clone(), validator.multiaddr.clone()));
 					}
 				}
 				Role::Authority { sentry_nodes } => {
 					for sentry_node in sentry_nodes {
 						sentries_and_validators.insert(sentry_node.peer_id.clone());
+						reserved_nodes.insert(sentry_node.peer_id.clone());
 						known_addresses.push((sentry_node.peer_id.clone(), sentry_node.multiaddr.clone()));
 					}
 				}


### PR DESCRIPTION
I'm totally lost in where we are in that, but here's a PR that adds sentry nodes and validator nodes as reserved. In other words `--sentry` and `--sentry-node` also imply `--reserved-node`.