### PR TITLE
Revert "Use Subscription Manager from `jsonrpc-pubsub`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -321,7 +321,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "regex",
  "rustc-hash",
  "shlex",
@@ -991,7 +991,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1031,7 +1031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1133,7 +1133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed9afacaea0301eefb738c9deea725e6d53938004597cdc518a8cf9a7aa2f03"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1286,7 +1286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "synstructure",
 ]
@@ -1477,7 +1477,7 @@ version = "2.0.0-rc2"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1488,7 +1488,7 @@ dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1497,7 +1497,7 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -1713,7 +1713,7 @@ checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -2234,7 +2234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-client-transports"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecbdaacc17243168d9d1fa6b2bd7556a27e1e60a621d8a2a6e590ae2b145d158"
+checksum = "2307a7e78cf969759e390a8a2151ea12e783849a45bb00aa871b468ba58ea79e"
 dependencies = [
  "failure",
  "futures 0.1.29",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0747307121ffb9703afd93afbd0fb4f854c38fb873f2c8b90e0e902f27c7b62"
+checksum = "25525f6002338fb4debb5167a89a0b47f727a5a48418417545ad3429758b7fec"
 dependencies = [
  "futures 0.1.29",
  "log",
@@ -2349,30 +2349,30 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core-client"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34221123bc79b66279a3fde2d3363553835b43092d629b34f2e760c44dc94713"
+checksum = "87f9382e831a6d630c658df103aac3f971da096deb57c136ea2b760d3b4e3f9f"
 dependencies = [
  "jsonrpc-client-transports",
 ]
 
 [[package]]
 name = "jsonrpc-derive"
-version = "14.2.1"
+version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
+checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da906d682799df05754480dac1b9e70ec92e12c19ebafd2662a5ea1c9fd6522"
+checksum = "d52860f0549694aa4abb12766856f56952ab46d3fb9f0815131b2db3d9cc2f29"
 dependencies = [
  "hyper 0.12.35",
  "jsonrpc-core",
@@ -2385,22 +2385,21 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-pubsub"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d44f5602a11d657946aac09357956d2841299ed422035edf140c552cb057986"
+checksum = "c4ca5e391d6c6a2261d4adca029f427fe63ea546ad6cef2957c654c08495ec16"
 dependencies = [
  "jsonrpc-core",
  "log",
  "parking_lot 0.10.2",
- "rand 0.7.3",
  "serde",
 ]
 
 [[package]]
 name = "jsonrpc-server-utils"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cbfb462e7f902e21121d9f0d1c2b77b2c5b642e1a4e8f4ebfa2e15b94402bb"
+checksum = "1f06add502b48351e05dd95814835327fb115e4e9f834ca42fd522d3b769d4d2"
 dependencies = [
  "bytes 0.4.12",
  "globset",
@@ -2414,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-ws-server"
-version = "14.2.0"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903d3109fe7c4acb932b567e1e607e0f524ed04741b09fb0e61841bc40a022fc"
+checksum = "017a7dd5083d9ed62c5e1dd3e317975c33c3115dac5447f4480fe05a8c354754"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -2642,7 +2641,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -4472,7 +4471,7 @@ version = "2.0.0-rc2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "sp-runtime",
  "syn 1.0.17",
 ]
@@ -4705,7 +4704,7 @@ checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -4824,7 +4823,7 @@ checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -4888,7 +4887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -5008,7 +5007,7 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "version_check",
 ]
@@ -5020,7 +5019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "syn-mid",
  "version_check",
@@ -5113,7 +5112,7 @@ dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -5181,9 +5180,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
@@ -5481,7 +5480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -5665,7 +5664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -5798,7 +5797,7 @@ version = "2.0.0-rc2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -6573,7 +6572,6 @@ dependencies = [
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "hash-db",
- "jsonrpc-pubsub",
  "lazy_static",
  "log",
  "netstat2",
@@ -6819,7 +6817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -6915,7 +6913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7035,7 +7033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7137,7 +7135,7 @@ dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7397,7 +7395,7 @@ name = "sp-debug-derive"
 version = "2.0.0-rc2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7514,7 +7512,7 @@ version = "2.0.0-rc2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7587,7 +7585,7 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7881,7 +7879,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -7902,7 +7900,7 @@ checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -8272,7 +8270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -8283,7 +8281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -8303,7 +8301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "unicode-xid 0.2.0",
 ]
@@ -8366,7 +8364,7 @@ checksum = "a605baa797821796a751f4a959e1206079b24a4b7e1ed302b7d785d81a9276c9"
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "version_check",
 ]
@@ -8396,7 +8394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -8602,7 +8600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -8780,7 +8778,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
 ]
 
@@ -9112,7 +9110,7 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "wasm-bindgen-shared",
 ]
@@ -9135,7 +9133,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.6",
+ "quote 1.0.3",
  "wasm-bindgen-macro-support",
 ]
 
@@ -9146,7 +9144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -9179,7 +9177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2f86cd78a2aa7b1fb4bb6ed854eccb7f9263089c79542dca1576a1518a8467"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
 ]
 
 [[package]]
@@ -9467,7 +9465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote 1.0.3",
  "syn 1.0.17",
  "synstructure",
 ]

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 futures-timer = "3.0.2"
 libp2p = { version = "0.19.1", default-features = false }
-jsonrpc-core = "14.2"
+jsonrpc-core = "14.0.5"
 serde = "1.0.106"
 serde_json = "1.0.48"
 wasm-bindgen = { version = "=0.2.62", features = ["serde-serialize"] }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -38,7 +38,7 @@ codec = { package = "parity-scale-codec", version = "1.3.0" }
 serde = { version = "1.0.102", features = ["derive"] }
 futures = { version = "0.3.1", features = ["compat"] }
 hex-literal = "0.2.1"
-jsonrpc-core = "14.2"
+jsonrpc-core = "14.0.3"
 log = "0.4.8"
 rand = "0.7.2"
 structopt = { version = "0.3.8", optional = true }

--- a/bin/node/rpc-client/Cargo.toml
+++ b/bin/node/rpc-client/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 env_logger = "0.7.0"
 futures = "0.1.29"
 hyper = "0.12.35"
-jsonrpc-core-client = { version = "14.2", default-features = false, features = ["http"] }
+jsonrpc-core-client = { version = "14.0.5", default-features = false, features = ["http"] }
 log = "0.4.8"
 node-primitives = { version = "2.0.0-rc2", path = "../primitives" }
 sc-rpc = { version = "2.0.0-rc2", path = "../../../client/rpc" }

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -12,7 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sc-client-api = { version = "2.0.0-rc2", path = "../../../client/api" }
-jsonrpc-core = "14.2"
+jsonrpc-core = "14.0.3"
 node-primitives = { version = "2.0.0-rc2", path = "../primitives" }
 node-runtime = { version = "2.0.0-rc2", path = "../runtime" }
 sp-runtime = { version = "2.0.0-rc2", path = "../../../primitives/runtime" }

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -31,7 +31,7 @@ rpassword = "4.0.1"
 itertools = "0.8.2"
 derive_more = { version = "0.99.2" }
 sc-rpc = { version = "2.0.0-rc2", path = "../../../client/rpc" }
-jsonrpc-core-client = { version = "14.2", features = ["http"] }
+jsonrpc-core-client = { version = "14.0.3", features = ["http"] }
 hyper = "0.12.35"
 libp2p = { version = "0.19.1", default-features = false }
 serde_json = "1.0"

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sc-consensus-babe = { version = "0.8.0-rc2", path = "../" }
 sc-rpc-api = { version = "0.8.0-rc2", path = "../../../rpc-api" }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.3"
 sp-consensus-babe = { version = "0.8.0-rc2", path = "../../../../primitives/consensus/babe" }
 serde = { version = "1.0.104", features=["derive"] }
 sp-blockchain = { version = "2.0.0-rc2", path = "../../../../primitives/blockchain" }

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 derive_more = "0.99.2"
 futures = "0.3.4"
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.5"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.5"
 log = "0.4.8"
 parking_lot = "0.10.0"
 serde = { version = "1.0", features=["derive"] }

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -10,9 +10,9 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 [dependencies]
 sc-finality-grandpa = { version = "0.8.0-rc2", path = "../" }
 finality-grandpa = { version = "0.12.3", features = ["derive-codec"] }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.3"
+jsonrpc-derive = "14.0.3"
 futures = { version = "0.3.4", features = ["compat"] }
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0.50"

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -15,10 +15,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 derive_more = "0.99.2"
 futures = { version = "0.3.1", features = ["compat"] }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
-jsonrpc-pubsub = "14.2"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.3"
+jsonrpc-pubsub = "14.0.3"
 log = "0.4.8"
 parking_lot = "0.10.0"
 sp-core = { version = "2.0.0-rc2", path = "../../primitives/core" }

--- a/client/rpc-api/src/lib.rs
+++ b/client/rpc-api/src/lib.rs
@@ -23,8 +23,10 @@
 mod errors;
 mod helpers;
 mod policy;
+mod subscriptions;
 
 pub use jsonrpc_core::IoHandlerExtension as RpcExtension;
+pub use subscriptions::{Subscriptions, TaskExecutor};
 pub use helpers::Receiver;
 pub use policy::DenyUnsafe;
 

--- a/client/rpc-api/src/subscriptions.rs
+++ b/client/rpc-api/src/subscriptions.rs
@@ -1,0 +1,121 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::sync::{Arc, atomic::{self, AtomicUsize}};
+
+use log::{error, warn};
+use jsonrpc_pubsub::{SubscriptionId, typed::{Sink, Subscriber}};
+use parking_lot::Mutex;
+use jsonrpc_core::futures::sync::oneshot;
+use jsonrpc_core::futures::{Future, future};
+
+type Id = u64;
+
+/// Alias for a an implementation of `futures::future::Executor`.
+pub type TaskExecutor = Arc<dyn future::Executor<Box<dyn Future<Item = (), Error = ()> + Send>> + Send + Sync>;
+
+/// Generate unique ids for subscriptions.
+#[derive(Clone, Debug)]
+pub struct IdProvider {
+	next_id: Arc<AtomicUsize>,
+}
+impl Default for IdProvider {
+	fn default() -> Self {
+		IdProvider {
+			next_id: Arc::new(AtomicUsize::new(1)),
+		}
+	}
+}
+
+impl IdProvider {
+	/// Returns next id for the subscription.
+	pub fn next_id(&self) -> Id {
+		self.next_id.fetch_add(1, atomic::Ordering::AcqRel) as u64
+	}
+}
+
+/// Subscriptions manager.
+///
+/// Takes care of assigning unique subscription ids and
+/// driving the sinks into completion.
+#[derive(Clone)]
+pub struct Subscriptions {
+	next_id: IdProvider,
+	active_subscriptions: Arc<Mutex<HashMap<Id, oneshot::Sender<()>>>>,
+	executor: TaskExecutor,
+}
+
+impl Subscriptions {
+	/// Creates new `Subscriptions` object.
+	pub fn new(executor: TaskExecutor) -> Self {
+		Subscriptions {
+			next_id: Default::default(),
+			active_subscriptions: Default::default(),
+			executor,
+		}
+	}
+
+	/// Borrows the internal task executor.
+	///
+	/// This can be used to spawn additional tasks on the underlying event loop.
+	pub fn executor(&self) -> &TaskExecutor {
+		&self.executor
+	}
+
+	/// Creates new subscription for given subscriber.
+	///
+	/// Second parameter is a function that converts Subscriber sink into a future.
+	/// This future will be driven to completion by the underlying event loop
+	/// or will be cancelled in case #cancel is invoked.
+	pub fn add<T, E, G, R, F>(&self, subscriber: Subscriber<T, E>, into_future: G) -> SubscriptionId where
+		G: FnOnce(Sink<T, E>) -> R,
+		R: future::IntoFuture<Future=F, Item=(), Error=()>,
+		F: future::Future<Item=(), Error=()> + Send + 'static,
+	{
+		let id = self.next_id.next_id();
+		let subscription_id: SubscriptionId = id.into();
+		if let Ok(sink) = subscriber.assign_id(subscription_id.clone()) {
+			let (tx, rx) = oneshot::channel();
+			let future = into_future(sink)
+				.into_future()
+				.select(rx.map_err(|e| warn!("Error timeing out: {:?}", e)))
+				.then(|_| Ok(()));
+
+			self.active_subscriptions.lock().insert(id, tx);
+			if self.executor.execute(Box::new(future)).is_err() {
+				error!("Failed to spawn RPC subscription task");
+			}
+		}
+
+		subscription_id
+	}
+
+	/// Cancel subscription.
+	///
+	/// Returns true if subscription existed or false otherwise.
+	pub fn cancel(&self, id: SubscriptionId) -> bool {
+		if let SubscriptionId::Number(id) = id {
+			if let Some(tx) = self.active_subscriptions.lock().remove(&id) {
+				let _ = tx.send(());
+				return true;
+			}
+		}
+		false
+	}
+}

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -12,13 +12,13 @@ description = "Substrate RPC servers."
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpc-core = "14.2"
-pubsub = { package = "jsonrpc-pubsub", version = "14.2" }
+jsonrpc-core = "14.0.3"
+pubsub = { package = "jsonrpc-pubsub", version = "14.0.3" }
 log = "0.4.8"
 serde = "1.0.101"
 serde_json = "1.0.41"
 sp-runtime = { version = "2.0.0-rc2", path = "../../primitives/runtime" }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-http = { package = "jsonrpc-http-server", version = "14.2" }
-ws = { package = "jsonrpc-ws-server", version = "14.2" }
+http = { package = "jsonrpc-http-server", version = "14.0.3" }
+ws = { package = "jsonrpc-ws-server", version = "14.0.3" }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -17,10 +17,10 @@ sc-client-api = { version = "2.0.0-rc2", path = "../api" }
 sp-api = { version = "2.0.0-rc2", path = "../../primitives/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 futures = { version = "0.3.1", features = ["compat"] }
-jsonrpc-pubsub = "14.2"
+jsonrpc-pubsub = "14.0.3"
 log = "0.4.8"
 sp-core = { version = "2.0.0-rc2", path = "../../primitives/core" }
-rpc = { package = "jsonrpc-core", version = "14.2" }
+rpc = { package = "jsonrpc-core", version = "14.0.3" }
 sp-version = { version = "2.0.0-rc2", path = "../../primitives/version" }
 serde_json = "1.0.41"
 sp-session = { version = "2.0.0-rc2", path = "../../primitives/session" }

--- a/client/rpc/src/author/mod.rs
+++ b/client/rpc/src/author/mod.rs
@@ -32,8 +32,8 @@ use rpc::futures::{
 };
 use futures::{StreamExt as _, compat::Compat};
 use futures::future::{ready, FutureExt, TryFutureExt};
-use sc_rpc_api::DenyUnsafe;
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
+use sc_rpc_api::{DenyUnsafe, Subscriptions};
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
 use codec::{Encode, Decode};
 use sp_core::{Bytes, traits::BareCryptoStorePtr};
 use sp_api::ProvideRuntimeApi;
@@ -55,7 +55,7 @@ pub struct Author<P, Client> {
 	/// Transactions pool
 	pool: Arc<P>,
 	/// Subscriptions manager
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	/// The key store.
 	keystore: BareCryptoStorePtr,
 	/// Whether to deny unsafe calls
@@ -67,7 +67,7 @@ impl<P, Client> Author<P, Client> {
 	pub fn new(
 		client: Arc<Client>,
 		pool: Arc<P>,
-		subscriptions: SubscriptionManager,
+		subscriptions: Subscriptions,
 		keystore: BareCryptoStorePtr,
 		deny_unsafe: DenyUnsafe,
 	) -> Self {
@@ -80,6 +80,7 @@ impl<P, Client> Author<P, Client> {
 		}
 	}
 }
+
 
 /// Currently we treat all RPC transactions as externals.
 ///

--- a/client/rpc/src/author/tests.rs
+++ b/client/rpc/src/author/tests.rs
@@ -81,7 +81,7 @@ impl TestSetup {
 		Author {
 			client: self.client.clone(),
 			pool: self.pool.clone(),
-			subscriptions: SubscriptionManager::new(Arc::new(crate::testing::TaskExecutor)),
+			subscriptions: Subscriptions::new(Arc::new(crate::testing::TaskExecutor)),
 			keystore: self.keystore.clone(),
 			deny_unsafe: DenyUnsafe::No,
 		}
@@ -133,14 +133,8 @@ fn should_watch_extrinsic() {
 		uxt(AccountKeyring::Alice, 0).encode().into(),
 	);
 
-	let id = executor::block_on(id_rx.compat()).unwrap().unwrap();
-	assert_matches!(id, SubscriptionId::String(_));
-
-	let id = match id {
-		SubscriptionId::String(id) => id,
-		_ => unreachable!(),
-	};
-
+	// then
+	assert_eq!(executor::block_on(id_rx.compat()), Ok(Ok(1.into())));
 	// check notifications
 	let replacement = {
 		let tx = Transfer {
@@ -153,22 +147,15 @@ fn should_watch_extrinsic() {
 	};
 	AuthorApi::submit_extrinsic(&p, replacement.encode().into()).wait().unwrap();
 	let (res, data) = executor::block_on(data.into_future().compat()).unwrap();
-
-	let expected = Some(format!(
-		r#"{{"jsonrpc":"2.0","method":"test","params":{{"result":"ready","subscription":"{}"}}}}"#,
-		id,
-	));
-	assert_eq!(res, expected);
-
+	assert_eq!(
+		res,
+		Some(r#"{"jsonrpc":"2.0","method":"test","params":{"result":"ready","subscription":1}}"#.into())
+	);
 	let h = blake2_256(&replacement.encode());
-	let expected = Some(format!(
-		r#"{{"jsonrpc":"2.0","method":"test","params":{{"result":{{"usurped":"0x{}"}},"subscription":"{}"}}}}"#,
-		HexDisplay::from(&h),
-		id,
-	));
-
-	let res = executor::block_on(data.into_future().compat()).unwrap().0;
-	assert_eq!(res, expected);
+	assert_eq!(
+		executor::block_on(data.into_future().compat()).unwrap().0,
+		Some(format!(r#"{{"jsonrpc":"2.0","method":"test","params":{{"result":{{"usurped":"0x{}"}},"subscription":1}}}}"#, HexDisplay::from(&h)))
+	);
 }
 
 #[test]

--- a/client/rpc/src/chain/chain_full.rs
+++ b/client/rpc/src/chain/chain_full.rs
@@ -18,8 +18,8 @@
 
 use std::sync::Arc;
 use rpc::futures::future::result;
-use jsonrpc_pubsub::manager::SubscriptionManager;
 
+use sc_rpc_api::Subscriptions;
 use sc_client_api::{BlockchainEvents, BlockBackend};
 use sp_runtime::{generic::{BlockId, SignedBlock}, traits::{Block as BlockT}};
 
@@ -32,14 +32,14 @@ pub struct FullChain<Block: BlockT, Client> {
 	/// Substrate client.
 	client: Arc<Client>,
 	/// Current subscriptions.
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	/// phantom member to pin the block type
 	_phantom: PhantomData<Block>,
 }
 
 impl<Block: BlockT, Client> FullChain<Block, Client> {
 	/// Create new Chain API RPC handler.
-	pub fn new(client: Arc<Client>, subscriptions: SubscriptionManager) -> Self {
+	pub fn new(client: Arc<Client>, subscriptions: Subscriptions) -> Self {
 		Self {
 			client,
 			subscriptions,
@@ -56,7 +56,7 @@ impl<Block, Client> ChainBackend<Client, Block> for FullChain<Block, Client> whe
 		&self.client
 	}
 
-	fn subscriptions(&self) -> &SubscriptionManager {
+	fn subscriptions(&self) -> &Subscriptions {
 		&self.subscriptions
 	}
 

--- a/client/rpc/src/chain/chain_light.rs
+++ b/client/rpc/src/chain/chain_light.rs
@@ -19,8 +19,8 @@
 use std::sync::Arc;
 use futures::{future::ready, FutureExt, TryFutureExt};
 use rpc::futures::future::{result, Future, Either};
-use jsonrpc_pubsub::manager::SubscriptionManager;
 
+use sc_rpc_api::Subscriptions;
 use sc_client_api::light::{Fetcher, RemoteBodyRequest, RemoteBlockchain};
 use sp_runtime::{
 	generic::{BlockId, SignedBlock},
@@ -37,7 +37,7 @@ pub struct LightChain<Block: BlockT, Client, F> {
 	/// Substrate client.
 	client: Arc<Client>,
 	/// Current subscriptions.
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	/// Remote blockchain reference
 	remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
 	/// Remote fetcher reference.
@@ -48,7 +48,7 @@ impl<Block: BlockT, Client, F: Fetcher<Block>> LightChain<Block, Client, F> {
 	/// Create new Chain API RPC handler.
 	pub fn new(
 		client: Arc<Client>,
-		subscriptions: SubscriptionManager,
+		subscriptions: Subscriptions,
 		remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
 		fetcher: Arc<F>,
 	) -> Self {
@@ -70,7 +70,7 @@ impl<Block, Client, F> ChainBackend<Client, Block> for LightChain<Block, Client,
 		&self.client
 	}
 
-	fn subscriptions(&self) -> &SubscriptionManager {
+	fn subscriptions(&self) -> &Subscriptions {
 		&self.subscriptions
 	}
 

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -32,8 +32,9 @@ use rpc::{
 	futures::{stream, Future, Sink, Stream},
 };
 
+use sc_rpc_api::Subscriptions;
 use sc_client_api::{BlockchainEvents, light::{Fetcher, RemoteBlockchain}};
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
 use sp_rpc::{number::NumberOrHex, list::ListOrValue};
 use sp_runtime::{
 	generic::{BlockId, SignedBlock},
@@ -56,7 +57,7 @@ trait ChainBackend<Client, Block: BlockT>: Send + Sync + 'static
 	fn client(&self) -> &Arc<Client>;
 
 	/// Get subscriptions reference.
-	fn subscriptions(&self) -> &SubscriptionManager;
+	fn subscriptions(&self) -> &Subscriptions;
 
 	/// Tries to unwrap passed block hash, or uses best block hash otherwise.
 	fn unwrap_or_best(&self, hash: Option<Block::Hash>) -> Block::Hash {
@@ -176,7 +177,7 @@ trait ChainBackend<Client, Block: BlockT>: Send + Sync + 'static
 /// Create new state API that works on full node.
 pub fn new_full<Block: BlockT, Client>(
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 ) -> Chain<Block, Client>
 	where
 		Block: BlockT + 'static,
@@ -190,7 +191,7 @@ pub fn new_full<Block: BlockT, Client>(
 /// Create new state API that works on light node.
 pub fn new_light<Block: BlockT, Client, F: Fetcher<Block>>(
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
 	fetcher: Arc<F>,
 ) -> Chain<Block, Client>
@@ -278,7 +279,7 @@ impl<Block, Client> ChainApi<NumberFor<Block>, Block::Hash, Block::Header, Signe
 /// Subscribe to new headers.
 fn subscribe_headers<Block, Client, F, G, S, ERR>(
 	client: &Arc<Client>,
-	subscriptions: &SubscriptionManager,
+	subscriptions: &Subscriptions,
 	subscriber: Subscriber<Block::Header>,
 	best_block_hash: G,
 	stream: F,

--- a/client/rpc/src/chain/tests.rs
+++ b/client/rpc/src/chain/tests.rs
@@ -31,7 +31,7 @@ use crate::testing::TaskExecutor;
 #[test]
 fn should_return_header() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 	assert_matches!(
 		api.header(Some(client.genesis_hash()).into()).wait(),
@@ -63,7 +63,7 @@ fn should_return_header() {
 #[test]
 fn should_return_a_block() {
 	let mut client = Arc::new(substrate_test_runtime_client::new());
-	let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 	let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
 	let block_hash = block.hash();
@@ -114,7 +114,7 @@ fn should_return_a_block() {
 #[test]
 fn should_return_block_hash() {
 	let mut client = Arc::new(substrate_test_runtime_client::new());
-	let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 	assert_matches!(
 		api.block_hash(None.into()),
@@ -158,7 +158,7 @@ fn should_return_block_hash() {
 #[test]
 fn should_return_finalized_hash() {
 	let mut client = Arc::new(substrate_test_runtime_client::new());
-	let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 	assert_matches!(
 		api.finalized_head(),
@@ -188,15 +188,12 @@ fn should_notify_about_latest_block() {
 
 	{
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		api.subscribe_all_heads(Default::default(), subscriber);
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 
 		let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
 		client.import(BlockOrigin::Own, block).unwrap();
@@ -218,15 +215,12 @@ fn should_notify_about_best_block() {
 
 	{
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		api.subscribe_new_heads(Default::default(), subscriber);
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 
 		let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
 		client.import(BlockOrigin::Own, block).unwrap();
@@ -248,15 +242,12 @@ fn should_notify_about_finalized_block() {
 
 	{
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let api = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let api = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		api.subscribe_finalized_heads(Default::default(), subscriber);
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 
 		let block = client.new_block(Default::default()).unwrap().build().unwrap().block;
 		client.import(BlockOrigin::Own, block).unwrap();

--- a/client/rpc/src/lib.rs
+++ b/client/rpc/src/lib.rs
@@ -24,7 +24,7 @@
 
 mod metadata;
 
-pub use sc_rpc_api::DenyUnsafe;
+pub use sc_rpc_api::{DenyUnsafe, Subscriptions};
 pub use self::metadata::Metadata;
 pub use rpc::IoHandlerExtension as RpcExtension;
 

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -25,10 +25,10 @@ mod state_light;
 mod tests;
 
 use std::sync::Arc;
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
 use rpc::{Result as RpcResult, futures::{Future, future::result}};
 
-use sc_rpc_api::state::ReadProof;
+use sc_rpc_api::{Subscriptions, state::ReadProof};
 use sc_client_api::light::{RemoteBlockchain, Fetcher};
 use sp_core::{Bytes, storage::{StorageKey, PrefixedStorageKey, StorageData, StorageChangeSet}};
 use sp_version::RuntimeVersion;
@@ -170,7 +170,7 @@ pub trait StateBackend<Block: BlockT, Client>: Send + Sync + 'static
 /// Create new state API that works on full node.
 pub fn new_full<BE, Block: BlockT, Client>(
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 ) -> (State<Block, Client>, ChildState<Block, Client>)
 	where
 		Block: BlockT + 'static,
@@ -191,7 +191,7 @@ pub fn new_full<BE, Block: BlockT, Client>(
 /// Create new state API that works on light node.
 pub fn new_light<BE, Block: BlockT, Client, F: Fetcher<Block>>(
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
 	fetcher: Arc<F>,
 ) -> (State<Block, Client>, ChildState<Block, Client>)

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -21,10 +21,10 @@ use std::sync::Arc;
 use std::ops::Range;
 use futures::{future, StreamExt as _, TryStreamExt as _};
 use log::warn;
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
 use rpc::{Result as RpcResult, futures::{stream, Future, Sink, Stream, future::result}};
 
-use sc_rpc_api::state::ReadProof;
+use sc_rpc_api::{Subscriptions, state::ReadProof};
 use sc_client_api::backend::Backend;
 use sp_blockchain::{Result as ClientResult, Error as ClientError, HeaderMetadata, CachedHeaderMetadata, HeaderBackend};
 use sc_client_api::BlockchainEvents;
@@ -60,7 +60,7 @@ struct QueryStorageRange<Block: BlockT> {
 /// State API backend for full nodes.
 pub struct FullState<BE, Block: BlockT, Client> {
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	_phantom: PhantomData<(BE, Block)>
 }
 
@@ -72,7 +72,7 @@ impl<BE, Block: BlockT, Client> FullState<BE, Block, Client>
 		Block: BlockT + 'static,
 {
 	/// Create new state API backend for full nodes.
-	pub fn new(client: Arc<Client>, subscriptions: SubscriptionManager) -> Self {
+	pub fn new(client: Arc<Client>, subscriptions: Subscriptions) -> Self {
 		Self { client, subscriptions, _phantom: PhantomData }
 	}
 

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -28,7 +28,7 @@ use futures::{
 	StreamExt as _, TryStreamExt as _,
 };
 use hash_db::Hasher;
-use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId, manager::SubscriptionManager};
+use jsonrpc_pubsub::{typed::Subscriber, SubscriptionId};
 use log::warn;
 use parking_lot::Mutex;
 use rpc::{
@@ -38,7 +38,7 @@ use rpc::{
 	futures::stream::Stream,
 };
 
-use sc_rpc_api::state::ReadProof;
+use sc_rpc_api::{Subscriptions, state::ReadProof};
 use sp_blockchain::{Error as ClientError, HeaderBackend};
 use sc_client_api::{
 	BlockchainEvents,
@@ -63,7 +63,7 @@ type StorageMap = HashMap<StorageKey, Option<StorageData>>;
 #[derive(Clone)]
 pub struct LightState<Block: BlockT, F: Fetcher<Block>, Client> {
 	client: Arc<Client>,
-	subscriptions: SubscriptionManager,
+	subscriptions: Subscriptions,
 	version_subscriptions: SimpleSubscriptions<Block::Hash, RuntimeVersion>,
 	storage_subscriptions: Arc<Mutex<StorageSubscriptions<Block>>>,
 	remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
@@ -143,7 +143,7 @@ impl<Block: BlockT, F: Fetcher<Block> + 'static, Client> LightState<Block, F, Cl
 	/// Create new state API backend for light nodes.
 	pub fn new(
 		client: Arc<Client>,
-		subscriptions: SubscriptionManager,
+		subscriptions: Subscriptions,
 		remote_blockchain: Arc<dyn RemoteBlockchain<Block>>,
 		fetcher: Arc<F>,
 	) -> Self {

--- a/client/rpc/src/state/tests.rs
+++ b/client/rpc/src/state/tests.rs
@@ -55,7 +55,7 @@ fn should_return_storage() {
 		.add_extra_child_storage(&child_info, KEY.to_vec(), CHILD_VALUE.to_vec())
 		.build();
 	let genesis_hash = client.genesis_hash();
-	let (client, child) = new_full(Arc::new(client), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let (client, child) = new_full(Arc::new(client), Subscriptions::new(Arc::new(TaskExecutor)));
 	let key = StorageKey(KEY.to_vec());
 
 	assert_eq!(
@@ -90,7 +90,7 @@ fn should_return_child_storage() {
 		.add_child_storage(&child_info, "key", vec![42_u8])
 		.build());
 	let genesis_hash = client.genesis_hash();
-	let (_client, child) = new_full(client, SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let (_client, child) = new_full(client, Subscriptions::new(Arc::new(TaskExecutor)));
 	let child_key = prefixed_storage_key();
 	let key = StorageKey(b"key".to_vec());
 
@@ -125,7 +125,7 @@ fn should_return_child_storage() {
 fn should_call_contract() {
 	let client = Arc::new(substrate_test_runtime_client::new());
 	let genesis_hash = client.genesis_hash();
-	let (client, _child) = new_full(client, SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let (client, _child) = new_full(client, Subscriptions::new(Arc::new(TaskExecutor)));
 
 	assert_matches!(
 		client.call("balanceOf".into(), Bytes(vec![1,2,3]), Some(genesis_hash).into()).wait(),
@@ -139,15 +139,12 @@ fn should_notify_about_storage_changes() {
 
 	{
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let (api, _child) = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		api.subscribe_storage(Default::default(), subscriber, None.into());
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 
 		let mut builder = client.new_block(Default::default()).unwrap();
 		builder.push_transfer(runtime::Transfer {
@@ -173,7 +170,7 @@ fn should_send_initial_storage_changes_and_notifications() {
 
 	{
 		let mut client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let (api, _child) = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		let alice_balance_key = blake2_256(&runtime::system::balance_of_key(AccountKeyring::Alice.into()));
 
@@ -182,10 +179,7 @@ fn should_send_initial_storage_changes_and_notifications() {
 		]).into());
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 
 		let mut builder = client.new_block(Default::default()).unwrap();
 		builder.push_transfer(runtime::Transfer {
@@ -211,7 +205,7 @@ fn should_send_initial_storage_changes_and_notifications() {
 #[test]
 fn should_query_storage() {
 	fn run_tests(mut client: Arc<TestClient>, has_changes_trie_config: bool) {
-		let (api, _child) = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let (api, _child) = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		let mut add_block = |nonce| {
 			let mut builder = client.new_block(Default::default()).unwrap();
@@ -428,7 +422,7 @@ fn should_split_ranges() {
 #[test]
 fn should_return_runtime_version() {
 	let client = Arc::new(substrate_test_runtime_client::new());
-	let (api, _child) = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+	let (api, _child) = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 	let result = "{\"specName\":\"test\",\"implName\":\"parity-test\",\"authoringVersion\":1,\
 		\"specVersion\":2,\"implVersion\":2,\"apis\":[[\"0xdf6acb689907609b\",3],\
@@ -451,16 +445,12 @@ fn should_notify_on_runtime_version_initially() {
 
 	{
 		let client = Arc::new(substrate_test_runtime_client::new());
-		let (api, _child) = new_full(client.clone(), SubscriptionManager::new(Arc::new(TaskExecutor)));
+		let (api, _child) = new_full(client.clone(), Subscriptions::new(Arc::new(TaskExecutor)));
 
 		api.subscribe_runtime_version(Default::default(), subscriber);
 
 		// assert id assigned
-		assert!(matches!(
-			executor::block_on(id.compat()),
-			Ok(Ok(SubscriptionId::String(_)))
-		));
-
+		assert_eq!(executor::block_on(id.compat()), Ok(Ok(SubscriptionId::Number(1))));
 	}
 
 	// assert initial version sent.

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -26,7 +26,6 @@ test-helpers = []
 derive_more = "0.99.2"
 futures01 = { package = "futures", version = "0.1.29" }
 futures = { version = "0.3.4", features = ["compat"] }
-jsonrpc-pubsub = "14.2"
 rand = "0.7.3"
 parking_lot = "0.10.0"
 lazy_static = "1.4.0"

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -36,7 +36,6 @@ use futures::{
 	Future, FutureExt, StreamExt,
 	future::ready,
 };
-use jsonrpc_pubsub::manager::SubscriptionManager;
 use sc_keystore::Store as Keystore;
 use log::{info, warn, error};
 use sc_network::config::{Role, FinalityProofProvider, OnDemand, BoxFinalityProofRequestBuilder};
@@ -1197,7 +1196,7 @@ ServiceBuilder<
 				chain_type: chain_spec.chain_type().clone(),
 			};
 
-			let subscriptions = SubscriptionManager::new(Arc::new(task_manager.spawn_handle()));
+			let subscriptions = sc_rpc::Subscriptions::new(Arc::new(task_manager.spawn_handle()));
 
 			let (chain, state, child_state) = if let (Some(remote_backend), Some(on_demand)) =
 				(remote_backend.as_ref(), on_demand.as_ref()) {

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -13,9 +13,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.3"
 sp-blockchain = { version = "2.0.0-rc2", path = "../../../primitives/blockchain" }
 sp-core = { version = "2.0.0-rc2", path = "../../../primitives/core" }
 sp-rpc = { version = "2.0.0-rc2", path = "../../../primitives/rpc" }

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -13,9 +13,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0" }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.3"
 sp-core = { version = "2.0.0-rc2", path = "../../../primitives/core" }
 sp-rpc = { version = "2.0.0-rc2", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }

--- a/utils/frame/rpc/support/Cargo.toml
+++ b/utils/frame/rpc/support/Cargo.toml
@@ -13,8 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = { version = "0.3.0", features = ["compat"] }
-jsonrpc-client-transports = { version = "14.2", default-features = false, features = ["http"] }
-jsonrpc-core = "14.2"
+jsonrpc-client-transports = { version = "14.0.5", default-features = false, features = ["http"] }
+jsonrpc-core = "14"
 codec = { package = "parity-scale-codec", version = "1" }
 serde = "1"
 frame-support = { version = "2.0.0-rc2", path = "../../../../frame/support" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -15,9 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 sc-client-api = { version = "2.0.0-rc2", path = "../../../../client/api" }
 codec = { package = "parity-scale-codec", version = "1.3.0" }
 futures = { version = "0.3.4", features = ["compat"] }
-jsonrpc-core = "14.2"
-jsonrpc-core-client = "14.2"
-jsonrpc-derive = "14.2.1"
+jsonrpc-core = "14.0.3"
+jsonrpc-core-client = "14.0.5"
+jsonrpc-derive = "14.0.3"
 log = "0.4.8"
 serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { version = "2.0.0-rc2", path = "../../../../primitives/runtime" }


### PR DESCRIPTION
Reverts paritytech/substrate#6208

Currently breaking the JS API and it's easier to revert this right away and give @jacogr some room to deal with compatibility breakage.