### PR TITLE
CI Test: test that benchmark tests are running on CI

### DIFF
--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -227,6 +227,7 @@ mod tests {
 
 	#[test]
 	fn test_benchmarks() {
+		panic!();
 		new_test_ext().execute_with(|| {
 			assert_ok!(test_benchmark_propose_spend::<Test>());
 			assert_ok!(test_benchmark_reject_proposal::<Test>());


### PR DESCRIPTION
As far as I see CI doesn't test for benchmark tests, and it seems not intentional, this test my assumption