### PR TITLE
Add `get_lock` api to `LockableCurrency`

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1268,13 +1268,13 @@ where
 		who: &T::AccountId,
 	) -> Option<(T::Balance, WithdrawReasons)> {
 		Self::locks(who).into_iter()
-		.find_map(|l| {
-			if l.id == id {
-				Some((l.amount, l.reasons.into()))
-			} else {
-				None
-			}
-		})
+			.find_map(|l| {
+				if l.id == id {
+					Some((l.amount, l.reasons.into()))
+				} else {
+					None
+				}
+			})
 	}
 
 	// Set a lock on the balance of `who`.

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -842,6 +842,21 @@ impl<T: Trait> Module<T> {
 		<FreeBalance<T>>::insert(asset_id, who, &balance);
 	}
 
+	// Gets a lock by `id` on an account, returning `None` if there is no lock.
+	fn get_lock(
+		id: LockIdentifier,
+		who: &T::AccountId,
+	) -> Option<(T::Balance, WithdrawReasons)> {
+		Self::locks(who).into_iter()
+		.find_map(|l| {
+			if l.id == id {
+				Some((l.amount, l.reasons.into()))
+			} else {
+				None
+			}
+		})
+	}
+
 	fn set_lock(
 		id: LockIdentifier,
 		who: &T::AccountId,
@@ -1346,6 +1361,13 @@ where
 	T::Balance: MaybeSerializeDeserialize + Debug,
 {
 	type Moment = T::BlockNumber;
+
+	fn get_lock(
+		id: LockIdentifier,
+		who: &T::AccountId,
+	) -> Option<(T::Balance, WithdrawReasons)> {
+		<Module<T>>::get_lock(id, who)
+	}
 
 	fn set_lock(
 		id: LockIdentifier,

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -848,13 +848,13 @@ impl<T: Trait> Module<T> {
 		who: &T::AccountId,
 	) -> Option<(T::Balance, WithdrawReasons)> {
 		Self::locks(who).into_iter()
-		.find_map(|l| {
-			if l.id == id {
-				Some((l.amount, l.reasons.into()))
-			} else {
-				None
-			}
-		})
+			.find_map(|l| {
+				if l.id == id {
+					Some((l.amount, l.reasons.into()))
+				} else {
+					None
+				}
+			})
 	}
 
 	fn set_lock(

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -852,6 +852,12 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// The quantity used to denote time; usually just a `BlockNumber`.
 	type Moment;
 
+	/// Retrieve lock information for `id`, returning `None` if no lock exists.
+	fn get_lock(
+		id: LockIdentifier,
+		who: &AccountId,
+	) -> Option<(Self::Balance, WithdrawReasons)>;
+
 	/// Create a new balance lock on account `who`.
 	///
 	/// If the new lock is valid (i.e. not already expired), it will push the struct to


### PR DESCRIPTION
Currently, there is no way to inspect any existing locks using the `LockableCurrency` trait.

This adds such an API, and implements it in the balances and generic assets pallet.

Unfortunately, lock reasons in these pallets are lossy. From `WithdrawReasons` we convert to a smaller subset `Reasons`. Then when getting a lock, we can only do best effort conversion back from `Reasons` to `WithdrawReasons`.

Its not perfect, but certainly better than what we have today.