### PR TITLE
client/api: fix possible deadlock when comparing with itself

### DIFF
--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -19,6 +19,7 @@
 //! In memory client backend
 
 use std::collections::HashMap;
+use std::ptr;
 use std::sync::Arc;
 use parking_lot::RwLock;
 use sp_core::{
@@ -191,11 +192,19 @@ impl<Block: BlockT> Blockchain<Block> {
 
 	/// Compare this blockchain with another in-mem blockchain
 	pub fn equals_to(&self, other: &Self) -> bool {
+		// Check ptr equality first to avoid double read locks.
+		if ptr::eq(self, other) {
+			return true;
+		}
 		self.canon_equals_to(other) && self.storage.read().blocks == other.storage.read().blocks
 	}
 
 	/// Compare canonical chain to other canonical chain.
 	pub fn canon_equals_to(&self, other: &Self) -> bool {
+		// Check ptr equality first to avoid double read locks.
+		if ptr::eq(self, other) {
+			return true;
+		}
 		let this = self.storage.read();
 		let other = other.storage.read();
 			this.hashes == other.hashes


### PR DESCRIPTION
This PR fixes possible deadlocks in client/api/src/in_mem.rs:
When comparing with itself, `fn equal_to(&self, other: &Self)` will have `self` and `other` point to the same `Blockchain`.

According to `parking_lot::RwLock`:
“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”

So the two read locks (once interleaved by a write lock from another thread) may lead to deadlock.

`fn canon_equals_to()` has a similar issue.

The fix is to compare the two addresses and return early when they are equal.
