### PR TITLE
Temporary and Heavy Weights for Society Pallet

### DIFF
--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -1036,10 +1036,14 @@ decl_module! {
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let mut members = vec![];
 
+			let mut weight = 0;
+
 			// Run a candidate/membership rotation
 			if (n % T::RotationPeriod::get()).is_zero() {
 				members = <Members<T, I>>::get();
 				Self::rotate_period(&mut members);
+
+				weight += T::MaximumBlockWeight::get() / 20;
 			}
 
 			// Run a challenge rotation
@@ -1049,9 +1053,11 @@ decl_module! {
 					members = <Members<T, I>>::get();
 				}
 				Self::rotate_challenge(&mut members);
+
+				weight += T::MaximumBlockWeight::get() / 20;
 			}
 
-			0
+			weight
 		}
 	}
 }

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -532,7 +532,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + B + C + logM + logB + X)
 		/// # </weight>
-		#[weight = 50_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn bid(origin, value: BalanceOf<T, I>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			ensure!(!<SuspendedCandidates<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
@@ -571,7 +571,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(B + X)
 		/// # </weight>
-		#[weight = 20_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn unbid(origin, pos: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
@@ -641,7 +641,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + B + C + logM + logB + X)
 		/// # </weight>
-		#[weight = 50_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn vouch(origin, who: T::AccountId, value: BalanceOf<T, I>, tip: BalanceOf<T, I>) -> DispatchResult {
 			let voucher = ensure_signed(origin)?;
 			// Check user is not suspended.
@@ -682,7 +682,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(B)
 		/// # </weight>
-		#[weight = 20_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn unvouch(origin, pos: u32) -> DispatchResult {
 			let voucher = ensure_signed(origin)?;
 			ensure!(Self::vouching(&voucher) == Some(VouchingStatus::Vouching), Error::<T, I>::NotVouching);
@@ -720,7 +720,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + logM + C)
 		/// # </weight>
-		#[weight = 30_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn vote(origin, candidate: <T::Lookup as StaticLookup>::Source, approve: bool) {
 			let voter = ensure_signed(origin)?;
 			let candidate = T::Lookup::lookup(candidate)?;
@@ -751,7 +751,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + logM)
 		/// # </weight>
-		#[weight = 20_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn defender_vote(origin, approve: bool) {
 			let voter = ensure_signed(origin)?;
 			let members = <Members<T, I>>::get();
@@ -783,7 +783,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + logM + P + X)
 		/// # </weight>
-		#[weight = 30_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		pub fn payout(origin) {
 			let who = ensure_signed(origin)?;
 
@@ -825,7 +825,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
-		#[weight = 0]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		fn found(origin, founder: T::AccountId, max_members: u32, rules: Vec<u8>) {
 			T::FounderSetOrigin::ensure_origin(origin)?;
 			ensure!(!<Head<T, I>>::exists(), Error::<T, I>::AlreadyFounded);
@@ -852,7 +852,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
-		#[weight = 20_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		fn unfound(origin) {
 			let founder = ensure_signed(origin)?;
 			ensure!(Founder::<T, I>::get() == Some(founder.clone()), Error::<T, I>::NotFounder);
@@ -894,7 +894,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + logM + B)
 		/// # </weight>
-		#[weight = 30_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		fn judge_suspended_member(origin, who: T::AccountId, forgive: bool) {
 			T::SuspensionJudgementOrigin::ensure_origin(origin)?;
 			ensure!(<SuspendedMembers<T, I>>::contains_key(&who), Error::<T, I>::NotSuspended);
@@ -965,7 +965,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(M + logM + B + X)
 		/// # </weight>
-		#[weight = 50_000_000]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		fn judge_suspended_candidate(origin, who: T::AccountId, judgement: Judgement) {
 			T::SuspensionJudgementOrigin::ensure_origin(origin)?;
 			if let Some((value, kind)) = <SuspendedCandidates<T, I>>::get(&who) {
@@ -1025,7 +1025,7 @@ decl_module! {
 		///
 		/// Total Complexity: O(1)
 		/// # </weight>
-		#[weight = 0]
+		#[weight = T::MaximumBlockWeight::get() / 10]
 		fn set_max_members(origin, max: u32) {
 			ensure_root(origin)?;
 			ensure!(max > 1, Error::<T, I>::MaxMembers);


### PR DESCRIPTION
This is a temporary patch that makes society weights very heavy, but almost certainly completely safe for the Kusama runtime.

An important follow up here is to add real weights to this pallet so that we can reduce the economic burden on those that want to use it.