### PR TITLE
Expose chain_spec and service in node-template

### DIFF
--- a/bin/node-template/node/src/lib.rs
+++ b/bin/node-template/node/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod chain_spec;
+pub mod service;


### PR DESCRIPTION
So that subxt can use the node-template for it's unit tests the chain spec and service need to be exposed.