### PR TITLE
Introduce in-origin filtering

### DIFF
--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -24,6 +24,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 impl system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -24,7 +24,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 }
 impl system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -136,7 +136,7 @@ parameter_types! {
 
 impl system::Trait for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The aggregated dispatch type that is available for extrinsics.

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -135,6 +135,8 @@ parameter_types! {
 }
 
 impl system::Trait for Runtime {
+	/// The basic call filter to use in dispatchable.
+	type BasicCallFilter = ();
 	/// The identifier used to distinguish between accounts.
 	type AccountId = AccountId;
 	/// The aggregated dispatch type that is available for extrinsics.

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -146,7 +146,7 @@ parameter_types! {
 const_assert!(AvailableBlockRatio::get().deconstruct() >= AVERAGE_ON_INITIALIZE_WEIGHT.deconstruct());
 
 impl frame_system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = Index;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -155,6 +155,7 @@ parameter_types! {
 const_assert!(AvailableBlockRatio::get().deconstruct() >= AVERAGE_ON_INITIALIZE_WEIGHT.deconstruct());
 
 impl frame_system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = Index;

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -33,7 +33,7 @@ use frame_support::{
 	traits::{Currency, Imbalance, KeyOwnerProofSystem, OnUnbalanced, Randomness, LockIdentifier},
 };
 use frame_system::{EnsureRoot, EnsureOneOf};
-use frame_support::traits::{Filter, InstanceFilter};
+use frame_support::traits::InstanceFilter;
 use codec::{Encode, Decode};
 use sp_core::{
 	crypto::KeyTypeId,
@@ -113,15 +113,6 @@ pub fn native_version() -> NativeVersion {
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;
 
-pub struct BaseFilter;
-impl Filter<Call> for BaseFilter {
-	fn filter(_call: &Call) -> bool {
-		true
-	}
-}
-pub struct IsCallable;
-frame_support::impl_filter_stack!(IsCallable, BaseFilter, Call, is_callable);
-
 pub struct DealWithFees;
 impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item=NegativeImbalance>) {
@@ -184,7 +175,6 @@ impl frame_system::Trait for Runtime {
 impl pallet_utility::Trait for Runtime {
 	type Event = Event;
 	type Call = Call;
-	type IsCallable = IsCallable;
 }
 
 parameter_types! {
@@ -202,7 +192,6 @@ impl pallet_multisig::Trait for Runtime {
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
 	type MaxSignatories = MaxSignatories;
-	type IsCallable = IsCallable;
 }
 
 parameter_types! {
@@ -252,7 +241,6 @@ impl pallet_proxy::Trait for Runtime {
 	type Event = Event;
 	type Call = Call;
 	type Currency = Balances;
-	type IsCallable = IsCallable;
 	type ProxyType = ProxyType;
 	type ProxyDepositBase = ProxyDepositBase;
 	type ProxyDepositFactor = ProxyDepositFactor;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -304,6 +304,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type Call = ();

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -304,7 +304,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type Call = ();

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -46,6 +46,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -143,7 +143,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = BlockNumber;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -143,6 +143,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = BlockNumber;

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -418,7 +418,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -418,6 +418,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -57,7 +57,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -57,6 +57,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -841,7 +841,7 @@ impl<T: Subtrait<I>, I: Instance> PartialEq for ElevatedTrait<T, I> {
 }
 impl<T: Subtrait<I>, I: Instance> Eq for ElevatedTrait<T, I> {}
 impl<T: Subtrait<I>, I: Instance> frame_system::Trait for ElevatedTrait<T, I> {
-	type BasicCallFilter = T::BasicCallFilter;
+	type BaseCallFilter = T::BaseCallFilter;
 	type Origin = T::Origin;
 	type Call = T::Call;
 	type Index = T::Index;

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -841,6 +841,7 @@ impl<T: Subtrait<I>, I: Instance> PartialEq for ElevatedTrait<T, I> {
 }
 impl<T: Subtrait<I>, I: Instance> Eq for ElevatedTrait<T, I> {}
 impl<T: Subtrait<I>, I: Instance> frame_system::Trait for ElevatedTrait<T, I> {
+	type BasicCallFilter = T::BasicCallFilter;
 	type Origin = T::Origin;
 	type Call = T::Call;
 	type Index = T::Index;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -67,7 +67,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -67,6 +67,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -67,7 +67,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -67,6 +67,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -29,7 +29,8 @@ pub use utils::*;
 pub use analysis::Analysis;
 #[doc(hidden)]
 pub use sp_io::storage::root as storage_root;
-pub use sp_runtime::traits::{Dispatchable, Zero};
+pub use sp_runtime::traits::Zero;
+pub use frame_support;
 pub use paste;
 
 /// Construct pallet benchmarks for weighing dispatchables.
@@ -242,7 +243,9 @@ macro_rules! benchmarks_iter {
 			{ $( $common )* }
 			( $( $names )* )
 			$name { $( $code )* }: {
-				<Call<T> as $crate::Dispatchable>::dispatch(Call::<T>::$dispatch($($arg),*), $origin.into())?;
+				<
+					Call<T> as $crate::frame_support::traits::PalletDispatchable
+				>::dispatch_bypass_filter(Call::<T>::$dispatch($($arg),*), $origin.into())?;
 			}
 			verify $postcode
 			$( $rest )*
@@ -262,7 +265,9 @@ macro_rules! benchmarks_iter {
 			{ $( $common )* }
 			( $( $names )* )
 			$name { $( $code )* }: {
-				<Call<T, I> as $crate::Dispatchable>::dispatch(Call::<T, I>::$dispatch($($arg),*), $origin.into())?;
+				<
+					Call<T, I> as $crate::frame_support::traits::PalletDispatchable
+				>::dispatch_bypass_filter(Call::<T, I>::$dispatch($($arg),*), $origin.into())?;
 			}
 			verify $postcode
 			$( $rest )*

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -244,7 +244,7 @@ macro_rules! benchmarks_iter {
 			( $( $names )* )
 			$name { $( $code )* }: {
 				<
-					Call<T> as $crate::frame_support::traits::PalletDispatchable
+					Call<T> as $crate::frame_support::traits::UnfilteredDispatchable
 				>::dispatch_bypass_filter(Call::<T>::$dispatch($($arg),*), $origin.into())?;
 			}
 			verify $postcode
@@ -266,7 +266,7 @@ macro_rules! benchmarks_iter {
 			( $( $names )* )
 			$name { $( $code )* }: {
 				<
-					Call<T, I> as $crate::frame_support::traits::PalletDispatchable
+					Call<T, I> as $crate::frame_support::traits::UnfilteredDispatchable
 				>::dispatch_bypass_filter(Call::<T, I>::$dispatch($($arg),*), $origin.into())?;
 			}
 			verify $postcode

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -67,7 +67,7 @@ pub trait Trait {
 pub struct Test;
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -67,6 +67,7 @@ pub trait Trait {
 pub struct Test;
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1015,7 +1015,7 @@ mod tests {
 		pub const MaxProposals: u32 = 100;
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1015,10 +1015,11 @@ mod tests {
 		pub const MaxProposals: u32 = 100;
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
@@ -1167,7 +1168,7 @@ mod tests {
 			let proposal_len: u32 = proposal.using_encoded(|p| p.len() as u32);
 			let proposal_weight = proposal.get_dispatch_info().weight;
 			let hash = BlakeTwo256::hash_of(&proposal);
-			assert_ok!(Collective::set_members(Origin::ROOT, vec![1, 2, 3], Some(3), MAX_MEMBERS));
+			assert_ok!(Collective::set_members(Origin::root(), vec![1, 2, 3], Some(3), MAX_MEMBERS));
 
 			assert_ok!(Collective::propose(Origin::signed(1), 3, Box::new(proposal.clone()), proposal_len));
 			assert_ok!(Collective::vote(Origin::signed(2), hash.clone(), 0, true));
@@ -1192,7 +1193,7 @@ mod tests {
 			let proposal_len: u32 = proposal.using_encoded(|p| p.len() as u32);
 			let proposal_weight = proposal.get_dispatch_info().weight;
 			let hash = BlakeTwo256::hash_of(&proposal);
-			assert_ok!(Collective::set_members(Origin::ROOT, vec![1, 2, 3], Some(1), MAX_MEMBERS));
+			assert_ok!(Collective::set_members(Origin::root(), vec![1, 2, 3], Some(1), MAX_MEMBERS));
 
 			assert_ok!(Collective::propose(Origin::signed(1), 3, Box::new(proposal.clone()), proposal_len));
 			assert_ok!(Collective::vote(Origin::signed(2), hash.clone(), 0, true));
@@ -1260,7 +1261,7 @@ mod tests {
 				Collective::voting(&hash),
 				Some(Votes { index: 0, threshold: 3, ayes: vec![1, 2], nays: vec![], end })
 			);
-			assert_ok!(Collective::set_members(Origin::ROOT, vec![2, 3, 4], None, MAX_MEMBERS));
+			assert_ok!(Collective::set_members(Origin::root(), vec![2, 3, 4], None, MAX_MEMBERS));
 			assert_eq!(
 				Collective::voting(&hash),
 				Some(Votes { index: 0, threshold: 3, ayes: vec![2], nays: vec![], end })
@@ -1275,7 +1276,7 @@ mod tests {
 				Collective::voting(&hash),
 				Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![3], end })
 			);
-			assert_ok!(Collective::set_members(Origin::ROOT, vec![2, 4], None, MAX_MEMBERS));
+			assert_ok!(Collective::set_members(Origin::root(), vec![2, 4], None, MAX_MEMBERS));
 			assert_eq!(
 				Collective::voting(&hash),
 				Some(Votes { index: 1, threshold: 2, ayes: vec![2], nays: vec![], end })
@@ -1618,7 +1619,7 @@ mod tests {
 			// Proposal would normally succeed
 			assert_ok!(Collective::vote(Origin::signed(2), hash.clone(), 0, true));
 			// But Root can disapprove and remove it anyway
-			assert_ok!(Collective::disapprove_proposal(Origin::ROOT, hash.clone()));
+			assert_ok!(Collective::disapprove_proposal(Origin::root(), hash.clone()));
 			let record = |event| EventRecord { phase: Phase::Initialization, event, topics: vec![] };
 			assert_eq!(System::events(), vec![
 				record(Event::collective_Instance1(RawEvent::Proposed(1, 0, hash.clone(), 2))),

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -82,11 +82,12 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
-	type Call = ();
+	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
@@ -936,7 +937,7 @@ fn call_contract_removals() {
 
 #[test]
 fn inherent_claim_surcharge_contract_removals() {
-	removals(|| Contracts::claim_surcharge(Origin::NONE, BOB, Some(ALICE)).is_ok());
+	removals(|| Contracts::claim_surcharge(Origin::none(), BOB, Some(ALICE)).is_ok());
 }
 
 #[test]
@@ -947,10 +948,10 @@ fn signed_claim_surcharge_contract_removals() {
 #[test]
 fn claim_surcharge_malus() {
 	// Test surcharge malus for inherent
-	claim_surcharge(4, || Contracts::claim_surcharge(Origin::NONE, BOB, Some(ALICE)).is_ok(), true);
-	claim_surcharge(3, || Contracts::claim_surcharge(Origin::NONE, BOB, Some(ALICE)).is_ok(), true);
-	claim_surcharge(2, || Contracts::claim_surcharge(Origin::NONE, BOB, Some(ALICE)).is_ok(), true);
-	claim_surcharge(1, || Contracts::claim_surcharge(Origin::NONE, BOB, Some(ALICE)).is_ok(), false);
+	claim_surcharge(4, || Contracts::claim_surcharge(Origin::none(), BOB, Some(ALICE)).is_ok(), true);
+	claim_surcharge(3, || Contracts::claim_surcharge(Origin::none(), BOB, Some(ALICE)).is_ok(), true);
+	claim_surcharge(2, || Contracts::claim_surcharge(Origin::none(), BOB, Some(ALICE)).is_ok(), true);
+	claim_surcharge(1, || Contracts::claim_surcharge(Origin::none(), BOB, Some(ALICE)).is_ok(), false);
 
 	// Test surcharge malus for signed
 	claim_surcharge(4, || Contracts::claim_surcharge(Origin::signed(ALICE), BOB, None).is_ok(), true);

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -82,7 +82,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -22,7 +22,7 @@ use super::*;
 use frame_benchmarking::{benchmarks, account};
 use frame_support::{
 	IterableStorageMap,
-	traits::{Currency, Get, EnsureOrigin, OnInitialize, PalletDispatchable},
+	traits::{Currency, Get, EnsureOrigin, OnInitialize, UnfilteredDispatchable},
 };
 use frame_system::{RawOrigin, Module as System, self, EventRecord};
 use sp_runtime::traits::{Bounded, One};

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -22,7 +22,7 @@ use super::*;
 use frame_benchmarking::{benchmarks, account};
 use frame_support::{
 	IterableStorageMap,
-	traits::{Currency, Get, EnsureOrigin, OnInitialize},
+	traits::{Currency, Get, EnsureOrigin, OnInitialize, PalletDispatchable},
 };
 use frame_system::{RawOrigin, Module as System, self, EventRecord};
 use sp_runtime::traits::{Bounded, One};
@@ -212,14 +212,14 @@ benchmarks! {
 		for i in 0 .. r {
 			let ref_idx = add_referendum::<T>(i)?;
 			let call = Call::<T>::emergency_cancel(ref_idx);
-			call.dispatch(origin.clone())?;
+			call.dispatch_bypass_filter(origin.clone())?;
 		}
 
 		// Lets now measure one more
 		let referendum_index = add_referendum::<T>(r)?;
 		let call = Call::<T>::emergency_cancel(referendum_index);
 		assert!(Democracy::<T>::referendum_status(referendum_index).is_ok());
-	}: { call.dispatch(origin)? }
+	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		// Referendum has been canceled
 		assert!(Democracy::<T>::referendum_status(referendum_index).is_err());
@@ -239,7 +239,7 @@ benchmarks! {
 		);
 
 		let call = Call::<T>::external_propose(proposal_hash);
-	}: { call.dispatch(origin)? }
+	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		// External proposal created
 		ensure!(<NextExternal<T>>::exists(), "External proposal didn't work");
@@ -251,7 +251,7 @@ benchmarks! {
 		let origin = T::ExternalMajorityOrigin::successful_origin();
 		let proposal_hash = T::Hashing::hash_of(&p);
 		let call = Call::<T>::external_propose_majority(proposal_hash);
-	}: { call.dispatch(origin)? }
+	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		// External proposal created
 		ensure!(<NextExternal<T>>::exists(), "External proposal didn't work");
@@ -263,7 +263,7 @@ benchmarks! {
 		let origin = T::ExternalDefaultOrigin::successful_origin();
 		let proposal_hash = T::Hashing::hash_of(&p);
 		let call = Call::<T>::external_propose_default(proposal_hash);
-	}: { call.dispatch(origin)? }
+	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		// External proposal created
 		ensure!(<NextExternal<T>>::exists(), "External proposal didn't work");
@@ -282,7 +282,7 @@ benchmarks! {
 		let delay = 0;
 		let call = Call::<T>::fast_track(proposal_hash, voting_period.into(), delay.into());
 
-	}: { call.dispatch(origin_fast_track)? }
+	}: { call.dispatch_bypass_filter(origin_fast_track)? }
 	verify {
 		assert_eq!(Democracy::<T>::referendum_count(), 1, "referendum not created")
 	}
@@ -306,7 +306,7 @@ benchmarks! {
 		let call = Call::<T>::veto_external(proposal_hash);
 		let origin = T::VetoOrigin::successful_origin();
 		ensure!(NextExternal::<T>::get().is_some(), "no external proposal");
-	}: { call.dispatch(origin)? }
+	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		assert!(NextExternal::<T>::get().is_none());
 		let (_, new_vetoers) = <Blacklist<T>>::get(&proposal_hash).ok_or("no blacklist")?;
@@ -347,7 +347,7 @@ benchmarks! {
 		let origin = T::ExternalMajorityOrigin::successful_origin();
 		let proposal_hash = T::Hashing::hash_of(&r);
 		let call = Call::<T>::external_propose_majority(proposal_hash);
-		call.dispatch(origin)?;
+		call.dispatch_bypass_filter(origin)?;
 		// External proposal created
 		ensure!(<NextExternal<T>>::exists(), "External proposal didn't work");
 

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -84,6 +84,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -84,7 +84,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/democracy/src/tests/cancellation.rs
+++ b/frame/democracy/src/tests/cancellation.rs
@@ -29,7 +29,7 @@ fn cancel_referendum_should_work() {
 			0
 		);
 		assert_ok!(Democracy::vote(Origin::signed(1), r, aye(1)));
-		assert_ok!(Democracy::cancel_referendum(Origin::ROOT, r.into()));
+		assert_ok!(Democracy::cancel_referendum(Origin::root(), r.into()));
 
 		next_block();
 		next_block();
@@ -53,8 +53,8 @@ fn cancel_queued_should_work() {
 
 		assert!(pallet_scheduler::Agenda::<Test>::get(6)[0].is_some());
 
-		assert_noop!(Democracy::cancel_queued(Origin::ROOT, 1), Error::<Test>::ProposalMissing);
-		assert_ok!(Democracy::cancel_queued(Origin::ROOT, 0));
+		assert_noop!(Democracy::cancel_queued(Origin::root(), 1), Error::<Test>::ProposalMissing);
+		assert_ok!(Democracy::cancel_queued(Origin::root(), 0));
 		assert!(pallet_scheduler::Agenda::<Test>::get(6)[0].is_none());
 	});
 }

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1070,7 +1070,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1070,10 +1070,11 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
@@ -1376,11 +1377,8 @@ mod tests {
 		// historical note: helper function was created in a period of time in which the API of vote
 		// call was changing. Currently it is a wrapper for the original call and does not do much.
 		// Nonetheless, totally harmless.
-		if let Origin::system(frame_system::RawOrigin::Signed(_account)) = origin {
-			Elections::vote(origin, votes, stake)
-		} else {
-			panic!("vote origin must be signed");
-		}
+		ensure_signed(origin.clone()).expect("vote origin must be signed");
+		Elections::vote(origin, votes, stake)
 	}
 
 	fn votes_of(who: &u64) -> Vec<u64> {
@@ -2358,7 +2356,7 @@ mod tests {
 			assert_ok!(submit_candidacy(Origin::signed(3)));
 			assert_ok!(vote(Origin::signed(3), vec![3], 30));
 
-			assert_ok!(Elections::remove_member(Origin::ROOT, 4, false));
+			assert_ok!(Elections::remove_member(Origin::root(), 4, false));
 
 			assert_eq!(balances(&4), (35, 2)); // slashed
 			assert_eq!(Elections::election_rounds(), 2); // new election round
@@ -2381,7 +2379,7 @@ mod tests {
 
 			// no replacement yet.
 			assert_err_with_weight!(
-				Elections::remove_member(Origin::ROOT, 4, true),
+				Elections::remove_member(Origin::root(), 4, true),
 				Error::<Test>::InvalidReplacement,
 				Some(6000000),
 			);
@@ -2403,7 +2401,7 @@ mod tests {
 
 			// there is a replacement! and this one needs a weight refund.
 			assert_err_with_weight!(
-				Elections::remove_member(Origin::ROOT, 4, false),
+				Elections::remove_member(Origin::root(), 4, false),
 				Error::<Test>::InvalidReplacement,
 				Some(6000000) // only thing that matters for now is that it is NOT the full block.
 			);
@@ -2562,7 +2560,7 @@ mod tests {
 			Elections::end_block(System::block_number());
 
 			assert_eq!(Elections::members_ids(), vec![2, 4]);
-			assert_ok!(Elections::remove_member(Origin::ROOT, 2, true));
+			assert_ok!(Elections::remove_member(Origin::root(), 2, true));
 			assert_eq!(Elections::members_ids(), vec![4, 5]);
 		});
 	}

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -39,8 +39,9 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
-	type Call = ();
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -39,7 +39,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/elections/src/tests.rs
+++ b/frame/elections/src/tests.rs
@@ -671,7 +671,7 @@ fn retracting_active_voter_should_slash_reporter() {
 		assert_ok!(Elections::end_block(System::block_number()));
 
 		System::set_block_number(8);
-		assert_ok!(Elections::set_desired_seats(Origin::ROOT, 3));
+		assert_ok!(Elections::set_desired_seats(Origin::root(), 3));
 		assert_ok!(Elections::end_block(System::block_number()));
 
 		System::set_block_number(10);
@@ -1245,7 +1245,7 @@ fn election_second_tally_should_use_runners_up() {
 
 		System::set_block_number(8);
 		assert_ok!(Elections::set_approvals(Origin::signed(6), vec![false, false, true, false], 1, 0, 60));
-		assert_ok!(Elections::set_desired_seats(Origin::ROOT, 3));
+		assert_ok!(Elections::set_desired_seats(Origin::root(), 3));
 		assert_ok!(Elections::end_block(System::block_number()));
 
 		System::set_block_number(10);

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -54,6 +54,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -54,7 +54,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -744,7 +744,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -256,7 +256,7 @@
 
 use sp_std::marker::PhantomData;
 use frame_support::{
-	dispatch::DispatchResult, decl_module, decl_storage, decl_event,
+	dispatch::{DispatchResult, IsSubType}, decl_module, decl_storage, decl_event,
 	weights::{DispatchClass, ClassifyDispatch, WeighData, Weight, PaysFee, Pays},
 };
 use sp_std::prelude::*;
@@ -609,14 +609,13 @@ impl<T: Trait + Send + Sync> sp_std::fmt::Debug for WatchDummy<T> {
 	}
 }
 
-impl<T: Trait + Send + Sync> SignedExtension for WatchDummy<T> {
+impl<T: Trait + Send + Sync> SignedExtension for WatchDummy<T>
+where
+	<T as frame_system::Trait>::Call: IsSubType<Module<T>, T>,
+{
 	const IDENTIFIER: &'static str = "WatchDummy";
 	type AccountId = T::AccountId;
-	// Note that this could also be assigned to the top-level call enum. It is passed into the
-	// Balances Pallet directly and since `Trait: pallet_balances::Trait`, you could also use `T::Call`.
-	// In that case, you would have had access to all call variants and could match on variants from
-	// other pallets.
-	type Call = Call<T>;
+	type Call = <T as frame_system::Trait>::Call;
 	type AdditionalSigned = ();
 	type Pre = ();
 
@@ -635,8 +634,8 @@ impl<T: Trait + Send + Sync> SignedExtension for WatchDummy<T> {
 		}
 
 		// check for `set_dummy`
-		match call {
-			Call::set_dummy(..) => {
+		match call.is_sub_type() {
+			Some(Call::set_dummy(..)) => {
 				sp_runtime::print("set_dummy was received.");
 
 				let mut valid_tx = ValidTransaction::default();
@@ -711,8 +710,8 @@ mod tests {
 	use super::*;
 
 	use frame_support::{
-		assert_ok, impl_outer_origin, parameter_types, weights::{DispatchInfo, GetDispatchInfo},
-		traits::{OnInitialize, OnFinalize}
+		assert_ok, impl_outer_origin, parameter_types, impl_outer_dispatch,
+		weights::{DispatchInfo, GetDispatchInfo}, traits::{OnInitialize, OnFinalize}
 	};
 	use sp_core::H256;
 	// The testing primitives are very useful for avoiding having to work with signatures
@@ -727,6 +726,12 @@ mod tests {
 		pub enum Origin for Test  where system = frame_system {}
 	}
 
+	impl_outer_dispatch! {
+		pub enum OuterCall for Test where origin: Origin {
+			self::Example,
+		}
+	}
+
 	// For testing the pallet, we construct most of a mock runtime. This means
 	// first constructing a configuration type (`Test`) which `impl`s each of the
 	// configuration traits of pallets we want to use.
@@ -739,11 +744,12 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
 		type Hash = H256;
-		type Call = ();
+		type Call = OuterCall;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
@@ -827,7 +833,7 @@ mod tests {
 	#[test]
 	fn signed_ext_watch_dummy_works() {
 		new_test_ext().execute_with(|| {
-			let call = <Call<Test>>::set_dummy(10);
+			let call = <Call<Test>>::set_dummy(10).into();
 			let info = DispatchInfo::default();
 
 			assert_eq!(

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -545,7 +545,7 @@ mod tests {
 		};
 	}
 	impl frame_system::Trait for Runtime {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type Call = Call;

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -545,6 +545,7 @@ mod tests {
 		};
 	}
 	impl frame_system::Trait for Runtime {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type Call = Call;

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -252,7 +252,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -252,6 +252,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
@@ -337,10 +338,7 @@ mod tests {
 					&Default::default(),
 					Default::default(),
 				);
-				assert_ok!(FinalityTracker::dispatch(
-					Call::final_hint(i-1),
-					Origin::NONE,
-				));
+				assert_ok!(FinalityTracker::final_hint(Origin::none(), i - 1));
 				FinalityTracker::on_finalize(i);
 				let hdr = System::finalize();
 				parent_hash = hdr.hash();

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -1120,6 +1120,7 @@ impl<T: Subtrait> PartialEq for ElevatedTrait<T> {
 }
 impl<T: Subtrait> Eq for ElevatedTrait<T> {}
 impl<T: Subtrait> frame_system::Trait for ElevatedTrait<T> {
+	type BasicCallFilter = T::BasicCallFilter;
 	type Origin = T::Origin;
 	type Call = T::Call;
 	type Index = T::Index;

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -1120,7 +1120,7 @@ impl<T: Subtrait> PartialEq for ElevatedTrait<T> {
 }
 impl<T: Subtrait> Eq for ElevatedTrait<T> {}
 impl<T: Subtrait> frame_system::Trait for ElevatedTrait<T> {
-	type BasicCallFilter = T::BasicCallFilter;
+	type BaseCallFilter = T::BaseCallFilter;
 	type Origin = T::Origin;
 	type Call = T::Call;
 	type Index = T::Index;

--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -46,6 +46,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -46,7 +46,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/generic-asset/src/tests.rs
+++ b/frame/generic-asset/src/tests.rs
@@ -598,7 +598,7 @@ fn create_reserved_should_create_a_default_account_with_the_balance_given() {
 		let created_asset_id = 9;
 		let created_account_id = 0;
 
-		assert_ok!(GenericAsset::create_reserved(Origin::ROOT, created_asset_id, options));
+		assert_ok!(GenericAsset::create_reserved(Origin::root(), created_asset_id, options));
 
 		// Tests for side effects.
 		assert_eq!(<TotalIssuance<Test>>::get(created_asset_id), expected_total_issuance);

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -94,6 +94,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -94,7 +94,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -25,7 +25,7 @@ use codec::{Decode, Encode};
 use fg_primitives::ScheduledChange;
 use frame_support::{
 	assert_err, assert_ok,
-	traits::{Currency, OnFinalize},
+	traits::{Currency, OnFinalize, PalletDispatchable},
 };
 use frame_system::{EventRecord, Phase};
 use sp_core::H256;
@@ -376,7 +376,7 @@ fn report_equivocation_current_set_works() {
 
 		// report the equivocation and the tx should be dispatched successfully
 		let inner = report_equivocation(equivocation_proof, key_owner_proof).unwrap();
-		assert_ok!(Grandpa::dispatch(inner, Origin::signed(1)));
+		assert_ok!(inner.dispatch_bypass_filter(Origin::signed(1)));
 
 		start_era(2);
 
@@ -457,7 +457,7 @@ fn report_equivocation_old_set_works() {
 		// report the equivocation using the key ownership proof generated on
 		// the old set, the tx should be dispatched successfully
 		let inner = report_equivocation(equivocation_proof, key_owner_proof).unwrap();
-		assert_ok!(Grandpa::dispatch(inner, Origin::signed(1)));
+		assert_ok!(inner.dispatch_bypass_filter(Origin::signed(1)));
 
 		start_era(3);
 

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -25,7 +25,7 @@ use codec::{Decode, Encode};
 use fg_primitives::ScheduledChange;
 use frame_support::{
 	assert_err, assert_ok,
-	traits::{Currency, OnFinalize, PalletDispatchable},
+	traits::{Currency, OnFinalize, UnfilteredDispatchable},
 };
 use frame_system::{EventRecord, Phase};
 use sp_core::H256;

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -1174,6 +1174,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -1174,7 +1174,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -26,7 +26,7 @@ use frame_benchmarking::benchmarks;
 use sp_core::offchain::{OpaquePeerId, OpaqueMultiaddr};
 use sp_runtime::traits::{ValidateUnsigned, Zero};
 use sp_runtime::transaction_validity::TransactionSource;
-use frame_support::traits::PalletDispatchable;
+use frame_support::traits::UnfilteredDispatchable;
 
 use crate::Module as ImOnline;
 

--- a/frame/im-online/src/benchmarking.rs
+++ b/frame/im-online/src/benchmarking.rs
@@ -24,8 +24,9 @@ use super::*;
 use frame_system::RawOrigin;
 use frame_benchmarking::benchmarks;
 use sp_core::offchain::{OpaquePeerId, OpaqueMultiaddr};
-use sp_runtime::traits::{ValidateUnsigned, Zero, Dispatchable};
+use sp_runtime::traits::{ValidateUnsigned, Zero};
 use sp_runtime::transaction_validity::TransactionSource;
+use frame_support::traits::PalletDispatchable;
 
 use crate::Module as ImOnline;
 
@@ -85,7 +86,7 @@ benchmarks! {
 		let call = Call::heartbeat(input_heartbeat, signature);
 	}: {
 		ImOnline::<T>::validate_unsigned(TransactionSource::InBlock, &call)?;
-		call.dispatch(RawOrigin::None.into())?;
+		call.dispatch_bypass_filter(RawOrigin::None.into())?;
 	}
 }
 

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -104,7 +104,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -104,6 +104,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/im-online/src/tests.rs
+++ b/frame/im-online/src/tests.rs
@@ -135,7 +135,7 @@ fn heartbeat(
 			e @ _ => <&'static str>::from(e),
 		})?;
 	ImOnline::heartbeat(
-		Origin::system(frame_system::RawOrigin::None),
+		Origin::none(),
 		heartbeat,
 		signature,
 	)

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -50,7 +50,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = ();
 	type Index = u64;

--- a/frame/indices/src/tests.rs
+++ b/frame/indices/src/tests.rs
@@ -101,7 +101,7 @@ fn transfer_index_on_accounts_should_work() {
 fn force_transfer_index_on_preowned_should_work() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Indices::claim(Some(1).into(), 0));
-		assert_ok!(Indices::force_transfer(Origin::ROOT, 3, 0, false));
+		assert_ok!(Indices::force_transfer(Origin::root(), 3, 0, false));
 		assert_eq!(Balances::reserved_balance(1), 0);
 		assert_eq!(Balances::reserved_balance(3), 0);
 		assert_eq!(Indices::lookup_index(0), Some(3));
@@ -111,7 +111,7 @@ fn force_transfer_index_on_preowned_should_work() {
 #[test]
 fn force_transfer_index_on_free_should_work() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Indices::force_transfer(Origin::ROOT, 3, 0, false));
+		assert_ok!(Indices::force_transfer(Origin::root(), 3, 0, false));
 		assert_eq!(Balances::reserved_balance(3), 0);
 		assert_eq!(Indices::lookup_index(0), Some(3));
 	});

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -291,6 +291,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -291,7 +291,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -23,7 +23,7 @@ use super::*;
 
 use frame_support::{
 	assert_ok, assert_noop, impl_outer_origin, parameter_types, impl_outer_dispatch,
-	weights::Weight, impl_outer_event
+	weights::Weight, impl_outer_event, traits::Filter,
 };
 use sp_core::H256;
 use sp_runtime::{Perbill, traits::{BlakeTwo256, IdentityLookup}, testing::Header};
@@ -60,7 +60,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BaseCallFilter = ();
+	type BaseCallFilter = TestBaseCallFilter;
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
@@ -100,8 +100,8 @@ parameter_types! {
 	pub const DepositFactor: u64 = 1;
 	pub const MaxSignatories: u16 = 3;
 }
-pub struct TestIsCallable;
-impl Filter<Call> for TestIsCallable {
+pub struct TestBaseCallFilter;
+impl Filter<Call> for TestBaseCallFilter {
 	fn filter(c: &Call) -> bool {
 		match *c {
 			Call::Balances(_) => true,
@@ -111,13 +111,6 @@ impl Filter<Call> for TestIsCallable {
 		}
 	}
 }
-impl FilterStack<Call> for TestIsCallable {
-	type Stack = ();
-	fn push(_: impl Fn(&Call) -> bool + 'static) {}
-	fn pop() {}
-	fn take() -> Self::Stack { () }
-	fn restore(_: Self::Stack) {}
-}
 impl Trait for Test {
 	type Event = TestEvent;
 	type Call = Call;
@@ -125,7 +118,6 @@ impl Trait for Test {
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
 	type MaxSignatories = MaxSignatories;
-	type IsCallable = TestIsCallable;
 }
 type System = frame_system::Module<Test>;
 type Balances = pallet_balances::Module<Test>;
@@ -404,8 +396,8 @@ fn multisig_filters() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::System(frame_system::Call::set_code(vec![])));
 		assert_noop!(
-			Multisig::as_multi(Origin::signed(1), 1, vec![], None, call.clone()),
-			Error::<Test>::Uncallable,
+			Multisig::as_multi(Origin::signed(1), 1, vec![2], None, call.clone()),
+			DispatchError::BadOrigin,
 		);
 	});
 }

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -60,6 +60,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -60,7 +60,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -266,6 +266,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -266,7 +266,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -42,7 +42,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -42,6 +42,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -96,7 +96,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -96,6 +96,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -62,7 +62,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -158,7 +158,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -158,6 +158,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -64,7 +64,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -64,6 +64,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/recovery/src/tests.rs
+++ b/frame/recovery/src/tests.rs
@@ -46,7 +46,7 @@ fn set_recovered_works() {
 		// Not accessible by a normal user
 		assert_noop!(Recovery::set_recovered(Origin::signed(1), 5, 1), BadOrigin);
 		// Root can set a recovered account though
-		assert_ok!(Recovery::set_recovered(Origin::ROOT, 5, 1));
+		assert_ok!(Recovery::set_recovered(Origin::root(), 5, 1));
 		// Account 1 should now be able to make a call through account 5
 		let call = Box::new(Call::Balances(BalancesCall::transfer(1, 100)));
 		assert_ok!(Recovery::as_recovered(Origin::signed(1), 5, call));

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -487,7 +487,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Call = Call;
 		type Index = u64;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -487,8 +487,9 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
-		type Call = ();
+		type Call = Call;
 		type Index = u64;
 		type BlockNumber = u64;
 		type Hash = H256;
@@ -708,14 +709,14 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let call = Box::new(Call::Logger(logger::Call::log(69, 1000)));
 			let call2 = Box::new(Call::Logger(logger::Call::log(42, 1000)));
-			assert_ok!(Scheduler::schedule_named(Origin::ROOT, 1u32.encode(), 4, None, 127, call));
-			assert_ok!(Scheduler::schedule(Origin::ROOT, 4, None, 127, call2));
+			assert_ok!(Scheduler::schedule_named(Origin::root(), 1u32.encode(), 4, None, 127, call));
+			assert_ok!(Scheduler::schedule(Origin::root(), 4, None, 127, call2));
 			run_to_block(3);
 			// Scheduled calls are in the agenda.
 			assert_eq!(Agenda::<Test>::get(4).len(), 2);
 			assert!(logger::log().is_empty());
-			assert_ok!(Scheduler::cancel_named(Origin::ROOT, 1u32.encode()));
-			assert_ok!(Scheduler::cancel(Origin::ROOT, 4, 1));
+			assert_ok!(Scheduler::cancel_named(Origin::root(), 1u32.encode()));
+			assert_ok!(Scheduler::cancel(Origin::root(), 4, 1));
 			// Scheduled calls are made NONE, so should not effect state
 			run_to_block(100);
 			assert!(logger::log().is_empty());

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -55,6 +55,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -55,7 +55,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -58,6 +58,7 @@ impl Convert<u128, u64> for CurrencyToVoteHandler {
 pub struct Test;
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -58,7 +58,7 @@ impl Convert<u128, u64> for CurrencyToVoteHandler {
 pub struct Test;
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -173,7 +173,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -173,6 +173,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -65,7 +65,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -65,6 +65,7 @@ ord_parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/society/src/tests.rs
+++ b/frame/society/src/tests.rs
@@ -813,7 +813,7 @@ fn max_limits_work() {
 		// No candidates because full
 		assert_eq!(Society::candidates().len(), 0);
 		// Increase member limit
-		assert_ok!(Society::set_max_members(Origin::ROOT, 200));
+		assert_ok!(Society::set_max_members(Origin::root(), 200));
 		// Rotate period
 		run_to_block(16);
 		// Candidates are back!

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -57,7 +57,7 @@ impl Convert<u128, u64> for CurrencyToVoteHandler {
 pub struct Test;
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type DbWeight = ();
 	type BlockExecutionWeight = ();

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -57,6 +57,7 @@ impl Convert<u128, u64> for CurrencyToVoteHandler {
 pub struct Test;
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type DbWeight = ();
 	type BlockExecutionWeight = ();

--- a/frame/staking/fuzzer/src/submit_solution.rs
+++ b/frame/staking/fuzzer/src/submit_solution.rs
@@ -23,9 +23,9 @@ use honggfuzz::fuzz;
 
 use mock::Test;
 use pallet_staking::testing_utils::*;
-use frame_support::{assert_ok, storage::StorageValue};
+use frame_support::{assert_ok, storage::StorageValue, traits::PalletDispatchable};
 use frame_system::RawOrigin;
-use sp_runtime::{traits::Dispatchable, DispatchError};
+use sp_runtime::DispatchError;
 use sp_core::offchain::{testing::TestOffchainExt, OffchainExt};
 use pallet_staking::{EraElectionStatus, ElectionStatus, Module as Staking, Call as StakingCall};
 
@@ -159,7 +159,7 @@ fn main() {
 				match mode {
 					Mode::WeakerSubmission => {
 						assert_eq!(
-							call.dispatch(origin.clone().into()).unwrap_err().error,
+							call.dispatch_bypass_filter(origin.clone().into()).unwrap_err().error,
 							DispatchError::Module {
 								index: 0,
 								error: 16,
@@ -170,7 +170,7 @@ fn main() {
 					// NOTE: so exhaustive pattern doesn't work here.. maybe some rust issue?
 					// or due to `#[repr(u32)]`?
 					Mode::InitialSubmission | Mode::StrongerSubmission => {
-						assert_ok!(call.dispatch(origin.into()));
+						assert_ok!(call.dispatch_bypass_filter(origin.into()));
 					}
 				};
 			})

--- a/frame/staking/fuzzer/src/submit_solution.rs
+++ b/frame/staking/fuzzer/src/submit_solution.rs
@@ -23,7 +23,7 @@ use honggfuzz::fuzz;
 
 use mock::Test;
 use pallet_staking::testing_utils::*;
-use frame_support::{assert_ok, storage::StorageValue, traits::PalletDispatchable};
+use frame_support::{assert_ok, storage::StorageValue, traits::UnfilteredDispatchable};
 use frame_system::RawOrigin;
 use sp_runtime::DispatchError;
 use sp_core::offchain::{testing::TestOffchainExt, OffchainExt};

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -21,7 +21,7 @@ use super::*;
 use crate::Module as Staking;
 use testing_utils::*;
 
-use sp_runtime::{traits::{Dispatchable, One}};
+use sp_runtime::traits::One;
 use frame_system::RawOrigin;
 pub use frame_benchmarking::{benchmarks, account};
 const SEED: u32 = 0;
@@ -379,12 +379,12 @@ benchmarks! {
 		let current_era = CurrentEra::get().unwrap();
 		let mut points_total = 0;
 		let mut points_individual = Vec::new();
-		let mut payout_calls = Vec::new();
+		let mut payout_calls_arg = Vec::new();
 
 		for validator in new_validators.iter() {
 			points_total += 10;
 			points_individual.push((validator.clone(), 10));
-			payout_calls.push(Call::<T>::payout_stakers(validator.clone(), current_era))
+			payout_calls_arg.push((validator.clone(), current_era));
 		}
 
 		// Give Era Points
@@ -401,8 +401,8 @@ benchmarks! {
 
 		let caller: T::AccountId = account("caller", 0, SEED);
 	}: {
-		for call in payout_calls {
-			call.dispatch(RawOrigin::Signed(caller.clone()).into())?;
+		for arg in payout_calls_arg {
+			<Staking<T>>::payout_stakers(RawOrigin::Signed(caller.clone()).into(), arg.0, arg.1)?;
 		}
 	}
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -200,7 +200,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -200,6 +200,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -47,7 +47,7 @@ fn force_unstake_works() {
 		// Force unstake needs correct number of slashing spans (for weight calculation)
 		assert_noop!(Staking::force_unstake(Origin::signed(11), 11, 0), BadOrigin);
 		// We now force them to unstake
-		assert_ok!(Staking::force_unstake(Origin::ROOT, 11, 2));
+		assert_ok!(Staking::force_unstake(Origin::root(), 11, 2));
 		// No longer bonded.
 		assert_eq!(Staking::bonded(&11), None);
 		// Transfer works.
@@ -1477,7 +1477,7 @@ fn on_free_balance_zero_stash_removes_validator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Reap the stash
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11, 0));
+		assert_ok!(Staking::reap_stash(Origin::none(), 11, 0));
 
 		// Check storage items do not exist
 		assert!(!<Ledger<Test>>::contains_key(&10));
@@ -1533,7 +1533,7 @@ fn on_free_balance_zero_stash_removes_nominator() {
 		assert_eq!(Balances::total_balance(&11), 0);
 
 		// Reap the stash
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11, 0));
+		assert_ok!(Staking::reap_stash(Origin::none(), 11, 0));
 
 		// Check storage items do not exist
 		assert!(!<Ledger<Test>>::contains_key(&10));
@@ -1928,7 +1928,7 @@ fn offence_forces_new_era() {
 #[test]
 fn offence_ensures_new_era_without_clobbering() {
 	ExtBuilder::default().build_and_execute(|| {
-		assert_ok!(Staking::force_new_era_always(Origin::ROOT));
+		assert_ok!(Staking::force_new_era_always(Origin::root()));
 		assert_eq!(Staking::force_era(), Forcing::ForceAlways);
 
 		on_offence_now(
@@ -2302,8 +2302,8 @@ fn garbage_collection_after_slashing() {
 		assert_eq!(slashing_spans.iter().count(), 2);
 
 		// reap_stash respects num_slashing_spans so that weight is accurate
-		assert_noop!(Staking::reap_stash(Origin::NONE, 11, 0), Error::<Test>::IncorrectSlashingSpans);
-		assert_ok!(Staking::reap_stash(Origin::NONE, 11, 2));
+		assert_noop!(Staking::reap_stash(Origin::none(), 11, 0), Error::<Test>::IncorrectSlashingSpans);
+		assert_ok!(Staking::reap_stash(Origin::none(), 11, 2));
 
 		assert!(<Staking as crate::Store>::SlashingSpans::get(&11).is_none());
 		assert_eq!(<Staking as crate::Store>::SpanSlash::get(&(11, 0)).amount_slashed(), &0);
@@ -2591,11 +2591,11 @@ fn remove_deferred() {
 
 		// fails if empty
 		assert_noop!(
-			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![]),
+			Staking::cancel_deferred_slash(Origin::root(), 1, vec![]),
 			Error::<Test>::EmptyTargets
 		);
 
-		assert_ok!(Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0]));
+		assert_ok!(Staking::cancel_deferred_slash(Origin::root(), 1, vec![0]));
 
 		assert_eq!(Balances::free_balance(11), 1000);
 		assert_eq!(Balances::free_balance(101), 2000);
@@ -2692,21 +2692,21 @@ fn remove_multi_deferred() {
 
 		// fails if list is not sorted
 		assert_noop!(
-			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![2, 0, 4]),
+			Staking::cancel_deferred_slash(Origin::root(), 1, vec![2, 0, 4]),
 			Error::<Test>::NotSortedAndUnique
 		);
 		// fails if list is not unique
 		assert_noop!(
-			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0, 2, 2]),
+			Staking::cancel_deferred_slash(Origin::root(), 1, vec![0, 2, 2]),
 			Error::<Test>::NotSortedAndUnique
 		);
 		// fails if bad index
 		assert_noop!(
-			Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![1, 2, 3, 4, 5]),
+			Staking::cancel_deferred_slash(Origin::root(), 1, vec![1, 2, 3, 4, 5]),
 			Error::<Test>::InvalidSlashIndex
 		);
 
-		assert_ok!(Staking::cancel_deferred_slash(Origin::ROOT, 1, vec![0, 2, 4]));
+		assert_ok!(Staking::cancel_deferred_slash(Origin::root(), 1, vec![0, 2, 4]));
 
 		let slashes = <Staking as Store>::UnappliedSlashes::get(&1);
 		assert_eq!(slashes.len(), 2);
@@ -4243,16 +4243,16 @@ fn test_max_nominator_rewarded_per_validator_and_cant_steal_someone_else_reward(
 fn set_history_depth_works() {
 	ExtBuilder::default().build_and_execute(|| {
 		mock::start_era(10);
-		Staking::set_history_depth(Origin::ROOT, 20, 0).unwrap();
+		Staking::set_history_depth(Origin::root(), 20, 0).unwrap();
 		assert!(<Staking as Store>::ErasTotalStake::contains_key(10 - 4));
 		assert!(<Staking as Store>::ErasTotalStake::contains_key(10 - 5));
-		Staking::set_history_depth(Origin::ROOT, 4, 0).unwrap();
+		Staking::set_history_depth(Origin::root(), 4, 0).unwrap();
 		assert!(<Staking as Store>::ErasTotalStake::contains_key(10 - 4));
 		assert!(!<Staking as Store>::ErasTotalStake::contains_key(10 - 5));
-		Staking::set_history_depth(Origin::ROOT, 3, 0).unwrap();
+		Staking::set_history_depth(Origin::root(), 3, 0).unwrap();
 		assert!(!<Staking as Store>::ErasTotalStake::contains_key(10 - 4));
 		assert!(!<Staking as Store>::ErasTotalStake::contains_key(10 - 5));
-		Staking::set_history_depth(Origin::ROOT, 8, 0).unwrap();
+		Staking::set_history_depth(Origin::root(), 8, 0).unwrap();
 		assert!(!<Staking as Store>::ErasTotalStake::contains_key(10 - 4));
 		assert!(!<Staking as Store>::ErasTotalStake::contains_key(10 - 5));
 	});

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -121,7 +121,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -121,6 +121,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1403,7 +1403,7 @@ macro_rules! decl_module {
 					$from;
 					$(#[doc = $doc_attr])*
 					///
-					/// NOTE: Calling this function bypass origin filters
+					/// NOTE: Calling this function will bypass origin filters.
 					$fn_vis fn $fn_name (
 						$from $(, $param_name : $param )*
 					) $( -> $result )* { $( $impl )* }

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -2050,7 +2050,7 @@ mod tests {
 		pub trait Trait {
 			type AccountId;
 			type Call;
-			type BasicCallFilter;
+			type BaseCallFilter;
 			type Origin: crate::traits::OriginTrait<Call = Self::Call>;
 		}
 
@@ -2195,7 +2195,7 @@ mod tests {
 		type Origin = OuterOrigin;
 		type AccountId = u32;
 		type Call = OuterCall;
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 	}
 
 	#[test]

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -2178,7 +2178,6 @@ mod tests {
 		type BlockNumber = u32;
 	}
 
-	/// HREHREHREHRE
 	type Test = Module<TraitImpl>;
 
 	impl_outer_origin!{

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -29,7 +29,7 @@ pub use crate::weights::{
 	PaysFee, PostDispatchInfo, WithPostDispatchInfo,
 };
 pub use sp_runtime::{traits::Dispatchable, DispatchError};
-pub use crate::traits::{CallMetadata, GetCallMetadata, GetCallName};
+pub use crate::traits::{CallMetadata, GetCallMetadata, GetCallName, PalletDispatchable};
 
 /// The return typ of a `Dispatchable` in frame. When returned explicitly from
 /// a dispatchable function it allows overriding the default `PostDispatchInfo`
@@ -47,10 +47,9 @@ pub type DispatchResult = Result<(), sp_runtime::DispatchError>;
 pub type DispatchErrorWithPostInfo =
 	sp_runtime::DispatchErrorWithPostInfo<crate::weights::PostDispatchInfo>;
 
-/// Serializable version of Dispatchable.
-/// This value can be used as a "function" in an extrinsic.
+/// Serializable version of pallet dispatchable.
 pub trait Callable<T> {
-	type Call: Dispatchable<Info=DispatchInfo, PostInfo=PostDispatchInfo> + Codec + Clone + PartialEq + Eq;
+	type Call: PalletDispatchable + Codec + Clone + PartialEq + Eq;
 }
 
 // dirty hack to work around serde_derive issue
@@ -1005,6 +1004,7 @@ macro_rules! decl_module {
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?> $module<$trait_instance $(, $instance)?>
 			where $( $other_where_bounds )*
 		{
+			/// Deposits an event using `frame_system::Module::deposit_event`.
 			$vis fn deposit_event(
 				event: impl Into<< $trait_instance as $trait_name $(<$instance>)? >::Event>
 			) {
@@ -1402,6 +1402,8 @@ macro_rules! decl_module {
 					$error_type;
 					$from;
 					$(#[doc = $doc_attr])*
+					///
+					/// NOTE: Calling this function bypass origin filters
 					$fn_vis fn $fn_name (
 						$from $(, $param_name : $param )*
 					) $( -> $result )* { $( $impl )* }
@@ -1546,14 +1548,11 @@ macro_rules! decl_module {
 			}
 		}
 
-		impl<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?> $crate::dispatch::Dispatchable
+		impl<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?> $crate::traits::PalletDispatchable
 			for $call_type<$trait_instance $(, $instance)?> where $( $other_where_bounds )*
 		{
-			type Trait = $trait_instance;
 			type Origin = $origin_type;
-			type Info = $crate::weights::DispatchInfo;
-			type PostInfo = $crate::weights::PostDispatchInfo;
-			fn dispatch(self, _origin: Self::Origin) -> $crate::dispatch::DispatchResultWithPostInfo {
+			fn dispatch_bypass_filter(self, _origin: Self::Origin) -> $crate::dispatch::DispatchResultWithPostInfo {
 				match self {
 					$(
 						$call_type::$fn_name( $( $param_name ),* ) => {
@@ -1574,17 +1573,6 @@ macro_rules! decl_module {
 			type Call = $call_type<$trait_instance $(, $instance)?>;
 		}
 
-		impl<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?> $mod_type<$trait_instance $(, $instance)?>
-			where $( $other_where_bounds )*
-		{
-			#[doc(hidden)]
-			pub fn dispatch<D: $crate::dispatch::Dispatchable<Trait = $trait_instance, PostInfo = $crate::weights::PostDispatchInfo>>(
-				d: D,
-				origin: D::Origin
-			) -> $crate::dispatch::DispatchResultWithPostInfo {
-				d.dispatch(origin)
-			}
-		}
 		$crate::__dispatch_impl_metadata! {
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>
 			{ $( $other_where_bounds )* }
@@ -1685,6 +1673,11 @@ macro_rules! impl_outer_dispatch {
 				self,
 				origin: $origin,
 			) -> $crate::dispatch::DispatchResultWithPostInfo {
+				use $crate::traits::PalletDispatchable;
+				if !<Self::Origin as $crate::traits::OriginTrait>::filter_call(&origin, &self) {
+					return $crate::sp_std::result::Result::Err($crate::dispatch::DispatchError::BadOrigin.into())
+				}
+
 				$crate::impl_outer_dispatch! {
 					@DISPATCH_MATCH
 					self
@@ -1731,7 +1724,7 @@ macro_rules! impl_outer_dispatch {
 			$origin
 			{
 				$( $generated )*
-				$call_type::$name(call) => call.dispatch($origin),
+				$call_type::$name(call) => call.dispatch_bypass_filter($origin),
 			}
 			$index + 1;
 			$( $rest ),*
@@ -2050,21 +2043,34 @@ mod tests {
 	};
 
 	pub trait Trait: system::Trait + Sized where Self::AccountId: From<u32> {
-		type Origin;
 		type BlockNumber: Into<u32>;
-		type Call: From<Call<Self>>;
 	}
 
 	pub mod system {
-		use super::*;
-
 		pub trait Trait {
 			type AccountId;
+			type Call;
+			type BasicCallFilter;
+			type Origin: crate::traits::OriginTrait<Call = Self::Call>;
 		}
 
-		pub fn ensure_root<R>(_: R) -> DispatchResult {
-			Ok(())
+		#[derive(Clone, PartialEq, Eq, Debug)]
+		pub enum RawOrigin<AccountId> {
+			Root,
+			Signed(AccountId),
+			None,
 		}
+
+		impl<AccountId> From<Option<AccountId>> for RawOrigin<AccountId> {
+			fn from(s: Option<AccountId>) -> RawOrigin<AccountId> {
+				match s {
+					Some(who) => RawOrigin::Signed(who),
+					None => RawOrigin::None,
+				}
+			}
+		}
+
+		pub type Origin<T> = RawOrigin<<T as Trait>::AccountId>;
 	}
 
 	decl_module! {
@@ -2169,21 +2175,27 @@ mod tests {
 	pub struct TraitImpl {}
 
 	impl Trait for TraitImpl {
-		type Origin = u32;
 		type BlockNumber = u32;
-		type Call = OuterCall;
 	}
 
+	/// HREHREHREHRE
 	type Test = Module<TraitImpl>;
 
+	impl_outer_origin!{
+		pub enum OuterOrigin for TraitImpl where system = system {}
+	}
+
 	impl_outer_dispatch! {
-		pub enum OuterCall for TraitImpl where origin: u32 {
+		pub enum OuterCall for TraitImpl where origin: OuterOrigin {
 			self::Test,
 		}
 	}
 
 	impl system::Trait for TraitImpl {
+		type Origin = OuterOrigin;
 		type AccountId = u32;
+		type Call = OuterCall;
+		type BasicCallFilter = ();
 	}
 
 	#[test]

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -51,13 +51,13 @@ pub use sp_runtime::RuntimeDebug;
 #[macro_use]
 pub mod debug;
 #[macro_use]
+mod origin;
+#[macro_use]
 pub mod dispatch;
 pub mod storage;
 mod hash;
 #[macro_use]
 pub mod event;
-#[macro_use]
-mod origin;
 #[macro_use]
 pub mod metadata;
 #[macro_use]

--- a/frame/support/src/metadata.rs
+++ b/frame/support/src/metadata.rs
@@ -290,7 +290,7 @@ mod tests {
 		use super::*;
 
 		pub trait Trait: 'static {
-			type BasicCallFilter;
+			type BaseCallFilter;
 			const ASSOCIATED_CONST: u64 = 500;
 			type Origin: Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
 				+ From<RawOrigin<Self::AccountId>>;
@@ -438,7 +438,7 @@ mod tests {
 	}
 
 	impl system::Trait for TestRuntime {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type AccountId = u32;
 		type BlockNumber = u32;

--- a/frame/support/src/metadata.rs
+++ b/frame/support/src/metadata.rs
@@ -290,6 +290,7 @@ mod tests {
 		use super::*;
 
 		pub trait Trait: 'static {
+			type BasicCallFilter;
 			const ASSOCIATED_CONST: u64 = 500;
 			type Origin: Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
 				+ From<RawOrigin<Self::AccountId>>;
@@ -297,6 +298,7 @@ mod tests {
 			type BlockNumber: From<u32> + Encode;
 			type SomeValue: Get<u32>;
 			type ModuleToIndex: crate::traits::ModuleToIndex;
+			type Call;
 		}
 
 		decl_module! {
@@ -436,11 +438,13 @@ mod tests {
 	}
 
 	impl system::Trait for TestRuntime {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type AccountId = u32;
 		type BlockNumber = u32;
 		type SomeValue = SystemValue;
 		type ModuleToIndex = ();
+		type Call = Call;
 	}
 
 	impl_runtime_metadata!(

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -198,14 +198,14 @@ macro_rules! impl_outer_origin {
 			type Call = <$runtime as $system::Trait>::Call;
 			type PalletsOrigin = $caller_name;
 
-			fn add_filter(&mut self, add_filter: impl Fn(&Self::Call) -> bool + 'static) {
+			fn add_filter(&mut self, filter: impl Fn(&Self::Call) -> bool + 'static) {
 				let no_op = $crate::sp_std::rc::Rc::new(Box::new(|_: &Self::Call| true)
 					as Box<dyn Fn(&Self::Call) -> bool>);
 
 				let f = $crate::sp_std::mem::replace(&mut self.filter, no_op);
 
 				self.filter = $crate::sp_std::rc::Rc::new(Box::new(move |call| {
-					f(call) && add_filter(call)
+					f(call) && filter(call)
 				}));
 			}
 

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -209,7 +209,7 @@ macro_rules! impl_outer_origin {
 
 			fn reset_filter(&mut self) {
 				let filter = <
-					<$runtime as $system::Trait>::BasicCallFilter
+					<$runtime as $system::Trait>::BaseCallFilter
 					as $crate::traits::Filter<<$runtime as $system::Trait>::Call>
 				>::filter;
 
@@ -333,7 +333,7 @@ mod tests {
 		pub trait Trait {
 			type AccountId;
 			type Call;
-			type BasicCallFilter;
+			type BaseCallFilter;
 		}
 
 		#[derive(Clone, PartialEq, Eq, Debug)]
@@ -370,8 +370,8 @@ mod tests {
 	#[derive(Clone, PartialEq, Eq, Debug)]
 	pub struct TestRuntime;
 
-	pub struct BasicCallFilter;
-	impl Filter<u32> for BasicCallFilter {
+	pub struct BaseCallFilter;
+	impl Filter<u32> for BaseCallFilter {
 		fn filter(c: &u32) -> bool {
 			*c % 2 == 0
 		}
@@ -380,7 +380,7 @@ mod tests {
 	impl system::Trait for TestRuntime {
 		type AccountId = u32;
 		type Call = u32;
-		type BasicCallFilter = BasicCallFilter;
+		type BaseCallFilter = BaseCallFilter;
 	}
 
 	impl_outer_origin!(

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -45,19 +45,23 @@ macro_rules! impl_outer_origin {
 			$( $rest_with_system:tt )*
 		}
 	) => {
-		$crate::impl_outer_origin!(
-			$( #[$attr] )*;
-			$name;
-			$runtime;
-			$system;
-			Modules { $( $rest_with_system )* };
-		);
+		$crate::paste::item! {
+			$crate::impl_outer_origin!(
+				$( #[$attr] )*;
+				$name;
+				[< $name Caller >];
+				$runtime;
+				$system;
+				Modules { $( $rest_with_system )* };
+			);
+		}
 	};
 
 	// Generic + Instance
 	(
 		$(#[$attr:meta])*;
 		$name:ident;
+		$caller_name:ident;
 		$runtime:ident;
 		$system:ident;
 		Modules {
@@ -69,6 +73,7 @@ macro_rules! impl_outer_origin {
 		$crate::impl_outer_origin!(
 			$( #[$attr] )*;
 			$name;
+			$caller_name;
 			$runtime;
 			$system;
 			Modules { $( $( $rest_module )* )? };
@@ -80,6 +85,7 @@ macro_rules! impl_outer_origin {
 	(
 		$(#[$attr:meta])*;
 		$name:ident;
+		$caller_name:ident;
 		$runtime:ident;
 		$system:ident;
 		Modules {
@@ -91,6 +97,7 @@ macro_rules! impl_outer_origin {
 		$crate::impl_outer_origin!(
 			$( #[$attr] )*;
 			$name;
+			$caller_name;
 			$runtime;
 			$system;
 			Modules { $( $rest_module )* };
@@ -102,6 +109,7 @@ macro_rules! impl_outer_origin {
 	(
 		$(#[$attr:meta])*;
 		$name:ident;
+		$caller_name:ident;
 		$runtime:ident;
 		$system:ident;
 		Modules {
@@ -113,6 +121,7 @@ macro_rules! impl_outer_origin {
 		$crate::impl_outer_origin!(
 			$( #[$attr] )*;
 			$name;
+			$caller_name;
 			$runtime;
 			$system;
 			Modules { $( $( $rest_module )* )? };
@@ -124,6 +133,7 @@ macro_rules! impl_outer_origin {
 	(
 		$(#[$attr:meta])*;
 		$name:ident;
+		$caller_name:ident;
 		$runtime:ident;
 		$system:ident;
 		Modules {
@@ -135,6 +145,7 @@ macro_rules! impl_outer_origin {
 		$crate::impl_outer_origin!(
 			$( #[$attr] )*;
 			$name;
+			$caller_name;
 			$runtime;
 			$system;
 			Modules { $( $( $rest_module )* )? };
@@ -146,16 +157,79 @@ macro_rules! impl_outer_origin {
 	(
 		$(#[$attr:meta])*;
 		$name:ident;
+		$caller_name:ident;
 		$runtime:ident;
 		$system:ident;
 		Modules { };
 		$( $module:ident $( < $generic:ident > )? $( { $generic_instance:ident } )? ,)*
 	) => {
+		#[derive(Clone)]
+		pub struct $name {
+			caller: $caller_name,
+			filter: $crate::sp_std::rc::Rc<Box<dyn Fn(&<$runtime as $system::Trait>::Call) -> bool>>,
+		}
+
+		#[cfg(not(feature = "std"))]
+		impl $crate::sp_std::fmt::Debug for $name {
+			fn fmt(
+				&self,
+				fmt: &mut $crate::sp_std::fmt::Formatter
+			) -> $crate::sp_std::result::Result<(), $crate::sp_std::fmt::Error> {
+				fmt.write_str("<wasm:stripped>")
+			}
+		}
+
+		#[cfg(feature = "std")]
+		impl $crate::sp_std::fmt::Debug for $name {
+			fn fmt(
+				&self,
+				fmt: &mut $crate::sp_std::fmt::Formatter
+			) -> $crate::sp_std::result::Result<(), $crate::sp_std::fmt::Error> {
+				fmt.debug_struct(stringify!($name))
+					.field("caller", &self.caller)
+					.field("filter", &"[function ptr]")
+					.finish()
+			}
+		}
+
+		impl $crate::traits::OriginTrait for $name {
+			type Call = <$runtime as $system::Trait>::Call;
+			type PalletsOrigin = $caller_name;
+
+			fn add_filter(&mut self, add_filter: impl Fn(&Self::Call) -> bool + 'static) {
+				let no_op = $crate::sp_std::rc::Rc::new(Box::new(|_: &Self::Call| true)
+					as Box<dyn Fn(&Self::Call) -> bool>);
+
+				let f = $crate::sp_std::mem::replace(&mut self.filter, no_op);
+
+				self.filter = $crate::sp_std::rc::Rc::new(Box::new(move |call| {
+					f(call) && add_filter(call)
+				}));
+			}
+
+			fn reset_filter(&mut self) {
+				let filter = <
+					<$runtime as $system::Trait>::BasicCallFilter
+					as $crate::traits::Filter<<$runtime as $system::Trait>::Call>
+				>::filter;
+
+				self.filter = $crate::sp_std::rc::Rc::new(Box::new(filter));
+			}
+
+			fn set_caller_from(&mut self, other: impl Into<Self>) {
+				self.caller = other.into().caller
+			}
+
+			fn filter_call(&self, call: &Self::Call) -> bool {
+				(self.filter)(call)
+			}
+		}
+
 		$crate::paste::item! {
 			#[derive(Clone, PartialEq, Eq, $crate::RuntimeDebug)]
 			$(#[$attr])*
 			#[allow(non_camel_case_types)]
-			pub enum $name {
+			pub enum $caller_name {
 				system($system::Origin<$runtime>),
 				$(
 					[< $module $( _ $generic_instance )? >]
@@ -168,20 +242,45 @@ macro_rules! impl_outer_origin {
 
 		#[allow(dead_code)]
 		impl $name {
-			pub const NONE: Self = $name::system($system::RawOrigin::None);
-			pub const ROOT: Self = $name::system($system::RawOrigin::Root);
+			pub fn none() -> Self {
+				let mut o = $name {
+					caller: $caller_name::system($system::RawOrigin::None),
+					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
+				};
+				$crate::traits::OriginTrait::reset_filter(&mut o);
+				o
+			}
+			pub fn root() -> Self {
+				let mut o = $name {
+					caller: $caller_name::system($system::RawOrigin::Root),
+					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
+				};
+				$crate::traits::OriginTrait::reset_filter(&mut o);
+				o
+			}
 			pub fn signed(by: <$runtime as $system::Trait>::AccountId) -> Self {
-				$name::system($system::RawOrigin::Signed(by))
+				let mut o = $name {
+					caller: $caller_name::system($system::RawOrigin::Signed(by)),
+					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
+				};
+				$crate::traits::OriginTrait::reset_filter(&mut o);
+				o
 			}
 		}
+
 		impl From<$system::Origin<$runtime>> for $name {
 			fn from(x: $system::Origin<$runtime>) -> Self {
-				$name::system(x)
+				let mut o = $name {
+					caller: $caller_name::system(x),
+					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
+				};
+				$crate::traits::OriginTrait::reset_filter(&mut o);
+				o
 			}
 		}
 		impl Into<$crate::sp_std::result::Result<$system::Origin<$runtime>, $name>> for $name {
 			fn into(self) -> $crate::sp_std::result::Result<$system::Origin<$runtime>, Self> {
-				if let $name::system(l) = self {
+				if let $caller_name::system(l) = self.caller {
 					Ok(l)
 				} else {
 					Err(self)
@@ -197,7 +296,12 @@ macro_rules! impl_outer_origin {
 			$crate::paste::item! {
 				impl From<$module::Origin < $( $generic )? $(, $module::$generic_instance )? > > for $name {
 					fn from(x: $module::Origin < $( $generic )? $(, $module::$generic_instance )? >) -> Self {
-						$name::[< $module $( _ $generic_instance )? >](x)
+						let mut o = $name {
+							caller: $caller_name::[< $module $( _ $generic_instance )? >](x),
+							filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
+						};
+						$crate::traits::OriginTrait::reset_filter(&mut o);
+						o
 					}
 				}
 				impl Into<
@@ -210,7 +314,7 @@ macro_rules! impl_outer_origin {
 						$module::Origin < $( $generic )? $(, $module::$generic_instance )? >,
 						Self,
 					> {
-						if let $name::[< $module $( _ $generic_instance )? >](l) = self {
+						if let $caller_name::[< $module $( _ $generic_instance )? >](l) = self.caller {
 							Ok(l)
 						} else {
 							Err(self)
@@ -224,9 +328,12 @@ macro_rules! impl_outer_origin {
 
 #[cfg(test)]
 mod tests {
+	use crate::traits::{Filter, OriginTrait};
 	mod system {
 		pub trait Trait {
 			type AccountId;
+			type Call;
+			type BasicCallFilter;
 		}
 
 		#[derive(Clone, PartialEq, Eq, Debug)]
@@ -263,8 +370,17 @@ mod tests {
 	#[derive(Clone, PartialEq, Eq, Debug)]
 	pub struct TestRuntime;
 
+	pub struct BasicCallFilter;
+	impl Filter<u32> for BasicCallFilter {
+		fn filter(c: &u32) -> bool {
+			*c % 2 == 0
+		}
+	}
+
 	impl system::Trait for TestRuntime {
 		type AccountId = u32;
+		type Call = u32;
+		type BasicCallFilter = BasicCallFilter;
 	}
 
 	impl_outer_origin!(
@@ -298,4 +414,35 @@ mod tests {
 	impl_outer_origin!(
 		pub enum OriginEmpty for TestRuntime where system = system {}
 	);
+
+	#[test]
+	fn test_default_filter() {
+		assert_eq!(OriginWithSystem::root().filter_call(&0), true);
+		assert_eq!(OriginWithSystem::root().filter_call(&1), false);
+		assert_eq!(OriginWithSystem::none().filter_call(&0), true);
+		assert_eq!(OriginWithSystem::none().filter_call(&1), false);
+		assert_eq!(OriginWithSystem::signed(0).filter_call(&0), true);
+		assert_eq!(OriginWithSystem::signed(0).filter_call(&1), false);
+		assert_eq!(OriginWithSystem::from(Some(0)).filter_call(&0), true);
+		assert_eq!(OriginWithSystem::from(Some(0)).filter_call(&1), false);
+		assert_eq!(OriginWithSystem::from(None).filter_call(&0), true);
+		assert_eq!(OriginWithSystem::from(None).filter_call(&1), false);
+		assert_eq!(OriginWithSystem::from(origin_without_generic::Origin).filter_call(&0), true);
+		assert_eq!(OriginWithSystem::from(origin_without_generic::Origin).filter_call(&1), false);
+
+		let mut origin = OriginWithSystem::from(Some(0));
+
+		origin.add_filter(|c| *c % 2 == 1);
+		assert_eq!(origin.filter_call(&0), false);
+		assert_eq!(origin.filter_call(&1), false);
+
+		origin.set_caller_from(OriginWithSystem::root());
+		assert!(matches!(origin.caller, OriginWithSystemCaller::system(system::RawOrigin::Root)));
+		assert_eq!(origin.filter_call(&0), false);
+		assert_eq!(origin.filter_call(&1), false);
+
+		origin.reset_filter();
+		assert_eq!(origin.filter_call(&0), true);
+		assert_eq!(origin.filter_call(&1), false);
+	}
 }

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -199,10 +199,7 @@ macro_rules! impl_outer_origin {
 			type PalletsOrigin = $caller_name;
 
 			fn add_filter(&mut self, filter: impl Fn(&Self::Call) -> bool + 'static) {
-				let no_op = $crate::sp_std::rc::Rc::new(Box::new(|_: &Self::Call| true)
-					as Box<dyn Fn(&Self::Call) -> bool>);
-
-				let f = $crate::sp_std::mem::replace(&mut self.filter, no_op);
+				let f = self.filter.clone();
 
 				self.filter = $crate::sp_std::rc::Rc::new(Box::new(move |call| {
 					f(call) && filter(call)

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -163,6 +163,8 @@ macro_rules! impl_outer_origin {
 		Modules { };
 		$( $module:ident $( < $generic:ident > )? $( { $generic_instance:ident } )? ,)*
 	) => {
+		// WARNING: All instance must hold the filter `frame_system::Trait::BaseCallFilter`.
+		// One can use `OriginTrait::reset_filter` to do so.
 		#[derive(Clone)]
 		pub struct $name {
 			caller: $caller_name,
@@ -243,28 +245,13 @@ macro_rules! impl_outer_origin {
 		#[allow(dead_code)]
 		impl $name {
 			pub fn none() -> Self {
-				let mut o = $name {
-					caller: $caller_name::system($system::RawOrigin::None),
-					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
-				};
-				$crate::traits::OriginTrait::reset_filter(&mut o);
-				o
+				$system::RawOrigin::None.into()
 			}
 			pub fn root() -> Self {
-				let mut o = $name {
-					caller: $caller_name::system($system::RawOrigin::Root),
-					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
-				};
-				$crate::traits::OriginTrait::reset_filter(&mut o);
-				o
+				$system::RawOrigin::Root.into()
 			}
 			pub fn signed(by: <$runtime as $system::Trait>::AccountId) -> Self {
-				let mut o = $name {
-					caller: $caller_name::system($system::RawOrigin::Signed(by)),
-					filter: $crate::sp_std::rc::Rc::new(Box::new(|_| true)),
-				};
-				$crate::traits::OriginTrait::reset_filter(&mut o);
-				o
+				$system::RawOrigin::Signed(by).into()
 			}
 		}
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1547,15 +1547,17 @@ pub trait EnsureOrigin<OuterOrigin> {
 	fn successful_origin() -> OuterOrigin;
 }
 
-/// Trait implemented for pallet dispatchable type by `decl_module`.
-pub trait PalletDispatchable {
+/// Type that can be dispatched with an origin but without checking the origin filter.
+///
+/// Implemented for pallet dispatchable type by `decl_module` and for runtime dispatchable by
+/// `construct_runtime` and `impl_outer_dispatch`.
+pub trait UnfilteredDispatchable {
 	/// The origin type of the runtime, (i.e. `frame_system::Trait::Origin`).
 	type Origin;
 
 	/// Dispatch this call but do not check the filter in origin.
 	fn dispatch_bypass_filter(self, origin: Self::Origin) -> crate::dispatch::DispatchResultWithPostInfo;
 }
-
 
 /// Methods available on `frame_system::Trait::Origin`.
 pub trait OriginTrait: Sized {

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1547,6 +1547,61 @@ pub trait EnsureOrigin<OuterOrigin> {
 	fn successful_origin() -> OuterOrigin;
 }
 
+/// Trait implemented for pallet dispatchable type by `decl_module`.
+pub trait PalletDispatchable {
+	/// The origin type of the runtime, (i.e. `frame_system::Trait::Origin`).
+	type Origin;
+
+	/// Dispatch this call but do not check the filter in origin.
+	fn dispatch_bypass_filter(self, origin: Self::Origin) -> crate::dispatch::DispatchResultWithPostInfo;
+}
+
+
+/// Methods available on `frame_system::Trait::Origin`.
+pub trait OriginTrait: Sized {
+	/// Runtime call type, as in `frame_system::Trait::Call`
+	type Call;
+
+	/// The caller origin, overarching type of all pallets origins.
+	type PalletsOrigin;
+
+	/// Add a filter to the origin.
+	fn add_filter(&mut self, filter: impl Fn(&Self::Call) -> bool + 'static);
+
+	/// Reset origin filters to default one, i.e `frame_system::Trait::BasicCallFilter`.
+	fn reset_filter(&mut self);
+
+	/// Replace the caller with caller from the other origin
+	fn set_caller_from(&mut self, other: impl Into<Self>);
+
+	/// Filter the call, if false then call is filtered out.
+	fn filter_call(&self, call: &Self::Call) -> bool;
+}
+
+/// Trait to be used when types are exactly same.
+///
+/// This allow to convert back and forth from type, a reference and a mutable reference.
+pub trait IsType<T>: Into<T> + From<T> {
+	/// Cast reference.
+	fn from_ref(t: &T) -> &Self;
+
+	/// Cast reference.
+	fn into_ref(&self) -> &T;
+
+	/// Cast mutable reference.
+	fn from_mut(t: &mut T) -> &mut Self;
+
+	/// Cast mutable reference.
+	fn into_mut(&mut self) -> &mut T;
+}
+
+impl<T> IsType<T> for T {
+	fn from_ref(t: &T) -> &Self { t }
+	fn into_ref(&self) -> &T { self }
+	fn from_mut(t: &mut T) -> &mut Self { t }
+	fn into_mut(&mut self) -> &mut T { self }
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1568,7 +1568,7 @@ pub trait OriginTrait: Sized {
 	/// Add a filter to the origin.
 	fn add_filter(&mut self, filter: impl Fn(&Self::Call) -> bool + 'static);
 
-	/// Reset origin filters to default one, i.e `frame_system::Trait::BasicCallFilter`.
+	/// Reset origin filters to default one, i.e `frame_system::Trait::BaseCallFilter`.
 	fn reset_filter(&mut self);
 
 	/// Replace the caller with caller from the other origin

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1550,7 +1550,7 @@ pub trait EnsureOrigin<OuterOrigin> {
 /// Trait implemented for pallet dispatchable type by `decl_module`.
 pub trait PalletDispatchable {
 	/// The origin type of the runtime, (i.e. `frame_system::Trait::Origin`).
-	type Origin;
+	type Origin: OriginTrait;
 
 	/// Dispatch this call but do not check the filter in origin.
 	fn dispatch_bypass_filter(self, origin: Self::Origin) -> crate::dispatch::DispatchResultWithPostInfo;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1550,7 +1550,7 @@ pub trait EnsureOrigin<OuterOrigin> {
 /// Trait implemented for pallet dispatchable type by `decl_module`.
 pub trait PalletDispatchable {
 	/// The origin type of the runtime, (i.e. `frame_system::Trait::Origin`).
-	type Origin: OriginTrait;
+	type Origin;
 
 	/// Dispatch this call but do not check the filter in origin.
 	fn dispatch_bypass_filter(self, origin: Self::Origin) -> crate::dispatch::DispatchResultWithPostInfo;

--- a/frame/support/test/tests/decl_error.rs
+++ b/frame/support/test/tests/decl_error.rs
@@ -89,12 +89,14 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;
 	type AccountId = AccountId;
 	type Event = Event;
 	type ModuleToIndex = ModuleToIndex;
+	type Call = Call;
 }
 
 frame_support::construct_runtime!(

--- a/frame/support/test/tests/decl_error.rs
+++ b/frame/support/test/tests/decl_error.rs
@@ -89,7 +89,7 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -233,7 +233,7 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Trait for Runtime {
-	type BasicCallFilter= ();
+	type BaseCallFilter= ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -233,12 +233,14 @@ pub type BlockNumber = u64;
 pub type Index = u64;
 
 impl system::Trait for Runtime {
+	type BasicCallFilter= ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;
 	type AccountId = AccountId;
 	type Event = Event;
 	type ModuleToIndex = ();
+	type Call = Call;
 }
 
 frame_support::construct_runtime!(

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -158,7 +158,7 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -158,12 +158,14 @@ pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
 
 impl system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Hash = H256;
 	type Origin = Origin;
 	type BlockNumber = BlockNumber;
 	type AccountId = AccountId;
 	type Event = Event;
 	type ModuleToIndex = ();
+	type Call = Call;
 }
 
 impl module::Trait for Runtime {}

--- a/frame/support/test/tests/system.rs
+++ b/frame/support/test/tests/system.rs
@@ -21,9 +21,11 @@ pub trait Trait: 'static + Eq + Clone {
 	type Origin: Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
 		+ From<RawOrigin<Self::AccountId>>;
 
+	type BasicCallFilter: frame_support::traits::Filter<Self::Call>;
 	type BlockNumber: Decode + Encode + EncodeLike + Clone + Default;
 	type Hash;
 	type AccountId: Encode + EncodeLike + Decode;
+	type Call;
 	type Event: From<Event<Self>>;
 	type ModuleToIndex: frame_support::traits::ModuleToIndex;
 }

--- a/frame/support/test/tests/system.rs
+++ b/frame/support/test/tests/system.rs
@@ -21,7 +21,7 @@ pub trait Trait: 'static + Eq + Clone {
 	type Origin: Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>
 		+ From<RawOrigin<Self::AccountId>>;
 
-	type BasicCallFilter: frame_support::traits::Filter<Self::Call>;
+	type BaseCallFilter: frame_support::traits::Filter<Self::Call>;
 	type BlockNumber: Decode + Encode + EncodeLike + Clone + Default;
 	type Hash;
 	type AccountId: Encode + EncodeLike + Decode;

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -61,6 +61,7 @@ frame_support::parameter_types! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Runtime;
 impl system::Trait for Runtime {
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -51,6 +51,7 @@ impl Dispatchable for Call {
 pub struct Test;
 
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -51,7 +51,7 @@ impl Dispatchable for Call {
 pub struct Test;
 
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = AccountIndex;
 	type BlockNumber = BlockNumber;

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1907,7 +1907,7 @@ pub(crate) mod tests {
 	use sp_core::H256;
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup, SignedExtension}, testing::Header, DispatchError};
 	use frame_support::{
-		impl_outer_origin, parameter_types, assert_ok, assert_noop, assert_err,
+		impl_outer_origin, parameter_types, assert_ok, assert_noop,
 		weights::WithPostDispatchInfo,
 	};
 
@@ -2737,8 +2737,8 @@ pub(crate) mod tests {
 			EnsureOneOf::<u64, EnsureRoot<u64>, EnsureSigned<u64>>::try_origin(o.into())
 		}
 
-		assert_ok!(ensure_root_or_signed(RawOrigin::Root), Either::Left(()));
-		assert_ok!(ensure_root_or_signed(RawOrigin::Signed(0)), Either::Right(0));
-		assert_err!(ensure_root_or_signed(RawOrigin::None), Origin::from(RawOrigin::None));
+		assert_eq!(ensure_root_or_signed(RawOrigin::Root).unwrap(), Either::Left(()));
+		assert_eq!(ensure_root_or_signed(RawOrigin::Signed(0)).unwrap(), Either::Right(0));
+		assert!(ensure_root_or_signed(RawOrigin::None).is_err())
 	}
 }

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -150,7 +150,7 @@ pub fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
 
 pub trait Trait: 'static + Eq + Clone {
 	/// The basic call filter to use in Origin.
-	type BasicCallFilter: Filter<Self::Call>;
+	type BaseCallFilter: Filter<Self::Call>;
 
 	/// The `Origin` type used by dispatchable calls.
 	type Origin:
@@ -1965,7 +1965,7 @@ pub(crate) mod tests {
 	}
 
 	impl Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Call = Call;
 		type Index = u64;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -314,6 +314,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
@@ -352,7 +353,7 @@ mod tests {
 	fn timestamp_works() {
 		new_test_ext().execute_with(|| {
 			Timestamp::set_timestamp(42);
-			assert_ok!(Timestamp::dispatch(Call::set(69), Origin::NONE));
+			assert_ok!(Timestamp::set(Origin::none(), 69));
 			assert_eq!(Timestamp::now(), 69);
 		});
 	}
@@ -362,8 +363,8 @@ mod tests {
 	fn double_timestamp_should_fail() {
 		new_test_ext().execute_with(|| {
 			Timestamp::set_timestamp(42);
-			assert_ok!(Timestamp::dispatch(Call::set(69), Origin::NONE));
-			let _ = Timestamp::dispatch(Call::set(70), Origin::NONE);
+			assert_ok!(Timestamp::set(Origin::none(), 69));
+			let _ = Timestamp::set(Origin::none(), 70);
 		});
 	}
 
@@ -372,7 +373,7 @@ mod tests {
 	fn block_period_minimum_enforced() {
 		new_test_ext().execute_with(|| {
 			Timestamp::set_timestamp(42);
-			let _ = Timestamp::dispatch(Call::set(46), Origin::NONE);
+			let _ = Timestamp::set(Origin::none(), 46);
 		});
 	}
 }

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -314,7 +314,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -428,7 +428,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Runtime {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -428,6 +428,7 @@ mod tests {
 	}
 
 	impl frame_system::Trait for Runtime {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -60,7 +60,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -60,6 +60,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
@@ -271,7 +272,7 @@ fn close_tip_works() {
 		assert_noop!(Treasury::close_tip(Origin::signed(0), h.into()), Error::<Test>::Premature);
 
 		System::set_block_number(2);
-		assert_noop!(Treasury::close_tip(Origin::NONE, h.into()), BadOrigin);
+		assert_noop!(Treasury::close_tip(Origin::none(), h.into()), BadOrigin);
 		assert_ok!(Treasury::close_tip(Origin::signed(0), h.into()));
 		assert_eq!(Balances::free_balance(3), 10);
 
@@ -381,7 +382,7 @@ fn accepted_spend_proposal_ignored_outside_spend_period() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
@@ -408,7 +409,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
-		assert_ok!(Treasury::reject_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::reject_proposal(Origin::root(), 0));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 0);
@@ -422,22 +423,22 @@ fn reject_already_rejected_spend_proposal_fails() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
-		assert_ok!(Treasury::reject_proposal(Origin::ROOT, 0));
-		assert_noop!(Treasury::reject_proposal(Origin::ROOT, 0), Error::<Test>::InvalidProposalIndex);
+		assert_ok!(Treasury::reject_proposal(Origin::root(), 0));
+		assert_noop!(Treasury::reject_proposal(Origin::root(), 0), Error::<Test>::InvalidProposalIndex);
 	});
 }
 
 #[test]
 fn reject_non_existent_spend_proposal_fails() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(Treasury::reject_proposal(Origin::ROOT, 0), Error::<Test>::InvalidProposalIndex);
+		assert_noop!(Treasury::reject_proposal(Origin::root(), 0), Error::<Test>::InvalidProposalIndex);
 	});
 }
 
 #[test]
 fn accept_non_existent_spend_proposal_fails() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(Treasury::approve_proposal(Origin::ROOT, 0), Error::<Test>::InvalidProposalIndex);
+		assert_noop!(Treasury::approve_proposal(Origin::root(), 0), Error::<Test>::InvalidProposalIndex);
 	});
 }
 
@@ -447,8 +448,8 @@ fn accept_already_rejected_spend_proposal_fails() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
-		assert_ok!(Treasury::reject_proposal(Origin::ROOT, 0));
-		assert_noop!(Treasury::approve_proposal(Origin::ROOT, 0), Error::<Test>::InvalidProposalIndex);
+		assert_ok!(Treasury::reject_proposal(Origin::root(), 0));
+		assert_noop!(Treasury::approve_proposal(Origin::root(), 0), Error::<Test>::InvalidProposalIndex);
 	});
 }
 
@@ -459,7 +460,7 @@ fn accepted_spend_proposal_enacted_on_spend_period() {
 		assert_eq!(Treasury::pot(), 100);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 100, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
@@ -474,7 +475,7 @@ fn pot_underflow_should_not_diminish() {
 		assert_eq!(Treasury::pot(), 100);
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 150, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
@@ -496,13 +497,13 @@ fn treasury_account_doesnt_get_deleted() {
 		let treasury_balance = Balances::free_balance(&Treasury::account_id());
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), treasury_balance, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), Treasury::pot(), 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 1));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
@@ -526,9 +527,9 @@ fn inexistent_account_works() {
 		assert_eq!(Treasury::pot(), 0); // Pot is empty
 
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 99, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 0));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 0));
 		assert_ok!(Treasury::propose_spend(Origin::signed(0), 1, 3));
-		assert_ok!(Treasury::approve_proposal(Origin::ROOT, 1));
+		assert_ok!(Treasury::approve_proposal(Origin::root(), 1));
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -140,7 +140,6 @@ decl_module! {
 		)]
 		fn batch(origin, calls: Vec<<T as Trait>::Call>) {
 			for (index, call) in calls.into_iter().enumerate() {
-				// TODO TODO: root no longer bypass IsCallable filter.
 				let result = call.dispatch(origin.clone());
 				if let Err(e) = result {
 					Self::deposit_event(Event::BatchInterrupted(index as u32, e.error));

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -54,7 +54,7 @@ use sp_std::prelude::*;
 use codec::{Encode, Decode};
 use sp_core::TypeId;
 use sp_io::hashing::blake2_256;
-use frame_support::{decl_module, decl_event, decl_error, decl_storage, Parameter, ensure};
+use frame_support::{decl_module, decl_event, decl_storage, Parameter};
 use frame_support::{
 	traits::{OriginTrait, UnfilteredDispatchable},
 	weights::{Weight, GetDispatchInfo, DispatchClass}, dispatch::PostDispatchInfo,

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -59,7 +59,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -59,6 +59,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 impl frame_system::Trait for Test {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
@@ -180,7 +181,7 @@ fn batch_with_root_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Balances::free_balance(1), 10);
 		assert_eq!(Balances::free_balance(2), 10);
-		assert_ok!(Utility::batch(Origin::ROOT, vec![
+		assert_ok!(Utility::batch(Origin::root(), vec![
 			Call::Balances(BalancesCall::force_transfer(1, 2, 5)),
 			Call::Balances(BalancesCall::force_transfer(1, 2, 5))
 		]));

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -380,6 +380,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
+		type BasicCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -380,7 +380,7 @@ mod tests {
 		pub const AvailableBlockRatio: Perbill = Perbill::one();
 	}
 	impl frame_system::Trait for Test {
-		type BasicCallFilter = ();
+		type BaseCallFilter = ();
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -144,7 +144,7 @@ impl<
 }
 
 /// An error type that indicates that the origin is invalid.
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, RuntimeDebug)]
 pub struct BadOrigin;
 
 impl From<BadOrigin> for &'static str {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -401,7 +401,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Runtime {
-	type BasicCallFilter = ();
+	type BaseCallFilter = ();
 	type Origin = Origin;
 	type Call = Extrinsic;
 	type Index = u64;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -184,7 +184,7 @@ impl ExtrinsicT for Extrinsic {
 }
 
 impl sp_runtime::traits::Dispatchable for Extrinsic {
-	type Origin = ();
+	type Origin = Origin;
 	type Trait = ();
 	type Info = ();
 	type PostInfo = ();
@@ -401,6 +401,7 @@ parameter_types! {
 }
 
 impl frame_system::Trait for Runtime {
+	type BasicCallFilter = ();
 	type Origin = Origin;
 	type Call = Extrinsic;
 	type Index = u64;


### PR DESCRIPTION
Change Origin into a struct with `caller` (old origin type, contains information related to the caller) and `filter` (a function which can filter out calls).

This allows crate like proxy not to use a global filtering https://github.com/paritytech/substrate/pull/6273

Main change is about pallet call structs. They doesn't implement `Dispatchable` anymore. `Dispatchable` implementation must check the origin filter, but the inside pallet call struct can't convert itself into `frame_system::Trait::Call` easily. Thus pallet call struct now implements a new trait `UnfilteredDispatchable` with a explicit method `dispatch_bypass_filter`.

Has also been removed PalletModule::dispatch function to avoid confusion.

The method on PalletModule created for each dispatchables still exists. I hope it doesn't bring confusion. The generated method now have an additionnal doc: `NOTE: Calling this function bypass origin filters`.

### TODO

* [x] remove global filtering IsCallable.
* [x] polkadot PR. https://github.com/paritytech/polkadot/pull/1226

### Additional notes

* filter is `Rc<Box<dyn Fn(&Call) -> bool>>` because it must implement Clone and `dyn SomeTrait + Clone` is not doable easily. One solution is to use DynClone (https://crates.io/crates/dyn-clone), I'll try in a following PR.
* we can move BaseCallFilter out of Origin, and make Dispatchable checking it itself. Thus no risk to miss it. (right now risk is low because API forbid it)