### PR TITLE
add extend_lock for StorageLock

### DIFF
--- a/primitives/runtime/src/offchain/storage_lock.rs
+++ b/primitives/runtime/src/offchain/storage_lock.rs
@@ -560,30 +560,34 @@ mod tests {
 			offchain::sleep_until(offchain::timestamp().add(Duration::from_millis(200)));
 
 			// the lock is still active, extend it successfully
-			assert_eq!(guard.extend_lock().is_ok(), true);
-			guard.forget();
+            assert_eq!(guard.extend_lock().is_ok(), true);
 
-			// sleep_until < deadline
-			offchain::sleep_until(offchain::timestamp().add(Duration::from_millis(200)));
+            // sleep_until < deadline
+            offchain::sleep_until(offchain::timestamp().add(Duration::from_millis(200)));
 
-			// the lock is still active, try_lock will fail
-			let mut lock = StorageLock::<'_, Time>::new(b"lock_4");
-			let res = lock.try_lock();
-			assert_eq!(res.is_ok(), false);
+            // the lock is still active, try_lock will fail
+            let mut lock = StorageLock::<'_, Time>::with_deadline(b"lock_4", lock_expiration);
+            let res = lock.try_lock();
+            assert_eq!(res.is_ok(), false);
 
-			// sleep_until > deadline
-			offchain::sleep_until(offchain::timestamp().add(Duration::from_millis(200)));
+            // sleep again untill sleep_until > deadline
+            offchain::sleep_until(offchain::timestamp().add(Duration::from_millis(200)));
 
-			// the lock has expired, try_lock will succeed
-			let mut lock = StorageLock::<'_, Time>::new(b"lock_4");
-			let res = lock.try_lock();
-			assert!(res.is_ok());
-			let guard = res.unwrap();
-			guard.forget();
-		});
+            // the lock has expired, failed to extend it
+            assert_eq!(guard.extend_lock().is_ok(), false);
+            guard.forget();
 
-		// lock must have been cleared at this point
-		let opt = state.read().persistent_storage.get(b"", b"lock_4");
-		assert!(opt.is_some());
+            // try_lock will succeed
+            let mut lock = StorageLock::<'_, Time>::with_deadline(b"lock_4", lock_expiration);
+            let res = lock.try_lock();
+            assert!(res.is_ok());
+            let guard = res.unwrap();
+
+            guard.forget();
+        });
+
+        // lock must have been cleared at this point
+        let opt = state.read().persistent_storage.get(b"", b"lock_4");
+        assert_eq!(opt.unwrap(), vec![132_u8, 3u8, 0, 0, 0, 0, 0, 0]); // 132 + 256 * 3 = 900
 	}
 }


### PR DESCRIPTION
In some cases, such as doing iterations in offchain worker, the time to be consumed is hard to estimate
, and it's necessary to extend the deadline of the `StorageLock` after each successful next step during the whole iteration process.

So I add new function for `StorageLock` to support extending deadline of an active lock.
