### PR TITLE
Refactor Multisig Pallet

### DIFF
--- a/frame/multisig/src/benchmarking.rs
+++ b/frame/multisig/src/benchmarking.rs
@@ -179,7 +179,7 @@ benchmarks! {
 		// Create the multi
 		let o = RawOrigin::Signed(caller.clone()).into();
 		Multisig::<T>::as_multi(o, s as u16, signatories.clone(), None, call.clone(), true)?;
-	}: _(RawOrigin::Signed(caller), s as u16, signatories, timepoint, call_hash)
+	}: cancel_as_multi(RawOrigin::Signed(caller), s as u16, signatories, timepoint, call_hash)
 }
 
 #[cfg(test)]

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -48,14 +48,16 @@
 
 use sp_std::prelude::*;
 use codec::{Encode, Decode};
-use sp_io::hashing::blake2_256;
 use frame_support::{decl_module, decl_event, decl_error, decl_storage, Parameter, ensure, RuntimeDebug};
 use frame_support::{traits::{Get, ReservableCurrency, Currency, Filter, FilterStack, ClearFilterGuard},
 	weights::{Weight, GetDispatchInfo, DispatchClass, Pays},
 	dispatch::{DispatchResultWithPostInfo, PostDispatchInfo},
 };
 use frame_system::{self as system, ensure_signed};
-use sp_runtime::{DispatchError, DispatchResult, traits::Dispatchable};
+use sp_runtime::{
+	DispatchError, DispatchResult,
+	traits::{Dispatchable, Hash},
+};
 
 mod tests;
 mod benchmarking;
@@ -120,10 +122,10 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Multisig {
 		/// The set of open multisig operations.
 		pub Multisigs: double_map
-			hasher(twox_64_concat) T::AccountId, hasher(blake2_128_concat) [u8; 32]
+			hasher(twox_64_concat) T::AccountId, hasher(blake2_128_concat) T::Hash
 			=> Option<Multisig<T::BlockNumber, BalanceOf<T>, T::AccountId>>;
 
-		pub Calls: map hasher(identity) [u8; 32] => Option<(Vec<u8>, T::AccountId, BalanceOf<T>)>;
+		pub Calls: map hasher(identity) T::Hash => Option<(Vec<u8>, T::AccountId, BalanceOf<T>)>;
 	}
 }
 
@@ -163,7 +165,7 @@ decl_event! {
 	pub enum Event<T> where
 		AccountId = <T as system::Trait>::AccountId,
 		BlockNumber = <T as system::Trait>::BlockNumber,
-		CallHash = [u8; 32]
+		CallHash = <T as system::Trait>::Hash
 	{
 		/// A new multisig operation has begun. First param is the account that is approving,
 		/// second is the multisig account, third is hash of the call.
@@ -255,7 +257,7 @@ decl_module! {
 		fn create(origin,
 			threshold: u16,
 			other_signatories: Vec<T::AccountId>,
-			call_hash: [u8; 32],
+			call_hash: T::Hash,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_valid_input(threshold, &other_signatories)?;
@@ -286,7 +288,7 @@ decl_module! {
 			let _guard = ClearFilterGuard::<T::IsCallable, <T as Trait>::Call>::new();
 			ensure!(T::IsCallable::filter(call.as_ref()), Error::<T>::Uncallable);
 			let encoded_call = call.encode();
-			let call_hash = blake2_256(&encoded_call);
+			let call_hash = T::Hashing::hash(&encoded_call);
 			Self::store_call(who.clone(), &call_hash, encoded_call)?;
 		}
 
@@ -340,7 +342,7 @@ decl_module! {
 			threshold: u16,
 			other_signatories: Vec<T::AccountId>,
 			timepoint: Timepoint<T::BlockNumber>,
-			call_hash: [u8; 32],
+			call_hash: T::Hash,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_valid_input(threshold, &other_signatories)?;
@@ -367,7 +369,7 @@ decl_module! {
 			threshold: u16,
 			other_signatories: Vec<T::AccountId>,
 			timepoint: Timepoint<T::BlockNumber>,
-			call_hash: [u8; 32],
+			call_hash: T::Hash,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			Self::ensure_valid_input(threshold, &other_signatories)?;
@@ -429,7 +431,7 @@ decl_module! {
 			threshold: u16,
 			other_signatories: Vec<T::AccountId>,
 			timepoint: Timepoint<T::BlockNumber>,
-			call_hash: [u8; 32],
+			call_hash: T::Hash,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::ensure_valid_input(threshold, &other_signatories)?;
@@ -458,12 +460,12 @@ impl<T: Trait> Module<T> {
 	///
 	/// NOTE: `who` must be sorted. If it is not, then you'll get the wrong answer.
 	pub fn multi_account_id(who: &[T::AccountId], threshold: u16) -> T::AccountId {
-		let entropy = (b"modlpy/utilisuba", who, threshold).using_encoded(blake2_256);
-		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
+		let entropy = (b"modlpy/utilisuba", who, threshold).using_encoded(T::Hashing::hash);
+		T::AccountId::decode(&mut &entropy.as_ref()[..]).unwrap_or_default()
 	}
 
 	/// Place a call's encoded data in storage, reserving funds as appropriate.
-	fn store_call(who: T::AccountId, hash: &[u8; 32], data: Vec<u8>) -> DispatchResult {
+	fn store_call(who: T::AccountId, hash: &T::Hash, data: Vec<u8>) -> DispatchResult {
 		if !Calls::<T>::contains_key(hash) {
 			let deposit = T::DepositBase::get()
 				+ T::DepositFactor::get() * BalanceOf::<T>::from(((data.len() + 31) / 32) as u32);
@@ -475,7 +477,7 @@ impl<T: Trait> Module<T> {
 	}
 
 	/// Attempt to remove a call from storage, returning it and any deposit on it to the owner.
-	fn take_call(hash: &[u8; 32]) -> Option<<T as Trait>::Call> {
+	fn take_call(hash: &T::Hash) -> Option<<T as Trait>::Call> {
 		if let Some((data, who, deposit)) = Calls::<T>::take(hash) {
 			T::Currency::unreserve(&who, deposit);
 			Decode::decode(&mut &data[..]).ok()

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -545,7 +545,7 @@ impl<T: Trait> Module<T> {
 		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}
 
-	/// Please a call in storage, reserving funds as appropriate.
+	/// Place a call's encoded data in storage, reserving funds as appropriate.
 	fn store_call(who: T::AccountId, hash: &[u8; 32], data: Vec<u8>) -> DispatchResult {
 		if !Calls::<T>::contains_key(hash) {
 			let deposit = T::DepositBase::get()
@@ -557,6 +557,7 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
+	/// Attempt to remove a call from storage, returning it and any deposit on it to the owner.
 	fn take_call(hash: &[u8; 32]) -> Option<<T as Trait>::Call> {
 		if let Some((data, who, deposit)) = Calls::<T>::take(hash) {
 			T::Currency::unreserve(&who, deposit);

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -164,7 +164,7 @@ fn multisig_deposit_is_taken_and_returned_when_approved() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_eq!(Balances::free_balance(1), 2);
 		assert_eq!(Balances::reserved_balance(1), 3);
@@ -186,7 +186,7 @@ fn multisig_deposit_is_taken_and_returned_when_canceled() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_eq!(Balances::free_balance(1), 2);
 		assert_eq!(Balances::reserved_balance(1), 3);
@@ -206,7 +206,7 @@ fn multisig_deposit_is_taken_and_returned_when_approved_with_call_storage() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
 		assert_eq!(Balances::free_balance(1), 0);
@@ -228,7 +228,7 @@ fn multisig_deposit_is_taken_and_returned_when_canceled_with_call_storage() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
 		assert_eq!(Balances::free_balance(1), 0);
@@ -250,7 +250,7 @@ fn multisig_deposit_is_taken_and_returned_when_canceled_with_call_storage() {
 // 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 // 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-// 		let hash = call.using_encoded(blake2_256);
+// 		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 
 // 		assert_ok!(Multisig::create(Origin::signed(1), 3, vec![2, 3], None, hash));
 // 		assert_eq!(Balances::free_balance(1), 1);
@@ -281,7 +281,7 @@ fn timepoint_checking_works() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
@@ -303,7 +303,7 @@ fn multisig_2_of_3_works_with_call_storing() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
 		assert_eq!(Balances::free_balance(6), 0);
@@ -323,7 +323,7 @@ fn multisig_2_of_3_works() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
 		assert_eq!(Balances::free_balance(6), 0);
@@ -343,7 +343,7 @@ fn multisig_3_of_3_works() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 3, vec![2, 3], hash));
 		assert_ok!(Multisig::approve(Origin::signed(2), 3, vec![1, 3], now(), hash));
 		assert_eq!(Balances::free_balance(6), 0);
@@ -359,7 +359,7 @@ fn multisig_3_of_3_works() {
 fn cancel_multisig_works() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 3, vec![2, 3], hash));
 		assert_ok!(Multisig::approve(Origin::signed(2), 3, vec![1, 3], now(), hash));
 		assert_noop!(
@@ -376,7 +376,7 @@ fn cancel_multisig_works() {
 fn cancel_multisig_with_call_storage_works() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 3, vec![2, 3], hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(1), call));
 		assert_eq!(Balances::free_balance(1), 4);
@@ -396,7 +396,7 @@ fn cancel_multisig_with_call_storage_works() {
 fn cancel_multisig_with_alt_call_storage_works() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 3, vec![2, 3], hash));
 		assert_eq!(Balances::free_balance(1), 6);
 		assert_ok!(Multisig::approve(Origin::signed(2), 3, vec![1, 3], now(), hash));
@@ -417,10 +417,10 @@ fn multisig_2_of_3_as_multi_with_many_calls_works() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call1 = Box::new(Call::Balances(BalancesCall::transfer(6, 10)));
-		let hash1 = call1.using_encoded(blake2_256);
+		let hash1 = call1.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 
 		let call2 = Box::new(Call::Balances(BalancesCall::transfer(7, 5)));
-		let hash2 = call2.using_encoded(blake2_256);
+		let hash2 = call2.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash1));
 		assert_ok!(Multisig::create(Origin::signed(2), 2, vec![1, 3], hash2));
@@ -446,7 +446,7 @@ fn multisig_2_of_3_cannot_reissue_same_call() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 10)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_ok!(Multisig::approve(Origin::signed(2), 2, vec![1, 3], now(), hash));
 		assert_ok!(Multisig::note_preimage(Origin::signed(2), call.clone()));
@@ -467,7 +467,7 @@ fn multisig_2_of_3_cannot_reissue_same_call() {
 fn zero_threshold_fails() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_noop!(
 			Multisig::create(Origin::signed(1), 0, vec![2], hash),
 			Error::<Test>::ZeroThreshold,
@@ -479,7 +479,7 @@ fn zero_threshold_fails() {
 fn too_many_signatories_fails() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_noop!(
 			Multisig::create(Origin::signed(1), 2, vec![2, 3, 4], hash),
 			Error::<Test>::TooManySignatories,
@@ -491,7 +491,7 @@ fn too_many_signatories_fails() {
 fn duplicate_approvals_are_ignored() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_noop!(
 			Multisig::approve(Origin::signed(1), 2, vec![2, 3], now(), hash),
@@ -514,7 +514,7 @@ fn multisig_1_of_3_works() {
 		assert_ok!(Balances::transfer(Origin::signed(3), multi, 5));
 
 		let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		// TODO: What is this?
 		// assert_noop!(
 		// 	Multisig::create(Origin::signed(4), 1, vec![2, 3], hash),
@@ -536,7 +536,7 @@ fn multisig_1_of_3_works() {
 fn multisig_filters() {
 	new_test_ext().execute_with(|| {
 		let call = Box::new(Call::System(frame_system::Call::set_code(vec![])));
-		let hash = call.using_encoded(blake2_256);
+		let hash = call.using_encoded(<Test as frame_system::Trait>::Hashing::hash);
 		assert_ok!(Multisig::create(Origin::signed(1), 2, vec![2, 3], hash));
 		assert_noop!(
 			Multisig::note_preimage(Origin::signed(1), call),


### PR DESCRIPTION
This is a PR that refactors the Multisig pallet to:
* Reduce complexity of the extrinsics
* Reduce duplicated code
* Simplify weight calculations

This PR splits the `approve_as_multi` and `as_multi` functions into clear linear steps that can be followed to complete a multi-signature operation:

1. `create`: Creates a multi-signature operation using the hash of the call.
2. `note_preimage`: Allows any sender to upload the raw call preimage for a multi-signature call hash.
3. `approve`: Allows anyone in the multi-signature to voice their approval for the call.
4. `complete`: When a multi-signature operation reaches the threshold number of approvals, this will dispatch the call using the preimage that was uploaded.
5. `cancel`: The original creator of the multisignature operation can close it before it is completed.

When combined with batch calls, this refactor can act just like the original pallet:

* batch(create, note_preimage): Create a multisig with some stored call preimage
* batch(approve, note_preimage, complete): The final approval of a multisig with no preimage can batch this call to complete the multisig.
* batch(create, note_preimage, complete): 1 user threshold multisig created and completed in a single transaction

In progress
