### PR TITLE
transaction-pool: expose blocking api for tx submission

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -111,7 +111,7 @@ pub fn new_full(config: Configuration) -> Result<impl AbstractService, ServiceEr
 			let provider = client as Arc<dyn StorageAndProofProvider<_, _>>;
 			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, provider)) as _)
 		})?
-		.build()?;
+		.build_full()?;
 
 	if role.is_authority() {
 		let proposer = sc_basic_authorship::ProposerFactory::new(
@@ -264,5 +264,5 @@ pub fn new_light(config: Configuration) -> Result<impl AbstractService, ServiceE
 			let provider = client as Arc<dyn StorageAndProofProvider<_, _>>;
 			Ok(Arc::new(GrandpaFinalityProofProvider::new(backend, provider)) as _)
 		})?
-		.build()
+		.build_light()
 }

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -179,7 +179,7 @@ macro_rules! new_full {
 				let provider = client as Arc<dyn grandpa::StorageAndProofProvider<_, _>>;
 				Ok(Arc::new(grandpa::FinalityProofProvider::new(backend, provider)) as _)
 			})?
-			.build()?;
+			.build_full()?;
 
 		let (block_import, grandpa_link, babe_link) = import_setup.take()
 			.expect("Link Half and Block Import are present for Full Services or setup failed before. qed");
@@ -405,7 +405,7 @@ pub fn new_light(config: Configuration)
 
 			Ok(node_rpc::create_light(light_deps))
 		})?
-		.build()?;
+		.build_light()?;
 
 	Ok(service)
 }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -959,8 +959,7 @@ ServiceBuilder<
 		Ok(self)
 	}
 
-	/// Builds the service.
-	pub fn build_light(self) -> Result<Service<
+	fn build_common(self) -> Result<Service<
 		TBl,
 		Client<TBackend, TExec, TBl, TRtApi>,
 		TSc,
@@ -1417,6 +1416,25 @@ ServiceBuilder<
 			_base_path: config.base_path.map(Arc::new),
 		})
 	}
+
+	/// Builds the light service.
+	pub fn build_light(self) -> Result<Service<
+		TBl,
+		Client<TBackend, TExec, TBl, TRtApi>,
+		TSc,
+		NetworkStatus<TBl>,
+		NetworkService<TBl, <TBl as BlockT>::Hash>,
+		TExPool,
+		sc_offchain::OffchainWorkers<
+			Client<TBackend, TExec, TBl, TRtApi>,
+			TBackend::OffchainStorage,
+			TBl
+		>,
+	>, Error>
+		where TExec: CallExecutor<TBl, Backend = TBackend>,
+	{
+		self.build_common()
+	}
 }
 
 impl<TBl, TRtApi, TBackend, TExec, TSc, TImpQu, TExPool, TRpc>
@@ -1454,7 +1472,7 @@ ServiceBuilder<
 	TRpc: sc_rpc::RpcExtension<sc_rpc::Metadata>,
 {
 
-	/// Builds the service.
+	/// Builds the full service.
 	pub fn build_full(self) -> Result<Service<
 		TBl,
 		Client<TBackend, TExec, TBl, TRtApi>,
@@ -1474,6 +1492,6 @@ ServiceBuilder<
 		self.client.execution_extensions()
 			.register_transaction_pool(Arc::downgrade(&self.transaction_pool) as _);
 
-		self.build_light()
+		self.build_common()
 	}
 }

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -57,7 +57,7 @@ use std::{
 };
 use wasm_timer::SystemTime;
 use sc_telemetry::{telemetry, SUBSTRATE_INFO};
-use sp_transaction_pool::MaintainedTransactionPool;
+use sp_transaction_pool::{LocalTransactionPool, MaintainedTransactionPool};
 use prometheus_endpoint::Registry;
 use sc_client_db::{Backend, DatabaseSettings};
 use sp_core::traits::CodeExecutor;
@@ -960,7 +960,7 @@ ServiceBuilder<
 	}
 
 	/// Builds the service.
-	pub fn build(self) -> Result<Service<
+	pub fn build_light(self) -> Result<Service<
 		TBl,
 		Client<TBackend, TExec, TBl, TRtApi>,
 		TSc,
@@ -1015,10 +1015,6 @@ ServiceBuilder<
 			"height" => chain_info.best_number.saturated_into::<u64>(),
 			"best" => ?chain_info.best_hash
 		);
-
-		// make transaction pool available for off-chain runtime calls.
-		client.execution_extensions()
-			.register_transaction_pool(Arc::downgrade(&transaction_pool) as _);
 
 		let transaction_pool_adapter = Arc::new(TransactionPoolAdapter {
 			imports_external_transactions: !matches!(config.role, Role::Light),
@@ -1420,5 +1416,64 @@ ServiceBuilder<
 			prometheus_registry: config.prometheus_config.map(|config| config.registry),
 			_base_path: config.base_path.map(Arc::new),
 		})
+	}
+}
+
+impl<TBl, TRtApi, TBackend, TExec, TSc, TImpQu, TExPool, TRpc>
+ServiceBuilder<
+	TBl,
+	TRtApi,
+	Client<TBackend, TExec, TBl, TRtApi>,
+	Arc<OnDemand<TBl>>,
+	TSc,
+	TImpQu,
+	BoxFinalityProofRequestBuilder<TBl>,
+	Arc<dyn FinalityProofProvider<TBl>>,
+	TExPool,
+	TRpc,
+	TBackend,
+> where
+	Client<TBackend, TExec, TBl, TRtApi>: ProvideRuntimeApi<TBl>,
+	<Client<TBackend, TExec, TBl, TRtApi> as ProvideRuntimeApi<TBl>>::Api:
+		sp_api::Metadata<TBl> +
+		sc_offchain::OffchainWorkerApi<TBl> +
+		sp_transaction_pool::runtime_api::TaggedTransactionQueue<TBl> +
+		sp_session::SessionKeys<TBl> +
+		sp_api::ApiErrorExt<Error = sp_blockchain::Error> +
+		sp_api::ApiExt<TBl, StateBackend = TBackend::State>,
+	TBl: BlockT,
+	TRtApi: 'static + Send + Sync,
+	TBackend: 'static + sc_client_api::backend::Backend<TBl> + Send,
+	TExec: 'static + CallExecutor<TBl> + Send + Sync + Clone,
+	TSc: Clone,
+	TImpQu: 'static + ImportQueue<TBl>,
+	TExPool: MaintainedTransactionPool<Block = TBl, Hash = <TBl as BlockT>::Hash> +
+		LocalTransactionPool<Block = TBl, Hash = <TBl as BlockT>::Hash> +
+		MallocSizeOfWasm +
+		'static,
+	TRpc: sc_rpc::RpcExtension<sc_rpc::Metadata>,
+{
+
+	/// Builds the service.
+	pub fn build_full(self) -> Result<Service<
+		TBl,
+		Client<TBackend, TExec, TBl, TRtApi>,
+		TSc,
+		NetworkStatus<TBl>,
+		NetworkService<TBl, <TBl as BlockT>::Hash>,
+		TExPool,
+		sc_offchain::OffchainWorkers<
+			Client<TBackend, TExec, TBl, TRtApi>,
+			TBackend::OffchainStorage,
+			TBl
+		>,
+	>, Error>
+		where TExec: CallExecutor<TBl, Backend = TBackend>,
+	{
+		// make transaction pool available for off-chain runtime calls.
+		self.client.execution_extensions()
+			.register_transaction_pool(Arc::downgrade(&self.transaction_pool) as _);
+
+		self.build_light()
 	}
 }

--- a/client/transaction-pool/src/api.rs
+++ b/client/transaction-pool/src/api.rs
@@ -87,29 +87,15 @@ where
 		let client = self.client.clone();
 		let at = at.clone();
 
-		self.pool.spawn_ok(futures_diagnose::diagnose("validate-transaction", async move {
-			sp_tracing::enter_span!("validate_transaction");
-			let runtime_api = client.runtime_api();
-			let has_v2 = sp_tracing::tracing_span! { "check_version";
-				runtime_api
-				.has_api_with::<dyn TaggedTransactionQueue<Self::Block, Error=()>, _>(
-					&at, |v| v >= 2,
-				)
-				.unwrap_or_default()
-			};
-
-			sp_tracing::enter_span!("runtime::validate_transaction");
-			let res = if has_v2 {
-				runtime_api.validate_transaction(&at, source, uxt)
-			} else {
-				#[allow(deprecated)] // old validate_transaction
-				runtime_api.validate_transaction_before_version_2(&at, uxt)
-			};
-			let res = res.map_err(|e| Error::RuntimeApi(e.to_string()));
-			if let Err(e) = tx.send(res) {
-				log::warn!("Unable to send a validate transaction result: {:?}", e);
-			}
-		}));
+		self.pool.spawn_ok(futures_diagnose::diagnose(
+			"validate-transaction",
+			async move {
+				let res = validate_transaction_blocking(&*client, &at, source, uxt);
+				if let Err(e) = tx.send(res) {
+					log::warn!("Unable to send a validate transaction result: {:?}", e);
+				}
+			},
+		));
 
 		Box::pin(async move {
 			match rx.await {
@@ -140,6 +126,62 @@ where
 		ex.using_encoded(|x| {
 			(<traits::HashFor::<Block> as traits::Hash>::hash(x), x.len())
 		})
+	}
+}
+
+/// Helper function to validate a transaction using a full chain API.
+/// This method will call into the runtime to perform the validation.
+fn validate_transaction_blocking<Client, Block>(
+	client: &Client,
+	at: &BlockId<Block>,
+	source: TransactionSource,
+	uxt: sc_transaction_graph::ExtrinsicFor<FullChainApi<Client, Block>>,
+) -> error::Result<TransactionValidity>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + BlockIdTo<Block>,
+	Client: Send + Sync + 'static,
+	Client::Api: TaggedTransactionQueue<Block>,
+	sp_api::ApiErrorFor<Client, Block>: Send + std::fmt::Display,
+{
+	sp_tracing::enter_span!("validate_transaction");
+	let runtime_api = client.runtime_api();
+	let has_v2 = sp_tracing::tracing_span! { "check_version";
+		runtime_api
+			.has_api_with::<dyn TaggedTransactionQueue<Block, Error=()>, _>(&at, |v| v >= 2)
+			.unwrap_or_default()
+	};
+
+	sp_tracing::enter_span!("runtime::validate_transaction");
+	let res = if has_v2 {
+		runtime_api.validate_transaction(&at, source, uxt)
+	} else {
+		#[allow(deprecated)] // old validate_transaction
+		runtime_api.validate_transaction_before_version_2(&at, uxt)
+	};
+
+	res.map_err(|e| Error::RuntimeApi(e.to_string()))
+}
+
+impl<Client, Block> FullChainApi<Client, Block>
+where
+	Block: BlockT,
+	Client: ProvideRuntimeApi<Block> + BlockBackend<Block> + BlockIdTo<Block>,
+	Client: Send + Sync + 'static,
+	Client::Api: TaggedTransactionQueue<Block>,
+	sp_api::ApiErrorFor<Client, Block>: Send + std::fmt::Display,
+{
+	/// Validates a transaction by calling into the runtime, same as
+	/// `validate_transaction` but blocks the current thread when performing
+	/// validation. Only implemented for `FullChainApi` since we can call into
+	/// the runtime locally.
+	pub fn validate_transaction_blocking(
+		&self,
+		at: &BlockId<Block>,
+		source: TransactionSource,
+		uxt: sc_transaction_graph::ExtrinsicFor<Self>,
+	) -> error::Result<TransactionValidity> {
+		validate_transaction_blocking(&*self.client, at, source, uxt)
 	}
 }
 

--- a/primitives/transaction-pool/src/pool.rs
+++ b/primitives/transaction-pool/src/pool.rs
@@ -141,6 +141,8 @@ pub type BlockHash<P> = <<P as TransactionPool>::Block as BlockT>::Hash;
 pub type TransactionFor<P> = <<P as TransactionPool>::Block as BlockT>::Extrinsic;
 /// Type of transactions event stream for a pool.
 pub type TransactionStatusStreamFor<P> = TransactionStatusStream<TxHash<P>, BlockHash<P>>;
+/// Transaction type for a local pool.
+pub type LocalTransactionFor<P> = <<P as LocalTransactionPool>::Block as BlockT>::Extrinsic;
 
 /// Typical future type used in transaction pool api.
 pub type PoolFuture<T, E> = std::pin::Pin<Box<dyn Future<Output=Result<T, E>> + Send>>;
@@ -273,6 +275,25 @@ pub trait MaintainedTransactionPool: TransactionPool {
 	fn maintain(&self, event: ChainEvent<Self::Block>) -> Pin<Box<dyn Future<Output=()> + Send>>;
 }
 
+/// Transaction pool interface for submitting local transactions that exposes a
+/// blocking interface for submission.
+pub trait LocalTransactionPool: Send + Sync {
+	/// Block type.
+	type Block: BlockT;
+	/// Transaction hash type.
+	type Hash: Hash + Eq + Member + Serialize;
+	/// Error type.
+	type Error: From<crate::error::Error> + crate::error::IntoPoolError;
+
+	/// Submits the given local unverified transaction to the pool blocking the
+	/// current thread for any necessary pre-verification.
+	fn submit_local(
+		&self,
+		at: &BlockId<Self::Block>,
+		xt: LocalTransactionFor<Self>,
+	) -> Result<Self::Hash, Self::Error>;
+}
+
 /// An abstraction for transaction pool.
 ///
 /// This trait is used by offchain calls to be able to submit transactions.
@@ -291,7 +312,7 @@ pub trait OffchainSubmitTransaction<Block: BlockT>: Send + Sync {
 	) -> Result<(), ()>;
 }
 
-impl<TPool: TransactionPool> OffchainSubmitTransaction<TPool::Block> for TPool {
+impl<TPool: LocalTransactionPool> OffchainSubmitTransaction<TPool::Block> for TPool {
 	fn submit_at(
 		&self,
 		at: &BlockId<TPool::Block>,
@@ -303,15 +324,14 @@ impl<TPool: TransactionPool> OffchainSubmitTransaction<TPool::Block> for TPool {
 			extrinsic
 		);
 
-		let result = futures::executor::block_on(self.submit_one(
-				&at, TransactionSource::Local, extrinsic,
-		));
+		let result = self.submit_local(&at, extrinsic);
 
-		result.map(|_| ())
-			.map_err(|e| log::warn!(
+		result.map(|_| ()).map_err(|e| {
+			log::warn!(
 				target: "txpool",
 				"(offchain call) Error submitting a transaction to the pool: {:?}",
 				e
-			))
+			)
+		})
 	}
 }

--- a/primitives/transaction-pool/src/pool.rs
+++ b/primitives/transaction-pool/src/pool.rs
@@ -287,6 +287,9 @@ pub trait LocalTransactionPool: Send + Sync {
 
 	/// Submits the given local unverified transaction to the pool blocking the
 	/// current thread for any necessary pre-verification.
+	/// NOTE: It MUST NOT be used for transactions that originate from the
+	/// network or RPC, since the validation is performed with
+	/// `TransactionSource::Local`.
 	fn submit_local(
 		&self,
 		at: &BlockId<Self::Block>,


### PR DESCRIPTION
This PR adds a new trait `LocalTransactionPool` that exposes a method for sending local transactions in a blocking manner. This is only implemented for full nodes as we can call into the runtime locally to validate the transaction. This trait is then used to implement the offchain extension for transaction submission. I needed this as I was calling into an offchain runtime from a future context, otherwise I'd get a panic due to nested calls to `futures::block_on`.

I had to separate the `ServiceBuilder::build()` into full and light variants. There is more stuff that can be moved out of the light builder (e.g. we don't need offchain workers on the light client). Since there is a pending refactor of the service builder I made an effort to minimize changes there.

polkadot companion: https://github.com/paritytech/polkadot/pull/1245