### PR TITLE
Fix check-line-width CI script

### DIFF
--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -10,14 +10,15 @@ BASE_BRANCH_NAME="master"
 LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
 BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
+git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth 100
+BASE_HASH=$(git merge-base ${BASE_BRANCH} HEAD)
 
-git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth 1
-git diff --name-only ${BASE_BRANCH} -- \*.rs | ( while read file
+git diff --name-only ${BASE_HASH} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];
   then
 	echo "Skipping removed file."
-  elif git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
+  elif git diff ${BASE_HASH} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
   then
     if [ -z "${FAIL}" ]
     then
@@ -29,11 +30,11 @@ do
       FAIL="true"
     fi
     echo "| file: ${file}"
-    git diff ${BASE_BRANCH} -- ${file} \
+    git diff ${BASE_HASH} -- ${file} \
       | grep -n "^+.\{$(( $LINE_WIDTH + 1))\}"
     echo "|"
   else
-    if git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+    if git diff ${BASE_HASH} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
     then
       if [ -z "${FAIL}" ]
       then
@@ -44,7 +45,7 @@ do
         echo "|"
       fi
       echo "| file: ${file}"
-      git diff ${BASE_BRANCH} -- ${file} | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+      git diff ${BASE_HASH} -- ${file} | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
       echo "|"
     fi
   fi

--- a/.maintain/gitlab/check_line_width.sh
+++ b/.maintain/gitlab/check_line_width.sh
@@ -5,20 +5,19 @@
 set -e
 set -o pipefail
 
+BASE_ORIGIN="origin"
+BASE_BRANCH_NAME="master"
 LINE_WIDTH="120"
 GOOD_LINE_WIDTH="100"
+BASE_BRANCH="${BASE_ORIGIN}/${BASE_BRANCH_NAME}"
 
-if [ -z $CI_COMMIT_BEFORE_SHA ]; then
-  echo "No ancestor commit set in \$CI_COMMIT_BEFORE_SHA"
-  exit -1;
-fi
-
-git diff --name-only ${CI_COMMIT_BEFORE_SHA} -- \*.rs | ( while read file
+git fetch ${BASE_ORIGIN} ${BASE_BRANCH_NAME} --depth 1
+git diff --name-only ${BASE_BRANCH} -- \*.rs | ( while read file
 do
   if [ ! -f ${file} ];
   then
 	echo "Skipping removed file."
-  elif git diff ${CI_COMMIT_BEFORE_SHA} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
+  elif git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $LINE_WIDTH + 1 ))\}"
   then
     if [ -z "${FAIL}" ]
     then
@@ -30,11 +29,11 @@ do
       FAIL="true"
     fi
     echo "| file: ${file}"
-    git diff ${CI_COMMIT_BEFORE_SHA} -- ${file} \
+    git diff ${BASE_BRANCH} -- ${file} \
       | grep -n "^+.\{$(( $LINE_WIDTH + 1))\}"
     echo "|"
   else
-    if git diff ${CI_COMMIT_BEFORE_SHA} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+    if git diff ${BASE_BRANCH} -- ${file} | grep -q "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
     then
       if [ -z "${FAIL}" ]
       then
@@ -45,7 +44,7 @@ do
         echo "|"
       fi
       echo "| file: ${file}"
-      git diff ${CI_COMMIT_BEFORE_SHA} -- ${file} | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
+      git diff ${BASE_BRANCH} -- ${file} | grep -n "^+.\{$(( $GOOD_LINE_WIDTH + 1 ))\}"
       echo "|"
     fi
   fi


### PR DESCRIPTION
Currently, the check-line-width checks all lines in the PR that are different from the current master. However, this is a moving target and will include foreign lines when the PR is not up to date with the current master.

This changes this behavior so that the comparison is made against the original commit where the PR branched off of.

This uses an environment variable supplied by gitlab CI. This makes this script not usable locally. I am not sure if this is a requirement.

Edit: For some reason `$CI_COMMIT_BEFORE_SHA` contains `0000000000000000000000000000000000000000`. Is there something wrong with our gitlab @gabreal ?