### PR TITLE
Add events for balance reserve and unreserve functions

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -217,7 +217,6 @@ impl<T: Trait<I>, I: Instance> Subtrait<I> for T {
 decl_event!(
 	pub enum Event<T, I: Instance = DefaultInstance> where
 		<T as frame_system::Trait>::AccountId,
-		<T as frame_support::traits>::Status,
 		<T as Trait<I>>::Balance
 	{
 		/// An account was created with some free balance.
@@ -1224,9 +1223,7 @@ impl<T: Trait<I>, I: Instance> ReservableCurrency<T::AccountId> for Module<T, I>
 					Status::Reserved => to_account.reserved = to_account.reserved.checked_add(&actual).ok_or(Error::<T, I>::Overflow)?,
 				}
 				from_account.reserved -= actual;
-				Self::deposit_event(RawEvent::ReserveRepatriated(
-					slashed.clone(), beneficiary.clone(), actual.clone(), status
-				));
+				Self::deposit_event(RawEvent::ReserveRepatriated(slashed.clone(), beneficiary.clone(), actual.clone(), status));
 				Ok(value - actual)
 			})
 		})

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -230,6 +230,8 @@ decl_event!(
 		BalanceSet(AccountId, Balance, Balance),
 		/// Some amount was deposited (e.g. for transaction fees).
 		Deposit(AccountId, Balance),
+		/// Some balance was reserved (moved from free to reserved).
+		Reserved(AccountId, Balance),
 		/// Some balance was unreserved (moved from reserved to free).
 		Unreserved(AccountId, Balance),
 		/// Some balance was moved from the reserve of the first account to the second account.
@@ -1155,6 +1157,7 @@ impl<T: Trait<I>, I: Instance> ReservableCurrency<T::AccountId> for Module<T, I>
 		Self::try_mutate_account(who, |account, _| -> DispatchResult {
 			account.free = account.free.checked_sub(&value).ok_or(Error::<T, I>::InsufficientBalance)?;
 			account.reserved = account.reserved.checked_add(&value).ok_or(Error::<T, I>::Overflow)?;
+			Self::deposit_event(RawEvent::Reserved(who.clone(), value.clone()));
 			Self::ensure_can_withdraw(who, value, WithdrawReason::Reserve.into(), account.free)
 		})
 	}

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -69,6 +69,10 @@ macro_rules! decl_tests {
 			evt
 		}
 
+		fn last_event() -> Event {
+			system::Module::<Test>::events().pop().expect("Event expected").event
+		}
+
 		#[test]
 		fn basic_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
@@ -486,15 +490,8 @@ macro_rules! decl_tests {
 				assert_ok!(Balances::reserve(&1, 110));
 				assert_ok!(Balances::repatriate_reserved(&1, &2, 41, Status::Free), 0);
 				assert_eq!(
-					events(),
-					[
-						Event::system(system::RawEvent::NewAccount(1)),
-						Event::balances(RawEvent::Endowed(1, 110)),
-						Event::system(system::RawEvent::NewAccount(2)),
-						Event::balances(RawEvent::Endowed(2, 1)),
-						Event::balances(RawEvent::Reserved(1, 110)),
-						Event::balances(RawEvent::ReserveRepatriated(1, 2, 41, Status::Free)),
-					]
+					last_event(),
+					Event::balances(RawEvent::ReserveRepatriated(1, 2, 41, Status::Free)),
 				);
 				assert_eq!(Balances::reserved_balance(1), 69);
 				assert_eq!(Balances::free_balance(1), 0);
@@ -705,22 +702,16 @@ macro_rules! decl_tests {
 					let _ = Balances::reserve(&1, 10);
 
 					assert_eq!(
-						events(),
-						[
-							Event::system(system::RawEvent::NewAccount(1)),
-							Event::balances(RawEvent::Endowed(1, 100)),
-							Event::balances(RawEvent::Reserved(1, 10)),
-						]
+						last_event(),
+						Event::balances(RawEvent::Reserved(1, 10)),
 					);
 
 					System::set_block_number(3);
 					let _ = Balances::unreserve(&1, 5);
 
 					assert_eq!(
-						events(),
-						[
-							Event::balances(RawEvent::Unreserved(1, 5)),
-						]
+						last_event(),
+						Event::balances(RawEvent::Unreserved(1, 5)),
 					);
 
 					System::set_block_number(4);
@@ -728,10 +719,8 @@ macro_rules! decl_tests {
 
 					// should only unreserve 5
 					assert_eq!(
-						events(),
-						[
-							Event::balances(RawEvent::Unreserved(1, 5)),
-						]
+						last_event(),
+						Event::balances(RawEvent::Unreserved(1, 5)),
 					);
 				});
 		}

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -168,7 +168,7 @@ macro_rules! decl_tests {
 						<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath),
 						Error::<$test, _>::LiquidityRestrictions
 					);
-					assert_noop!(
+					assert_err!(
 						<Balances as ReservableCurrency<_>>::reserve(&1, 1),
 						Error::<$test, _>::LiquidityRestrictions
 					);

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -168,7 +168,7 @@ macro_rules! decl_tests {
 						<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath),
 						Error::<$test, _>::LiquidityRestrictions
 					);
-					assert_err!(
+					assert_noop!(
 						<Balances as ReservableCurrency<_>>::reserve(&1, 1),
 						Error::<$test, _>::LiquidityRestrictions
 					);
@@ -485,6 +485,17 @@ macro_rules! decl_tests {
 				let _ = Balances::deposit_creating(&2, 1);
 				assert_ok!(Balances::reserve(&1, 110));
 				assert_ok!(Balances::repatriate_reserved(&1, &2, 41, Status::Free), 0);
+				assert_eq!(
+					events(),
+					[
+						Event::system(system::RawEvent::NewAccount(1)),
+						Event::balances(RawEvent::Endowed(1, 110)),
+						Event::system(system::RawEvent::NewAccount(2)),
+						Event::balances(RawEvent::Endowed(2, 1)),
+						Event::balances(RawEvent::Reserved(1, 110)),
+						Event::balances(RawEvent::ReserveRepatriated(1, 2, 41, Status::Free)),
+					]
+				);
 				assert_eq!(Balances::reserved_balance(1), 69);
 				assert_eq!(Balances::free_balance(1), 0);
 				assert_eq!(Balances::reserved_balance(2), 0);
@@ -680,6 +691,48 @@ macro_rules! decl_tests {
 					assert!(Balances::is_dead_account(&1));
 					assert_eq!(Balances::free_balance(1), 0);
 					assert_eq!(Balances::reserved_balance(1), 0);
+				});
+		}
+
+		#[test]
+		fn emit_events_with_reserve_and_unreserve() {
+			<$ext_builder>::default()
+				.build()
+				.execute_with(|| {
+					let _ = Balances::deposit_creating(&1, 100);
+
+					System::set_block_number(2);
+					let _ = Balances::reserve(&1, 10);
+
+					assert_eq!(
+						events(),
+						[
+							Event::system(system::RawEvent::NewAccount(1)),
+							Event::balances(RawEvent::Endowed(1, 100)),
+							Event::balances(RawEvent::Reserved(1, 10)),
+						]
+					);
+
+					System::set_block_number(3);
+					let _ = Balances::unreserve(&1, 5);
+
+					assert_eq!(
+						events(),
+						[
+							Event::balances(RawEvent::Unreserved(1, 5)),
+						]
+					);
+
+					System::set_block_number(4);
+					let _ = Balances::unreserve(&1, 6);
+
+					// should only unreserve 5
+					assert_eq!(
+						events(),
+						[
+							Event::balances(RawEvent::Unreserved(1, 5)),
+						]
+					);
 				});
 		}
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -24,7 +24,7 @@ use sp_runtime::{
 };
 use sp_staking::offence::OffenceDetails;
 use frame_support::{
-	assert_ok, assert_noop, assert_err, StorageMap,
+	assert_ok, assert_noop, StorageMap,
 	traits::{Currency, ReservableCurrency, OnInitialize, OnFinalize},
 };
 use pallet_balances::Error as BalancesError;
@@ -338,7 +338,7 @@ fn staking_should_work() {
 				})
 			);
 			// e.g. it cannot reserve more than 500 that it has free from the total 2000
-			assert_err!(
+			assert_noop!(
 				Balances::reserve(&3, 501),
 				BalancesError::<Test, _>::LiquidityRestrictions
 			);
@@ -784,9 +784,10 @@ fn cannot_reserve_staked_balance() {
 		// Confirm account 11 (via controller 10) is totally staked
 		assert_eq!(Staking::eras_stakers(Staking::active_era().unwrap().index, 11).own, 1000);
 		// Confirm account 11 cannot reserve as a result
-		assert_eq!(Balances::reserved_balance(11), 0);
-		let _ = Balances::reserve(&11, 1);
-		assert_eq!(Balances::reserved_balance(11), 0);
+		assert_noop!(
+			Balances::reserve(&11, 1),
+			BalancesError::<Test, _>::LiquidityRestrictions,
+		);
 
 		// Give account 11 extra free balance
 		let _ = Balances::make_free_balance_be(&11, 10000);

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -24,7 +24,7 @@ use sp_runtime::{
 };
 use sp_staking::offence::OffenceDetails;
 use frame_support::{
-	assert_ok, assert_noop, StorageMap,
+	assert_ok, assert_noop, assert_err, StorageMap,
 	traits::{Currency, ReservableCurrency, OnInitialize, OnFinalize},
 };
 use pallet_balances::Error as BalancesError;
@@ -337,8 +337,8 @@ fn staking_should_work() {
 					claimed_rewards: vec![0],
 				})
 			);
-			// e.g. it cannot spend more than 500 that it has free from the total 2000
-			assert_noop!(
+			// e.g. it cannot reserve more than 500 that it has free from the total 2000
+			assert_err!(
 				Balances::reserve(&3, 501),
 				BalancesError::<Test, _>::LiquidityRestrictions
 			);
@@ -783,11 +783,10 @@ fn cannot_reserve_staked_balance() {
 		assert_eq!(Balances::free_balance(11), 1000);
 		// Confirm account 11 (via controller 10) is totally staked
 		assert_eq!(Staking::eras_stakers(Staking::active_era().unwrap().index, 11).own, 1000);
-		// Confirm account 11 cannot transfer as a result
-		assert_noop!(
-			Balances::reserve(&11, 1),
-			BalancesError::<Test, _>::LiquidityRestrictions
-		);
+		// Confirm account 11 cannot reserve as a result
+		assert_eq!(Balances::reserved_balance(11), 0);
+		let _ = Balances::reserve(&11, 1);
+		assert_eq!(Balances::reserved_balance(11), 0);
 
 		// Give account 11 extra free balance
 		let _ = Balances::make_free_balance_be(&11, 10000);

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1006,6 +1006,7 @@ pub trait Currency<AccountId> {
 }
 
 /// Status of funds.
+#[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
 pub enum BalanceStatus {
 	/// Funds are free, as corresponding to `free` item in Balances.
 	Free,


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/6329

Two things in particular I could use feedback on:
1. Are all the `clone`s OK? It didn't compile without them (or using references), but maybe there's a more elegant solution.
2. I put the `derive(...)` impls on `BalanceStatus` that copied other enums that emit in events. Again, maybe another way that's better.