### PR TITLE
Deprecate FunctionOf and remove its users

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -117,7 +117,7 @@ use frame_support::{
 	parameter_types, IsSubType, storage::child::{self, ChildInfo},
 };
 use frame_support::traits::{OnUnbalanced, Currency, Get, Time, Randomness};
-use frame_support::weights::{FunctionOf, DispatchClass, Weight, GetDispatchInfo, Pays};
+use frame_support::weights::GetDispatchInfo;
 use frame_system::{self as system, ensure_signed, RawOrigin, ensure_root};
 use pallet_contracts_primitives::{RentProjection, ContractAccessError};
 
@@ -481,11 +481,7 @@ decl_module! {
 
 		/// Stores the given binary Wasm code into the chain's storage and returns its `codehash`.
 		/// You can instantiate contracts only with stored code.
-		#[weight = FunctionOf(
-			|args: (&Vec<u8>,)| Module::<T>::calc_code_put_costs(args.0),
-			DispatchClass::Normal,
-			Pays::Yes
-		)]
+		#[weight = Module::<T>::calc_code_put_costs(&code)]
 		pub fn put_code(
 			origin,
 			code: Vec<u8>
@@ -506,11 +502,7 @@ decl_module! {
 		/// * If the account is a regular account, any value will be transferred.
 		/// * If no account exists and the call value is not less than `existential_deposit`,
 		/// a regular account will be created and any value will be transferred.
-		#[weight = FunctionOf(
-			|args: (&<T::Lookup as StaticLookup>::Source, &BalanceOf<T>, &Weight, &Vec<u8>)| *args.2,
-			DispatchClass::Normal,
-			Pays::Yes
-		)]
+		#[weight = *gas_limit]
 		pub fn call(
 			origin,
 			dest: <T::Lookup as StaticLookup>::Source,
@@ -538,11 +530,7 @@ decl_module! {
 		///   after the execution is saved as the `code` of the account. That code will be invoked
 		///   upon any call received by this account.
 		/// - The contract is initialized.
-		#[weight = FunctionOf(
-			|args: (&BalanceOf<T>, &Weight, &CodeHash<T>, &Vec<u8>)| *args.1,
-			DispatchClass::Normal,
-			Pays::Yes
-		)]
+		#[weight = *gas_limit]
 		pub fn instantiate(
 			origin,
 			#[compact] endowment: BalanceOf<T>,

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -30,7 +30,7 @@ use codec::{Encode, Decode};
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
 use frame_support::{ensure, decl_module, decl_storage, decl_event, decl_error};
-use frame_support::weights::{Weight, DispatchClass, FunctionOf, Pays};
+use frame_support::weights::Weight;
 use frame_support::traits::{Currency, WithdrawReason, ExistenceRequirement, Get};
 use frame_system::{self as system, ensure_signed};
 use sp_runtime::ModuleId;
@@ -273,12 +273,7 @@ decl_module! {
 		}
 
 		/// Issue an EVM call operation. This is similar to a message call transaction in Ethereum.
-		#[weight = FunctionOf(
-			|(_, _, _, gas_limit, gas_price, _): (&H160, &Vec<u8>, &U256, &u32, &U256, &Option<U256>)|
-				(*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight),
-			DispatchClass::Normal,
-			Pays::Yes,
-		)]
+		#[weight = (*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight)]
 		fn call(
 			origin,
 			target: H160,
@@ -306,12 +301,7 @@ decl_module! {
 
 		/// Issue an EVM create operation. This is similar to a contract creation transaction in
 		/// Ethereum.
-		#[weight = FunctionOf(
-			|(_, _, gas_limit, gas_price, _): (&Vec<u8>, &U256, &u32, &U256, &Option<U256>)|
-				(*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight),
-			DispatchClass::Normal,
-			Pays::Yes,
-		)]
+		#[weight = (*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight)]
 		fn create(
 			origin,
 			init: Vec<u8>,
@@ -339,12 +329,7 @@ decl_module! {
 		}
 
 		/// Issue an EVM create2 operation.
-		#[weight = FunctionOf(
-			|(_, _, _, gas_limit, gas_price, _): (&Vec<u8>, &H256, &U256, &u32, &U256, &Option<U256>)|
-				(*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight),
-			DispatchClass::Normal,
-			Pays::Yes,
-		)]
+		#[weight = (*gas_price).saturated_into::<Weight>().saturating_mul(*gas_limit as Weight)]
 		fn create2(
 			origin,
 			init: Vec<u8>,

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -160,7 +160,7 @@ use codec::{Encode, Decode};
 
 use frame_support::{
 	decl_module, decl_event, decl_storage, decl_error, ensure,
-	Parameter, RuntimeDebug, weights::{GetDispatchInfo, FunctionOf, Pays},
+	Parameter, RuntimeDebug, weights::GetDispatchInfo,
 	traits::{Currency, ReservableCurrency, Get, BalanceStatus},
 	dispatch::PostDispatchInfo,
 };
@@ -336,11 +336,7 @@ decl_module! {
 		/// - The weight of the `call` + 10,000.
 		/// - One storage lookup to check account is recovered by `who`. O(1)
 		/// # </weight>
-		#[weight = FunctionOf(
-			|args: (&T::AccountId, &Box<<T as Trait>::Call>)| args.1.get_dispatch_info().weight + 10_000,
-			|args: (&T::AccountId, &Box<<T as Trait>::Call>)| args.1.get_dispatch_info().class,
-			Pays::Yes,
-		)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
 		fn as_recovered(origin,
 			account: T::AccountId,
 			call: Box<<T as Trait>::Call>

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -402,7 +402,7 @@ mod tests {
 	use frame_support::{
 		impl_outer_event, impl_outer_origin, impl_outer_dispatch, parameter_types, assert_ok,
 		traits::{OnInitialize, OnFinalize},
-		weights::{DispatchClass, FunctionOf, Pays, constants::RocksDbWeight},
+		weights::constants::RocksDbWeight,
 	};
 	use sp_core::H256;
 	// The testing primitives are very useful for avoiding having to work with signatures
@@ -441,11 +441,7 @@ mod tests {
 			pub struct Module<T: Trait> for enum Call where origin: <T as system::Trait>::Origin {
 				fn deposit_event() = default;
 
-				#[weight = FunctionOf(
-					|args: (&u32, &Weight)| *args.1,
-					|_: (&u32, &Weight)| DispatchClass::Normal,
-					Pays::Yes,
-				)]
+				#[weight = *weight]
 				fn log(origin, i: u32, weight: Weight) {
 					ensure_root(origin)?;
 					Self::deposit_event(Event::Logged(i, weight));

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -93,7 +93,7 @@ use sp_runtime::{DispatchResult, traits::{StaticLookup, Dispatchable}};
 use frame_support::{
 	Parameter, decl_module, decl_event, decl_storage, decl_error, ensure,
 };
-use frame_support::weights::{Weight, GetDispatchInfo, FunctionOf, Pays};
+use frame_support::weights::{Weight, GetDispatchInfo};
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
@@ -126,11 +126,7 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = FunctionOf(
-			|args: (&Box<<T as Trait>::Call>,)| args.0.get_dispatch_info().weight + 10_000,
-			|args: (&Box<<T as Trait>::Call>,)| args.0.get_dispatch_info().class,
-			Pays::Yes,
-		)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
 		fn sudo(origin, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -150,11 +146,7 @@ decl_module! {
 		/// - O(1).
 		/// - The weight of this call is defined by the caller.
 		/// # </weight>
-		#[weight = FunctionOf(
-			|(_, &weight): (&Box<<T as Trait>::Call>,&Weight,)| weight,
-			|(call, _): (&Box<<T as Trait>::Call>,&Weight,)| call.get_dispatch_info().class,
-			Pays::Yes,
-		)]
+		#[weight = (*_weight, call.get_dispatch_info().class)]
 		fn sudo_unchecked_weight(origin, call: Box<<T as Trait>::Call>, _weight: Weight) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -195,15 +187,7 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = FunctionOf(
-			|args: (&<T::Lookup as StaticLookup>::Source, &Box<<T as Trait>::Call>,)| {
-				args.1.get_dispatch_info().weight + 10_000
-			},
-			|args: (&<T::Lookup as StaticLookup>::Source, &Box<<T as Trait>::Call>,)| {
-				args.1.get_dispatch_info().class
-			},
-			Pays::Yes,
-		)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
 		fn sudo_as(origin, who: <T::Lookup as StaticLookup>::Source, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -56,11 +56,7 @@ pub mod logger {
 		pub struct Module<T: Trait> for enum Call where origin: <T as system::Trait>::Origin {
 			fn deposit_event() = default;
 
-			#[weight = FunctionOf(
-				|args: (&i32, &Weight)| *args.1,
-				DispatchClass::Normal,
-				Pays::Yes,
-			)]
+			#[weight = *weight]
 			fn privileged_i32_log(origin, i: i32, weight: Weight){
 				// Ensure that the `origin` is `Root`.	
 				ensure_root(origin)?;
@@ -68,11 +64,7 @@ pub mod logger {
 				Self::deposit_event(RawEvent::AppendI32(i, weight));
 			}
 
-			#[weight = FunctionOf(
-				|args: (&i32, &Weight)| *args.1,
-				DispatchClass::Normal,
-				Pays::Yes,
-			)]
+			#[weight = *weight]
 			fn non_privileged_log(origin, i: i32, weight: Weight){
 				// Ensure that the `origin` is some signed account.		
 				let sender = ensure_signed(origin)?;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -20,7 +20,7 @@
 use super::*;
 use frame_support::{
 	impl_outer_origin, impl_outer_dispatch, impl_outer_event, parameter_types,
-	weights::{Weight, DispatchClass}
+	weights::Weight,
 };
 use sp_core::H256;
 // The testing primitives are very useful for avoiding having to work with signatures

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -425,9 +425,11 @@ impl<T> PaysFee<T> for (Weight, Pays) {
 ///   with the same argument list as the dispatched, wrapped in a tuple.
 /// - `PF`: a `Pays` variant for whether this dispatch pays fee or not or a closure that
 ///   returns a `Pays` variant with the same argument list as the dispatched, wrapped in a tuple.
+#[deprecated = "Function arguments are available directly inside the annotation now."]
 pub struct FunctionOf<WD, CD, PF>(pub WD, pub CD, pub PF);
 
 // `WeighData` as a raw value
+#[allow(deprecated)]
 impl<Args, CD, PF> WeighData<Args> for FunctionOf<Weight, CD, PF> {
 	fn weigh_data(&self, _: Args) -> Weight {
 		self.0
@@ -435,6 +437,7 @@ impl<Args, CD, PF> WeighData<Args> for FunctionOf<Weight, CD, PF> {
 }
 
 // `WeighData` as a closure
+#[allow(deprecated)]
 impl<Args, WD, CD, PF> WeighData<Args> for FunctionOf<WD, CD, PF> where
 	WD : Fn(Args) -> Weight
 {
@@ -444,6 +447,7 @@ impl<Args, WD, CD, PF> WeighData<Args> for FunctionOf<WD, CD, PF> where
 }
 
 // `ClassifyDispatch` as a raw value
+#[allow(deprecated)]
 impl<Args, WD, PF> ClassifyDispatch<Args> for FunctionOf<WD, DispatchClass, PF> {
 	fn classify_dispatch(&self, _: Args) -> DispatchClass {
 		self.1
@@ -451,6 +455,7 @@ impl<Args, WD, PF> ClassifyDispatch<Args> for FunctionOf<WD, DispatchClass, PF> 
 }
 
 // `ClassifyDispatch` as a raw value
+#[allow(deprecated)]
 impl<Args, WD, CD, PF> ClassifyDispatch<Args> for FunctionOf<WD, CD, PF> where
 	CD : Fn(Args) -> DispatchClass
 {
@@ -460,6 +465,7 @@ impl<Args, WD, CD, PF> ClassifyDispatch<Args> for FunctionOf<WD, CD, PF> where
 }
 
 // `PaysFee` as a raw value
+#[allow(deprecated)]
 impl<Args, WD, CD> PaysFee<Args> for FunctionOf<WD, CD, Pays> {
 	fn pays_fee(&self, _: Args) -> Pays {
 		self.2
@@ -467,6 +473,7 @@ impl<Args, WD, CD> PaysFee<Args> for FunctionOf<WD, CD, Pays> {
 }
 
 // `PaysFee` as a closure
+#[allow(deprecated)]
 impl<Args, WD, CD, PF> PaysFee<Args> for FunctionOf<WD, CD, PF> where
 	PF : Fn(Args) -> Pays
 {
@@ -663,10 +670,10 @@ mod tests {
 			fn f03(_origin) { unimplemented!(); }
 
 			// weight = a x 10 + b
-			#[weight = FunctionOf(|args: (&u32, &u32)| (args.0 * 10 + args.1) as Weight, DispatchClass::Normal, Pays::Yes)]
+			#[weight = ((_a * 10 + _eb * 1) as Weight, DispatchClass::Normal, Pays::Yes)]
 			fn f11(_origin, _a: u32, _eb: u32) { unimplemented!(); }
 
-			#[weight = FunctionOf(|_: (&u32, &u32)| 0, DispatchClass::Operational, Pays::Yes)]
+			#[weight = (0, DispatchClass::Operational, Pays::Yes)]
 			fn f12(_origin, _a: u32, _eb: u32) { unimplemented!(); }
 
 			#[weight = T::DbWeight::get().reads(3) + T::DbWeight::get().writes(2) + 10_000]


### PR DESCRIPTION
Closes #6104

This marks the `FunctionOf` struct used in weight annotations as deprecated and removes all users. Polkadot does not use it. So no companion necessary.

# Motivation

As it turns out we never really needed this struct as the `#[weight]` macro already makes the arguments of the function (with the exception of `origin`) available. Removing this macro makes the weight annotation much more easy on the eyes and removes the need for explicitly specifying the `class` and `pays` when their defaults are used.

# Future Work

* We should remove the struct with our next major release.
* Make origin available in the annotation: #6316  (wasn't available in `FunctionOf`)