### PR TITLE
.gitlab-ci.yml: Run promtool on Prometheus alerting rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -366,7 +366,7 @@ test-prometheus-alerting-rules:
   script:
     - curl -L https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz --output prometheus.tar.gz
     - tar -xzf prometheus.tar.gz
-    - ./prometheus/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
+    - ./prometheus-*/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
 
 #### stage:                        build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,11 +361,12 @@ cargo-check-macos:
 
 test-prometheus-alerting-rules:
   stage:                           test
-  <<:                              *docker-env
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-build
   script:
-    - wget https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz
-    - tar -xzf prometheus-*.tar.gz
-    - ./prometheus-*/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
+    - curl https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz --output prometheus.tar.gz
+    - tar -xzf prometheus.tar.gz
+    - ./prometheus/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
 
 #### stage:                        build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,6 +359,14 @@ cargo-check-macos:
   tags:
     - osx
 
+test-prometheus-alerting-rules:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - wget https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz
+    - tar -xzf prometheus-*.tar.gz
+    - ./prometheus-*/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
+
 #### stage:                        build
 
 check-polkadot-companion-status:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -364,7 +364,7 @@ test-prometheus-alerting-rules:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   script:
-    - curl https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz --output prometheus.tar.gz
+    - curl -L https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz --output prometheus.tar.gz
     - tar -xzf prometheus.tar.gz
     - ./prometheus/promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
 


### PR DESCRIPTION
Add a CI stage to test the Prometheus alerting rules within
`.maintain/monitoring`.