### PR TITLE
adding a ss58 format for Stafi Network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -470,6 +470,8 @@ ss58_address_format!(
 		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
 	DarwiniaAccount =>
 		(18, "darwinia", "Darwinia Chain mainnet, standard account (*25519).")
+	StafiAccount =>
+		(20, "stafi", "Stafi mainnet, standard account (*25519).")
 	RobonomicsAccount =>
 		(32, "robonomics", "Any Robonomics network standard account (*25519).")
 	CentrifugeAccount =>


### PR DESCRIPTION
Hi, in order to prevent the re-usage across networks, decreasing the value at risk if a private key is lost, and also to identify easily. We want to registry the Subkey Address Type as 20 for Stafi mainnet. If there are any concerns please kindly tell us.

Many thanks for your hard-working on Substrate.