### PR TITLE
Add IPC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-ipc-server"
+version = "14.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedccd693325d833963b549e959137f30a7a0ea650cde92feda81dc0c1393cb5"
+dependencies = [
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log",
+ "parity-tokio-ipc",
+ "parking_lot 0.10.2",
+ "tokio-service",
+]
+
+[[package]]
 name = "jsonrpc-pubsub"
 version = "14.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,7 +3106,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -3108,6 +3122,18 @@ dependencies = [
  "log",
  "mio",
  "slab",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.5",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3131,6 +3157,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -4733,6 +4769,25 @@ name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
+
+[[package]]
+name = "parity-tokio-ipc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e57fea504fea33f9fbb5f49f378359030e7e026a6ab849bb9e8f0787376f1bf"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.29",
+ "libc",
+ "log",
+ "mio-named-pipes",
+ "miow 0.3.5",
+ "rand 0.7.3",
+ "tokio 0.1.22",
+ "tokio-named-pipes",
+ "tokio-uds",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "parity-util-mem"
@@ -6580,6 +6635,7 @@ version = "2.0.0-rc3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
+ "jsonrpc-ipc-server",
  "jsonrpc-pubsub",
  "jsonrpc-ws-server",
  "log",
@@ -8656,6 +8712,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-named-pipes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d282d483052288b2308ba5ee795f5673b159c9bdf63c385a05609da782a5eae"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.29",
+ "mio",
+ "mio-named-pipes",
+ "tokio 0.1.22",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8684,6 +8753,15 @@ dependencies = [
  "rustls",
  "tokio 0.2.18",
  "webpki",
+]
+
+[[package]]
+name = "tokio-service"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
+dependencies = [
+ "futures 0.1.29",
 ]
 
 [[package]]

--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -285,6 +285,12 @@ macro_rules! substrate_cli_subcommands {
 				}
 			}
 
+			fn rpc_ipc(&self) -> $crate::Result<::std::option::Option<::std::string::String>> {
+				match self {
+					$($enum::$variant(cmd) => cmd.rpc_ipc()),*
+				}
+			}
+
 			fn rpc_http(&self) -> $crate::Result<::std::option::Option<::std::net::SocketAddr>> {
 				match self {
 					$($enum::$variant(cmd) => cmd.rpc_http()),*

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -122,6 +122,10 @@ pub struct RunCmd {
 	#[structopt(long = "prometheus-external")]
 	pub prometheus_external: bool,
 
+	/// Specify IPC RPC server path
+	#[structopt(long = "ipc-path", value_name = "PATH")]
+	pub ipc_path: Option<String>,
+
 	/// Specify HTTP RPC server TCP port.
 	#[structopt(long = "rpc-port", value_name = "PORT")]
 	pub rpc_port: Option<u16>,
@@ -432,6 +436,10 @@ impl CliConfiguration for RunCmd {
 		)?;
 
 		Ok(Some(SocketAddr::new(interface, self.rpc_port.unwrap_or(9933))))
+	}
+
+	fn rpc_ipc(&self) -> Result<Option<String>> {
+		Ok(self.ipc_path.clone())
 	}
 
 	fn rpc_ws(&self) -> Result<Option<SocketAddr>> {

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -264,6 +264,13 @@ pub trait CliConfiguration: Sized {
 		Ok(Default::default())
 	}
 
+	/// Get the RPC IPC path (`None` if disabled).
+	///
+	/// By default this is `None`.
+	fn rpc_ipc(&self) -> Result<Option<String>> {
+		Ok(Default::default())
+	}
+
 	/// Get the RPC websocket address (`None` if disabled).
 	///
 	/// By default this is `None`.
@@ -451,6 +458,7 @@ pub trait CliConfiguration: Sized {
 			execution_strategies: self.execution_strategies(is_dev, is_validator)?,
 			rpc_http: self.rpc_http()?,
 			rpc_ws: self.rpc_ws()?,
+			rpc_ipc: self.rpc_ipc()?,
 			rpc_methods: self.rpc_methods()?,
 			rpc_ws_max_connections: self.rpc_ws_max_connections()?,
 			rpc_cors: self.rpc_cors(is_dev)?,

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -22,3 +22,4 @@ sp-runtime = { version = "2.0.0-rc3", path = "../../primitives/runtime" }
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 http = { package = "jsonrpc-http-server", version = "14.2.0" }
 ws = { package = "jsonrpc-ws-server", version = "14.2.0" }
+ipc = { version = "14.2.0", package = "jsonrpc-ipc-server" }

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -67,6 +67,8 @@ pub struct Configuration {
 	pub rpc_http: Option<SocketAddr>,
 	/// RPC over Websockets binding address. `None` if disabled.
 	pub rpc_ws: Option<SocketAddr>,
+	/// RPC over IPC binding path. `None` if disabled.
+	pub rpc_ipc: Option<String>,
 	/// Maximum number of connections for WebSockets RPC server. `None` if default.
 	pub rpc_ws_max_connections: Option<usize>,
 	/// CORS settings for HTTP & WS servers. `None` if all origins are allowed.

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -194,6 +194,7 @@ fn node_config<G: RuntimeGenesis + 'static, E: ChainSpecExtension + Clone + 'sta
 		wasm_method: sc_service::config::WasmExecutionMethod::Interpreted,
 		execution_strategies: Default::default(),
 		rpc_http: None,
+		rpc_ipc: None,
 		rpc_ws: None,
 		rpc_ws_max_connections: None,
 		rpc_cors: None,

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -86,6 +86,7 @@ where
 		pruning: Default::default(),
 		rpc_cors: Default::default(),
 		rpc_http: Default::default(),
+		rpc_ipc: Default::default(),
 		rpc_ws: Default::default(),
 		rpc_ws_max_connections: Default::default(),
 		rpc_methods: Default::default(),


### PR DESCRIPTION
This is useful for both security and performance reasons. IPC is faster
than TCP, and it is subject to OS access controls.