### PR TITLE
client/authority-discovery: Add option to disable querying

### DIFF
--- a/client/authority-discovery/src/error.rs
+++ b/client/authority-discovery/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
 	ReceivingDhtValueFoundEventWithDifferentKeys,
 	/// Received dht value found event with no records.
 	ReceivingDhtValueFoundEventWithNoRecords,
+	/// Received dht value found event even though querying for authorities is disabled.
+	ReceivingDhtValueFoundEventWithQueryingDisabled,
 	/// Failed to verify a dht payload with the given signature.
 	VerifyingDhtPayload,
 	/// Failed to hash the authority id to be used as a dht key.

--- a/client/authority-discovery/src/tests.rs
+++ b/client/authority-discovery/src/tests.rs
@@ -231,6 +231,7 @@ fn new_registers_metrics() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		Some(registry.clone()),
 	);
 
@@ -259,6 +260,7 @@ fn request_addresses_of_others_triggers_dht_get_query() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		None,
 	);
 
@@ -301,6 +303,7 @@ fn publish_discover_cycle() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		None,
 	);
 
@@ -330,6 +333,7 @@ fn publish_discover_cycle() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		None,
 	);
 
@@ -373,6 +377,7 @@ fn terminate_when_event_stream_terminates() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		None,
 	);
 
@@ -414,6 +419,7 @@ fn dont_stop_polling_when_error_is_returned() {
 		vec![],
 		dht_event_rx.boxed(),
 		Role::Authority(key_store),
+		true,
 		None,
 	);
 

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -536,7 +536,7 @@ pub enum TransportConfig {
 }
 
 /// The policy for connections to non-reserved peers.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NonReservedPeerMode {
 	/// Accept them. This is the default.
 	Accept,


### PR DESCRIPTION
The authority discovery module (1) publishes a nodes address onto the
DHT and (2) queryies the DHT for the addresses of other authorities.

When a node is only allowed to connect to the configured reserved nodes
there is no benefit in discovering other authorities (2). To reduce the
unnecessary overhead this patch adds an option to disable (2) while
still running (1).

In the scenario above where a node can only connect to a small subset of
the nodes (reserved nodes) of the DHT the publishing of addresses (1) is
likely failing as the node can not place its addresses on the node
closest to its chain identity. For now the node will still try to
publish its addresses, hoping that (a) one of its reserved nodes is
close enough to accept the record and (b) the reserved node will
republish the record to other nodes.

polkadot companion: https://github.com/paritytech/polkadot/pull/1262

Relates to https://github.com/paritytech/substrate/issues/6031.