### PR TITLE
[CI] Auto-label new PRs according to draft status

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -17,3 +17,4 @@ jobs:
         if: github.event.pull_request.draft == false
         with:
           add-labels: 'A0-pleasereview'
+          remove-labels: 'A3-inprogress'

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,0 +1,19 @@
+name: Label new PRs
+on:
+  pull_request:
+    types: [opened,ready_for_review]
+
+jobs:
+  label-new-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label new drafts
+        uses: andymckay/labeler@master
+        if: github.event.pull_request.draft == true
+        with:
+          add-labels: 'A3-inprogress'
+      - name: Label new PRs
+        uses: andymckay/labeler@master
+        if: github.event.pull_request.draft == false
+        with:
+          add-labels: 'A0-pleasereview'


### PR DESCRIPTION
If a new PR is created as a draft, gets auto-labeled with A3-inprogress.
If a new PR is created and is not a draft, gets auto-labeled with A0-pleasereview
If 'ready for review' is clicked, the A3-inprogress label is removed and A0-pleasereview is added.