### PR TITLE
Allow empty values in the storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-db"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
+dependencies = [
+ "ahash",
+ "hash-db",
+ "hashbrown",
+ "parity-util-mem",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7733,7 +7745,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-trie",
- "trie-db",
+ "trie-db 0.21.0",
  "trie-root",
 ]
 
@@ -7806,13 +7818,13 @@ dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "hex-literal",
- "memory-db",
+ "memory-db 0.21.0",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
  "sp-std",
  "trie-bench",
- "trie-db",
+ "trie-db 0.21.0",
  "trie-root",
  "trie-standardmap",
 ]
@@ -8111,7 +8123,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "log",
- "memory-db",
+ "memory-db 0.21.0",
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -8141,7 +8153,7 @@ dependencies = [
  "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
- "trie-db",
+ "trie-db 0.21.0",
 ]
 
 [[package]]
@@ -8857,9 +8869,9 @@ dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "keccak-hasher",
- "memory-db",
+ "memory-db 0.20.1",
  "parity-scale-codec",
- "trie-db",
+ "trie-db 0.20.1",
  "trie-root",
  "trie-standardmap",
 ]
@@ -8869,6 +8881,19 @@ name = "trie-db"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
+dependencies = [
+ "hash-db",
+ "hashbrown",
+ "log",
+ "rustc-hex",
+ "smallvec 1.4.0",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
 dependencies = [
  "hash-db",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,18 +3042,6 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be512cb2ccb4ecbdca937fdd4a62ea5f09f8e7195466a85e4632b3d5bcce82e6"
-dependencies = [
- "ahash",
- "hash-db",
- "hashbrown",
- "parity-util-mem",
-]
-
-[[package]]
-name = "memory-db"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
@@ -7745,7 +7733,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-trie",
- "trie-db 0.21.0",
+ "trie-db",
  "trie-root",
 ]
 
@@ -7818,13 +7806,13 @@ dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "hex-literal",
- "memory-db 0.21.0",
+ "memory-db",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
  "sp-std",
  "trie-bench",
- "trie-db 0.21.0",
+ "trie-db",
  "trie-root",
  "trie-standardmap",
 ]
@@ -8123,7 +8111,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "log",
- "memory-db 0.21.0",
+ "memory-db",
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -8153,7 +8141,7 @@ dependencies = [
  "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
- "trie-db 0.21.0",
+ "trie-db",
 ]
 
 [[package]]
@@ -8862,31 +8850,18 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trie-bench"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48b309cdda1abbdada28424bdc46f8b85362b3e66d6786d91223e83874429c7"
+checksum = "ed8419971832eb3333dc26066e50943a20e0934efeb451b3df5ee94f7f7323ab"
 dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "keccak-hasher",
- "memory-db 0.20.1",
+ "memory-db",
  "parity-scale-codec",
- "trie-db 0.20.1",
+ "trie-db",
  "trie-root",
  "trie-standardmap",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc309f34008563989045a4c4dbcc5770467f3a3785ee80a9b5cc0d83362475f"
-dependencies = [
- "hash-db",
- "hashbrown",
- "log",
- "rustc-hex",
- "smallvec 1.4.0",
 ]
 
 [[package]]

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -709,7 +709,7 @@ mod tests {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
 					number: 1,
-					state_root: hex!("05a38fa4a48ca80ffa8482304be7749a484dc8c9c31462a570d0fbadde6a3633").into(),
+					state_root: hex!("e8ff7b3dd4375f6f3a76e24a1999e2a7be2d15b353e49ac94ace1eae3e80eb87").into(),
 					extrinsics_root: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into(),
 					digest: Digest { logs: vec![], },
 				},

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.8"
 parking_lot = "0.10.0"
 hash-db = "0.15.2"
-trie-db = "0.20.1"
+trie-db = "0.21.0"
 trie-root = "0.16.0"
 sp-trie = { version = "2.0.0-rc3", path = "../trie" }
 sp-core = { version = "2.0.0-rc3", path = "../core" }

--- a/primitives/state-machine/src/testing.rs
+++ b/primitives/state-machine/src/testing.rs
@@ -225,7 +225,7 @@ impl<H, N> sp_externalities::ExtensionStore for TestExternalities<H, N> where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use sp_core::traits::Externalities;
+	use sp_core::{H256, traits::Externalities};
 	use sp_runtime::traits::BlakeTwo256;
 	use hex_literal::hex;
 
@@ -236,8 +236,8 @@ mod tests {
 		ext.set_storage(b"doe".to_vec(), b"reindeer".to_vec());
 		ext.set_storage(b"dog".to_vec(), b"puppy".to_vec());
 		ext.set_storage(b"dogglesworth".to_vec(), b"cat".to_vec());
-		const ROOT: [u8; 32] = hex!("555d4777b52e9196e3f6373c556cc661e79cd463f881ab9e921e70fc30144bf4");
-		assert_eq!(&ext.storage_root()[..], &ROOT);
+		let root = H256::from(hex!("2a340d3dfd52f5992c6b117e9e45f479e6da5afffafeb26ab619cf137a95aeb8"));
+		assert_eq!(H256::from_slice(ext.storage_root().as_slice()), root);
 	}
 
 	#[test]

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -26,7 +26,7 @@ memory-db = { version = "0.21.0", default-features = false }
 sp-core = { version = "2.0.0-rc3", default-features = false, path = "../core" }
 
 [dev-dependencies]
-trie-bench = "0.21.0"
+trie-bench = "0.22.0"
 trie-standardmap = "0.15.2"
 criterion = "0.2.11"
 hex-literal = "0.2.1"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -20,9 +20,9 @@ harness = false
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 sp-std = { version = "2.0.0-rc3", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.20.1", default-features = false }
+trie-db = { version = "0.21.0", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
-memory-db = { version = "0.20.0", default-features = false }
+memory-db = { version = "0.21.0", default-features = false }
 sp-core = { version = "2.0.0-rc3", default-features = false, path = "../core" }
 
 [dev-dependencies]

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -51,6 +51,7 @@ pub struct Layout<H>(sp_std::marker::PhantomData<H>);
 
 impl<H: Hasher> TrieLayout for Layout<H> {
 	const USE_EXTENSION: bool = false;
+	const ALLOW_EMPTY: bool = true;
 	type Hash = H;
 	type Codec = NodeCodec<Self::Hash>;
 }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 frame-executive = { version = "2.0.0-rc3", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-rc3", optional = true, path = "../../primitives/keyring" }
-memory-db = { version = "0.20.0", default-features = false }
+memory-db = { version = "0.21.0", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-rc3"}
 sp-core = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/std" }
@@ -39,7 +39,7 @@ pallet-timestamp = { version = "2.0.0-rc3", default-features = false, path = "..
 sp-finality-grandpa = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-trie = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.20.1", default-features = false }
+trie-db = { version = "0.21.0", default-features = false }
 parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.8.0-rc3", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 


### PR DESCRIPTION
Closes #5986

State root changed in some tests because test externalities come with empty code and this affects the root. 
I've verified that this does not break consensus for polkadot and kusama so far.

@bkchr could you please confirm that `clear_storage` is called when runtime actually wishes to delete storage. E.g. drop a map.
