### PR TITLE
Remove penalty on duplicate Status message

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -104,8 +104,6 @@ mod rep {
 	pub const CLOGGED_PEER: Rep = Rep::new(-(1 << 12), "Clogged message queue");
 	/// Reputation change when a peer doesn't respond in time to our messages.
 	pub const TIMEOUT: Rep = Rep::new(-(1 << 10), "Request timeout");
-	/// Reputation change when a peer sends us a status message while we already received one.
-	pub const UNEXPECTED_STATUS: Rep = Rep::new(-(1 << 20), "Unexpected status message");
 	/// Reputation change when we are a light client and a peer is behind us.
 	pub const PEER_BEHIND_US_LIGHT: Rep = Rep::new(-(1 << 8), "Useless for a light peer");
 	/// Reputation change when a peer sends us any extrinsic.
@@ -979,12 +977,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		trace!(target: "sync", "New peer {} {:?}", who, status);
 		let _protocol_version = {
 			if self.context_data.peers.contains_key(&who) {
-				log!(
-					target: "sync",
-					if self.important_peers.contains(&who) { Level::Warn } else { Level::Debug },
-					"Unexpected status packet from {}", who
-				);
-				self.peerset_handle.report_peer(who, rep::UNEXPECTED_STATUS);
+				debug!(target: "sync", "Ignoring duplicate status packet from {}", who);
 				return CustomMessageOutcome::None;
 			}
 			if status.genesis_hash != self.genesis_hash {


### PR DESCRIPTION
This change has been extracted from #5938 
We no longer shut down all connections and ban the peer if more than one `Status` message has been received.

Relates to #2010 

## Context

At the moment, the network protocol defines that it is forbidden to send messages on notifications substreams as long as the `Status` messages haven't been exchanged on the legacy substream.
This is currently enforced by the "network worker" (i.e. the main networking task).

Additionally, if multiple TCP connections between the same two peers exist, we only send the `Status` message on one of them, and not both. If we were to send `Status` on both, the remote would instantly shut down all connections (because of the code that this PR removes).

Whenever a legacy substream is open, we therefore need to know whether we have to send the `Status` message on it. As explained above, we cannot just sent it unconditionally, otherwise the remote would shut down all connections.
We also need to know whether or not we are still waiting for a `Status` message to come.

In order to make progress towards #5670, I would like to make the legacy substream optional.
The objective is that we would no longer actively try to open a legacy substream, and instead only process the legacy substreams that are opened by the remote peer (if any).

The processing of `Status` messages explained above is already quite complicated, and unfortunately, making the legacy substream optional would introduce even more complexity and would require introducing even more synchronization and messages passing around between the various connection tasks and the network worker.

In order to solve this question, a way more simple fix is proposed by this PR: send a `Status` message unconditionally whenever a legacy substream is open.

This PR does *not* send a `Status` message unconditionally, but prepares the ground to it by removing the code that shut down all connections if more than one `Status` message has been received from a given peer.