### PR TITLE
Confusing Error Reproduction

### DIFF
--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -10,6 +10,7 @@
 /// https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs
 
 use frame_support::{decl_module, decl_storage, decl_event, decl_error, dispatch};
+use frame_support::weights::Weight;
 use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]

--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -72,6 +72,14 @@ decl_module! {
 		// this is needed only if you are using events in your pallet
 		fn deposit_event() = default;
 
+		fn on_initialize() -> Weight {
+			0
+		}
+
+		fn on_initialize() -> Weight {
+			0
+		}
+
 		/// Just a dummy entry point.
 		/// function that can be called by the external world as an extrinsics call
 		/// takes a parameter of the type `AccountId`, stores it, and emits an event


### PR DESCRIPTION
#### Note: This PR is only to reproduce the error for https://github.com/paritytech/substrate/issues/6379

Add duplicate dispatchable to trigger confusing error:
```
error: Implicit conversion to privileged function has been removed. First parameter of dispatch should be marked `origin`. For root-matching dispatch, also add `ensure_root(origin)?`.
   --> pallets/template/src/lib.rs:63:1
    |
63  | / decl_module! {
64  | |     /// The module declaration.
65  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
66  | |         // Initializing errors
...   |
116 | |     }
117 | | }
    | |_^
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```