### PR TITLE
`decl_module!` print better error on duplicate reserved keyword

### DIFF
--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -399,6 +399,29 @@ macro_rules! decl_module {
 			"`deposit_event` function is reserved and must follow the syntax: `$vis:vis fn deposit_event() = default;`"
 		);
 	};
+	// Compile error on `deposit_event` being added a second time.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )+ }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		$vis:vis fn deposit_event() = default;
+		$($rest:tt)*
+	) => {
+		compile_error!("`deposit_event` can only be passed once as input.");
+	};
 	// Add on_finalize
 	(@normalize
 		$(#[$attr:meta])*
@@ -461,6 +484,30 @@ macro_rules! decl_module {
 			"`on_finalize` can't be given weight attribute anymore, weight must be returned by \
 			`on_initialize` or `on_runtime_upgrade` instead"
 		);
+	};
+	// Compile error on `on_finalize` being added a second time.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )+ }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		#[weight = $weight:expr]
+		fn on_finalize( $( $param_name:ident : $param:ty ),* $(,)? ) { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!("`on_finalize` can only be passed once as input.");
 	};
 	// compile_error on_runtime_upgrade, without a given weight removed syntax.
 	(@normalize
@@ -554,6 +601,29 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
+	// Compile error on `on_runtime_upgrade` being added a second time.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )+ }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_runtime_upgrade( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!("`on_runtime_upgrade` can only be passed once as input.");
+	};
 	// Add integrity_test
 	(@normalize
 		$(#[$attr:meta])*
@@ -594,6 +664,29 @@ macro_rules! decl_module {
 			[ $( $dispatchables )* ]
 			$($rest)*
 		);
+	};
+	// Compile error on `integrity_test` being added a second time.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )+ }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn integrity_test() { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!("`integrity_test` can only be passed once as input.");
 	};
 	// compile_error on_initialize, without a given weight removed syntax.
 	(@normalize
@@ -687,6 +780,29 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
+	// Compile error on trying to add a second `on_initialize`.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )+ }
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )* }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn on_initialize( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!("`on_initialize` can only be passed once as input.");
+	};
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<
@@ -727,7 +843,29 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-
+	// Compile error on trying to add a second `on_initialize`.
+	(@normalize
+		$(#[$attr:meta])*
+		pub struct $mod_type:ident<
+			$trait_instance:ident: $trait_name:ident$(<I>, I: $instantiable:path $(= $module_default_instance:path)?)?
+		>
+		for enum $call_type:ident where origin: $origin_type:ty, system = $system:ident
+		{ $( $other_where_bounds:tt )* }
+		{ $( $deposit_event:tt )* }
+		{ $( $on_initialize:tt )* }
+		{ $( $on_runtime_upgrade:tt )* }
+		{ $( $on_finalize:tt )* }
+		{ $( $offchain:tt )+ }
+		{ $( $constants:tt )* }
+		{ $( $error_type:tt )* }
+		{ $( $integrity_test:tt )* }
+		[ $( $dispatchables:tt )* ]
+		$(#[doc = $doc_attr:tt])*
+		fn offchain_worker( $( $param_name:ident : $param:ty ),* $(,)? ) -> $return:ty { $( $impl:tt )* }
+		$($rest:tt)*
+	) => {
+		compile_error!("`offchain_worker` can only be passed once as input.");
+	};
 	// This puts a constant in the parsed constants list.
 	(@normalize
 		$(#[$attr:meta])*

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -843,7 +843,7 @@ macro_rules! decl_module {
 			$($rest)*
 		);
 	};
-	// Compile error on trying to add a second `on_initialize`.
+	// Compile error on trying to add a second `offchain_worker`.
 	(@normalize
 		$(#[$attr:meta])*
 		pub struct $mod_type:ident<

--- a/frame/support/test/tests/decl_module_ui.rs
+++ b/frame/support/test/tests/decl_module_ui.rs
@@ -1,6 +1,6 @@
 // This file is part of Substrate.
 
-// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/frame/support/test/tests/decl_module_ui.rs
+++ b/frame/support/test/tests/decl_module_ui.rs
@@ -1,0 +1,26 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//#[rustversion::attr(not(stable), ignore)]
+#[test]
+fn decl_module_ui() {
+	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
+	std::env::set_var("BUILD_DUMMY_WASM_BINARY", "1");
+
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/decl_module_ui/*.rs");
+}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs
@@ -1,0 +1,7 @@
+frame_support::decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		fn integrity_test() {}
+
+		fn integrity_test() {}
+	}
+}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
@@ -1,0 +1,25 @@
+error: `integrity_test` can only be passed once as input.
+ --> $DIR/reserved_keyword_two_times_integrity_test.rs:1:1
+  |
+1 | / frame_support::decl_module! {
+2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+3 | |         fn integrity_test() {}
+4 | |
+5 | |         fn integrity_test() {}
+6 | |     }
+7 | | }
+  | |_^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> $DIR/reserved_keyword_two_times_integrity_test.rs:1:1
+  |
+1 | / frame_support::decl_module! {
+2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+3 | |         fn integrity_test() {}
+4 | |
+5 | |         fn integrity_test() {}
+6 | |     }
+7 | | }
+  | |_^ consider adding a `main` function to `$DIR/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs`

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs
@@ -1,0 +1,11 @@
+frame_support::decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		fn on_initialize() -> Weight {
+			0
+		}
+
+		fn on_initialize() -> Weight {
+			0
+		}
+	}
+}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
@@ -1,0 +1,25 @@
+error: `on_initialize` can only be passed once as input.
+  --> $DIR/reserved_keyword_two_times_on_initialize.rs:1:1
+   |
+1  | / frame_support::decl_module! {
+2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+3  | |         fn on_initialize() -> Weight {
+4  | |             0
+...  |
+10 | |     }
+11 | | }
+   | |_^
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> $DIR/reserved_keyword_two_times_on_initialize.rs:1:1
+   |
+1  | / frame_support::decl_module! {
+2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+3  | |         fn on_initialize() -> Weight {
+4  | |             0
+...  |
+10 | |     }
+11 | | }
+   | |_^ consider adding a `main` function to `$DIR/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs`


### PR DESCRIPTION
This prints a better error message on duplicated reserved keywords,
instead of complaining because of missing `origin`.

Fixes: https://github.com/paritytech/substrate/pull/6378