### PR TITLE
Fix cargo unleash check for the atomic-swap pallet

### DIFF
--- a/frame/atomic-swap/Cargo.toml
+++ b/frame/atomic-swap/Cargo.toml
@@ -22,7 +22,7 @@ sp-io = { version = "2.0.0-rc3", default-features = false, path = "../../primiti
 sp-core = { version = "2.0.0-rc3", default-features = false, path = "../../primitives/core" }
 
 [dev-dependencies]
-pallet-balances = { version = "2.0.0-rc3", default-features = false, path = "../balances" }
+pallet-balances = { version = "2.0.0-rc3", path = "../balances" }
 
 [features]
 default = ["std"]
@@ -35,5 +35,4 @@ std = [
 	"sp-std/std",
 	"sp-io/std",
 	"sp-core/std",
-	"pallet-balances/std",
 ]


### PR DESCRIPTION
[cargo unleash check](https://gitlab.parity.io/parity/substrate/-/jobs/559369#L575) shows there is dependency issue on the newly added `pallet-atomic-swap`: when removing the dev-dependencies, the parsing of the manifest fails because it is still referenced in the `std`-feature. Which means we can't release the crate after removing the dev-deps (what we always do to remove the internal cycles were are seeing).

This PR removes that reference and sets the default features to true on the dependency in dev. We are running our tests in `std`/native only anyways.