### PR TITLE
Root origin use no filter by default. Scheduler and Democracy dispatch without asserting BaseCallFilter

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -149,7 +149,8 @@ pub fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
 }
 
 pub trait Trait: 'static + Eq + Clone {
-	/// The basic call filter to use in Origin.
+	/// The basic call filter to use in Origin. All origins are built with this filter as base,
+	/// except Root.
 	type BaseCallFilter: Filter<Self::Call>;
 
 	/// The `Origin` type used by dispatchable calls.


### PR DESCRIPTION
In sudo, democracy and scheduler we want to dispatch with origin root and without using BaseCallFilter.

To fix this I see two solution:
* we can do as we have done for sudo https://github.com/paritytech/substrate/pull/6375: use `dispatch_bypass_filter`.
* or do not use BaseCallFilter to create Root runtime origin.

This PR implement the second technique.

## Done:

* frame-system build root origin with no filter
* tests added in democracy and scheduler to ensure they dispatch call filtered out by BaseCallFilter
* doc added in frame-system

CC @gavofyork 