### PR TITLE
[CI] Label PRs if polkadot companion build fails

### DIFF
--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Monitor the status of the gitlab-check-companion-build job
-        uses: Sibz/await-status-action@v1
+        uses: s3krit/await-status-action@4528ebbdf6e29bbec77c41caad1b2dec148ba894
         id: 'check-companion-status'
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -15,6 +15,8 @@ jobs:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
           contexts: 'continuous-integration/gitlab-check-polkadot-companion-build'
+          timeout: 1200
+          notPresentTimeout: 600
       - name: Label success
         uses: andymckay/labeler@master
         if: steps.check-companion-status.outputs.result == 'success'

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -1,0 +1,32 @@
+name: Check Polkadot Companion and Label
+
+on:
+  pull_request:
+    types: [synchronize]
+  
+jobs:
+  check_status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Monitor the status of the gitlab-check-companion-build job
+        uses: Sibz/await-status-action@v1
+        id: 'check-companion-status'
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          contexts: 'continuous-integration/gitlab-check-companion-build'
+      - name: Label success
+        uses: andymckay/labeler@master
+        if: steps.check-companion-status.outputs.result == 'success'
+        with:
+          remove-labels: 'A7-needspolkadotpr'
+      - name: Label failure
+        uses: andymckay/labeler@master
+        if: steps.check-companion-status.outputs.result == 'failure'
+        with:
+          add-labels: 'A7-needspolkadotpr'
+      - name: Label timeout
+        uses: andymckay/labeler@master
+        if: steps.check-companion-status.outputs.result == 'timeout'
+        with:
+          add-labels: 'A7-needspolkadotpr'

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -15,8 +15,8 @@ jobs:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
           contexts: 'continuous-integration/gitlab-check-polkadot-companion-build'
-          timeout: 1200
-          notPresentTimeout: 600
+          timeout: 1800
+          notPresentTimeout: 3600 # It can take quite a while before the job starts...
       - name: Label success
         uses: andymckay/labeler@master
         if: steps.check-companion-status.outputs.result == 'success'

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
-          contexts: 'continuous-integration/gitlab-check-companion-build'
+          contexts: 'continuous-integration/gitlab-check-polkadot-companion-build'
       - name: Label success
         uses: andymckay/labeler@master
         if: steps.check-companion-status.outputs.result == 'success'

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -2,7 +2,7 @@ name: Check Polkadot Companion and Label
 
 on:
   pull_request:
-    types: [synchronize]
+    types: [opened, synchronize]
   
 jobs:
   check_status:

--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -25,8 +25,3 @@ jobs:
         if: steps.check-companion-status.outputs.result == 'failure'
         with:
           add-labels: 'A7-needspolkadotpr'
-      - name: Label timeout
-        uses: andymckay/labeler@master
-        if: steps.check-companion-status.outputs.result == 'timeout'
-        with:
-          add-labels: 'A7-needspolkadotpr'


### PR DESCRIPTION
This PR will add a CI check that monitors the status of the `gitlab-check-polkadot-companion-build` job. If it fails, the PR gets labelled with `A7-needspolkadotpr`. If a subsequent check passes, the label will be removed.

Might be buggy in the case that the job on gitlab is just re-run, since it relies on Github's `synchronize` event for pull requests, which is only fired when the head branch is updated (i.e., more changes pushed).