### PR TITLE
Update `libp2p-ping`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c189cf1dfe4b3f01e2c0fe5e97a6f5df8aeb6f3569e26981015eb7c08015ce5f"
+checksum = "ffb3c4f9273313357d4977799aec69f581cfe9568854919c5b8066018ccf59f5"
 dependencies = [
  "futures 0.3.4",
  "libp2p-core",


### PR DESCRIPTION
Bugfix release, see [CHANGELOG].

[CHANGELOG]: https://github.com/libp2p/rust-libp2p/blob/master/protocols/ping/CHANGELOG.md

**Edit**: https://github.com/paritytech/substrate/issues/6311 should be resolved by this PR.