### PR TITLE
Print bad mandatory error

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1591,7 +1591,10 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckWeight<T> where
 		// Since mandatory dispatched do not get validated for being overweight, we are sensitive
 		// to them actually being useful. Block producers are thus not allowed to include mandatory
 		// extrinsics that result in error.
-		if info.class == DispatchClass::Mandatory && result.is_err() {
+		if let (DispatchClass::Mandatory, Err(e)) = (info.class, result) {
+			"Bad mandantory".print();
+			err.print();
+
 			Err(InvalidTransaction::BadMandatory)?
 		}
 

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1593,7 +1593,7 @@ impl<T: Trait + Send + Sync> SignedExtension for CheckWeight<T> where
 		// extrinsics that result in error.
 		if let (DispatchClass::Mandatory, Err(e)) = (info.class, result) {
 			"Bad mandantory".print();
-			err.print();
+			e.print();
 
 			Err(InvalidTransaction::BadMandatory)?
 		}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -112,7 +112,7 @@ use sp_runtime::{
 		self, CheckEqual, AtLeast32Bit, Zero, SignedExtension, Lookup, LookupError,
 		SimpleBitOps, Hash, Member, MaybeDisplay, BadOrigin, SaturatedConversion,
 		MaybeSerialize, MaybeSerializeDeserialize, MaybeMallocSizeOf, StaticLookup, One, Bounded,
-		Dispatchable, DispatchInfoOf, PostDispatchInfoOf,
+		Dispatchable, DispatchInfoOf, PostDispatchInfoOf, Printable,
 	},
 	offchain::storage_lock::BlockNumberProvider,
 };


### PR DESCRIPTION
This prints the error that leads to bad mandatory.