### PR TITLE
Expose Constants from Proxy Pallet

### DIFF
--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -135,6 +135,15 @@ decl_module! {
 		/// Deposit one of this module's events by using the default implementation.
 		fn deposit_event() = default;
 
+		/// The base amount of currency needed to reserve for creating a proxy.
+		const ProxyDepositBase: BalanceOf<T> = T::ProxyDepositBase::get();
+
+		/// The amount of currency needed per proxy added.
+		const ProxyDepositFactor: BalanceOf<T> = T::ProxyDepositFactor::get();
+
+		/// The maximum amount of proxies allowed for a single account.
+		const MaxProxies: u16 = T::MaxProxies::get();
+
 		/// Dispatch the given `call` from an account that the sender is authorised for through
 		/// `add_proxy`.
 		///


### PR DESCRIPTION
This exposes the constants in the Proxy Pallet to the metadata.