### PR TITLE
pallet-atomic-swap: generialized swap action

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 253,
+	spec_version: 254,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -136,6 +136,7 @@ fn two_party_successful_swap() {
 		AtomicSwap::claim_swap(
 			Origin::signed(A),
 			proof.to_vec(),
+			BalanceSwapAction::new(75),
 		).unwrap();
 
 		assert_eq!(Balances::free_balance(A), 100 + 75);
@@ -147,6 +148,7 @@ fn two_party_successful_swap() {
 		AtomicSwap::claim_swap(
 			Origin::signed(B),
 			proof.to_vec(),
+			BalanceSwapAction::new(50),
 		).unwrap();
 
 		assert_eq!(Balances::free_balance(A), 100 - 50);

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -21,7 +21,7 @@ impl_outer_origin! {
 // For testing the pallet, we construct most of a mock runtime. This means
 // first constructing a configuration type (`Test`) which `impl`s each of the
 // configuration traits of pallets we want to use.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, Debug, PartialEq)]
 pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -71,7 +71,7 @@ parameter_types! {
 }
 impl Trait for Test {
 	type Event = ();
-	type Currency = Balances;
+	type SwapAction = BalanceSwapAction<Test, Balances>;
 	type ProofLimit = ProofLimit;
 }
 type System = frame_system::Module<Test>;
@@ -109,7 +109,7 @@ fn two_party_successful_swap() {
 			Origin::signed(A),
 			B,
 			hashed_proof.clone(),
-			50,
+			BalanceSwapAction::new(50),
 			1000,
 		).unwrap();
 
@@ -123,7 +123,7 @@ fn two_party_successful_swap() {
 			Origin::signed(B),
 			A,
 			hashed_proof.clone(),
-			75,
+			BalanceSwapAction::new(75),
 			1000,
 		).unwrap();
 


### PR DESCRIPTION
This generalizes the swap action in pallet-atomic-swap, allowing not only sending balances, but also other assets (customized by runtime).

As an usage example -- a runtime that has contract module enabled can define a swap action that allows arbitrary contract calls. There are two contracts -- SubstrateKitties, and MyTokens. SubstrateKitties allows users to send cats to each other, and MyTokens is an asset stored on chain. If users A and B want to exchange a cat for some tokens, they can use the atomic swap to make it happen -- avoiding going through an exchange.