### PR TITLE
Update sync chain info on own block import

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -549,6 +549,11 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 		self.sync.update_chain_info(&info.best_hash, info.best_number);
 	}
 
+	/// Inform sync about an own imported block.
+	pub fn own_block_imported(&mut self, hash: B::Hash, number: NumberFor<B>) {
+		self.sync.update_chain_info(&hash, number);
+	}
+
 	fn update_peer_info(&mut self, who: &PeerId) {
 		if let Some(info) = self.sync.peer_info(who) {
 			if let Some(ref mut peer) = self.context_data.peers.get_mut(who) {

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -55,7 +55,7 @@ use sc_network::{NetworkService, NetworkStatus, network_state::NetworkState, Pee
 use log::{log, warn, debug, error, Level};
 use codec::{Encode, Decode};
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::Block as BlockT;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use parity_util_mem::MallocSizeOf;
 use sp_utils::{status_sinks, mpsc::{tracing_unbounded, TracingUnboundedReceiver,  TracingUnboundedSender}};
 
@@ -381,6 +381,13 @@ fn build_network_future<
 		while let Poll::Ready(Some(notification)) = Pin::new(&mut imported_blocks_stream).poll_next(cx) {
 			if announce_imported_blocks {
 				network.service().announce_block(notification.hash, Vec::new());
+			}
+
+			if let sp_consensus::BlockOrigin::Own = notification.origin {
+				network.service().own_block_imported(
+					notification.hash,
+					notification.header.number().clone(),
+				);
 			}
 		}
 


### PR DESCRIPTION
Before we only updated the chain info of sync when we have imported
something using the import queue. However, if you import your own
blocks, this is not done using the import queue and so sync is not
updated. If we don't do this, it can lead to sync switching to "major
sync" mode because sync is not informed about new blocks. This
especially happens on Cumulus, where a collator is selected multiple
times to include its block into the relay chain and thus, sync switches
to major sync mode while the node is still building blocks.
