### PR TITLE
More descriptive error message when invalid slot duration is used

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -285,7 +285,7 @@ impl Config {
 		C: AuxStore + ProvideRuntimeApi<B>, C::Api: BabeApi<B, Error = sp_blockchain::Error>,
 	{
 		trace!(target: "babe", "Getting slot duration");
-		let config = match sc_consensus_slots::SlotDuration::get_or_compute(client, |a, b| {
+		match sc_consensus_slots::SlotDuration::get_or_compute(client, |a, b| {
 			let has_api_v1 = a.has_api_with::<dyn BabeApi<B, Error = sp_blockchain::Error>, _>(
 				&b, |v| v == 1,
 			)?;
@@ -310,15 +310,7 @@ impl Config {
 				warn!(target: "babe", "Failed to get slot duration");
 				Err(s)
 			}
-		}?;
-
-		if config.slot_duration == 0 {
-			return Err(sp_blockchain::Error::Msg(
-				"Invalid value for slot_duration: the value must be greater than 0.".to_string(),
-			))
 		}
-
-		Ok(config)
 	}
 }
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -285,7 +285,7 @@ impl Config {
 		C: AuxStore + ProvideRuntimeApi<B>, C::Api: BabeApi<B, Error = sp_blockchain::Error>,
 	{
 		trace!(target: "babe", "Getting slot duration");
-		match sc_consensus_slots::SlotDuration::get_or_compute(client, |a, b| {
+		let config = match sc_consensus_slots::SlotDuration::get_or_compute(client, |a, b| {
 			let has_api_v1 = a.has_api_with::<dyn BabeApi<B, Error = sp_blockchain::Error>, _>(
 				&b, |v| v == 1,
 			)?;
@@ -310,7 +310,15 @@ impl Config {
 				warn!(target: "babe", "Failed to get slot duration");
 				Err(s)
 			}
+		}?;
+
+		if config.slot_duration == 0 {
+			return Err(sp_blockchain::Error::Msg(
+				"Invalid value for slot_duration: the value must be greater than 0.".to_string(),
+			))
 		}
+
+		Ok(config)
 	}
 }
 

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -483,7 +483,7 @@ impl<T: Clone> SlotDuration<T> {
 
 		if slot_duration.slot_duration() == 0 {
 			return Err(sp_blockchain::Error::Msg(
-				"Invalid value for slot_duration: the value must be greater than 0.".to_string(),
+				"Invalid value for slot_duration: the value must be greater than 0.".into(),
 			))
 		}
 

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -455,7 +455,7 @@ impl<T: Clone> SlotDuration<T> {
 		CB: FnOnce(ApiRef<C::Api>, &BlockId<B>) -> sp_blockchain::Result<T>,
 		T: SlotData + Encode + Decode + Debug,
 	{
-		match client.get_aux(T::SLOT_KEY)? {
+		let slot_duration = match client.get_aux(T::SLOT_KEY)? {
 			Some(v) => <T as codec::Decode>::decode(&mut &v[..])
 				.map(SlotDuration)
 				.map_err(|_| {
@@ -479,7 +479,15 @@ impl<T: Clone> SlotDuration<T> {
 
 				Ok(SlotDuration(genesis_slot_duration))
 			}
+		}?;
+
+		if slot_duration.slot_duration() == 0 {
+			return Err(sp_blockchain::Error::Msg(
+				"Invalid value for slot_duration: the value must be greater than 0.".to_string(),
+			))
 		}
+
+		Ok(slot_duration)
 	}
 
 	/// Returns slot data value.


### PR DESCRIPTION
This is a small check during the node creation that will ensure that the slot_duration is greater than 0.

During test, before:
> thread 'async-std/executor' panicked at 'attempt to calculate the remainder with a divisor of zero', /home/cecile/.cargo/git/checkouts/substrate-7e08433d4c370a21/65365aa/client/consensus/slots/src/slots.rs:66:49

During test, after:
> thread 'ensure_test_service_build_blocks' panicked at 'called `Result::unwrap()` on an `Err` value: Client(Msg("Invalid value for slot_duration: the value must be greater than 0."))', polkadot-test-service/tests/build-blocks.rs:30:21

On cli it should not panic but end the process properly.