### PR TITLE
Ensure the listen addresses are consistent with the transport

### DIFF
--- a/client/network/src/error.rs
+++ b/client/network/src/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
 	},
 	/// Prometheus metrics error.
 	Prometheus(prometheus_endpoint::PrometheusError),
-	/// Invalid configuration
+	/// Invalid configuration.
 	InvalidConfiguration(String),
 }
 

--- a/client/network/src/error.rs
+++ b/client/network/src/error.rs
@@ -18,6 +18,7 @@
 
 //! Substrate network possible errors.
 
+use crate::config::TransportConfig;
 use libp2p::{PeerId, Multiaddr};
 
 use std::fmt;
@@ -49,8 +50,17 @@ pub enum Error {
 	},
 	/// Prometheus metrics error.
 	Prometheus(prometheus_endpoint::PrometheusError),
-	/// Invalid configuration.
-	InvalidConfiguration(String),
+	/// The network addresses are invalid because they don't matche the transport.
+	#[display(
+		fmt = "The following addresses are invalid because they don't match the transport: {:?}",
+		addresses,
+	)]
+	AddressesForAnotherTransport {
+		/// Transport used.
+		transport: TransportConfig,
+		/// The invalid addresses.
+		addresses: Vec<Multiaddr>,
+	},
 }
 
 // Make `Debug` use the `Display` implementation.
@@ -67,7 +77,7 @@ impl std::error::Error for Error {
 			Error::Client(ref err) => Some(err),
 			Error::DuplicateBootnode { .. } => None,
 			Error::Prometheus(ref err) => Some(err),
-			Error::InvalidConfiguration(_) => None,
+			Error::AddressesForAnotherTransport { .. } => None,
 		}
 	}
 }

--- a/client/network/src/error.rs
+++ b/client/network/src/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
 	},
 	/// Prometheus metrics error.
 	Prometheus(prometheus_endpoint::PrometheusError),
-	/// The network addresses are invalid because they don't matche the transport.
+	/// The network addresses are invalid because they don't match the transport.
 	#[display(
 		fmt = "The following addresses are invalid because they don't match the transport: {:?}",
 		addresses,

--- a/client/network/src/error.rs
+++ b/client/network/src/error.rs
@@ -48,7 +48,9 @@ pub enum Error {
 		second_id: PeerId,
 	},
 	/// Prometheus metrics error.
-	Prometheus(prometheus_endpoint::PrometheusError)
+	Prometheus(prometheus_endpoint::PrometheusError),
+	/// Invalid configuration
+	InvalidConfiguration(String),
 }
 
 // Make `Debug` use the `Display` implementation.
@@ -65,6 +67,7 @@ impl std::error::Error for Error {
 			Error::Client(ref err) => Some(err),
 			Error::DuplicateBootnode { .. } => None,
 			Error::Prometheus(ref err) => Some(err),
+			Error::InvalidConfiguration(_) => None,
 		}
 	}
 }

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -107,7 +107,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 	/// for the network processing to advance. From it, you can extract a `NetworkService` using
 	/// `worker.service()`. The `NetworkService` can be shared through the codebase.
 	pub fn new(params: Params<B, H>) -> Result<NetworkWorker<B, H>, Error> {
-		// Ensure the listen addresses are consistent with the transport
+		// Ensure the listen addresses are consistent with the transport.
 		for addr in &params.network_config.listen_addresses {
 			if addr.iter().any(|x| matches!(x, libp2p::core::multiaddr::Protocol::Memory(_)))
 				&& !matches!(params.network_config.transport, TransportConfig::MemoryOnly) {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -109,22 +109,34 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 	pub fn new(params: Params<B, H>) -> Result<NetworkWorker<B, H>, Error> {
 		// Ensure the listen addresses are consistent with the transport.
 		for addr in &params.network_config.listen_addresses {
-			if addr.iter().any(|x| matches!(x, libp2p::core::multiaddr::Protocol::Memory(_)))
-				&& !matches!(params.network_config.transport, TransportConfig::MemoryOnly) {
-				return Err(Error::InvalidConfiguration(format!(
-					"The network address {} is invalid because the transport is not set on {:?}",
-					addr,
-					TransportConfig::MemoryOnly,
-				)))
-			}
+			if !matches!(params.network_config.transport, TransportConfig::MemoryOnly) {
+				let invalid_addresses: Vec<_> = addr.iter()
+					.filter(|x| matches!(x, libp2p::core::multiaddr::Protocol::Memory(_)))
+					.map(|x| x.to_string())
+					.collect();
 
-			if !addr.iter().any(|x| matches!(x, libp2p::core::multiaddr::Protocol::Memory(_)))
-				&& matches!(params.network_config.transport, TransportConfig::MemoryOnly) {
-				return Err(Error::InvalidConfiguration(format!(
-					"The network address {} is invalid because the transport is set on {:?}",
-					addr,
-					TransportConfig::MemoryOnly,
-				)))
+				if !invalid_addresses.is_empty() {
+					return Err(Error::InvalidConfiguration(format!(
+						"The following network addresses are invalid because the transport is \
+						not set on {:?}: {}",
+						TransportConfig::MemoryOnly,
+						invalid_addresses.join(", "),
+					)))
+				}
+			} else {
+				let invalid_addresses: Vec<_> = addr.iter()
+					.filter(|x| !matches!(x, libp2p::core::multiaddr::Protocol::Memory(_)))
+					.map(|x| x.to_string())
+					.collect();
+
+				if !invalid_addresses.is_empty() {
+					return Err(Error::InvalidConfiguration(format!(
+						"The following network addresses are invalid because the transport is \
+						set on {:?}: {}",
+						TransportConfig::MemoryOnly,
+						invalid_addresses.join(", "),
+					)))
+				}
 			}
 		}
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -116,6 +116,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 			params.network_config.boot_nodes.iter().map(|x| &x.multiaddr),
 			&params.network_config.transport,
 		)?;
+		ensure_addresses_consistent_with_transport(
+			params.network_config.reserved_nodes.iter().map(|x| &x.multiaddr),
+			&params.network_config.transport,
+		)?;
 
 		let (to_worker, from_worker) = tracing_unbounded("mpsc_network_worker");
 

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -138,6 +138,7 @@ fn build_nodes_one_proto()
 
 	let (node2, events_stream2) = build_test_full_node(config::NetworkConfiguration {
 		notifications_protocols: vec![(ENGINE_ID, From::from(&b"/foo"[..]))],
+		listen_addresses: vec![],
 		reserved_nodes: vec![config::MultiaddrWithPeerId {
 			multiaddr: listen_addr,
 			peer_id: node1.local_peer_id().clone(),
@@ -340,5 +341,32 @@ fn lots_of_incoming_peers_works() {
 
 	futures::executor::block_on(async move {
 		future::join_all(background_tasks_to_wait).await
+	});
+}
+
+#[test]
+#[should_panic(expected = "the transport is set on MemoryOnly")]
+fn ensure_listen_addresses_consistent_with_transport_memory() {
+	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		notifications_protocols: vec![(ENGINE_ID, From::from(&b"/foo"[..]))],
+		listen_addresses: vec![listen_addr.clone()],
+		in_peers: u32::max_value(),
+		transport: config::TransportConfig::MemoryOnly,
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
+	});
+}
+
+#[test]
+#[should_panic(expected = "the transport is not set on MemoryOnly")]
+fn ensure_listen_addresses_consistent_with_transport_not_memory() {
+	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		notifications_protocols: vec![(ENGINE_ID, From::from(&b"/foo"[..]))],
+		listen_addresses: vec![listen_addr.clone()],
+		in_peers: u32::max_value(),
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
 	});
 }

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -400,3 +400,36 @@ fn ensure_boot_node_addresses_consistent_with_transport_not_memory() {
 		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
 	});
 }
+
+#[test]
+#[should_panic(expected = "the transport is set on MemoryOnly")]
+fn ensure_reserved_node_addresses_consistent_with_transport_memory() {
+	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
+	let reserved_node = config::MultiaddrWithPeerId {
+		multiaddr: config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)],
+		peer_id: PeerId::random(),
+	};
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		listen_addresses: vec![listen_addr.clone()],
+		transport: config::TransportConfig::MemoryOnly,
+		reserved_nodes: vec![reserved_node],
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
+	});
+}
+
+#[test]
+#[should_panic(expected = "the transport is not set on MemoryOnly")]
+fn ensure_reserved_node_addresses_consistent_with_transport_not_memory() {
+	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
+	let reserved_node = config::MultiaddrWithPeerId {
+		multiaddr: config::build_multiaddr![Memory(rand::random::<u64>())],
+		peer_id: PeerId::random(),
+	};
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		listen_addresses: vec![listen_addr.clone()],
+		reserved_nodes: vec![reserved_node],
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
+	});
+}

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -346,7 +346,7 @@ fn lots_of_incoming_peers_works() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_listen_addresses_consistent_with_transport_memory() {
 	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
 
@@ -358,7 +358,7 @@ fn ensure_listen_addresses_consistent_with_transport_memory() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is not set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_listen_addresses_consistent_with_transport_not_memory() {
 	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 
@@ -369,7 +369,7 @@ fn ensure_listen_addresses_consistent_with_transport_not_memory() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_boot_node_addresses_consistent_with_transport_memory() {
 	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 	let boot_node = config::MultiaddrWithPeerId {
@@ -386,7 +386,7 @@ fn ensure_boot_node_addresses_consistent_with_transport_memory() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is not set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_boot_node_addresses_consistent_with_transport_not_memory() {
 	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
 	let boot_node = config::MultiaddrWithPeerId {
@@ -402,7 +402,7 @@ fn ensure_boot_node_addresses_consistent_with_transport_not_memory() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_reserved_node_addresses_consistent_with_transport_memory() {
 	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 	let reserved_node = config::MultiaddrWithPeerId {
@@ -419,7 +419,7 @@ fn ensure_reserved_node_addresses_consistent_with_transport_memory() {
 }
 
 #[test]
-#[should_panic(expected = "the transport is not set on MemoryOnly")]
+#[should_panic(expected = "don't match the transport")]
 fn ensure_reserved_node_addresses_consistent_with_transport_not_memory() {
 	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
 	let reserved_node = config::MultiaddrWithPeerId {
@@ -430,6 +430,33 @@ fn ensure_reserved_node_addresses_consistent_with_transport_not_memory() {
 	let _ = build_test_full_node(config::NetworkConfiguration {
 		listen_addresses: vec![listen_addr.clone()],
 		reserved_nodes: vec![reserved_node],
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
+	});
+}
+
+#[test]
+#[should_panic(expected = "don't match the transport")]
+fn ensure_public_addresses_consistent_with_transport_memory() {
+	let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
+	let public_address = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		listen_addresses: vec![listen_addr.clone()],
+		transport: config::TransportConfig::MemoryOnly,
+		public_addresses: vec![public_address],
+		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
+	});
+}
+
+#[test]
+#[should_panic(expected = "don't match the transport")]
+fn ensure_public_addresses_consistent_with_transport_not_memory() {
+	let listen_addr = config::build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(0_u16)];
+	let public_address = config::build_multiaddr![Memory(rand::random::<u64>())];
+
+	let _ = build_test_full_node(config::NetworkConfiguration {
+		listen_addresses: vec![listen_addr.clone()],
+		public_addresses: vec![public_address],
 		.. config::NetworkConfiguration::new("test-node", "test-client", Default::default(), None)
 	});
 }


### PR DESCRIPTION
This PR improves the error message **AND** return early with a failure if the network configuration is inconsistent.

The only checks that are done are:
1. if the TransportConfig is MemoryOnly but a listening address is not Memory
2. if the TransportConfig is not MemoryOnly but a listening address is Memory

Example during test before:

> 2020-06-19 14:22:16 Can't listen on /memory/10872111545232357078 because: MultiaddrNotSupported("/memory/10872111545232357078")
(continue running the done)

Example during test after:

> thread 'ensure_test_service_build_blocks' panicked at 'called `Result::unwrap()` on an `Err` value: Network(The network address /memory/18303963195922760223 is invalid because the transport is not set on MemoryOnly)', polkadot-test-service/tests/build-blocks.rs:31:21

In cli there will be a change of behavior as the node won't start at all but the process will stop.

:thinking: it also detected something wrong in the test `service::tests::notifications_state_consistent` that I fixed.

Related to #6409