### PR TITLE
sp-npos-elections should not depend on itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7634,7 +7634,6 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "sp-arithmetic",
- "sp-npos-elections",
  "sp-npos-elections-compact",
  "sp-runtime",
  "sp-std",

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -21,7 +21,6 @@ sp-arithmetic = { version = "2.0.0-rc3", default-features = false, path = "../ar
 [dev-dependencies]
 substrate-test-utils = { version = "2.0.0-rc3", path = "../../test-utils" }
 rand = "0.7.3"
-sp-npos-elections = { version = "2.0.0-rc3", path = "." }
 sp-runtime = { version = "2.0.0-rc3", path = "../../primitives/runtime" }
 
 [features]

--- a/primitives/npos-elections/compact/src/assignment.rs
+++ b/primitives/npos-elections/compact/src/assignment.rs
@@ -18,8 +18,8 @@
 //! Code generation for the ratio assignment type.
 
 use crate::field_name_for;
-use proc_macro2::{TokenStream as TokenStream2};
-use syn::{GenericArgument};
+use proc_macro2::TokenStream as TokenStream2;
+use syn::GenericArgument;
 use quote::quote;
 
 fn from_impl(count: usize) -> TokenStream2 {

--- a/primitives/npos-elections/compact/src/lib.rs
+++ b/primitives/npos-elections/compact/src/lib.rs
@@ -224,17 +224,19 @@ fn struct_def(
 }
 
 fn imports() -> Result<TokenStream2> {
-	let sp_phragmen_imports = match crate_name("sp-npos-elections") {
-		Ok(sp_npos_elections) => {
-			let ident = syn::Ident::new(&sp_npos_elections, Span::call_site());
-			quote!( extern crate #ident as _phragmen; )
+	if std::env::var("CARGO_PKG_NAME").unwrap() == "sp-npos-elections" {
+		Ok(quote! {
+			use crate as _phragmen;
+		})
+	} else {
+		match crate_name("sp-npos-elections") {
+			Ok(sp_npos_elections) => {
+				let ident = syn::Ident::new(&sp_npos_elections, Span::call_site());
+				Ok(quote!( extern crate #ident as _phragmen; ))
+			},
+			Err(e) => Err(syn::Error::new(Span::call_site(), &e)),
 		}
-		Err(e) => return Err(syn::Error::new(Span::call_site(), &e)),
-	};
-
-	Ok(quote!(
-		#sp_phragmen_imports
-	))
+	}
 }
 
 struct CompactSolutionDef {

--- a/primitives/npos-elections/src/tests.rs
+++ b/primitives/npos-elections/src/tests.rs
@@ -17,8 +17,6 @@
 
 //! Tests for npos-elections.
 
-#![cfg(test)]
-
 use crate::mock::*;
 use crate::{
 	seq_phragmen, balance_solution, build_support_map, is_score_better, helpers::*,
@@ -772,10 +770,12 @@ fn score_comparison_large_value() {
 
 mod compact {
 	use codec::{Decode, Encode};
-	use crate::{generate_compact_solution_type, VoteWeight};
-	use super::{AccountId};
+	use super::AccountId;
 	// these need to come from the same dev-dependency `sp-npos-elections`, not from the crate.
-	use sp_npos_elections::{Assignment, StakedAssignment, Error as PhragmenError, ExtendedBalance};
+	use crate::{
+		generate_compact_solution_type, VoteWeight, Assignment, StakedAssignment,
+		Error as PhragmenError, ExtendedBalance,
+	};
 	use sp_std::{convert::{TryInto, TryFrom}, fmt::Debug};
 	use sp_arithmetic::Percent;
 


### PR DESCRIPTION
This removes the `dev-dependency` onto `sp-npos-elections` from itself.
A crate should not depend on itself directly, especially not to make any
macros work.
