### PR TITLE
Optimize offchain worker api by re-using http-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6564,12 +6564,12 @@ version = "2.0.0-rc3"
 dependencies = [
  "bytes 0.5.4",
  "env_logger 0.7.1",
- "fdlimit",
  "fnv",
  "futures 0.3.4",
  "futures-timer 3.0.2",
  "hyper 0.13.4",
  "hyper-rustls",
+ "lazy_static",
  "log",
  "num_cpus",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,7 +6570,6 @@ dependencies = [
  "futures-timer 3.0.2",
  "hyper 0.13.4",
  "hyper-rustls",
- "lazy_static",
  "log",
  "num_cpus",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "hyper 0.13.4",
  "hyper-rustls",
+ "lazy_static",
  "log",
  "num_cpus",
  "parity-scale-codec",

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -37,12 +37,12 @@ hyper-rustls = "0.20"
 
 [dev-dependencies]
 env_logger = "0.7.0"
-fdlimit = "0.1.4"
 sc-client-db = { version = "0.8.0-rc3", default-features = true, path = "../db/" }
 sc-transaction-pool = { version = "2.0.0-rc3", path = "../../client/transaction-pool" }
 sp-transaction-pool = { version = "2.0.0-rc3", path = "../../primitives/transaction-pool" }
 substrate-test-runtime-client = { version = "2.0.0-rc3", path = "../../test-utils/runtime/client" }
 tokio = "0.2"
+lazy_static = "1.4.0"
 
 [features]
 default = []

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -30,6 +30,7 @@ sp-runtime = { version = "2.0.0-rc3", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 sc-network = { version = "0.8.0-rc3", path = "../network" }
 sc-keystore = { version = "2.0.0-rc3", path = "../keystore" }
+lazy_static = "1.4.0"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 hyper = "0.13.2"

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -30,7 +30,6 @@ sp-runtime = { version = "2.0.0-rc3", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0-rc3", path = "../../primitives/utils" }
 sc-network = { version = "0.8.0-rc3", path = "../network" }
 sc-keystore = { version = "2.0.0-rc3", path = "../keystore" }
-lazy_static = "1.4.0"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 hyper = "0.13.2"

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -260,8 +260,9 @@ impl AsyncApi {
 		db: S,
 		network_state: Arc<dyn NetworkStateInfo + Send + Sync>,
 		is_validator: bool,
+		hyper_client: Arc<hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>>,
 	) -> (Api<S>, Self) {
-		let (http_api, http_worker) = http::http();
+		let (http_api, http_worker) = http::http(hyper_client);
 
 		let api = Api {
 			db,

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -292,6 +292,8 @@ mod tests {
 	use std::{convert::{TryFrom, TryInto}, time::SystemTime};
 	use sc_client_db::offchain::LocalStorage;
 	use sc_network::PeerId;
+	use hyper_rustls::HttpsConnector;
+	use hyper::{Client as HyperClient};
 
 	struct MockNetworkStateInfo();
 
@@ -309,11 +311,14 @@ mod tests {
 		let _ = env_logger::try_init();
 		let db = LocalStorage::new_test();
 		let mock = Arc::new(MockNetworkStateInfo());
+		let hyper_client = Arc::new(HyperClient::builder().build(HttpsConnector::new()));
+
 
 		AsyncApi::new(
 			db,
 			mock,
 			false,
+			hyper_client,
 		)
 	}
 

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -261,9 +261,9 @@ impl AsyncApi {
 		db: S,
 		network_state: Arc<dyn NetworkStateInfo + Send + Sync>,
 		is_validator: bool,
-		hyper_client: SharedClient,
+		shared_client: SharedClient,
 	) -> (Api<S>, Self) {
-		let (http_api, http_worker) = http::http(hyper_client);
+		let (http_api, http_worker) = http::http(shared_client);
 
 		let api = Api {
 			db,
@@ -293,8 +293,6 @@ mod tests {
 	use std::{convert::{TryFrom, TryInto}, time::SystemTime};
 	use sc_client_db::offchain::LocalStorage;
 	use sc_network::PeerId;
-	use hyper_rustls::HttpsConnector;
-	use hyper::{Client as HyperClient};
 
 	struct MockNetworkStateInfo();
 
@@ -312,14 +310,14 @@ mod tests {
 		let _ = env_logger::try_init();
 		let db = LocalStorage::new_test();
 		let mock = Arc::new(MockNetworkStateInfo());
-		let hyper_client = Arc::new(HyperClient::builder().build(HttpsConnector::new()));
+		let shared_client = SharedClient::new();
 
 
 		AsyncApi::new(
 			db,
 			mock,
 			false,
-			hyper_client,
+			shared_client,
 		)
 	}
 

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -260,7 +260,7 @@ impl AsyncApi {
 		db: S,
 		network_state: Arc<dyn NetworkStateInfo + Send + Sync>,
 		is_validator: bool,
-	) -> (Api<S>, AsyncApi) {
+	) -> (Api<S>, Self) {
 		let (http_api, http_worker) = http::http();
 
 		let api = Api {
@@ -270,7 +270,7 @@ impl AsyncApi {
 			http: http_api,
 		};
 
-		let async_api = AsyncApi {
+		let async_api = Self {
 			http: Some(http_worker),
 		};
 

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -31,6 +31,7 @@ use sp_core::offchain::{
 	OpaqueNetworkState, OpaquePeerId, OpaqueMultiaddr, StorageKind,
 };
 pub use sp_offchain::STORAGE_PREFIX;
+pub use http::SharedClient;
 
 #[cfg(not(target_os = "unknown"))]
 mod http;
@@ -260,7 +261,7 @@ impl AsyncApi {
 		db: S,
 		network_state: Arc<dyn NetworkStateInfo + Send + Sync>,
 		is_validator: bool,
-		hyper_client: Arc<hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>>,
+		hyper_client: SharedClient,
 	) -> (Api<S>, Self) {
 		let (http_api, http_worker) = http::http(hyper_client);
 

--- a/client/offchain/src/api/http.rs
+++ b/client/offchain/src/api/http.rs
@@ -709,12 +709,6 @@ mod tests {
 	// server that runs in the background as well.
 	macro_rules! build_api_server {
 		() => {{
-			// We spawn quite a bit of HTTP servers here due to how async API
-			// works for offchain workers, so be sure to raise the FD limit
-			// (particularly useful for macOS where the default soft limit may
-			// not be enough).
-			fdlimit::raise_fd_limit();
-
 			let hyper_client = Arc::new(HyperClient::builder().build(HttpsConnector::new()));
 			let (api, worker) = http(hyper_client.clone());
 

--- a/client/offchain/src/api/http.rs
+++ b/client/offchain/src/api/http.rs
@@ -709,6 +709,12 @@ mod tests {
 	// server that runs in the background as well.
 	macro_rules! build_api_server {
 		() => {{
+			// We spawn quite a bit of HTTP servers here due to how async API
+			// works for offchain workers, so be sure to raise the FD limit
+			// (particularly useful for macOS where the default soft limit may
+			// not be enough).
+			fdlimit::raise_fd_limit();
+
 			let hyper_client = Arc::new(HyperClient::builder().build(HttpsConnector::new()));
 			let (api, worker) = http(hyper_client.clone());
 

--- a/client/offchain/src/api/http_dummy.rs
+++ b/client/offchain/src/api/http_dummy.rs
@@ -19,8 +19,18 @@
 use sp_core::offchain::{HttpRequestId, Timestamp, HttpRequestStatus, HttpError};
 use std::{future::Future, pin::Pin, task::Context, task::Poll};
 
+/// Wrapper struct (wrapping nothing in case of http_dummy) used for keeping the hyper_rustls client running.
+#[derive(Clone)]
+pub struct SharedClient;
+
+impl SharedClient {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
 /// Creates a pair of [`HttpApi`] and [`HttpWorker`].
-pub fn http() -> (HttpApi, HttpWorker) {
+pub fn http(_: SharedClient) -> (HttpApi, HttpWorker) {
 	(HttpApi, HttpWorker)
 }
 

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -19,7 +19,7 @@
 //! The offchain workers is a special function of the runtime that
 //! gets executed after block is imported. During execution
 //! it's able to asynchronously submit extrinsics that will either
-//! be propagated to other nodes added to the next block
+//! be propagated to other nodes or added to the next block
 //! produced by the node as unsigned transactions.
 //!
 //! Offchain workers can be used for computation-heavy tasks

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -44,10 +44,9 @@ use sc_network::NetworkStateInfo;
 use sp_core::{offchain::{self, OffchainStorage}, ExecutionContext, traits::SpawnNamed};
 use sp_runtime::{generic::BlockId, traits::{self, Header}};
 use futures::{prelude::*, future::ready};
-use hyper_rustls::HttpsConnector;
-use hyper::{Client as HyperClient, Body, client};
 
 mod api;
+use api::SharedClient;
 
 pub use sp_offchain::{OffchainWorkerApi, STORAGE_PREFIX};
 
@@ -57,19 +56,19 @@ pub struct OffchainWorkers<Client, Storage, Block: traits::Block> {
 	db: Storage,
 	_block: PhantomData<Block>,
 	thread_pool: Mutex<ThreadPool>,
-	hyper_client: Arc<HyperClient<HttpsConnector<client::HttpConnector>, Body>>,
+	shared_client: SharedClient,
 }
 
 impl<Client, Storage, Block: traits::Block> OffchainWorkers<Client, Storage, Block> {
 	/// Creates new `OffchainWorkers`.
 	pub fn new(client: Arc<Client>, db: Storage) -> Self {
-		let hyper_client = Arc::new(HyperClient::builder().build(HttpsConnector::new()));
+		let shared_client = SharedClient::new();
 		Self {
 			client,
 			db,
 			_block: PhantomData,
 			thread_pool: Mutex::new(ThreadPool::new(num_cpus::get())),
-			hyper_client,
+			shared_client,
 		}
 	}
 }
@@ -125,7 +124,7 @@ impl<Client, Storage, Block> OffchainWorkers<
 				self.db.clone(),
 				network_state.clone(),
 				is_validator,
-				self.hyper_client.clone(),
+				self.shared_client.clone(),
 			);
 			debug!("Spawning offchain workers at {:?}", at);
 			let header = header.clone();

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -44,11 +44,17 @@ use sc_network::NetworkStateInfo;
 use sp_core::{offchain::{self, OffchainStorage}, ExecutionContext, traits::SpawnNamed};
 use sp_runtime::{generic::BlockId, traits::{self, Header}};
 use futures::{prelude::*, future::ready};
+use lazy_static::lazy_static;
 
 mod api;
 use api::SharedClient;
 
 pub use sp_offchain::{OffchainWorkerApi, STORAGE_PREFIX};
+
+lazy_static! {
+	// Using lazy_static to have the `SharedClient` shared amongst the different OffchainWorkers.
+	static ref SHARED_CLIENT: SharedClient = SharedClient::new();
+}
 
 /// An offchain workers manager.
 pub struct OffchainWorkers<Client, Storage, Block: traits::Block> {
@@ -62,7 +68,7 @@ pub struct OffchainWorkers<Client, Storage, Block: traits::Block> {
 impl<Client, Storage, Block: traits::Block> OffchainWorkers<Client, Storage, Block> {
 	/// Creates new `OffchainWorkers`.
 	pub fn new(client: Arc<Client>, db: Storage) -> Self {
-		let shared_client = SharedClient::new();
+		let shared_client = SHARED_CLIENT.clone();
 		Self {
 			client,
 			db,

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -44,17 +44,11 @@ use sc_network::NetworkStateInfo;
 use sp_core::{offchain::{self, OffchainStorage}, ExecutionContext, traits::SpawnNamed};
 use sp_runtime::{generic::BlockId, traits::{self, Header}};
 use futures::{prelude::*, future::ready};
-use lazy_static::lazy_static;
 
 mod api;
 use api::SharedClient;
 
 pub use sp_offchain::{OffchainWorkerApi, STORAGE_PREFIX};
-
-lazy_static! {
-	// Using lazy_static to have the `SharedClient` shared amongst the different OffchainWorkers.
-	static ref SHARED_CLIENT: SharedClient = SharedClient::new();
-}
 
 /// An offchain workers manager.
 pub struct OffchainWorkers<Client, Storage, Block: traits::Block> {
@@ -68,7 +62,7 @@ pub struct OffchainWorkers<Client, Storage, Block: traits::Block> {
 impl<Client, Storage, Block: traits::Block> OffchainWorkers<Client, Storage, Block> {
 	/// Creates new `OffchainWorkers`.
 	pub fn new(client: Arc<Client>, db: Storage) -> Self {
-		let shared_client = SHARED_CLIENT.clone();
+		let shared_client = SharedClient::new();
 		Self {
 			client,
 			db,


### PR DESCRIPTION
This PR adds a field to the OffchainWorker struct to allow the re-use of the http_client, removing the need to call some CPU intensive hyper_rustls function each time we run an offchain worker on a block.

Bonus commits: fix a minor typo, use Self keyword in `AsyncApi::new()`

Closes #6304 
