### PR TITLE
Allow where clause in benchmarking

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -88,6 +88,8 @@ pub use paste;
 ///   // common parameter; just one for this example.
 ///   // will be `1`, `MAX_LENGTH` or any value inbetween
 ///   _ {
+///   // Or optionally: `_ where T::A: From<u32>, ..., ... {`
+///   // Allow to put additional bound on the generic `T: Trait`
 ///     let l in 1 .. MAX_LENGTH => initialize_l(l);
 ///   }
 ///

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -555,7 +555,9 @@ macro_rules! benchmark_backend {
 				)*
 				$(
 					// Prepare instance
-					let $param = components.iter().find(|&c| c.0 == $crate::BenchmarkParameter::$param).unwrap().1;
+					let $param = components.iter()
+						.find(|&c| c.0 == $crate::BenchmarkParameter::$param)
+						.unwrap().1;
 				)*
 				$(
 					let $pre_id : $pre_ty = $pre_ex;
@@ -574,7 +576,9 @@ macro_rules! benchmark_backend {
 				)*
 				$(
 					// Prepare instance
-					let $param = components.iter().find(|&c| c.0 == $crate::BenchmarkParameter::$param).unwrap().1;
+					let $param = components.iter()
+						.find(|&c| c.0 == $crate::BenchmarkParameter::$param)
+						.unwrap().1;
 				)*
 				$(
 					let $pre_id : $pre_ty = $pre_ex;
@@ -617,7 +621,9 @@ macro_rules! benchmark_backend {
 				)*
 				$(
 					// Prepare instance
-					let $param = components.iter().find(|&c| c.0 == $crate::BenchmarkParameter::$param).unwrap().1;
+					let $param = components.iter()
+						.find(|&c| c.0 == $crate::BenchmarkParameter::$param)
+						.unwrap().1;
 				)*
 				$(
 					let $pre_id : $pre_ty = $pre_ex;
@@ -636,7 +642,9 @@ macro_rules! benchmark_backend {
 				)*
 				$(
 					// Prepare instance
-					let $param = components.iter().find(|&c| c.0 == $crate::BenchmarkParameter::$param).unwrap().1;
+					let $param = components.iter()
+						.find(|&c| c.0 == $crate::BenchmarkParameter::$param)
+						.unwrap().1;
 				)*
 				$(
 					let $pre_id : $pre_ty = $pre_ex;
@@ -818,8 +826,11 @@ macro_rules! impl_benchmark {
 
 						// Run the benchmark `repeat` times.
 						for _ in 0..repeat {
-							// Set up the externalities environment for the setup we want to benchmark.
-							let closure_to_benchmark = <SelectedBenchmark as $crate::BenchmarkingSetup<T>>::instance(&selected_benchmark, &c)?;
+							// Set up the externalities environment for the setup we want to
+							// benchmark.
+							let closure_to_benchmark = <
+								SelectedBenchmark as $crate::BenchmarkingSetup<T>
+							>::instance(&selected_benchmark, &c)?;
 
 							// Set the block number to at least 1 so events are deposited.
 							if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
@@ -831,12 +842,20 @@ macro_rules! impl_benchmark {
 							$crate::benchmarking::commit_db();
 
 							// Time the extrinsic logic.
-							frame_support::debug::trace!(target: "benchmark", "Start Benchmark: {:?} {:?}", name, component_value);
+							frame_support::debug::trace!(
+								target: "benchmark",
+								"Start Benchmark: {:?} {:?}", name, component_value
+							);
+
 							let start_extrinsic = $crate::benchmarking::current_time();
 							closure_to_benchmark()?;
 							let finish_extrinsic = $crate::benchmarking::current_time();
 							let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
-							frame_support::debug::trace!(target: "benchmark", "End Benchmark: {} ns", elapsed_extrinsic);
+
+							frame_support::debug::trace!(
+								target: "benchmark",
+								"End Benchmark: {} ns", elapsed_extrinsic
+							);
 
 							// Time the storage root recalculation.
 							let start_storage_root = $crate::benchmarking::current_time();
@@ -859,7 +878,8 @@ macro_rules! impl_benchmark {
 		{ $( $where_clause:tt )* }
 		INSTANCE $( $name:ident ),*
 	) => {
-		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults> for Module<T, I>
+		impl<T: Trait<I>, I: Instance> $crate::Benchmarking<$crate::BenchmarkResults>
+			for Module<T, I>
 			where T: frame_system::Trait, $( $where_clause )*
 		{
 			fn benchmarks() -> Vec<&'static [u8]> {
@@ -885,7 +905,9 @@ macro_rules! impl_benchmark {
 				$crate::benchmarking::commit_db();
 				$crate::benchmarking::wipe_db();
 
-				let components = <SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>>::components(&selected_benchmark);
+				let components = <
+					SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>
+				>::components(&selected_benchmark);
 				let mut results: Vec<$crate::BenchmarkResults> = Vec::new();
 
 				// Default number of steps for a component.
@@ -928,7 +950,9 @@ macro_rules! impl_benchmark {
 						// Run the benchmark `repeat` times.
 						for _ in 0..repeat {
 							// Set up the externalities environment for the setup we want to benchmark.
-							let closure_to_benchmark = <SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>>::instance(&selected_benchmark, &c)?;
+							let closure_to_benchmark = <
+								SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>
+							>::instance(&selected_benchmark, &c)?;
 
 							// Set the block number to at least 1 so events are deposited.
 							if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
@@ -940,12 +964,20 @@ macro_rules! impl_benchmark {
 							$crate::benchmarking::commit_db();
 
 							// Time the extrinsic logic.
-							frame_support::debug::trace!(target: "benchmark", "Start Benchmark: {:?} {:?}", name, component_value);
+							frame_support::debug::trace!(
+								target: "benchmark",
+								"Start Benchmark: {:?} {:?}", name, component_value
+							);
+
 							let start_extrinsic = $crate::benchmarking::current_time();
 							closure_to_benchmark()?;
 							let finish_extrinsic = $crate::benchmarking::current_time();
 							let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
-							frame_support::debug::trace!(target: "benchmark", "End Benchmark: {} ns", elapsed_extrinsic);
+
+							frame_support::debug::trace!(
+								target: "benchmark",
+								"End Benchmark: {} ns", elapsed_extrinsic
+							);
 
 							// Time the storage root recalculation.
 							let start_storage_root = $crate::benchmarking::current_time();
@@ -982,7 +1014,9 @@ macro_rules! impl_benchmark_test {
 				where T: frame_system::Trait, $( $where_clause )*
 			{
 				let selected_benchmark = SelectedBenchmark::$name;
-				let components = <SelectedBenchmark as $crate::BenchmarkingSetup<T>>::components(&selected_benchmark);
+				let components = <
+					SelectedBenchmark as $crate::BenchmarkingSetup<T>
+				>::components(&selected_benchmark);
 
 				assert!(
 					components.len() != 0,
@@ -1004,7 +1038,9 @@ macro_rules! impl_benchmark_test {
 							.collect();
 
 						// Set up the verification state
-						let closure_to_verify = <SelectedBenchmark as $crate::BenchmarkingSetup<T>>::verify(&selected_benchmark, &c)?;
+						let closure_to_verify = <
+							SelectedBenchmark as $crate::BenchmarkingSetup<T>
+						>::verify(&selected_benchmark, &c)?;
 
 						// Set the block number to at least 1 so events are deposited.
 						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
@@ -1032,7 +1068,9 @@ macro_rules! impl_benchmark_test {
 				where T: frame_system::Trait, $( $where_clause )*
 			{
 				let selected_benchmark = SelectedBenchmark::$name;
-				let components = <SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>>::components(&selected_benchmark);
+				let components = <
+					SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>
+				>::components(&selected_benchmark);
 
 				for (_, (name, low, high)) in components.iter().enumerate() {
 					// Test only the low and high value, assuming values in the middle won't break
@@ -1050,7 +1088,9 @@ macro_rules! impl_benchmark_test {
 							.collect();
 
 						// Set up the verification state
-						let closure_to_verify = <SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>>::verify(&selected_benchmark, &c)?;
+						let closure_to_verify = <
+							SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>
+						>::verify(&selected_benchmark, &c)?;
 
 						// Set the block number to at least 1 so events are deposited.
 						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -173,7 +173,7 @@ pub use paste;
 #[macro_export]
 macro_rules! benchmarks {
 	(
-		_ {
+		_ $( where $( $where_ty:ty: $where_bound:path ),* $(,)? )? {
 			$(
 				let $common:ident in $common_from:tt .. $common_to:expr => $common_instancer:expr;
 			)*
@@ -182,6 +182,7 @@ macro_rules! benchmarks {
 	) => {
 		$crate::benchmarks_iter!(
 			NO_INSTANCE
+			{ $( $where_ty: $where_bound )* }
 			{ $( { $common , $common_from , $common_to , $common_instancer } )* }
 			( )
 			$( $rest )*
@@ -192,7 +193,7 @@ macro_rules! benchmarks {
 #[macro_export]
 macro_rules! benchmarks_instance {
 	(
-		_ {
+		_ $( where $( $where_ty:ty: $where_bound:path ),* $(,)? )? {
 			$(
 				let $common:ident in $common_from:tt .. $common_to:expr => $common_instancer:expr;
 			)*
@@ -201,6 +202,7 @@ macro_rules! benchmarks_instance {
 	) => {
 		$crate::benchmarks_iter!(
 			INSTANCE
+			{ $( $where_ty: $where_bound )* }
 			{ $( { $common , $common_from , $common_to , $common_instancer } )* }
 			( )
 			$( $rest )*
@@ -214,6 +216,7 @@ macro_rules! benchmarks_iter {
 	// mutation arm:
 	(
 		$instance:ident
+		{ $( $where_clause:tt )* }
 		{ $( $common:tt )* }
 		( $( $names:ident )* )
 		$name:ident { $( $code:tt )* }: _ ( $origin:expr $( , $arg:expr )* )
@@ -222,6 +225,7 @@ macro_rules! benchmarks_iter {
 	) => {
 		$crate::benchmarks_iter! {
 			$instance
+			{ $( $where_clause )* }
 			{ $( $common )* }
 			( $( $names )* )
 			$name { $( $code )* }: $name ( $origin $( , $arg )* )
@@ -232,6 +236,7 @@ macro_rules! benchmarks_iter {
 	// no instance mutation arm:
 	(
 		NO_INSTANCE
+		{ $( $where_clause:tt )* }
 		{ $( $common:tt )* }
 		( $( $names:ident )* )
 		$name:ident { $( $code:tt )* }: $dispatch:ident ( $origin:expr $( , $arg:expr )* )
@@ -240,6 +245,7 @@ macro_rules! benchmarks_iter {
 	) => {
 		$crate::benchmarks_iter! {
 			NO_INSTANCE
+			{ $( $where_clause )* }
 			{ $( $common )* }
 			( $( $names )* )
 			$name { $( $code )* }: {
@@ -254,6 +260,7 @@ macro_rules! benchmarks_iter {
 	// instance mutation arm:
 	(
 		INSTANCE
+		{ $( $where_clause:tt )* }
 		{ $( $common:tt )* }
 		( $( $names:ident )* )
 		$name:ident { $( $code:tt )* }: $dispatch:ident ( $origin:expr $( , $arg:expr )* )
@@ -262,6 +269,7 @@ macro_rules! benchmarks_iter {
 	) => {
 		$crate::benchmarks_iter! {
 			INSTANCE
+			{ $( $where_clause )* }
 			{ $( $common )* }
 			( $( $names )* )
 			$name { $( $code )* }: {
@@ -276,6 +284,7 @@ macro_rules! benchmarks_iter {
 	// iteration arm:
 	(
 		$instance:ident
+		{ $( $where_clause:tt )* }
 		{ $( $common:tt )* }
 		( $( $names:ident )* )
 		$name:ident { $( $code:tt )* }: $eval:block
@@ -285,6 +294,7 @@ macro_rules! benchmarks_iter {
 		$crate::benchmark_backend! {
 			$instance
 			$name
+			{ $( $where_clause )* }
 			{ $( $common )* }
 			{ }
 			{ $eval }
@@ -293,13 +303,14 @@ macro_rules! benchmarks_iter {
 		}
 		$crate::benchmarks_iter!(
 			$instance
+			{ $( $where_clause )* }
 			{ $( $common )* }
 			( $( $names )* $name )
 			$( $rest )*
 		);
 	};
 	// iteration-exit arm
-	( $instance:ident { $( $common:tt )* } ( $( $names:ident )* ) ) => {
+	( $instance:ident { $( $where_clause:tt )* } { $( $common:tt )* } ( $( $names:ident )* ) ) => {
 		$crate::selected_benchmark!( $instance $( $names ),* );
 		$crate::impl_benchmark!( $instance $( $names ),* );
 		#[cfg(test)]

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -85,11 +85,11 @@ pub use paste;
 /// Example:
 /// ```ignore
 /// benchmarks! {
+///   where_clause {  where T::A: From<u32> } // Optional line to give additional bound on `T`.
+///
 ///   // common parameter; just one for this example.
 ///   // will be `1`, `MAX_LENGTH` or any value inbetween
 ///   _ {
-///   // Or optionally: `_ where T::A: From<u32>, ..., ... {`
-///   // Allow to put additional bound on the generic `T: Trait`
 ///     let l in 1 .. MAX_LENGTH => initialize_l(l);
 ///   }
 ///
@@ -175,7 +175,8 @@ pub use paste;
 #[macro_export]
 macro_rules! benchmarks {
 	(
-		_ $( where $( $where_ty:ty: $where_bound:path ),* $(,)? )? {
+		$( where_clause { where $( $where_ty:ty: $where_bound:path ),* $(,)? } )?
+		_ {
 			$(
 				let $common:ident in $common_from:tt .. $common_to:expr => $common_instancer:expr;
 			)*
@@ -196,7 +197,8 @@ macro_rules! benchmarks {
 #[macro_export]
 macro_rules! benchmarks_instance {
 	(
-		_ $( where $( $where_ty:ty: $where_bound:path ),* $(,)? )? {
+		$( where_clause { where $( $where_ty:ty: $where_bound:path ),* $(,)? } )?
+		_ {
 			$(
 				let $common:ident in $common_from:tt .. $common_to:expr => $common_instancer:expr;
 			)*

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -119,7 +119,9 @@ fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 benchmarks!{
-	_ where <T as OtherTrait>::OtherEvent: Into<<T as Trait>::Event> {
+	where_clause { where <T as OtherTrait>::OtherEvent: Into<<T as Trait>::Event> }
+
+	_ {
 		// Define a common range for `b`.
 		let b in 1 .. 1000 => ();
 	}

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -68,7 +68,8 @@ pub trait Trait: OtherTrait where Self::OtherEvent: Into<Self::Event> {
 	type Event;
 	type BlockNumber;
 	type AccountId: 'static + Default + Decode;
-	type Origin: From<frame_system::RawOrigin<Self::AccountId>> + Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>;
+	type Origin: From<frame_system::RawOrigin<Self::AccountId>> +
+		Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>;
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -170,13 +171,13 @@ benchmarks!{
 #[test]
 fn benchmarks_macro_works() {
 	// Check benchmark creation for `set_value`.
-	let selected_benchmark = SelectedBenchmark::set_value;
+	let selected = SelectedBenchmark::set_value;
 
-	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
+	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected);
 	assert_eq!(components, vec![(BenchmarkParameter::b, 1, 1000)]);
 
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
+		&selected,
 		&[(BenchmarkParameter::b, 1)],
 	).expect("failed to create closure");
 
@@ -188,12 +189,12 @@ fn benchmarks_macro_works() {
 #[test]
 fn benchmarks_macro_rename_works() {
 	// Check benchmark creation for `other_dummy`.
-	let selected_benchmark = SelectedBenchmark::other_name;
-	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
+	let selected = SelectedBenchmark::other_name;
+	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected);
 	assert_eq!(components, vec![(BenchmarkParameter::b, 1, 1000)]);
 
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
+		&selected,
 		&[(BenchmarkParameter::b, 1)],
 	).expect("failed to create closure");
 
@@ -204,13 +205,13 @@ fn benchmarks_macro_rename_works() {
 
 #[test]
 fn benchmarks_macro_works_for_non_dispatchable() {
-	let selected_benchmark = SelectedBenchmark::sort_vector;
+	let selected = SelectedBenchmark::sort_vector;
 
-	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected_benchmark);
+	let components = <SelectedBenchmark as BenchmarkingSetup<Test>>::components(&selected);
 	assert_eq!(components, vec![(BenchmarkParameter::x, 1, 10000)]);
 
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
-		&selected_benchmark,
+		&selected,
 		&[(BenchmarkParameter::x, 1)],
 	).expect("failed to create closure");
 
@@ -220,10 +221,10 @@ fn benchmarks_macro_works_for_non_dispatchable() {
 #[test]
 fn benchmarks_macro_verify_works() {
 	// Check postcondition for benchmark `set_value` is valid.
-	let selected_benchmark = SelectedBenchmark::set_value;
+	let selected = SelectedBenchmark::set_value;
 
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::verify(
-		&selected_benchmark,
+		&selected,
 		&[(BenchmarkParameter::b, 1)],
 	).expect("failed to create closure");
 


### PR DESCRIPTION
this doesn't break anything but allow the new syntax:

```rust
benchmarks!{
	_ where <T as OtherTrait>::OtherEvent: Into<<T as Trait>::Event> {
		// Define a common range for `b`.
		let b in 1 .. 1000 => ();
	}
...
```

Maybe we can put the where clause in a better place though, and not sure about doc.

### Notes

* the where clause is automatically tested to be everywhere because otherwise it wouldn't compile, see https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=fe4e3e09e03e7fdcebeb18634d2f6c36

Fix https://github.com/paritytech/substrate/issues/6432