### PR TITLE
client/network/service: Add primary dimension to connection metrics

### DIFF
--- a/.maintain/monitoring/grafana-dashboards/substrate-networking.json
+++ b/.maintain/monitoring/grafana-dashboards/substrate-networking.json
@@ -1790,7 +1790,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(increase(${metric_namespace}_sub_libp2p_connections_closed_total{instance=~\"${nodename}\"}[$__interval])) by (reason)",
+          "expr": "avg(sum(rate(${metric_namespace}_sub_libp2p_connections_closed_total{instance=~\"${nodename}\"}[$__interval])) by (instance, reason)) by (reason)",
           "interval": "",
           "legendFormat": "{{reason}}",
           "refId": "A"

--- a/.maintain/monitoring/grafana-dashboards/substrate-networking.json
+++ b/.maintain/monitoring/grafana-dashboards/substrate-networking.json
@@ -1790,7 +1790,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum(rate(${metric_namespace}_sub_libp2p_connections_closed_total{instance=~\"${nodename}\"}[$__interval])) by (instance, reason)) by (reason)",
+          "expr": "avg(increase(${metric_namespace}_sub_libp2p_connections_closed_total{instance=~\"${nodename}\"}[$__interval])) by (reason)",
           "interval": "",
           "legendFormat": "{{reason}}",
           "refId": "A"

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -889,16 +889,16 @@ impl Metrics {
 			connections_closed_total: register(CounterVec::new(
 				Opts::new(
 					"sub_libp2p_connections_closed_total",
-					"Total number of connections closed, by reason and direction"
+					"Total number of connections closed, by direction, reason and by being primary or not"
 				),
-				&["direction", "reason"]
+				&["direction", "reason", "was_primary"]
 			)?, registry)?,
 			connections_opened_total: register(CounterVec::new(
 				Opts::new(
 					"sub_libp2p_connections_opened_total",
-					"Total number of connections opened"
+					"Total number of connections opened by direction and by being primary or not"
 				),
-				&["direction"]
+				&["direction", "is_primary"]
 			)?, registry)?,
 			import_queue_blocks_submitted: register(Counter::new(
 				"import_queue_blocks_submitted",
@@ -1214,41 +1214,44 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 					}
 					this.event_streams.send(ev);
 				},
-				Poll::Ready(SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. }) => {
+				Poll::Ready(SwarmEvent::ConnectionEstablished { peer_id, endpoint, num_established }) => {
 					trace!(target: "sub-libp2p", "Libp2p => Connected({:?})", peer_id);
+
+					let is_primary = if num_established.get() == 1 { "true" } else { "false" };
+
 					if let Some(metrics) = this.metrics.as_ref() {
 						match endpoint {
 							ConnectedPoint::Dialer { .. } =>
-								metrics.connections_opened_total.with_label_values(&["out"]).inc(),
+								metrics.connections_opened_total.with_label_values(&["out", is_primary]).inc(),
 							ConnectedPoint::Listener { .. } =>
-								metrics.connections_opened_total.with_label_values(&["in"]).inc(),
+								metrics.connections_opened_total.with_label_values(&["in", is_primary]).inc(),
 						}
 					}
 				},
-				Poll::Ready(SwarmEvent::ConnectionClosed { peer_id, cause, endpoint, .. }) => {
+				Poll::Ready(SwarmEvent::ConnectionClosed { peer_id, cause, endpoint, num_established }) => {
 					trace!(target: "sub-libp2p", "Libp2p => Disconnected({:?}, {:?})", peer_id, cause);
 					if let Some(metrics) = this.metrics.as_ref() {
-						let dir = match endpoint {
+						let direction = match endpoint {
 							ConnectedPoint::Dialer { .. } => "out",
 							ConnectedPoint::Listener { .. } => "in",
 						};
 
-						match cause {
-							ConnectionError::IO(_) =>
-								metrics.connections_closed_total.with_label_values(&[dir, "transport-error"]).inc(),
+						let reason = match cause {
+							ConnectionError::IO(_) => "transport-error",
 							ConnectionError::Handler(NodeHandlerWrapperError::Handler(EitherError::A(EitherError::A(
 								EitherError::A(EitherError::A(EitherError::B(
-								EitherError::A(PingFailure::Timeout)))))))) =>
-								metrics.connections_closed_total.with_label_values(&[dir, "ping-timeout"]).inc(),
+								EitherError::A(PingFailure::Timeout)))))))) => "ping-timeout",
 							ConnectionError::Handler(NodeHandlerWrapperError::Handler(EitherError::A(EitherError::A(
 								EitherError::A(EitherError::A(EitherError::A(
-								EitherError::B(LegacyConnectionKillError)))))))) =>
-								metrics.connections_closed_total.with_label_values(&[dir, "force-closed"]).inc(),
-							ConnectionError::Handler(NodeHandlerWrapperError::Handler(_)) =>
-								metrics.connections_closed_total.with_label_values(&[dir, "protocol-error"]).inc(),
-							ConnectionError::Handler(NodeHandlerWrapperError::KeepAliveTimeout) =>
-								metrics.connections_closed_total.with_label_values(&[dir, "keep-alive-timeout"]).inc(),
-						}
+								EitherError::B(LegacyConnectionKillError)))))))) =>	"force-closed",
+							ConnectionError::Handler(NodeHandlerWrapperError::Handler(_)) => "protocol-error",
+							ConnectionError::Handler(NodeHandlerWrapperError::KeepAliveTimeout) => "keep-alive-timeout",
+						};
+
+						// `num_established` represents the number of *remaining* connections.
+						let was_primary = if num_established == 0 { "true" } else { "false" };
+
+						metrics.connections_closed_total.with_label_values(&[direction, reason, was_primary]).inc();
 					}
 				},
 				Poll::Ready(SwarmEvent::NewListenAddr(addr)) => {


### PR DESCRIPTION
Two nodes can be interconnected via one or more connections. The first
of those connections is called the primary connection.

This commit adds another dimension to the
`sub_libp2p_connections_{closed,opened}_total` metrics to differentiate
primary and non-primary connections being opened / closed.

By intuition more than one connection between two nodes is rare.
Tracking the fact whether a connection is primary or not will help prove
or disprove this intuition.

```
$ curl localhost:9615/metrics | grep "primary"  
# HELP substrate_sub_libp2p_connections_closed_total Total number of connections closed, by direction, reason and by being primary or not
substrate_sub_libp2p_connections_closed_total{direction="out",reason="transport-error",was_primary="true"} 1
# HELP substrate_sub_libp2p_connections_opened_total Total number of connections opened by direction and by being primary or not
substrate_sub_libp2p_connections_opened_total{direction="in",is_primary="true"} 1
substrate_sub_libp2p_connections_opened_total{direction="out",is_primary="true"} 1
