### PR TITLE
.maintain/sentry-node: Remove UI and update Prometheus target

### DIFF
--- a/.maintain/sentry-node/docker-compose.yml
+++ b/.maintain/sentry-node/docker-compose.yml
@@ -131,11 +131,6 @@ services:
       - "sub-authority-discovery=trace"
       - "--prometheus-external"
 
-  ui:
-    image: polkadot-js/apps
-    ports:
-      - "3000:80"
-
   prometheus:
     image: prom/prometheus
     networks:

--- a/.maintain/sentry-node/prometheus/prometheus.yml
+++ b/.maintain/sentry-node/prometheus/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 15s
 
 scrape_configs:
-  - job_name: 'substrate_validator-a'
+  - job_name: 'substrate-nodes'
     static_configs:
       - targets: ['validator-a:9615']
         labels:


### PR DESCRIPTION
Context: `.maintain/sentry-nodes` spins up a simple environment with two validators, one sentry, Prometheus and Grafana (including all dashboards from `.maintain/monitoring`) for local development via `docker-compose -f .maintain/sentry-node/docker-compose.yml up`.

This patch contains:

- Remove burden on user to build polkadot-js apps Docker image locally in
order to get started.

- Update Prometheus config fixing target name.
