### PR TITLE
Label new issues with Z0-unconfirmed

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,17 @@
+# If the author of the issues is not a contributor to the project, label
+# the issue with 'Z0-unconfirmed'
+
+name: Label New Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-new-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label drafts
+        uses: andymckay/labeler@master
+        if: github.event.issue.author_association == "NONE"
+        with:
+          add-labels: 'Z0-unconfirmed'


### PR DESCRIPTION
Any new issues submitted will be labelled with `Z0-unconfirmed` if the author has 'author_association' of 'NONE' (i.e., has no association with this repository).
Due to a quirk with how the author_association field works, if the author of the issue has code in the repo, the issue will not be autolabelled (since they will be considered a CONTRIBUTOR).
Author_association is documented here: https://developer.github.com/v4/enum/commentauthorassociation/

was requested as part of https://github.com/paritytech/substrate/issues/6175 - if we no longer want this functionality, feel free to drop the PR.