### PR TITLE
Controller account must be alive

### DIFF
--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -386,6 +386,7 @@ pub fn new_test_ext_raw_authorities(authorities: AuthorityList) -> sp_io::TestEx
 		.collect();
 
 	let balances: Vec<_> = (0..authorities.len())
+		.chain(1000..authorities.len()+1000)
 		.map(|i| (i as u64, 10_000_000))
 		.collect();
 


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/6415

This PR updates the logic in the Staking Pallet to require that the controller account is alive and stays alive. This requirement already implicitly exists for stash accounts.

To do this, we introduce a check on the `controller` account in `bond` and `set_controller` to make sure the the account is not `is_dead_account()`. After passing this check, we place a reference counter on the controller, forcing it to stay alive as long as it stays a controller.

To make sure the account can later be killed, we remove the reference counter from old controllers in `set_controller` and `kill_stash`.

Tests have been added and updated to verify this behavior.