### PR TITLE
client: fix print of slot duration on startup

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -471,7 +471,7 @@ impl<T: Clone> SlotDuration<T> {
 
 				info!(
 					"⏱  Loaded block-time = {:?} milliseconds from genesis on first-launch",
-					genesis_slot_duration
+					genesis_slot_duration.slot_duration()
 				);
 
 				genesis_slot_duration


### PR DESCRIPTION
Before:

```
2020-06-24 15:11:34 ⏱  Loaded block-time = BabeGenesisConfiguration { slot_duration: 3000, epoch_length: 200, c: (1, 4), genesis_authorities: [(Public(d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (5GrwvaEF...)), 1)], randomness: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots } milliseconds from genesis on first-launch
```

After:

```
2020-06-24 15:10:56 ⏱  Loaded block-time = 3000 milliseconds from genesis on first-launch
```