### PR TITLE
Include genesis hash in system.connected

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -46,7 +46,7 @@ use sc_network::NetworkService;
 use parking_lot::{Mutex, RwLock};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{
-	Block as BlockT, NumberFor, SaturatedConversion, HashFor,
+	Block as BlockT, NumberFor, SaturatedConversion, HashFor, Zero,
 };
 use sp_api::ProvideRuntimeApi;
 use sc_executor::{NativeExecutor, NativeExecutionDispatch, RuntimeInfo};
@@ -1070,8 +1070,13 @@ ServiceBuilder<
 
 		// Telemetry
 		let telemetry = config.telemetry_endpoints.clone().map(|endpoints| {
+			let genesis_hash = match client.block_hash(Zero::zero()) {
+				Ok(Some(hash)) => hash,
+				_ => Default::default(),
+			};
+
 			let (telemetry, future) = build_telemetry(
-				&mut config, endpoints, telemetry_connection_sinks.clone(), network.clone()
+				&mut config, endpoints, telemetry_connection_sinks.clone(), network.clone(), genesis_hash,
 			);
 
 			spawn_handle.spawn(
@@ -1270,7 +1275,8 @@ fn build_telemetry<TBl: BlockT>(
 	config: &mut Configuration,
 	endpoints: sc_telemetry::TelemetryEndpoints,
 	telemetry_connection_sinks: Arc<Mutex<Vec<TracingUnboundedSender<()>>>>,
-	network: Arc<NetworkService<TBl, <TBl as BlockT>::Hash>>
+	network: Arc<NetworkService<TBl, <TBl as BlockT>::Hash>>,
+	genesis_hash: <TBl as BlockT>::Hash,
 ) -> (sc_telemetry::Telemetry, Pin<Box<dyn Future<Output = ()> + Send>>) {
 	let is_authority = config.role.is_authority();
 	let network_id = network.local_peer_id().to_base58();
@@ -1289,6 +1295,7 @@ fn build_telemetry<TBl: BlockT>(
 		.for_each(move |event| {
 			// Safe-guard in case we add more events in the future.
 			let sc_telemetry::TelemetryEvent::Connected = event;
+			// let genesis_hash = genesis_hash.map(|hash| hash.as_ref()).unwrap_or(&[]);
 
 			telemetry!(SUBSTRATE_INFO; "system.connected";
 				"name" => name.clone(),
@@ -1296,6 +1303,7 @@ fn build_telemetry<TBl: BlockT>(
 				"version" => version,
 				"config" => "",
 				"chain" => chain_name.clone(),
+				"genesis_hash" => ?genesis_hash,
 				"authority" => is_authority,
 				"startup_time" => startup_time,
 				"network_id" => network_id.clone()

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1299,7 +1299,6 @@ fn build_telemetry<TBl: BlockT>(
 		.for_each(move |event| {
 			// Safe-guard in case we add more events in the future.
 			let sc_telemetry::TelemetryEvent::Connected = event;
-			// let genesis_hash = genesis_hash.map(|hash| hash.as_ref()).unwrap_or(&[]);
 
 			telemetry!(SUBSTRATE_INFO; "system.connected";
 				"name" => name.clone(),

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1076,7 +1076,11 @@ ServiceBuilder<
 			};
 
 			let (telemetry, future) = build_telemetry(
-				&mut config, endpoints, telemetry_connection_sinks.clone(), network.clone(), genesis_hash,
+				&mut config,
+				endpoints,
+				telemetry_connection_sinks.clone(),
+				network.clone(),
+				genesis_hash,
 			);
 
 			spawn_handle.spawn(


### PR DESCRIPTION
Include the genesis hash in the `system.connected` telemetry message, so that the telemetry server can differentiate between different networks with the same name. Required for: https://github.com/paritytech/substrate-telemetry/issues/263
