### PR TITLE
Refactor as_sub to make things clearer.

### DIFF
--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -201,19 +201,9 @@ fn filtering_works() {
 		assert_ok!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Err(DispatchError::BadOrigin)));
 
-		let alternative_id = Utility::alternative_account_id(1, 0);
-		Balances::mutate_account(&alternative_id, |a| a.free = 1000);
 		let derivative_id = Utility::derivative_account_id(1, 0);
 		Balances::mutate_account(&derivative_id, |a| a.free = 1000);
 		let inner = Box::new(Call::Balances(BalancesCall::transfer(6, 1)));
-
-		let call = Box::new(Call::Utility(UtilityCall::as_alternative(0, inner.clone())));
-		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
-		expect_event(RawEvent::ProxyExecuted(Ok(())));
-		assert_ok!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()));
-		expect_event(RawEvent::ProxyExecuted(Err(DispatchError::BadOrigin)));
-		assert_ok!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()));
-		expect_event(RawEvent::ProxyExecuted(Ok(())));
 
 		let call = Box::new(Call::Utility(UtilityCall::as_derivative(0, inner.clone())));
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -207,7 +207,7 @@ fn filtering_works() {
 		Balances::mutate_account(&derivative_id, |a| a.free = 1000);
 		let inner = Box::new(Call::Balances(BalancesCall::transfer(6, 1)));
 
-		let call = Box::new(Call::Utility(UtilityCall::as_derivative(0, inner.clone())));
+		let call = Box::new(Call::Utility(UtilityCall::as_alternative(0, inner.clone())));
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_ok!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()));
@@ -215,7 +215,7 @@ fn filtering_works() {
 		assert_ok!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 
-		let call = Box::new(Call::Utility(UtilityCall::as_alternative(0, inner.clone())));
+		let call = Box::new(Call::Utility(UtilityCall::as_derivative(0, inner.clone())));
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_ok!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()));

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -205,7 +205,7 @@ fn filtering_works() {
 		Balances::mutate_account(&sub_id, |a| a.free = 1000);
 		let inner = Box::new(Call::Balances(BalancesCall::transfer(6, 1)));
 
-		let call = Box::new(Call::Utility(UtilityCall::as_sub(0, inner.clone())));
+		let call = Box::new(Call::Utility(UtilityCall::as_derivative(0, inner.clone())));
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_ok!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()));
@@ -213,7 +213,7 @@ fn filtering_works() {
 		assert_ok!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 
-		let call = Box::new(Call::Utility(UtilityCall::as_limited_sub(0, inner.clone())));
+		let call = Box::new(Call::Utility(UtilityCall::as_alternative(0, inner.clone())));
 		assert_ok!(Proxy::proxy(Origin::signed(2), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Ok(())));
 		assert_ok!(Proxy::proxy(Origin::signed(3), 1, None, call.clone()));

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -201,8 +201,10 @@ fn filtering_works() {
 		assert_ok!(Proxy::proxy(Origin::signed(4), 1, None, call.clone()));
 		expect_event(RawEvent::ProxyExecuted(Err(DispatchError::BadOrigin)));
 
-		let sub_id = Utility::sub_account_id(1, 0);
-		Balances::mutate_account(&sub_id, |a| a.free = 1000);
+		let alternative_id = Utility::alternative_account_id(1, 0);
+		Balances::mutate_account(&alternative_id, |a| a.free = 1000);
+		let derivative_id = Utility::derivative_account_id(1, 0);
+		Balances::mutate_account(&derivative_id, |a| a.free = 1000);
 		let inner = Box::new(Call::Balances(BalancesCall::transfer(6, 1)));
 
 		let call = Box::new(Call::Utility(UtilityCall::as_derivative(0, inner.clone())));

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -43,12 +43,6 @@ benchmarks! {
 		let caller = account("caller", u, SEED);
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
 	}: _(RawOrigin::Signed(caller), u as u16, call)
-
-	as_alternative {
-		let u in 0 .. 1000;
-		let caller = account("caller", u, SEED);
-		let call = Box::new(frame_system::Call::remark(vec![]).into());
-	}: _(RawOrigin::Signed(caller), u as u16, call)
 }
 
 #[cfg(test)]
@@ -62,7 +56,6 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			assert_ok!(test_benchmark_batch::<Test>());
 			assert_ok!(test_benchmark_as_derivative::<Test>());
-			assert_ok!(test_benchmark_as_alternative::<Test>());
 		});
 	}
 }

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -38,13 +38,13 @@ benchmarks! {
 		let caller = account("caller", 0, SEED);
 	}: _(RawOrigin::Signed(caller), calls)
 
-	as_sub {
+	as_derivative {
 		let u in 0 .. 1000;
 		let caller = account("caller", u, SEED);
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
 	}: _(RawOrigin::Signed(caller), u as u16, call)
 
-	as_limited_sub {
+	as_alternative {
 		let u in 0 .. 1000;
 		let caller = account("caller", u, SEED);
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
@@ -61,8 +61,8 @@ mod tests {
 	fn test_benchmarks() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(test_benchmark_batch::<Test>());
-			assert_ok!(test_benchmark_as_sub::<Test>());
-			assert_ok!(test_benchmark_as_limited_sub::<Test>());
+			assert_ok!(test_benchmark_as_derivative::<Test>());
+			assert_ok!(test_benchmark_as_alternative::<Test>());
 		});
 	}
 }

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 //! # Utility Module
-//! A stateless module with helpers for dispatch management.
+//! A stateless module with helpers for dispatch management which does no re-authentication.
 //!
 //! - [`utility::Trait`](./trait.Trait.html)
 //! - [`Call`](./enum.Call.html)
@@ -34,7 +34,10 @@
 //!   need multiple distinct accounts (e.g. as controllers for many staking accounts), but where
 //!   it's perfectly fine to have each of them controlled by the same underlying keypair.
 //!   Derivative accounts are, for the purposes of proxy filtering considered exactly the same as
-//!   the oigin and are thus hampered with the origin's filters, much like `batch`.
+//!   the oigin and are thus hampered with the origin's filters.
+//!
+//! Since proxy filters are respected in all dispatches of this module, it should never need to be
+//! filtered by any proxy.
 //!
 //! ## Interface
 //!

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -182,7 +182,7 @@ decl_module! {
 			let who = ensure_signed(origin)?;
 
 			// This is a freshly authenticated new account, the origin restrictions doesn't apply.
-			let pseudonym = Self::alt_account_id(who, index);
+			let pseudonym = Self::alternative_account_id(who, index);
 			call.dispatch(frame_system::RawOrigin::Signed(pseudonym).into())
 				.map(|_| ()).map_err(|e| e.error)
 		}
@@ -211,7 +211,7 @@ decl_module! {
 		fn as_derivative(origin, index: u16, call: Box<<T as Trait>::Call>) -> DispatchResult {
 			let mut origin = origin;
 			let who = ensure_signed(origin.clone())?;
-			let pseudonym = Self::sub_account_id(who, index);
+			let pseudonym = Self::derivative_account_id(who, index);
 			origin.set_caller_from(frame_system::RawOrigin::Signed(pseudonym));
 			call.dispatch(origin).map(|_| ()).map_err(|e| e.error)
 		}
@@ -220,13 +220,13 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
 	/// Derive a sub-account ID from the owner account and the sub-account index.
-	pub fn alt_account_id(who: T::AccountId, index: u16) -> T::AccountId {
+	pub fn alternative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
 		let entropy = (b"modlpy/utilisuba", who, index).using_encoded(blake2_256);
 		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}
 
 	/// Derive an alt-account ID from the owner account and the sub-account index.
-	pub fn sub_account_id(who: T::AccountId, index: u16) -> T::AccountId {
+	pub fn derivative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
 		let entropy = (b"modlpy/utililsba", who, index).using_encoded(blake2_256);
 		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -29,10 +29,14 @@
 //!   corresponding `set_storage`s, for efficient multiple payouts with just a single signature
 //!   verify, or in combination with one of the other two dispatch functionality.
 //! - Pseudonymal dispatch: A stateless operation, allowing a signed origin to execute a call from
-//!   an alternative signed origin. Each account has 2**16 possible "pseudonyms" (alternative
+//!   an alternative signed origin. Each account has 2 * 2**16 possible "pseudonyms" (alternative
 //!   account IDs) and these can be stacked. This can be useful as a key management tool, where you
 //!   need multiple distinct accounts (e.g. as controllers for many staking accounts), but where
-//!   it's perfectly fine to have each of them controlled by the same underlying keypair.
+//!   it's perfectly fine to have each of them controlled by the same underlying keypair. There
+//!   exist two sets of these pseudonymous accounts: *alternative* IDs (`as_alternative`) and *sub
+//!   account* IDs (`as_derivative`). The only difference between then is that *alternative*
+//!   accounts are, for the purposes of proxy filtering, considered a re-authentication and not a
+//!   direct "derivative" and thus are *not* hampered with the origin's filters.
 //!
 //! ## Interface
 //!
@@ -42,7 +46,8 @@
 //! * `batch` - Dispatch multiple calls from the sender's origin.
 //!
 //! #### For pseudonymal dispatch
-//! * `as_sub` - Dispatch a call from a secondary ("sub") signed origin.
+//! * `as_derivative` - Dispatch a call from a derivative signed origin.
+//! * `as_alternative` - Dispatch a call from a alternative signed origin.
 //!
 //! [`Call`]: ./enum.Call.html
 //! [`Trait`]: ./trait.Trait.html
@@ -159,7 +164,9 @@ decl_module! {
 		///
 		/// NOTE: If you need to ensure that any account-based filtering is honored (i.e. because
 		/// you expect `proxy` to have been used prior in the call stack and you want it to apply to
-		/// any sub-accounts), then use `as_limited_sub` instead.
+		/// any sub-accounts), then use `as_derivative` instead.
+		///
+		/// NOTE: Prior to version *12, this was called `as_derivative`.
 		///
 		/// The dispatch origin for this call must be _Signed_.
 		///
@@ -171,11 +178,11 @@ decl_module! {
 			call.get_dispatch_info().weight.saturating_add(3_000_000),
 			call.get_dispatch_info().class,
 		)]
-		fn as_sub(origin, index: u16, call: Box<<T as Trait>::Call>) -> DispatchResult {
+		fn as_alternative(origin, index: u16, call: Box<<T as Trait>::Call>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
 			// This is a freshly authenticated new account, the origin restrictions doesn't apply.
-			let pseudonym = Self::sub_account_id(who, index);
+			let pseudonym = Self::alt_account_id(who, index);
 			call.dispatch(frame_system::RawOrigin::Signed(pseudonym).into())
 				.map(|_| ()).map_err(|e| e.error)
 		}
@@ -187,7 +194,9 @@ decl_module! {
 		///
 		/// NOTE: If you need to ensure that any account-based filtering is not honored (i.e.
 		/// because you expect `proxy` to have been used prior in the call stack and you do not want
-		/// the call restrictions to apply to any sub-accounts), then use `as_sub` instead.
+		/// the call restrictions to apply to any sub-accounts), then use `as_alternative` instead.
+		///
+		/// NOTE: Prior to version *12, this was called `as_limited_sub`.
 		///
 		/// The dispatch origin for this call must be _Signed_.
 		///
@@ -199,7 +208,7 @@ decl_module! {
 			call.get_dispatch_info().weight.saturating_add(3_000_000),
 			call.get_dispatch_info().class,
 		)]
-		fn as_limited_sub(origin, index: u16, call: Box<<T as Trait>::Call>) -> DispatchResult {
+		fn as_derivative(origin, index: u16, call: Box<<T as Trait>::Call>) -> DispatchResult {
 			let mut origin = origin;
 			let who = ensure_signed(origin.clone())?;
 			let pseudonym = Self::sub_account_id(who, index);
@@ -211,8 +220,14 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
 	/// Derive a sub-account ID from the owner account and the sub-account index.
-	pub fn sub_account_id(who: T::AccountId, index: u16) -> T::AccountId {
+	pub fn alt_account_id(who: T::AccountId, index: u16) -> T::AccountId {
 		let entropy = (b"modlpy/utilisuba", who, index).using_encoded(blake2_256);
+		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
+	}
+
+	/// Derive an alt-account ID from the owner account and the sub-account index.
+	pub fn sub_account_id(who: T::AccountId, index: u16) -> T::AccountId {
+		let entropy = (b"modlpy/utililsba", who, index).using_encoded(blake2_256);
 		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}
 }

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -138,9 +138,29 @@ fn expect_event<E: Into<TestEvent>>(e: E) {
 }
 
 #[test]
+fn as_alternative_works() {
+	new_test_ext().execute_with(|| {
+		let sub_1_0 = Utility::alternative_account_id(1, 0);
+		assert_ok!(Balances::transfer(Origin::signed(1), sub_1_0, 5));
+		assert_noop!(Utility::as_alternative(
+			Origin::signed(1),
+			1,
+			Box::new(Call::Balances(BalancesCall::transfer(6, 3))),
+		), BalancesError::<Test, _>::InsufficientBalance);
+		assert_ok!(Utility::as_alternative(
+			Origin::signed(1),
+			0,
+			Box::new(Call::Balances(BalancesCall::transfer(2, 3))),
+		));
+		assert_eq!(Balances::free_balance(sub_1_0), 2);
+		assert_eq!(Balances::free_balance(2), 13);
+	});
+}
+
+#[test]
 fn as_derivative_works() {
 	new_test_ext().execute_with(|| {
-		let sub_1_0 = Utility::sub_account_id(1, 0);
+		let sub_1_0 = Utility::derivative_account_id(1, 0);
 		assert_ok!(Balances::transfer(Origin::signed(1), sub_1_0, 5));
 		assert_noop!(Utility::as_derivative(
 			Origin::signed(1),

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -138,26 +138,6 @@ fn expect_event<E: Into<TestEvent>>(e: E) {
 }
 
 #[test]
-fn as_alternative_works() {
-	new_test_ext().execute_with(|| {
-		let sub_1_0 = Utility::alternative_account_id(1, 0);
-		assert_ok!(Balances::transfer(Origin::signed(1), sub_1_0, 5));
-		assert_noop!(Utility::as_alternative(
-			Origin::signed(1),
-			1,
-			Box::new(Call::Balances(BalancesCall::transfer(6, 3))),
-		), BalancesError::<Test, _>::InsufficientBalance);
-		assert_ok!(Utility::as_alternative(
-			Origin::signed(1),
-			0,
-			Box::new(Call::Balances(BalancesCall::transfer(2, 3))),
-		));
-		assert_eq!(Balances::free_balance(sub_1_0), 2);
-		assert_eq!(Balances::free_balance(2), 13);
-	});
-}
-
-#[test]
 fn as_derivative_works() {
 	new_test_ext().execute_with(|| {
 		let sub_1_0 = Utility::derivative_account_id(1, 0);

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -138,16 +138,16 @@ fn expect_event<E: Into<TestEvent>>(e: E) {
 }
 
 #[test]
-fn as_sub_works() {
+fn as_derivative_works() {
 	new_test_ext().execute_with(|| {
 		let sub_1_0 = Utility::sub_account_id(1, 0);
 		assert_ok!(Balances::transfer(Origin::signed(1), sub_1_0, 5));
-		assert_noop!(Utility::as_sub(
+		assert_noop!(Utility::as_derivative(
 			Origin::signed(1),
 			1,
 			Box::new(Call::Balances(BalancesCall::transfer(6, 3))),
 		), BalancesError::<Test, _>::InsufficientBalance);
-		assert_ok!(Utility::as_sub(
+		assert_ok!(Utility::as_derivative(
 			Origin::signed(1),
 			0,
 			Box::new(Call::Balances(BalancesCall::transfer(2, 3))),
@@ -158,9 +158,9 @@ fn as_sub_works() {
 }
 
 #[test]
-fn as_sub_filters() {
+fn as_derivative_filters() {
 	new_test_ext().execute_with(|| {
-		assert_noop!(Utility::as_sub(
+		assert_noop!(Utility::as_derivative(
 			Origin::signed(1),
 			1,
 			Box::new(Call::System(frame_system::Call::remark(vec![]))),


### PR DESCRIPTION
- `as_sub` is removed
- `as_sub_limited` becomes `as_derivative`

Polkadot companion: https://github.com/paritytech/polkadot/pull/1315