### PR TITLE
Fix mocking multiple http calls in the same function call

### DIFF
--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -497,9 +497,7 @@ fn offchain_http_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let (offchain, state) = testing::TestOffchainExt::new();
 	ext.register_extension(OffchainExt::new(offchain));
-	state.write().expect_request(
-		0,
-		testing::PendingRequest {
+	state.write().expect_request(testing::PendingRequest {
 			method: "POST".into(),
 			uri: "http://localhost:12345".into(),
 			body: vec![1, 2, 3, 4],

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -120,6 +120,8 @@ impl OffchainStorage for TestPersistentOffchainDB {
 pub struct OffchainState {
 	/// A list of pending requests.
 	pub requests: BTreeMap<RequestId, PendingRequest>,
+	/// Request counter
+	pub request_ctr: u16,
 	expected_requests: BTreeMap<RequestId, PendingRequest>,
 	/// Persistent local storage
 	pub persistent_storage: TestPersistentOffchainDB,
@@ -156,10 +158,12 @@ impl OffchainState {
 	}
 
 	fn fulfill_expected(&mut self, id: u16) {
-		if let Some(mut req) = self.expected_requests.remove(&RequestId(id)) {
-			let response = req.response.take().expect("Response checked while added.");
+		if let Some(mut req) = self.expected_requests.remove(&RequestId(self.request_ctr)) {
+			let response = req.response.take().expect("Response checked when added.");
 			let headers = std::mem::take(&mut req.response_headers);
 			self.fulfill_pending_request(id, req, response, headers);
+
+			self.request_ctr = self.request_ctr.saturating_add(1);
 		}
 	}
 

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -158,7 +158,7 @@ impl OffchainState {
 	}
 
 	fn fulfill_expected(&mut self, id: u16) {
-		if let Some(mut req) = self.expected_requests.remove(&RequestId(self.request_ctr)) {
+		if let Some(mut req) = self.expected_requests.remove(&RequestId(self.request_counter)) {
 			let response = req.response.take().expect("Response checked when added.");
 			let headers = std::mem::take(&mut req.response_headers);
 			self.fulfill_pending_request(id, req, response, headers);

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -121,7 +121,7 @@ pub struct OffchainState {
 	/// A list of pending requests.
 	pub requests: BTreeMap<RequestId, PendingRequest>,
 	/// Request counter
-	pub request_ctr: u16,
+	pub request_counter: u16,
 	expected_requests: BTreeMap<RequestId, PendingRequest>,
 	/// Persistent local storage
 	pub persistent_storage: TestPersistentOffchainDB,

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -163,7 +163,7 @@ impl OffchainState {
 			let headers = std::mem::take(&mut req.response_headers);
 			self.fulfill_pending_request(id, req, response, headers);
 
-			self.request_ctr = self.request_ctr.saturating_add(1);
+			self.request_counter = self.request_counter.checked_add(1).expect("The max number of mocked requests is u16::MAX");
 		}
 	}
 

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -21,7 +21,7 @@
 //! the extra APIs.
 
 use std::{
-	collections::BTreeMap,
+	collections::{BTreeMap, VecDeque},
 	sync::Arc,
 };
 use crate::offchain::{
@@ -120,9 +120,8 @@ impl OffchainStorage for TestPersistentOffchainDB {
 pub struct OffchainState {
 	/// A list of pending requests.
 	pub requests: BTreeMap<RequestId, PendingRequest>,
-	/// Request counter
-	pub request_counter: u16,
-	expected_requests: BTreeMap<RequestId, PendingRequest>,
+	// Queue of requests that the test is expected to perform (in order).
+	expected_requests: VecDeque<PendingRequest>,
 	/// Persistent local storage
 	pub persistent_storage: TestPersistentOffchainDB,
 	/// Local storage
@@ -158,12 +157,10 @@ impl OffchainState {
 	}
 
 	fn fulfill_expected(&mut self, id: u16) {
-		if let Some(mut req) = self.expected_requests.remove(&RequestId(self.request_counter)) {
+		if let Some(mut req) = self.expected_requests.pop_back() {
 			let response = req.response.take().expect("Response checked when added.");
 			let headers = std::mem::take(&mut req.response_headers);
 			self.fulfill_pending_request(id, req, response, headers);
-
-			self.request_counter = self.request_counter.checked_add(1).expect("The max number of mocked requests is u16::MAX");
 		}
 	}
 
@@ -173,11 +170,12 @@ impl OffchainState {
 	/// before running the actual code that utilizes them (for instance before calling into runtime).
 	/// Expected request has to be fulfilled before this struct is dropped,
 	/// the `response` and `response_headers` fields will be used to return results to the callers.
-	pub fn expect_request(&mut self, id: u16, expected: PendingRequest) {
+	/// Requests are expected to be performed in the insertion order.
+	pub fn expect_request(&mut self, expected: PendingRequest) {
 		if expected.response.is_none() {
 			panic!("Expected request needs to have a response.");
 		}
-		self.expected_requests.insert(RequestId(id), expected);
+		self.expected_requests.push_front(expected);
 	}
 }
 


### PR DESCRIPTION
Fixes an issue with a function call in tests that performs more than one http request and waits for each to complete before proceeding. 
The `RequestId` comes from the length of the `requests` collection in the `OffchainState` and if a request is completed before the next one starts it will be removed and the "next expected" will be off by one. 
This PR tries to fix that by using a request counter that tracks how many requests have been performed so that we can `remove()` items from the `expected_requests` at the right index.

I suspect that this is a sub-optimal solution and perhaps requests and their mocks should live side by side in the same collection, e.g. in a tuple of `(PendingRequest, Option<ExpectedRequest>)`.