### PR TITLE
Allow `retract_tip` on `tip_new`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,6 +4665,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-storage",
 ]
 
 [[package]]

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 254,
+	spec_version: 255,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -25,6 +25,7 @@ frame-benchmarking = { version = "2.0.0-rc3", default-features = false, path = "
 [dev-dependencies]
 sp-io ={ version = "2.0.0-rc3", path = "../../primitives/io" }
 sp-core = { version = "2.0.0-rc3", path = "../../primitives/core" }
+sp-storage = { version = "2.0.0-rc3", path = "../../primitives/storage" }
 
 [features]
 default = ["std"]

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -776,7 +776,7 @@ impl<T: Trait> Module<T> {
 			.saturating_sub(T::Currency::minimum_balance())
 	}
 
-	fn migrate_retract_tip_for_tip_new() {
+	pub fn migrate_retract_tip_for_tip_new() {
 		/// An open tipping "motion". Retains all details of a tip including information on the finder
 		/// and the members who have voted.
 		#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -780,7 +780,7 @@ impl<T: Trait> Module<T> {
 		/// An open tipping "motion". Retains all details of a tip including information on the finder
 		/// and the members who have voted.
 		#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug)]
-		pub struct OpenTipOld<
+		pub struct OldOpenTip<
 			AccountId: Parameter,
 			Balance: Parameter,
 			BlockNumber: Parameter,
@@ -804,7 +804,7 @@ impl<T: Trait> Module<T> {
 
 		for (hash, old_tip) in StorageKeyIterator::<
 			T::Hash,
-			OpenTipOld<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
+			OldOpenTip<T::AccountId, BalanceOf<T>, T::BlockNumber, T::Hash>,
 			Twox64Concat,
 		>::new(b"Treasury", b"Tips").drain()
 		{

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -293,6 +293,7 @@ fn close_tip_works() {
 #[test]
 fn retract_tip_works() {
 	new_test_ext().execute_with(|| {
+		// with report awesome
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_ok!(Treasury::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
 		let h = tip_hash();
@@ -303,6 +304,17 @@ fn retract_tip_works() {
 		assert_ok!(Treasury::retract_tip(Origin::signed(0), h.clone()));
 		System::set_block_number(2);
 		assert_noop!(Treasury::close_tip(Origin::signed(0), h.into()), Error::<Test>::UnknownTip);
+
+		// with tip new
+		Balances::make_free_balance_be(&Treasury::account_id(), 101);
+		assert_ok!(Treasury::tip_new(Origin::signed(10), b"awesome.dot".to_vec(), 3, 10));
+		let h = tip_hash();
+		assert_ok!(Treasury::tip(Origin::signed(11), h.clone(), 10));
+		assert_ok!(Treasury::tip(Origin::signed(12), h.clone(), 10));
+		assert_noop!(Treasury::retract_tip(Origin::signed(0), h.clone()), Error::<Test>::NotFinder);
+		assert_ok!(Treasury::retract_tip(Origin::signed(10), h.clone()));
+		System::set_block_number(2);
+		assert_noop!(Treasury::close_tip(Origin::signed(10), h.into()), Error::<Test>::UnknownTip);
 	});
 }
 


### PR DESCRIPTION
This is a PR that allows the Tippers set to retract tips they open with `tip_new`.

To enable this we do a slight refactor to the `OpenTip` struct.

Before, there was a single item `finder` that was an `Option<(AccountId, Balance)>` representing the user who founded the tip and their deposit. In the case of a `Tipper` opening a tip, we set this value to None. This value being none also implied that the finders fee is not paid out.

In order to enable this feature, we need to always have a record of who opened the tip, so I have opted to split this object into two mandatory properties:

* `finder: AccountId`
* `deposit: Balance`

Finally, we need a new way to track whether we pay out a finders fee, so I have opted to simply add a new item to the struct which determines this:

* `finders_fee: bool`

It is possible, if we don't want this last value to exist, we could make `deposit` an option and assume that `None` implies a finders fee isn't paid, but this seems more clear and has the same footprint in bytes.

TODO:

- [x] Migration

@jacogr 

Polkadot companion: https://github.com/paritytech/polkadot/pull/1321