### PR TITLE
benchmarking: Re-enter runtime after resetting overlay from runtime

### DIFF
--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -575,6 +575,9 @@ where
 		).expect(EXT_NOT_ALLOWED_TO_FAIL);
 		self.backend.wipe().expect(EXT_NOT_ALLOWED_TO_FAIL);
 		self.mark_dirty();
+		self.overlay
+			.enter_runtime()
+			.expect("We have reset the overlay above, so we can not be in the runtime; qed");
 	}
 
 	fn commit(&mut self) {
@@ -593,6 +596,9 @@ where
 			changes.main_storage_changes,
 		).expect(EXT_NOT_ALLOWED_TO_FAIL);
 		self.mark_dirty();
+		self.overlay
+			.enter_runtime()
+			.expect("We have reset the overlay above, so we can not be in the runtime; qed");
 	}
 
 	fn read_write_count(&self) -> (u32, u32, u32, u32) {


### PR DESCRIPTION
This PR fixes runtime benchmarking which needs to commit the overlay to backend from the runtime which is something we generally disallow for production runtimes.

This still assumes that the client did not start any transactions before calling into runtime. This is the case for benchmarking as long as either `NativeWhenPossible` or `AlwaysWasm` execution strategy is chosen. Using any other will result in a panic. This is OK as the host functions which could lead to this are only available when the `runtime-benchmarks` feature is set.