### PR TITLE
Fix an extra semi-colon yielding a wrong error

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -325,7 +325,7 @@ impl CliConfiguration for RunCmd {
 			Error::Input(format!(
 				"Invalid node name '{}'. Reason: {}. If unsure, use none.",
 				name, msg
-			))
+		))
 		})?;
 
 		Ok(name)

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -325,7 +325,7 @@ impl CliConfiguration for RunCmd {
 			Error::Input(format!(
 				"Invalid node name '{}'. Reason: {}. If unsure, use none.",
 				name, msg
-			));
+			))
 		})?;
 
 		Ok(name)

--- a/client/cli/src/error.rs
+++ b/client/cli/src/error.rs
@@ -37,6 +37,7 @@ pub enum Error {
 	Input(String),
 	/// Invalid listen multiaddress
 	#[display(fmt="Invalid listen multiaddress")]
+	#[from(ignore)]
 	InvalidListenMultiaddress,
 	/// Other uncategorized error.
 	#[from(ignore)]


### PR DESCRIPTION
Fix #6497 

Without the `#[from(ignore)]`, the macro generates an `impl From<()> for Error`, which accidentally gets used because of the extra semicolon.
