### PR TITLE
Impl From<UncheckedExtrinsic> for OpaqueExtrinsic

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -424,13 +424,12 @@ mod tests {
 	use node_primitives::{Block, DigestItem, Signature};
 	use node_runtime::{BalancesCall, Call, UncheckedExtrinsic, Address};
 	use node_runtime::constants::{currency::CENTS, time::SLOT_DURATION};
-	use codec::{Encode, Decode};
+	use codec::Encode;
 	use sp_core::{crypto::Pair as CryptoPair, H256};
 	use sp_runtime::{
 		generic::{BlockId, Era, Digest, SignedPayload},
 		traits::{Block as BlockT, Header as HeaderT},
 		traits::Verify,
-		OpaqueExtrinsic,
 	};
 	use sp_timestamp;
 	use sp_finality_tracker;
@@ -605,16 +604,13 @@ mod tests {
 					signer.sign(payload)
 				});
 				let (function, extra, _) = raw_payload.deconstruct();
-				let xt = UncheckedExtrinsic::new_signed(
+				index += 1;
+				UncheckedExtrinsic::new_signed(
 					function,
 					from.into(),
 					signature.into(),
 					extra,
-				).encode();
-				let v: Vec<u8> = Decode::decode(&mut xt.as_slice()).unwrap();
-
-				index += 1;
-				OpaqueExtrinsic(v)
+				).into()
 			},
 		);
 	}

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -327,7 +327,10 @@ where
 {
 	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
 		OpaqueExtrinsic::decode(&mut extrinsic.encode().as_slice())
-			.expect("decoding from something we have encoded cannot fail; qed")
+			.expect(
+				"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
+				raw Vec<u8> encoding; qed"
+			)
 	}
 }
 

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -326,7 +326,7 @@ where
 	Extra: SignedExtension,
 {
 	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
-		OpaqueExtrinsic::decode(&mut extrinsic.encode().as_slice())
+		OpaqueExtrinsic::from_bytes(extrinsic.encode().as_slice())
 			.expect(
 				"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
 				raw Vec<u8> encoding; qed"

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -714,7 +714,14 @@ macro_rules! assert_eq_error_rate {
 /// Simple blob to hold an extrinsic without committing to its format and ensure it is serialized
 /// correctly.
 #[derive(PartialEq, Eq, Clone, Default, Encode, Decode)]
-pub struct OpaqueExtrinsic(pub Vec<u8>);
+pub struct OpaqueExtrinsic(Vec<u8>);
+
+impl OpaqueExtrinsic {
+	/// Convert an encoded extrinsic to an `OpaqueExtrinsic`.
+	pub fn from_bytes(mut bytes: &[u8]) -> Result<Self, codec::Error> {
+		OpaqueExtrinsic::decode(&mut bytes)
+	}
+}
 
 #[cfg(feature = "std")]
 impl parity_util_mem::MallocSizeOf for OpaqueExtrinsic {


### PR DESCRIPTION
# Use case

I'm working currently on some test in cumulus and my runtime is using UncheckedExtrinsic but the allowed extrinsic type for PolkadotClient is OpaqueExtrinsic.

This is fine and it can be converted easily using this command:

```rust
builder.push(OpaqueExtrinsic::decode(&mut extrinsic.encode().as_slice()).unwrap()).unwrap()
```

But this is not what I did first. Since OpaqueExtrinsic exposes its inner type (Vec<u8>) I thought I would need to wrap my extrinsic in the OpaqueExtrinsic:

```rust
builder.push(OpaqueExtrinsic(&mut extrinsic.encode())).unwrap()
```

This felt more natural to me but it is not correct. When OpaqueExtrinsic will be encoded it will add 4 additional bytes in the beginning.

# The problem

This is error prone and requires debugging to figure out what is wrong. But even with debugging, I didn't see what was wrong and it's actually @bkchr who found it. I just noticed the 4 bytes different.

# Solution proposed

My first instinct when doing Rust and facing a type issue like this is to use `.into()`. If the type can be converted with it, I trust the implementation will be correct. So I'm adding this `From` implementation which will allow to convert easily to Opaque.

```rust
builder.push(extrinsic.into()).unwrap()
```