### PR TITLE
Increase the limit for the maximum size of the telemetry name

### DIFF
--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -610,7 +610,9 @@ mod tests {
 
 	#[test]
 	fn tests_node_name_bad() {
-		assert!(is_node_name_valid("long names are not very cool for the ui").is_err());
+		assert!(is_node_name_valid(
+			"very very long names are really not very cool for the ui at all, really they're not"
+		).is_err());
 		assert!(is_node_name_valid("Dots.not.Ok").is_err());
 		assert!(is_node_name_valid("http://visit.me").is_err());
 		assert!(is_node_name_valid("https://visit.me").is_err());

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -36,7 +36,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 
 /// The maximum number of characters for a node name.
-pub(crate) const NODE_NAME_MAX_LENGTH: usize = 32;
+pub(crate) const NODE_NAME_MAX_LENGTH: usize = 64;
 
 /// default sub directory to store network config
 pub(crate) const DEFAULT_NETWORK_CONFIG_PATH: &'static str = "network";


### PR DESCRIPTION
Increases the maximum telemetry name to 64 bytes.

Since there was a concern that it would break the UI, here's a screenshot of the telemetry on my standard 1900-something-by-something screen with a 63-characters-long node name:

![image](https://user-images.githubusercontent.com/1412254/85860070-73a3b800-b7be-11ea-9484-d057b471ca62.png)


cc @maciejhirsz  @TriplEight 
