### PR TITLE
Remove @cecton from CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -66,7 +66,3 @@
 
 # Prometheus endpoint
 /utils/prometheus/ @mxinden
-
-# CLI API
-/client/cli @cecton
-/client/cli-derive @cecton


### PR DESCRIPTION
I don't want to block an entire PR just for little changes in sc-cli