### PR TITLE
[CI] Add Github Action to notify devops of PRs labelled with A1-needsburnin

### DIFF
--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify devops
-        if: github.event.label_name == 'A1-needsburnin'
+        if: github.event.label.name == 'A1-needsburnin'
         uses: s3krit/matrix-message-action@v0.0.2
         with:
           room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ACCESS_TOKEN }}
-          message: "@room Burn-in request received for the following PR: ${{ github.event.pull_request.html_url }}"
+          message: "@room Burn-in request received for [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})"
           server: "matrix.parity.io"

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -1,0 +1,14 @@
+name: Notify devops when burn-in label applied
+on:
+  pull_request:
+    type: [labelled]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify devops
+        if: github.event.label_name == "A1-needsburnin"
+        uses: s3krit/matrix-message-action@v0.0.2
+        with:
+          room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}
+          access_token: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ACCESS_TOKEN }}
+          message: "@room Burn-in request received for the following PR: ${{ github.event.pull_request.html_url }}"
+          server: "matrix.parity.io"

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify devops
-        if: github.event.label_name == "A1-needsburnin"
+        if: github.event.label_name == 'A1-needsburnin'
         uses: s3krit/matrix-message-action@v0.0.2
         with:
           room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -1,7 +1,7 @@
 name: Notify devops when burn-in label applied
 on:
   pull_request:
-    type: [labeled]
+    types: [labeled]
 
 jobs:
   notify-devops:

--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -1,7 +1,10 @@
 name: Notify devops when burn-in label applied
 on:
   pull_request:
-    type: [labelled]
+    type: [labeled]
+
+jobs:
+  notify-devops:
     runs-on: ubuntu-latest
     steps:
       - name: Notify devops


### PR DESCRIPTION
This is a temporary/preliminary Github action that will trigger a message in the #polkadot-devops Matrix channel whenever a PR is labelled with A1-needsburnin. The intention is to fully automate the deployment of PRs requiring burn-in, so this is a stand-in until that functionality has been developed.