### PR TITLE
Add ss58 address format network identifier prefix for DataHighway parachain

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -474,6 +474,8 @@ ss58_address_format!(
 		(20, "stafi", "Stafi mainnet, standard account (*25519).")
 	RobonomicsAccount =>
 		(32, "robonomics", "Any Robonomics network standard account (*25519).")
+	DataHighwayAccount =>
+		(33, "datahighway", "DataHighway mainnet, standard account (*25519).")
 	CentrifugeAccount =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
 	SubstrateAccount =>


### PR DESCRIPTION
Previous PR was #5465. This PR has been created instead to request available ss58 prefixes 33, which has not already been reserved

- What does it do?
    * We would like to claim these ss58 prefixes:
      * 33: DataHighway Mainnet
    * We will be using Substrate's ss58 prefix of 42 for DataHighway Harbour Testnet
    * [DataHighway](https://github.com/DataHighway-DHX/node) will be a parachain supported by the Polkadot network. The chain's repo requires an ss58 address format network identifier prefix, see associated [issue](https://github.com/DataHighway-DHX/node/issues/87).