### PR TITLE
[CI] Fix auto-label-issues.yml

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   label-new-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest 
     steps:
       - name: Label drafts
         uses: andymckay/labeler@master
-        if: github.event.issue.author_association == "NONE"
+        if: github.event.issue.author_association == 'NONE'
         with:
           add-labels: 'Z0-unconfirmed'


### PR DESCRIPTION
Statements in github actions cannot use ", must use '