### PR TITLE
pallet-evm: customizable chain id

### DIFF
--- a/frame/evm/src/backend.rs
+++ b/frame/evm/src/backend.rs
@@ -5,6 +5,7 @@ use serde::{Serialize, Deserialize};
 use codec::{Encode, Decode};
 use sp_core::{U256, H256, H160};
 use sp_runtime::traits::UniqueSaturatedInto;
+use frame_support::traits::Get;
 use frame_support::storage::{StorageMap, StorageDoubleMap};
 use sha3::{Keccak256, Digest};
 use evm::backend::{Backend as BackendT, ApplyBackend, Apply};
@@ -91,7 +92,7 @@ impl<'vicinity, T: Trait> BackendT for Backend<'vicinity, T> {
 	}
 
 	fn chain_id(&self) -> U256 {
-		U256::from(sp_io::misc::chain_id())
+		U256::from(T::ChainId::get())
 	}
 
 	fn exists(&self, _address: H160) -> bool {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -118,6 +118,15 @@ impl Precompiles for () {
 	}
 }
 
+/// Substrate system chain ID.
+pub struct SystemChainId;
+
+impl Get<u64> for SystemChainId {
+	fn get() -> u64 {
+		sp_io::misc::chain_id()
+	}
+}
+
 static ISTANBUL_CONFIG: Config = Config::istanbul();
 
 /// EVM module trait
@@ -134,6 +143,8 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 	/// Precompiles associated with this EVM engine.
 	type Precompiles: Precompiles;
+	/// Chain ID of EVM.
+	type ChainId: Get<U256>;
 
 	/// EVM config used in the module.
 	fn config() -> &'static Config {
@@ -159,7 +170,7 @@ decl_storage! {
 	trait Store for Module<T: Trait> as EVM {
 		Accounts get(fn accounts): map hasher(blake2_128_concat) H160 => Account;
 		AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
-		AccountStorages get(fn account_storages): 
+		AccountStorages get(fn account_storages):
 			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
 	}
 


### PR DESCRIPTION
This allows chain id in EVM to be customized. To revert to old behavior, simply set `ChainId = SystemChainId`.