### PR TITLE
Remove unecessary &mut in call argument

### DIFF
--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -83,7 +83,7 @@ fn generate_impl_call(
 			let (#( #pnames ),*) : ( #( #ptypes ),* ) =
 				match #c::DecodeLimit::decode_all_with_depth_limit(
 					#c::MAX_EXTRINSIC_DEPTH,
-					&mut #input,
+					&#input,
 				) {
 					Ok(res) => res,
 					Err(e) => panic!("Bad input data provided to {}: {}", #fn_name_str, e.what()),


### PR DESCRIPTION
[`parity_scale_codec::DecodeLimit::decode_all_with_depth_limit`][1] doesn’t require the second argument to be a mutable reference.

[1]: https://docs.rs/parity-scale-codec/1.3.1/parity_scale_codec/trait.DecodeLimit.html#tymethod.decode_all_with_depth_limit