### PR TITLE
Drop the tokio runtime before the task_manager

### DIFF
--- a/client/cli/src/runner.rs
+++ b/client/cli/src/runner.rs
@@ -210,7 +210,7 @@ impl<C: SubstrateCli> Runner<C> {
 		self.tokio_runtime.block_on(main(task_manager.future().fuse()))
 			.map_err(|e| e.to_string())?;
 		task_manager.terminate();
-		drop(task_manager);
+		drop(self.tokio_runtime);
 		Ok(())
 	}
 


### PR DESCRIPTION
I commented [here](https://github.com/paritytech/substrate/pull/6352#discussion_r447733107) that this had no importance but I was wrong. The tokio runtime must be dropped before the task_manager. Otherwise the objects the task_manager keep alive are dropped before the tasks are finished.

