### PR TITLE
client/network: Remove unused Result returned by NetworkWorker

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -62,7 +62,7 @@ use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnbound
 use std::{
 	borrow::{Borrow, Cow},
 	collections::HashSet,
-	fs, io,
+	fs,
 	marker::PhantomData,
 	num:: NonZeroUsize,
 	pin::Pin,
@@ -1111,7 +1111,7 @@ impl Metrics {
 }
 
 impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
-	type Output = Result<(), io::Error>;
+	type Output = ();
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
 		let this = &mut *self;
@@ -1138,7 +1138,7 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 			// Process the next message coming from the `NetworkService`.
 			let msg = match this.from_worker.poll_next_unpin(cx) {
 				Poll::Ready(Some(msg)) => msg,
-				Poll::Ready(None) => return Poll::Ready(Ok(())),
+				Poll::Ready(None) => return Poll::Ready(()),
 				Poll::Pending => break,
 			};
 

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -861,13 +861,13 @@ pub trait TestNetFactory: Sized {
 		);
 	}
 
-	/// Polls the testnet. Processes all the pending actions and returns `NotReady`.
+	/// Polls the testnet. Processes all the pending actions.
 	fn poll(&mut self, cx: &mut FutureContext) {
 		self.mut_peers(|peers| {
 			for peer in peers {
 				trace!(target: "sync", "-- Polling {}", peer.id());
-				if let Poll::Ready(res) = Pin::new(&mut peer.network).poll(cx) {
-					res.unwrap();
+				if let Poll::Ready(()) = peer.network.poll_unpin(cx) {
+					panic!("NetworkWorker has terminated unexpectedly.")
 				}
 				trace!(target: "sync", "-- Polling complete {}", peer.id());
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -307,9 +307,7 @@ fn build_network_future<
 		});
 
 		// Main network polling.
-		if let Poll::Ready(Ok(())) = Pin::new(&mut network).poll(cx).map_err(|err| {
-			warn!(target: "service", "Error in network: {:?}", err);
-		}) {
+		if let Poll::Ready(()) = network.poll_unpin(cx) {
 			return Poll::Ready(());
 		}
 


### PR DESCRIPTION
`<NetworkWorker as Future>` never makes any use of the `Result` in its `type Output = Result<(), io::Error>;` associated type. This is likely from the `futures-0.1` days. This pull request removes the `Result`.

Follow up to https://github.com/paritytech/substrate/pull/6533#discussion_r448347931.

polkadot companion: https://github.com/paritytech/polkadot/pull/1338