### PR TITLE
 Move `create_inherents` into the block-builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,6 +5986,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
+ "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -26,7 +26,6 @@ use codec::Decode;
 use sp_consensus::{evaluation, Proposal, RecordProof};
 use sp_inherents::InherentData;
 use log::{error, info, debug, trace, warn};
-use sp_core::ExecutionContext;
 use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, Hash as HashT, Header as HeaderT, DigestFor, BlakeTwo256},

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -200,15 +200,7 @@ impl<A, B, Block, C> Proposer<B, Block, C, A>
 			record_proof,
 		)?;
 
-		// We don't check the API versions any further here since the dispatch compatibility
-		// check should be enough.
-		for inherent in self.client.runtime_api()
-			.inherent_extrinsics_with_context(
-				&self.parent_id,
-				ExecutionContext::BlockConstruction,
-				inherent_data
-			)?
-		{
+		for inherent in block_builder.create_inherents(inherent_data)? {
 			match block_builder.push(inherent) {
 				Err(ApplyExtrinsicFailed(Validity(e))) if e.exhausted_resources() =>
 					warn!("⚠️  Dropping non-mandatory inherent from overweight block."),

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -20,6 +20,7 @@ sp-consensus = { version = "0.8.0-rc4", path = "../../primitives/consensus/commo
 sp-blockchain = { version = "2.0.0-rc4", path = "../../primitives/blockchain" }
 sp-core = { version = "2.0.0-rc4", path = "../../primitives/core" }
 sp-block-builder = { version = "2.0.0-rc4", path = "../../primitives/block-builder" }
+sp-inherents = { version = "2.0.0-rc4", path = "../../primitives/inherents" }
 sc-client-api = { version = "2.0.0-rc4", path = "../api" }
 codec = { package = "parity-scale-codec", version = "1.3.1", features = ["derive"] }
 

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -34,7 +34,10 @@ use sp_runtime::{
 };
 use sp_blockchain::{ApplyExtrinsicFailed, Error};
 use sp_core::ExecutionContext;
-use sp_api::{Core, ApiExt, ApiErrorFor, ApiRef, ProvideRuntimeApi, StorageChanges, StorageProof};
+use sp_api::{
+	Core, ApiExt, ApiErrorFor, ApiRef, ProvideRuntimeApi, StorageChanges, StorageProof,
+	TransactionOutcome,
+};
 use sp_consensus::RecordProof;
 
 pub use sp_block_builder::BlockBuilder as BlockBuilderApi;
@@ -156,17 +159,22 @@ where
 		let block_id = &self.block_id;
 		let extrinsics = &mut self.extrinsics;
 
-		self.api.map_api_result(|api| {
+		self.api.execute_in_transaction(|api| {
 			match api.apply_extrinsic_with_context(
 				block_id,
 				ExecutionContext::BlockConstruction,
 				xt.clone(),
-			)? {
-				Ok(_) => {
+			) {
+				Ok(Ok(_)) => {
 					extrinsics.push(xt);
-					Ok(())
+					TransactionOutcome::Commit(Ok(()))
 				}
-				Err(tx_validity) => Err(ApplyExtrinsicFailed::Validity(tx_validity).into()),
+				Ok(Err(tx_validity)) => {
+					TransactionOutcome::Rollback(
+						Err(ApplyExtrinsicFailed::Validity(tx_validity).into()),
+					)
+				},
+				Err(e) => TransactionOutcome::Rollback(Err(e)),
 			}
 		})
 	}
@@ -210,6 +218,23 @@ where
 			block: <Block as BlockT>::new(header, self.extrinsics),
 			storage_changes,
 			proof,
+		})
+	}
+
+	/// Create the inherents for the block.
+	///
+	/// Returns the inherents created by the runtime or an error if something failed.
+	pub fn create_inherents(
+		&mut self,
+		inherent_data: sp_inherents::InherentData,
+	) -> Result<Vec<Block::Extrinsic>, ApiErrorFor<A, Block>> {
+		let block_id = self.block_id;
+		self.api.execute_in_transaction(move |api| {
+			TransactionOutcome::Rollback(api.inherent_extrinsics_with_context(
+				&block_id,
+				ExecutionContext::BlockConstruction,
+				inherent_data
+			))
 		})
 	}
 }

--- a/client/block-builder/src/lib.rs
+++ b/client/block-builder/src/lib.rs
@@ -230,6 +230,8 @@ where
 	) -> Result<Vec<Block::Extrinsic>, ApiErrorFor<A, Block>> {
 		let block_id = self.block_id;
 		self.api.execute_in_transaction(move |api| {
+			// `create_inherents` should not change any state, to ensure this we always rollback
+			// the transaction.
 			TransactionOutcome::Rollback(api.inherent_extrinsics_with_context(
 				&block_id,
 				ExecutionContext::BlockConstruction,

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -21,6 +21,7 @@ use sp_std::{prelude::*, marker::PhantomData};
 use codec::{FullCodec, FullEncode, Encode, EncodeLike, Decode};
 use crate::hash::{Twox128, StorageHasher};
 use sp_runtime::generic::{Digest, DigestItem};
+pub use sp_runtime::TransactionOutcome;
 
 pub mod unhashed;
 pub mod hashed;
@@ -28,14 +29,6 @@ pub mod child;
 #[doc(hidden)]
 pub mod generator;
 pub mod migration;
-
-/// Describes whether a storage transaction should be committed or rolled back.
-pub enum TransactionOutcome<T> {
-	/// Transaction should be committed.
-	Commit(T),
-	/// Transaction should be rolled back.
-	Rollback(T),
-}
 
 /// Execute the supplied function in a new storage transaction.
 ///

--- a/primitives/api/proc-macro/src/mock_impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/mock_impl_runtime_apis.rs
@@ -73,11 +73,11 @@ fn implement_common_api_traits(
 		impl #crate_::ApiExt<#block_type> for #self_ty {
 			type StateBackend = #crate_::InMemoryBackend<#crate_::HashFor<#block_type>>;
 
-			fn map_api_result<F: FnOnce(&Self) -> std::result::Result<R, E>, R, E>(
+			fn execute_in_transaction<F: FnOnce(&Self) -> #crate_::TransactionOutcome<R>, R>(
 				&self,
-				map_call: F,
-			) -> std::result::Result<R, E> where Self: Sized {
-				map_call(self)
+				call: F,
+			) -> R where Self: Sized {
+				call(self).into_inner()
 			}
 
 			fn has_api<A: #crate_::RuntimeApiInfo + ?Sized>(

--- a/primitives/api/src/lib.rs
+++ b/primitives/api/src/lib.rs
@@ -58,7 +58,7 @@ pub use sp_runtime::{
 		Block as BlockT, GetNodeBlockType, GetRuntimeBlockType, HashFor, NumberFor,
 		Header as HeaderT, Hash as HashT,
 	},
-	generic::BlockId, transaction_validity::TransactionValidity, RuntimeString,
+	generic::BlockId, transaction_validity::TransactionValidity, RuntimeString, TransactionOutcome,
 };
 #[doc(hidden)]
 pub use sp_core::{offchain, ExecutionContext};
@@ -348,24 +348,6 @@ pub trait ConstructRuntimeApi<Block: BlockT, C: CallApiAt<Block>> {
 pub trait ApiErrorExt {
 	/// Error type used by the runtime apis.
 	type Error: std::fmt::Debug + From<String>;
-}
-
-/// Describes on what should happen with a transaction.
-pub enum TransactionOutcome<R> {
-	/// Commit the transaction.
-	Commit(R),
-	/// Rollback the transaction.
-	Rollback(R),
-}
-
-impl<R> TransactionOutcome<R> {
-	/// Convert into the inner type.
-	pub fn into_inner(self) -> R {
-		match self {
-			Self::Commit(r) => r,
-			Self::Rollback(r) => r,
-		}
-	}
 }
 
 /// Extends the runtime api implementation with some common functionality.

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -801,7 +801,7 @@ impl Drop for SignatureBatching {
 	}
 }
 
-/// Describes on what should happen with a transaction.
+/// Describes on what should happen with a storage transaction.
 pub enum TransactionOutcome<R> {
 	/// Commit the transaction.
 	Commit(R),

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -801,6 +801,23 @@ impl Drop for SignatureBatching {
 	}
 }
 
+/// Describes on what should happen with a transaction.
+pub enum TransactionOutcome<R> {
+	/// Commit the transaction.
+	Commit(R),
+	/// Rollback the transaction.
+	Rollback(R),
+}
+
+impl<R> TransactionOutcome<R> {
+	/// Convert into the inner type.
+	pub fn into_inner(self) -> R {
+		match self {
+			Self::Commit(r) => r,
+			Self::Rollback(r) => r,
+		}
+	}
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This moves the `create_inherents` call into the block-builder. This has
the advantage that `create_inherents` will be able to reuse the same
context that will be used when applying the extrinsics and we also save
one call to `on_initialize`. To make sure that `create_inherents` does
not modify any state, we execute it in a transaction that is
rolled-back after doing the runtime call.