### PR TITLE
primitives: use generic Header in testing runtime

### DIFF
--- a/client/db/src/cache/list_cache.rs
+++ b/client/db/src/cache/list_cache.rs
@@ -860,16 +860,15 @@ fn read_forks<Block: BlockT, T: CacheItemT, S: Storage<Block, T>>(
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
 	use substrate_test_runtime_client::runtime::H256;
 	use sp_runtime::testing::{Header, Block as RawBlock, ExtrinsicWrapper};
-	use sp_runtime::traits::Header as HeaderT;
 	use crate::cache::list_storage::tests::{DummyStorage, FaultyStorage, DummyTransaction};
 	use super::*;
 
 	type Block = RawBlock<ExtrinsicWrapper<u64>>;
 
-	pub fn test_id(number: u64) -> ComplexBlockId<Block> {
+	fn test_id(number: u64) -> ComplexBlockId<Block> {
 		ComplexBlockId::new(H256::from_low_u64_be(number), number)
 	}
 

--- a/client/db/src/cache/list_entry.rs
+++ b/client/db/src/cache/list_entry.rs
@@ -117,9 +117,13 @@ impl<Block: BlockT, T: CacheItemT> StorageEntry<Block, T> {
 
 #[cfg(test)]
 mod tests {
-	use crate::cache::list_cache::tests::test_id;
 	use crate::cache::list_storage::tests::{DummyStorage, FaultyStorage};
+	use substrate_test_runtime_client::runtime::{H256, Block};
 	use super::*;
+
+	fn test_id(number: u64) -> ComplexBlockId<Block> {
+		ComplexBlockId::new(H256::from_low_u64_be(number), number)
+	}
 
 	#[test]
 	fn entry_try_update_works() {

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -209,8 +209,9 @@ mod tests {
 	use sp_io::TestExternalities;
 	use sp_core::H256;
 	use sp_runtime::{
-		testing::Header, Perbill,
-		traits::{BlakeTwo256, IdentityLookup, Header as HeaderT},
+		testing::Header,
+		traits::{BlakeTwo256, IdentityLookup},
+		Perbill,
 	};
 	use frame_support::{
 		assert_ok, impl_outer_origin, parameter_types,

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -40,8 +40,8 @@ use sp_runtime::{
 	impl_opaque_keys,
 	testing::{Header, TestXt, UintAuthorityId},
 	traits::{
-		Convert, Extrinsic as ExtrinsicT, Header as _, IdentityLookup, OpaqueKeys,
-		SaturatedConversion, SignedExtension,
+		Convert, Extrinsic as ExtrinsicT, IdentityLookup, OpaqueKeys, SaturatedConversion,
+		SignedExtension,
 	},
 	transaction_validity::TransactionValidityError,
 	DigestItem, Perbill,

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -30,7 +30,7 @@ use frame_support::{
 use frame_system::{EventRecord, Phase};
 use sp_core::H256;
 use sp_keyring::Ed25519Keyring;
-use sp_runtime::{testing::Digest, traits::Header};
+use sp_runtime::testing::Digest;
 
 #[test]
 fn authorities_change_logged() {

--- a/primitives/runtime/src/testing.rs
+++ b/primitives/runtime/src/testing.rs
@@ -160,74 +160,18 @@ pub type DigestItem = generic::DigestItem<H256>;
 pub type Digest = generic::Digest<H256>;
 
 /// Block Header
-#[derive(PartialEq, Eq, Clone, Serialize, Debug, Encode, Decode, Default, parity_util_mem::MallocSizeOf)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-pub struct Header {
-	/// Parent hash
-	pub parent_hash: H256,
-	/// Block Number
-	pub number: u64,
-	/// Post-execution state trie root
-	pub state_root: H256,
-	/// Merkle root of block's extrinsics
-	pub extrinsics_root: H256,
-	/// Digest items
-	pub digest: Digest,
-}
-
-impl traits::Header for Header {
-	type Number = u64;
-	type Hashing = BlakeTwo256;
-	type Hash = H256;
-
-	fn number(&self) -> &Self::Number { &self.number }
-	fn set_number(&mut self, num: Self::Number) { self.number = num }
-
-	fn extrinsics_root(&self) -> &Self::Hash { &self.extrinsics_root }
-	fn set_extrinsics_root(&mut self, root: Self::Hash) { self.extrinsics_root = root }
-
-	fn state_root(&self) -> &Self::Hash { &self.state_root }
-	fn set_state_root(&mut self, root: Self::Hash) { self.state_root = root }
-
-	fn parent_hash(&self) -> &Self::Hash { &self.parent_hash }
-	fn set_parent_hash(&mut self, hash: Self::Hash) { self.parent_hash = hash }
-
-	fn digest(&self) -> &Digest { &self.digest }
-	fn digest_mut(&mut self) -> &mut Digest { &mut self.digest }
-
-	fn new(
-		number: Self::Number,
-		extrinsics_root: Self::Hash,
-		state_root: Self::Hash,
-		parent_hash: Self::Hash,
-		digest: Digest,
-	) -> Self {
-		Header {
-			number,
-			extrinsics_root,
-			state_root,
-			parent_hash,
-			digest,
-		}
-	}
-}
+pub type Header = generic::Header<u64, BlakeTwo256>;
 
 impl Header {
 	/// A new header with the given number and default hash for all other fields.
 	pub fn new_from_number(number: <Self as traits::Header>::Number) -> Self {
 		Self {
 			number,
-			..Default::default()
+			extrinsics_root: Default::default(),
+			state_root: Default::default(),
+			parent_hash: Default::default(),
+			digest: Default::default(),
 		}
-	}
-}
-
-impl<'a> Deserialize<'a> for Header {
-	fn deserialize<D: Deserializer<'a>>(de: D) -> Result<Self, D::Error> {
-		let r = <Vec<u8>>::deserialize(de)?;
-		Decode::decode(&mut &r[..])
-			.map_err(|e| DeError::custom(format!("Invalid value passed into decode: {}", e.what())))
 	}
 }
 


### PR DESCRIPTION
We have a custom `Header` type for testing but it doesn't seem to have any difference compared to `generic::Header`. This PR replaces that type with an alias to `generic::Header`.