### PR TITLE
Remove polkadot companion detection from branch name 

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -87,15 +87,7 @@ then
     git checkout pr/${pr_companion}
     git merge origin/master
   else
-    pr_ref="$(grep -Po '"ref"\s*:\s*"\K(?!master)[^"]*' "${pr_data_file}")"
-    if git fetch origin "$pr_ref":branch/"$pr_ref" 2>/dev/null
-    then
-      boldprint "companion branch detected: $pr_ref"
-      git checkout branch/"$pr_ref"
-      git merge origin/master
-    else
-      boldprint "no companion branch found - building polkadot:master"
-    fi
+    boldprint "no companion branch found - building polkadot:master"
   fi
   rm -f "${pr_data_file}"
 else


### PR DESCRIPTION
Even though it was nice it was also error prone as there were no indication whatsoever on the PR
that a polkadot companion branch exists.