### PR TITLE
Make the encoded-Call Vec<u8> explicitly so in metadata

### DIFF
--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -61,6 +61,8 @@ mod tests;
 mod benchmarking;
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+/// Just a bunch of bytes, but they should decode to a valid `Call`.
+pub type OpaqueCall = Vec<u8>;
 
 /// Configuration trait.
 pub trait Trait: frame_system::Trait {
@@ -122,7 +124,7 @@ decl_storage! {
 			hasher(twox_64_concat) T::AccountId, hasher(blake2_128_concat) [u8; 32]
 			=> Option<Multisig<T::BlockNumber, BalanceOf<T>, T::AccountId>>;
 
-		pub Calls: map hasher(identity) [u8; 32] => Option<(Vec<u8>, T::AccountId, BalanceOf<T>)>;
+		pub Calls: map hasher(identity) [u8; 32] => Option<(OpaqueCall, T::AccountId, BalanceOf<T>)>;
 	}
 }
 
@@ -224,7 +226,7 @@ mod weight_of {
 }
 
 enum CallOrHash {
-	Call(Vec<u8>, bool),
+	Call(OpaqueCall, bool),
 	Hash([u8; 32]),
 }
 
@@ -357,7 +359,7 @@ decl_module! {
 			threshold: u16,
 			other_signatories: Vec<T::AccountId>,
 			maybe_timepoint: Option<Timepoint<T::BlockNumber>>,
-			call: Vec<u8>,
+			call: OpaqueCall,
 			store_call: bool,
 			max_weight: Weight,
 		) -> DispatchResultWithPostInfo {
@@ -630,9 +632,12 @@ impl<T: Trait> Module<T> {
 	/// We store `data` here because storing `call` would result in needing another `.encode`.
 	///
 	/// Returns a `bool` indicating whether the data did end up being stored.
-	fn store_call_and_reserve(who: T::AccountId, hash: &[u8; 32], data: Vec<u8>, other_deposit: BalanceOf<T>)
-		-> DispatchResult
-	{
+	fn store_call_and_reserve(
+		who: T::AccountId,
+		hash: &[u8; 32],
+		data: OpaqueCall,
+		other_deposit: BalanceOf<T>,
+	) -> DispatchResult {
 		ensure!(!Calls::<T>::contains_key(hash), Error::<T>::AlreadyStored);
 		let deposit = other_deposit + T::DepositBase::get()
 			+ T::DepositFactor::get() * BalanceOf::<T>::from(((data.len() + 31) / 32) as u32);


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate/issues/6544

cc @jacogr