### PR TITLE
 Remove polkadot companion detection from branch name 

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -69,7 +69,7 @@ To create a Polkadot companion PR:
 . Pull latest Polkadot master (or clone it, if you haven't yet).
 . Override your local cargo config to point to your local substrate (pointing to your WIP branch): place `paths = ["path/to/substrate"]` in `~/.cargo/config`.
 . Make the changes required and build polkadot locally.
-. Submit all this as a PR against the Polkadot Repo. Link to your Polkadot PR in the _description_ of your Substrate PR as "polkadot companion: [URL]" OR use the same name for your Polkdadot branch as the Substrate branch.
+. Submit all this as a PR against the Polkadot Repo. Link to your Polkadot PR in the _description_ of your Substrate PR as "polkadot companion: [URL]"
 . Now you should see that the `check_polkadot` CI job will build your Substrate PR agains the mentioned Polkadot branch in your PR description.
 . Wait for reviews on both
 . Once both PRs have been green lit, they can both be merged 🍻.


### PR DESCRIPTION
Even though it was nice it was also error prone as there were no indication whatsoever on the PR that a polkadot companion branch exists.