### PR TITLE
Add `WeightInfo` to all pallets with benchmarks.

### DIFF
--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -48,6 +48,7 @@ impl system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 impl Trait for Test {
 	type Event = ();

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -189,6 +189,8 @@ impl system::Trait for Runtime {
 	type OnKilledAccount = ();
 	/// The data to be stored in an account.
 	type AccountData = balances::AccountData<Balance>;
+	/// Weight information for the extrinsics of this pallet.
+	type SystemWeightInfo = ();
 }
 
 impl aura::Trait for Runtime {
@@ -221,6 +223,7 @@ impl timestamp::Trait for Runtime {
 	type Moment = u64;
 	type OnTimestampSet = Aura;
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -235,6 +238,7 @@ impl balances::Trait for Runtime {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -299,6 +299,7 @@ impl pallet_balances::Trait for Runtime {
 	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = frame_system::Module<Runtime>;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -177,6 +177,7 @@ impl frame_system::Trait for Runtime {
 impl pallet_utility::Trait for Runtime {
 	type Event = Event;
 	type Call = Call;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -194,6 +195,7 @@ impl pallet_multisig::Trait for Runtime {
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
 	type MaxSignatories = MaxSignatories;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -247,6 +249,7 @@ impl pallet_proxy::Trait for Runtime {
 	type ProxyDepositBase = ProxyDepositBase;
 	type ProxyDepositFactor = ProxyDepositFactor;
 	type MaxProxies = MaxProxies;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -260,6 +263,7 @@ impl pallet_scheduler::Trait for Runtime {
 	type Call = Call;
 	type MaximumWeight = MaximumSchedulerWeight;
 	type ScheduleOrigin = EnsureRoot<AccountId>;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -282,6 +286,7 @@ impl pallet_indices::Trait for Runtime {
 	type Currency = Balances;
 	type Deposit = IndexDeposit;
 	type Event = Event;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -320,6 +325,7 @@ impl pallet_timestamp::Trait for Runtime {
 	type Moment = Moment;
 	type OnTimestampSet = Babe;
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -356,6 +362,7 @@ impl pallet_session::Trait for Runtime {
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+	type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Runtime {
@@ -412,6 +419,7 @@ impl pallet_staking::Trait for Runtime {
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = StakingUnsignedPriority;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -460,6 +468,7 @@ impl pallet_democracy::Trait for Runtime {
 	type Scheduler = Scheduler;
 	type PalletsOrigin = OriginCaller;
 	type MaxVotes = MaxVotes;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -474,6 +483,7 @@ impl pallet_collective::Trait<CouncilCollective> for Runtime {
 	type Event = Event;
 	type MotionDuration = CouncilMotionDuration;
 	type MaxProposals = CouncilMaxProposals;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -505,6 +515,7 @@ impl pallet_elections_phragmen::Trait for Runtime {
 	type DesiredMembers = DesiredMembers;
 	type DesiredRunnersUp = DesiredRunnersUp;
 	type TermDuration = TermDuration;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -519,6 +530,7 @@ impl pallet_collective::Trait<TechnicalCollective> for Runtime {
 	type Event = Event;
 	type MotionDuration = TechnicalMotionDuration;
 	type MaxProposals = TechnicalMaxProposals;
+	type WeightInfo = ();
 }
 
 type EnsureRootOrHalfCouncil = EnsureOneOf<
@@ -573,6 +585,7 @@ impl pallet_treasury::Trait for Runtime {
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -674,6 +687,7 @@ impl pallet_im_online::Trait for Runtime {
 	type SessionDuration = SessionDuration;
 	type ReportUnresponsiveness = Offences;
 	type UnsignedPriority = ImOnlineUnsignedPriority;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -685,6 +699,7 @@ impl pallet_offences::Trait for Runtime {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
+	type WeightInfo = ();
 }
 
 impl pallet_authority_discovery::Trait for Runtime {}
@@ -743,6 +758,7 @@ impl pallet_identity::Trait for Runtime {
 	type Slashed = Treasury;
 	type ForceOrigin = EnsureRootOrHalfCouncil;
 	type RegistrarOrigin = EnsureRootOrHalfCouncil;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -799,6 +815,7 @@ impl pallet_vesting::Trait for Runtime {
 	type Currency = Balances;
 	type BlockNumberToBalance = ConvertInto;
 	type MinVestedTransfer = MinVestedTransfer;
+	type WeightInfo = ();
 }
 
 construct_runtime!(

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -171,6 +171,7 @@ impl frame_system::Trait for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl pallet_utility::Trait for Runtime {

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -328,6 +328,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	impl Trait for Test {
 		type Event = ();

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -54,6 +54,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
@@ -64,6 +65,7 @@ impl pallet_balances::Trait for Test {
 	type Event = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const ProofLimit: u32 = 1024;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -70,12 +70,14 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = Aura;
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -123,6 +123,7 @@ mod tests {
 		type ValidatorIdOf = ConvertInto;
 		type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 		type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+		type WeightInfo = ();
 	}
 
 	impl pallet_session::historical::Trait for Test {
@@ -167,6 +168,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	impl_outer_origin! {

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -442,6 +442,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	parameter_types! {

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -81,6 +81,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl_opaque_keys! {
@@ -99,12 +100,14 @@ impl pallet_session::Trait for Test {
 	type Keys = MockSessionKeys;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = Babe;
+	type WeightInfo = ();
 }
 
 impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = Babe;
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -157,6 +157,7 @@ impl pallet_balances::Trait for Test {
 	type Event = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 pallet_staking_reward_curve::build! {
@@ -216,6 +217,7 @@ impl pallet_staking::Trait for Test {
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -227,6 +229,7 @@ impl pallet_offences::Trait for Test {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -212,6 +212,7 @@ impl<T: Trait<I>, I: Instance> Subtrait<I> for T {
 	type Balance = T::Balance;
 	type ExistentialDeposit = T::ExistentialDeposit;
 	type AccountStore = T::AccountStore;
+	type WeightInfo = <T as Trait<I>>::WeightInfo;
 }
 
 decl_event!(
@@ -872,6 +873,7 @@ impl<T: Subtrait<I>, I: Instance> frame_system::Trait for ElevatedTrait<T, I> {
 	type OnNewAccount = T::OnNewAccount;
 	type OnKilledAccount = T::OnKilledAccount;
 	type AccountData = T::AccountData;
+	type SystemWeightInfo = T::SystemWeightInfo;
 }
 impl<T: Subtrait<I>, I: Instance> Trait<I> for ElevatedTrait<T, I> {
 	type Balance = T::Balance;
@@ -879,6 +881,7 @@ impl<T: Subtrait<I>, I: Instance> Trait<I> for ElevatedTrait<T, I> {
 	type DustRemoval = ();
 	type ExistentialDeposit = T::ExistentialDeposit;
 	type AccountStore = T::AccountStore;
+	type WeightInfo = <T as Subtrait<I>>::WeightInfo;
 }
 
 impl<T: Trait<I>, I: Instance> Currency<T::AccountId> for Module<T, I> where

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -160,6 +160,7 @@ use sp_std::{cmp, result, mem, fmt::Debug, ops::BitOr, convert::Infallible};
 use codec::{Codec, Encode, Decode};
 use frame_support::{
 	StorageValue, Parameter, decl_event, decl_storage, decl_module, decl_error, ensure,
+	weights::Weight,
 	traits::{
 		Currency, OnKilledAccount, OnUnbalanced, TryDrop, StoredMap,
 		WithdrawReason, WithdrawReasons, LockIdentifier, LockableCurrency, ExistenceRequirement,
@@ -178,6 +179,22 @@ use frame_system::{self as system, ensure_signed, ensure_root};
 
 pub use self::imbalances::{PositiveImbalance, NegativeImbalance};
 
+pub trait WeightInfo {
+	fn transfer(u: u32, e: u32, ) -> Weight;
+	fn transfer_best_case(u: u32, e: u32, ) -> Weight;
+	fn transfer_keep_alive(u: u32, e: u32, ) -> Weight;
+	fn set_balance(u: u32, e: u32, ) -> Weight;
+	fn set_balance_killing(u: u32, e: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn transfer(_u: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn transfer_best_case(_u: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn transfer_keep_alive(_u: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn set_balance(_u: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn set_balance_killing(_u: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Subtrait<I: Instance = DefaultInstance>: frame_system::Trait {
 	/// The balance of an account.
 	type Balance: Parameter + Member + AtLeast32BitUnsigned + Codec + Default + Copy +
@@ -188,6 +205,9 @@ pub trait Subtrait<I: Instance = DefaultInstance>: frame_system::Trait {
 
 	/// The means of storing the balances of an account.
 	type AccountStore: StoredMap<Self::AccountId, AccountData<Self::Balance>>;
+
+	/// Weight information for the extrinsics in this pallet.
+	type WeightInfo: WeightInfo;
 }
 
 pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait {
@@ -206,6 +226,9 @@ pub trait Trait<I: Instance = DefaultInstance>: frame_system::Trait {
 
 	/// The means of storing the balances of an account.
 	type AccountStore: StoredMap<Self::AccountId, AccountData<Self::Balance>>;
+
+	/// Weight information for extrinsics in this pallet.
+	type WeightInfo: WeightInfo;
 }
 
 impl<T: Trait<I>, I: Instance> Subtrait<I> for T {

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -91,6 +91,7 @@ impl frame_system::Trait for Test {
 	type AccountData = super::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -109,6 +109,7 @@ impl Trait for Test {
 	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = system::Module<Test>;
+	type WeightInfo = ();
 }
 
 pub struct ExtBuilder {

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -91,6 +91,7 @@ impl frame_system::Trait for Test {
 	type AccountData = super::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = Module<Test>;
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -114,6 +114,7 @@ impl Trait for Test {
 		system::CallKillAccount<Test>,
 		u64, super::AccountData<u64>
 	>;
+	type WeightInfo = ();
 }
 
 pub struct ExtBuilder {

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -100,6 +100,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -119,6 +119,7 @@ pub trait Trait<I: Instance=DefaultInstance>: frame_system::Trait {
 	/// Maximum number of proposals allowed to be active in parallel.
 	type MaxProposals: Get<u32>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -76,6 +76,30 @@ pub type MemberCount = u32;
 /// + This pallet assumes that dependents keep to the limit without enforcing it.
 pub const MAX_MEMBERS: MemberCount = 100;
 
+pub trait WeightInfo {
+	fn set_members(m: u32, n: u32, p: u32, ) -> Weight;
+	fn execute(m: u32, b: u32, ) -> Weight;
+	fn propose_execute(m: u32, b: u32, ) -> Weight;
+	fn propose_proposed(m: u32, p: u32, b: u32, ) -> Weight;
+	fn vote(m: u32, ) -> Weight;
+	fn close_early_disapproved(m: u32, p: u32, b: u32, ) -> Weight;
+	fn close_early_approved(m: u32, p: u32, b: u32, ) -> Weight;
+	fn close_disapproved(m: u32, p: u32, b: u32, ) -> Weight;
+	fn close_approved(m: u32, p: u32, b: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn set_members(_m: u32, _n: u32, _p: u32, ) -> Weight { 1_000_000_000 }
+	fn execute(_m: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn propose_execute(_m: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn propose_proposed(_m: u32, _p: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn vote(_m: u32, ) -> Weight { 1_000_000_000 }
+	fn close_early_disapproved(_m: u32, _p: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn close_early_approved(_m: u32, _p: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn close_disapproved(_m: u32, _p: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+	fn close_approved(_m: u32, _p: u32, _b: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait<I: Instance=DefaultInstance>: frame_system::Trait {
 	/// The outer origin type.
 	type Origin: From<RawOrigin<Self::AccountId, I>>;
@@ -94,6 +118,8 @@ pub trait Trait<I: Instance=DefaultInstance>: frame_system::Trait {
 
 	/// Maximum number of proposals allowed to be active in parallel.
 	type MaxProposals: Get<u32>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// Origin for the collective module.
@@ -1046,6 +1072,7 @@ mod tests {
 		type Event = Event;
 		type MotionDuration = MotionDuration;
 		type MaxProposals = MaxProposals;
+		type WeightInfo = ();
 	}
 	impl Trait for Test {
 		type Origin = Origin;
@@ -1053,6 +1080,7 @@ mod tests {
 		type Event = Event;
 		type MotionDuration = MotionDuration;
 		type MaxProposals = MaxProposals;
+		type WeightInfo = ();
 	}
 
 	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1065,6 +1065,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	impl Trait<Instance1> for Test {
 		type Origin = Origin;

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -132,6 +132,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 impl pallet_balances::Trait for Test {
 	type Balance = u64;
@@ -139,6 +140,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const MinimumPeriod: u64 = 1;
@@ -147,6 +149,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const SignedClaimHandicap: u64 = 2;

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -350,6 +350,7 @@ pub trait Trait: frame_system::Trait + Sized {
 	/// lead to extrinsic with very big weight: see `delegate` for instance.
 	type MaxVotes: Get<u32>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -201,6 +201,66 @@ type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trai
 type NegativeImbalanceOf<T> =
 	<<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;
 
+pub trait WeightInfo {
+	fn propose(p: u32, ) -> Weight;
+	fn second(s: u32, ) -> Weight;
+	fn vote_new(r: u32, ) -> Weight;
+	fn vote_existing(r: u32, ) -> Weight;
+	fn emergency_cancel(r: u32, ) -> Weight;
+	fn external_propose(p: u32, v: u32, ) -> Weight;
+	fn external_propose_majority(p: u32, ) -> Weight;
+	fn external_propose_default(p: u32, ) -> Weight;
+	fn fast_track(p: u32, ) -> Weight;
+	fn veto_external(v: u32, ) -> Weight;
+	fn cancel_referendum(r: u32, ) -> Weight;
+	fn cancel_queued(r: u32, ) -> Weight;
+	fn on_initialize_external(r: u32, ) -> Weight;
+	fn on_initialize_public(r: u32, ) -> Weight;
+	fn on_initialize_no_launch_no_maturing(r: u32, ) -> Weight;
+	fn delegate(r: u32, ) -> Weight;
+	fn undelegate(r: u32, ) -> Weight;
+	fn clear_public_proposals(p: u32, ) -> Weight;
+	fn note_preimage(b: u32, ) -> Weight;
+	fn note_imminent_preimage(b: u32, ) -> Weight;
+	fn reap_preimage(b: u32, ) -> Weight;
+	fn unlock_remove(r: u32, ) -> Weight;
+	fn unlock_set(r: u32, ) -> Weight;
+	fn remove_vote(r: u32, ) -> Weight;
+	fn remove_other_vote(r: u32, ) -> Weight;
+	fn enact_proposal_execute(b: u32, ) -> Weight;
+	fn enact_proposal_slash(b: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn propose(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn second(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn vote_new(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn vote_existing(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn emergency_cancel(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn external_propose(_p: u32, _v: u32, ) -> Weight { 1_000_000_000 }
+	fn external_propose_majority(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn external_propose_default(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn fast_track(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn veto_external(_v: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_referendum(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_queued(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize_external(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize_public(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize_no_launch_no_maturing(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn delegate(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn undelegate(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn clear_public_proposals(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn note_preimage(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn note_imminent_preimage(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn reap_preimage(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn unlock_remove(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn unlock_set(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_vote(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_other_vote(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn enact_proposal_execute(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn enact_proposal_slash(_b: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait + Sized {
 	type Proposal: Parameter + Dispatchable<Origin=Self::Origin> + From<Call<Self>>;
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -289,6 +349,8 @@ pub trait Trait: frame_system::Trait + Sized {
 	/// Also used to compute weight, an overly big value can
 	/// lead to extrinsic with very big weight: see `delegate` for instance.
 	type MaxVotes: Get<u32>;
+
+	type WeightInfo: WeightInfo;
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug)]

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -116,6 +116,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * MaximumBlockWeight::get();
@@ -127,6 +128,7 @@ impl pallet_scheduler::Trait for Test {
 	type Call = Call;
 	type MaximumWeight = MaximumSchedulerWeight;
 	type ScheduleOrigin = EnsureRoot<u64>;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -137,6 +137,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const LaunchPeriod: u64 = 2;
@@ -199,6 +200,7 @@ impl super::Trait for Test {
 	type MaxVotes = MaxVotes;
 	type OperationalPreimageOrigin = EnsureSignedBy<Six, u64>;
 	type PalletsOrigin = OriginCaller;
+	type WeightInfo = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1128,6 +1128,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	parameter_types! {

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -137,6 +137,38 @@ pub struct DefunctVoter<AccountId> {
 	pub candidate_count: u32
 }
 
+pub trait WeightInfo {
+	fn vote(u: u32, ) -> Weight;
+	fn vote_update(u: u32, ) -> Weight;
+	fn remove_voter(u: u32, ) -> Weight;
+	fn report_defunct_voter_correct(c: u32, v: u32, ) -> Weight;
+	fn report_defunct_voter_incorrect(c: u32, v: u32, ) -> Weight;
+	fn submit_candidacy(c: u32, ) -> Weight;
+	fn renounce_candidacy_candidate(c: u32, ) -> Weight;
+	fn renounce_candidacy_member_runner_up(u: u32, ) -> Weight;
+	fn remove_member_without_replacement(c: u32, ) -> Weight;
+	fn remove_member_with_replacement(u: u32, ) -> Weight;
+	fn remove_member_wrong_refund(u: u32, ) -> Weight;
+	fn on_initialize(c: u32, ) -> Weight;
+	fn phragmen(c: u32, v: u32, e: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn vote(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn vote_update(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_voter(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn report_defunct_voter_correct(_c: u32, _v: u32, ) -> Weight { 1_000_000_000 }
+	fn report_defunct_voter_incorrect(_c: u32, _v: u32, ) -> Weight { 1_000_000_000 }
+	fn submit_candidacy(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn renounce_candidacy_candidate(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn renounce_candidacy_member_runner_up(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_member_without_replacement(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_member_with_replacement(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_member_wrong_refund(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn phragmen(_c: u32, _v: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.c
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -184,6 +216,8 @@ pub trait Trait: frame_system::Trait {
 	/// round will happen. If set to zero, no elections are ever triggered and the module will
 	/// be in passive mode.
 	type TermDuration: Get<Self::BlockNumber>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {
@@ -1106,7 +1140,8 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = frame_system::Module<Test>;
-}
+		type WeightInfo = ();
+	}
 
 	parameter_types! {
 		pub const CandidacyBond: u64 = 3;
@@ -1214,6 +1249,7 @@ mod tests {
 		type LoserCandidate = ();
 		type KickedMember = ();
 		type BadReport = ();
+		type WeightInfo = ();
 	}
 
 	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -217,6 +217,7 @@ pub trait Trait: frame_system::Trait {
 	/// be in passive mode.
 	type TermDuration: Get<Self::BlockNumber>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -63,6 +63,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {
@@ -74,6 +75,7 @@ impl pallet_balances::Trait for Test {
 	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -128,7 +130,7 @@ impl ChangeMembers<u64> for TestChangeMembers {
 }
 
 parameter_types!{
-	pub const ElectionModuleId: LockIdentifier = *b"py/elect"; 
+	pub const ElectionModuleId: LockIdentifier = *b"py/elect";
 }
 
 impl elections::Trait for Test {

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -61,6 +61,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {
@@ -72,6 +73,7 @@ impl pallet_balances::Trait for Test {
 	type Event = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -81,6 +83,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 /// Fixed gas price of `0`.

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -78,6 +78,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 type Extrinsic = TestXt<Call<Test>, ()>;

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -768,6 +768,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 1;

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -779,6 +779,7 @@ mod tests {
 		type Event = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 	impl Trait for Test {
 		type Event = ();

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -582,6 +582,7 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 
 	parameter_types! {

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -569,6 +569,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<Balance>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	type Balance = u64;

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -277,6 +277,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	parameter_types! {
 		pub const WindowSize: u64 = 11;

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -1135,6 +1135,7 @@ impl<T: Subtrait> frame_system::Trait for ElevatedTrait<T> {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 impl<T: Subtrait> Trait for ElevatedTrait<T> {
 	type Balance = T::Balance;

--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -70,6 +70,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -118,6 +118,7 @@ impl frame_system::Trait for Test {
 	type AccountData = balances::AccountData<u128>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl<C> system::offchain::SendTransactionTypes<C> for Test

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -146,6 +146,7 @@ impl session::Trait for Test {
 	type SessionHandler = <TestSessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = TestSessionKeys;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
+	type WeightInfo = ();
 }
 
 impl session::historical::Trait for Test {
@@ -163,6 +164,7 @@ impl balances::Trait for Test {
 	type Event = TestEvent;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -173,6 +175,7 @@ impl timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 pallet_staking_reward_curve::build! {
@@ -232,6 +235,7 @@ impl staking::Trait for Test {
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -243,6 +247,7 @@ impl offences::Trait for Test {
 	type IdentificationTuple = session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -151,6 +151,7 @@ pub trait Trait: frame_system::Trait {
 	/// The origin which may add or remove registrars. Root can always do this.
 	type RegistrarOrigin: EnsureOrigin<Self::Origin>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -85,6 +85,34 @@ mod benchmarking;
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
 type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;
 
+pub trait WeightInfo {
+	fn add_registrar(r: u32, ) -> Weight;
+	fn set_identity(r: u32, x: u32, ) -> Weight;
+	fn set_subs(p: u32, s: u32, ) -> Weight;
+	fn clear_identity(r: u32, s: u32, x: u32, ) -> Weight;
+	fn request_judgement(r: u32, x: u32, ) -> Weight;
+	fn cancel_request(r: u32, x: u32, ) -> Weight;
+	fn set_fee(r: u32, ) -> Weight;
+	fn set_account_id(r: u32, ) -> Weight;
+	fn set_fields(r: u32, ) -> Weight;
+	fn provide_judgement(r: u32, x: u32, ) -> Weight;
+	fn kill_identity(r: u32, s: u32, x: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn add_registrar(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn set_identity(_r: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+	fn set_subs(_p: u32, _s: u32, ) -> Weight { 1_000_000_000 }
+	fn clear_identity(_r: u32, _s: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+	fn request_judgement(_r: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_request(_r: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+	fn set_fee(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn set_account_id(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn set_fields(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn provide_judgement(_r: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+	fn kill_identity(_r: u32, _s: u32, _x: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -122,6 +150,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// The origin which may add or remove registrars. Root can always do this.
 	type RegistrarOrigin: EnsureOrigin<Self::Origin>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// Either underlying data blob if it is at most 32 bytes, or a hash of it. If the data is greater
@@ -1208,6 +1238,7 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 	parameter_types! {
 		pub const BasicDeposit: u64 = 10;
@@ -1243,6 +1274,7 @@ mod tests {
 		type MaxRegistrars = MaxRegistrars;
 		type RegistrarOrigin = EnsureOneOrRoot;
 		type ForceOrigin = EnsureTwoOrRoot;
+		type WeightInfo = ();
 	}
 	type System = frame_system::Module<Test>;
 	type Balances = pallet_balances::Module<Test>;

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -1228,6 +1228,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 1;

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -226,6 +226,18 @@ pub struct Heartbeat<BlockNumber>
 	pub validators_len: u32,
 }
 
+pub trait WeightInfo {
+	fn heartbeat(k: u32, e: u32, ) -> Weight;
+	fn validate_unsigned(k: u32, e: u32, ) -> Weight;
+	fn validate_unsigned_and_then_heartbeat(k: u32, e: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn heartbeat(_k: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn validate_unsigned(_k: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+	fn validate_unsigned_and_then_heartbeat(_k: u32, _e: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: SendTransactionTypes<Call<Self>> + pallet_session::historical::Trait {
 	/// The identifier type for an authority.
 	type AuthorityId: Member + Parameter + RuntimeAppPublic + Default + Ord;
@@ -254,6 +266,8 @@ pub trait Trait: SendTransactionTypes<Call<Self>> + pallet_session::historical::
 	/// This is exposed so that it can be tuned for particular runtime, when
 	/// multiple pallets send unsigned transactions.
 	type UnsignedPriority: Get<TransactionPriority>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_event!(

--- a/frame/im-online/src/lib.rs
+++ b/frame/im-online/src/lib.rs
@@ -267,6 +267,7 @@ pub trait Trait: SendTransactionTypes<Call<Self>> + pallet_session::historical::
 	/// multiple pallets send unsigned transactions.
 	type UnsignedPriority: Get<TransactionPriority>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -177,6 +177,7 @@ impl Trait for Runtime {
 	type ReportUnresponsiveness = OffenceHandler;
 	type SessionDuration = Period;
 	type UnsignedPriority = UnsignedPriority;
+	type WeightInfo = ();
 }
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Runtime where

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -150,6 +150,7 @@ impl pallet_session::Trait for Runtime {
 	type Event = ();
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Runtime {

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -128,6 +128,7 @@ impl frame_system::Trait for Runtime {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -28,7 +28,7 @@ use sp_runtime::traits::{
 use frame_support::{Parameter, decl_module, decl_error, decl_event, decl_storage, ensure};
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{Currency, ReservableCurrency, Get, BalanceStatus::Reserved};
-use frame_support::weights::constants::WEIGHT_PER_MICROS;
+use frame_support::weights::{Weight, constants::WEIGHT_PER_MICROS};
 use frame_system::{ensure_signed, ensure_root};
 use self::address::Address as RawAddress;
 
@@ -39,6 +39,22 @@ mod benchmarking;
 
 pub type Address<T> = RawAddress<<T as frame_system::Trait>::AccountId, <T as Trait>::AccountIndex>;
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
+pub trait WeightInfo {
+	fn claim(i: u32, ) -> Weight;
+	fn transfer(i: u32, ) -> Weight;
+	fn free(i: u32, ) -> Weight;
+	fn force_transfer(i: u32, ) -> Weight;
+	fn freeze(i: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn claim(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn transfer(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn free(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn force_transfer(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn freeze(_i: u32, ) -> Weight { 1_000_000_000 }
+}
 
 /// The module's config trait.
 pub trait Trait: frame_system::Trait {
@@ -54,6 +70,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -71,6 +71,7 @@ pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -86,6 +86,7 @@ impl pallet_balances::Trait for Test {
 	type Event = MetaEvent;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -97,6 +98,7 @@ impl Trait for Test {
 	type Currency = Balances;
 	type Deposit = Deposit;
 	type Event = MetaEvent;
+	type WeightInfo = ();
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -74,6 +74,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -329,6 +329,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	ord_parameter_types! {
 		pub const One: u64 = 1;

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -118,6 +118,7 @@ pub trait Trait: frame_system::Trait {
 	/// The maximum amount of signatories allowed in the multisig.
 	type MaxSignatories: Get<u16>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -64,6 +64,32 @@ type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trai
 /// Just a bunch of bytes, but they should decode to a valid `Call`.
 pub type OpaqueCall = Vec<u8>;
 
+pub trait WeightInfo {
+	fn as_multi_threshold_1(z: u32, ) -> Weight;
+	fn as_multi_create(s: u32, z: u32, ) -> Weight;
+	fn as_multi_create_store(s: u32, z: u32, ) -> Weight;
+	fn as_multi_approve(s: u32, z: u32, ) -> Weight;
+	fn as_multi_complete(s: u32, z: u32, ) -> Weight;
+	fn approve_as_multi_create(s: u32, z: u32, ) -> Weight;
+	fn approve_as_multi_approve(s: u32, z: u32, ) -> Weight;
+	fn approve_as_multi_complete(s: u32, z: u32, ) -> Weight;
+	fn cancel_as_multi(s: u32, z: u32, ) -> Weight;
+	fn cancel_as_multi_store(s: u32, z: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn as_multi_threshold_1(_z: u32, ) -> Weight { 1_000_000_000 }
+	fn as_multi_create(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn as_multi_create_store(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn as_multi_approve(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn as_multi_complete(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn approve_as_multi_create(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn approve_as_multi_approve(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn approve_as_multi_complete(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_as_multi(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_as_multi_store(_s: u32, _z: u32, ) -> Weight { 1_000_000_000 }
+}
+
 /// Configuration trait.
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
@@ -91,6 +117,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// The maximum amount of signatories allowed in the multisig.
 	type MaxSignatories: Get<u16>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// A global extrinsic index, formed as the extrinsic index within a block, together with that

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -84,6 +84,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -94,6 +94,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const DepositBase: u64 = 1;
@@ -118,6 +119,7 @@ impl Trait for Test {
 	type DepositBase = DepositBase;
 	type DepositFactor = DepositFactor;
 	type MaxSignatories = MaxSignatories;
+	type WeightInfo = ();
 }
 type System = frame_system::Module<Test>;
 type Balances = pallet_balances::Module<Test>;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -301,6 +301,7 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 	parameter_types! {
 		pub const ReservationFee: u64 = 2;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -290,6 +290,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 1;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -66,6 +66,7 @@ impl frame_system::Trait for Test {
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
 	type MaximumExtrinsicWeight = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;
@@ -76,6 +77,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -85,6 +87,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 impl pallet_session::historical::Trait for Test {
 	type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
@@ -127,6 +130,7 @@ impl pallet_session::Trait for Test {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;
 	type DisabledValidatorsThreshold = ();
+	type WeightInfo = ();
 }
 pallet_staking_reward_curve::build! {
 	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
@@ -178,6 +182,7 @@ impl pallet_staking::Trait for Test {
 	type UnsignedPriority = ();
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();
+	type WeightInfo = ();
 }
 
 impl pallet_im_online::Trait for Test {
@@ -186,6 +191,7 @@ impl pallet_im_online::Trait for Test {
 	type SessionDuration = Period;
 	type ReportUnresponsiveness = Offences;
 	type UnsignedPriority = ();
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -197,6 +203,7 @@ impl pallet_offences::Trait for Test {
 	type IdentificationTuple = pallet_session::historical::IdentificationTuple<Self>;
 	type OnOffenceHandler = Staking;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
+	type WeightInfo = ();
 }
 
 impl<T> frame_system::offchain::SendTransactionTypes<T> for Test where Call: From<T> {

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -52,6 +52,20 @@ pub type DeferredOffenceOf<T> = (
 	SessionIndex,
 );
 
+pub trait WeightInfo {
+	fn report_offence_im_online(r: u32, o: u32, n: u32, ) -> Weight;
+	fn report_offence_grandpa(r: u32, n: u32, ) -> Weight;
+	fn report_offence_babe(r: u32, n: u32, ) -> Weight;
+	fn on_initialize(d: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn report_offence_im_online(_r: u32, _o: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+	fn report_offence_grandpa(_r: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+	fn report_offence_babe(_r: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize(_d: u32, ) -> Weight { 1_000_000_000 }
+}
+
 /// Offences trait
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
@@ -64,6 +78,8 @@ pub trait Trait: frame_system::Trait {
 	/// `on_initialize`.
 	/// Note it's going to be exceeded before we stop adding to it, so it has to be set conservatively.
 	type WeightSoftLimit: Get<Weight>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {

--- a/frame/offences/src/lib.rs
+++ b/frame/offences/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Trait: frame_system::Trait {
 	/// `on_initialize`.
 	/// Note it's going to be exceeded before we stop adding to it, so it has to be set conservatively.
 	type WeightSoftLimit: Get<Weight>;
-
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -120,6 +120,7 @@ impl frame_system::Trait for Runtime {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -131,6 +131,7 @@ impl Trait for Runtime {
 	type IdentificationTuple = u64;
 	type OnOffenceHandler = OnOffenceHandler;
 	type WeightSoftLimit = OffencesWeightSoftLimit;
+	type WeightInfo = ();
 }
 
 mod offences {

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -106,6 +106,7 @@ pub trait Trait: frame_system::Trait {
 	/// The maximum amount of proxies allowed for a single account.
 	type MaxProxies: Get<u16>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{
 	decl_module, decl_event, decl_error, decl_storage, Parameter, ensure, traits::{
 		Get, ReservableCurrency, Currency, InstanceFilter,
 		OriginTrait, IsType,
-	}, weights::{GetDispatchInfo, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
+	}, weights::{Weight, GetDispatchInfo, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
 	dispatch::{PostDispatchInfo, IsSubType},
 };
 use frame_system::{self as system, ensure_signed};
@@ -52,6 +52,24 @@ mod tests;
 mod benchmarking;
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
+pub trait WeightInfo {
+	fn proxy(p: u32, ) -> Weight;
+	fn add_proxy(p: u32, ) -> Weight;
+	fn remove_proxy(p: u32, ) -> Weight;
+	fn remove_proxies(p: u32, ) -> Weight;
+	fn anonymous(p: u32, ) -> Weight;
+	fn kill_anonymous(p: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn proxy(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn add_proxy(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_proxy(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn remove_proxies(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn anonymous(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn kill_anonymous(_p: u32, ) -> Weight { 1_000_000_000 }
+}
 
 /// Configuration trait.
 pub trait Trait: frame_system::Trait {
@@ -87,6 +105,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// The maximum amount of proxies allowed for a single account.
 	type MaxProxies: Get<u16>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -86,6 +86,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
@@ -96,6 +97,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 impl pallet_utility::Trait for Test {
 	type Event = TestEvent;
@@ -144,6 +146,7 @@ impl Trait for Test {
 	type ProxyDepositBase = ProxyDepositBase;
 	type ProxyDepositFactor = ProxyDepositFactor;
 	type MaxProxies = MaxProxies;
+	type WeightInfo = ();
 }
 
 type System = frame_system::Module<Test>;

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -102,6 +102,7 @@ impl pallet_balances::Trait for Test {
 impl pallet_utility::Trait for Test {
 	type Event = TestEvent;
 	type Call = Call;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const ProxyDepositBase: u64 = 1;

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -182,6 +182,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	type System = frame_system::Module<Test>;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -88,6 +88,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u128>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -101,6 +101,7 @@ impl pallet_balances::Trait for Test {
 	type Event = TestEvent;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -64,6 +64,22 @@ use frame_support::{
 };
 use frame_system::{self as system};
 
+pub trait WeightInfo {
+	fn schedule(s: u32, ) -> Weight;
+	fn cancel(s: u32, ) -> Weight;
+	fn schedule_named(s: u32, ) -> Weight;
+	fn cancel_named(s: u32, ) -> Weight;
+	fn on_initialize(s: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn schedule(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn schedule_named(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_named(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize(_s: u32, ) -> Weight { 1_000_000_000 }
+}
+
 /// Our pallet's configuration trait. All our types and constants go in here. If the
 /// pallet is dependent on specific other pallets, then their configuration traits
 /// should be added to our implied traits list.
@@ -89,6 +105,8 @@ pub trait Trait: system::Trait {
 
 	/// Required origin to schedule or cancel calls.
 	type ScheduleOrigin: EnsureOrigin<<Self as system::Trait>::Origin>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// Just a simple index for naming period tasks.
@@ -655,6 +673,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	impl logger::Trait for Test {
 		type Event = ();
@@ -673,6 +692,7 @@ mod tests {
 		type Call = Call;
 		type MaximumWeight = MaximumSchedulerWeight;
 		type ScheduleOrigin = EnsureOneOf<u64, EnsureRoot<u64>, EnsureSignedBy<One, u64>>;
+		type WeightInfo = ();
 	}
 	type System = system::Module<Test>;
 	type Logger = logger::Module<Test>;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -106,6 +106,7 @@ pub trait Trait: system::Trait {
 	/// Required origin to schedule or cancel calls.
 	type ScheduleOrigin: EnsureOrigin<<Self as system::Trait>::Origin>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -88,6 +88,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 thread_local! {

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -79,6 +79,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl pallet_balances::Trait for Test {

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -81,7 +81,8 @@ impl frame_system::Trait for Test {
 	type ModuleToIndex = ();
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
-	type OnKilledAccount = (Balances,);
+	type OnKilledAccount = Balances;
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;
@@ -92,6 +93,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 parameter_types! {
@@ -101,6 +103,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 impl pallet_session::historical::Trait for Test {
 	type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
@@ -138,6 +141,7 @@ impl pallet_session::Trait for Test {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;
 	type DisabledValidatorsThreshold = ();
+	type WeightInfo = ();
 }
 pallet_staking_reward_curve::build! {
 	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
@@ -185,6 +189,7 @@ impl pallet_staking::Trait for Test {
 	type UnsignedPriority = UnsignedPriority;
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();
+	type WeightInfo = ();
 }
 
 impl crate::Trait for Test {}

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -351,6 +351,16 @@ impl<T: Trait> ValidatorRegistration<T::ValidatorId> for Module<T> {
 	}
 }
 
+pub trait WeightInfo {
+	fn set_keys(n: u32, ) -> Weight;
+	fn purge_keys(n: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn set_keys(_n: u32, ) -> Weight { 1_000_000_000 }
+	fn purge_keys(_n: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
 	type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
@@ -385,6 +395,8 @@ pub trait Trait: frame_system::Trait {
 	/// After the threshold is reached `disabled` method starts to return true,
 	/// which in combination with `pallet_staking` forces a new era.
 	type DisabledValidatorsThreshold: Get<Perbill>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -396,6 +396,7 @@ pub trait Trait: frame_system::Trait {
 	/// which in combination with `pallet_staking` forces a new era.
 	type DisabledValidatorsThreshold: Get<Perbill>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -197,6 +197,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl pallet_timestamp::Trait for Test {
@@ -222,6 +223,7 @@ impl Trait for Test {
 	type Event = ();
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = ();
+	type WeightInfo = ();
 }
 
 #[cfg(feature = "historical")]

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -204,6 +204,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -89,6 +89,7 @@ impl frame_system::Trait for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type AccountData = pallet_balances::AccountData<u64>;
+	type SystemWeightInfo = ();
 }
 
 impl pallet_balances::Trait for Test {
@@ -97,6 +98,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 
 impl Trait for Test {

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -81,6 +81,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = (Balances,);
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;
@@ -91,12 +92,14 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 impl pallet_indices::Trait for Test {
 	type AccountIndex = AccountIndex;
 	type Event = ();
 	type Currency = Balances;
 	type Deposit = ();
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const MinimumPeriod: u64 = 5;
@@ -105,6 +108,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 impl pallet_session::historical::Trait for Test {
 	type FullIdentification = pallet_staking::Exposure<AccountId, Balance>;
@@ -142,6 +146,7 @@ impl pallet_session::Trait for Test {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;
 	type DisabledValidatorsThreshold = ();
+	type WeightInfo = ();
 }
 pallet_staking_reward_curve::build! {
 	const I_NPOS: sp_runtime::curve::PiecewiseLinear<'static> = curve!(
@@ -189,4 +194,5 @@ impl pallet_staking::Trait for Test {
 	type MinSolutionScoreBump = ();
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
+	type WeightInfo = ();
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -978,6 +978,7 @@ pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// multiple pallets send unsigned transactions.
 	type UnsignedPriority: Get<TransactionPriority>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -829,6 +829,68 @@ pub mod weight {
 	}
 }
 
+pub trait WeightInfo {
+	fn bond(u: u32, ) -> Weight;
+	fn bond_extra(u: u32, ) -> Weight;
+	fn unbond(u: u32, ) -> Weight;
+	fn withdraw_unbonded_update(s: u32, ) -> Weight;
+	fn withdraw_unbonded_kill(s: u32, ) -> Weight;
+	fn validate(u: u32, ) -> Weight;
+	fn nominate(n: u32, ) -> Weight;
+	fn chill(u: u32, ) -> Weight;
+	fn set_payee(u: u32, ) -> Weight;
+	fn set_controller(u: u32, ) -> Weight;
+	fn set_validator_count(c: u32, ) -> Weight;
+	fn force_no_eras(i: u32, ) -> Weight;
+	fn force_new_era(i: u32, ) -> Weight;
+	fn force_new_era_always(i: u32, ) -> Weight;
+	fn set_invulnerables(v: u32, ) -> Weight;
+	fn force_unstake(s: u32, ) -> Weight;
+	fn cancel_deferred_slash(s: u32, ) -> Weight;
+	fn payout_stakers(n: u32, ) -> Weight;
+	fn payout_stakers_alive_controller(n: u32, ) -> Weight;
+	fn rebond(l: u32, ) -> Weight;
+	fn set_history_depth(e: u32, ) -> Weight;
+	fn reap_stash(s: u32, ) -> Weight;
+	fn new_era(v: u32, n: u32, ) -> Weight;
+	fn do_slash(l: u32, ) -> Weight;
+	fn payout_all(v: u32, n: u32, ) -> Weight;
+	fn submit_solution_initial(v: u32, n: u32, a: u32, w: u32, ) -> Weight;
+	fn submit_solution_better(v: u32, n: u32, a: u32, w: u32, ) -> Weight;
+	fn submit_solution_weaker(v: u32, n: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn bond(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn bond_extra(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn unbond(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn withdraw_unbonded_update(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn withdraw_unbonded_kill(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn validate(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn nominate(_n: u32, ) -> Weight { 1_000_000_000 }
+	fn chill(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn set_payee(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn set_controller(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn set_validator_count(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn force_no_eras(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn force_new_era(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn force_new_era_always(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn set_invulnerables(_v: u32, ) -> Weight { 1_000_000_000 }
+	fn force_unstake(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn cancel_deferred_slash(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn payout_stakers(_n: u32, ) -> Weight { 1_000_000_000 }
+	fn payout_stakers_alive_controller(_n: u32, ) -> Weight { 1_000_000_000 }
+	fn rebond(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn set_history_depth(_e: u32, ) -> Weight { 1_000_000_000 }
+	fn reap_stash(_s: u32, ) -> Weight { 1_000_000_000 }
+	fn new_era(_v: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+	fn do_slash(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn payout_all(_v: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+	fn submit_solution_initial(_v: u32, _n: u32, _a: u32, _w: u32, ) -> Weight { 1_000_000_000 }
+	fn submit_solution_better(_v: u32, _n: u32, _a: u32, _w: u32, ) -> Weight { 1_000_000_000 }
+	fn submit_solution_weaker(_v: u32, _n: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// The staking balance.
 	type Currency: LockableCurrency<Self::AccountId, Moment=Self::BlockNumber>;
@@ -915,6 +977,8 @@ pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// This is exposed so that it can be tuned for particular runtime, when
 	/// multiple pallets send unsigned transactions.
 	type UnsignedPriority: Get<TransactionPriority>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// Mode of era-forcing.

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -274,6 +274,7 @@ impl pallet_timestamp::Trait for Test {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 pallet_staking_reward_curve::build! {
 	const I_NPOS: PiecewiseLinear<'static> = curve!(

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -224,6 +224,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 impl pallet_balances::Trait for Test {
 	type Balance = Balance;
@@ -231,6 +232,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const Offset: BlockNumber = 0;
@@ -252,6 +254,7 @@ impl pallet_session::Trait for Test {
 	type ValidatorIdOf = crate::StashOf<Test>;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type WeightInfo = ();
 }
 
 impl pallet_session::historical::Trait for Test {
@@ -326,6 +329,7 @@ impl Trait for Test {
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
+	type WeightInfo = ();
 }
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test where

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -145,6 +145,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 // Implement the logger module's `Trait` on the Test runtime.

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -85,6 +85,7 @@ impl system::Trait for Runtime {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl module::Trait for Runtime {

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -75,6 +75,7 @@ impl frame_system::Trait for Test {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl crate::Trait for Test {}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -158,6 +158,28 @@ pub fn extrinsics_data_root<H: Hash>(xts: Vec<Vec<u8>>) -> H::Output {
 	H::ordered_trie_root(xts)
 }
 
+pub trait WeightInfo {
+	fn remark(b: u32, ) -> Weight;
+	fn set_heap_pages(i: u32, ) -> Weight;
+	fn set_code_without_checks(b: u32, ) -> Weight;
+	fn set_changes_trie_config(d: u32, ) -> Weight;
+	fn set_storage(i: u32, ) -> Weight;
+	fn kill_storage(i: u32, ) -> Weight;
+	fn kill_prefix(p: u32, ) -> Weight;
+	fn suicide(n: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn remark(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn set_heap_pages(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn set_code_without_checks(_b: u32, ) -> Weight { 1_000_000_000 }
+	fn set_changes_trie_config(_d: u32, ) -> Weight { 1_000_000_000 }
+	fn set_storage(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn kill_storage(_i: u32, ) -> Weight { 1_000_000_000 }
+	fn kill_prefix(_p: u32, ) -> Weight { 1_000_000_000 }
+	fn suicide(_n: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: 'static + Eq + Clone {
 	/// The basic call filter to use in Origin. All origins are built with this filter as base,
 	/// except Root.
@@ -262,6 +284,8 @@ pub trait Trait: 'static + Eq + Clone {
 	///
 	/// All resources should be cleaned up associated with the given account.
 	type OnKilledAccount: OnKilledAccount<Self::AccountId>;
+
+	type SystemWeightInfo: WeightInfo;
 }
 
 pub type DigestOf<T> = generic::Digest<<T as Trait>::Hash>;

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -105,7 +105,7 @@ impl Trait for Test {
 	type AccountData = u32;
 	type OnNewAccount = ();
 	type OnKilledAccount = RecordKilled;
-	type WeightInfo = ();
+	type SystemWeightInfo = ();
 }
 
 pub type System = Module<Test>;

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -105,6 +105,7 @@ impl Trait for Test {
 	type AccountData = u32;
 	type OnNewAccount = ();
 	type OnKilledAccount = RecordKilled;
+	type WeightInfo = ();
 }
 
 pub type System = Module<Test>;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -115,6 +115,16 @@ use sp_timestamp::{
 	OnTimestampSet,
 };
 
+pub trait WeightInfo {
+	fn set(t: u32, ) -> Weight;
+	fn on_finalize(t: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn set(_t: u32, ) -> Weight { 1_000_000_000 }
+	fn on_finalize(_t: u32, ) -> Weight { 1_000_000_000 }
+}
+
 /// The module configuration trait
 pub trait Trait: frame_system::Trait {
 	/// Type used for expressing timestamp.
@@ -129,6 +139,8 @@ pub trait Trait: frame_system::Trait {
 	/// work with this to determine a sensible block time. e.g. For Aura, it will be double this
 	/// period on default settings.
 	type MinimumPeriod: Get<Self::Moment>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_module! {
@@ -338,6 +350,7 @@ mod tests {
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	parameter_types! {
 		pub const MinimumPeriod: u64 = 5;
@@ -346,6 +359,7 @@ mod tests {
 		type Moment = u64;
 		type OnTimestampSet = ();
 		type MinimumPeriod = MinimumPeriod;
+		type WeightInfo = ();
 	}
 	type Timestamp = Module<Test>;
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -140,6 +140,7 @@ pub trait Trait: frame_system::Trait {
 	/// period on default settings.
 	type MinimumPeriod: Get<Self::Moment>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -594,6 +594,7 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 	thread_local! {
 		static TRANSACTION_BYTE_FEE: RefCell<u64> = RefCell::new(1);

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -581,6 +581,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 
 	parameter_types! {

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -111,6 +111,30 @@ type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trai
 type PositiveImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::PositiveImbalance;
 type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;
 
+pub trait WeightInfo {
+	fn propose_spend(u: u32, ) -> Weight;
+	fn reject_proposal(u: u32, ) -> Weight;
+	fn approve_proposal(u: u32, ) -> Weight;
+	fn report_awesome(r: u32, ) -> Weight;
+	fn retract_tip(r: u32, ) -> Weight;
+	fn tip_new(r: u32, t: u32, ) -> Weight;
+	fn tip(t: u32, ) -> Weight;
+	fn close_tip(t: u32, ) -> Weight;
+	fn on_initialize(p: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn propose_spend(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn reject_proposal(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn approve_proposal(_u: u32, ) -> Weight { 1_000_000_000 }
+	fn report_awesome(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn retract_tip(_r: u32, ) -> Weight { 1_000_000_000 }
+	fn tip_new(_r: u32, _t: u32, ) -> Weight { 1_000_000_000 }
+	fn tip(_t: u32, ) -> Weight { 1_000_000_000 }
+	fn close_tip(_t: u32, ) -> Weight { 1_000_000_000 }
+	fn on_initialize(_p: u32, ) -> Weight { 1_000_000_000 }
+}
+
 pub trait Trait: frame_system::Trait {
 	/// The treasury's module id, used for deriving its sovereign account ID.
 	type ModuleId: Get<ModuleId>;
@@ -159,6 +183,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// Percentage of spare funds (if any) that are burnt per spend period.
 	type Burn: Get<Permill>;
+
+	type WeightInfo: WeightInfo;
 }
 
 /// An index of a proposal. Just a `u32`.

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -184,6 +184,7 @@ pub trait Trait: frame_system::Trait {
 	/// Percentage of spare funds (if any) that are burnt per spend period.
 	type Burn: Get<Permill>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -84,6 +84,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
@@ -94,6 +95,7 @@ impl pallet_balances::Trait for Test {
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 thread_local! {
 	static TEN_TO_FOURTEEN: RefCell<Vec<u64>> = RefCell::new(vec![10,11,12,13,14]);
@@ -147,6 +149,7 @@ impl Trait for Test {
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
 	type Burn = Burn;
+	type WeightInfo = ();
 }
 type System = frame_system::Module<Test>;
 type Balances = pallet_balances::Module<Test>;

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -90,6 +90,7 @@ pub trait Trait: frame_system::Trait {
 		+ GetDispatchInfo + From<frame_system::Call<Self>>
 		+ UnfilteredDispatchable<Origin=Self::Origin>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -70,6 +70,16 @@ use sp_runtime::{DispatchError, DispatchResult, traits::Dispatchable};
 mod tests;
 mod benchmarking;
 
+pub trait WeightInfo {
+	fn batch(c: u32, ) -> Weight;
+	fn as_derivative(u: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn batch(_c: u32, ) -> Weight { 1_000_000_000 }
+	fn as_derivative(_u: u32, ) -> Weight { 1_000_000_000 }
+}
+
 /// Configuration trait.
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
@@ -79,6 +89,8 @@ pub trait Trait: frame_system::Trait {
 	type Call: Parameter + Dispatchable<Origin=Self::Origin, PostInfo=PostDispatchInfo>
 		+ GetDispatchInfo + From<frame_system::Call<Self>>
 		+ UnfilteredDispatchable<Origin=Self::Origin>;
+
+	type WeightInfo: WeightInfo;
 }
 
 decl_storage! {

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -83,6 +83,7 @@ impl frame_system::Trait for Test {
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
@@ -93,6 +94,7 @@ impl pallet_balances::Trait for Test {
 	type Event = TestEvent;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
+	type WeightInfo = ();
 }
 parameter_types! {
 	pub const MultisigDepositBase: u64 = 1;
@@ -113,6 +115,7 @@ impl Filter<Call> for TestBaseCallFilter {
 impl Trait for Test {
 	type Event = TestEvent;
 	type Call = Call;
+	type WeightInfo = ();
 }
 type System = frame_system::Module<Test>;
 type Balances = pallet_balances::Module<Test>;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -93,6 +93,7 @@ pub trait Trait: frame_system::Trait {
 	/// The minimum amount transferred to call `vested_transfer`.
 	type MinVestedTransfer: Get<BalanceOf<Self>>;
 
+	/// Weight information for extrinsics in this pallet.
 	type WeightInfo: WeightInfo;
 }
 

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -53,16 +53,32 @@ use codec::{Encode, Decode};
 use sp_runtime::{DispatchResult, RuntimeDebug, traits::{
 	StaticLookup, Zero, AtLeast32BitUnsigned, MaybeSerializeDeserialize, Convert
 }};
-use frame_support::{decl_module, decl_event, decl_storage, decl_error, ensure};
+use frame_support::{decl_module, decl_event, decl_storage, decl_error, ensure, weights::Weight};
 use frame_support::traits::{
 	Currency, LockableCurrency, VestingSchedule, WithdrawReason, LockIdentifier,
-	ExistenceRequirement, Get
+	ExistenceRequirement, Get,
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
 
 mod benchmarking;
 
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
+pub trait WeightInfo {
+	fn vest_locked(l: u32, ) -> Weight;
+	fn vest_unlocked(l: u32, ) -> Weight;
+	fn vest_other_locked(l: u32, ) -> Weight;
+	fn vest_other_unlocked(l: u32, ) -> Weight;
+	fn vested_transfer(l: u32, ) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn vest_locked(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn vest_unlocked(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn vest_other_locked(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn vest_other_unlocked(_l: u32, ) -> Weight { 1_000_000_000 }
+	fn vested_transfer(_l: u32, ) -> Weight { 1_000_000_000 }
+}
 
 pub trait Trait: frame_system::Trait {
 	/// The overarching event type.
@@ -76,6 +92,8 @@ pub trait Trait: frame_system::Trait {
 
 	/// The minimum amount transferred to call `vested_transfer`.
 	type MinVestedTransfer: Get<BalanceOf<Self>>;
+
+	type WeightInfo: WeightInfo;
 }
 
 const VESTING_ID: LockIdentifier = *b"vesting ";
@@ -446,6 +464,7 @@ mod tests {
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
 	}
 	impl pallet_balances::Trait for Test {
 		type Balance = u64;
@@ -453,6 +472,7 @@ mod tests {
 		type Event = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
+		type WeightInfo = ();
 	}
 	parameter_types! {
 		pub const MinVestedTransfer: u64 = 256 * 2;
@@ -462,6 +482,7 @@ mod tests {
 		type Currency = Balances;
 		type BlockNumberToBalance = Identity;
 		type MinVestedTransfer = MinVestedTransfer;
+		type WeightInfo = ();
 	}
 	type System = frame_system::Module<Test>;
 	type Balances = pallet_balances::Module<Test>;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -449,6 +449,7 @@ impl pallet_timestamp::Trait for Runtime {
 	type Moment = u64;
 	type OnTimestampSet = ();
 	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -441,6 +441,7 @@ impl frame_system::Trait for Runtime {
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
 impl pallet_timestamp::Trait for Runtime {


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/1352

This introduces a custom type and trait `WeightInfo` that exists in each pallet with benchmarked extrinsics weight.

This `WeightInfo` trait defines the set of functions that need to exist to be able to weigh the extrinsics in the pallet.

This approach moves weight values out of the pallet, and into the runtime definition, allowing any custom blockchain to define custom weights for each pallet based on their specific runtime configuration.

This PR does not actually take advantage of this new `WeightInfo` trait/type, but that will be incrementally added to Substrate as we migrate from the existing weight system to the new one.

Note that Frame System uses the name `SystemWeightInfo` because all other pallets inherent the System trait, and if we didn't name it differently, we would run into a name conflict that would need to resolve with extra trait code.