### PR TITLE
pallet-swap-action: Change `BalanceSwapAction` signature

### DIFF
--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -71,7 +71,7 @@ parameter_types! {
 }
 impl Trait for Test {
 	type Event = ();
-	type SwapAction = BalanceSwapAction<Test, Balances>;
+	type SwapAction = BalanceSwapAction<u64, Balances>;
 	type ProofLimit = ProofLimit;
 }
 type System = frame_system::Module<Test>;


### PR DESCRIPTION
Instead of requiring `T: Trait` in `BalanceSwapAction`, we directly
depend on `AccountId`. This fixes a compilation error on wasm, where
`Runtime` does not implement `Debug`, but `BalanceSwapAction` required it.

