### PR TITLE
Ignore `Multiaddr`s with DNS protocol components.

### DIFF
--- a/client/authority-discovery/src/lib.rs
+++ b/client/authority-discovery/src/lib.rs
@@ -477,6 +477,15 @@ where
 
 				false // Multiaddr does not contain a PeerId.
 			}))
+			// Ignore DNS records (cf. https://github.com/paritytech/substrate/issues/5756).
+			.filter(|addr| !addr.iter().any(|protocol| {
+				match protocol {
+					| multiaddr::Protocol::Dns(_)
+					| multiaddr::Protocol::Dns4(_)
+					| multiaddr::Protocol::Dns6(_) => true,
+					_ => false
+				}
+			}))
 			.collect();
 
 		if !remote_addresses.is_empty() {

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -315,17 +315,11 @@ impl DiscoveryBehaviour {
 
 	/// Can the given `Multiaddr` be put into the DHT?
 	///
-	/// This test is successful only for global IP addresses and DNS names.
-	//
-	// NB: Currently all DNS names are allowed and no check for TLD suffixes is done
-	// because the set of valid domains is highly dynamic and would require frequent
-	// updates, for example by utilising publicsuffix.org or IANA.
-	pub fn can_add_to_dht(&self, addr: &Multiaddr) -> bool {
+	/// This test is successful only for global IP addresses.
+	fn can_add_to_dht(&self, addr: &Multiaddr) -> bool {
 		let ip = match addr.iter().next() {
 			Some(Protocol::Ip4(ip)) => IpNetwork::from(ip),
 			Some(Protocol::Ip6(ip)) => IpNetwork::from(ip),
-			Some(Protocol::Dns(_)) | Some(Protocol::Dns4(_)) | Some(Protocol::Dns6(_))
-				=> return true,
 			_ => return false
 		};
 		ip.is_global()


### PR DESCRIPTION
Issue #5756 recommends not resolving DNS names to prevent leaking DNS configuration. In order to achieve this the following modifications are applied:

- `Multiaddr` values received via libp2p-identify are ignored if they contain a DNS protocol component.
- In `Discovery` `Multiaddr` values with a DNS protocol component are not inserted into the DHT unless the command-line option `discover-local` is present which allows non-global IP addresses and DNS names in the DHT and is meant for site-local deployments.
- In `authority-discovery` we filter `Multiaddr` values received from the DHT and ignore those with a DNS protocol component.
