### PR TITLE
Upgrade `kvdb-*`, `trie-db` and `memory-db`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
  "log",
  "regalloc",
  "serde",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "target-lexicon",
  "thiserror",
 ]
@@ -823,7 +823,7 @@ checksum = "e45f82e3446dd1ebb8c2c2f6a6b0e6cd6cd52965c7e5f7b1b35e9a9ace31ccde"
 dependencies = [
  "cranelift-codegen",
  "log",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "target-lexicon",
 ]
 
@@ -1543,7 +1543,7 @@ dependencies = [
  "paste",
  "pretty_assertions",
  "serde",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1957,7 +1957,7 @@ dependencies = [
  "byteorder",
  "fallible-iterator",
  "indexmap",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "stable_deref_trait",
 ]
 
@@ -2611,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
 dependencies = [
  "parity-util-mem 0.6.0",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2621,7 +2621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem 0.7.0",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2661,7 +2661,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2761,7 +2761,7 @@ dependencies = [
  "parity-multiaddr 0.9.1",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2792,7 +2792,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2832,7 +2832,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2856,7 +2856,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2880,7 +2880,7 @@ dependencies = [
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "void",
  "wasm-timer",
 ]
@@ -2977,7 +2977,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "void",
  "wasm-timer",
 ]
@@ -3373,7 +3373,7 @@ dependencies = [
  "futures 0.3.5",
  "log",
  "pin-project",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
 ]
 
@@ -4787,7 +4787,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -5019,7 +5019,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "winapi 0.3.8",
 ]
 
@@ -5095,7 +5095,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "winapi 0.3.8",
 ]
 
@@ -5805,7 +5805,7 @@ checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
 dependencies = [
  "log",
  "rustc-hash",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -7423,9 +7423,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "snow"
@@ -8067,7 +8067,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pretty_assertions",
  "rand 0.7.3",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -9244,7 +9244,7 @@ dependencies = [
  "hashbrown 0.8.0",
  "log",
  "rustc-hex",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -9348,7 +9348,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,20 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.21.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63029dea45031f949a79ff15430f11112bfe86a980b657c165cd4043fb4d9203"
-dependencies = [
- "hash-db",
- "hashbrown 0.8.0",
- "parity-util-mem 0.7.0",
-]
-
-[[package]]
-name = "memory-db"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fbfa526b4b3bb77997c014e1161410c92c28c9bd811fd562be6e5f4c69fa77"
+checksum = "0777fbb396f666701d939e9b3876c18ada6b3581257d88631f2590bc366d8ebe"
 dependencies = [
  "hash-db",
  "hashbrown 0.8.0",
@@ -8148,7 +8137,7 @@ dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "hex-literal",
- "memory-db 0.22.0",
+ "memory-db",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
@@ -8458,7 +8447,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "log",
- "memory-db 0.22.0",
+ "memory-db",
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -9220,14 +9209,14 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trie-bench"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6aa610cca82513f55723cbb7156b89fbf8768b7931bb14d43edf2ae1dced7f"
+checksum = "24987a413863acfa081fb75051d0c2824cd4c450e2f0a7e03dca93ac989775fc"
 dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "keccak-hasher",
- "memory-db 0.21.2",
+ "memory-db",
  "parity-scale-codec",
  "trie-db",
  "trie-root",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,6 +3223,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-db"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fbfa526b4b3bb77997c014e1161410c92c28c9bd811fd562be6e5f4c69fa77"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.8.0",
+ "parity-util-mem 0.7.0",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8062,7 +8073,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-trie",
- "trie-db 0.22.0",
+ "trie-db",
  "trie-root",
 ]
 
@@ -8137,13 +8148,13 @@ dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "hex-literal",
- "memory-db",
+ "memory-db 0.22.0",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
  "sp-std",
  "trie-bench",
- "trie-db 0.22.0",
+ "trie-db",
  "trie-root",
  "trie-standardmap",
 ]
@@ -8447,7 +8458,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "log",
- "memory-db",
+ "memory-db 0.22.0",
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -8477,7 +8488,7 @@ dependencies = [
  "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
- "trie-db 0.22.0",
+ "trie-db",
 ]
 
 [[package]]
@@ -9209,31 +9220,18 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trie-bench"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8419971832eb3333dc26066e50943a20e0934efeb451b3df5ee94f7f7323ab"
+checksum = "8e6aa610cca82513f55723cbb7156b89fbf8768b7931bb14d43edf2ae1dced7f"
 dependencies = [
  "criterion 0.2.11",
  "hash-db",
  "keccak-hasher",
- "memory-db",
+ "memory-db 0.21.2",
  "parity-scale-codec",
- "trie-db 0.21.1",
+ "trie-db",
  "trie-root",
  "trie-standardmap",
-]
-
-[[package]]
-name = "trie-db"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabee036bb83228a99cf5dcc8e1f4766396103dc85265426fda6396b55e13f89"
-dependencies = [
- "hash-db",
- "hashbrown 0.8.0",
- "log",
- "rustc-hex",
- "smallvec 1.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1539,7 @@ dependencies = [
  "log",
  "once_cell",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "paste",
  "pretty_assertions",
  "serde",
@@ -2062,8 +2068,18 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 dependencies = [
- "ahash",
+ "ahash 0.2.18",
  "autocfg 0.1.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9b7860757ce258c89fd48d28b68c41713e597a7b09e793f6c6a6e2ea37c827"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -2594,7 +2610,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e763b2a9b500ba47948061d1e8bc3b5f03a8a1f067dbcf822a4d2c84d2b54a3a"
 dependencies = [
- "parity-util-mem",
+ "parity-util-mem 0.6.0",
+ "smallvec 1.4.0",
+]
+
+[[package]]
+name = "kvdb"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
+dependencies = [
+ "parity-util-mem 0.7.0",
  "smallvec 1.4.0",
 ]
 
@@ -2604,23 +2630,34 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73027d5e228de6f503b5b7335d530404fc26230a6ae3e09b33ec6e45408509a4"
 dependencies = [
- "kvdb",
- "parity-util-mem",
+ "kvdb 0.6.0",
+ "parity-util-mem 0.6.0",
+ "parking_lot 0.10.2",
+]
+
+[[package]]
+name = "kvdb-memorydb"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73de822b260a3bdfb889dbbb65bb2d473eee2253973d6fa4a5d149a2a4a7c66e"
+dependencies = [
+ "kvdb 0.7.0",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84384eca250c7ff67877eda5336f28a86586aaee24acb945643590671f6bfce1"
+checksum = "7c341ef15cfb1f923fa3b5138bfbd2d4813a2c1640b473727a53351c7f0b0fa2"
 dependencies = [
  "fs-swap",
- "kvdb",
+ "kvdb 0.7.0",
  "log",
  "num_cpus",
  "owning_ref",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
@@ -2629,16 +2666,16 @@ dependencies = [
 
 [[package]]
 name = "kvdb-web"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7f36acb1841d4c701d30ae1f2cfd242e805991443f75f6935479ed3de64903"
+checksum = "2701a1369d6ea4f1b9f606db46e5e2a4a8e47f22530a07823d653f85ab1f6c34"
 dependencies = [
  "futures 0.3.5",
  "js-sys",
- "kvdb",
- "kvdb-memorydb",
+ "kvdb 0.7.0",
+ "kvdb-memorydb 0.7.0",
  "log",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "send_wrapper 0.3.0",
  "wasm-bindgen",
  "web-sys",
@@ -3107,7 +3144,16 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.6.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297efb9401445cf7b6986a583d7ac194023334b46b294ff7da0d36662c1251c2"
+dependencies = [
+ "hashbrown 0.6.3",
 ]
 
 [[package]]
@@ -3167,14 +3213,13 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2999ff7a65d5a1d72172f6d51fa2ea03024b51aee709ba5ff81c3c629a2410"
+checksum = "63029dea45031f949a79ff15430f11112bfe86a980b657c165cd4043fb4d9203"
 dependencies = [
- "ahash",
  "hash-db",
- "hashbrown",
- "parity-util-mem",
+ "hashbrown 0.8.0",
+ "parity-util-mem 0.7.0",
 ]
 
 [[package]]
@@ -3394,7 +3439,7 @@ dependencies = [
  "futures 0.3.5",
  "hash-db",
  "hex",
- "kvdb",
+ "kvdb 0.7.0",
  "kvdb-rocksdb",
  "lazy_static",
  "log",
@@ -3402,7 +3447,7 @@ dependencies = [
  "node-runtime",
  "node-testing",
  "parity-db",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "rand 0.7.3",
  "sc-basic-authorship",
  "sc-cli",
@@ -4938,15 +4983,28 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e2583649a3ca84894d1d71da249abcfda54d5aca24733d72ca10d0f02361c"
+checksum = "6e42755f26e5ea21a6a819d9e63cbd70713e9867a2b767ec2cc65ca7659532c5"
+dependencies = [
+ "cfg-if",
+ "impl-trait-for-tuples",
+ "parity-util-mem-derive",
+ "parking_lot 0.10.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parity-util-mem"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297ff91fa36aec49ce183484b102f6b75b46776822bd81525bfc4cc9b0dd0f5c"
 dependencies = [
  "cfg-if",
  "ethereum-types",
- "hashbrown",
+ "hashbrown 0.8.0",
  "impl-trait-for-tuples",
- "lru",
+ "lru 0.5.2",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
@@ -6082,7 +6140,7 @@ dependencies = [
  "log",
  "names",
  "nix",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -6117,8 +6175,8 @@ dependencies = [
  "futures 0.3.5",
  "hash-db",
  "hex-literal",
- "kvdb",
- "kvdb-memorydb",
+ "kvdb 0.7.0",
+ "kvdb-memorydb 0.6.0",
  "lazy_static",
  "log",
  "parity-scale-codec",
@@ -6153,14 +6211,14 @@ dependencies = [
  "blake2-rfc",
  "env_logger 0.7.1",
  "hash-db",
- "kvdb",
- "kvdb-memorydb",
+ "kvdb 0.7.0",
+ "kvdb-memorydb 0.7.0",
  "kvdb-rocksdb",
  "linked-hash-map",
  "log",
  "parity-db",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "quickcheck",
  "sc-client-api",
@@ -6563,7 +6621,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
  "log",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "sc-client-api",
  "sc-network",
@@ -6632,7 +6690,7 @@ dependencies = [
  "linked-hash-map",
  "linked_hash_set",
  "log",
- "lru",
+ "lru 0.4.3",
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -6677,7 +6735,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "lru",
+ "lru 0.4.3",
  "quickcheck",
  "rand 0.7.3",
  "sc-network",
@@ -6873,7 +6931,7 @@ dependencies = [
  "netstat2",
  "parity-multiaddr 0.7.3",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "pin-project",
  "procfs",
@@ -6965,7 +7023,7 @@ dependencies = [
  "env_logger 0.7.1",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "sc-client-api",
@@ -7020,7 +7078,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "serde",
  "sp-blockchain",
@@ -7044,7 +7102,7 @@ dependencies = [
  "intervalier",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "sc-block-builder",
  "sc-client-api",
@@ -7547,7 +7605,7 @@ version = "2.0.0-rc4"
 dependencies = [
  "derive_more",
  "log",
- "lru",
+ "lru 0.4.3",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "sp-block-builder",
@@ -7671,7 +7729,7 @@ dependencies = [
  "merlin",
  "num-traits 0.2.11",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "pretty_assertions",
  "primitive-types",
@@ -7701,7 +7759,7 @@ dependencies = [
 name = "sp-database"
 version = "2.0.0-rc4"
 dependencies = [
- "kvdb",
+ "kvdb 0.7.0",
  "parking_lot 0.10.2",
 ]
 
@@ -7860,7 +7918,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "paste",
  "rand 0.7.3",
  "serde",
@@ -8028,7 +8086,7 @@ name = "sp-test-primitives"
 version = "2.0.0-rc4"
 dependencies = [
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -8393,7 +8451,7 @@ dependencies = [
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-util-mem",
+ "parity-util-mem 0.7.0",
  "sc-block-builder",
  "sc-executor",
  "sc-service",
@@ -9167,12 +9225,12 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb230c24c741993b04cfccbabb45acff6f6480c5f00d3ed8794ea43db3a9d727"
+checksum = "aabee036bb83228a99cf5dcc8e1f4766396103dc85265426fda6396b55e13f89"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.8.0",
  "log",
  "rustc-hex",
  "smallvec 1.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297efb9401445cf7b6986a583d7ac194023334b46b294ff7da0d36662c1251c2"
+checksum = "35c456c123957de3a220cd03786e0d86aa542a88b46029973b542f426da6ef34"
 dependencies = [
  "hashbrown 0.6.3",
 ]
@@ -5004,7 +5004,7 @@ dependencies = [
  "ethereum-types",
  "hashbrown 0.8.0",
  "impl-trait-for-tuples",
- "lru 0.5.2",
+ "lru 0.5.3",
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
@@ -8062,7 +8062,7 @@ dependencies = [
  "sp-panic-handler",
  "sp-runtime",
  "sp-trie",
- "trie-db",
+ "trie-db 0.22.0",
  "trie-root",
 ]
 
@@ -8143,7 +8143,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "trie-bench",
- "trie-db",
+ "trie-db 0.22.0",
  "trie-root",
  "trie-standardmap",
 ]
@@ -8477,7 +8477,7 @@ dependencies = [
  "sp-version",
  "substrate-test-runtime-client",
  "substrate-wasm-builder-runner",
- "trie-db",
+ "trie-db 0.22.0",
 ]
 
 [[package]]
@@ -9218,7 +9218,7 @@ dependencies = [
  "keccak-hasher",
  "memory-db",
  "parity-scale-codec",
- "trie-db",
+ "trie-db 0.21.1",
  "trie-root",
  "trie-standardmap",
 ]
@@ -9228,6 +9228,19 @@ name = "trie-db"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabee036bb83228a99cf5dcc8e1f4766396103dc85265426fda6396b55e13f89"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.8.0",
+ "log",
+ "rustc-hex",
+ "smallvec 1.4.0",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f1a9a9252d38c5337cf0c5392988821a5cf1b2103245016968f2ab41de9e38"
 dependencies = [
  "hash-db",
  "hashbrown 0.8.0",

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -21,8 +21,8 @@ serde = "1.0.101"
 serde_json = "1.0.41"
 structopt = "0.3"
 derive_more = "0.99.2"
-kvdb = "0.6"
-kvdb-rocksdb = "0.8"
+kvdb = "0.7"
+kvdb-rocksdb = "0.9"
 sp-trie = { version = "2.0.0-rc4", path = "../../../primitives/trie" }
 sp-core = { version = "2.0.0-rc4", path = "../../../primitives/core" }
 sp-consensus = { version = "0.8.0-rc4", path = "../../../primitives/consensus/common" }
@@ -37,6 +37,6 @@ fs_extra = "1"
 hex = "0.4.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 lazy_static = "1.4.0"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 parity-db = { version = "0.1.2" }
 futures = "0.3.1"

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -25,7 +25,7 @@ sp-blockchain = { version = "2.0.0-rc4", path = "../../primitives/blockchain" }
 hex-literal = { version = "0.2.1" }
 sp-inherents = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-rc4", path = "../../primitives/keyring" }
-kvdb = "0.6.0"
+kvdb = "0.7.0"
 log = { version = "0.4.8" }
 parking_lot = "0.10.0"
 lazy_static =  "1.4.0"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -42,7 +42,7 @@ names = "0.11.0"
 structopt = "0.3.8"
 sc-tracing = { version = "2.0.0-rc4", path = "../tracing" }
 chrono = "0.4.10"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 serde = "1.0.111"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -14,12 +14,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parking_lot = "0.10.0"
 log = "0.4.8"
-kvdb = "0.6.0"
-kvdb-rocksdb = { version = "0.8", optional = true }
-kvdb-memorydb = "0.6.0"
+kvdb = "0.7.0"
+kvdb-rocksdb = { version = "0.9", optional = true }
+kvdb-memorydb = "0.7.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["std"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "1.3.1", features = ["derive"] }
 blake2-rfc = "0.2.18"
 
@@ -41,7 +41,7 @@ sp-keyring = { version = "2.0.0-rc4", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-rc4", path = "../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 quickcheck = "0.9"
-kvdb-rocksdb = "0.8"
+kvdb-rocksdb = "0.9"
 tempfile = "3"
 
 [features]

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 ansi_term = "0.12.1"
 futures = "0.3.4"
 log = "0.4.8"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 wasm-timer = "0.2"
 sc-client-api = { version = "2.0.0-rc4", path = "../api" }
 sc-network = { version = "0.8.0-rc4", path = "../network" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -74,7 +74,7 @@ parity-multiaddr = { package = "parity-multiaddr", version = "0.7.3" }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus" , version = "0.8.0-rc4"}
 sc-tracing = { version = "2.0.0-rc4", path = "../tracing" }
 tracing = "0.1.10"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 
 
 [target.'cfg(all(any(unix, windows), not(target_os = "android")))'.dependencies]

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.8"
 sc-client-api = { version = "2.0.0-rc4", path = "../api" }
 sp-core = { version = "2.0.0-rc4", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "1.3.1", features = ["derive"] }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 parity-util-mem-derive = "0.1.0"
 
 [dev-dependencies]

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -18,7 +18,7 @@ futures = { version = "0.3.1", features = ["compat"] }
 futures-diagnose = "1.0"
 intervalier = "0.4.0"
 log = "0.4.8"
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 parking_lot = "0.10.0"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0-rc4"}
 sc-client-api = { version = "2.0.0-rc4", path = "../api" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -23,7 +23,7 @@ sp-utils = { version = "2.0.0-rc4", path = "../../../primitives/utils" }
 sp-core = { version = "2.0.0-rc4", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0-rc4", path = "../../../primitives/runtime" }
 sp-transaction-pool = { version = "2.0.0-rc4", path = "../../../primitives/transaction-pool" }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 linked-hash-map = "0.5.2"
 
 [dev-dependencies]

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = { version = "1", default-features = false, optional = true }
 sp-state-machine = { version = "0.8.0-rc4", optional = true, path = "../../primitives/state-machine" }
 bitmask = { version = "0.5.0", default-features = false }
 impl-trait-for-tuples = "0.1.3"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -34,7 +34,7 @@ smallvec = "1.4.0"
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 frame-system = { version = "2.0.0-rc4", path = "../system" }
-parity-util-mem = { version = "0.6.1", features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", features = ["primitive-types"] }
 
 [features]
 default = ["std"]

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { version = "2.0.0-rc4", default-features = false, path = "../../pr
 frame-support = { version = "2.0.0-rc4", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc4", default-features = false, path = "../system" }
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-rc4", default-features = false, path = "./rpc/runtime-api" }
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 
 [dev-dependencies]
 sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot = { version = "0.10.0", optional = true }
 sp-debug-derive = { version = "2.0.0-rc4", path = "../debug-derive" }
 sp-externalities = { version = "0.8.0-rc4", optional = true, path = "../externalities" }
 sp-storage = { version = "2.0.0-rc4", default-features = false, path = "../storage" }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 futures = { version = "0.3.1", optional = true }
 
 # full crypto

--- a/primitives/database/Cargo.toml
+++ b/primitives/database/Cargo.toml
@@ -11,4 +11,4 @@ documentation = "https://docs.rs/sp-database"
 
 [dependencies]
 parking_lot = "0.10.0"
-kvdb = "0.6.0"
+kvdb = "0.7.0"

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -26,7 +26,7 @@ paste = "0.1.6"
 rand = { version = "0.7.2", optional = true }
 impl-trait-for-tuples = "0.1.3"
 sp-inherents = { version = "2.0.0-rc4", default-features = false, path = "../inherents" }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 either = { version = "1.5", default-features = false }
 

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2.8"
 rand = "0.7.2"
 sp-externalities = { version = "0.8.0-rc4", path = "../externalities" }
 itertools = "0.9"
-smallvec = "1.4"
+smallvec = "1.4.1"
 
 [dev-dependencies]
 hex-literal = "0.2.1"

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.8"
 parking_lot = "0.10.0"
 hash-db = "0.15.2"
-trie-db = "0.21.0"
+trie-db = "0.21.1"
 trie-root = "0.16.0"
 sp-trie = { version = "2.0.0-rc4", path = "../trie" }
 sp-core = { version = "2.0.0-rc4", path = "../core" }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.8"
 parking_lot = "0.10.0"
 hash-db = "0.15.2"
-trie-db = "0.21.1"
+trie-db = "0.22.0"
 trie-root = "0.16.0"
 sp-trie = { version = "2.0.0-rc4", path = "../trie" }
 sp-core = { version = "2.0.0-rc4", path = "../core" }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-runtime = { version = "2.0.0-rc4", default-features = false, path = "../runtime" }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 
 [features]
 default = [

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -26,7 +26,7 @@ memory-db = { version = "0.22.0", default-features = false }
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }
 
 [dev-dependencies]
-trie-bench = "0.22.0"
+trie-bench = "0.23.0"
 trie-standardmap = "0.15.2"
 criterion = "0.2.11"
 hex-literal = "0.2.1"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -22,7 +22,7 @@ sp-std = { version = "2.0.0-rc4", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.0", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
-memory-db = { version = "0.21.2", default-features = false }
+memory-db = { version = "0.22.0", default-features = false }
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }
 
 [dev-dependencies]

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -22,11 +22,11 @@ sp-std = { version = "2.0.0-rc4", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.22.0", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
-memory-db = { version = "0.22.0", default-features = false }
+memory-db = { version = "0.24.0", default-features = false }
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }
 
 [dev-dependencies]
-trie-bench = "0.23.0"
+trie-bench = "0.24.0"
 trie-standardmap = "0.15.2"
 criterion = "0.2.11"
 hex-literal = "0.2.1"

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.21.1", default-features = false }
+trie-db = { version = "0.22.0", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 memory-db = { version = "0.21.2", default-features = false }
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -20,9 +20,9 @@ harness = false
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.21.0", default-features = false }
+trie-db = { version = "0.21.1", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
-memory-db = { version = "0.21.0", default-features = false }
+memory-db = { version = "0.21.2", default-features = false }
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../core" }
 
 [dev-dependencies]

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 frame-executive = { version = "2.0.0-rc4", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-rc4", optional = true, path = "../../primitives/keyring" }
-memory-db = { version = "0.22.0", default-features = false }
+memory-db = { version = "0.24.0", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-rc4"}
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/std" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -39,7 +39,7 @@ pallet-timestamp = { version = "2.0.0-rc4", default-features = false, path = "..
 sp-finality-grandpa = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-trie = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.21.1", default-features = false }
+trie-db = { version = "0.22.0", default-features = false }
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.8.0-rc4", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 frame-executive = { version = "2.0.0-rc4", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-rc4", optional = true, path = "../../primitives/keyring" }
-memory-db = { version = "0.21.2", default-features = false }
+memory-db = { version = "0.22.0", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-rc4"}
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/std" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -21,7 +21,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 frame-executive = { version = "2.0.0-rc4", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "2.0.0-rc4", optional = true, path = "../../primitives/keyring" }
-memory-db = { version = "0.21.0", default-features = false }
+memory-db = { version = "0.21.2", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "2.0.0-rc4"}
 sp-core = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/std" }
@@ -39,8 +39,8 @@ pallet-timestamp = { version = "2.0.0-rc4", default-features = false, path = "..
 sp-finality-grandpa = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-trie = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.21.0", default-features = false }
-parity-util-mem = { version = "0.6.1", default-features = false, features = ["primitive-types"] }
+trie-db = { version = "0.21.1", default-features = false }
+parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.8.0-rc4", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 
 # 3rd party

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -21,7 +21,7 @@ console_log = "0.1.2"
 js-sys = "0.3.34"
 wasm-bindgen = "0.2.57"
 wasm-bindgen-futures = "0.4.7"
-kvdb-web = "0.6"
+kvdb-web = "0.7"
 sp-database = { version = "2.0.0-rc4", path = "../../primitives/database" }
 sc-informant = { version = "0.8.0-rc4", path = "../../client/informant" }
 sc-service = { version = "0.8.0-rc4", path = "../../client/service", default-features = false }


### PR DESCRIPTION
The updates of `trie-db` and `memory-db` are important, as they fix the
non-deterministic build of Polkadot/Substrate.

polkadot-companion: https://github.com/paritytech/polkadot/pull/1373
