### PR TITLE
 Improved send_transaction helper to return an error in case of error 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7231,9 +7231,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -8371,6 +8371,8 @@ dependencies = [
  "sc-executor",
  "sc-light",
  "sc-service",
+ "serde",
+ "serde_json",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -12,20 +12,22 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-client-api = { version = "2.0.0-rc4", path = "../../client/api" }
-sc-light = { version = "2.0.0-rc4", path = "../../client/light" }
-sc-client-db = { version = "0.8.0-rc4", features = ["test-helpers"], path = "../../client/db" }
-sp-consensus = { version = "0.8.0-rc4", path = "../../primitives/consensus/common" }
-sc-executor = { version = "0.8.0-rc4", path = "../../client/executor" }
-sc-consensus = { version = "0.8.0-rc4", path = "../../client/consensus/common" }
-sc-service = { version = "0.8.0-rc4", default-features = false, features = ["test-helpers"],  path = "../../client/service" }
+codec = { package = "parity-scale-codec", version = "1.3.1" }
 futures = "0.3.4"
 futures01 = { package = "futures", version = "0.1.29" }
 hash-db = "0.15.2"
 hex = "0.4"
-sp-keyring = { version = "2.0.0-rc4", path = "../../primitives/keyring" }
-codec = { package = "parity-scale-codec", version = "1.3.1" }
-sp-core = { version = "2.0.0-rc4", path = "../../primitives/core" }
-sp-runtime = { version = "2.0.0-rc4", path = "../../primitives/runtime" }
+serde = "1.0.56"
+serde_json = "1.0.56"
+sc-client-api = { version = "2.0.0-rc4", path = "../../client/api" }
+sc-client-db = { version = "0.8.0-rc4", features = ["test-helpers"], path = "../../client/db" }
+sc-consensus = { version = "0.8.0-rc4", path = "../../client/consensus/common" }
+sc-executor = { version = "0.8.0-rc4", path = "../../client/executor" }
+sc-light = { version = "2.0.0-rc4", path = "../../client/light" }
+sc-service = { version = "0.8.0-rc4", default-features = false, features = ["test-helpers"],  path = "../../client/service" }
 sp-blockchain = { version = "2.0.0-rc4", path = "../../primitives/blockchain" }
+sp-consensus = { version = "0.8.0-rc4", path = "../../primitives/consensus/common" }
+sp-core = { version = "2.0.0-rc4", path = "../../primitives/core" }
+sp-keyring = { version = "2.0.0-rc4", path = "../../primitives/keyring" }
+sp-runtime = { version = "2.0.0-rc4", path = "../../primitives/runtime" }
 sp-state-machine = { version = "0.8.0-rc4", path = "../../primitives/state-machine" }

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -17,8 +17,8 @@ futures = "0.3.4"
 futures01 = { package = "futures", version = "0.1.29" }
 hash-db = "0.15.2"
 hex = "0.4"
-serde = "1.0.56"
-serde_json = "1.0.56"
+serde = "1.0.55"
+serde_json = "1.0.55"
 sc-client-api = { version = "2.0.0-rc4", path = "../../client/api" }
 sc-client-db = { version = "0.8.0-rc4", features = ["test-helpers"], path = "../../client/db" }
 sc-consensus = { version = "0.8.0-rc4", path = "../../client/consensus/common" }


### PR DESCRIPTION
Follow up of #6555 

As suggested by @bkchr, it would have been nice to have:
1. [x] a Result for when the `send_transaction()` call failed
2. [x] a nice documented struct that describes what are the return values