### PR TITLE
Send Status message on all newly-opened legacy substreams

### DIFF
--- a/client/network/src/protocol/generic_proto/tests.rs
+++ b/client/network/src/protocol/generic_proto/tests.rs
@@ -83,7 +83,7 @@ fn build_nodes() -> (Swarm<CustomProtoWithAddr>, Swarm<CustomProtoWithAddr>) {
 		});
 
 		let behaviour = CustomProtoWithAddr {
-			inner: GenericProto::new(local_peer_id, &b"test"[..], &[1], peerset, None),
+			inner: GenericProto::new(local_peer_id, &b"test"[..], &[1], vec![], peerset, None),
 			addrs: addrs
 				.iter()
 				.enumerate()

--- a/client/network/src/protocol/generic_proto/tests.rs
+++ b/client/network/src/protocol/generic_proto/tests.rs
@@ -241,6 +241,8 @@ fn two_nodes_transfer_lots_of_packets() {
 						);
 					}
 				},
+				// An empty handshake is being sent after opening.
+				Some(GenericProtoOut::LegacyMessage { message, .. }) if message.is_empty() => {},
 				_ => panic!(),
 			}
 		}
@@ -251,6 +253,8 @@ fn two_nodes_transfer_lots_of_packets() {
 		loop {
 			match ready!(service2.poll_next_unpin(cx)) {
 				Some(GenericProtoOut::CustomProtocolOpen { .. }) => {},
+				// An empty handshake is being sent after opening.
+				Some(GenericProtoOut::LegacyMessage { message, .. }) if message.is_empty() => {},
 				Some(GenericProtoOut::LegacyMessage { message, .. }) => {
 					match Message::<Block>::decode(&mut &message[..]).unwrap() {
 						Message::<Block>::BlockResponse(BlockResponse { id: _, blocks }) => {
@@ -312,6 +316,8 @@ fn basic_two_nodes_requests_in_parallel() {
 						service1.send_packet(&peer_id, msg.encode());
 					}
 				},
+				// An empty handshake is being sent after opening.
+				Some(GenericProtoOut::LegacyMessage { message, .. }) if message.is_empty() => {},
 				_ => panic!(),
 			}
 		}
@@ -321,6 +327,8 @@ fn basic_two_nodes_requests_in_parallel() {
 		loop {
 			match ready!(service2.poll_next_unpin(cx)) {
 				Some(GenericProtoOut::CustomProtocolOpen { .. }) => {},
+				// An empty handshake is being sent after opening.
+				Some(GenericProtoOut::LegacyMessage { message, .. }) if message.is_empty() => {},
 				Some(GenericProtoOut::LegacyMessage { message, .. }) => {
 					let pos = to_receive.iter().position(|m| m.encode() == message).unwrap();
 					to_receive.remove(pos);


### PR DESCRIPTION
Changes extracted from https://github.com/paritytech/substrate/pull/5938

Let's summarize the situation again:

- When more than one legacy substreams is open, we only send the `Status` message on the first one, and only expect one `Status` message to be sent by the remote on all substreams combined.
- Since https://github.com/paritytech/substrate/pull/6377, it is no longer illegal to send multiple `Status` messages. This PR is deployed as part of Polkadot 0.8.11.
- https://github.com/paritytech/substrate/pull/5938 introduces two changes: it sends a `Status` message on all newly-opened legacy substreams, and also expects a `Status` message to be received on all newly-opened legacy substreams.

(I also invite you to look at the description of #6377 for more context)

Unfortunately #5938 is a breaking change. When a node with #5938 opens more than one substream with a node that does not have #5938, it will wait for a `Status` message on the other substream as well, and this will end up timing out and closing the connection.

This breaking change was known and deemed acceptable considering that secondary connections are something uncommon.

Unfortunately I fear merging #5938 as-is. Testing has shown that it has trouble reaching its maximum number of peers.
Instead of merging #5938, I thereby open a new pull request that only sends a `Status` message on all newly-opened legacy substreams but does not necessarily expect a `Status` message to be received on all of them.
Once this PR is deployed, we can consider #5938 again.
