### PR TITLE
change ss58 format for SubstraTEE from 44 to 13 and add ChainX

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -427,6 +427,8 @@ ss58_address_format!(
 		(11, "laminar", "Laminar mainnet, standard account (*25519).")
 	PolymathAccount =>
 		(12, "polymath", "Polymath network, standard account (*25519).")
+	SubstraTeeAccount =>
+		(13, "substratee", "Any SubstraTEE off-chain network private account (*25519).")
 	KulupuAccount =>
 		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
 	DarwiniaAccount =>
@@ -443,8 +445,8 @@ ss58_address_format!(
 		(42, "substrate", "Any Substrate network, standard account (*25519).")
 	Reserved43 =>
 		(43, "reserved43", "Reserved for future use (43).")
-	SubstraTeeAccount =>
-		(44, "substratee", "Any SubstraTEE off-chain network private account (*25519).")
+	ChainXAccount =>
+		(44, "chainx", "ChainX mainnet, standard account (*25519).")
 	Reserved46 =>
 		(46, "reserved46", "Reserved for future use (46).")
 	Reserved47 =>


### PR DESCRIPTION
We are ChainX developers(https://github.com/chainx-org/ChainX) and we launch our mainnet at 05.25.2019. At that time, Substrate have not provide a way to set ss58 version for chain. Thus we just follow the docs about address version, and choose 44 as our mainnet ss58 version. We forked substrate to set 42 to 44 directly for our chain. 
Later,  at 01.29.2020, the pr https://github.com/paritytech/substrate/pull/4764 from the team SCS(https://github.com/scs/substraTEE-node) which have done a request to set 44 as their blockchain address type.

Now, we are developing ChainX to update to substrate 2.0, therefore we connect the SCS team to discuss whether they could allow us to use 44, and they change to another address type.

They agree this proposal, and choose 13 as their ss58 address type, so that I do this pr to change 44 as ChainX substrate ss58 address version, and add 13 as Substratee substrate ss58 address version istead.
![image](https://user-images.githubusercontent.com/5023721/86919300-9a68d380-c15a-11ea-9db5-f454d0dd5f8b.png)

