### PR TITLE
Use compiled wasm runtime to make debugging easier

### DIFF
--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -16,7 +16,7 @@ sc-client-api = { version = "2.0.0-rc4", path = "../../client/api" }
 sc-light = { version = "2.0.0-rc4", path = "../../client/light" }
 sc-client-db = { version = "0.8.0-rc4", features = ["test-helpers"], path = "../../client/db" }
 sp-consensus = { version = "0.8.0-rc4", path = "../../primitives/consensus/common" }
-sc-executor = { version = "0.8.0-rc4", path = "../../client/executor" }
+sc-executor = { version = "0.8.0-rc4", path = "../../client/executor", features = ["wasmtime"] }
 sc-consensus = { version = "0.8.0-rc4", path = "../../client/consensus/common" }
 sc-service = { version = "0.8.0-rc4", default-features = false, features = ["test-helpers"],  path = "../../client/service" }
 futures = "0.3.4"

--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -251,7 +251,7 @@ impl<Block: BlockT, E, Backend, G: GenesisInit> TestClientBuilder<
 		Backend: sc_client_api::backend::Backend<Block> + 'static,
 	{
 		let executor = executor.into().unwrap_or_else(||
-			NativeExecutor::new(WasmExecutionMethod::Interpreted, None, 8)
+			NativeExecutor::new(WasmExecutionMethod::Compiled, None, 8)
 		);
 		let executor = LocalCallExecutor::new(self.backend.clone(), executor, tasks_executor(), Default::default());
 


### PR DESCRIPTION
While I'm debugging I would like to be able to add println statements here and there but for that I need the crates to be compiled with std. Hopefully that won't change anything for the tests that use the test-client