### PR TITLE
Make signature batching use specialized methods

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -293,11 +293,13 @@ where
 		// any initial checks
 		Self::initial_checks(&block);
 
-		let batching_safeguard = sp_runtime::SignatureBatching::start();
+		let signature_batching = sp_runtime::SignatureBatching::start();
+
 		// execute extrinsics
 		let (header, extrinsics) = block.deconstruct();
 		Self::execute_extrinsics_with_book_keeping(extrinsics, *header.number());
-		if !sp_runtime::SignatureBatching::verify(batching_safeguard) {
+
+		if !signature_batching.verify() {
 			panic!("Signature verification failed.");
 		}
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -201,7 +201,6 @@ pub trait Storage {
 /// from within the runtime.
 #[runtime_interface]
 pub trait DefaultChildStorage {
-
 	/// Get a default child storage value for a given key.
 	///
 	/// Parameter `storage_key` is the unprefixed location of the root of the child trie in the parent trie.
@@ -454,68 +453,63 @@ pub trait Crypto {
 
 	/// Verify `ed25519` signature.
 	///
-	/// Returns `true` when the verification is either successful or batched.
-	/// If no batching verification extension registered, this will return the result
-	/// of verification immediately. If batching verification extension is registered
-	/// caller should call `crypto::finish_batch_verify` to actualy check all submitted
-	/// signatures.
+	/// Returns `true` when the verification was successful.
 	fn ed25519_verify(
 		sig: &ed25519::Signature,
 		msg: &[u8],
 		pub_key: &ed25519::Public,
 	) -> bool {
-		// TODO: see #5554, this is used outside of externalities context/runtime, thus this manual
-		// `with_externalities`.
-		//
-		// This `with_externalities(..)` block returns Some(Some(result)) if signature verification was successfully
-		// batched, everything else (Some(None)/None) means it was not batched and needs to be verified.
-		let evaluated = sp_externalities::with_externalities(|mut instance|
-			instance.extension::<VerificationExt>().map(
-				|extension| extension.push_ed25519(
-					sig.clone(),
-					pub_key.clone(),
-					msg.to_vec(),
-				)
-			)
-		);
+		ed25519::Pair::verify(sig, msg, pub_key)
+	}
 
-		match evaluated {
-			Some(Some(val)) => val,
-			_ => ed25519::Pair::verify(sig, msg, pub_key),
-		}
+	/// Register a `ed25519` signature for batch verification.
+	///
+	/// Batch verification must be enabled by calling [`start_batch_verify`].
+	/// If batch verification is not enabled, the signature will be verified immediatley.
+	/// To get the result of the batch verification, [`finish_batch_verify`]
+	/// needs to be called.
+	///
+	/// Returns `true` when the verification is either successful or batched.
+	fn ed25519_batch_verify(
+		&mut self,
+		sig: &ed25519::Signature,
+		msg: &[u8],
+		pub_key: &ed25519::Public,
+	) -> bool {
+		self.extension::<VerificationExt>().map(
+			|extension| extension.push_ed25519(sig.clone(), pub_key.clone(), msg.to_vec())
+		).unwrap_or_else(|| ed25519_verify(sig, msg, pub_key))
 	}
 
 	/// Verify `sr25519` signature.
 	///
-	/// Returns `true` when the verification is either successful or batched.
-	/// If no batching verification extension registered, this will return the result
-	/// of verification immediately. If batching verification extension is registered,
-	/// caller should call `crypto::finish_batch_verify` to actualy check all submitted
+	/// Returns `true` when the verification was successful.
 	#[version(2)]
 	fn sr25519_verify(
 		sig: &sr25519::Signature,
 		msg: &[u8],
 		pub_key: &sr25519::Public,
 	) -> bool {
-		// TODO: see #5554, this is used outside of externalities context/runtime, thus this manual
-		// `with_externalities`.
-		//
-		// This `with_externalities(..)` block returns Some(Some(result)) if signature verification was successfully
-		// batched, everything else (Some(None)/None) means it was not batched and needs to be verified.
-		let evaluated = sp_externalities::with_externalities(|mut instance|
-			instance.extension::<VerificationExt>().map(
-				|extension| extension.push_sr25519(
-					sig.clone(),
-					pub_key.clone(),
-					msg.to_vec(),
-				)
-			)
-		);
+		sr25519::Pair::verify(sig, msg, pub_key)
+	}
 
-		match evaluated {
-			Some(Some(val)) => val,
-			_ => sr25519::Pair::verify(sig, msg, pub_key),
-		}
+	/// Register a `sr25519` signature for batch verification.
+	///
+	/// Batch verification must be enabled by calling [`start_batch_verify`].
+	/// If batch verification is not enabled, the signature will be verified immediatley.
+	/// To get the result of the batch verification, [`finish_batch_verify`]
+	/// needs to be called.
+	///
+	/// Returns `true` when the verification is either successful or batched.
+	fn sr25519_batch_verify(
+		&mut self,
+		sig: &sr25519::Signature,
+		msg: &[u8],
+		pub_key: &sr25519::Public,
+	) -> bool {
+		self.extension::<VerificationExt>().map(
+			|extension| extension.push_sr25519(sig.clone(), pub_key.clone(), msg.to_vec())
+		).unwrap_or_else(|| sr25519_verify(sig, msg, pub_key))
 	}
 
 	/// Start verification extension.
@@ -638,35 +632,32 @@ pub trait Crypto {
 
 	/// Verify `ecdsa` signature.
 	///
-	/// Returns `true` when the verification is either successful or batched.
-	/// If no batching verification extension registered, this will return the result
-	/// of verification immediately. If batching verification extension is registered
-	/// caller should call `crypto::finish_batch_verify` to actualy check all submitted
-	/// signatures.
+	/// Returns `true` when the verification was successful.
 	fn ecdsa_verify(
 		sig: &ecdsa::Signature,
 		msg: &[u8],
 		pub_key: &ecdsa::Public,
 	) -> bool {
-		// TODO: see #5554, this is used outside of externalities context/runtime, thus this manual
-		// `with_externalities`.
-		//
-		// This `with_externalities(..)` block returns Some(Some(result)) if signature verification was successfully
-		// batched, everything else (Some(None)/None) means it was not batched and needs to be verified.
-		let evaluated = sp_externalities::with_externalities(|mut instance|
-			instance.extension::<VerificationExt>().map(
-				|extension| extension.push_ecdsa(
-					sig.clone(),
-					pub_key.clone(),
-					msg.to_vec(),
-				)
-			)
-		);
+		ecdsa::Pair::verify(sig, msg, pub_key)
+	}
 
-		match evaluated {
-			Some(Some(val)) => val,
-			_ => ecdsa::Pair::verify(sig, msg, pub_key),
-		}
+	/// Register a `ecdsa` signature for batch verification.
+	///
+	/// Batch verification must be enabled by calling [`start_batch_verify`].
+	/// If batch verification is not enabled, the signature will be verified immediatley.
+	/// To get the result of the batch verification, [`finish_batch_verify`]
+	/// needs to be called.
+	///
+	/// Returns `true` when the verification is either successful or batched.
+	fn ecdsa_batch_verify(
+		&mut self,
+		sig: &ecdsa::Signature,
+		msg: &[u8],
+		pub_key: &ecdsa::Public,
+	) -> bool {
+		self.extension::<VerificationExt>().map(
+			|extension| extension.push_ecdsa(sig.clone(), pub_key.clone(), msg.to_vec())
+		).unwrap_or_else(|| ecdsa_verify(sig, msg, pub_key))
 	}
 
 	/// Verify and recover a SECP256k1 ECDSA signature.
@@ -1281,7 +1272,7 @@ mod tests {
 	}
 
 	#[test]
-	fn dynamic_extensions_work() {
+	fn batch_verify_start_finish_works() {
 		let mut ext = BasicExternalities::with_tasks_executor();
 		ext.execute_with(|| {
 			crypto::start_batch_verify();
@@ -1290,7 +1281,7 @@ mod tests {
 		assert!(ext.extensions().get_mut(TypeId::of::<VerificationExt>()).is_some());
 
 		ext.execute_with(|| {
-			crypto::finish_batch_verify();
+			assert!(crypto::finish_batch_verify());
 		});
 
 		assert!(ext.extensions().get_mut(TypeId::of::<VerificationExt>()).is_none());
@@ -1305,11 +1296,11 @@ mod tests {
 			for it in 0..70 {
 				let msg = format!("Schnorrkel {}!", it);
 				let signature = pair.sign(msg.as_bytes());
-				crypto::sr25519_verify(&signature, msg.as_bytes(), &pair.public());
+				crypto::sr25519_batch_verify(&signature, msg.as_bytes(), &pair.public());
 			}
 
 			// push invlaid
-			crypto::sr25519_verify(
+			crypto::sr25519_batch_verify(
 				&Default::default(),
 				&Vec::new(),
 				&Default::default(),
@@ -1320,7 +1311,7 @@ mod tests {
 			for it in 0..70 {
 				let msg = format!("Schnorrkel {}!", it);
 				let signature = pair.sign(msg.as_bytes());
-				crypto::sr25519_verify(&signature, msg.as_bytes(), &pair.public());
+				crypto::sr25519_batch_verify(&signature, msg.as_bytes(), &pair.public());
 			}
 			assert!(crypto::finish_batch_verify());
 		});
@@ -1332,7 +1323,7 @@ mod tests {
 		ext.execute_with(|| {
 			// invalid ed25519 signature
 			crypto::start_batch_verify();
-			crypto::ed25519_verify(
+			crypto::ed25519_batch_verify(
 				&Default::default(),
 				&Vec::new(),
 				&Default::default(),
@@ -1345,12 +1336,12 @@ mod tests {
 			let pair = ed25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Important message";
 			let signature = pair.sign(msg);
-			crypto::ed25519_verify(&signature, msg, &pair.public());
+			crypto::ed25519_batch_verify(&signature, msg, &pair.public());
 
 			let pair = ed25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Even more important message";
 			let signature = pair.sign(msg);
-			crypto::ed25519_verify(&signature, msg, &pair.public());
+			crypto::ed25519_batch_verify(&signature, msg, &pair.public());
 
 			assert!(crypto::finish_batch_verify());
 
@@ -1360,9 +1351,9 @@ mod tests {
 			let pair = ed25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Important message";
 			let signature = pair.sign(msg);
-			crypto::ed25519_verify(&signature, msg, &pair.public());
+			crypto::ed25519_batch_verify(&signature, msg, &pair.public());
 
-			crypto::ed25519_verify(
+			crypto::ed25519_batch_verify(
 				&Default::default(),
 				&Vec::new(),
 				&Default::default(),
@@ -1376,17 +1367,17 @@ mod tests {
 			let pair = ed25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Ed25519 batching";
 			let signature = pair.sign(msg);
-			crypto::ed25519_verify(&signature, msg, &pair.public());
+			crypto::ed25519_batch_verify(&signature, msg, &pair.public());
 
 			let pair = sr25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Schnorrkel rules";
 			let signature = pair.sign(msg);
-			crypto::sr25519_verify(&signature, msg, &pair.public());
+			crypto::sr25519_batch_verify(&signature, msg, &pair.public());
 
 			let pair = sr25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Schnorrkel batches!";
 			let signature = pair.sign(msg);
-			crypto::sr25519_verify(&signature, msg, &pair.public());
+			crypto::sr25519_batch_verify(&signature, msg, &pair.public());
 
 			assert!(crypto::finish_batch_verify());
 
@@ -1396,9 +1387,9 @@ mod tests {
 			let pair = sr25519::Pair::generate_with_phrase(None).0;
 			let msg = b"Schnorrkcel!";
 			let signature = pair.sign(msg);
-			crypto::sr25519_verify(&signature, msg, &pair.public());
+			crypto::sr25519_batch_verify(&signature, msg, &pair.public());
 
-			crypto::sr25519_verify(
+			crypto::sr25519_batch_verify(
 				&Default::default(),
 				&Vec::new(),
 				&Default::default(),


### PR DESCRIPTION
It was a mistake to use the `*_verify` methods for signature batching.
This pr move the signature batching into their own functions. This is
required, because otherwise transaction signature verification infers
with other signature verifications.

This pr also temporarily disables signature batching. The functionality
stays, but we need to make sure that all nodes have the new runtime
interface, before we can bring back signature batching.

Fixes: #5554 https://github.com/paritytech/substrate/issues/6585
