### PR TITLE
Make test header generic

### DIFF
--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -33,7 +33,7 @@ impl system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -39,7 +39,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -55,7 +55,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
 		type Hashing = ::sp_runtime::traits::BlakeTwo256;
 		type AccountId = AuthorityId;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -399,7 +399,7 @@ mod tests {
 	use super::*;
 	use sp_core::H256;
 	use sp_runtime::{
-		traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic::DigestItem, Perbill,
+		traits::{BlakeTwo256, IdentityLookup}, testing::Header as GenericHeader, generic::DigestItem, Perbill,
 	};
 	use frame_support::{parameter_types, impl_outer_origin, ConsensusEngineId, weights::Weight};
 
@@ -455,7 +455,7 @@ mod tests {
 		type FilterUncle = SealVerify<VerifyBlock>;
 		type EventHandler = ();
 	}
-
+	type Header = GenericHeader<u64>;
 	type System = frame_system::Module<Test>;
 	type Authorship = Module<Test>;
 

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -76,7 +76,7 @@ impl frame_system::Trait for Test {
 	type Hashing = sp_runtime::traits::BlakeTwo256;
 	type AccountId = DummyValidatorId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -76,7 +76,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -76,7 +76,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -85,7 +85,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = ();
 	type MaximumBlockWeight = ();

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -1051,7 +1051,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;
@@ -1085,7 +1085,7 @@ mod tests {
 		type WeightInfo = ();
 	}
 
-	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+	pub type Block = sp_runtime::generic::Block<Header<u64>, UncheckedExtrinsic>;
 	pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
 	frame_support::construct_runtime!(

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -117,7 +117,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = MetaEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -101,7 +101,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1113,7 +1113,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;
@@ -1253,7 +1253,7 @@ mod tests {
 		type WeightInfo = ();
 	}
 
-	pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+	pub type Block = sp_runtime::generic::Block<Header<u64>, UncheckedExtrinsic>;
 	pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
 	frame_support::construct_runtime!(

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -48,7 +48,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
@@ -153,7 +153,7 @@ impl elections::Trait for Test {
 	type ModuleId = ElectionModuleId;
 }
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+pub type Block = sp_runtime::generic::Block<Header<u64>, UncheckedExtrinsic>;
 pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
 
 use frame_system as system;

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -46,7 +46,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = H256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -63,7 +63,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = sp_core::sr25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -753,7 +753,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -554,7 +554,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<u64>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = MetaEvent;
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;
@@ -650,7 +650,7 @@ mod tests {
 
 	type Executive = super::Executive<
 		Runtime,
-		Block<TestXt>,
+		Block<TestXt, u64>,
 		ChainContext<Runtime>,
 		Runtime,
 		AllModules,

--- a/frame/finality-tracker/src/lib.rs
+++ b/frame/finality-tracker/src/lib.rs
@@ -262,7 +262,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<u64>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/generic-asset/src/mock.rs
+++ b/frame/generic-asset/src/mock.rs
@@ -55,7 +55,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<u64>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type DbWeight = ();

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -103,7 +103,7 @@ impl frame_system::Trait for Test {
 	type Hashing = sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -1214,7 +1214,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -119,7 +119,7 @@ impl frame_system::Trait for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -59,7 +59,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = Indices;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = MetaEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -314,7 +314,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -69,7 +69,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -105,7 +105,7 @@ impl frame_system::Trait for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -71,7 +71,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -167,7 +167,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -73,7 +73,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -659,7 +659,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -64,7 +64,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -182,7 +182,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -74,7 +74,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u128;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -209,7 +209,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = MetaEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -130,7 +130,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -219,7 +219,7 @@ mod tests {
 		}
 	}
 
-	type Block = testing::Block<Extrinsic>;
+	type Block = testing::Block<Extrinsic, u64>;
 
 	#[derive(codec::Encode, codec::Decode, Clone, PartialEq, Eq, Debug, serde::Serialize)]
 	struct Extrinsic {

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -70,7 +70,7 @@ impl system::Trait for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -60,7 +60,7 @@ impl frame_system::Trait for Test {
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = sp_runtime::testing::Header;
+	type Header = sp_runtime::testing::Header<u64>;
 	type Event = ();
 	type BlockHashCount = ();
 	type MaximumBlockWeight = ();

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -90,7 +90,7 @@ impl Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event<Self>;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -336,7 +336,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -566,7 +566,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -69,7 +69,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -68,7 +68,7 @@ impl frame_system::Trait for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = Header<u64>;
 	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -450,7 +450,7 @@ mod tests {
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
+		type Header = Header<u64>;
 		type Event = ();
 		type BlockHashCount = BlockHashCount;
 		type MaximumBlockWeight = MaximumBlockWeight;


### PR DESCRIPTION
The exact use case that lead to me wanting to see this in substrate is a bit verbose for here, but in short: we use `u32` as the real block number in out chains, yet our test header was imposing `u64`, for which I could not find any good reason. 

This PR makes the test header generic over the block number type (instead of the lazy way of just making it u32, because that's not the substrate way of doing it :D)

All changes to modules still use u64, so no tangible change is applied by this PR to any code. 