### PR TITLE
Make `init_logging` more easily usable

### DIFF
--- a/bin/node/bench/src/main.rs
+++ b/bin/node/bench/src/main.rs
@@ -63,9 +63,6 @@ struct Opt {
 	#[structopt(long)]
 	transactions: Option<usize>,
 
-	#[structopt(flatten)]
-	log_rotation_opt: sc_cli::LogRotationOpt,
-
 	/// Mode
 	///
 	/// "regular" for regular benchmark
@@ -80,7 +77,7 @@ fn main() {
 	let opt = Opt::from_args();
 
 	if !opt.json {
-		sc_cli::init_logger("", &opt.log_rotation_opt).expect("init_logger should not fail.");
+		sc_cli::init_logger("", None).expect("init_logger should not fail.");
 	}
 
 	let mut import_benchmarks = Vec::new();

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -490,10 +490,10 @@ pub trait CliConfiguration: Sized {
 	}
 
 	/// Get the log directory for logging.
-	/// 
+	///
 	/// By default this is retrieved from `SharedParams`.
-	fn log_rotation_opt(&self) -> Result<&LogRotationOpt> {
-		Ok(self.shared_params().log_rotation_opt())
+	fn log_rotation_opt(&self) -> Result<LogRotationOpt> {
+		Ok(self.shared_params().log_rotation_opt().clone())
 	}
 
 	/// Initialize substrate. This must be done only once.
@@ -510,7 +510,7 @@ pub trait CliConfiguration: Sized {
 		sp_panic_handler::set(&C::support_url(), &C::impl_version());
 
 		fdlimit::raise_fd_limit();
-		init_logger(&logger_pattern, log_rotation_opt)?;
+		init_logger(&logger_pattern, Some(log_rotation_opt))?;
 
 		Ok(())
 	}


### PR DESCRIPTION
Instead of requiring the `LogRotationOpt`, it now requires an
`Option<LogRotationOpt>`. This makes it much more easy to use the
interface when someone isn't interested on the `LogRotationOpt`'s

polkadot-companion: https://github.com/paritytech/polkadot/pull/1386
