### PR TITLE
add ios to cfg gates in client/service

### DIFF
--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,6 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.13.3"
 sc-keystore = { version = "2.0.0-rc4", path = "../keystore" }
 sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc4", path = "../../primitives/runtime" }
@@ -76,8 +75,10 @@ sc-tracing = { version = "2.0.0-rc4", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 
+[target.'cfg(all(any(unix, windows), not(all(target_os = "android", target_os = "ios"))))'.dependencies]
+sysinfo = "0.13.3"
 
-[target.'cfg(all(any(unix, windows), not(target_os = "android")))'.dependencies]
+[target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))'.dependencies]
 netstat2 = "0.8.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -75,7 +75,7 @@ sc-tracing = { version = "2.0.0-rc4", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 
-[target.'cfg(all(any(unix, windows), not(all(target_os = "android", target_os = "ios"))))'.dependencies]
+[target.'cfg(all(any(unix, windows), not(target_os = "ios")))'.dependencies]
 sysinfo = "0.13.3"
 
 [target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))'.dependencies]

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,6 +39,7 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
+sysinfo = "0.13.3"
 sc-keystore = { version = "2.0.0-rc4", path = "../keystore" }
 sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc4", path = "../../primitives/runtime" }
@@ -74,9 +75,6 @@ prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../..
 sc-tracing = { version = "2.0.0-rc4", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
-
-[target.'cfg(all(any(unix, windows), not(target_os = "ios")))'.dependencies]
-sysinfo = "0.13.3"
 
 [target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))'.dependencies]
 netstat2 = "0.8.1"


### PR DESCRIPTION
`sysinfo` and `netstat2` cause compilation problems on `ios` https://github.com/sunshine-protocol/sunshine-identity-ui/issues/1

so this PR adds `not(target_os = "ios")` in the places where the same is already done for `android`