### PR TITLE
Remove rental crate and implement the required functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,27 +5871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rental"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
-dependencies = [
- "rental-impl",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "rental-impl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
-dependencies = [
- "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8158,7 +8137,6 @@ name = "sp-tracing"
 version = "2.0.0-rc4"
 dependencies = [
  "log",
- "rental",
  "tracing",
 ]
 

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -66,3 +66,7 @@
 
 # Prometheus endpoint
 /utils/prometheus/ @mxinden
+
+# Tracing
+/client/tracing/ @mattrutherford
+/primitives/tracing/ @mattrutherford

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -69,5 +69,5 @@
 
 # Tracing
 /client/tracing/ @mattrutherford
-/primitives/tracing/proxy.rs @mattrutherford
-/primitives/tracing/proxied_span.rs @mattrutherford
+/primitives/tracing/src/proxy.rs @mattrutherford
+/primitives/tracing/src/proxied_span.rs @mattrutherford

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -69,4 +69,5 @@
 
 # Tracing
 /client/tracing/ @mattrutherford
-/primitives/tracing/ @mattrutherford
+/primitives/tracing/proxy.rs @mattrutherford
+/primitives/tracing/proxied_span.rs @mattrutherford

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -13,9 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 tracing = { version = "0.1.13", optional = true }
-rental = { version = "0.5.5", optional = true }
 log = { version = "0.4.8", optional = true }
 
 [features]
 default = [ "std" ]
-std = [ "tracing", "rental", "log" ]
+std = [ "tracing", "log" ]

--- a/primitives/tracing/src/lib.rs
+++ b/primitives/tracing/src/lib.rs
@@ -31,15 +31,14 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-#[macro_use]
-extern crate rental;
-
-#[cfg(feature = "std")]
 #[doc(hidden)]
 pub use tracing;
 
 #[cfg(feature = "std")]
 pub mod proxy;
+
+#[cfg(feature = "std")]
+mod proxied_span;
 
 #[cfg(feature = "std")]
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/primitives/tracing/src/proxied_span.rs
+++ b/primitives/tracing/src/proxied_span.rs
@@ -1,0 +1,56 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Comprises the struct `ProxiedTrace` required by the proxy, encapsulates
+//! the necessary associated unsafe code and provides a safe interface.
+
+use std::pin::Pin;
+use tracing::{span::Entered, Span};
+
+/// Container for a proxied tracing Span and it's associated guard
+pub struct ProxiedSpan {
+	id: u64,
+	// Note that `guard` and `span` must be declared in this order so that `guard` is dropped first.
+	_guard: Entered<'static>,
+	span: Pin<Box<Span>>,
+}
+
+impl ProxiedSpan {
+	/// Enter the supplied span and return a new instance of ProxiedTrace containing it
+	pub fn enter_span(id: u64, span: Pin<Box<Span>>) -> Self {
+		// Transmute to static lifetime to enable guard to be stored
+		// along with the span that it references
+		let guard = unsafe {
+			std::mem::transmute::<Entered<'_>, Entered<'static>>(span.enter())
+		};
+
+		ProxiedSpan {
+			id,
+			_guard: guard,
+			span,
+		}
+	}
+
+	/// Return copy of the span id
+	pub fn id(&self) -> u64 {
+		self.id
+	}
+
+	/// Return immutable reference to the span
+	pub fn span(&self) -> &Span {
+		&*self.span
+	}
+}


### PR DESCRIPTION
Closes #6312

Introduces new struct `ProxiedSpan` that replaces `SpanAndGuard` that was used in conjunction with `rental`. 

This allows us to remove the now unmaintained `rental` crate. 