### PR TITLE
Remove warning about networking taking a lot of time

### DIFF
--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -38,13 +38,12 @@ use std::{io, pin::Pin};
 use std::net::SocketAddr;
 use std::collections::HashMap;
 use std::time::Duration;
-use wasm_timer::Instant;
 use std::task::Poll;
 use parking_lot::Mutex;
 
 use futures::{Future, FutureExt, Stream, StreamExt, stream, compat::*};
 use sc_network::{NetworkStatus, network_state::NetworkState, PeerId};
-use log::{log, warn, debug, error, Level};
+use log::{warn, debug, error};
 use codec::{Encode, Decode};
 use sp_runtime::generic::BlockId;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -156,7 +156,7 @@ pub struct ServiceComponents<TBl: BlockT, TBackend: Backend<TBl>, TSc, TExPool, 
 	pub client: Arc<TCl>,
 	/// A shared transaction pool instance.
 	pub transaction_pool: Arc<TExPool>,
-	/// The chain task manager. 
+	/// The chain task manager.
 	pub task_manager: TaskManager,
 	/// A keystore that stores keys.
 	pub keystore: sc_keystore::KeyStorePtr,
@@ -216,8 +216,6 @@ async fn build_network_future<
 	};
 
 	loop {
-		let before_polling = Instant::now();
-
 		futures::select!{
 			// List of blocks that the client has imported.
 			notification = imported_blocks_stream.next() => {
@@ -334,15 +332,6 @@ async fn build_network_future<
 				ready_sink.send((status, state));
 			}
 		}
-
-		// Now some diagnostic for performances.
-		let polling_dur = before_polling.elapsed();
-		log!(
-			target: "service",
-			if polling_dur >= Duration::from_secs(1) { Level::Warn } else { Level::Trace },
-			"⚠️  Polling the network future took {:?}",
-			polling_dur
-		);
 	}
 }
 


### PR DESCRIPTION
After https://github.com/paritytech/substrate/pull/6533, this duration no longer represents how long it took to poll the networking worker, but the time it took to wait plus poll. In other words, this log entry is misleading.

The information about how much time it takes to poll tasks is already tracked in Prometheus, so this warning doesn't bring much anymore anyway.
