### PR TITLE
[CI] Fix check_polkadot_companion_status.sh

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 #
-# check for a polkadot companion pr and ensure it has approvals and is 
+# check for a polkadot companion pr and ensure it has approvals and is
 # mergeable
 #
 
 github_api_substrate_pull_url="https://api.github.com/repos/paritytech/substrate/pulls"
 github_api_polkadot_pull_url="https://api.github.com/repos/paritytech/polkadot/pulls"
 # use github api v3 in order to access the data without authentication
-github_header="Authorization: token ${GITHUB_PR_TOKEN}" 
+github_header="Authorization: token ${GITHUB_PR_TOKEN}"
 
 boldprint () { printf "|\n| \033[1m${@}\033[0m\n|\n" ; }
 boldcat () { printf "|\n"; while read l; do printf "| \033[1m${l}\033[0m\n"; done; printf "|\n" ; }
@@ -24,7 +24,7 @@ this job checks if there is a string in the description of the pr like
 
 polkadot companion: paritytech/polkadot#567
 
-or any other polkadot pr is mentioned in this pr's description and checks its 
+or any other polkadot pr is mentioned in this pr's description and checks its
 status.
 
 
@@ -68,7 +68,10 @@ boldprint "companion pr: #${pr_companion}"
 # mergable and approved
 
 curl -H "${github_header}" -sS -o companion_pr.json \
-  ${github_api_polkadot_pull_url}/${pr_companion} 
+  ${github_api_polkadot_pull_url}/${pr_companion}
+
+pr_head_sha=$(jq -r -e '.head.sha' < companion_pr.json)
+boldprint "Polkadot PR's HEAD SHA: $pr_head_sha"
 
 if jq -e .merged < companion_pr.json >/dev/null
 then
@@ -85,11 +88,16 @@ else
 fi
 
 curl -H "${github_header}" -sS -o companion_pr_reviews.json \
-  ${github_api_polkadot_pull_url}/${pr_companion}/reviews 
+  ${github_api_polkadot_pull_url}/${pr_companion}/reviews
 
-if [ -n "$(jq -r -e '.[].state | select(. == "CHANGES_REQUESTED")' < companion_pr_reviews.json)" ] && \
-  [ -z "$(jq -r -e '.[].state | select(. == "APPROVED")' < companion_pr_reviews.json)" ]
-then
+# If there are any 'CHANGES_REQUESTED' reviews for the *current* review
+if [ "$(jq -r -e '.[] | select(.state == "CHANGES_REQUESTED").commit_id' < companion_pr_reviews.json)" = "$pr_head_sha" ]; then
+  boldprint "polkadot pr #${pr_companion} has CHANGES_REQUESTED for the latest commit"
+  exit 1
+fi
+
+# Then we check for at least 1 APPROVED
+if [ -z "$(jq -r -e '.[].state | select(. == "APPROVED")' < companion_pr_reviews.json)" ]; then
   boldprint "polkadot pr #${pr_companion} not APPROVED"
   exit 1
 fi

--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -91,10 +91,12 @@ curl -H "${github_header}" -sS -o companion_pr_reviews.json \
   ${github_api_polkadot_pull_url}/${pr_companion}/reviews
 
 # If there are any 'CHANGES_REQUESTED' reviews for the *current* review
-if [ "$(jq -r -e '.[] | select(.state == "CHANGES_REQUESTED").commit_id' < companion_pr_reviews.json)" = "$pr_head_sha" ]; then
-  boldprint "polkadot pr #${pr_companion} has CHANGES_REQUESTED for the latest commit"
-  exit 1
-fi
+while IFS= read -r line; do
+  if [ "$line" = "$pr_head_sha" ]; then
+    boldprint "polkadot pr #${pr_companion} has CHANGES_REQUESTED for the latest commit"
+    exit 1
+  fi
+done <<< $(jq -r -e '.[] | select(.state == "CHANGES_REQUESTED").commit_id' < companion_pr_reviews.json)
 
 # Then we check for at least 1 APPROVED
 if [ -z "$(jq -r -e '.[].state | select(. == "APPROVED")' < companion_pr_reviews.json)" ]; then


### PR DESCRIPTION
Logic around checking for review approvals was faulty. This changes the logic such that:
- If there are any 'CHANGES_REQUESTED' reviews for the *most recent* commit to the companion PR, we fail
- After this, check for *any* approvals and fail if there are none
- Fall through to 'APPROVED' (no changes here)