### PR TITLE
Fix tx-payment integrity-test

### DIFF
--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1302,6 +1302,7 @@ macro_rules! decl_module {
 		$(#[doc = $doc_attr:tt])*
 		fn integrity_test() { $( $impl:tt )* }
 	) => {
+		#[cfg(feature = "std")]
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::IntegrityTest
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
@@ -1317,6 +1318,7 @@ macro_rules! decl_module {
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
+		#[cfg(feature = "std")]
 		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::IntegrityTest
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -20,10 +20,10 @@ frame-support = { version = "2.0.0-rc4", default-features = false, path = "../su
 frame-system = { version = "2.0.0-rc4", default-features = false, path = "../system" }
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-rc4", default-features = false, path = "./rpc/runtime-api" }
 smallvec = "1.4.1"
+sp-io = { version = "2.0.0-rc4", path = "../../primitives/io", default-features = false }
+sp-core = { version = "2.0.0-rc4", path = "../../primitives/core", default-features = false }
 
 [dev-dependencies]
-sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }
-sp-core = { version = "2.0.0-rc4", path = "../../primitives/core" }
 pallet-balances = { version = "2.0.0-rc4", path = "../balances" }
 sp-storage = { version = "2.0.0-rc4", path = "../../primitives/storage" }
 
@@ -36,5 +36,7 @@ std = [
 	"sp-runtime/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-transaction-payment-rpc-runtime-api/std"
+	"pallet-transaction-payment-rpc-runtime-api/std",
+	"sp-io/std",
+	"sp-core/std",
 ]

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -118,7 +118,7 @@ pub trait MultiplierUpdate: Convert<Multiplier, Multiplier> {
 	/// Target block saturation level
 	fn target() -> Perquintill;
 	/// Variability factor
-	fn v() -> Multiplier;
+	fn variability() -> Multiplier;
 }
 
 impl MultiplierUpdate for () {
@@ -128,7 +128,7 @@ impl MultiplierUpdate for () {
 	fn target() -> Perquintill {
 		Default::default()
 	}
-	fn v() -> Multiplier {
+	fn variability() -> Multiplier {
 		Default::default()
 	}
 }
@@ -142,7 +142,7 @@ impl<T, S, V, M> MultiplierUpdate for TargetedFeeAdjustment<T, S, V, M>
 	fn target() -> Perquintill {
 		S::get()
 	}
-	fn v() -> Multiplier {
+	fn variability() -> Multiplier {
 		V::get()
 	}
 }
@@ -271,7 +271,9 @@ decl_module! {
 			// that if we collapse to minimum, the trend will be positive with a weight value
 			// which is 1% more than the target.
 			let min_value = T::FeeMultiplierUpdate::min();
-			let mut target = T::FeeMultiplierUpdate::target() * (T::AvailableBlockRatio::get() * T::MaximumBlockWeight::get());
+			let mut target =
+				T::FeeMultiplierUpdate::target() *
+				(T::AvailableBlockRatio::get() * T::MaximumBlockWeight::get());
 
 			// add 1 percent;
 			let addition = target / 100;

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -268,7 +268,7 @@ decl_module! {
 
 			// This is the minimum value of the multiplier. Make sure that if we collapse to this
 			// value, we can recover with a reasonable amount of traffic. For this test we assert
-			// that if we collapse to minimum, we the trend will be positive with a weight value
+			// that if we collapse to minimum, the trend will be positive with a weight value
 			// which is 1% more than the target.
 			let min_value = T::FeeMultiplierUpdate::min();
 			let mut target = T::FeeMultiplierUpdate::target() * (T::AvailableBlockRatio::get() * T::MaximumBlockWeight::get());
@@ -286,7 +286,7 @@ decl_module! {
 				let next = T::FeeMultiplierUpdate::convert(min_value);
 				assert!(next > min_value, "The minimum bound of the multiplier is too low. When \
 					block saturation is more than target by 1% and multiplier is minimal then \
-					multiplier don't increased."
+					the multiplier doesn't increase."
 				);
 			})
 		}

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -113,8 +113,11 @@ pub struct TargetedFeeAdjustment<T, S, V, M>(sp_std::marker::PhantomData<(T, S, 
 
 /// Something that can convert the current multiplier to the next one.
 pub trait MultiplierUpdate: Convert<Multiplier, Multiplier> {
+	/// Minimum multiplier
 	fn min() -> Multiplier;
+	/// Target block saturation level
 	fn target() -> Perquintill;
+	/// Variability factor
 	fn v() -> Multiplier;
 }
 
@@ -134,13 +137,13 @@ impl<T, S, V, M> MultiplierUpdate for TargetedFeeAdjustment<T, S, V, M>
 	where T: frame_system::Trait, S: Get<Perquintill>, V: Get<Multiplier>, M: Get<Multiplier>,
 {
 	fn min() -> Multiplier {
-		 M::get()
+		M::get()
 	}
 	fn target() -> Perquintill {
-		  S::get()
+		S::get()
 	}
 	fn v() -> Multiplier {
-		 V::get()
+		V::get()
 	}
 }
 
@@ -281,7 +284,7 @@ decl_module! {
 			sp_io::TestExternalities::new_empty().execute_with(|| {
 				<frame_system::Module<T>>::set_block_limits(target, 0);
 				let next = T::FeeMultiplierUpdate::convert(min_value);
-				assert!(next > min_value, "The minimum bound of the multiplier is too low.");
+				assert!(next > min_value, "The minimum bound of the multiplier is too low. When block saturation is more than target by 1% and multiplier is minimal then multiplier don't increased.");
 			})
 		}
 	}

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -111,6 +111,39 @@ type NegativeImbalanceOf<T> =
 /// https://w3f-research.readthedocs.io/en/latest/polkadot/Token%20Economics.html
 pub struct TargetedFeeAdjustment<T, S, V, M>(sp_std::marker::PhantomData<(T, S, V, M)>);
 
+/// Something that can convert the current multiplier to the next one.
+pub trait MultiplierUpdate: Convert<Multiplier, Multiplier> {
+	fn min() -> Multiplier;
+	fn target() -> Perquintill;
+	fn v() -> Multiplier;
+}
+
+impl MultiplierUpdate for () {
+	fn min() -> Multiplier {
+		Default::default()
+	}
+	fn target() -> Perquintill {
+		Default::default()
+	}
+	fn v() -> Multiplier {
+		Default::default()
+	}
+}
+
+impl<T, S, V, M> MultiplierUpdate for TargetedFeeAdjustment<T, S, V, M>
+	where T: frame_system::Trait, S: Get<Perquintill>, V: Get<Multiplier>, M: Get<Multiplier>,
+{
+	fn min() -> Multiplier {
+		 M::get()
+	}
+	fn target() -> Perquintill {
+		  S::get()
+	}
+	fn v() -> Multiplier {
+		 V::get()
+	}
+}
+
 impl<T, S, V, M> Convert<Multiplier, Multiplier> for TargetedFeeAdjustment<T, S, V, M>
 	where T: frame_system::Trait, S: Get<Perquintill>, V: Get<Multiplier>, M: Get<Multiplier>,
 {
@@ -192,7 +225,7 @@ pub trait Trait: frame_system::Trait {
 	type WeightToFee: WeightToFeePolynomial<Balance=BalanceOf<Self>>;
 
 	/// Update the multiplier of the next block, based on the previous block's weight.
-	type FeeMultiplierUpdate: Convert<Multiplier, Multiplier>;
+	type FeeMultiplierUpdate: MultiplierUpdate;
 }
 
 decl_storage! {
@@ -229,6 +262,24 @@ decl_module! {
 					<T as frame_system::Trait>::MaximumBlockWeight::get().try_into().unwrap()
 				).unwrap(),
 			);
+
+			// This is the minimum value of the multiplier. Make sure that if we collapse to this
+			// value, we can recover with a reasonable amount of traffic. For this test we assert
+			// that if we collapse to minimum, we the trend will be positive with a weight value
+			// which is 1% more than the target.
+			let min_value = T::FeeMultiplierUpdate::min();
+			let mut target = T::FeeMultiplierUpdate::target() * (T::AvailableBlockRatio::get() * T::MaximumBlockWeight::get());
+
+			// add 1 percent;
+			let addition = target / 100;
+			assert!(addition > 0);
+			target += addition;
+
+			sp_io::TestExternalities::new_empty().execute_with(|| {
+				<frame_system::Module<T>>::set_block_limits(target, 0);
+				let next = T::FeeMultiplierUpdate::convert(min_value);
+				assert!(next > min_value);
+			})
 		}
 	}
 }

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -272,13 +272,16 @@ decl_module! {
 
 			// add 1 percent;
 			let addition = target / 100;
-			assert!(addition > 0);
+			if addition == 0 {
+				// this is most likely because in a test setup we set everything to ().
+				return;
+			}
 			target += addition;
 
 			sp_io::TestExternalities::new_empty().execute_with(|| {
 				<frame_system::Module<T>>::set_block_limits(target, 0);
 				let next = T::FeeMultiplierUpdate::convert(min_value);
-				assert!(next > min_value);
+				assert!(next > min_value, "The minimum bound of the multiplier is too low.");
 			})
 		}
 	}

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -284,7 +284,10 @@ decl_module! {
 			sp_io::TestExternalities::new_empty().execute_with(|| {
 				<frame_system::Module<T>>::set_block_limits(target, 0);
 				let next = T::FeeMultiplierUpdate::convert(min_value);
-				assert!(next > min_value, "The minimum bound of the multiplier is too low. When block saturation is more than target by 1% and multiplier is minimal then multiplier don't increased.");
+				assert!(next > min_value, "The minimum bound of the multiplier is too low. When \
+					block saturation is more than target by 1% and multiplier is minimal then \
+					multiplier don't increased."
+				);
 			})
 		}
 	}


### PR DESCRIPTION
This integrity test was living in in the `node-runtime` tests, which does not make sense, because it will not be applied to any of the chains built with substrate. 

https://github.com/paritytech/substrate/blob/56cf04f289f9cd5e8bb96fe5bd23a923e21acf1c/bin/node/runtime/src/impls.rs#L139-L147

This is the first usage of `integrity_test`, And I really couldn't think of any other use case. I've made an issue (https://github.com/paritytech/substrate/issues/6632) about the limitations here. 

This test is quite important, so I prefer keeping it, but I still think this (creating TestExt inside the module) is quite unergonomic and could be improved later. 