### PR TITLE
[WIP]: Related #6042. Replace AccountId in dispatchable call params

### DIFF
--- a/frame/atomic-swap/src/lib.rs
+++ b/frame/atomic-swap/src/lib.rs
@@ -226,7 +226,7 @@ decl_module! {
 		#[weight = T::DbWeight::get().reads_writes(1, 1).saturating_add(40_000_000)]
 		fn create_swap(
 			origin,
-			target: T::AccountId,
+			target: <T::Lookup as StaticLookup>::Source,
 			hashed_proof: HashedProof,
 			action: T::SwapAction,
 			duration: T::BlockNumber,
@@ -300,7 +300,7 @@ decl_module! {
 		#[weight = T::DbWeight::get().reads_writes(1, 1).saturating_add(40_000_000)]
 		fn cancel_swap(
 			origin,
-			target: T::AccountId,
+			target: <T::Lookup as StaticLookup>::Source,
 			hashed_proof: HashedProof,
 		) {
 			let source = ensure_signed(origin)?;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -561,7 +561,7 @@ decl_module! {
 		/// If contract is not evicted as a result of this call, no actions are taken and
 		/// the sender is not eligible for the reward.
 		#[weight = 0]
-		fn claim_surcharge(origin, dest: T::AccountId, aux_sender: Option<T::AccountId>) {
+		fn claim_surcharge(origin, dest: <T::Lookup as StaticLookup>::Source, aux_sender: Option<T::AccountId>) {
 			let origin = origin.into();
 			let (signed, rewarded) = match (origin, aux_sender) {
 				(Ok(frame_system::RawOrigin::Signed(account)), None) => {

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1025,7 +1025,7 @@ decl_module! {
 		#[weight = weight_for::delegate::<T>(T::MaxVotes::get().into())]
 		pub fn delegate(
 			origin,
-			to: T::AccountId,
+			to: <T::Lookup as StaticLookup>::Source,
 			conviction: Conviction,
 			balance: BalanceOf<T>
 		) -> DispatchResultWithPostInfo {

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1195,7 +1195,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = 43_000_000 + 330_000 * Weight::from(T::MaxVotes::get())
 			+ T::DbWeight::get().reads_writes(3, 3)]
-		fn unlock(origin, target: T::AccountId) {
+		fn unlock(origin, target: <T::Lookup as StaticLookup>::Source) {
 			ensure_signed(origin)?;
 			Self::update_lock(&target);
 		}
@@ -1259,7 +1259,7 @@ decl_module! {
 		/// - Base Weight: 19.15 + .372 * R
 		/// # </weight>
 		#[weight = 19_000_000 + 370_000 * Weight::from(T::MaxVotes::get()) + T::DbWeight::get().reads_writes(2, 2)]
-		fn remove_other_vote(origin, target: T::AccountId, index: ReferendumIndex) -> DispatchResult {
+		fn remove_other_vote(origin, target: <T::Lookup as StaticLookup>::Source, index: ReferendumIndex) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let scope = if target == who { UnvoteScope::Any } else { UnvoteScope::OnlyExpired };
 			Self::try_remove_vote(&target, index, scope)?;

--- a/frame/generic-asset/src/lib.rs
+++ b/frame/generic-asset/src/lib.rs
@@ -359,7 +359,7 @@ decl_module! {
 
 		/// Transfer some liquid free balance to another account.
 		#[weight = 0]
-		pub fn transfer(origin, #[compact] asset_id: T::AssetId, to: T::AccountId, #[compact] amount: T::Balance) {
+		pub fn transfer(origin, #[compact] asset_id: T::AssetId, to: <T::Lookup as StaticLookup>::Source, #[compact] amount: T::Balance) {
 			let origin = ensure_signed(origin)?;
 			ensure!(!amount.is_zero(), Error::<T>::ZeroAmount);
 			Self::make_transfer_with_event(&asset_id, &origin, &to, amount)?;
@@ -392,7 +392,7 @@ decl_module! {
 		/// Mints an asset, increases its total issuance.
 		/// The origin must have `mint` permissions.
 		#[weight = 0]
-		fn mint(origin, #[compact] asset_id: T::AssetId, to: T::AccountId, amount: T::Balance) -> DispatchResult {
+		fn mint(origin, #[compact] asset_id: T::AssetId, to: <T::Lookup as StaticLookup>::Source, amount: T::Balance) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::mint_free(&asset_id, &who, &to, &amount)?;
 			Self::deposit_event(RawEvent::Minted(asset_id, to, amount));
@@ -402,7 +402,7 @@ decl_module! {
 		/// Burns an asset, decreases its total issuance.
 		/// The `origin` must have `burn` permissions.
 		#[weight = 0]
-		fn burn(origin, #[compact] asset_id: T::AssetId, to: T::AccountId, amount: T::Balance) -> DispatchResult {
+		fn burn(origin, #[compact] asset_id: T::AssetId, to: <T::Lookup as StaticLookup>::Source, amount: T::Balance) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::burn_free(&asset_id, &who, &to, &amount)?;
 			Self::deposit_event(RawEvent::Burned(asset_id, to, amount));

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -1004,7 +1004,7 @@ decl_module! {
 		]
 		fn set_account_id(origin,
 			#[compact] index: RegistrarIndex,
-			new: T::AccountId,
+			new: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -665,7 +665,7 @@ decl_module! {
 		/// - One event.
 		/// # </weight>
 		#[weight = weight_for::add_registrar::<T>(T::MaxRegistrars::get().into()) ]
-		fn add_registrar(origin, account: T::AccountId) -> DispatchResultWithPostInfo {
+		fn add_registrar(origin, account: <T::Lookup as StaticLookup>::Source) -> DispatchResultWithPostInfo {
 			T::RegistrarOrigin::ensure_origin(origin)?;
 
 			let (i, registrar_count) = <Registrars<T>>::try_mutate(

--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -176,7 +176,7 @@ decl_module! {
 		///    - Writes: Indices Accounts, System Account (recipient)
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(2, 2) + 35 * WEIGHT_PER_MICROS]
-		fn transfer(origin, new: T::AccountId, index: T::AccountIndex) {
+		fn transfer(origin, new: <T::Lookup as StaticLookup>::Source, index: T::AccountIndex) {
 			let who = ensure_signed(origin)?;
 			ensure!(who != new, Error::<T>::NotTransfer);
 
@@ -247,7 +247,7 @@ decl_module! {
 		///    - Writes: Indices Accounts, System Account (original owner)
 		/// # </weight>
 		#[weight = T::DbWeight::get().reads_writes(2, 2) + 25 * WEIGHT_PER_MICROS]
-		fn force_transfer(origin, new: T::AccountId, index: T::AccountIndex, freeze: bool) {
+		fn force_transfer(origin, new: <T::Lookup as StaticLookup>::Source, index: T::AccountIndex, freeze: bool) {
 			ensure_root(origin)?;
 
 			Accounts::<T>::mutate(index, |maybe_value| {

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -156,7 +156,7 @@ decl_module! {
 		///
 		/// Prime membership is *not* passed from `remove` to `add`, if extant.
 		#[weight = 50_000_000]
-		pub fn swap_member(origin, remove: <T::Lookup as StaticLookup>::Source, add: T::AccountId) {
+		pub fn swap_member(origin, remove: <T::Lookup as StaticLookup>::Source, add: <T::Lookup as StaticLookup>::Source) {
 			T::SwapOrigin::ensure_origin(origin)?;
 
 			if remove == add { return Ok(()) }

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -119,7 +119,7 @@ decl_module! {
 		///
 		/// May only be called from `T::AddOrigin`.
 		#[weight = 50_000_000]
-		pub fn add_member(origin, who: T::AccountId) {
+		pub fn add_member(origin, who: <T::Lookup as StaticLookup>::Source) {
 			T::AddOrigin::ensure_origin(origin)?;
 
 			let mut members = <Members<T, I>>::get();
@@ -136,7 +136,7 @@ decl_module! {
 		///
 		/// May only be called from `T::RemoveOrigin`.
 		#[weight = 50_000_000]
-		pub fn remove_member(origin, who: T::AccountId) {
+		pub fn remove_member(origin, who: <T::Lookup as StaticLookup>::Source) {
 			T::RemoveOrigin::ensure_origin(origin)?;
 
 			let mut members = <Members<T, I>>::get();
@@ -234,7 +234,7 @@ decl_module! {
 		///
 		/// May only be called from `T::PrimeOrigin`.
 		#[weight = 50_000_000]
-		pub fn set_prime(origin, who: T::AccountId) {
+		pub fn set_prime(origin, who: <T::Lookup as StaticLookup>::Source) {
 			T::PrimeOrigin::ensure_origin(origin)?;
 			Self::members().binary_search(&who).ok().ok_or(Error::<T, I>::NotMember)?;
 			Prime::<T, I>::put(&who);

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -156,7 +156,7 @@ decl_module! {
 		///
 		/// Prime membership is *not* passed from `remove` to `add`, if extant.
 		#[weight = 50_000_000]
-		pub fn swap_member(origin, remove: T::AccountId, add: T::AccountId) {
+		pub fn swap_member(origin, remove: <T::Lookup as StaticLookup>::Source, add: T::AccountId) {
 			T::SwapOrigin::ensure_origin(origin)?;
 
 			if remove == add { return Ok(()) }

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -204,7 +204,7 @@ decl_module! {
 		///
 		/// Prime membership is passed from the origin account to `new`, if extant.
 		#[weight = 50_000_000]
-		pub fn change_key(origin, new: T::AccountId) {
+		pub fn change_key(origin, new: <T::Lookup as StaticLookup>::Source) {
 			let remove = ensure_signed(origin)?;
 
 			if remove != new {

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -190,7 +190,7 @@ decl_module! {
 			di.class)
 		}]
 		fn proxy(origin,
-			real: T::AccountId,
+			real: <T::Lookup as StaticLookup>::Source,
 			force_proxy_type: Option<T::ProxyType>,
 			call: Box<<T as Trait>::Call>
 		) {

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -378,7 +378,7 @@ decl_module! {
 			.saturating_add((140 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
 		fn kill_anonymous(origin,
-			spawner: T::AccountId,
+			spawner: <T::Lookup as StaticLookup>::Source,
 			proxy_type: T::ProxyType,
 			index: u16,
 			#[compact] height: T::BlockNumber,

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -232,7 +232,7 @@ decl_module! {
 			.saturating_add(18 * WEIGHT_PER_MICROS)
 			.saturating_add((200 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
-		fn add_proxy(origin, proxy: T::AccountId, proxy_type: T::ProxyType) -> DispatchResult {
+		fn add_proxy(origin, proxy: <T::Lookup as StaticLookup>::Source, proxy_type: T::ProxyType) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Proxies::<T>::try_mutate(&who, |(ref mut proxies, ref mut deposit)| {
 				ensure!(proxies.len() < T::MaxProxies::get() as usize, Error::<T>::TooMany);
@@ -268,7 +268,7 @@ decl_module! {
 			.saturating_add(14 * WEIGHT_PER_MICROS)
 			.saturating_add((160 * WEIGHT_PER_NANOS).saturating_mul(T::MaxProxies::get().into()))
 		]
-		fn remove_proxy(origin, proxy: T::AccountId, proxy_type: T::ProxyType) -> DispatchResult {
+		fn remove_proxy(origin, proxy: <T::Lookup as StaticLookup>::Source, proxy_type: T::ProxyType) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Proxies::<T>::try_mutate_exists(&who, |x| {
 				let (mut proxies, old_deposit) = x.take().ok_or(Error::<T>::NotFound)?;

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -375,7 +375,7 @@ decl_module! {
 		/// - One event
 		/// # </weight>
 		#[weight = 0]
-		fn set_recovered(origin, lost: T::AccountId, rescuer: T::AccountId) {
+		fn set_recovered(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: T::AccountId) {
 			ensure_root(origin)?;
 			// Create the recovery storage item.
 			<Proxy<T>>::insert(&rescuer, &lost);
@@ -516,7 +516,7 @@ decl_module! {
 		/// Total Complexity: O(F + logF + V + logV)
 		/// # </weight>
 		#[weight = 100_000_000]
-		fn vouch_recovery(origin, lost: T::AccountId, rescuer: T::AccountId) {
+		fn vouch_recovery(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: T::AccountId) {
 			let who = ensure_signed(origin)?;
 			// Get the recovery configuration for the lost account.
 			let recovery_config = Self::recovery_config(&lost).ok_or(Error::<T>::NotRecoverable)?;

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -600,7 +600,7 @@ decl_module! {
 		/// Total Complexity: O(V + X)
 		/// # </weight>
 		#[weight = 30_000_000]
-		fn close_recovery(origin, rescuer: T::AccountId) {
+		fn close_recovery(origin, rescuer: <T::Lookup as StaticLookup>::Source) {
 			let who = ensure_signed(origin)?;
 			// Take the active recovery process started by the rescuer for this account.
 			let active_recovery = <ActiveRecoveries<T>>::take(&who, &rescuer).ok_or(Error::<T>::NotStarted)?;

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -375,7 +375,7 @@ decl_module! {
 		/// - One event
 		/// # </weight>
 		#[weight = 0]
-		fn set_recovered(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: T::AccountId) {
+		fn set_recovered(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: <T::Lookup as StaticLookup>::Source) {
 			ensure_root(origin)?;
 			// Create the recovery storage item.
 			<Proxy<T>>::insert(&rescuer, &lost);
@@ -516,7 +516,7 @@ decl_module! {
 		/// Total Complexity: O(F + logF + V + logV)
 		/// # </weight>
 		#[weight = 100_000_000]
-		fn vouch_recovery(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: T::AccountId) {
+		fn vouch_recovery(origin, lost: <T::Lookup as StaticLookup>::Source, rescuer: <T::Lookup as StaticLookup>::Source) {
 			let who = ensure_signed(origin)?;
 			// Get the recovery configuration for the lost account.
 			let recovery_config = Self::recovery_config(&lost).ok_or(Error::<T>::NotRecoverable)?;

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -350,7 +350,7 @@ decl_module! {
 		/// # </weight>
 		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
 		fn as_recovered(origin,
-			account: T::AccountId,
+			account: <T::Lookup as StaticLookup>::Source,
 			call: Box<<T as Trait>::Call>
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -470,7 +470,7 @@ decl_module! {
 		/// Total Complexity: O(F + X)
 		/// # </weight>
 		#[weight = 100_000_000]
-		fn initiate_recovery(origin, account: T::AccountId) {
+		fn initiate_recovery(origin, account: <T::Lookup as StaticLookup>::Source) {
 			let who = ensure_signed(origin)?;
 			// Check that the account is recoverable
 			ensure!(<Recoverable<T>>::contains_key(&account), Error::<T>::NotRecoverable);
@@ -555,7 +555,7 @@ decl_module! {
 		/// Total Complexity: O(F + V)
 		/// # </weight>
 		#[weight = 100_000_000]
-		fn claim_recovery(origin, account: T::AccountId) {
+		fn claim_recovery(origin, account: <T::Lookup as StaticLookup>::Source) {
 			let who = ensure_signed(origin)?;
 			// Get the recovery configuration for the lost account
 			let recovery_config = Self::recovery_config(&account).ok_or(Error::<T>::NotRecoverable)?;
@@ -657,7 +657,7 @@ decl_module! {
 		/// - One storage mutation to check account is recovered by `who`. O(1)
 		/// # </weight>
 		#[weight = 0]
-		fn cancel_recovered(origin, account: T::AccountId) {
+		fn cancel_recovered(origin, account: <T::Lookup as StaticLookup>::Source) {
 			let who = ensure_signed(origin)?;
 			// Check `who` is allowed to make a call on behalf of `account`
 			ensure!(Self::proxy(&who) == Some(account), Error::<T>::NotAllowed);

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -826,7 +826,7 @@ decl_module! {
 		/// Total Complexity: O(1)
 		/// # </weight>
 		#[weight = T::MaximumBlockWeight::get() / 10]
-		fn found(origin, founder: T::AccountId, max_members: u32, rules: Vec<u8>) {
+		fn found(origin, founder: <T::Lookup as StaticLookup>::Source, max_members: u32, rules: Vec<u8>) {
 			T::FounderSetOrigin::ensure_origin(origin)?;
 			ensure!(!<Head<T, I>>::exists(), Error::<T, I>::AlreadyFounded);
 			ensure!(max_members > 1, Error::<T, I>::MaxMembers);

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -642,7 +642,7 @@ decl_module! {
 		/// Total Complexity: O(M + B + C + logM + logB + X)
 		/// # </weight>
 		#[weight = T::MaximumBlockWeight::get() / 10]
-		pub fn vouch(origin, who: T::AccountId, value: BalanceOf<T, I>, tip: BalanceOf<T, I>) -> DispatchResult {
+		pub fn vouch(origin, who: <T::Lookup as StaticLookup>::Source, value: BalanceOf<T, I>, tip: BalanceOf<T, I>) -> DispatchResult {
 			let voucher = ensure_signed(origin)?;
 			// Check user is not suspended.
 			ensure!(!<SuspendedCandidates<T, I>>::contains_key(&who), Error::<T, I>::Suspended);
@@ -895,7 +895,7 @@ decl_module! {
 		/// Total Complexity: O(M + logM + B)
 		/// # </weight>
 		#[weight = T::MaximumBlockWeight::get() / 10]
-		fn judge_suspended_member(origin, who: T::AccountId, forgive: bool) {
+		fn judge_suspended_member(origin, who: <T::Lookup as StaticLookup>::Source, forgive: bool) {
 			T::SuspensionJudgementOrigin::ensure_origin(origin)?;
 			ensure!(<SuspendedMembers<T, I>>::contains_key(&who), Error::<T, I>::NotSuspended);
 
@@ -966,7 +966,7 @@ decl_module! {
 		/// Total Complexity: O(M + logM + B + X)
 		/// # </weight>
 		#[weight = T::MaximumBlockWeight::get() / 10]
-		fn judge_suspended_candidate(origin, who: T::AccountId, judgement: Judgement) {
+		fn judge_suspended_candidate(origin, who: <T::Lookup as StaticLookup>::Source, judgement: Judgement) {
 			T::SuspensionJudgementOrigin::ensure_origin(origin)?;
 			if let Some((value, kind)) = <SuspendedCandidates<T, I>>::get(&who) {
 				match judgement {

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1967,7 +1967,7 @@ decl_module! {
 			// if slashing spans is non-zero, add 1 more write
 			.saturating_add(T::DbWeight::get().writes(Weight::from(*num_slashing_spans > 0)))
 		]
-		fn force_unstake(origin, stash: T::AccountId, num_slashing_spans: u32) {
+		fn force_unstake(origin, stash: <T::Lookup as StaticLookup>::Source, num_slashing_spans: u32) {
 			ensure_root(origin)?;
 
 			// remove all staking-related information.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2059,7 +2059,7 @@ decl_module! {
 			+ T::DbWeight::get().reads(5)  * Weight::from(T::MaxNominatorRewardedPerValidator::get() + 1)
 			+ T::DbWeight::get().writes(3) * Weight::from(T::MaxNominatorRewardedPerValidator::get() + 1)
 		]
-		fn payout_stakers(origin, validator_stash: T::AccountId, era: EraIndex) -> DispatchResult {
+		fn payout_stakers(origin, validator_stash: <T::Lookup as StaticLookup>::Source, era: EraIndex) -> DispatchResult {
 			ensure!(Self::era_election_status().is_closed(), Error::<T>::CallNotAllowed);
 			ensure_signed(origin)?;
 			Self::do_payout_stakers(validator_stash, era)

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -443,7 +443,7 @@ decl_module! {
 		/// - DbWrites: `Tips`, `who account data`
 		/// # </weight>
 		#[weight = 140_000_000 + 4_000 * reason.len() as Weight + T::DbWeight::get().reads_writes(3, 2)]
-		fn report_awesome(origin, reason: Vec<u8>, who: T::AccountId) {
+		fn report_awesome(origin, reason: Vec<u8>, who: <T::Lookup as StaticLookup>::Source) {
 			let finder = ensure_signed(origin)?;
 
 			const MAX_SENSIBLE_REASON_LENGTH: usize = 16384;
@@ -531,7 +531,7 @@ decl_module! {
 			+ 4_000 * reason.len() as Weight
 			+ 480_000 * T::Tippers::max_len() as Weight
 			+ T::DbWeight::get().reads_writes(2, 2)]
-		fn tip_new(origin, reason: Vec<u8>, who: T::AccountId, tip_value: BalanceOf<T>) {
+		fn tip_new(origin, reason: Vec<u8>, who: <T::Lookup as StaticLookup>::Source, tip_value: BalanceOf<T>) {
 			let tipper = ensure_signed(origin)?;
 			ensure!(T::Tippers::contains(&tipper), BadOrigin);
 			let reason_hash = T::Hashing::hash(&reason[..]);


### PR DESCRIPTION
## Questions
  * [ ] Do we have to update usage of `AccountId` in `Option` types, e.g.
```
fn claim_surcharge(origin, dest: <T::Lookup as StaticLookup>::Source, aux_sender: Option<T::AccountId>) {
```
  * [ ] Do we have to update usage of `AccountId` in struct types, e.g.
```
fn create(origin, options: AssetOptions<T::Balance, T::AccountId>) -> DispatchResult {

fn update_permission(
  origin,
  #[compact] asset_id: T::AssetId,
  new_permission: PermissionLatest<T::AccountId>
```
  * [ ] Do we have to update usage of `AccountId` in `Vec` types, e.g.
```
fn set_subs(origin, subs: Vec<(T::AccountId, Data)>) -> DispatchResultWithPostInfo {

pub fn reset_members(origin, members: Vec<T::AccountId>) {

fn as_multi_threshold_1(origin,
  other_signatories: Vec<T::AccountId>,

fn as_multi(origin,
  threshold: u16,
  other_signatories: Vec<T::AccountId>,

fn approve_as_multi(origin,
  threshold: u16,
  other_signatories: Vec<T::AccountId>,

fn cancel_as_multi(origin,
  threshold: u16,
  other_signatories: Vec<T::AccountId>,

fn create_recovery(origin,
  friends: Vec<T::AccountId>,

pub fn encode_accounts(_origin, accounts: Vec<T::AccountId>) {

fn set_invulnerables(origin, validators: Vec<T::AccountId>) {

fn set_members(origin,
  new_members: Vec<T::AccountId>,
  prime: Option<T::AccountId>,

fn vote(
	origin,
	votes: Vec<T::AccountId>,
```
  * [ ] If there are multiple `AccountId`'s where there's an `origin`, should we update both in the signature (I've replaced some instances like this already), e.g.
```
pub fn bare_call(
  origin: T::AccountId,
  dest: T::AccountId,
```

  * [ ] Do we update those without `origin` that have `AccountId` in the signature like
```
fn operate(
  who: T::AccountId,
  threshold: u16,
  other_signatories: Vec<T::AccountId>,
```
  * [ ] If a function has `origin`, do we have to update return types that use `T::AccountId`?
  * [ ] Do we update those with `T::AccountIndex` in any way?
```
fn claim(origin, index: T::AccountIndex) {
fn transfer(origin, new: <T::Lookup as StaticLookup>::Source, index: T::AccountIndex) {
fn free(origin, index: T::AccountIndex) {
fn force_transfer(origin, new: <T::Lookup as StaticLookup>::Source, index: T::AccountIndex, freeze: bool) {
fn freeze(origin, index: T::AccountIndex) {
```
  * [ ] Do we update ones like this?
```
fn execute_wasm(
  origin: T::AccountId,

pub fn restore_to<T: Trait>(
  origin: T::AccountId,

fn contract_address_for(code_hash: &CodeHash<T>, data: &[u8], origin: &T::AccountId) -> T::AccountId {

fn transfer<'a, T: Trait, V: Vm<T>, L: Loader<T>>(
	gas_meter: &mut GasMeter<T>,
	cause: TransferCause,
	origin: TransactorKind,
	transactor: &T::AccountId,
	dest: &T::AccountId,
```

### Further Tasks
* [ ] Check and update Linting
* [ ] Check and update Tests
* [ ] Check and update examples, e.g.
```
//! \##### <code>\`example_setter_name(origin, parameter_name: T::ExampleType)\`</code>
```
* [ ] Check and update Docs
* [ ] Peer review