### PR TITLE
Support Component-less Runtime Benchmarks

### DIFF
--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -38,6 +38,7 @@ pub enum BenchmarkSelector {
 
 impl Analysis {
 	// Useful for when there are no components, and we just need an median value of the benchmark results.
+	// Note: We choose the median value because it is more robust to outliers.
 	fn median_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
 		if r.is_empty() { return None }
 

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -38,7 +38,7 @@ pub enum BenchmarkSelector {
 
 impl Analysis {
 	// Useful for when there are no components, and we just need an mean value of the benchmark results.
-	pub fn mean_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+	fn mean_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
 		if r.is_empty() { return None }
 
 		let total: u128 = r.iter().map(|result|
@@ -61,7 +61,7 @@ impl Analysis {
 	}
 
 	// Useful for when there are no components, and we just need an median value of the benchmark results.
-	pub fn median_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+	fn median_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
 		if r.is_empty() { return None }
 
 		let mut values: Vec<u128> = r.iter().map(|result|

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -37,29 +37,6 @@ pub enum BenchmarkSelector {
 }
 
 impl Analysis {
-	// Useful for when there are no components, and we just need an mean value of the benchmark results.
-	fn mean_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
-		if r.is_empty() { return None }
-
-		let total: u128 = r.iter().map(|result|
-			match selector {
-				BenchmarkSelector::ExtrinsicTime => result.extrinsic_time,
-				BenchmarkSelector::StorageRootTime => result.storage_root_time,
-				BenchmarkSelector::Reads => result.reads.into(),
-				BenchmarkSelector::Writes => result.writes.into(),
-			}
-		).sum();
-
-		let average: u128 = total / r.len() as u128;
-		Some(Self {
-			base: average,
-			slopes: Vec::new(),
-			names: Vec::new(),
-			value_dists: None,
-			model: None,
-		})
-	}
-
 	// Useful for when there are no components, and we just need an median value of the benchmark results.
 	fn median_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
 		if r.is_empty() { return None }
@@ -164,7 +141,7 @@ impl Analysis {
 	}
 
 	pub fn min_squares_iqr(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
-		if r[0].components.is_empty() { return Self::mean_value(r, selector) }
+		if r[0].components.is_empty() { return Self::median_value(r, selector) }
 
 		let mut results = BTreeMap::<Vec<u32>, Vec<u128>>::new();
 		for result in r.iter() {

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -37,7 +37,57 @@ pub enum BenchmarkSelector {
 }
 
 impl Analysis {
+	// Useful for when there are no components, and we just need an mean value of the benchmark results.
+	pub fn mean_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+		if r.is_empty() { return None }
+
+		let total: u128 = r.iter().map(|result|
+			match selector {
+				BenchmarkSelector::ExtrinsicTime => result.extrinsic_time,
+				BenchmarkSelector::StorageRootTime => result.storage_root_time,
+				BenchmarkSelector::Reads => result.reads.into(),
+				BenchmarkSelector::Writes => result.writes.into(),
+			}
+		).sum();
+
+		let average: u128 = total / r.len() as u128;
+		Some(Self {
+			base: average,
+			slopes: Vec::new(),
+			names: Vec::new(),
+			value_dists: None,
+			model: None,
+		})
+	}
+
+	// Useful for when there are no components, and we just need an median value of the benchmark results.
+	pub fn median_value(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+		if r.is_empty() { return None }
+
+		let mut values: Vec<u128> = r.iter().map(|result|
+			match selector {
+				BenchmarkSelector::ExtrinsicTime => result.extrinsic_time,
+				BenchmarkSelector::StorageRootTime => result.storage_root_time,
+				BenchmarkSelector::Reads => result.reads.into(),
+				BenchmarkSelector::Writes => result.writes.into(),
+			}
+		).collect();
+
+		values.sort();
+		let mid = values.len() / 2;
+
+		Some(Self {
+			base: values[mid],
+			slopes: Vec::new(),
+			names: Vec::new(),
+			value_dists: None,
+			model: None,
+		})
+	}
+
 	pub fn median_slopes(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+		if r[0].components.is_empty() { return Self::median_value(r, selector) }
+
 		let results = r[0].components.iter().enumerate().map(|(i, &(param, _))| {
 			let mut counted = BTreeMap::<Vec<u32>, usize>::new();
 			for result in r.iter() {
@@ -114,6 +164,8 @@ impl Analysis {
 	}
 
 	pub fn min_squares_iqr(r: &Vec<BenchmarkResults>, selector: BenchmarkSelector) -> Option<Self> {
+		if r[0].components.is_empty() { return Self::mean_value(r, selector) }
+
 		let mut results = BTreeMap::<Vec<u32>, Vec<u128>>::new();
 		for result in r.iter() {
 			let p = result.components.iter().map(|x| x.1).collect::<Vec<_>>();

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -794,100 +794,115 @@ macro_rules! impl_benchmark {
 				// Default number of steps for a component.
 				let mut prev_steps = 10;
 
-				// Select the component we will be benchmarking. Each component will be benchmarked.
-				for (idx, (name, low, high)) in components.iter().enumerate() {
-					// Get the number of steps for this component.
-					let steps = steps.get(idx).cloned().unwrap_or(prev_steps);
-					prev_steps = steps;
+				let repeat_benchmark = |
+					repeat: u32,
+					c: Vec<($crate::BenchmarkParameter, u32)>,
+					results: &mut Vec<$crate::BenchmarkResults>,
+				| -> Result<(), &'static str> {
+					// Run the benchmark `repeat` times.
+					for _ in 0..repeat {
+						// Set up the externalities environment for the setup we want to
+						// benchmark.
+						let closure_to_benchmark = <
+							SelectedBenchmark as $crate::BenchmarkingSetup<T>
+						>::instance(&selected_benchmark, &c)?;
 
-					// Skip this loop if steps is zero
-					if steps == 0 { continue }
+						// Set the block number to at least 1 so events are deposited.
+						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
+							frame_system::Module::<T>::set_block_number(1.into());
+						}
 
-					let lowest = lowest_range_values.get(idx).cloned().unwrap_or(*low);
-					let highest = highest_range_values.get(idx).cloned().unwrap_or(*high);
+						// Commit the externalities to the database, flushing the DB cache.
+						// This will enable worst case scenario for reading from the database.
+						$crate::benchmarking::commit_db();
 
-					let diff = highest - lowest;
+						// Reset the read/write counter so we don't count operations in the setup process.
+						$crate::benchmarking::reset_read_write_count();
 
-					// Create up to `STEPS` steps for that component between high and low.
-					let step_size = (diff / steps).max(1);
-					let num_of_steps = diff / step_size + 1;
+						// // Time the extrinsic logic.
+						// frame_support::debug::trace!(
+						// 	target: "benchmark",
+						// 	"Start Benchmark: {:?} {:?}", name, component_value
+						// );
 
-					for s in 0..num_of_steps {
-						// This is the value we will be testing for component `name`
-						let component_value = lowest + step_size * s;
+						let start_extrinsic = $crate::benchmarking::current_time();
+						closure_to_benchmark()?;
+						let finish_extrinsic = $crate::benchmarking::current_time();
+						let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
+						// Commit the changes to get proper write count
+						$crate::benchmarking::commit_db();
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"End Benchmark: {} ns", elapsed_extrinsic
+						);
+						let read_write_count = $crate::benchmarking::read_write_count();
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"Read/Write Count {:?}", read_write_count
+						);
 
-						// Select the max value for all the other components.
-						let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
-							.enumerate()
-							.map(|(idx, (n, _, h))|
-								if n == name {
-									(*n, component_value)
-								} else {
-									(*n, *highest_range_values.get(idx).unwrap_or(h))
-								}
-							)
-							.collect();
+						// Time the storage root recalculation.
+						let start_storage_root = $crate::benchmarking::current_time();
+						$crate::storage_root();
+						let finish_storage_root = $crate::benchmarking::current_time();
+						let elapsed_storage_root = finish_storage_root - start_storage_root;
 
-						// Run the benchmark `repeat` times.
-						for _ in 0..repeat {
-							// Set up the externalities environment for the setup we want to
-							// benchmark.
-							let closure_to_benchmark = <
-								SelectedBenchmark as $crate::BenchmarkingSetup<T>
-							>::instance(&selected_benchmark, &c)?;
+						results.push($crate::BenchmarkResults {
+							components: c.clone(),
+							extrinsic_time: elapsed_extrinsic,
+							storage_root_time: elapsed_storage_root,
+							reads: read_write_count.0,
+							repeat_reads: read_write_count.1,
+							writes: read_write_count.2,
+							repeat_writes: read_write_count.3,
+						});
 
-							// Set the block number to at least 1 so events are deposited.
-							if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
-								frame_system::Module::<T>::set_block_number(1.into());
-							}
+						// Wipe the DB back to the genesis state.
+						$crate::benchmarking::wipe_db();
+					}
 
-							// Commit the externalities to the database, flushing the DB cache.
-							// This will enable worst case scenario for reading from the database.
-							$crate::benchmarking::commit_db();
+					Ok(())
+				};
 
-							// Reset the read/write counter so we don't count operations in the setup process.
-							$crate::benchmarking::reset_read_write_count();
+				if components.is_empty() {
+					let c = Vec::new();
+					repeat_benchmark(repeat, c, &mut results)?;
+				} else {
+					// Select the component we will be benchmarking. Each component will be benchmarked.
+					for (idx, (name, low, high)) in components.iter().enumerate() {
+						// Get the number of steps for this component.
+						let steps = steps.get(idx).cloned().unwrap_or(prev_steps);
+						prev_steps = steps;
 
-							// Time the extrinsic logic.
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"Start Benchmark: {:?} {:?}", name, component_value
-							);
+						// Skip this loop if steps is zero
+						if steps == 0 { continue }
 
-							let start_extrinsic = $crate::benchmarking::current_time();
-							closure_to_benchmark()?;
-							let finish_extrinsic = $crate::benchmarking::current_time();
-							let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
-							// Commit the changes to get proper write count
-							$crate::benchmarking::commit_db();
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"End Benchmark: {} ns", elapsed_extrinsic
-							);
-							let read_write_count = $crate::benchmarking::read_write_count();
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"Read/Write Count {:?}", read_write_count
-							);
+						let lowest = lowest_range_values.get(idx).cloned().unwrap_or(*low);
+						let highest = highest_range_values.get(idx).cloned().unwrap_or(*high);
 
-							// Time the storage root recalculation.
-							let start_storage_root = $crate::benchmarking::current_time();
-							$crate::storage_root();
-							let finish_storage_root = $crate::benchmarking::current_time();
-							let elapsed_storage_root = finish_storage_root - start_storage_root;
+						let diff = highest - lowest;
 
-							results.push($crate::BenchmarkResults {
-								components: c.clone(),
-								extrinsic_time: elapsed_extrinsic,
-								storage_root_time: elapsed_storage_root,
-								reads: read_write_count.0,
-								repeat_reads: read_write_count.1,
-								writes: read_write_count.2,
-								repeat_writes: read_write_count.3,
-							});
+						// Create up to `STEPS` steps for that component between high and low.
+						let step_size = (diff / steps).max(1);
+						let num_of_steps = diff / step_size + 1;
 
-							// Wipe the DB back to the genesis state.
-							$crate::benchmarking::wipe_db();
+						for s in 0..num_of_steps {
+							// This is the value we will be testing for component `name`
+							let component_value = lowest + step_size * s;
+
+							// Select the max value for all the other components.
+							let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
+								.enumerate()
+								.map(|(idx, (n, _, h))|
+									if n == name {
+										(*n, component_value)
+									} else {
+										(*n, *highest_range_values.get(idx).unwrap_or(h))
+									}
+								)
+								.collect();
+
+							repeat_benchmark(repeat, c, &mut results)?;
 						}
 					}
 				}
@@ -938,99 +953,115 @@ macro_rules! impl_benchmark {
 				// Default number of steps for a component.
 				let mut prev_steps = 10;
 
-				// Select the component we will be benchmarking. Each component will be benchmarked.
-				for (idx, (name, low, high)) in components.iter().enumerate() {
-					// Get the number of steps for this component.
-					let steps = steps.get(idx).cloned().unwrap_or(prev_steps);
-					prev_steps = steps;
+				let repeat_benchmark = |
+					repeat: u32,
+					c: Vec<($crate::BenchmarkParameter, u32)>,
+					results: &mut Vec<$crate::BenchmarkResults>,
+				| -> Result<(), &'static str> {
+					// Run the benchmark `repeat` times.
+					for _ in 0..repeat {
+						// Set up the externalities environment for the setup we want to
+						// benchmark.
+						let closure_to_benchmark = <
+							SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>
+						>::instance(&selected_benchmark, &c)?;
 
-					// Skip this loop if steps is zero
-					if steps == 0 { continue }
+						// Set the block number to at least 1 so events are deposited.
+						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
+							frame_system::Module::<T>::set_block_number(1.into());
+						}
 
-					let lowest = lowest_range_values.get(idx).cloned().unwrap_or(*low);
-					let highest = highest_range_values.get(idx).cloned().unwrap_or(*high);
+						// Commit the externalities to the database, flushing the DB cache.
+						// This will enable worst case scenario for reading from the database.
+						$crate::benchmarking::commit_db();
 
-					let diff = highest - lowest;
+						// Reset the read/write counter so we don't count operations in the setup process.
+						$crate::benchmarking::reset_read_write_count();
 
-					// Create up to `STEPS` steps for that component between high and low.
-					let step_size = (diff / steps).max(1);
-					let num_of_steps = diff / step_size + 1;
+						// // Time the extrinsic logic.
+						// frame_support::debug::trace!(
+						// 	target: "benchmark",
+						// 	"Start Benchmark: {:?} {:?}", name, component_value
+						// );
 
-					for s in 0..num_of_steps {
-						// This is the value we will be testing for component `name`
-						let component_value = lowest + step_size * s;
+						let start_extrinsic = $crate::benchmarking::current_time();
+						closure_to_benchmark()?;
+						let finish_extrinsic = $crate::benchmarking::current_time();
+						let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
+						// Commit the changes to get proper write count
+						$crate::benchmarking::commit_db();
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"End Benchmark: {} ns", elapsed_extrinsic
+						);
+						let read_write_count = $crate::benchmarking::read_write_count();
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"Read/Write Count {:?}", read_write_count
+						);
 
-						// Select the max value for all the other components.
-						let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
-							.enumerate()
-							.map(|(idx, (n, _, h))|
-								if n == name {
-									(*n, component_value)
-								} else {
-									(*n, *highest_range_values.get(idx).unwrap_or(h))
-								}
-							)
-							.collect();
+						// Time the storage root recalculation.
+						let start_storage_root = $crate::benchmarking::current_time();
+						$crate::storage_root();
+						let finish_storage_root = $crate::benchmarking::current_time();
+						let elapsed_storage_root = finish_storage_root - start_storage_root;
 
-						// Run the benchmark `repeat` times.
-						for _ in 0..repeat {
-							// Set up the externalities environment for the setup we want to benchmark.
-							let closure_to_benchmark = <
-								SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, I>
-							>::instance(&selected_benchmark, &c)?;
+						results.push($crate::BenchmarkResults {
+							components: c.clone(),
+							extrinsic_time: elapsed_extrinsic,
+							storage_root_time: elapsed_storage_root,
+							reads: read_write_count.0,
+							repeat_reads: read_write_count.1,
+							writes: read_write_count.2,
+							repeat_writes: read_write_count.3,
+						});
 
-							// Set the block number to at least 1 so events are deposited.
-							if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
-								frame_system::Module::<T>::set_block_number(1.into());
-							}
+						// Wipe the DB back to the genesis state.
+						$crate::benchmarking::wipe_db();
+					}
 
-							// Commit the externalities to the database, flushing the DB cache.
-							// This will enable worst case scenario for reading from the database.
-							$crate::benchmarking::commit_db();
+					Ok(())
+				};
 
-							// Reset the read/write counter so we don't count operations in the setup process.
-							$crate::benchmarking::reset_read_write_count();
+				if components.is_empty() {
+					let c = Vec::new();
+					repeat_benchmark(repeat, c, &mut results)?;
+				} else {
+					// Select the component we will be benchmarking. Each component will be benchmarked.
+					for (idx, (name, low, high)) in components.iter().enumerate() {
+						// Get the number of steps for this component.
+						let steps = steps.get(idx).cloned().unwrap_or(prev_steps);
+						prev_steps = steps;
 
-							// Time the extrinsic logic.
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"Start Benchmark: {:?} {:?}", name, component_value
-							);
+						// Skip this loop if steps is zero
+						if steps == 0 { continue }
 
-							let start_extrinsic = $crate::benchmarking::current_time();
-							closure_to_benchmark()?;
-							let finish_extrinsic = $crate::benchmarking::current_time();
-							let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
-							// Commit the changes to get proper write count
-							$crate::benchmarking::commit_db();
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"End Benchmark: {} ns", elapsed_extrinsic
-							);
-							let read_write_count = $crate::benchmarking::read_write_count();
-							frame_support::debug::trace!(
-								target: "benchmark",
-								"Read/Write Count {:?}", read_write_count
-							);
+						let lowest = lowest_range_values.get(idx).cloned().unwrap_or(*low);
+						let highest = highest_range_values.get(idx).cloned().unwrap_or(*high);
 
-							// Time the storage root recalculation.
-							let start_storage_root = $crate::benchmarking::current_time();
-							$crate::storage_root();
-							let finish_storage_root = $crate::benchmarking::current_time();
-							let elapsed_storage_root = finish_storage_root - start_storage_root;
+						let diff = highest - lowest;
 
-							results.push($crate::BenchmarkResults {
-								components: c.clone(),
-								extrinsic_time: elapsed_extrinsic,
-								storage_root_time: elapsed_storage_root,
-								reads: read_write_count.0,
-								repeat_reads: read_write_count.1,
-								writes: read_write_count.2,
-								repeat_writes: read_write_count.3,
-							});
+						// Create up to `STEPS` steps for that component between high and low.
+						let step_size = (diff / steps).max(1);
+						let num_of_steps = diff / step_size + 1;
 
-							// Wipe the DB back to the genesis state.
-							$crate::benchmarking::wipe_db();
+						for s in 0..num_of_steps {
+							// This is the value we will be testing for component `name`
+							let component_value = lowest + step_size * s;
+
+							// Select the max value for all the other components.
+							let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
+								.enumerate()
+								.map(|(idx, (n, _, h))|
+									if n == name {
+										(*n, component_value)
+									} else {
+										(*n, *highest_range_values.get(idx).unwrap_or(h))
+									}
+								)
+								.collect();
+
+							repeat_benchmark(repeat, c, &mut results)?;
 						}
 					}
 				}
@@ -1060,40 +1091,49 @@ macro_rules! impl_benchmark_test {
 					SelectedBenchmark as $crate::BenchmarkingSetup<T>
 				>::components(&selected_benchmark);
 
-				assert!(
-					components.len() != 0,
-					"You need to add components to your benchmark!",
-				);
-				for (_, (name, low, high)) in components.iter().enumerate() {
-					// Test only the low and high value, assuming values in the middle won't break
-					for component_value in vec![low, high] {
-						// Select the max value for all the other components.
-						let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
-							.enumerate()
-							.map(|(_, (n, _, h))|
-								if n == name {
-									(*n, *component_value)
-								} else {
-									(*n, *h)
-								}
-							)
-							.collect();
+				let execute_benchmark = |
+					c: Vec<($crate::BenchmarkParameter, u32)>
+				| -> Result<(), &'static str> {
+					// Set up the verification state
+					let closure_to_verify = <
+						SelectedBenchmark as $crate::BenchmarkingSetup<T>
+					>::verify(&selected_benchmark, &c)?;
 
-						// Set up the verification state
-						let closure_to_verify = <
-							SelectedBenchmark as $crate::BenchmarkingSetup<T>
-						>::verify(&selected_benchmark, &c)?;
+					// Set the block number to at least 1 so events are deposited.
+					if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
+						frame_system::Module::<T>::set_block_number(1.into());
+					}
 
-						// Set the block number to at least 1 so events are deposited.
-						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
-							frame_system::Module::<T>::set_block_number(1.into());
+					// Run verification
+					closure_to_verify()?;
+
+					// Reset the state
+					$crate::benchmarking::wipe_db();
+
+					Ok(())
+				};
+
+				if components.is_empty() {
+					let c = Vec::new();
+					execute_benchmark(c)?;
+				} else {
+					for (_, (name, low, high)) in components.iter().enumerate() {
+						// Test only the low and high value, assuming values in the middle won't break
+						for component_value in vec![low, high] {
+							// Select the max value for all the other components.
+							let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
+								.enumerate()
+								.map(|(_, (n, _, h))|
+									if n == name {
+										(*n, *component_value)
+									} else {
+										(*n, *h)
+									}
+								)
+								.collect();
+
+							execute_benchmark(c)?;
 						}
-
-						// Run verification
-						closure_to_verify()?;
-
-						// Reset the state
-						$crate::benchmarking::wipe_db();
 					}
 				}
 				Ok(())
@@ -1114,6 +1154,28 @@ macro_rules! impl_benchmark_test {
 					SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>
 				>::components(&selected_benchmark);
 
+				let execute_benchmark = |
+					c: Vec<($crate::BenchmarkParameter, u32)>
+				| -> Result<(), &'static str> {
+					// Set up the verification state
+					let closure_to_verify = <
+						SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>
+					>::verify(&selected_benchmark, &c)?;
+
+					// Set the block number to at least 1 so events are deposited.
+					if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
+						frame_system::Module::<T>::set_block_number(1.into());
+					}
+
+					// Run verification
+					closure_to_verify()?;
+
+					// Reset the state
+					$crate::benchmarking::wipe_db();
+
+					Ok(())
+				};
+
 				for (_, (name, low, high)) in components.iter().enumerate() {
 					// Test only the low and high value, assuming values in the middle won't break
 					for component_value in vec![low, high] {
@@ -1129,21 +1191,7 @@ macro_rules! impl_benchmark_test {
 							)
 							.collect();
 
-						// Set up the verification state
-						let closure_to_verify = <
-							SelectedBenchmark as $crate::BenchmarkingSetupInstance<T, _>
-						>::verify(&selected_benchmark, &c)?;
-
-						// Set the block number to at least 1 so events are deposited.
-						if $crate::Zero::is_zero(&frame_system::Module::<T>::block_number()) {
-							frame_system::Module::<T>::set_block_number(1.into());
-						}
-
-						// Run verification
-						closure_to_verify()?;
-
-						// Reset the state
-						$crate::benchmarking::wipe_db();
+						execute_benchmark(c)?;
 					}
 				}
 				Ok(())

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -865,8 +865,7 @@ macro_rules! impl_benchmark {
 				};
 
 				if components.is_empty() {
-					let c = Vec::new();
-					repeat_benchmark(repeat, c, &mut results)?;
+					repeat_benchmark(repeat, Default::default(), &mut results)?;
 				} else {
 					// Select the component we will be benchmarking. Each component will be benchmarked.
 					for (idx, (name, low, high)) in components.iter().enumerate() {
@@ -981,7 +980,7 @@ macro_rules! impl_benchmark {
 						// Time the extrinsic logic.
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"Start Benchmark: {:?}", 
+							"Start Benchmark: {:?}",
 							c,
 						);
 
@@ -993,13 +992,13 @@ macro_rules! impl_benchmark {
 						$crate::benchmarking::commit_db();
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"End Benchmark: {} ns", 
+							"End Benchmark: {} ns",
 							elapsed_extrinsic,
 						);
 						let read_write_count = $crate::benchmarking::read_write_count();
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"Read/Write Count {:?}", 
+							"Read/Write Count {:?}",
 							read_write_count,
 						);
 
@@ -1027,8 +1026,7 @@ macro_rules! impl_benchmark {
 				};
 
 				if components.is_empty() {
-					let c = Vec::new();
-					repeat_benchmark(repeat, c, &mut results)?;
+					repeat_benchmark(repeat, Default::default(), &mut results)?;
 				} else {
 					// Select the component we will be benchmarking. Each component will be benchmarked.
 					for (idx, (name, low, high)) in components.iter().enumerate() {

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -981,7 +981,8 @@ macro_rules! impl_benchmark {
 						// Time the extrinsic logic.
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"Start Benchmark: {:?}", c
+							"Start Benchmark: {:?}", 
+							c,
 						);
 
 						let start_extrinsic = $crate::benchmarking::current_time();
@@ -992,12 +993,14 @@ macro_rules! impl_benchmark {
 						$crate::benchmarking::commit_db();
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"End Benchmark: {} ns", elapsed_extrinsic
+							"End Benchmark: {} ns", 
+							elapsed_extrinsic,
 						);
 						let read_write_count = $crate::benchmarking::read_write_count();
 						frame_support::debug::trace!(
 							target: "benchmark",
-							"Read/Write Count {:?}", read_write_count
+							"Read/Write Count {:?}", 
+							read_write_count,
 						);
 
 						// Time the storage root recalculation.
@@ -1114,8 +1117,7 @@ macro_rules! impl_benchmark_test {
 				};
 
 				if components.is_empty() {
-					let c = Vec::new();
-					execute_benchmark(c)?;
+					execute_benchmark(Default::default())?;
 				} else {
 					for (_, (name, low, high)) in components.iter().enumerate() {
 						// Test only the low and high value, assuming values in the middle won't break

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -819,11 +819,11 @@ macro_rules! impl_benchmark {
 						// Reset the read/write counter so we don't count operations in the setup process.
 						$crate::benchmarking::reset_read_write_count();
 
-						// // Time the extrinsic logic.
-						// frame_support::debug::trace!(
-						// 	target: "benchmark",
-						// 	"Start Benchmark: {:?} {:?}", name, component_value
-						// );
+						// Time the extrinsic logic.
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"Start Benchmark: {:?}", c
+						);
 
 						let start_extrinsic = $crate::benchmarking::current_time();
 						closure_to_benchmark()?;
@@ -978,11 +978,11 @@ macro_rules! impl_benchmark {
 						// Reset the read/write counter so we don't count operations in the setup process.
 						$crate::benchmarking::reset_read_write_count();
 
-						// // Time the extrinsic logic.
-						// frame_support::debug::trace!(
-						// 	target: "benchmark",
-						// 	"Start Benchmark: {:?} {:?}", name, component_value
-						// );
+						// Time the extrinsic logic.
+						frame_support::debug::trace!(
+							target: "benchmark",
+							"Start Benchmark: {:?}", c
+						);
 
 						let start_extrinsic = $crate::benchmarking::current_time();
 						closure_to_benchmark()?;

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -167,6 +167,10 @@ benchmarks!{
 	verify {
 		ensure!(m[0] == 0, "You forgot to sort!")
 	}
+
+	no_components {
+		let caller = account::<T::AccountId>("caller", 0, 0);
+	}: set_value(RawOrigin::Signed(caller), 0)
 }
 
 #[test]
@@ -242,5 +246,6 @@ fn benchmarks_generate_unit_tests() {
 		assert_ok!(test_benchmark_sort_vector::<Test>());
 		assert_err!(test_benchmark_bad_origin::<Test>(), "Bad origin");
 		assert_err!(test_benchmark_bad_verify::<Test>(), "You forgot to sort!");
+		assert_ok!(test_benchmark_no_components::<Test>());
 	});
 }

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -30,12 +30,15 @@ pub fn open_file(path: &str) -> Result<File, std::io::Error> {
 		.open(path)
 }
 
-pub fn write_trait(file: &mut File, batches: Result<Vec<BenchmarkBatch>, String>) -> Result<(), std::io::Error> {
-	let batches = batches.unwrap();
-
+pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), std::io::Error> {
 	let mut current_pallet = Vec::<u8>::new();
 
+	// Skip writing if there are no batches
+	if batches.is_empty() { return Ok(()) }
+
 	batches.iter().for_each(|batch| {
+		// Skip writing if there are no results
+		if batch.results.is_empty() { return }
 
 		let pallet_string = String::from_utf8(batch.pallet.clone()).unwrap();
 		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
@@ -55,7 +58,7 @@ pub fn write_trait(file: &mut File, batches: Result<Vec<BenchmarkBatch>, String>
 		}
 
 		// function name
-		write!(file, "	fn {}(", benchmark_string).unwrap();
+		write!(file, "\tfn {}(", benchmark_string).unwrap();
 
 		// params
 		let components = &batch.results[0].components;
@@ -91,7 +94,7 @@ pub fn write_trait(file: &mut File, batches: Result<Vec<BenchmarkBatch>, String>
 		}
 
 		// function name
-		write!(file, "	fn {}(", benchmark_string).unwrap();
+		write!(file, "\tfn {}(", benchmark_string).unwrap();
 
 		// params
 		let components = &batch.results[0].components;
@@ -108,15 +111,18 @@ pub fn write_trait(file: &mut File, batches: Result<Vec<BenchmarkBatch>, String>
 	Ok(())
 }
 
-pub fn write_results(file: &mut File, batches: Result<Vec<BenchmarkBatch>, String>) -> Result<(), std::io::Error> {
-	let batches = batches.unwrap();
-
+pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), std::io::Error> {
 	let mut current_pallet = Vec::<u8>::new();
+
+	// Skip writing if there are no batches
+	if batches.is_empty() { return Ok(()) }
 
 	// general imports
 	write!(file, "use frame_support::weights::{{Weight, constants::RocksDbWeight as DbWeight}};\n").unwrap();
 
 	batches.iter().for_each(|batch| {
+		// Skip writing if there are no results
+		if batch.results.is_empty() { return }
 
 		let pallet_string = String::from_utf8(batch.pallet.clone()).unwrap();
 		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
@@ -143,7 +149,7 @@ pub fn write_results(file: &mut File, batches: Result<Vec<BenchmarkBatch>, Strin
 		}
 
 		// function name
-		write!(file, "	fn {}(", benchmark_string).unwrap();
+		write!(file, "\tfn {}(", benchmark_string).unwrap();
 
 		// params
 		let components = &batch.results[0].components;
@@ -154,34 +160,34 @@ pub fn write_results(file: &mut File, batches: Result<Vec<BenchmarkBatch>, Strin
 		write!(file, ") -> Weight {{\n").unwrap();
 
 		let extrinsic_time = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::ExtrinsicTime).unwrap();
-		write!(file, "		({} as Weight)\n", extrinsic_time.base.saturating_mul(1000)).unwrap();
+		write!(file, "\t\t({} as Weight)\n", extrinsic_time.base.saturating_mul(1000)).unwrap();
 		extrinsic_time.slopes.iter().zip(extrinsic_time.names.iter()).for_each(|(slope, name)| {
-			write!(file, "			.saturating_add(({} as Weight).saturating_mul({} as Weight))\n",
+			write!(file, "\t\t\t.saturating_add(({} as Weight).saturating_mul({} as Weight))\n",
 				slope.saturating_mul(1000),
 				name,
 			).unwrap();
 		});
 
 		let reads = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Reads).unwrap();
-		write!(file, "			.saturating_add(DbWeight::get().reads({} as Weight))\n", reads.base).unwrap();
+		write!(file, "\t\t\t.saturating_add(DbWeight::get().reads({} as Weight))\n", reads.base).unwrap();
 		reads.slopes.iter().zip(reads.names.iter()).for_each(|(slope, name)| {
-			write!(file, "			.saturating_add(DbWeight::get().reads(({} as Weight).saturating_mul({} as Weight)))\n",
+			write!(file, "\t\t\t.saturating_add(DbWeight::get().reads(({} as Weight).saturating_mul({} as Weight)))\n",
 				slope,
 				name,
 			).unwrap();
 		});
 
 		let writes = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Writes).unwrap();
-		write!(file, "			.saturating_add(DbWeight::get().writes({} as Weight))\n", writes.base).unwrap();
+		write!(file, "\t\t\t.saturating_add(DbWeight::get().writes({} as Weight))\n", writes.base).unwrap();
 		writes.slopes.iter().zip(writes.names.iter()).for_each(|(slope, name)| {
-			write!(file, "			.saturating_add(DbWeight::get().writes(({} as Weight).saturating_mul({} as Weight)))\n",
+			write!(file, "\t\t\t.saturating_add(DbWeight::get().writes(({} as Weight).saturating_mul({} as Weight)))\n",
 				slope,
 				name,
 			).unwrap();
 		});
 
 		// close function
-		write!(file, "	}}\n").unwrap();
+		write!(file, "\t}}\n").unwrap();
 	});
 
 	// final close trait

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -36,9 +36,9 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 	// Skip writing if there are no batches
 	if batches.is_empty() { return Ok(()) }
 
-	batches.iter().for_each(|batch| {
+	for batch in &batches {
 		// Skip writing if there are no results
-		if batch.results.is_empty() { return }
+		if batch.results.is_empty() { continue }
 
 		let pallet_string = String::from_utf8(batch.pallet.clone()).unwrap();
 		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
@@ -67,7 +67,7 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 		}
 		// return value
 		write!(file, ") -> Weight;\n").unwrap();
-	});
+	}
 
 	// final close trait
 	write!(file, "}}\n").unwrap();
@@ -75,7 +75,8 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 	// Reset
 	current_pallet = Vec::<u8>::new();
 
-	batches.iter().for_each(|batch| {
+	for batch in &batches {
+		if batch.results.is_empty() { continue }
 
 		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
 
@@ -103,7 +104,7 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 		}
 		// return value
 		write!(file, ") -> Weight {{ 1_000_000_000 }}\n").unwrap();
-	});
+	}
 
 	// final close trait
 	write!(file, "}}\n").unwrap();
@@ -120,9 +121,9 @@ pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<()
 	// general imports
 	write!(file, "use frame_support::weights::{{Weight, constants::RocksDbWeight as DbWeight}};\n").unwrap();
 
-	batches.iter().for_each(|batch| {
+	for batch in &batches {
 		// Skip writing if there are no results
-		if batch.results.is_empty() { return }
+		if batch.results.is_empty() { continue }
 
 		let pallet_string = String::from_utf8(batch.pallet.clone()).unwrap();
 		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
@@ -188,7 +189,7 @@ pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<()
 
 		// close function
 		write!(file, "\t}}\n").unwrap();
-	});
+	}
 
 	// final close trait
 	write!(file, "}}\n").unwrap();


### PR DESCRIPTION
This PR updates the benchmark pipeline to support constant time benchmarks that do not have component values to iterate over.

To support this we basically needed to remove the components loop when running benchmarks or tests.

Then for analysis, we fallback to using a pure median value instead of median slopes analysis, and a pure mean value instead of least squares analysis.

Beyond these changes, I have also made the benchmarking pipeline a bit more robust to panics caused by accessing empty vecs.
