### PR TITLE
Fix two minor warnings

### DIFF
--- a/frame/babe/src/benchmarking.rs
+++ b/frame/babe/src/benchmarking.rs
@@ -17,8 +17,6 @@
 
 //! Benchmarks for the BABE Pallet.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use super::*;
 use frame_benchmarking::benchmarks;
 

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -31,7 +31,6 @@ use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
 #[cfg(feature = "std")]
 use sp_core::traits::BareCryptoStorePtr;
-use sp_std::convert::TryInto;
 
 #[cfg(feature = "std")]
 use log::debug;
@@ -385,6 +384,7 @@ where
 {
 	use sp_core::crypto::Public;
 	use sp_application_crypto::AppKey;
+	use sp_std::convert::TryInto;
 
 	let encoded = localized_payload(round, set_id, &message);
 	let signature = keystore.read()


### PR DESCRIPTION
* Unused import in no_std builds
* Global attribute in non-root of a crate