### PR TITLE
Remove legacy Clogged event

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -310,15 +310,6 @@ pub enum GenericProtoOut {
 		/// Message that has been received.
 		message: BytesMut,
 	},
-
-	/// The substream used by the protocol is pretty large. We should print avoid sending more
-	/// messages on it if possible.
-	Clogged {
-		/// Id of the peer which is clogged.
-		peer_id: PeerId,
-		/// Copy of the messages that are within the buffer, for further diagnostic.
-		messages: Vec<Vec<u8>>,
-	},
 }
 
 impl GenericProto {
@@ -1310,18 +1301,6 @@ impl NetworkBehaviour for GenericProto {
 				};
 
 				self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
-			}
-
-			NotifsHandlerOut::Clogged { messages } => {
-				debug_assert!(self.is_open(&source));
-				trace!(target: "sub-libp2p", "Handler({:?}) => Clogged", source);
-				trace!(target: "sub-libp2p", "External API <= Clogged({:?})", source);
-				warn!(target: "sub-libp2p", "Queue of packets to send to {:?} is \
-					pretty large", source);
-				self.events.push_back(NetworkBehaviourAction::GenerateEvent(GenericProtoOut::Clogged {
-					peer_id: source,
-					messages,
-				}));
 			}
 
 			// Don't do anything for non-severe errors except report them.

--- a/client/network/src/protocol/generic_proto/handler/group.rs
+++ b/client/network/src/protocol/generic_proto/handler/group.rs
@@ -215,13 +215,6 @@ pub enum NotifsHandlerOut {
 		message: BytesMut,
 	},
 
-	/// A substream to the remote is clogged. The send buffer is very large, and we should print
-	/// a diagnostic message and/or avoid sending more data.
-	Clogged {
-		/// Copy of the messages that are within the buffer, for further diagnostic.
-		messages: Vec<Vec<u8>>,
-	},
-
 	/// An error has happened on the protocol level with this node.
 	ProtocolError {
 		/// If true the error is severe, such as a protocol violation.
@@ -483,10 +476,6 @@ impl ProtocolsHandler for NotifsHandler {
 				ProtocolsHandlerEvent::Custom(LegacyProtoHandlerOut::CustomMessage { message }) =>
 					Poll::Ready(ProtocolsHandlerEvent::Custom(
 						NotifsHandlerOut::CustomMessage { message }
-					)),
-				ProtocolsHandlerEvent::Custom(LegacyProtoHandlerOut::Clogged { messages }) =>
-					Poll::Ready(ProtocolsHandlerEvent::Custom(
-						NotifsHandlerOut::Clogged { messages }
 					)),
 				ProtocolsHandlerEvent::Custom(LegacyProtoHandlerOut::ProtocolError { is_severe, error }) =>
 					Poll::Ready(ProtocolsHandlerEvent::Custom(

--- a/client/network/src/protocol/generic_proto/upgrade/legacy.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/legacy.rs
@@ -142,10 +142,7 @@ pub enum RegisteredProtocolEvent {
 
 	/// Diagnostic event indicating that the connection is clogged and we should avoid sending too
 	/// many messages to it.
-	Clogged {
-		/// Copy of the messages that are within the buffer, for further diagnostic.
-		messages: Vec<Vec<u8>>,
-	},
+	Clogged,
 }
 
 impl<TSubstream> Stream for RegisteredProtocolSubstream<TSubstream>
@@ -183,11 +180,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin {
 				// 	if you remove the fuse, then we will always return early from this function and
 				//	thus never read any message from the network.
 				self.clogged_fuse = true;
-				return Poll::Ready(Some(Ok(RegisteredProtocolEvent::Clogged {
-					messages: self.send_queue.iter()
-						.map(|m| m.clone().to_vec())
-						.collect(),
-				})))
+				return Poll::Ready(Some(Ok(RegisteredProtocolEvent::Clogged)))
 			}
 		} else {
 			self.clogged_fuse = false;


### PR DESCRIPTION
At the moment, if we send messages on the legacy substream at a faster rate than the remote can process, we generate a `Clogged` event containing the messages (as opaque bytes) that were pending in the buffer.

This `Clogged` event is propagated through the layers until `protocol.rs`, where the messages are decoded and logged for the purpose of understanding why the clogging happened.

Considering that these `Clogged` events have only ever been emitted for a very short period of time around one to two years ago, and considering that the legacy substream has now become almost unused, I'm proposing to remove this `Clogged` event in order to simplify the code.

If we indeed send messages on the legacy substream at a faster than that the remote can process (which is extremely unlikely to happen considering that we normally only send one `Status` message), the substream would now be shut down directly by the `ProtocolsHandler`, rather than being reported as an event to the outer layers.
