### PR TITLE
grandpa: report equivocations with unsigned extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,6 +4357,7 @@ dependencies = [
  "finality-grandpa",
  "frame-support",
  "frame-system",
+ "pallet-authorship",
  "pallet-balances",
  "pallet-finality-tracker",
  "pallet-offences",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,6 +4355,7 @@ name = "pallet-grandpa"
 version = "2.0.0-rc4"
 dependencies = [
  "finality-grandpa",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-authorship",

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -397,7 +397,7 @@ impl_runtime_apis! {
 			Grandpa::grandpa_authorities()
 		}
 
-		fn submit_report_equivocation_extrinsic(
+		fn submit_report_equivocation_unsigned_extrinsic(
 			_equivocation_proof: fg_primitives::EquivocationProof<
 				<Block as BlockT>::Hash,
 				NumberFor<Block>,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -628,7 +628,6 @@ mod tests {
 				let check_nonce = frame_system::CheckNonce::from(index);
 				let check_weight = frame_system::CheckWeight::new();
 				let payment = pallet_transaction_payment::ChargeTransactionPayment::from(0);
-				let validate_grandpa_equivocation = pallet_grandpa::ValidateEquivocationReport::new();
 				let extra = (
 					check_spec_version,
 					check_tx_version,
@@ -637,12 +636,11 @@ mod tests {
 					check_nonce,
 					check_weight,
 					payment,
-					validate_grandpa_equivocation,
 				);
 				let raw_payload = SignedPayload::from_raw(
 					function,
 					extra,
-					(spec_version, transaction_version, genesis_hash, genesis_hash, (), (), (), ())
+					(spec_version, transaction_version, genesis_hash, genesis_hash, (), (), ())
 				);
 				let signature = raw_payload.using_encoded(|payload|	{
 					signer.sign(payload)

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -154,6 +154,7 @@ runtime-benchmarks = [
 	"pallet-collective/runtime-benchmarks",
 	"pallet-democracy/runtime-benchmarks",
 	"pallet-elections-phragmen/runtime-benchmarks",
+	"pallet-grandpa/runtime-benchmarks",
 	"pallet-identity/runtime-benchmarks",
 	"pallet-im-online/runtime-benchmarks",
 	"pallet-indices/runtime-benchmarks",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -851,7 +851,7 @@ construct_runtime!(
 		Elections: pallet_elections_phragmen::{Module, Call, Storage, Event<T>, Config<T>},
 		TechnicalMembership: pallet_membership::<Instance1>::{Module, Call, Storage, Event<T>, Config<T>},
 		FinalityTracker: pallet_finality_tracker::{Module, Call, Inherent},
-		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},
+		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event, ValidateUnsigned},
 		Treasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
 		Contracts: pallet_contracts::{Module, Call, Config, Storage, Event<T>},
 		Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
@@ -1155,6 +1155,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_collective, Council);
 			add_benchmark!(params, batches, pallet_democracy, Democracy);
 			add_benchmark!(params, batches, pallet_elections_phragmen, Elections);
+			add_benchmark!(params, batches, pallet_grandpa, Grandpa);
 			add_benchmark!(params, batches, pallet_identity, Identity);
 			add_benchmark!(params, batches, pallet_im_online, ImOnline);
 			add_benchmark!(params, batches, pallet_indices, Indices);

--- a/bin/node/testing/src/keyring.rs
+++ b/bin/node/testing/src/keyring.rs
@@ -77,7 +77,6 @@ pub fn signed_extra(nonce: Index, extra_fee: Balance) -> SignedExtra {
 		frame_system::CheckNonce::from(nonce),
 		frame_system::CheckWeight::new(),
 		pallet_transaction_payment::ChargeTransactionPayment::from(extra_fee),
-		pallet_grandpa::ValidateEquivocationReport::new(),
 	)
 }
 

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -725,7 +725,6 @@ fn create_extrinsic<C: Crypto>(
 			frame_system::CheckNonce::<Runtime>::from(i),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(f),
-			pallet_grandpa::ValidateEquivocationReport::<Runtime>::new(),
 		)
 	};
 	let raw_payload = SignedPayload::from_raw(
@@ -736,7 +735,6 @@ fn create_extrinsic<C: Crypto>(
 			VERSION.transaction_version,
 			genesis_hash,
 			genesis_hash,
-			(),
 			(),
 			(),
 			(),

--- a/client/finality-grandpa/src/environment.rs
+++ b/client/finality-grandpa/src/environment.rs
@@ -515,12 +515,14 @@ where
 			equivocation,
 		);
 
-		self.client.runtime_api()
-			.submit_report_equivocation_extrinsic(
+		self.client
+			.runtime_api()
+			.submit_report_equivocation_unsigned_extrinsic(
 				&BlockId::Hash(best_header.hash()),
 				equivocation_proof,
 				key_owner_proof,
-			).map_err(Error::Client)?;
+			)
+			.map_err(Error::Client)?;
 
 		Ok(())
 	}

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -217,7 +217,7 @@ sp_api::mock_impl_runtime_apis! {
 			self.inner.genesis_authorities.clone()
 		}
 
-		fn submit_report_equivocation_extrinsic(
+		fn submit_report_equivocation_unsigned_extrinsic(
 			_equivocation_proof: EquivocationProof<Hash, BlockNumber>,
 			_key_owner_proof: OpaqueKeyOwnershipProof,
 		) -> Option<()> {

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -21,6 +21,7 @@ sp-session = { version = "2.0.0-rc4", default-features = false, path = "../../pr
 sp-std = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/runtime" }
 sp-staking = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/staking" }
+frame-benchmarking = { version = "2.0.0-rc4", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "2.0.0-rc4", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc4", default-features = false, path = "../system" }
 pallet-authorship = { version = "2.0.0-rc4", default-features = false, path = "../authorship" }
@@ -28,6 +29,7 @@ pallet-session = { version = "2.0.0-rc4", default-features = false, path = "../s
 pallet-finality-tracker = { version = "2.0.0-rc4", default-features = false, path = "../finality-tracker" }
 
 [dev-dependencies]
+frame-benchmarking = { version = "2.0.0-rc4", path = "../benchmarking" }
 grandpa = { package = "finality-grandpa", version = "0.12.3", features = ["derive-codec"] }
 sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }
 sp-keyring = { version = "2.0.0-rc4", path = "../../primitives/keyring" }
@@ -42,6 +44,7 @@ default = ["std"]
 std = [
 	"serde",
 	"codec/std",
+	"frame-benchmarking/std",
 	"sp-application-crypto/std",
 	"sp-core/std",
 	"sp-finality-grandpa/std",
@@ -55,3 +58,4 @@ std = [
 	"pallet-session/std",
 	"pallet-finality-tracker/std",
 ]
+runtime-benchmarks = ["frame-benchmarking"]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -23,6 +23,7 @@ sp-runtime = { version = "2.0.0-rc4", default-features = false, path = "../../pr
 sp-staking = { version = "2.0.0-rc4", default-features = false, path = "../../primitives/staking" }
 frame-support = { version = "2.0.0-rc4", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc4", default-features = false, path = "../system" }
+pallet-authorship = { version = "2.0.0-rc4", default-features = false, path = "../authorship" }
 pallet-session = { version = "2.0.0-rc4", default-features = false, path = "../session" }
 pallet-finality-tracker = { version = "2.0.0-rc4", default-features = false, path = "../finality-tracker" }
 
@@ -50,6 +51,7 @@ std = [
 	"sp-runtime/std",
 	"sp-staking/std",
 	"frame-system/std",
+	"pallet-authorship/std",
 	"pallet-session/std",
 	"pallet-finality-tracker/std",
 ]

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -1,0 +1,106 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmarks for the GRANDPA pallet.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use super::*;
+use frame_benchmarking::benchmarks;
+use sp_core::H256;
+
+benchmarks! {
+	_ {	}
+
+	check_equivocation_proof {
+		let x in 0 .. 1;
+
+		// NOTE: generated with the test below `test_generate_equivocation_report_blob`.
+		// the output should be deterministic since the keys we use are static.
+		// with the current benchmark setup it is not possible to generate this
+		// programatically from the benchmark setup.
+		const EQUIVOCATION_PROOF_BLOB: [u8; 257] = [
+			1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 136, 220, 52, 23,
+			213, 5, 142, 196, 180, 80, 62, 12, 18, 234, 26, 10, 137, 190, 32,
+			15, 233, 137, 34, 66, 61, 67, 52, 1, 79, 166, 176, 238, 207, 48,
+			195, 55, 171, 225, 252, 130, 161, 56, 151, 29, 193, 32, 25, 157,
+			249, 39, 80, 193, 214, 96, 167, 147, 25, 130, 45, 42, 64, 208, 182,
+			164, 10, 0, 0, 0, 0, 0, 0, 0, 234, 236, 231, 45, 70, 171, 135, 246,
+			136, 153, 38, 167, 91, 134, 150, 242, 215, 83, 56, 238, 16, 119, 55,
+			170, 32, 69, 255, 248, 164, 20, 57, 50, 122, 115, 135, 96, 80, 203,
+			131, 232, 73, 23, 149, 86, 174, 59, 193, 92, 121, 76, 154, 211, 44,
+			96, 10, 84, 159, 133, 211, 56, 103, 0, 59, 2, 96, 20, 69, 2, 32,
+			179, 16, 184, 108, 76, 215, 64, 195, 78, 143, 73, 177, 139, 20, 144,
+			98, 231, 41, 117, 255, 220, 115, 41, 59, 27, 75, 56, 10, 0, 0, 0, 0,
+			0, 0, 0, 128, 179, 250, 48, 211, 76, 10, 70, 74, 230, 219, 139, 96,
+			78, 88, 112, 33, 170, 44, 184, 59, 200, 155, 143, 128, 40, 222, 179,
+			210, 190, 84, 16, 182, 21, 34, 94, 28, 193, 163, 226, 51, 251, 134,
+			233, 187, 121, 63, 157, 240, 165, 203, 92, 16, 146, 120, 190, 229,
+			251, 129, 29, 45, 32, 29, 6
+		];
+
+		let equivocation_proof1: sp_finality_grandpa::EquivocationProof<H256, u64> =
+			Decode::decode(&mut &EQUIVOCATION_PROOF_BLOB[..]).unwrap();
+
+		let equivocation_proof2 = equivocation_proof1.clone();
+	}: {
+		sp_finality_grandpa::check_equivocation_proof(equivocation_proof1);
+	} verify {
+		assert!(sp_finality_grandpa::check_equivocation_proof(equivocation_proof2));
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mock::*;
+	use frame_support::assert_ok;
+
+	#[test]
+	fn test_benchmarks() {
+		new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
+			assert_ok!(test_benchmark_check_equivocation_proof::<Test>());
+		})
+	}
+
+	#[test]
+	fn test_generate_equivocation_report_blob() {
+		let authorities = crate::tests::test_authorities();
+
+		let equivocation_authority_index = 0;
+		let equivocation_key = &authorities[equivocation_authority_index].0;
+		let equivocation_keyring = extract_keyring(equivocation_key);
+
+		new_test_ext_raw_authorities(authorities).execute_with(|| {
+			start_era(1);
+
+			// generate an equivocation proof, with two votes in the same round for
+			// different block hashes signed by the same key
+			let equivocation_proof = generate_equivocation_proof(
+				1,
+				(1, H256::random(), 10, &equivocation_keyring),
+				(1, H256::random(), 10, &equivocation_keyring),
+			);
+
+			println!("equivocation_proof: {:?}", equivocation_proof);
+			println!(
+				"equivocation_proof.encode(): {:?}",
+				equivocation_proof.encode()
+			);
+		});
+	}
+}

--- a/frame/grandpa/src/equivocation.rs
+++ b/frame/grandpa/src/equivocation.rs
@@ -24,6 +24,7 @@
 //! part of a session);
 //! - a system for reporting offences;
 //! - a system for signing and submitting transactions;
+//! - a way to get the current block author;
 //!
 //! These can be used in an offchain context in order to submit equivocation
 //! reporting extrinsics (from the client that's running the GRANDPA protocol).
@@ -32,165 +33,34 @@
 //!
 //! IMPORTANT:
 //! When using this module for enabling equivocation reporting it is required
-//! that the `ValidateEquivocationReport` signed extension is used in the runtime
-//! definition. Failure to do so will allow invalid equivocation reports to be
-//! accepted by the runtime.
+//! that the `ValidateUnsigned` for the GRANDPA pallet is used in the runtime
+//! definition.
 //!
 
 use sp_std::prelude::*;
 
 use codec::{self as codec, Decode, Encode};
-use frame_support::{debug, dispatch::IsSubType, traits::KeyOwnerProofSystem};
-use frame_system::offchain::{AppCrypto, CreateSignedTransaction, Signer};
+use frame_support::{debug, traits::KeyOwnerProofSystem};
 use sp_finality_grandpa::{EquivocationProof, RoundNumber, SetId};
 use sp_runtime::{
-	traits::{DispatchInfoOf, SignedExtension},
 	transaction_validity::{
-		InvalidTransaction, TransactionValidity, TransactionValidityError, ValidTransaction,
+		InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
+		TransactionValidityError, ValidTransaction,
 	},
 	DispatchResult, Perbill,
 };
-use sp_session::GetSessionNumber;
 use sp_staking::{
 	offence::{Kind, Offence, OffenceError, ReportOffence},
 	SessionIndex,
 };
 
-/// Ensure that equivocation reports are only processed if valid.
-#[derive(Encode, Decode, Clone, Eq, PartialEq)]
-pub struct ValidateEquivocationReport<T>(sp_std::marker::PhantomData<T>);
-
-impl<T> Default for ValidateEquivocationReport<T> {
-	fn default() -> ValidateEquivocationReport<T> {
-		ValidateEquivocationReport::new()
-	}
-}
-
-impl<T> ValidateEquivocationReport<T> {
-	pub fn new() -> ValidateEquivocationReport<T> {
-		ValidateEquivocationReport(Default::default())
-	}
-}
-
-impl<T> sp_std::fmt::Debug for ValidateEquivocationReport<T> {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		write!(f, "ValidateEquivocationReport<T>")
-	}
-}
-
-/// Custom validity error used when validating equivocation reports.
-#[derive(Debug)]
-#[repr(u8)]
-pub enum ReportEquivocationValidityError {
-	/// The proof provided in the report is not valid.
-	InvalidEquivocationProof = 1,
-	/// The proof provided in the report is not valid.
-	InvalidKeyOwnershipProof = 2,
-	/// The set id provided in the report is not valid.
-	InvalidSetId = 3,
-	/// The session index provided in the report is not valid.
-	InvalidSession = 4,
-}
-
-impl From<ReportEquivocationValidityError> for TransactionValidityError {
-	fn from(e: ReportEquivocationValidityError) -> TransactionValidityError {
-		TransactionValidityError::from(InvalidTransaction::Custom(e as u8))
-	}
-}
-
-impl<T: super::Trait + Send + Sync> SignedExtension for ValidateEquivocationReport<T>
-where
-	<T as frame_system::Trait>::Call: IsSubType<super::Call<T>>,
-{
-	const IDENTIFIER: &'static str = "ValidateEquivocationReport";
-	type AccountId = T::AccountId;
-	type Call = <T as frame_system::Trait>::Call;
-	type AdditionalSigned = ();
-	type Pre = ();
-
-	fn additional_signed(
-		&self,
-	) -> sp_std::result::Result<Self::AdditionalSigned, TransactionValidityError> {
-		Ok(())
-	}
-
-	fn validate(
-		&self,
-		_who: &Self::AccountId,
-		call: &Self::Call,
-		_info: &DispatchInfoOf<Self::Call>,
-		_len: usize,
-	) -> TransactionValidity {
-		let (equivocation_proof, key_owner_proof) = match call.is_sub_type() {
-			Some(super::Call::report_equivocation(equivocation_proof, key_owner_proof)) => {
-				(equivocation_proof, key_owner_proof)
-			}
-			_ => return Ok(ValidTransaction::default()),
-		};
-
-		// validate the key ownership proof extracting the id of the offender.
-		if let None = T::KeyOwnerProofSystem::check_proof(
-			(
-				sp_finality_grandpa::KEY_TYPE,
-				equivocation_proof.offender().clone(),
-			),
-			key_owner_proof.clone(),
-		) {
-			return Err(ReportEquivocationValidityError::InvalidKeyOwnershipProof.into());
-		}
-
-		// we check the equivocation within the context of its set id (and
-		// associated session).
-		let set_id = equivocation_proof.set_id();
-		let session_index = key_owner_proof.session();
-
-		// validate equivocation proof (check votes are different and
-		// signatures are valid).
-		if !sp_finality_grandpa::check_equivocation_proof(equivocation_proof.clone()) {
-			return Err(ReportEquivocationValidityError::InvalidEquivocationProof.into());
-		}
-
-		// fetch the current and previous sets last session index. on the
-		// genesis set there's no previous set.
-		let previous_set_id_session_index = if set_id == 0 {
-			None
-		} else {
-			let session_index =
-				if let Some(session_id) = <super::Module<T>>::session_for_set(set_id - 1) {
-					session_id
-				} else {
-					return Err(ReportEquivocationValidityError::InvalidSetId.into());
-				};
-
-			Some(session_index)
-		};
-
-		let set_id_session_index =
-			if let Some(session_id) = <super::Module<T>>::session_for_set(set_id) {
-				session_id
-			} else {
-				return Err(ReportEquivocationValidityError::InvalidSetId.into());
-			};
-
-		// check that the session id for the membership proof is within the
-		// bounds of the set id reported in the equivocation.
-		if session_index > set_id_session_index ||
-			previous_set_id_session_index
-				.map(|previous_index| session_index <= previous_index)
-				.unwrap_or(false)
-		{
-			return Err(ReportEquivocationValidityError::InvalidSession.into());
-		}
-
-		Ok(ValidTransaction::default())
-	}
-}
+use super::{Call, Module, Trait};
 
 /// A trait with utility methods for handling equivocation reports in GRANDPA.
 /// The offence type is generic, and the trait provides , reporting an offence
 /// triggered by a valid equivocation report, and also for creating and
 /// submitting equivocation report extrinsics (useful only in offchain context).
-pub trait HandleEquivocation<T: super::Trait> {
+pub trait HandleEquivocation<T: Trait> {
 	/// The offence type used for reporting offences on valid equivocation reports.
 	type Offence: GrandpaOffence<T::KeyOwnerIdentification>;
 
@@ -200,14 +70,23 @@ pub trait HandleEquivocation<T: super::Trait> {
 		offence: Self::Offence,
 	) -> Result<(), OffenceError>;
 
+	/// Returns true if all of the offenders at the given time slot have already been reported.
+	fn is_known_offence(
+		offenders: &[T::KeyOwnerIdentification],
+		time_slot: &<Self::Offence as Offence<T::KeyOwnerIdentification>>::TimeSlot,
+	) -> bool;
+
 	/// Create and dispatch an equivocation report extrinsic.
-	fn submit_equivocation_report(
+	fn submit_unsigned_equivocation_report(
 		equivocation_proof: EquivocationProof<T::Hash, T::BlockNumber>,
 		key_owner_proof: T::KeyOwnerProof,
 	) -> DispatchResult;
+
+	/// Fetch the current block author id, if defined.
+	fn block_author() -> Option<T::AccountId>;
 }
 
-impl<T: super::Trait> HandleEquivocation<T> for () {
+impl<T: Trait> HandleEquivocation<T> for () {
 	type Offence = GrandpaEquivocationOffence<T::KeyOwnerIdentification>;
 
 	fn report_offence(
@@ -217,11 +96,22 @@ impl<T: super::Trait> HandleEquivocation<T> for () {
 		Ok(())
 	}
 
-	fn submit_equivocation_report(
+	fn is_known_offence(
+		_offenders: &[T::KeyOwnerIdentification],
+		_time_slot: &GrandpaTimeSlot,
+	) -> bool {
+		true
+	}
+
+	fn submit_unsigned_equivocation_report(
 		_equivocation_proof: EquivocationProof<T::Hash, T::BlockNumber>,
 		_key_owner_proof: T::KeyOwnerProof,
 	) -> DispatchResult {
 		Ok(())
+	}
+
+	fn block_author() -> Option<T::AccountId> {
+		None
 	}
 }
 
@@ -229,11 +119,11 @@ impl<T: super::Trait> HandleEquivocation<T> for () {
 /// using existing subsystems that are part of frame (type bounds described
 /// below) and will dispatch to them directly, it's only purpose is to wire all
 /// subsystems together.
-pub struct EquivocationHandler<I, C, S, R, O = GrandpaEquivocationOffence<I>> {
-	_phantom: sp_std::marker::PhantomData<(I, C, S, R, O)>,
+pub struct EquivocationHandler<I, R, O = GrandpaEquivocationOffence<I>> {
+	_phantom: sp_std::marker::PhantomData<(I, R, O)>,
 }
 
-impl<I, C, S, R, O> Default for EquivocationHandler<I, C, S, R, O> {
+impl<I, R, O> Default for EquivocationHandler<I, R, O> {
 	fn default() -> Self {
 		Self {
 			_phantom: Default::default(),
@@ -241,18 +131,17 @@ impl<I, C, S, R, O> Default for EquivocationHandler<I, C, S, R, O> {
 	}
 }
 
-impl<T, C, S, R, O> HandleEquivocation<T>
-	for EquivocationHandler<T::KeyOwnerIdentification, C, S, R, O>
+impl<T, R, O> HandleEquivocation<T> for EquivocationHandler<T::KeyOwnerIdentification, R, O>
 where
-	// A signed transaction creator. Used for signing and submitting equivocation reports.
-	T: super::Trait + CreateSignedTransaction<super::Call<T>>,
-	// Application-specific crypto bindings.
-	C: AppCrypto<T::Public, T::Signature>,
-	// The offence type that should be used when reporting.
-	O: GrandpaOffence<T::KeyOwnerIdentification>,
+	// We use the authorship pallet to fetch the current block author and use
+	// `offchain::SendTransactionTypes` for unsigned extrinsic creation and
+	// submission.
+	T: Trait + pallet_authorship::Trait + frame_system::offchain::SendTransactionTypes<Call<T>>,
 	// A system for reporting offences after valid equivocation reports are
 	// processed.
 	R: ReportOffence<T::AccountId, T::KeyOwnerIdentification, O>,
+	// The offence type that should be used when reporting.
+	O: GrandpaOffence<T::KeyOwnerIdentification>,
 {
 	type Offence = O;
 
@@ -260,35 +149,28 @@ where
 		R::report_offence(reporters, offence)
 	}
 
-	fn submit_equivocation_report(
+	fn is_known_offence(offenders: &[T::KeyOwnerIdentification], time_slot: &O::TimeSlot) -> bool {
+		R::is_known_offence(offenders, time_slot)
+	}
+
+	fn submit_unsigned_equivocation_report(
 		equivocation_proof: EquivocationProof<T::Hash, T::BlockNumber>,
 		key_owner_proof: T::KeyOwnerProof,
 	) -> DispatchResult {
-		use frame_system::offchain::SendSignedTransaction;
+		use frame_system::offchain::SubmitTransaction;
 
-		let signer = Signer::<T, C>::all_accounts();
-		if !signer.can_sign() {
-			return Err(
-				"No local accounts available. Consider adding one via `author_insertKey` RPC.",
-			)?;
-		}
+		let call = Call::report_equivocation_unsigned(equivocation_proof, key_owner_proof);
 
-		let results = signer.send_signed_transaction(|_account| {
-			super::Call::report_equivocation(equivocation_proof.clone(), key_owner_proof.clone())
-		});
-
-		for (acc, res) in &results {
-			match res {
-				Ok(()) => debug::info!("[{:?}] Submitted GRANDPA equivocation report.", acc.id),
-				Err(e) => debug::error!(
-					"[{:?}] Error submitting equivocation report: {:?}",
-					acc.id,
-					e
-				),
-			}
+		match SubmitTransaction::<T, Call<T>>::submit_unsigned_transaction(call.into()) {
+			Ok(()) => debug::info!("Submitted GRANDPA equivocation report."),
+			Err(e) => debug::error!("Error submitting equivocation report: {:?}", e),
 		}
 
 		Ok(())
+	}
+
+	fn block_author() -> Option<T::AccountId> {
+		Some(<pallet_authorship::Module<T>>::author())
 	}
 }
 
@@ -300,6 +182,75 @@ pub struct GrandpaTimeSlot {
 	pub set_id: SetId,
 	/// Round number.
 	pub round: RoundNumber,
+}
+
+/// A `ValidateUnsigned` implementation that restricts calls to `report_equivocation_unsigned`
+/// to local calls (i.e. extrinsics generated on this node) or that already in a block. This
+/// guarantees that only block authors can include unsigned equivocation reports.
+impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
+	type Call = Call<T>;
+	fn validate_unsigned(source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+		if let Call::report_equivocation_unsigned(equivocation_proof, _) = call {
+			// discard equivocation report not coming from the local node
+			match source {
+				TransactionSource::Local | TransactionSource::InBlock => { /* allowed */ }
+				_ => {
+					debug::warn!(
+						target: "afg",
+						"rejecting unsigned report equivocation transaction because it is not local/in-block."
+					);
+
+					return InvalidTransaction::Call.into();
+				}
+			}
+
+			ValidTransaction::with_tag_prefix("GrandpaEquivocation")
+				// We assign the maximum priority for any equivocation report.
+				.priority(TransactionPriority::max_value())
+				// Only one equivocation report for the same offender at the same slot.
+				.and_provides((
+					equivocation_proof.offender().clone(),
+					equivocation_proof.set_id(),
+					equivocation_proof.round(),
+				))
+				// We don't propagate this. This can never be included on a remote node.
+				.propagate(false)
+				.build()
+		} else {
+			InvalidTransaction::Call.into()
+		}
+	}
+
+	fn pre_dispatch(call: &Self::Call) -> Result<(), TransactionValidityError> {
+		if let Call::report_equivocation_unsigned(equivocation_proof, key_owner_proof) = call {
+			// check the membership proof to extract the offender's id
+			let key = (
+				sp_finality_grandpa::KEY_TYPE,
+				equivocation_proof.offender().clone(),
+			);
+
+			let offender = T::KeyOwnerProofSystem::check_proof(key, key_owner_proof.clone())
+				.ok_or(InvalidTransaction::BadProof)?;
+
+			// check if the offence has already been reported,
+			// and if so then we can discard the report.
+			let time_slot =
+				<T::HandleEquivocation as HandleEquivocation<T>>::Offence::new_time_slot(
+					equivocation_proof.set_id(),
+					equivocation_proof.round(),
+				);
+
+			let is_known_offence = T::HandleEquivocation::is_known_offence(&[offender], &time_slot);
+
+			if is_known_offence {
+				Err(InvalidTransaction::Stale.into())
+			} else {
+				Ok(())
+			}
+		} else {
+			Err(InvalidTransaction::Call.into())
+		}
+	}
 }
 
 /// A grandpa equivocation offence report.
@@ -327,6 +278,9 @@ pub trait GrandpaOffence<FullIdentification>: Offence<FullIdentification> {
 		set_id: SetId,
 		round: RoundNumber,
 	) -> Self;
+
+	/// Create a new GRANDPA offence time slot.
+	fn new_time_slot(set_id: SetId, round: RoundNumber) -> Self::TimeSlot;
 }
 
 impl<FullIdentification: Clone> GrandpaOffence<FullIdentification>
@@ -345,6 +299,10 @@ impl<FullIdentification: Clone> GrandpaOffence<FullIdentification>
 			offender,
 			time_slot: GrandpaTimeSlot { set_id, round },
 		}
+	}
+
+	fn new_time_slot(set_id: SetId, round: RoundNumber) -> Self::TimeSlot {
+		GrandpaTimeSlot { set_id, round }
 	}
 }
 

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -53,6 +53,9 @@ use sp_session::{GetSessionNumber, GetValidatorCount};
 use sp_staking::SessionIndex;
 
 mod equivocation;
+
+#[cfg(any(feature = "runtime-benchmarks", test))]
+mod benchmarking;
 #[cfg(all(feature = "std", test))]
 mod mock;
 #[cfg(all(feature = "std", test))]

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -371,7 +371,7 @@ mod weight_for {
 			.saturating_add(95 * WEIGHT_PER_MICROS)
 			// report offence
 			.saturating_add(110 * WEIGHT_PER_MICROS)
-			.saturating_add(25 * WEIGHT_PER_NANOS * MAX_NOMINATORS)
+			.saturating_add(25 * WEIGHT_PER_MICROS * MAX_NOMINATORS)
 			.saturating_add(T::DbWeight::get().reads(14 + 3 * MAX_NOMINATORS))
 			.saturating_add(T::DbWeight::get().writes(10 + 3 * MAX_NOMINATORS))
 			// fetching set id -> session index mappings

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -19,10 +19,7 @@
 
 #![cfg(test)]
 
-use crate::{
-	equivocation::ValidateEquivocationReport, AuthorityId, AuthorityList, Call as GrandpaCall,
-	ConsensusLog, Module, Trait,
-};
+use crate::{AuthorityId, AuthorityList, Call as GrandpaCall, ConsensusLog, Module, Trait};
 use ::grandpa as finality_grandpa;
 use codec::Encode;
 use frame_support::{

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -19,13 +19,13 @@
 
 #![cfg(test)]
 
-use crate::{AuthorityId, AuthorityList, Call as GrandpaCall, ConsensusLog, Module, Trait};
+use crate::{AuthorityId, AuthorityList, ConsensusLog, Module, Trait};
 use ::grandpa as finality_grandpa;
 use codec::Encode;
 use frame_support::{
 	impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types,
 	traits::{KeyOwnerProofSystem, OnFinalize, OnInitialize},
-	weights::{DispatchInfo, Weight},
+	weights::Weight,
 };
 use pallet_staking::EraIndex;
 use sp_core::{crypto::KeyTypeId, H256};
@@ -36,11 +36,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	impl_opaque_keys,
 	testing::{Header, TestXt, UintAuthorityId},
-	traits::{
-		Convert, Extrinsic as ExtrinsicT, IdentityLookup, OpaqueKeys, SaturatedConversion,
-		SignedExtension,
-	},
-	transaction_validity::TransactionValidityError,
+	traits::{Convert, IdentityLookup, OpaqueKeys, SaturatedConversion},
 	DigestItem, Perbill,
 };
 use sp_staking::SessionIndex;
@@ -149,6 +145,17 @@ impl session::Trait for Test {
 impl session::historical::Trait for Test {
 	type FullIdentification = staking::Exposure<u64, u128>;
 	type FullIdentificationOf = staking::ExposureOf<Self>;
+}
+
+parameter_types! {
+	pub const UncleGenerations: u64 = 0;
+}
+
+impl pallet_authorship::Trait for Test {
+	type FindAuthor = ();
+	type UncleGenerations = UncleGenerations;
+	type FilterUncle = ();
+	type EventHandler = ();
 }
 
 parameter_types! {
@@ -261,66 +268,7 @@ impl Trait for Test {
 		AuthorityId,
 	)>>::IdentificationTuple;
 
-	type HandleEquivocation = super::EquivocationHandler<
-		Self::KeyOwnerIdentification,
-		reporting_keys::ReporterAppCrypto,
-		Test,
-		Offences,
-	>;
-}
-
-pub mod reporting_keys {
-	use sp_core::crypto::KeyTypeId;
-
-	pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"test");
-
-	mod app {
-		use sp_application_crypto::{app_crypto, ed25519};
-		app_crypto!(ed25519, super::KEY_TYPE);
-
-		impl sp_runtime::traits::IdentifyAccount for Public {
-			type AccountId = u64;
-			fn into_account(self) -> Self::AccountId {
-				super::super::Grandpa::grandpa_authorities()
-					.iter()
-					.map(|(k, _)| k)
-					.position(|b| *b == self.0.clone().into())
-					.unwrap() as u64
-			}
-		}
-	}
-
-	pub type ReporterId = app::Public;
-
-	pub struct ReporterAppCrypto;
-	impl frame_system::offchain::AppCrypto<ReporterId, sp_core::ed25519::Signature>
-		for ReporterAppCrypto
-	{
-		type RuntimeAppPublic = ReporterId;
-		type GenericSignature = sp_core::ed25519::Signature;
-		type GenericPublic = sp_core::ed25519::Public;
-	}
-}
-
-type Extrinsic = TestXt<Call, ()>;
-
-impl<LocalCall> system::offchain::CreateSignedTransaction<LocalCall> for Test
-where
-	Call: From<LocalCall>,
-{
-	fn create_transaction<C: system::offchain::AppCrypto<Self::Public, Self::Signature>>(
-		call: Call,
-		_public: reporting_keys::ReporterId,
-		_account: <Test as system::Trait>::AccountId,
-		nonce: <Test as system::Trait>::Index,
-	) -> Option<(Call, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
-		Some((call, (nonce, ())))
-	}
-}
-
-impl frame_system::offchain::SigningTypes for Test {
-	type Public = reporting_keys::ReporterId;
-	type Signature = sp_core::ed25519::Signature;
+	type HandleEquivocation = super::EquivocationHandler<Self::KeyOwnerIdentification, Offences>;
 }
 
 mod grandpa {
@@ -463,18 +411,6 @@ pub fn initialize_block(number: u64, parent_hash: H256) {
 		&Default::default(),
 		Default::default(),
 	);
-}
-
-pub fn report_equivocation(
-	equivocation_proof: sp_finality_grandpa::EquivocationProof<H256, u64>,
-	key_owner_proof: sp_session::MembershipProof,
-) -> Result<GrandpaCall<Test>, TransactionValidityError> {
-	let inner = GrandpaCall::report_equivocation(equivocation_proof, key_owner_proof);
-	let call = Call::Grandpa(inner.clone());
-
-	ValidateEquivocationReport::<Test>::new().validate(&0, &call, &DispatchInfo::default(), 0)?;
-
-	Ok(inner)
 }
 
 pub fn generate_equivocation_proof(

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -316,7 +316,9 @@ fn time_slot_have_sane_ord() {
 	assert!(FIXTURE.windows(2).all(|f| f[0] < f[1]));
 }
 
-fn test_authorities() -> AuthorityList {
+/// Returns a list with 3 authorities with known keys:
+/// Alice, Bob and Charlie.
+pub fn test_authorities() -> AuthorityList {
 	let authorities = vec![
 		Ed25519Keyring::Alice,
 		Ed25519Keyring::Bob,

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -282,21 +282,16 @@ benchmarks! {
 	}
 
 	report_offence_grandpa {
-		let r in 1 .. MAX_REPORTERS;
 		let n in 0 .. MAX_NOMINATORS.min(MAX_NOMINATIONS as u32);
-		let o = 1;
 
-		// Make r reporters
-		let mut reporters = vec![];
-		for i in 0 .. r {
-			let reporter = account("reporter", i, SEED);
-			reporters.push(reporter);
-		}
+		// for grandpa equivocation reports the number of reporters
+		// and offenders is always 1
+		let reporters = vec![account("reporter", 1, SEED)];
 
 		// make sure reporters actually get rewarded
 		Staking::<T>::set_slash_reward_fraction(Perbill::one());
 
-		let (mut offenders, raw_offenders) = make_offenders::<T>(o, n)?;
+		let (mut offenders, raw_offenders) = make_offenders::<T>(1, n)?;
 		let keys = ImOnline::<T>::keys();
 
 		let offence = GrandpaEquivocationOffence {
@@ -316,9 +311,9 @@ benchmarks! {
 		assert_eq!(
 			System::<T>::event_count(), 0
 			+ 1 // offence
-			+ 2 * r // reporter (reward + endowment)
-			+ o // offenders slashed
-			+ o * n // nominators slashed
+			+ 2 // reporter (reward + endowment)
+			+ 1 // offenders slashed
+			+ n // nominators slashed
 		);
 	}
 

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -497,16 +497,15 @@ sp_api::decl_runtime_apis! {
 		/// is finalized by the authorities from block B-1.
 		fn grandpa_authorities() -> AuthorityList;
 
-		/// Submits an extrinsic to report an equivocation. The caller must
-		/// provide the equivocation proof and a key ownership proof (should be
-		/// obtained using `generate_key_ownership_proof`). This method will
-		/// sign the extrinsic with any reporting keys available in the keystore
-		/// and will push the transaction to the pool. This method returns `None`
-		/// when creation of the extrinsic fails, either due to unavailability
-		/// of keys to sign, or because equivocation reporting is disabled for
-		/// the given runtime (i.e. this method is hardcoded to return `None`).
-		/// Only useful in an offchain context.
-		fn submit_report_equivocation_extrinsic(
+		/// Submits an unsigned extrinsic to report an equivocation. The caller
+		/// must provide the equivocation proof and a key ownership proof
+		/// (should be obtained using `generate_key_ownership_proof`). The
+		/// extrinsic will be unsigned and should only be accepted for local
+		/// authorship (not to be broadcast to the network). This method returns
+		/// `None` when creation of the extrinsic fails, e.g. if equivocation
+		/// reporting is disabled for the given runtime (i.e. this method is
+		/// hardcoded to return `None`). Only useful in an offchain context.
+		fn submit_report_equivocation_unsigned_extrinsic(
 			equivocation_proof: EquivocationProof<Block::Hash, NumberFor<Block>>,
 			key_owner_proof: OpaqueKeyOwnershipProof,
 		) -> Option<()>;

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -750,7 +750,7 @@ cfg_if! {
 					Vec::new()
 				}
 
-				fn submit_report_equivocation_extrinsic(
+				fn submit_report_equivocation_unsigned_extrinsic(
 					_equivocation_proof: sp_finality_grandpa::EquivocationProof<
 						<Block as BlockT>::Hash,
 						NumberFor<Block>,


### PR DESCRIPTION
This PR changes the GRANDPA equivocation reporting code to instead report using unsigned extrinsics (similar to what was done in #6362). The extrinsics are not broadcast onto the network and are only available for inclusion locally by block authors. Validation of the equivocation report is no longer done in a signed extension and instead the full validation is performed as part of the runtime method (i.e. `report_equivocation`) which was updated with a proper weight. Additionally a `ValidateUnsigned` will check for and reject duplicate equivocation reports (common assuming most validators will observe equivocations).

The advantage of this approach is that we perform all validation on the runtime method and assign it a proper weight, while guaranteeing that equivocation reporting works out of the box for validators (there's no need to setup/fund separate accounts for reporting).

For now only block authors will report equivocations although a method for reporting through a signed extrinsic also exists (although unused by the client).

polkadot companion: https://github.com/paritytech/polkadot/pull/1407