### PR TITLE
Make sudo calls inherit fee payment (Pays) of the dispatch they wrap.

### DIFF
--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -126,7 +126,7 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class, call.get_dispatch_info().pays_fee)]
 		fn sudo(origin, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -146,7 +146,7 @@ decl_module! {
 		/// - O(1).
 		/// - The weight of this call is defined by the caller.
 		/// # </weight>
-		#[weight = (*_weight, call.get_dispatch_info().class)]
+		#[weight = (*_weight, call.get_dispatch_info().class, call.get_dispatch_info().pays_fee)]
 		fn sudo_unchecked_weight(origin, call: Box<<T as Trait>::Call>, _weight: Weight) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -187,7 +187,7 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class, call.get_dispatch_info().pays_fee)]
 		fn sudo_as(origin, who: <T::Lookup as StaticLookup>::Source, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -126,7 +126,8 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class, call.get_dispatch_info().pays_fee)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class,
+			call.get_dispatch_info().pays_fee)]
 		fn sudo(origin, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -187,7 +188,8 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class, call.get_dispatch_info().pays_fee)]
+		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class,
+			call.get_dispatch_info().pays_fee)]
 		fn sudo_as(origin, who: <T::Lookup as StaticLookup>::Source, call: Box<<T as Trait>::Call>) {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;


### PR DESCRIPTION
Calls to sudo pallet's functions `sudo`, `sudo_unchecked_weight` and `sudo_as`
inherit the `Pays` enum to pay or not pay fee depending on whether the
dispatched call pays or not. Currently, sudo pallet's functions only inherit the weight and dispatch class of the dispatch.

Helps in https://github.com/paritytech/substrate/issues/6657

