### PR TITLE
The telemetry should not be initialized if no telemetry has been provided

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -1012,7 +1012,12 @@ ServiceBuilder<
 		let telemetry_connection_sinks: Arc<Mutex<Vec<TracingUnboundedSender<()>>>> = Default::default();
 
 		// Telemetry
-		let telemetry = config.telemetry_endpoints.clone().map(|endpoints| {
+		let telemetry = config.telemetry_endpoints.clone().and_then(|endpoints| {
+			if endpoints.is_empty() {
+				// we don't want the telemetry to be initialized if telemetry_endpoints == Some([])
+				return None;
+			}
+
 			let genesis_hash = match client.block_hash(Zero::zero()) {
 				Ok(Some(hash)) => hash,
 				_ => Default::default(),
@@ -1031,7 +1036,7 @@ ServiceBuilder<
 				future,
 			);
 
-			telemetry
+			Some(telemetry)
 		});
 
 		// Instrumentation

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -123,6 +123,14 @@ impl TelemetryEndpoints {
 	}
 }
 
+impl std::ops::Deref for TelemetryEndpoints {
+	type Target = Vec<(Multiaddr, u8)>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
 /// Parses a WebSocket URL into a libp2p `Multiaddr`.
 fn url_to_multiaddr(url: &str) -> Result<Multiaddr, libp2p::multiaddr::Error> {
 	// First, assume that we have a `Multiaddr`.

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -124,9 +124,10 @@ impl TelemetryEndpoints {
 }
 
 impl TelemetryEndpoints {
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
+	/// Return `true` if there are telemetry endpoints, `false` otherwise.
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
 }
 
 /// Parses a WebSocket URL into a libp2p `Multiaddr`.

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -123,12 +123,10 @@ impl TelemetryEndpoints {
 	}
 }
 
-impl std::ops::Deref for TelemetryEndpoints {
-	type Target = Vec<(Multiaddr, u8)>;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+impl TelemetryEndpoints {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// Parses a WebSocket URL into a libp2p `Multiaddr`.

--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -124,7 +124,7 @@ impl TelemetryEndpoints {
 }
 
 impl TelemetryEndpoints {
-	/// Return `true` if there are telemetry endpoints, `false` otherwise.
+	/// Return `true` if there are no telemetry endpoints, `false` otherwise.
 	pub fn is_empty(&self) -> bool {
 		self.0.is_empty()
 	}


### PR DESCRIPTION
# Use case

While developing on cumulus we usually never use telemetry so it never failed before. But with the token-transfer parachain we are currently deploying we did try to enable telemetry for the parachain. This resulted in:

```
====================

Version: 0.1.0-unknown-commit-x86_64-linux-gnu

   0: sp_panic_handler::set::{{closure}}
   1: std::panicking::rust_panic_with_hook
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/libstd/panicking.rs:515
   2: rust_begin_unwind
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/libstd/panicking.rs:419
   3: core::panicking::panic_fmt
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/libcore/panicking.rs:111
   4: core::option::expect_failed
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/libcore/option.rs:1260
   5: futures_channel::mpsc::Receiver<T>::next_message
   6: <futures_channel::mpsc::Receiver<T> as futures_core::stream::Stream>::poll_next
   7: <sc_telemetry::Telemetry as futures_core::stream::Stream>::poll_next
   8: <futures_util::stream::stream::for_each::ForEach<St,Fut,F> as core::future::future::Future>::poll
   9: <sc_service::task_manager::prometheus_future::PrometheusFuture<T> as core::future::future::Future>::poll
  10: <futures_util::future::select::Select<A,B> as core::future::future::Future>::poll
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  12: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
  13: tokio::runtime::task::raw::poll
  14: std::thread::local::LocalKey<T>::with
  15: tokio::runtime::thread_pool::worker::Context::run_task
  16: tokio::runtime::thread_pool::worker::Context::run
  17: tokio::macros::scoped_tls::ScopedKey<T>::set
  18: tokio::runtime::thread_pool::worker::run
  19: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  20: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
  21: tokio::runtime::task::raw::poll
  22: tokio::runtime::blocking::pool::Inner::run
  23: tokio::runtime::context::enter
  24: std::sys_common::backtrace::__rust_begin_short_backtrace
  25: core::ops::function::FnOnce::call_once{{vtable.shim}}
  26: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/liballoc/boxed.rs:1008
      <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/liballoc/boxed.rs:1008
      std::sys::unix::thread::Thread::new::thread_start
             at /rustc/c7087fe00d2ba919df1d813c040a5d47e43b0fe7/src/libstd/sys/unix/thread.rs:87
  27: start_thread
  28: __clone


Thread 'tokio-runtime-worker' panicked at 'Receiver::next_message called after `None`', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec8
```

# The problem

I noticed this note in the code of sc-telemetry:

```
/// Initializes the telemetry. See the crate root documentation for more information.
///
/// Please be careful to not call this function twice in the same program. The `slog` crate
/// doesn't provide any way of knowing whether a global logger has already been registered.
```

So I tried to force deactivate the telemetry on the relay chain to have only the parachain's telemetry and this is what I found while debugging:

```
parachain telemetry: Some(TelemetryEndpoints([("/dns/xxxxxxxxxxxxxxxx/tcp/1024/ws", 10)]))
polkadot telemetry: Some(TelemetryEndpoints([]))
```

But the current code does initialize the telemetry for polkadot because it is Some and not None (even if the telemetry endpoints is empty!)

# Solution

Don't initialized if the telemetryendpoints is empty.