### PR TITLE
bump sysinfo for ios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8684,9 +8684,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.13.3"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0338198966bde7feb14b011a33d404a62a6e03b843352c71512a2a002634b7"
+checksum = "eec476c3d107e7fc2c445e4edc26836c49ba5be0dae74146ee94ecb62759c31d"
 dependencies = [
  "cfg-if",
  "doc-comment",

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,7 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.13.3"
+sysinfo = "0.14.3"
 sc-keystore = { version = "2.0.0-rc4", path = "../keystore" }
 sp-io = { version = "2.0.0-rc4", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc4", path = "../../primitives/runtime" }


### PR DESCRIPTION
bumps sysinfo so it compiles on iOS (done by shekohex in this PR https://github.com/GuillaumeGomez/sysinfo/pull/343 s.t. lowest version supported is `0.14.11` -- I can bump it down to this but it compiles for me with the latest version `0.14.3`)