### PR TITLE
Tiny change: change unknown-commit to unknown to make parsing easier

### DIFF
--- a/bin/node/cli/tests/version.rs
+++ b/bin/node/cli/tests/version.rs
@@ -22,7 +22,7 @@ use regex::Regex;
 use std::process::Command;
 
 fn expected_regex() -> Regex {
-	Regex::new(r"^substrate (\d+\.\d+\.\d+(?:-.+?)?)-([a-f\d]+|unknown-commit)-(.+?)-(.+?)(?:-(.+))?$").unwrap()
+	Regex::new(r"^substrate (\d+\.\d+\.\d+(?:-.+?)?)-([a-f\d]+|unknown)-(.+?)-(.+?)(?:-(.+))?$").unwrap()
 }
 
 #[test]

--- a/utils/build-script-utils/src/version.rs
+++ b/utils/build-script-utils/src/version.rs
@@ -31,11 +31,11 @@ pub fn generate_cargo_keys() {
 		}
 		Ok(o) => {
 			println!("cargo:warning=Git command failed with status: {}", o.status);
-			Cow::from("unknown-commit")
+			Cow::from("unknown")
 		},
 		Err(err) => {
 			println!("cargo:warning=Failed to execute git command: {}", err);
-			Cow::from("unknown-commit")
+			Cow::from("unknown")
 		},
 	};
 


### PR DESCRIPTION
While building cumulus in a container I realized that if the .git is not available, unknown-commit is used but then the version is a bit weird if I wanted to parse it. The number of hypens should stay the same.

```
0.1.0-unknown-commit-x86_64-linux-gnu
```

Normally:

```
0.1.0-c7084b9-x86_64-linux-gnu
```

An underscore would be ok too but I think just "unkown" is fine.