### PR TITLE
Properly filter out duplicate voters in elections.

### DIFF
--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -371,6 +371,10 @@ pub fn seq_phragmen<AccountId, R>(
 	voters.extend(initial_voters.into_iter().map(|(who, voter_stake, votes)| {
 		let mut edges: Vec<Edge<AccountId>> = Vec::with_capacity(votes.len());
 		for v in votes {
+			if edges.iter().position(|e| e.who == v).is_some() {
+				// duplicate edge.
+				continue;
+			}
 			if let Some(idx) = c_idx_cache.get(&v) {
 				// This candidate is valid + already cached.
 				candidates[*idx].approval_stake = candidates[*idx].approval_stake

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -371,7 +371,7 @@ pub fn seq_phragmen<AccountId, R>(
 	voters.extend(initial_voters.into_iter().map(|(who, voter_stake, votes)| {
 		let mut edges: Vec<Edge<AccountId>> = Vec::with_capacity(votes.len());
 		for v in votes {
-			if edges.iter().position(|e| e.who == v).is_some() {
+			if edges.iter().any(|e| e.who == v) {
 				// duplicate edge.
 				continue;
 			}

--- a/primitives/npos-elections/src/tests.rs
+++ b/primitives/npos-elections/src/tests.rs
@@ -588,6 +588,66 @@ fn self_votes_should_be_kept() {
 	);
 }
 
+#[test]
+fn duplicate_target_is_ignored() {
+	let candidates = vec![1, 2, 3];
+	let voters = vec![
+		(10, 100, vec![1, 1, 2, 3]),
+		(20, 100, vec![2, 3]),
+		(30, 50, vec![1, 1, 2]),
+	];
+
+	let ElectionResult { winners, assignments } = seq_phragmen::<_, Perbill>(
+		2,
+		2,
+		candidates,
+		voters,
+	).unwrap();
+	let winners = to_without_backing(winners);
+
+	assert_eq!(winners, vec![(2), (3)]);
+	assert_eq!(
+		assignments
+			.into_iter()
+			.map(|x| (x.who, x.distribution.into_iter().map(|(w, _)| w).collect::<Vec<_>>()))
+			.collect::<Vec<_>>(),
+		vec![
+			(10, vec![2, 3]),
+			(20, vec![2, 3]),
+			(30, vec![2]),
+		],
+	);
+}
+
+#[test]
+fn duplicate_target_is_ignored_when_winner() {
+	let candidates = vec![1, 2, 3];
+	let voters = vec![
+		(10, 100, vec![1, 1, 2, 3]),
+		(20, 100, vec![1, 2]),
+	];
+
+	let ElectionResult { winners, assignments } = seq_phragmen::<_, Perbill>(
+		2,
+		2,
+		candidates,
+		voters,
+	).unwrap();
+	let winners = to_without_backing(winners);
+
+	assert_eq!(winners, vec![1, 2]);
+	assert_eq!(
+		assignments
+			.into_iter()
+			.map(|x| (x.who, x.distribution.into_iter().map(|(w, _)| w).collect::<Vec<_>>()))
+			.collect::<Vec<_>>(),
+		vec![
+			(10, vec![1, 2]),
+			(20, vec![1, 2]),
+		],
+	);
+}
+
 mod assignment_convert_normalize {
 	use super::*;
 	#[test]


### PR DESCRIPTION
Major part of https://github.com/paritytech/substrate/issues/4593. See the comments I added there today; Staking and elections-phragmen both prevent duplicate candidate and voters, so we didn't need to treat them in the underlying npos-elections layer yet and the above issue is open to grab. Nonetheless, we totally ignored **duplicate votes**, which is totally valid and causes confusion in the npos-election algorithms. 

I haven't spent much time investigating the impact of the bug and immediately prepared the patch, nonetheless:
1. Luckily it seems like _it didn't break the offchain-phragmen pipeline in any way_, and all the submissions submitted to polkadot by validators have been valid.
2. This _does corrupt the election result_, so the results of the election, with this bug, are _somewhat dubious_. I don't quite know how the results are corrupt, but for example the tests that I added in this PR both fail without the patch and `winners` is different.

--- 

I think this patch should exist anyhow. Later on, we can decide to validate inputs of `nominate()` transaction directly and prevent duplicates from the get go.  

Given the nomination/vote limit of 16, the performance impact should be low in either way. Nonetheless fixing this in the transaction requires re-benchmarking etc. and I don't want to do that now. 