### PR TITLE
Update to latest sysinfo prevents leaking fd-handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8815,9 +8815,8 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec476c3d107e7fc2c445e4edc26836c49ba5be0dae74146ee94ecb62759c31d"
+version = "0.14.14"
+source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=tasks-cleanup#9d7ef472900b95230c5ad33b96ac3bc936860b6b"
 dependencies = [
  "cfg-if",
  "doc-comment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8815,8 +8815,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.14.14"
-source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=tasks-cleanup#9d7ef472900b95230c5ad33b96ac3bc936860b6b"
+version = "0.14.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
 dependencies = [
  "cfg-if",
  "doc-comment",

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,7 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.14.3"
+sysinfo = { git = "https://github.com/GuillaumeGomez/sysinfo", branch = "tasks-cleanup"}
 sc-keystore = { version = "2.0.0-rc5", path = "../keystore" }
 sp-io = { version = "2.0.0-rc5", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../primitives/runtime" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,7 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = { git = "https://github.com/GuillaumeGomez/sysinfo", branch = "tasks-cleanup"}
+sysinfo = "0.14.15"
 sc-keystore = { version = "2.0.0-rc5", path = "../keystore" }
 sp-io = { version = "2.0.0-rc5", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../primitives/runtime" }

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -284,15 +284,14 @@ impl MetricsService {
 	fn process_info_for(&mut self, pid: &sysinfo::Pid) -> ProcessInfo {
 		// FIXME: sysinfo::System leaks fd-handlers on Linux. We have to drop it to clean this up
 		//        https://github.com/GuillaumeGomez/sysinfo/issues/352
-		self.system = sysinfo::System::new();
+		self.system = sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes());
 
 		let mut info = ProcessInfo::default();
-		if self.system.refresh_process(*pid) {
-			let prc = self.system.get_process(*pid)
-				.expect("Above refresh_process succeeds, this must be Some(), qed");
+		self.system.refresh_process(*pid);
+		self.system.get_process(*pid).map(|prc| {
 			info.cpu_usage = prc.cpu_usage().into();
 			info.memory = prc.memory();
-		}
+		});
 		info
 	}
 

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -206,6 +206,7 @@ impl MetricsService {
 
 	fn process_info(&mut self) -> ProcessInfo {
 		let pid = self.pid.clone().expect("unix always has a pid. qed");
+		self.system.clear_procs(); // ensure we close old, released tasks handles
 		let mut info = self.process_info_for(&pid);
 		let process = procfs::process::Process::new(pid).expect("Our process exists. qed.");
 		info.threads = process.stat().ok().map(|s|
@@ -240,6 +241,7 @@ impl MetricsService {
 	}
 
 	fn process_info(&mut self) -> ProcessInfo {
+		self.system.clear_procs(); // ensure we close old, released tasks handles
 		self.pid.map(|pid| self.process_info_for(&pid)).unwrap_or_default()
 	}
 }

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -199,7 +199,7 @@ impl MetricsService {
 
 		Self {
 			metrics,
-			system: sysinfo::System::new(),
+			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
 			pid: Some(process.pid),
 		}
 	}
@@ -234,7 +234,7 @@ impl MetricsService {
 	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
 		Self {
 			metrics,
-			system: sysinfo::System::new(),
+			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
 			pid: sysinfo::get_current_pid().ok(),
 		}
 	}
@@ -282,10 +282,6 @@ impl MetricsService {
 
 	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
 	fn process_info_for(&mut self, pid: &sysinfo::Pid) -> ProcessInfo {
-		// FIXME: sysinfo::System leaks fd-handlers on Linux. We have to drop it to clean this up
-		//        https://github.com/GuillaumeGomez/sysinfo/issues/352
-		self.system = sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes());
-
 		let mut info = ProcessInfo::default();
 		self.system.refresh_process(*pid);
 		self.system.get_process(*pid).map(|prc| {


### PR DESCRIPTION
Following https://github.com/GuillaumeGomez/sysinfo/issues/352 , this upgrades to the freshly released version 0.14.15 . It also adds some smaller helpers to ensure we only fetch the system resources we need. This fixes https://github.com/paritytech/polkadot/issues/1434 

On Linux through `sysinfo::System` we are leaking file-handlers  to `/proc/[pid]/task/[t]/stats`. This hasn't been shown up previously because we had mostly long-living threads. This recently changed we have quite a few more short lived threads – unfortunately `sysinfo` isn't cleaning up the file handlers to their stats properly. The latest version of sysinfo fixes that bug.