### PR TITLE
Remove clear_on_drop from browser util crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,15 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8450,7 +8441,6 @@ name = "substrate-browser-utils"
 version = "0.8.0-rc5"
 dependencies = [
  "chrono",
- "clear_on_drop",
  "console_error_panic_hook",
  "console_log",
  "futures 0.1.29",

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -28,8 +28,6 @@ sc-service = { version = "0.8.0-rc5", path = "../../client/service", default-fea
 sc-network = { path = "../../client/network", version = "0.8.0-rc5"}
 sc-chain-spec = { path = "../../client/chain-spec", version = "2.0.0-rc5"}
 
-# Imported just for the `no_cc` feature
-clear_on_drop = { version = "0.2.3", features = ["no_cc"] }
 # Imported just for the `wasm-bindgen` feature
 rand6 = { package = "rand", version = "0.6", features = ["wasm-bindgen"] }
 rand = { version = "0.7", features = ["wasm-bindgen"] }


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/6677

The fact that `clear_on_drop` has disappeared from the `Cargo.lock` is the proof that this was no longer useful.