### PR TITLE
PoC implementation of async/await support in the off-chain workers 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7913,6 +7913,7 @@ version = "2.0.0-rc5"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
+ "lazy_static",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -7925,6 +7926,7 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
+ "spin",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7916,7 +7916,6 @@ version = "2.0.0-rc5"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
- "lazy_static",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -7929,7 +7928,6 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
- "spin",
 ]
 
 [[package]]
@@ -8011,10 +8009,12 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
+ "lazy_static",
  "log",
  "parity-scale-codec",
  "parity-util-mem 0.7.0",
  "paste",
+ "pin-project",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -8025,6 +8025,7 @@ dependencies = [
  "sp-io",
  "sp-state-machine",
  "sp-std",
+ "spin",
 ]
 
 [[package]]

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -248,6 +248,10 @@ sp_core::wasm_export_functions! {
 		run().is_some()
 	}
 
+	fn test_pollable() -> bool {
+		sp_io::pollable::is_ready(sp_io::PollableId::from(0))
+	}
+
 	// Just some test to make sure that `sp-allocator` compiles on `no_std`.
 	fn test_sp_allocator_compiles() {
 		sp_allocator::FreeingBumpHeapAllocator::new(0);

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -260,7 +260,7 @@ sp_core::wasm_export_functions! {
 			// let status = sp_io::offchain::http_response_wait(&[id], None);
 
 			let id = sp_core::offchain::PollableId::from_parts(PollableKind::Http, id.0 as u32);
-			sp_io::offchain::pollable_wait(&[id]);
+			sp_io::offchain::pollable_wait(&[id], None);
 
 			Some(())
 		};

--- a/client/executor/runtime-test/src/lib.rs
+++ b/client/executor/runtime-test/src/lib.rs
@@ -248,8 +248,24 @@ sp_core::wasm_export_functions! {
 		run().is_some()
 	}
 
-	fn test_pollable() -> bool {
-		sp_io::pollable::is_ready(sp_io::PollableId::from(0))
+	fn test_offchain_pollable() -> bool {
+		use sp_core::offchain::{PollableKind, PollableId};
+		let run = || -> Option<()> {
+			let id = sp_io::offchain::http_request_start(
+				"POST",
+				"http://localhost:12345",
+				&[],
+			).ok()?;
+			sp_io::offchain::http_request_write_body(id, &[], None).ok()?;
+			// let status = sp_io::offchain::http_response_wait(&[id], None);
+
+			let id = sp_core::offchain::PollableId::from_parts(PollableKind::Http, id.0 as u32);
+			sp_io::offchain::pollable_wait(&[id]);
+
+			Some(())
+		};
+
+		run().is_some()
 	}
 
 	// Just some test to make sure that `sp-allocator` compiles on `no_std`.

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -522,6 +522,22 @@ fn offchain_http_should_work(wasm_method: WasmExecutionMethod) {
 
 #[test_case(WasmExecutionMethod::Interpreted)]
 #[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+fn pollable_smoke_test(wasm_method: WasmExecutionMethod) {
+	let mut ext = TestExternalities::default();
+
+	assert_eq!(
+		call_in_wasm(
+			"test_pollable",
+			&[0],
+			wasm_method,
+			&mut ext.ext(),
+		).unwrap(),
+		false.encode(),
+	);
+}
+
+#[test_case(WasmExecutionMethod::Interpreted)]
+#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
 #[should_panic(expected = "Allocator ran out of space")]
 fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -218,11 +218,14 @@ impl<Storage: OffchainStorage> offchain::Externalities for Api<Storage> {
 		let simplistic_stream = stream
 			.by_ref()
 			.skip_while(|&x| {
-				let skip = ids.iter().find(|&id| *id != x).is_some();
-				if skip {
+				let found = ids.iter().find(|&id| *id == x).is_some();
+				// Even if we're not interested in this ready ID, make sure to
+				// remember it for the possible subsequent calls asking about it
+				// can be succesful
+				if !found {
 					buffer.insert(x);
 				}
-				futures::future::ready(skip)
+				futures::future::ready(!found)
 			})
 			.into_future();
 

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -19,7 +19,7 @@ use std::{
 	sync::Arc,
 	convert::TryFrom,
 	thread::sleep,
-	collections::BTreeSet,
+	collections::HashSet,
 };
 
 use sp_core::offchain::OffchainStorage;
@@ -65,7 +65,7 @@ pub(crate) struct Api<Storage> {
 	/// Buffered pollable IDs. Incoming IDs ready to be processed are buffered
 	/// here whenever they arrive while the offchain worker is waiting for other
 	/// IDs.
-	buffered_ready_ids: BTreeSet<PollableId>,
+	buffered_ready_ids: HashSet<PollableId>,
 	/// Timers are handled by a separate struct.
 	timer: timer::TimerApi,
 }

--- a/client/offchain/src/api.rs
+++ b/client/offchain/src/api.rs
@@ -27,7 +27,7 @@ use log::error;
 use sc_network::{PeerId, Multiaddr, NetworkStateInfo};
 use codec::{Encode, Decode};
 use sp_core::offchain::{
-	Externalities as OffchainExt, HttpRequestId, Timestamp, HttpRequestStatus, HttpError,
+	self, HttpRequestId, Timestamp, HttpRequestStatus, HttpError,
 	OpaqueNetworkState, OpaquePeerId, OpaqueMultiaddr, StorageKind,
 };
 pub use sp_offchain::STORAGE_PREFIX;
@@ -67,7 +67,7 @@ fn unavailable_yet<R: Default>(name: &str) -> R {
 
 const LOCAL_DB: &str = "LOCAL (fork-aware) DB";
 
-impl<Storage: OffchainStorage> OffchainExt for Api<Storage> {
+impl<Storage: OffchainStorage> offchain::Externalities for Api<Storage> {
 	fn is_validator(&self) -> bool {
 		self.is_validator
 	}
@@ -291,6 +291,7 @@ impl AsyncApi {
 mod tests {
 	use super::*;
 	use std::{convert::{TryFrom, TryInto}, time::SystemTime};
+	use sp_core::offchain::Externalities;
 	use sc_client_db::offchain::LocalStorage;
 	use sc_network::PeerId;
 

--- a/client/offchain/src/api/timer.rs
+++ b/client/offchain/src/api/timer.rs
@@ -1,0 +1,153 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! TODO: Add more docs to timer module
+
+use sp_core::offchain;
+use sp_core::offchain::Timestamp;
+use sp_core::offchain::PollableId;
+use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
+
+use core::future::Future;
+use core::mem;
+use core::pin::Pin;
+use core::task::{self, Poll};
+use core::time;
+use std::collections::BTreeMap;
+
+use futures::Stream;
+use futures_timer::Delay;
+
+pub use sp_core::offchain::TimerId;
+
+pub fn timer(sink: TracingUnboundedSender<PollableId>) -> (TimerApi, TimerWorker) {
+    // let (to_api, from_worker) = tracing_unbounded("mpsc_ocw_timer_to");
+    let (to_worker, from_api) = tracing_unbounded("mpsc_ocw_timer_from");
+
+    let worker = TimerWorker {
+        to_api: sink,
+        from_api,
+        delay: None,
+        ids: Default::default(),
+    };
+
+    let api = TimerApi {
+        to_worker,
+        // from_worker,
+        next_id: TimerId(0),
+    };
+
+    (api, worker)
+}
+
+pub struct TimerApi {
+    /// Used to sends messages to the `HttpApi`.
+	to_worker: TracingUnboundedSender<(TimerId, Timestamp)>,
+	// /// Used to receive messages from the `TimerApi`.
+	// from_worker: TracingUnboundedReceiver<TimerId>,
+    /// Counter to generate new timer IDs with.
+    next_id: TimerId,
+}
+
+impl TimerApi {
+	pub fn start_timer(&mut self, duration: offchain::Duration) -> Result<TimerId, ()> {
+		let id = self.next_id;
+		self.next_id = TimerId(self.next_id.0 + 1);
+
+		let timestamp = super::timestamp::now().add(duration);
+
+		self.to_worker.unbounded_send((id, timestamp))
+			.map(|_| id)
+			.map_err(drop)
+	}
+}
+
+pub struct TimerWorker {
+	/// Used to sends messages to the `HttpApi`.
+	to_api: TracingUnboundedSender<PollableId>,
+	/// Used to receive messages from the `TimerApi`.
+    from_api: TracingUnboundedReceiver<(TimerId, Timestamp)>,
+    /// Timer future driving the wakeups for worker future.
+	delay: Option<(Timestamp, Delay)>,
+	// TODO: Replace with a binary heap because we can have multiple timers for
+	// the same timestamp
+    ids: BTreeMap<Timestamp, TimerId>,
+}
+
+impl Future for TimerWorker {
+	type Output = ();
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+		let this = &mut *self;
+
+		if let Some((_, delay)) = &mut this.delay {
+			match Future::poll(Pin::new(delay), cx) {
+				Poll::Ready(..) => { this.delay.take(); },
+				Poll::Pending => {},
+			}
+		}
+
+		// Process elapsed timers
+		let future = super::timestamp::now().add(offchain::Duration::from_millis(1));
+		let future_timers = this.ids.split_off(&future);
+		let elapsed = mem::replace(&mut this.ids, future_timers);
+
+		for (_, id) in elapsed {
+			let _ = this.to_api.unbounded_send(id.into());
+		}
+
+		// Register the task for wakeup up when we can progress with the nearest timers
+		match (this.ids.iter().nth(0), this.delay.as_ref()) {
+			(Some((&timestamp, _)), None) => {
+                let diff = super::timestamp::timestamp_from_now(timestamp);
+                let duration = time::Duration::from_millis(diff.as_millis() as u64);
+
+				this.delay = Some((timestamp, Delay::new(duration)));
+				// Reschedule the task to poll the new underlying timer future
+				cx.waker().wake_by_ref();
+			},
+			_ => {},
+		}
+
+		// Check for messages coming from the [`HttpApi`].
+		match Stream::poll_next(Pin::new(&mut this.from_api), cx) {
+			Poll::Pending => Poll::Pending,
+			Poll::Ready(Some((id, timestamp))) => {
+				this.ids.insert(timestamp, id);
+                // this.next_id = TimerId(this.next_id.0 + 1);
+
+                // Newly added timer may resolve before currently registered
+                // earliest one - if that's the case, adjust the new delay.
+                match this.delay.as_mut() {
+                    Some((earliest, delay)) if earliest.diff(&timestamp).millis() > 0 => {
+                        let diff = super::timestamp::timestamp_from_now(timestamp);
+                        let duration = time::Duration::from_millis(diff.as_millis() as u64);
+
+                        delay.reset(duration);
+                    },
+                    _ => {},
+                }
+                // Reschedule the task to poll the new underlying timer future
+                // (delay could have changed or a first timer to process could've been added)
+				cx.waker().wake_by_ref();
+
+				Poll::Pending
+			},
+			// Finished, stop the worker
+			Poll::Ready(None) => Poll::Ready(()),
+		}
+	}
+}

--- a/primitives/core/src/offchain/mod.rs
+++ b/primitives/core/src/offchain/mod.rs
@@ -556,7 +556,11 @@ pub trait Externalities: Send {
 	) -> Result<usize, HttpError>;
 
 	/// TODO:
-	fn pollable_wait(&mut self, ids: &[PollableId]);
+	fn pollable_wait(
+		&mut self,
+		ids: &[PollableId],
+		deadline: Option<Timestamp>
+	) -> Option<PollableId>;
 }
 
 impl<T: Externalities + ?Sized> Externalities for Box<T> {
@@ -636,8 +640,12 @@ impl<T: Externalities + ?Sized> Externalities for Box<T> {
 		(&mut **self).http_response_read_body(request_id, buffer, deadline)
 	}
 
-	fn pollable_wait(&mut self, ids: &[PollableId]) {
-		(&mut **self).pollable_wait(ids)
+	fn pollable_wait(
+		&mut self,
+		ids: &[PollableId],
+		deadline: Option<Timestamp>
+	) -> Option<PollableId> {
+		(&mut **self).pollable_wait(ids, deadline)
 	}
 }
 
@@ -758,9 +766,14 @@ impl<T: Externalities> Externalities for LimitedExternalities<T> {
 		self.externalities.http_response_read_body(request_id, buffer, deadline)
 	}
 
-	fn pollable_wait(&mut self, ids: &[PollableId]) {
-		self.check(Capability::Http, "pollable_wait");
-		self.externalities.pollable_wait(ids)
+	fn pollable_wait(
+		&mut self,
+		ids: &[PollableId],
+		deadline: Option<Timestamp>
+	) -> Option<PollableId> {
+		// NOTE: Waiting on a pollable does not require any capability - it
+		// should be enforced on creation of a pollable itself (e.g. HTTP request).
+		self.externalities.pollable_wait(ids, deadline)
 	}
 }
 

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -30,9 +30,11 @@ use crate::offchain::{
 	HttpError,
 	HttpRequestId as RequestId,
 	HttpRequestStatus as RequestStatus,
+	Duration,
 	Timestamp,
 	StorageKind,
 	PollableId,
+	TimerId,
 	OpaqueNetworkState,
 	TransactionPool,
 	OffchainStorage,
@@ -227,6 +229,10 @@ impl offchain::Externalities for TestOffchainExt {
 
 	fn sleep_until(&mut self, deadline: Timestamp) {
 		self.0.write().timestamp = deadline;
+	}
+
+	fn timer_until(&mut self, duration: Duration) -> Result<TimerId, ()> {
+		unimplemented!()
 	}
 
 	fn random_seed(&mut self) -> [u8; 32] {

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -377,7 +377,11 @@ impl offchain::Externalities for TestOffchainExt {
 		}
 	}
 
-	fn pollable_wait(&mut self, ids: &[PollableId]) {
+	fn pollable_wait(
+		&mut self,
+		ids: &[PollableId],
+		deadline: Option<Timestamp>
+	) -> Option<PollableId> {
 		let state = self.0.read();
 
 		use std::convert::TryFrom;
@@ -385,9 +389,12 @@ impl offchain::Externalities for TestOffchainExt {
 			match state.requests.get(&id) {
 				Some(req) if req.response.is_none() =>
 					panic!("No `response` provided for request with id: {:?}", id),
-				_ => (),
+				Some(..) => return Some(id.into()),
+				None => {},
 			}
 		}
+
+		None
 	}
 }
 

--- a/primitives/core/src/offchain/testing.rs
+++ b/primitives/core/src/offchain/testing.rs
@@ -32,6 +32,7 @@ use crate::offchain::{
 	HttpRequestStatus as RequestStatus,
 	Timestamp,
 	StorageKind,
+	PollableId,
 	OpaqueNetworkState,
 	TransactionPool,
 	OffchainStorage,
@@ -373,6 +374,19 @@ impl offchain::Externalities for TestOffchainExt {
 			}
 		} else {
 			Err(HttpError::IoError)
+		}
+	}
+
+	fn pollable_wait(&mut self, ids: &[PollableId]) {
+		let state = self.0.read();
+
+		use std::convert::TryFrom;
+		for id in ids.iter().copied().map(RequestId::try_from).filter_map(Result::ok) {
+			match state.requests.get(&id) {
+				Some(req) if req.response.is_none() =>
+					panic!("No `response` provided for request with id: {:?}", id),
+				_ => (),
+			}
 		}
 	}
 }

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -30,6 +30,7 @@ futures = { version = "0.3.1", default-features = false, features = ["thread-poo
 parking_lot = { version = "0.10.0", optional = true }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.5"
+pin-project = "0.4"
 
 [features]
 default = ["std"]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -26,8 +26,10 @@ sp-trie = { version = "2.0.0-rc5", optional = true, path = "../../primitives/tri
 sp-externalities = { version = "0.8.0-rc5", optional = true, path = "../externalities" }
 sp-tracing = { version = "2.0.0-rc5", default-features = false, path = "../tracing" }
 log = { version = "0.4.8", optional = true }
-futures = { version = "0.3.1", features = ["thread-pool"], optional = true }
+futures = { version = "0.3.1", default-features = false, features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.10.0", optional = true }
+lazy_static = "1.0"
+spin = "0.5"
 
 [features]
 default = ["std"]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -28,7 +28,7 @@ sp-tracing = { version = "2.0.0-rc5", default-features = false, path = "../traci
 log = { version = "0.4.8", optional = true }
 futures = { version = "0.3.1", default-features = false, features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.10.0", optional = true }
-lazy_static = "1.0"
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.5"
 
 [features]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -28,9 +28,6 @@ sp-tracing = { version = "2.0.0-rc5", default-features = false, path = "../traci
 log = { version = "0.4.8", optional = true }
 futures = { version = "0.3.1", default-features = false, features = ["thread-pool"], optional = true }
 parking_lot = { version = "0.10.0", optional = true }
-lazy_static = { version = "1.0", features = ["spin_no_std"] }
-spin = "0.5"
-pin-project = "0.4"
 
 [features]
 default = ["std"]

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -65,8 +65,6 @@ mod batch_verifier;
 #[cfg(feature = "std")]
 use batch_verifier::BatchVerifier;
 
-pub mod message;
-
 /// Error verifying ECDSA signature
 #[derive(Encode, Decode)]
 pub enum EcdsaVerifyError {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -64,6 +64,8 @@ mod batch_verifier;
 #[cfg(feature = "std")]
 use batch_verifier::BatchVerifier;
 
+pub mod message;
+
 /// Error verifying ECDSA signature
 #[derive(Encode, Decode)]
 pub enum EcdsaVerifyError {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -45,7 +45,7 @@ use sp_core::{
 	crypto::KeyTypeId, ed25519, sr25519, ecdsa, H256, LogLevel,
 	offchain::{
 		Timestamp, HttpRequestId, HttpRequestStatus, HttpError, StorageKind, OpaqueNetworkState,
-		PollableId,
+		PollableId, TimerId, Duration,
 	},
 };
 
@@ -809,6 +809,13 @@ pub trait Offchain {
 		self.extension::<OffchainExt>()
 			.expect("sleep_until can be called only in the offchain worker context")
 			.sleep_until(deadline)
+	}
+
+	/// Pause the execution until `deadline` is reached.
+	fn timer_until(&mut self, duration: Duration) -> Result<TimerId, ()> {
+		self.extension::<OffchainExt>()
+			.expect("timer_until can be called only in the offchain worker context")
+			.timer_until(duration)
 	}
 
 	/// Returns a random seed.

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -964,10 +964,14 @@ pub trait Offchain {
 			.map(|r| r as u32)
 	}
 
-	fn pollable_wait(&mut self, ids: &[PollableId]) {
+	fn pollable_wait(
+		&mut self,
+		ids: &[PollableId],
+		deadline: Option<Timestamp>
+	) -> Option<PollableId> {
 		self.extension::<OffchainExt>()
 			.expect("pollable_wait can be called only in the offchain worker context")
-			.pollable_wait(ids)
+			.pollable_wait(ids, deadline)
 	}
 }
 

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -969,14 +969,20 @@ pub trait Offchain {
 			.map(|r| r as u32)
 	}
 
+	/// Wait until some pollable ID is marked as "ready" to process.
+	///
+	/// This can be used to monitor multiple IDs with an optional timeout.
+	/// Calling this will block until either:
+	/// - a pollable ID becomes ready;
+	/// - the timeout expires (unless a `None` deadline was passed).
 	fn pollable_wait(
 		&mut self,
-		ids: &[PollableId],
+		interest_list: &[PollableId],
 		deadline: Option<Timestamp>
 	) -> Option<PollableId> {
 		self.extension::<OffchainExt>()
 			.expect("pollable_wait can be called only in the offchain worker context")
-			.pollable_wait(ids, deadline)
+			.pollable_wait(interest_list, deadline)
 	}
 }
 

--- a/primitives/io/src/message.rs
+++ b/primitives/io/src/message.rs
@@ -50,6 +50,7 @@ fn epoll_wait(interest_list: &[MessageId]) -> MessageId {
 fn decode(id: MessageId) -> Message {
     // TODO: Handle FFI boundary and output bytes
     match id.kind() {
+        PollableKind::Timer => Message(Vec::new()),
         PollableKind::Http | _ => unimplemented!(),
     }
 }

--- a/primitives/io/src/message.rs
+++ b/primitives/io/src/message.rs
@@ -1,0 +1,218 @@
+#![allow(dead_code, unused_variables)]
+
+// Based on https://github.com/tomaka/redshirt/blob/802e4ab44078e15b47dc72afc6b7e45bab1b72df/interfaces/syscalls/src/block_on.rs#L88.
+
+/// Pins a value on the stack.
+// A copy of `futures::pin_mut!` without having to pull `futures` in the no_std
+// context.
+macro_rules! pin_mut {
+    ($($x:ident),* $(,)?) => { $(
+        // Move the value to ensure that it is owned
+        let mut $x = $x;
+        // Shadow the original binding so that it can't be directly accessed
+        // ever again.
+        #[allow(unused_mut)]
+        let mut $x = unsafe {
+            core::pin::Pin::new_unchecked(&mut $x)
+        };
+    )* }
+}
+
+use sp_std::{rc::Rc, collections::btree_map::BTreeMap, vec::Vec};
+use sp_std::cell::RefCell;
+
+use core::pin::Pin;
+use core::future::Future;
+use core::{task::{self, Context, Poll, Waker}};
+
+use spin::Mutex;
+
+pub(crate) type MessageId = u64;
+
+// TODO: Decode actual events
+pub(crate) struct Message(Vec<u8>);
+
+fn epoll_peek(interest_list: &[MessageId]) -> MessageId {
+    unimplemented!()
+}
+
+fn epoll_wait(interest_list: &[MessageId]) -> MessageId {
+    unimplemented!()
+}
+
+fn decode(id: MessageId) -> Message {
+    unimplemented!()
+}
+
+pub(crate) fn next_notification(interest_list: &[MessageId], block: bool) -> Option<(Message, MessageId, usize)> {
+    let id = if !block { epoll_peek(interest_list) } else { epoll_wait(interest_list) };
+
+    // TODO: Handle FFI boundary and output bytes
+    Some((
+        decode(id),
+        // TODO: Fetch message_id from interest_list
+        0,
+        // TODO: Fetch index from interest_list
+        0,
+    ))
+}
+
+/// Registers a message ID and a waker. The `block_on` function will
+/// then ask the kernel for a message corresponding to this ID. If one is received, the `Waker`
+/// is called.
+///
+/// For non-interface messages, there can only ever be one registered `Waker`. Registering a
+/// `Waker` a second time overrides the one previously registered.
+pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) {
+    let mut state = (&*STATE).lock();
+
+    if let Some(pos) = state
+        .message_ids
+        .iter()
+        .position(|msg| *msg == From::from(message_id))
+    {
+        state.wakers[pos] = waker;
+        return;
+    }
+
+    state.message_ids.push(From::from(message_id));
+    state.wakers.push(waker);
+}
+
+// TODO: Executor + reactor for wasm-side futures, waits on host-executed
+// futures like HTTP requests etc.
+pub fn block_on<T>(future: impl Future<Output = T>) -> T {
+    pin_mut!(future);
+
+    // We don't have `Arc` to use convenient `ArcWake` and we're always running
+    // on a single thread in WASM so ¯\_(ツ)_/¯
+    fn trigger_wakeup(data: *const ()) {
+        let data: *const RefCell<bool> = data as _;
+        unsafe { *(*data).borrow_mut() = true; }
+    };
+    fn drop_shared_wakeup(data: *const ()) {
+        unsafe { Rc::from_raw(data as *const RefCell<bool>); }
+    }
+    fn create_waker(data: *const()) -> core::task::RawWaker {
+        let data = unsafe { Rc::from_raw(data as *const RefCell<bool>) };
+        let cloned = Rc::clone(&data);
+        core::task::RawWaker::new(Rc::into_raw(cloned) as _, &core::task::RawWakerVTable::new(
+            create_waker,
+            |data| { trigger_wakeup(data); drop_shared_wakeup(data) },
+            trigger_wakeup,
+            drop_shared_wakeup,
+        ))
+    }
+
+    let woken_up = Rc::new(RefCell::new(false));
+    let waker = {
+        let raw = create_waker(Rc::into_raw(Rc::clone(&woken_up)) as _);
+        unsafe { task::Waker::from_raw(raw) }
+    };
+
+    let mut context = Context::from_waker(&waker);
+
+    loop {
+        // We poll the future continuously until it is either Ready, or the waker stops being
+        // invoked during the polling.
+        loop {
+            if let Poll::Ready(val) = Future::poll(future.as_mut(), &mut context) {
+                return val;
+            }
+
+            // If the waker has been used during the polling of this future,
+            // then we have to poll again.
+            let was_woken = *woken_up.borrow();
+            *woken_up.borrow_mut() = false;
+
+            if was_woken {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        let mut state = (&*STATE).lock();
+        debug_assert_eq!(state.message_ids.len(), state.wakers.len());
+
+        // `block` indicates whether we should block the thread or just peek.
+        // Always `true` during the first iteration, and `false` in further iterations.
+        let mut block = true;
+
+        // We process in a loop all pending messages.
+        while let Some((msg, message_id, index_in_list)) = next_notification(&mut state.message_ids, block) {
+            block = false;
+
+            let _was_in = state.message_ids.remove(index_in_list as usize);
+
+            let waker = state.wakers.remove(index_in_list as usize);
+            waker.wake();
+
+            let _was_in = state.pending_messages.insert(message_id, msg);
+            debug_assert!(_was_in.is_none());
+        }
+
+        debug_assert!(!block);
+    }
+}
+
+lazy_static::lazy_static! {
+    // TODO: we're using a Mutex, which is ok for as long as WASM doesn't have threads
+    // if WASM ever gets threads and no pre-emptive multitasking, then we might spin forever
+    static ref STATE: Mutex<BlockOnState> = {
+        Mutex::new(BlockOnState {
+            message_ids: Vec::new(),
+            wakers: Vec::new(),
+            pending_messages: BTreeMap::new(),
+        })
+    };
+}
+
+/// State of the global `block_on` mechanism.
+///
+/// This is instantiated only once.
+struct BlockOnState {
+    /// List of messages for which we are waiting for a response. A pointer to this list is passed
+    /// to the kernel.
+    message_ids: Vec<u64>,
+
+    /// List whose length is identical to [`BlockOnState::messages_ids`]. For each element in
+    /// [`BlockOnState::messages_ids`], contains a corresponding `Waker` that must be waken up
+    /// when a response comes.
+    wakers: Vec<Waker>,
+
+    /// Queue of response messages waiting to be delivered.
+    ///
+    /// > **Note**: We have to maintain this queue as a global variable rather than a per-future
+    /// >           channel, otherwise dropping a `Future` would silently drop messages that have
+    /// >           already been received.
+    pending_messages: BTreeMap<MessageId, Message>,
+}
+
+/// Future that drives `message_response` to completion.
+#[must_use = "futures do nothing unless polled"]
+pub(crate) struct MessageResponseFuture {
+    msg_id: MessageId,
+    finished: bool,
+}
+
+impl Future for MessageResponseFuture {
+    type Output = Message;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        assert!(!self.finished);
+        if let Some(response) = peek_response(self.msg_id) {
+            self.finished = true;
+            Poll::Ready(response)
+        } else {
+            register_message_waker(self.msg_id, cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+/// If a response to this message ID has previously been obtained, extracts it for processing.
+pub(crate) fn peek_response(msg_id: MessageId) -> Option<Message> {
+    let mut state = (&*STATE).lock();
+    state.pending_messages.remove(&msg_id)
+}

--- a/primitives/io/src/message.rs
+++ b/primitives/io/src/message.rs
@@ -64,7 +64,7 @@ pub(crate) fn next_notification(interest_list: &[MessageId], block: bool) -> Opt
 /// For non-interface messages, there can only ever be one registered `Waker`. Registering a
 /// `Waker` a second time overrides the one previously registered.
 pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) {
-    let mut state = (&*STATE).lock();
+    let mut state = STATE.lock();
 
     if let Some(pos) = state
         .message_ids
@@ -166,7 +166,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
             }
         }
 
-        let mut state = (&*STATE).lock();
+        let mut state = STATE.lock();
         debug_assert_eq!(state.message_ids.len(), state.wakers.len());
 
         // `block` indicates whether we should block the thread or just peek.
@@ -256,6 +256,6 @@ impl Future for HostFuture {
 
 /// If a response to this message ID has previously been obtained, extracts it for processing.
 pub(crate) fn peek_response(msg_id: MessageId) -> bool {
-    let mut state = (&*STATE).lock();
+    let mut state = STATE.lock();
     state.pending_messages.remove(&msg_id)
 }

--- a/primitives/io/src/message.rs
+++ b/primitives/io/src/message.rs
@@ -80,13 +80,13 @@ pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) {
     if let Some(pos) = state
         .message_ids
         .iter()
-        .position(|msg| *msg == From::from(message_id))
+        .position(|msg| *msg == message_id)
     {
         state.wakers[pos] = waker;
         return;
     }
 
-    state.message_ids.push(From::from(message_id));
+    state.message_ids.push(message_id);
     state.wakers.push(waker);
 }
 
@@ -170,7 +170,7 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
                 Poll::Ready(value) => return value,
                 // If the waker has been used during the polling of this future,
                 // then we have to poll again.
-                Poll::Pending if mem::replace(&mut *woken_up.0.borrow_mut(), false) => {},
+                Poll::Pending if mem::replace(&mut *woken_up.0.borrow_mut(), false) => continue,
                 // Otherwise, we need to wait for an external notification for
                 // this future to make progress.
                 Poll::Pending => break,

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -21,7 +21,7 @@ sp-application-crypto = { version = "2.0.0-rc5", default-features = false, path 
 sp-arithmetic = { version = "2.0.0-rc5", default-features = false, path = "../arithmetic" }
 sp-std = { version = "2.0.0-rc5", default-features = false, path = "../std" }
 sp-io = { version = "2.0.0-rc5", default-features = false, path = "../io" }
-log = { version = "0.4.8", optional = true }
+log = { version = "0.4.8", default-features = false }
 paste = "0.1.6"
 rand = { version = "0.7.2", optional = true }
 impl-trait-for-tuples = "0.1.3"
@@ -29,6 +29,9 @@ sp-inherents = { version = "2.0.0-rc5", default-features = false, path = "../inh
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 either = { version = "1.5", default-features = false }
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
+spin = "0.5"
+pin-project = "0.4"
 
 [dev-dependencies]
 serde_json = "1.0.41"
@@ -43,7 +46,7 @@ std = [
 	"sp-application-crypto/std",
 	"sp-arithmetic/std",
 	"codec/std",
-	"log",
+	"log/std",
 	"sp-core/std",
 	"rand",
 	"sp-std/std",

--- a/primitives/runtime/src/offchain/mod.rs
+++ b/primitives/runtime/src/offchain/mod.rs
@@ -18,6 +18,7 @@
 //! A collection of higher lever helpers for offchain calls.
 
 pub mod http;
+pub mod pollable;
 pub mod storage;
 pub mod storage_lock;
 

--- a/primitives/runtime/src/offchain/pollable.rs
+++ b/primitives/runtime/src/offchain/pollable.rs
@@ -430,7 +430,10 @@ impl Future for HttpBodyFuture {
 /// immediately available but the response body needs to be driven separately.
 #[derive(Debug)]
 pub struct HttpResponse {
+	/// HTTP status code (e.g. 200 is "OK").
 	pub code: u16,
+	/// HTTP headers map.
 	pub headers: Vec<(Vec<u8>, Vec<u8>)>,
+	/// A future HTTP body.
 	pub body: HttpBodyFuture,
 }

--- a/primitives/runtime/src/offchain/pollable.rs
+++ b/primitives/runtime/src/offchain/pollable.rs
@@ -283,7 +283,7 @@ impl core::convert::TryFrom<HostFuture> for HttpFuture {
 impl Future for HttpFuture {
     type Output = Result<HttpResponse, sp_core::offchain::HttpError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         use sp_core::offchain::HttpRequestId;
         use sp_core::offchain::HttpRequestStatus;
         use sp_core::offchain::HttpError;


### PR DESCRIPTION
This PR borders on the WIP status because:
- style needs to be addressed
    - make sure all the changed files use tabs
    - be more strict wrt 100/120 char limit
- probably needs a companion Polkadot PR
- urgently needs still unit/integration tests

but I wanted to discuss the architecture and (most importantly) bikeshed the names/module hierarchy first.

I'm not sure about the `B` and `C` labels, feel free to adjust them accordingly.

### Example
```rust
fn offchain_worker(block_number: T::BlockNumber) {
    use sp_io::offchain;
    use sp_runtime::offchain::{http, pollable};

    let req = http::Request::get(
        "https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=USD"
    ).send().map_err(|_| http::Error::IoError)?;

    let future = pollable::HostFuture::from(req.id);
    let http_future: pollable::HttpFuture = future.try_into().unwrap();

    let timer1 = offchain::timer_until(Duration::from_millis(50)).unwrap();
    let timer2 = offchain::timer_until(Duration::from_millis(100)).unwrap();
    let timer3 = offchain::timer_until(Duration::from_millis(5)).unwrap();
    pollable::block_on(async move {
        let fut1 = pollable::HostFuture::from(timer1);
        let fut2 = pollable::HostFuture::from(timer2);
        // FIXME: Due to Cargo feature conflation bug, `futures_util` crate needs to be a fork...
        futures_util::future::join(fut1, fut2).await;

        let fut3 = pollable::HostFuture::from(timer3);
        let ((), response) = futures_util::future::join(fut3, http_future).await;
        let response = response.unwrap();
        assert_eq!(response.code, 200);
        let body = response.body.await;
        let body = sp_std::str::from_utf8(&body).unwrap();
        assert!(body.starts_with(r#"{"USD":"#));
    });
}
```
## Implementation overview
The additional timer scheduling functionality is implemented in an analogous fashion to `HttpWorker`/`HttpApi`. The worker does the scheduling and communicates back to `TimerApi`.

Both of these workers now also send via an unbounded MPSC channel a `PollableId` (domain-specific id) once the task/pollable is marked as ready to progress (e.g. timer has elapsed, another HTTP body chunk is received). The name is very much open to bikeshedding.

A simple executor/reactor is implemented on the runtime side (stripped down version of @tomaka's work on redshirt, kudos!), which then processes pending IDs by fetching them from the channel and drives the corresponding futures.

Because of this, the only `Future`s that are supported are ones that either immediately return `Poll::Ready` or its leaf futures are notified via the pollable ID API (so this also includes future combinators).

The pollable API here is more similar to the `select` rather than `epoll` API. One reason for that is that it simplifies the host interface:
1. We can simplify the host interface by exposing only one `pollable_wait` (`select`) call rather than what's typically three (`epoll_{create,ctl,wait}`) calls
2. The advantage of epoll is maintaining a helper data structure directly on the host side rather than serializing/creating it across the host/runtime boundary whenever we wait, to quickly see if the monitored ID has been "awoken". This is much quicker than a linear scan for numerous, long-lived IDs (which is why this shines in e.g. network I/O scenarios) but for now we speculate that's not going to be the case in the typical OCW use cases.

### Remaining notes

The `pollable::{HttpResponse, HttpBodyFuture}` should probably be replaced with a respective `Future` impl for `sp_runtime::offchain::http` types - this was mostly a PoC/exploration on what the HTTP future API might look like.

As mentioned above, unit/integration tests still need to be written.

Because we have two future runtimes on the host/runtime side, it's not immediately obvious who should drive what. For example, `http_response_wait` plays a big part in driving all of the HTTP futures internally (and not only for the IDs passed). I have to admit that I'd be much more confident in this implementation if someone smarter and more well-versed in async/await takes a thorough look first at who polls/wakes who and why... (looking at you @tomaka :eyes: )

It's worth noting that there is no `spawn`ing tasks yet but rather converting the existing long-lived task/pollable IDs themselves into awaitable futures.

This should probably not land in the 2.0 from what I understand. Should this PR be frozen until the stable crates' release, then? (cc @gnunicorn)