### PR TITLE
grandpa: allow noting that the set has stalled

### DIFF
--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -428,9 +428,9 @@ where
 					Vec::new(),
 				);
 
+				// we will keep all forced change for any later blocks and that are a
+				// descendent of the finalized block (i.e. they are from this fork).
 				for change in pending_forced_changes {
-					// we will keep all forced change for any later blocks and that are a
-					// descendent of the finalized block (i.e. they are from this fork).
 					if change.effective_number() > finalized_number &&
 						is_descendent_of(&finalized_hash, &change.canon_hash)
 							.map_err(fork_tree::Error::Client)?
@@ -1174,5 +1174,125 @@ mod tests {
 			),
 			Err(Error::InvalidAuthoritySet)
 		));
+	}
+
+	#[test]
+	fn cleans_up_stale_forced_changes_when_applying_standard_change() {
+		let current_authorities = vec![(AuthorityId::from_slice(&[1; 32]), 1)];
+
+		let mut authorities = AuthoritySet {
+			current_authorities: current_authorities.clone(),
+			set_id: 0,
+			pending_standard_changes: ForkTree::new(),
+			pending_forced_changes: Vec::new(),
+		};
+
+		let new_set = current_authorities.clone();
+
+		// Create the following pending changes tree:
+		//
+		//               [#C3]
+		//              /
+		//             /- (#C2)
+		//            /
+		// (#A) - (#B) - [#C1]
+		//            \
+		//             (#C0) - [#D]
+		//
+		// () - Standard change
+		// [] - Forced change
+
+		let is_descendent_of = {
+			let hashes = vec!["B", "C0", "C1", "C2", "C3", "D"];
+			is_descendent_of(move |base, hash| match (*base, *hash) {
+				("B", "B") => false, // required to have the simpler case below
+				("A", b) | ("B", b) => hashes.iter().any(|h| *h == b),
+				("C0", "D") => true,
+				_ => false,
+			})
+		};
+
+		let mut add_pending_change = |canon_height, canon_hash, forced| {
+			let change = PendingChange {
+				next_authorities: new_set.clone(),
+				delay: 0,
+				canon_height,
+				canon_hash,
+				delay_kind: if forced {
+					DelayKind::Best {
+						median_last_finalized: 0,
+					}
+				} else {
+					DelayKind::Finalized
+				},
+			};
+
+			authorities
+				.add_pending_change(change, &is_descendent_of)
+				.unwrap();
+		};
+
+		add_pending_change(5, "A", false);
+		add_pending_change(10, "B", false);
+		add_pending_change(15, "C0", false);
+		add_pending_change(15, "C1", true);
+		add_pending_change(15, "C2", false);
+		add_pending_change(15, "C3", true);
+		add_pending_change(20, "D", true);
+
+		println!(
+			"pending_changes: {:?}",
+			authorities
+				.pending_changes()
+				.map(|c| c.canon_hash)
+				.collect::<Vec<_>>()
+		);
+
+		// applying the standard change at A should not prune anything
+		// other then the change that was applied
+		authorities
+			.apply_standard_changes("A", 5, &is_descendent_of, false)
+			.unwrap();
+		println!(
+			"pending_changes: {:?}",
+			authorities
+				.pending_changes()
+				.map(|c| c.canon_hash)
+				.collect::<Vec<_>>()
+		);
+
+		assert_eq!(authorities.pending_changes().count(), 6);
+
+		// same for B
+		authorities
+			.apply_standard_changes("B", 10, &is_descendent_of, false)
+			.unwrap();
+
+		assert_eq!(authorities.pending_changes().count(), 5);
+
+		let authorities2 = authorities.clone();
+
+		// finalizing C2 should clear all forced changes
+		authorities
+			.apply_standard_changes("C2", 15, &is_descendent_of, false)
+			.unwrap();
+
+		assert_eq!(authorities.pending_forced_changes.len(), 0);
+
+		// finalizing C0 should clear all forced changes but D
+		let mut authorities = authorities2;
+		authorities
+			.apply_standard_changes("C0", 15, &is_descendent_of, false)
+			.unwrap();
+
+		assert_eq!(authorities.pending_forced_changes.len(), 1);
+		assert_eq!(
+			authorities
+				.pending_forced_changes
+				.first()
+				.unwrap()
+				.canon_hash,
+			"D"
+		);
 	}
 }

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -65,9 +65,10 @@ benchmarks! {
 	}
 
 	note_stalled {
+		let delay = 1000.into();
 		let best_finalized_block_number = 1.into();
 
-	}: _(RawOrigin::Root, best_finalized_block_number)
+	}: _(RawOrigin::Root, delay, best_finalized_block_number)
 	verify {
 		assert!(Grandpa::<T>::stalled().is_some());
 	}

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -69,7 +69,7 @@ benchmarks! {
 		let n in 0 .. 1000;
 
 		let next_authorities = (0..n)
-			.map(|n| (AuthorityId::from_slice(&n.to_be_bytes().repeat(8)), 1))
+			.map(|n| AuthorityId::from_slice(&n.to_be_bytes().repeat(8)))
 			.collect();
 
 		let best_finalized_block_number = 1.into();

--- a/frame/grandpa/src/benchmarking.rs
+++ b/frame/grandpa/src/benchmarking.rs
@@ -22,7 +22,6 @@
 use super::{*, Module as Grandpa};
 use frame_benchmarking::benchmarks;
 use frame_system::RawOrigin;
-use sp_application_crypto::Public;
 use sp_core::H256;
 
 benchmarks! {
@@ -65,19 +64,12 @@ benchmarks! {
 		assert!(sp_finality_grandpa::check_equivocation_proof(equivocation_proof2));
 	}
 
-	schedule_forced_change {
-		let n in 0 .. 1000;
-
-		let next_authorities = (0..n)
-			.map(|n| AuthorityId::from_slice(&n.to_be_bytes().repeat(8)))
-			.collect();
-
+	note_stalled {
 		let best_finalized_block_number = 1.into();
 
-	}: _(RawOrigin::Root, next_authorities, best_finalized_block_number)
+	}: _(RawOrigin::Root, best_finalized_block_number)
 	verify {
-		let pending_change = Grandpa::<T>::pending_change().unwrap();
-		assert!(pending_change.forced.is_some())
+		assert!(Grandpa::<T>::stalled().is_some());
 	}
 }
 
@@ -91,7 +83,7 @@ mod tests {
 	fn test_benchmarks() {
 		new_test_ext(vec![(1, 1), (2, 1), (3, 1)]).execute_with(|| {
 			assert_ok!(test_benchmark_check_equivocation_proof::<Test>());
-			assert_ok!(test_benchmark_schedule_forced_change::<Test>());
+			assert_ok!(test_benchmark_note_stalled::<Test>());
 		})
 	}
 

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -66,6 +66,10 @@ pub use equivocation::{
 	HandleEquivocation,
 };
 
+/// The default number of blocks a forced change is delayed by,
+/// i.e. it will be activated at `block_signal_number + delay`.
+pub const FORCED_CHANGE_DELAY: u32 = 1000;
+
 pub trait Trait: frame_system::Trait {
 	/// The event type of this module.
 	type Event: From<Event> + Into<<Self as frame_system::Trait>::Event>;
@@ -290,7 +294,7 @@ decl_module! {
 
 			Self::schedule_change(
 				next_authorities.into_iter().map(|k| (k, 1)).collect(),
-				1000.into(),
+				FORCED_CHANGE_DELAY.into(),
 				Some(best_finalized_block_number),
 			)?;
 		}

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -398,8 +398,8 @@ mod weight_for {
 	}
 
 	pub fn schedule_forced_change<T: super::Trait>(next_authorities: usize) -> Weight {
-		(20 * WEIGHT_PER_MICROS)
-			.saturating_add((50 * WEIGHT_PER_NANOS).saturating_mul(next_authorities as u64))
+		(18 * WEIGHT_PER_MICROS)
+			.saturating_add((55 * WEIGHT_PER_NANOS).saturating_mul(next_authorities as u64))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -580,42 +580,6 @@ impl<T: Trait> Module<T> {
 	}
 }
 
-impl<T: Trait> Module<T> {
-	/// Attempt to extract a GRANDPA log from a generic digest.
-	pub fn grandpa_log(digest: &DigestOf<T>) -> Option<ConsensusLog<T::BlockNumber>> {
-		let id = OpaqueDigestItemId::Consensus(&GRANDPA_ENGINE_ID);
-		digest.convert_first(|l| l.try_to::<ConsensusLog<T::BlockNumber>>(id))
-	}
-
-	/// Attempt to extract a pending set-change signal from a digest.
-	pub fn pending_change(digest: &DigestOf<T>)
-		-> Option<ScheduledChange<T::BlockNumber>>
-	{
-		Self::grandpa_log(digest).and_then(|signal| signal.try_into_change())
-	}
-
-	/// Attempt to extract a forced set-change signal from a digest.
-	pub fn forced_change(digest: &DigestOf<T>)
-		-> Option<(T::BlockNumber, ScheduledChange<T::BlockNumber>)>
-	{
-		Self::grandpa_log(digest).and_then(|signal| signal.try_into_forced_change())
-	}
-
-	/// Attempt to extract a pause signal from a digest.
-	pub fn pending_pause(digest: &DigestOf<T>)
-		-> Option<T::BlockNumber>
-	{
-		Self::grandpa_log(digest).and_then(|signal| signal.try_into_pause())
-	}
-
-	/// Attempt to extract a resume signal from a digest.
-	pub fn pending_resume(digest: &DigestOf<T>)
-		-> Option<T::BlockNumber>
-	{
-		Self::grandpa_log(digest).and_then(|signal| signal.try_into_resume())
-	}
-}
-
 impl<T: Trait> sp_runtime::BoundToRuntimeAppPublic for Module<T> {
 	type Public = AuthorityId;
 }

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -283,13 +283,13 @@ decl_module! {
 		#[weight = weight_for::schedule_forced_change::<T>(next_authorities.len())]
 		fn schedule_forced_change(
 			origin,
-			next_authorities: AuthorityList,
+			next_authorities: Vec<AuthorityId>,
 			best_finalized_block_number: T::BlockNumber,
 		) {
 			ensure_root(origin)?;
 
 			Self::schedule_change(
-				next_authorities,
+				next_authorities.into_iter().map(|k| (k, 1)).collect(),
 				1000.into(),
 				Some(best_finalized_block_number),
 			)?;

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -626,7 +626,7 @@ impl<T: Trait> pallet_session::OneSessionHandler<T::AccountId> for Module<T>
 		// Always issue a change if `session` says that the validators have changed.
 		// Even if their session keys are the same as before, the underlying economic
 		// identities have changed.
-		let current_set_id = if changed {
+		let current_set_id = if changed || <Stalled<T>>::exists() {
 			let next_authorities = validators.map(|(_, k)| (k, 1)).collect::<Vec<_>>();
 			if let Some((further_wait, median)) = <Stalled<T>>::take() {
 				let _ = Self::schedule_change(next_authorities, further_wait, Some(median));

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -342,14 +342,15 @@ fn report_equivocation_current_set_works() {
 		start_era(1);
 
 		let authorities = Grandpa::grandpa_authorities();
+		let validators = Session::validators();
 
-		// make sure that all authorities have the same balance
-		for i in 0..authorities.len() {
-			assert_eq!(Balances::total_balance(&(i as u64)), 10_000_000);
-			assert_eq!(Staking::slashable_balance_of(&(i as u64)), 10_000);
+		// make sure that all validators have the same balance
+		for validator in &validators {
+			assert_eq!(Balances::total_balance(validator), 10_000_000);
+			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(1, i as u64),
+				Staking::eras_stakers(1, validator),
 				pallet_staking::Exposure {
 					total: 10_000,
 					own: 10_000,
@@ -388,11 +389,12 @@ fn report_equivocation_current_set_works() {
 		start_era(2);
 
 		// check that the balance of 0-th validator is slashed 100%.
-		assert_eq!(Balances::total_balance(&0), 10_000_000 - 10_000);
-		assert_eq!(Staking::slashable_balance_of(&0), 0);
+		let equivocation_validator_id = validators[equivocation_authority_index];
 
+		assert_eq!(Balances::total_balance(&equivocation_validator_id), 10_000_000 - 10_000);
+		assert_eq!(Staking::slashable_balance_of(&equivocation_validator_id), 0);
 		assert_eq!(
-			Staking::eras_stakers(2, 0),
+			Staking::eras_stakers(2, equivocation_validator_id),
 			pallet_staking::Exposure {
 				total: 0,
 				own: 0,
@@ -401,12 +403,16 @@ fn report_equivocation_current_set_works() {
 		);
 
 		// check that the balances of all other validators are left intact.
-		for i in 1..authorities.len() {
-			assert_eq!(Balances::total_balance(&(i as u64)), 10_000_000);
-			assert_eq!(Staking::slashable_balance_of(&(i as u64)), 10_000);
+		for validator in &validators {
+			if *validator == equivocation_validator_id {
+				continue;
+			}
+
+			assert_eq!(Balances::total_balance(validator), 10_000_000);
+			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(2, i as u64),
+				Staking::eras_stakers(2, validator),
 				pallet_staking::Exposure {
 					total: 10_000,
 					own: 10_000,
@@ -425,6 +431,7 @@ fn report_equivocation_old_set_works() {
 		start_era(1);
 
 		let authorities = Grandpa::grandpa_authorities();
+		let validators = Session::validators();
 
 		let equivocation_authority_index = 0;
 		let equivocation_key = &authorities[equivocation_authority_index].0;
@@ -436,12 +443,12 @@ fn report_equivocation_old_set_works() {
 		start_era(2);
 
 		// make sure that all authorities have the same balance
-		for i in 0..authorities.len() {
-			assert_eq!(Balances::total_balance(&(i as u64)), 10_000_000);
-			assert_eq!(Staking::slashable_balance_of(&(i as u64)), 10_000);
+		for validator in &validators {
+			assert_eq!(Balances::total_balance(validator), 10_000_000);
+			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(2, i as u64),
+				Staking::eras_stakers(2, validator),
 				pallet_staking::Exposure {
 					total: 10_000,
 					own: 10_000,
@@ -474,11 +481,13 @@ fn report_equivocation_old_set_works() {
 		start_era(3);
 
 		// check that the balance of 0-th validator is slashed 100%.
-		assert_eq!(Balances::total_balance(&0), 10_000_000 - 10_000);
-		assert_eq!(Staking::slashable_balance_of(&0), 0);
+		let equivocation_validator_id = validators[equivocation_authority_index];
+
+		assert_eq!(Balances::total_balance(&equivocation_validator_id), 10_000_000 - 10_000);
+		assert_eq!(Staking::slashable_balance_of(&equivocation_validator_id), 0);
 
 		assert_eq!(
-			Staking::eras_stakers(3, 0),
+			Staking::eras_stakers(3, equivocation_validator_id),
 			pallet_staking::Exposure {
 				total: 0,
 				own: 0,
@@ -487,12 +496,16 @@ fn report_equivocation_old_set_works() {
 		);
 
 		// check that the balances of all other validators are left intact.
-		for i in 1..authorities.len() {
-			assert_eq!(Balances::total_balance(&(i as u64)), 10_000_000);
-			assert_eq!(Staking::slashable_balance_of(&(i as u64)), 10_000);
+		for validator in &validators {
+			if *validator == equivocation_validator_id {
+				continue;
+			}
+
+			assert_eq!(Balances::total_balance(validator), 10_000_000);
+			assert_eq!(Staking::slashable_balance_of(validator), 10_000);
 
 			assert_eq!(
-				Staking::eras_stakers(3, i as u64),
+				Staking::eras_stakers(3, validator),
 				pallet_staking::Exposure {
 					total: 10_000,
 					own: 10_000,


### PR DESCRIPTION
This PR adds an extrinsic `note_stalled` to the GRANDPA pallet that will note to the module that the finality gadget has stalled at a given block. This will trigger a forced authority set change at the beginning of the next session which will be enacted after the given delay in number blocks (this is necessary to guarantee that it is deep enough not to be re-orged).

I re-read all the code related to forced changes (since it's never been used live) and fixed a bug in the client (related to pruning of forced changes after we finalize a standard change), and two on the grandpa pallet related to how we deal with scheduling changes on session rotation. Tested this on a local testnet and was successful, the plan is to run this on Westend to resurrect a stalled set (offline validators).