### PR TITLE
prometheus: don't use protobuf feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5442,14 +5442,13 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
+checksum = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "protobuf",
  "spin",
  "thiserror",
 ]
@@ -5504,12 +5503,6 @@ dependencies = [
  "bytes 0.5.4",
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
 
 [[package]]
 name = "pwasm-utils"

--- a/primitives/utils/Cargo.toml
+++ b/primitives/utils/Cargo.toml
@@ -12,7 +12,7 @@ description = "I/O for Substrate runtimes"
 futures = "0.3.4"
 futures-core = "0.3.4"
 lazy_static = "1.4.0"
-prometheus = "0.8.0"
+prometheus = { version = "0.9.0", default-features = false }
 futures-timer = "3.0.2"
 
 [features]

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = "0.4.8"
-prometheus = "0.8"
+prometheus = { version = "0.9", default-features = false }
 futures-util = { version = "0.3.1", default-features = false, features = ["io"] }
 derive_more = "0.99"
 


### PR DESCRIPTION
This PR bumps prometheus to 0.9 and removes `protobuf` features used by default.

From https://github.com/tikv/rust-prometheus/issues/210:
> The protobuf crate is huge when compiled (a bit less than 400KB) and it bloats the binaries that are using rust-prometheus without the protobuf format.
> Prometheus > 2.0 does not support Protobuf at all anymore.

this feature is only useful for legacy versions of prometheus (< 2.0)