### PR TITLE
Cleanup our sort usage

### DIFF
--- a/client/authority-discovery/src/addr_cache.rs
+++ b/client/authority-discovery/src/addr_cache.rs
@@ -64,7 +64,7 @@ where
 			return;
 		}
 
-		addresses.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+		addresses.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
 		self.cache.insert(id, addresses);
 	}
 
@@ -94,7 +94,7 @@ where
 			.collect::<Vec<Addr>>();
 
 		addresses.dedup();
-		addresses.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+		addresses.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
 
 		addresses
 			.choose_multiple(&mut rng, MAX_NUM_AUTHORITY_CONN)

--- a/client/network/src/protocol/generic_proto/upgrade/legacy.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/legacy.rs
@@ -57,7 +57,7 @@ impl RegisteredProtocol {
 			id: protocol,
 			supported_versions: {
 				let mut tmp = versions.to_vec();
-				tmp.sort_unstable_by(|a, b| b.cmp(&a));
+				tmp.sort_by(|a, b| b.cmp(&a));
 				tmp
 			},
 			handshake_message,

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -893,7 +893,7 @@ impl<T: Trait<I>, I: Instance> ChangeMembers<T::AccountId> for Module<T, I> {
 		}
 		// remove accounts from all current voting in motions.
 		let mut outgoing = outgoing.to_vec();
-		outgoing.sort_unstable();
+		outgoing.sort();
 		for h in Self::proposals().into_iter() {
 			<Voting<T, I>>::mutate(h, |v|
 				if let Some(mut votes) = v.take() {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -1211,7 +1211,7 @@ where
 /// the order of items is not preserved.
 fn has_duplicates<T: PartialEq + AsRef<[u8]>>(items: &mut Vec<T>) -> bool {
 	// Sort the vector
-	items.sort_unstable_by(|a, b| {
+	items.sort_by(|a, b| {
 		Ord::cmp(a.as_ref(), b.as_ref())
 	});
 	// And then find any two consecutive equal elements.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1238,12 +1238,12 @@ decl_storage! {
 decl_event!(
 	pub enum Event<T> where Balance = BalanceOf<T>, <T as frame_system::Trait>::AccountId {
 		/// The era payout has been set; the first balance is the validator-payout; the second is
-		/// the remainder from the maximum amount of reward. 
+		/// the remainder from the maximum amount of reward.
 		/// [era_index, validator_payout, remainder]
 		EraPayout(EraIndex, Balance, Balance),
 		/// The staker has been rewarded by this amount. [stash, amount]
 		Reward(AccountId, Balance),
-		/// One validator (and its nominators) has been slashed by the given amount. 
+		/// One validator (and its nominators) has been slashed by the given amount.
 		/// [validator, amount]
 		Slash(AccountId, Balance),
 		/// An old slashing report from a prior era was discarded because it could
@@ -2889,7 +2889,7 @@ impl<T: Trait> Module<T> {
 				let mut exposure_clipped = exposure;
 				let clipped_max_len = T::MaxNominatorRewardedPerValidator::get() as usize;
 				if exposure_clipped.others.len() > clipped_max_len {
-					exposure_clipped.others.sort_unstable_by(|a, b| a.value.cmp(&b.value).reverse());
+					exposure_clipped.others.sort_by(|a, b| a.value.cmp(&b.value).reverse());
 					exposure_clipped.others.truncate(clipped_max_len);
 				}
 				<ErasStakersClipped<T>>::insert(&current_era, &stash, exposure_clipped);

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1238,7 +1238,7 @@ pub trait ChangeMembers<AccountId: Clone + Ord> {
 	///
 	/// This resets any previous value of prime.
 	fn change_members(incoming: &[AccountId], outgoing: &[AccountId], mut new: Vec<AccountId>) {
-		new.sort_unstable();
+		new.sort();
 		Self::change_members_sorted(incoming, outgoing, &new[..]);
 	}
 

--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -384,7 +384,7 @@ fn generate_call_api_at_calls(decl: &ItemTrait) -> Result<TokenStream> {
 			renames.push((version, prefix_function_with_trait(&trait_name, &old_name)));
 		}
 
-		renames.sort_unstable_by(|l, r| r.cmp(l));
+		renames.sort_by(|l, r| r.cmp(l));
 		let (versions, old_names) = renames.into_iter().fold(
 			(Vec::new(), Vec::new()),
 			|(mut versions, mut old_names), (version, old_name)| {

--- a/primitives/arithmetic/src/lib.rs
+++ b/primitives/arithmetic/src/lib.rs
@@ -180,7 +180,7 @@ pub fn normalize<T>(input: &[T], targeted_sum: T) -> Result<Vec<T>, &'static str
 	// sort output once based on diff. This will require more data transfer and saving original
 	// index, but we sort only twice instead: once now and once at the very end.
 	let mut output_with_idx = input.iter().cloned().enumerate().collect::<Vec<(usize, T)>>();
-	output_with_idx.sort_unstable_by_key(|x| x.1);
+	output_with_idx.sort_by_key(|x| x.1);
 
 	if needs_bump {
 		// must increase the values a bit. Bump from the min element. Index of minimum is now zero
@@ -262,7 +262,7 @@ pub fn normalize<T>(input: &[T], targeted_sum: T) -> Result<Vec<T>, &'static str
 	);
 
 	// sort again based on the original index.
-	output_with_idx.sort_unstable_by_key(|x| x.0);
+	output_with_idx.sort_by_key(|x| x.0);
 	Ok(output_with_idx.into_iter().map(|(_, t)| t).collect())
 }
 

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -749,7 +749,7 @@ fn do_balancing<AccountId>(
 		e.1 = 0;
 	});
 
-	elected_edges.sort_unstable_by_key(|e|
+	elected_edges.sort_by_key(|e|
 		if let Some(e) = support_map.get(&e.0) { e.total } else { Zero::zero() }
 	);
 

--- a/primitives/npos-elections/src/mock.rs
+++ b/primitives/npos-elections/src/mock.rs
@@ -264,7 +264,7 @@ pub(crate) fn do_equalize_float<A>(
 		e.1 = 0.0;
 	});
 
-	elected_edges.sort_unstable_by(|x, y|
+	elected_edges.sort_by(|x, y|
 		support_map.get(&x.0)
 			.and_then(|x| support_map.get(&y.0).and_then(|y| x.total.partial_cmp(&y.total)))
 			.unwrap_or(sp_std::cmp::Ordering::Equal)

--- a/primitives/state-machine/src/changes_trie/build.rs
+++ b/primitives/state-machine/src/changes_trie/build.rs
@@ -174,7 +174,7 @@ fn prepare_extrinsics_input_inner<'a, B, H, Number>(
 					extrinsics.extend(
 						v.extrinsics().cloned()
 					);
-					extrinsics.sort_unstable();
+					extrinsics.sort();
 				},
 			}
 

--- a/primitives/trie/src/lib.rs
+++ b/primitives/trie/src/lib.rs
@@ -566,7 +566,7 @@ mod tests {
 			count: 1000,
 		};
 		let mut d = st.make();
-		d.sort_unstable_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
+		d.sort_by(|&(ref a, _), &(ref b, _)| a.cmp(b));
 		let dr = d.iter().map(|v| (&v.0[..], &v.1[..])).collect();
 		check_equivalent::<Layout>(&dr);
 		check_iteration::<Layout>(&dr);


### PR DESCRIPTION
There's really no need to be using unstable sorts as Rust's default is actually pretty fast.