### PR TITLE
Add a `DefaultQueue` type alias to remove the need to use `sp_api::TransactionFor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7749,6 +7749,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
+ "sp-api",
  "sp-core",
  "sp-inherents",
  "sp-runtime",

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -24,7 +24,7 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponents<
 	FullClient, FullBackend, FullSelectChain,
-	sp_consensus::import_queue::DefaultImportQueue<Block, FullClient>,
+	sp_consensus::DefaultImportQueue<Block, FullClient>,
 	sc_transaction_pool::FullPool<Block, FullClient>,
 	(
 		sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -24,7 +24,7 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponents<
 	FullClient, FullBackend, FullSelectChain,
-	sc_consensus_aura::AuraImportQueue<Block, FullClient>,
+	sp_consensus::import_queue::DefaultImportQueue<Block, FullClient>,
 	sc_transaction_pool::FullPool<Block, FullClient>,
 	(
 		sc_finality_grandpa::GrandpaBlockImport<FullBackend, Block, FullClient, FullSelectChain>,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -46,7 +46,7 @@ type LightClient = sc_service::TLightClient<Block, RuntimeApi, Executor>;
 
 pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponents<
 	FullClient, FullBackend, FullSelectChain,
-	sc_consensus_babe::BabeImportQueue<Block, FullClient>,
+	sp_consensus::import_queue::DefaultImportQueue<Block, FullClient>,
 	sc_transaction_pool::FullPool<Block, FullClient>,
 	(
 		impl Fn(node_rpc::DenyUnsafe) -> node_rpc::IoHandler,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -46,7 +46,7 @@ type LightClient = sc_service::TLightClient<Block, RuntimeApi, Executor>;
 
 pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponents<
 	FullClient, FullBackend, FullSelectChain,
-	sp_consensus::import_queue::DefaultImportQueue<Block, FullClient>,
+	sp_consensus::DefaultImportQueue<Block, FullClient>,
 	sc_transaction_pool::FullPool<Block, FullClient>,
 	(
 		impl Fn(node_rpc::DenyUnsafe) -> node_rpc::IoHandler,

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -47,7 +47,7 @@ use sp_consensus::{
 	BlockOrigin, Error as ConsensusError, SelectChain, SlotData, BlockCheckParams, ImportResult
 };
 use sp_consensus::import_queue::{
-	Verifier, BasicQueue, BoxJustificationImport, BoxFinalityProofImport,
+	Verifier, BasicQueue, DefaultImportQueue, BoxJustificationImport, BoxFinalityProofImport,
 };
 use sc_client_api::{backend::AuxStore, BlockOf};
 use sp_blockchain::{
@@ -713,9 +713,6 @@ fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, Consensus
 		.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet.into())
 }
 
-/// The Aura import queue type.
-pub type AuraImportQueue<B, Client> = BasicQueue<B, sp_api::TransactionFor<Client, B>>;
-
 /// Register the aura inherent data provider, if not registered already.
 fn register_aura_inherent_data_provider(
 	inherent_data_providers: &InherentDataProviders,
@@ -824,7 +821,7 @@ pub fn import_queue<B, I, C, P, S>(
 	inherent_data_providers: InherentDataProviders,
 	spawner: &S,
 	registry: Option<&Registry>,
-) -> Result<AuraImportQueue<B, C>, sp_consensus::Error> where
+) -> Result<DefaultImportQueue<B, C>, sp_consensus::Error> where
 	B: BlockT,
 	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B, Error = sp_blockchain::Error>,
 	C: 'static + ProvideRuntimeApi<B> + BlockOf + ProvideCache<B> + Send + Sync + AuxStore + HeaderBackend<B>,

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -100,7 +100,7 @@ use sp_consensus::{
 };
 use sp_consensus_babe::inherents::BabeInherentData;
 use sp_timestamp::{TimestampInherentData, InherentType as TimestampInherent};
-use sp_consensus::import_queue::{Verifier, BasicQueue, CacheKeyId};
+use sp_consensus::import_queue::{Verifier, BasicQueue, DefaultImportQueue, CacheKeyId};
 use sc_client_api::{
 	backend::AuxStore,
 	BlockchainEvents, ProvideUncles,
@@ -967,9 +967,6 @@ where
 	}
 }
 
-/// The BABE import queue type.
-pub type BabeImportQueue<B, Client> = BasicQueue<B, sp_api::TransactionFor<Client, B>>;
-
 /// Register the babe inherent data provider, if not registered already.
 fn register_babe_inherent_data_provider(
 	inherent_data_providers: &InherentDataProviders,
@@ -1368,7 +1365,7 @@ pub fn import_queue<Block: BlockT, Client, SelectChain, Inner>(
 	inherent_data_providers: InherentDataProviders,
 	spawner: &impl sp_core::traits::SpawnNamed,
 	registry: Option<&Registry>,
-) -> ClientResult<BabeImportQueue<Block, Client>> where
+) -> ClientResult<DefaultImportQueue<Block, Client>> where
 	Inner: BlockImport<Block, Error = ConsensusError, Transaction = sp_api::TransactionFor<Client, Block>>
 		+ Send + Sync + 'static,
 	Client: ProvideRuntimeApi<Block> + ProvideCache<Block> + Send + Sync + AuxStore + 'static,

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -27,6 +27,7 @@ sp-version = { version = "2.0.0-rc5", path = "../../version" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../runtime" }
 sp-utils = { version = "2.0.0-rc5", path = "../../utils" }
 sp-trie = { version = "2.0.0-rc5", path = "../../trie" }
+sp-api = { version = "2.0.0-rc5", path = "../../api" }
 codec = { package = "parity-scale-codec", version = "1.3.1", features = ["derive"] }
 parking_lot = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/primitives/consensus/common/src/import_queue.rs
+++ b/primitives/consensus/common/src/import_queue.rs
@@ -40,6 +40,11 @@ use crate::{
 };
 pub use basic_queue::BasicQueue;
 
+/// A commonly-used Import Queue type.
+///
+/// This defines the transaction type of the `BasicQueue` to be the transaction type for a client.
+pub type DefaultImportQueue<Block, Client> = BasicQueue<Block, sp_api::TransactionFor<Client, Block>>;
+
 mod basic_queue;
 pub mod buffered_link;
 

--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -56,6 +56,7 @@ pub use block_import::{
 };
 pub use select_chain::SelectChain;
 pub use sp_state_machine::Backend as StateBackend;
+pub use import_queue::DefaultImportQueue;
 
 /// Block status.
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
I noticed that `AuraImportQueue` and `BabeImportQueue` have the exact same type definition of `BasicQueue<Block, sp_api::TransactionFor<Client, Block>>`, and that `sc_consensus_manual_seal::import_queue` usually (always?) returns this type as well, so it made sense to have an alias for this and remove the implementation-specific aliases.

polkadot companion: https://github.com/paritytech/polkadot/pull/1499