### PR TITLE
Allow task manager to have children

### DIFF
--- a/client/service/src/task_manager/mod.rs
+++ b/client/service/src/task_manager/mod.rs
@@ -316,7 +316,7 @@ impl TaskManager {
 			futures::select! {
 				_ = t1 => Err(Error::Other("Essential task failed.".into())),
 				_ = t2 => Ok(()),
-				res = t3 => res.map(|_| ()),
+				res = t3 => Err(res.map(|_| ()).expect_err("this future never ends; qed")),
 			}
 		})
 	}

--- a/client/service/src/task_manager/mod.rs
+++ b/client/service/src/task_manager/mod.rs
@@ -221,7 +221,7 @@ pub struct TaskManager {
 	/// A list of other `TaskManager`'s to terminate and gracefully shutdown when the parent
 	/// terminates and gracefully shutdown. Also ends the parent `future()` if a child's essential
 	/// task fails.
-	children: Vec<Box<TaskManager>>,
+	children: Vec<TaskManager>,
 }
 
 impl TaskManager {
@@ -356,7 +356,7 @@ impl TaskManager {
 	/// terminates and gracefully shutdown. Also ends the parent `future()` if a child's essential
 	/// task fails. (But don't end the parent if a child's normal task fails.)
 	pub fn add_children(&mut self, child: TaskManager) {
-		self.children.push(Box::new(child));
+		self.children.push(child);
 	}
 }
 

--- a/client/service/src/task_manager/mod.rs
+++ b/client/service/src/task_manager/mod.rs
@@ -18,7 +18,7 @@ use exit_future::Signal;
 use log::{debug, error};
 use futures::{
 	Future, FutureExt, StreamExt,
-	future::{select, Either, BoxFuture, join_all, try_join_all, select_all, self},
+	future::{select, Either, BoxFuture, select_all, join_all},
 	sink::SinkExt,
 };
 use prometheus_endpoint::{
@@ -305,20 +305,34 @@ impl TaskManager {
 	///
 	/// This function will not wait until the end of the remaining task. You must call and await
 	/// `clean_shutdown()` after this.
-	pub fn future<'a>(
-		&'a mut self,
-	) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
-		let t1 = self.essential_failed_rx
-			.next()
-			.then(|_| future::ready(Err(Error::Other("Essential task failed.".into()))))
-			.boxed();
-		let t2 = self.on_exit.clone().then(|_| future::ready(Ok(()))).boxed();
-		let res = select_all(vec![t1, t2]).map(|v| v.0).boxed();
+	pub fn future<'a>(&'a mut self) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+		Box::pin(async move {
+			let mut t1 = self.essential_failed_rx.next().fuse();
+			let mut t2 = self.on_exit.clone().fuse();
 
-		// Join all the task managers to make sure everything has finished as intended.
-		try_join_all(
-			self.children.iter_mut().map(|x| x.future().boxed()).chain(std::iter::once(res)),
-		).map(|res| res.map(drop)).boxed()
+			if self.children.is_empty() {
+				loop {
+					futures::select! {
+						_ = t1 => break Err(Error::Other("Essential task failed.".into())),
+						_ = t2 => break Ok(()),
+					}
+				}
+			} else {
+				let mut t3 = select_all(self.children.iter_mut().map(|x| x.future())).fuse();
+
+				loop {
+					futures::select! {
+						_ = t1 => break Err(Error::Other("Essential task failed.".into())),
+						_ = t2 => break Ok(()),
+						(res, _, _) = t3 => if res.is_err() {
+							break res;
+						} else {
+							continue;
+						},
+					}
+				}
+			}
+		})
 	}
 
 	/// Signal to terminate all the running tasks.

--- a/client/service/src/task_manager/mod.rs
+++ b/client/service/src/task_manager/mod.rs
@@ -347,14 +347,14 @@ impl TaskManager {
 		}
 	}
 
-	/// Set what the task manager should keep alivei
+	/// Set what the task manager should keep alive.
 	pub(super) fn keep_alive<T: 'static + Send + Sync>(&mut self, to_keep_alive: T) {
 		self.keep_alive = Box::new(to_keep_alive);
 	}
 
 	/// Register another TaskManager to terminate and gracefully shutdown when the parent
 	/// terminates and gracefully shutdown. Also ends the parent `future()` if a child's essential
-	/// task fails. (But don't end the parent if a child terminates without failure.)
+	/// task fails. (But don't end the parent if a child's normal task fails.)
 	pub fn add_children(&mut self, child: TaskManager) {
 		self.children.push(Box::new(child));
 	}

--- a/client/service/src/task_manager/mod.rs
+++ b/client/service/src/task_manager/mod.rs
@@ -344,7 +344,7 @@ impl TaskManager {
 
 	/// Register another TaskManager to terminate and gracefully shutdown when the parent
 	/// terminates and gracefully shutdown. Also ends the parent `future()` if a child's essential
-	/// task fails.
+	/// task fails. (But don't end the parent if a child terminates without failure.)
 	pub fn add_children(&mut self, child: TaskManager) {
 		self.children.push(Box::new(child));
 	}

--- a/client/service/src/task_manager/tests.rs
+++ b/client/service/src/task_manager/tests.rs
@@ -300,7 +300,7 @@ fn ensure_task_manager_future_continues_when_childs_not_essential_task_fails() {
 		pin_mut!(t1, t2);
 
 		select! {
-			_ = t1 => panic!("task should not have stopped"),
+			res = t1 => panic!("task should not have stopped: {:?}", res),
 			_ = t2 => {},
 		}
 	});

--- a/client/service/src/task_manager/tests.rs
+++ b/client/service/src/task_manager/tests.rs
@@ -18,7 +18,7 @@
 
 use crate::config::TaskExecutor;
 use crate::task_manager::TaskManager;
-use futures::future::FutureExt;
+use futures::{future::FutureExt, pin_mut, select};
 use parking_lot::Mutex;
 use std::any::Any;
 use std::sync::Arc;
@@ -82,7 +82,7 @@ async fn run_background_task_blocking(duration: Duration, _keep_alive: impl Any)
 }
 
 #[test]
-fn ensure_futures_are_awaited_on_shutdown() {
+fn ensure_tasks_are_awaited_on_shutdown() {
 	let mut runtime = tokio::runtime::Runtime::new().unwrap();
 	let handle = runtime.handle().clone();
 	let task_executor: TaskExecutor = (move |future, _| handle.spawn(future).map(|_| ())).into();
@@ -187,7 +187,7 @@ fn ensure_task_manager_future_ends_when_task_manager_terminated() {
 }
 
 #[test]
-fn ensure_task_manager_future_ends_with_error_when_essential_task_ends() {
+fn ensure_task_manager_future_ends_with_error_when_essential_task_fails() {
 	let mut runtime = tokio::runtime::Runtime::new().unwrap();
 	let handle = runtime.handle().clone();
 	let task_executor: TaskExecutor = (move |future, _| handle.spawn(future).map(|_| ())).into();
@@ -205,6 +205,106 @@ fn ensure_task_manager_future_ends_with_error_when_essential_task_ends() {
 	spawn_essential_handle.spawn("task3", async { panic!("task failed") });
 	runtime.block_on(task_manager.future()).expect_err("future()'s Result must be Err");
 	assert_eq!(drop_tester, 2);
+	runtime.block_on(task_manager.clean_shutdown());
+	assert_eq!(drop_tester, 0);
+}
+
+#[test]
+fn ensure_children_tasks_ends_when_task_manager_terminated() {
+	let mut runtime = tokio::runtime::Runtime::new().unwrap();
+	let handle = runtime.handle().clone();
+	let task_executor: TaskExecutor = (move |future, _| handle.spawn(future).map(|_| ())).into();
+
+	let mut task_manager = TaskManager::new(task_executor.clone(), None).unwrap();
+	let child_1 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_1 = child_1.spawn_handle();
+	let child_2 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_2 = child_2.spawn_handle();
+	task_manager.add_children(child_1);
+	task_manager.add_children(child_2);
+	let spawn_handle = task_manager.spawn_handle();
+	let drop_tester = DropTester::new();
+	spawn_handle.spawn("task1", run_background_task(drop_tester.new_ref()));
+	spawn_handle.spawn("task2", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_1.spawn("task3", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_2.spawn("task4", run_background_task(drop_tester.new_ref()));
+	assert_eq!(drop_tester, 4);
+	// allow the tasks to even start
+	runtime.block_on(async { tokio::time::delay_for(Duration::from_secs(1)).await });
+	assert_eq!(drop_tester, 4);
+	task_manager.terminate();
+	runtime.block_on(task_manager.future()).expect("future has ended without error");
+	runtime.block_on(task_manager.clean_shutdown());
+	assert_eq!(drop_tester, 0);
+}
+
+#[test]
+fn ensure_task_manager_future_ends_with_error_when_childs_essential_task_fails() {
+	let mut runtime = tokio::runtime::Runtime::new().unwrap();
+	let handle = runtime.handle().clone();
+	let task_executor: TaskExecutor = (move |future, _| handle.spawn(future).map(|_| ())).into();
+
+	let mut task_manager = TaskManager::new(task_executor.clone(), None).unwrap();
+	let child_1 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_1 = child_1.spawn_handle();
+	let spawn_essential_handle_child_1 = child_1.spawn_essential_handle();
+	let child_2 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_2 = child_2.spawn_handle();
+	task_manager.add_children(child_1);
+	task_manager.add_children(child_2);
+	let spawn_handle = task_manager.spawn_handle();
+	let drop_tester = DropTester::new();
+	spawn_handle.spawn("task1", run_background_task(drop_tester.new_ref()));
+	spawn_handle.spawn("task2", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_1.spawn("task3", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_2.spawn("task4", run_background_task(drop_tester.new_ref()));
+	assert_eq!(drop_tester, 4);
+	// allow the tasks to even start
+	runtime.block_on(async { tokio::time::delay_for(Duration::from_secs(1)).await });
+	assert_eq!(drop_tester, 4);
+	spawn_essential_handle_child_1.spawn("task5", async { panic!("task failed") });
+	runtime.block_on(task_manager.future()).expect_err("future()'s Result must be Err");
+	assert_eq!(drop_tester, 4);
+	runtime.block_on(task_manager.clean_shutdown());
+	assert_eq!(drop_tester, 0);
+}
+
+#[test]
+fn ensure_task_manager_future_continues_when_childs_not_essential_task_fails() {
+	let mut runtime = tokio::runtime::Runtime::new().unwrap();
+	let handle = runtime.handle().clone();
+	let task_executor: TaskExecutor = (move |future, _| handle.spawn(future).map(|_| ())).into();
+
+	let mut task_manager = TaskManager::new(task_executor.clone(), None).unwrap();
+	let child_1 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_1 = child_1.spawn_handle();
+	let child_2 = TaskManager::new(task_executor.clone(), None).unwrap();
+	let spawn_handle_child_2 = child_2.spawn_handle();
+	task_manager.add_children(child_1);
+	task_manager.add_children(child_2);
+	let spawn_handle = task_manager.spawn_handle();
+	let drop_tester = DropTester::new();
+	spawn_handle.spawn("task1", run_background_task(drop_tester.new_ref()));
+	spawn_handle.spawn("task2", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_1.spawn("task3", run_background_task(drop_tester.new_ref()));
+	spawn_handle_child_2.spawn("task4", run_background_task(drop_tester.new_ref()));
+	assert_eq!(drop_tester, 4);
+	// allow the tasks to even start
+	runtime.block_on(async { tokio::time::delay_for(Duration::from_secs(1)).await });
+	assert_eq!(drop_tester, 4);
+	spawn_handle_child_1.spawn("task5", async { panic!("task failed") });
+	runtime.block_on(async {
+		let t1 = task_manager.future().fuse();
+		let t2 = tokio::time::delay_for(Duration::from_secs(3)).fuse();
+
+		pin_mut!(t1, t2);
+
+		select! {
+			_ = t1 => panic!("task should not have stopped"),
+			_ = t2 => {},
+		}
+	});
+	assert_eq!(drop_tester, 4);
 	runtime.block_on(task_manager.clean_shutdown());
 	assert_eq!(drop_tester, 0);
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 
+Client
+------
+
+* Child nodes can be handled by adding a child `TaskManager` to the parent's `TaskManager` (#6771)
+
 ## 2.0.0-rc4 -> 2.0.0-rc5 – River Dolphin
 
 Runtime


### PR DESCRIPTION
Register another TaskManager to terminate and gracefully shutdown when the parent terminates and gracefully shutdown. Also ends the parent `future()` if a child's essential task fails. 

This is related to https://github.com/paritytech/cumulus/issues/164