### PR TITLE
seal: Fix and improve error reporting

### DIFF
--- a/frame/contracts/fixtures/call_return_code.wat
+++ b/frame/contracts/fixtures/call_return_code.wat
@@ -7,40 +7,38 @@
 	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
-    ;; [0, 8) address of django
-    (data (i32.const 0) "\04\00\00\00\00\00\00\00")
+	;; [0, 8) address of django
+	(data (i32.const 0) "\04\00\00\00\00\00\00\00")
 
 	;; [8, 16) 100 balance
 	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
 
 	;; [16, 20) here we store the return code of the transfer
 
-    ;; [20, 24) here we store the input data
+	;; [20, 24) here we store the input data
 
-    ;; [24, 28) size of the input data
-    (data (i32.const 24) "\04")
+	;; [24, 28) size of the input data
+	(data (i32.const 24) "\04")
 
-    (func (export "deploy"))
+	(func (export "deploy"))
 
 	(func (export "call")
-        (call $ext_input (i32.const 20) (i32.const 24))
-
-        (i32.store 
-            (i32.const 16)
-            (call $ext_call
-				(i32.const 0)	;; Pointer to "callee" address.
-				(i32.const 8)	;; Length of "callee" address.
-				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
-				(i32.const 8)	;; Pointer to the buffer with value to transfer
-				(i32.const 8)	;; Length of the buffer with value to transfer.
-				(i32.const 20)	;; Pointer to input data buffer address
+		(call $ext_input (i32.const 20) (i32.const 24))
+		(i32.store
+			(i32.const 16)
+			(call $ext_call
+				(i32.const 0) ;; Pointer to "callee" address.
+				(i32.const 8) ;; Length of "callee" address.
+				(i64.const 0) ;; How much gas to devote for the execution. 0 = all.
+				(i32.const 8) ;; Pointer to the buffer with value to transfer
+				(i32.const 8) ;; Length of the buffer with value to transfer.
+				(i32.const 20) ;; Pointer to input data buffer address
 				(i32.load (i32.const 24)) ;; Length of input data buffer
 				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
 				(i32.const 0) ;; Ptr to output buffer len
 			)
-        )
-
-        ;; exit with success and take transfer return code to the output buffer
-        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
-    )
+		)
+		;; exit with success and take transfer return code to the output buffer
+		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+	)
 )

--- a/frame/contracts/fixtures/call_return_code.wat
+++ b/frame/contracts/fixtures/call_return_code.wat
@@ -1,0 +1,46 @@
+;; This calls Django (4) and transfers 100 balance during this call and copies the return code
+;; of this call to the output buffer.
+;; It also forwards its input to the callee.
+(module
+	(import "env" "ext_input" (func $ext_input (param i32 i32)))
+	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+    ;; [0, 8) address of django
+    (data (i32.const 0) "\04\00\00\00\00\00\00\00")
+
+	;; [8, 16) 100 balance
+	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
+
+	;; [16, 20) here we store the return code of the transfer
+
+    ;; [20, 24) here we store the input data
+
+    ;; [24, 28) size of the input data
+    (data (i32.const 24) "\04")
+
+    (func (export "deploy"))
+
+	(func (export "call")
+        (call $ext_input (i32.const 20) (i32.const 24))
+
+        (i32.store 
+            (i32.const 16)
+            (call $ext_call
+				(i32.const 0)	;; Pointer to "callee" address.
+				(i32.const 8)	;; Length of "callee" address.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 8)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 20)	;; Pointer to input data buffer address
+				(i32.load (i32.const 24)) ;; Length of input data buffer
+				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
+				(i32.const 0) ;; Ptr to output buffer len
+			)
+        )
+
+        ;; exit with success and take transfer return code to the output buffer
+        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+    )
+)

--- a/frame/contracts/fixtures/call_return_code.wat
+++ b/frame/contracts/fixtures/call_return_code.wat
@@ -34,7 +34,7 @@
 				(i32.const 8) ;; Length of the buffer with value to transfer.
 				(i32.const 20) ;; Pointer to input data buffer address
 				(i32.load (i32.const 24)) ;; Length of input data buffer
-				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
+				(i32.const 0xffffffff) ;; u32 max sentinel value: do not copy output
 				(i32.const 0) ;; Ptr to output buffer len
 			)
 		)

--- a/frame/contracts/fixtures/caller_contract.wat
+++ b/frame/contracts/fixtures/caller_contract.wat
@@ -89,7 +89,7 @@
 			(call $ext_instantiate
 				(i32.const 24)	;; Pointer to the code hash.
 				(i32.const 32)	;; Length of the code hash.
-				(i64.const 200)	;; How much gas to devote for the execution.
+				(i64.const 187500000) ;; Just enough to pay for the instantiate
 				(i32.const 0)	;; Pointer to the buffer with value to transfer
 				(i32.const 8)	;; Length of the buffer with value to transfer.
 				(i32.const 8)	;; Pointer to input data buffer address
@@ -206,7 +206,7 @@
 			(call $ext_call
 				(i32.const 16)	;; Pointer to "callee" address.
 				(i32.const 8)	;; Length of "callee" address.
-				(i64.const 100)	;; How much gas to devote for the execution.
+				(i64.const 117500000) ;; Just enough to make the call
 				(i32.const 0)	;; Pointer to the buffer with value to transfer
 				(i32.const 8)	;; Length of the buffer with value to transfer.
 				(i32.const 8)	;; Pointer to input data buffer address

--- a/frame/contracts/fixtures/destroy_and_transfer.wat
+++ b/frame/contracts/fixtures/destroy_and_transfer.wat
@@ -3,6 +3,7 @@
 	(import "env" "ext_get_storage" (func $ext_get_storage (param i32 i32 i32) (result i32)))
 	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
 	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
@@ -139,16 +140,11 @@
 		;; does not keep the contract alive.
 		(call $assert
 			(i32.eq
-				(call $ext_call
+				(call $ext_transfer
 					(i32.const 80)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
-					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
 					(i32.const 0)	;; Pointer to the buffer with value to transfer
 					(i32.const 8)	;; Length of the buffer with value to transfer
-					(i32.const 0)	;; Pointer to input data buffer address
-					(i32.const 1)	;; Length of input data buffer
-					(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
-					(i32.const 0) ;; Length is ignored in this case
 				)
 				(i32.const 0)
 			)

--- a/frame/contracts/fixtures/drain.wat
+++ b/frame/contracts/fixtures/drain.wat
@@ -1,6 +1,6 @@
 (module
 	(import "env" "ext_balance" (func $ext_balance (param i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) reserved for $ext_balance output
@@ -36,18 +36,13 @@
 		;; Self-destruct by sending full balance to the 0 address.
 		(call $assert
 			(i32.eq
-				(call $ext_call
+				(call $ext_transfer
 					(i32.const 16)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
-					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
 					(i32.const 0)	;; Pointer to the buffer with value to transfer
 					(i32.const 8)	;; Length of the buffer with value to transfer
-					(i32.const 0)	;; Pointer to input data buffer address
-					(i32.const 0)	;; Length of input data buffer
-					(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
-					(i32.const 0) ;; Length is ignored in this case
 				)
-				(i32.const 0)
+				(i32.const 4) ;; ReturnCode::BelowSubsistenceThreshold
 			)
 		)
 	)

--- a/frame/contracts/fixtures/instantiate_return_code.wat
+++ b/frame/contracts/fixtures/instantiate_return_code.wat
@@ -35,9 +35,9 @@
 				(i32.const 8) ;; Length of the buffer with value to transfer.
 				(i32.const 56) ;; Pointer to input data buffer address
 				(i32.sub (i32.load (i32.const 20)) (i32.const 32)) ;; Length of input data buffer
-				(i32.const 4294967295) ;; u32 max sentinel value: do not copy address
+				(i32.const 0xffffffff) ;; u32 max sentinel value: do not copy address
 				(i32.const 0) ;; Length is ignored in this case
-				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
+				(i32.const 0xffffffff) ;; u32 max sentinel value: do not copy output
 				(i32.const 0) ;; Length is ignored in this case
 			)
 		)

--- a/frame/contracts/fixtures/instantiate_return_code.wat
+++ b/frame/contracts/fixtures/instantiate_return_code.wat
@@ -8,42 +8,40 @@
 	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
-    ;; [0, 8) address of django
-    (data (i32.const 0) "\04\00\00\00\00\00\00\00")
+	;; [0, 8) address of django
+	(data (i32.const 0) "\04\00\00\00\00\00\00\00")
 
 	;; [8, 16) 100 balance
 	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
 
 	;; [16, 20) here we store the return code of the transfer
 
-    ;; [20, 24) size of the input buffer
-    (data (i32.const 20) "\FF")
+	;; [20, 24) size of the input buffer
+	(data (i32.const 20) "\FF")
 
-    ;; [24, inf) input buffer
+	;; [24, inf) input buffer
 
-    (func (export "deploy"))
+	(func (export "deploy"))
 
 	(func (export "call")
-        (call $ext_input (i32.const 24) (i32.const 20))
-
-        (i32.store 
-            (i32.const 16)
+		(call $ext_input (i32.const 24) (i32.const 20))
+		(i32.store
+			(i32.const 16)
 			(call $ext_instantiate
-				(i32.const 24)	;; Pointer to the code hash.
-				(i32.const 32)	;; Length of the code hash.
-				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
-				(i32.const 8)	;; Pointer to the buffer with value to transfer
-				(i32.const 8)	;; Length of the buffer with value to transfer.
-				(i32.const 56)	;; Pointer to input data buffer address
-				(i32.sub (i32.load (i32.const 20)) (i32.const 32))	;; Length of input data buffer
+				(i32.const 24) ;; Pointer to the code hash.
+				(i32.const 32) ;; Length of the code hash.
+				(i64.const 0) ;; How much gas to devote for the execution. 0 = all.
+				(i32.const 8) ;; Pointer to the buffer with value to transfer
+				(i32.const 8) ;; Length of the buffer with value to transfer.
+				(i32.const 56) ;; Pointer to input data buffer address
+				(i32.sub (i32.load (i32.const 20)) (i32.const 32)) ;; Length of input data buffer
 				(i32.const 4294967295) ;; u32 max sentinel value: do not copy address
 				(i32.const 0) ;; Length is ignored in this case
 				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
 				(i32.const 0) ;; Length is ignored in this case
 			)
-        )
-
-        ;; exit with success and take transfer return code to the output buffer
-        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
-    )
+		)
+		;; exit with success and take transfer return code to the output buffer
+		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+	)
 )

--- a/frame/contracts/fixtures/instantiate_return_code.wat
+++ b/frame/contracts/fixtures/instantiate_return_code.wat
@@ -1,0 +1,49 @@
+;; This instantiats Charlie (3) and transfers 100 balance during this call and copies the return code
+;; of this call to the output buffer.
+;; The first 32 byte of input is the code hash to instantiate
+;; The rest of the input is forwarded to the constructor of the callee
+(module
+	(import "env" "ext_input" (func $ext_input (param i32 i32)))
+	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+    ;; [0, 8) address of django
+    (data (i32.const 0) "\04\00\00\00\00\00\00\00")
+
+	;; [8, 16) 100 balance
+	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
+
+	;; [16, 20) here we store the return code of the transfer
+
+    ;; [20, 24) size of the input buffer
+    (data (i32.const 20) "\FF")
+
+    ;; [24, inf) input buffer
+
+    (func (export "deploy"))
+
+	(func (export "call")
+        (call $ext_input (i32.const 24) (i32.const 20))
+
+        (i32.store 
+            (i32.const 16)
+			(call $ext_instantiate
+				(i32.const 24)	;; Pointer to the code hash.
+				(i32.const 32)	;; Length of the code hash.
+				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
+				(i32.const 8)	;; Pointer to the buffer with value to transfer
+				(i32.const 8)	;; Length of the buffer with value to transfer.
+				(i32.const 56)	;; Pointer to input data buffer address
+				(i32.sub (i32.load (i32.const 20)) (i32.const 32))	;; Length of input data buffer
+				(i32.const 4294967295) ;; u32 max sentinel value: do not copy address
+				(i32.const 0) ;; Length is ignored in this case
+				(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
+				(i32.const 0) ;; Length is ignored in this case
+			)
+        )
+
+        ;; exit with success and take transfer return code to the output buffer
+        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+    )
+)

--- a/frame/contracts/fixtures/ok_trap_revert.wat
+++ b/frame/contracts/fixtures/ok_trap_revert.wat
@@ -1,0 +1,35 @@
+(module
+	(import "env" "ext_input" (func $ext_input (param i32 i32)))
+	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+    (func (export "deploy")
+        (call $ok_trap_revert)
+    )
+
+    (func (export "call")
+        (call $ok_trap_revert)
+    )
+
+    (func $ok_trap_revert
+        (i32.store (i32.const 4) (i32.const 4))
+        (call $ext_input (i32.const 0) (i32.const 4))
+        (block $IF_2
+            (block $IF_1
+                (block $IF_0
+                    (br_table $IF_0 $IF_1 $IF_2
+                        (i32.load8_u (i32.const 0))
+                    )
+                    (unreachable)
+                )
+                ;; 0 = return with success
+                return
+            )
+            ;; 1 = revert
+            (call $ext_return (i32.const 1) (i32.const 0) (i32.const 0))
+            (unreachable)
+        )
+        ;; 2 = trap
+        (unreachable)
+    )
+)

--- a/frame/contracts/fixtures/self_destructing_constructor.wat
+++ b/frame/contracts/fixtures/self_destructing_constructor.wat
@@ -1,14 +1,6 @@
 (module
-	(import "env" "ext_balance" (func $ext_balance (param i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
-
-	;; [0, 8) reserved for $ext_balance output
-
-	;; [8, 16) length of the buffer
-	(data (i32.const 8) "\08")
-
-	;; [16, inf) zero initialized
 
 	(func $assert (param i32)
 		(block $ok
@@ -20,33 +12,10 @@
 	)
 
 	(func (export "deploy")
-		;; Send entire remaining balance to the 0 address.
-		(call $ext_balance (i32.const 0) (i32.const 8))
-
-		;; Balance should be encoded as a u64.
-		(call $assert
-			(i32.eq
-				(i32.load (i32.const 8))
-				(i32.const 8)
-			)
-		)
-
 		;; Self-destruct by sending full balance to the 0 address.
-		(call $assert
-			(i32.eq
-				(call $ext_call
-					(i32.const 16)	;; Pointer to destination address
-					(i32.const 8)	;; Length of destination address
-					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
-					(i32.const 0)	;; Pointer to the buffer with value to transfer
-					(i32.const 8)	;; Length of the buffer with value to transfer
-					(i32.const 0)	;; Pointer to input data buffer address
-					(i32.const 0)	;; Length of input data buffer
-					(i32.const 4294967295) ;; u32 max sentinel value: do not copy output
-					(i32.const 0) ;; Length is ignored in this case
-				)
-				(i32.const 0)
-			)
+		(call $ext_terminate
+			(i32.const 0)	;; Pointer to destination address
+			(i32.const 8)	;; Length of destination address
 		)
 	)
 

--- a/frame/contracts/fixtures/set_rent.wat
+++ b/frame/contracts/fixtures/set_rent.wat
@@ -1,5 +1,5 @@
 (module
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32)))
+	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
 	(import "env" "ext_clear_storage" (func $ext_clear_storage (param i32)))
 	(import "env" "ext_set_rent_allowance" (func $ext_set_rent_allowance (param i32 i32)))
@@ -24,7 +24,12 @@
 
 	;; transfer 50 to CHARLIE
 	(func $call_2
-		(call $ext_transfer (i32.const 68) (i32.const 8) (i32.const 76) (i32.const 8))
+		(call $assert
+			(i32.eq
+				(call $ext_transfer (i32.const 68) (i32.const 8) (i32.const 76) (i32.const 8))
+				(i32.const 0)
+			)
+		)
 	)
 
 	;; do nothing

--- a/frame/contracts/fixtures/transfer_return_code.wat
+++ b/frame/contracts/fixtures/transfer_return_code.wat
@@ -1,0 +1,32 @@
+;; This transfers 100 balance to the zero account and copies the return code
+;; of this transfer to the output buffer.
+(module
+	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "memory" (memory 1 1))
+
+    ;; [0, 8) zero-adress
+    (data (i32.const 0) "\00\00\00\00\00\00\00\00")
+
+	;; [8, 16) 100 balance
+	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
+
+	;; [16, 20) here we store the return code of the transfer
+
+    (func (export "deploy"))
+
+	(func (export "call")
+        (i32.store 
+            (i32.const 16)
+            (call $ext_transfer
+                (i32.const 0) ;; ptr to destination address
+                (i32.const 8) ;; length of destination address
+                (i32.const 8) ;; ptr to value to transfer
+                (i32.const 8) ;; length of value to transfer
+            )
+        )
+
+        ;; exit with success and take transfer return code to the output buffer
+        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+    )
+)

--- a/frame/contracts/fixtures/transfer_return_code.wat
+++ b/frame/contracts/fixtures/transfer_return_code.wat
@@ -5,28 +5,27 @@
 	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
-    ;; [0, 8) zero-adress
-    (data (i32.const 0) "\00\00\00\00\00\00\00\00")
+	;; [0, 8) zero-adress
+	(data (i32.const 0) "\00\00\00\00\00\00\00\00")
 
 	;; [8, 16) 100 balance
 	(data (i32.const 8) "\64\00\00\00\00\00\00\00")
 
 	;; [16, 20) here we store the return code of the transfer
 
-    (func (export "deploy"))
+	(func (export "deploy"))
 
 	(func (export "call")
-        (i32.store 
-            (i32.const 16)
-            (call $ext_transfer
-                (i32.const 0) ;; ptr to destination address
-                (i32.const 8) ;; length of destination address
-                (i32.const 8) ;; ptr to value to transfer
-                (i32.const 8) ;; length of value to transfer
-            )
-        )
-
-        ;; exit with success and take transfer return code to the output buffer
-        (call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
-    )
+		(i32.store
+			(i32.const 16)
+			(call $ext_transfer
+				(i32.const 0) ;; ptr to destination address
+				(i32.const 8) ;; length of destination address
+				(i32.const 8) ;; ptr to value to transfer
+				(i32.const 8) ;; length of value to transfer
+			)
+		)
+		;; exit with success and take transfer return code to the output buffer
+		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+	)
 )

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -83,9 +83,12 @@ pub enum ErrorOrigin {
 	Callee,
 }
 
+/// Error returned by contract exection.
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub struct ExecError {
+	/// The reason why the execution failed.
 	pub error: DispatchError,
+	/// Origin of the error.
 	pub origin: ErrorOrigin,
 }
 
@@ -98,7 +101,8 @@ impl<T: Into<DispatchError>> From<T> for ExecError {
 	}
 }
 
-/// The error returned from functions calling into contract execution.
+/// The result that is returned from contract execution. It either contains the output
+/// buffer or an error describing the reason for failure.
 pub type ExecResult = Result<ExecReturnValue, ExecError>;
 
 /// An interface that provides access to the external environment in which the

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -359,7 +359,7 @@ where
 		let contract = if let Some(ContractInfo::Alive(info)) = rent::collect_rent::<T>(&dest) {
 			info
 		} else {
-			Err(Error::<T>::InvalidContractCalled)?
+			Err(Error::<T>::NotCallable)?
 		};
 
 		let transactor_kind = self.transactor_kind();

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
-use super::{CodeHash, Config, ContractAddressFor, Event, RawEvent, Trait,
-	TrieId, BalanceOf, ContractInfo, TrieIdGenerator};
-use crate::{gas::{Gas, GasMeter, Token}, rent, storage, Error, ContractInfoOf};
+use crate::{
+	CodeHash, Config, ContractAddressFor, Event, RawEvent, Trait,
+	TrieId, BalanceOf, ContractInfo, TrieIdGenerator,
+	gas::{Gas, GasMeter, Token}, rent, storage, Error, ContractInfoOf
+};
 use bitflags::bitflags;
 use sp_std::prelude::*;
 use sp_runtime::traits::{Bounded, Zero, Convert, Saturating};
@@ -69,7 +71,34 @@ impl ExecReturnValue {
 	}
 }
 
-pub type ExecResult = Result<ExecReturnValue, DispatchError>;
+/// Call or instantiate both call into other contracts and pass through errors happening
+/// in those to the caller. This enum is for  the caller to distinguish whether the error
+/// happened during the execution of the callee or during the supervisor code execution.
+#[cfg_attr(test, derive(PartialEq, Eq, Debug))]
+pub enum ErrorOrigin {
+	/// The error happened during the setup phase of the contract that is to be called.
+	Supervisor,
+	/// The error happened during execution of the called contract.
+	Callee,
+}
+
+#[cfg_attr(test, derive(PartialEq, Eq, Debug))]
+pub struct ExecError {
+	pub error: DispatchError,
+	pub origin: ErrorOrigin,
+}
+
+impl<T: Into<DispatchError>> From<T> for ExecError {
+	fn from(error: T) -> Self {
+		Self {
+			error: error.into(),
+			origin: ErrorOrigin::Supervisor,
+		}
+	}
+}
+
+/// The error returned from functions calling into contract execution.
+pub type ExecResult = Result<ExecReturnValue, ExecError>;
 
 /// An interface that provides access to the external environment in which the
 /// smart-contract is executed.
@@ -99,7 +128,7 @@ pub trait Ext {
 		value: BalanceOf<Self::T>,
 		gas_meter: &mut GasMeter<Self::T>,
 		input_data: Vec<u8>,
-	) -> Result<(AccountIdOf<Self::T>, ExecReturnValue), DispatchError>;
+	) -> Result<(AccountIdOf<Self::T>, ExecReturnValue), ExecError>;
 
 	/// Transfer some amount of funds into the specified account.
 	fn transfer(
@@ -307,31 +336,31 @@ where
 		input_data: Vec<u8>,
 	) -> ExecResult {
 		if self.depth == self.config.max_depth as usize {
-			Err("reached maximum depth, cannot make a call")?
+			Err(Error::<T>::MaxCallDepthReached)?
 		}
 
 		if gas_meter
 			.charge(self.config, ExecFeeToken::Call)
 			.is_out_of_gas()
 		{
-			Err("not enough gas to pay base call fee")?
+			Err(Error::<T>::OutOfGas)?
 		}
 
 		// Assumption: `collect_rent` doesn't collide with overlay because
 		// `collect_rent` will be done on first call and destination contract and balance
 		// cannot be changed before the first call
-		let contract_info = rent::collect_rent::<T>(&dest);
-
-		// Calls to dead contracts always fail.
-		if let Some(ContractInfo::Tombstone(_)) = contract_info {
-			Err("contract has been evicted")?
+		// We do not allow 'calling' plain accounts. For transfering value
+		// `ext_transfer` must be used.
+		let contract = if let Some(ContractInfo::Alive(info)) = rent::collect_rent::<T>(&dest) {
+			info
+		} else {
+			Err(Error::<T>::InvalidContractCalled)?
 		};
 
 		let transactor_kind = self.transactor_kind();
 		let caller = self.self_account.clone();
-		let dest_trie_id = contract_info.and_then(|i| i.as_alive().map(|i| i.trie_id.clone()));
 
-		self.with_nested_context(dest.clone(), dest_trie_id, |nested| {
+		self.with_nested_context(dest.clone(), Some(contract.trie_id.clone()), |nested| {
 			if value > BalanceOf::<T>::zero() {
 				transfer(
 					gas_meter,
@@ -344,22 +373,15 @@ where
 				)?
 			}
 
-			// If code_hash is not none, then the destination account is a live contract, otherwise
-			// it is a regular account since tombstone accounts have already been rejected.
-			match storage::code_hash::<T>(&dest) {
-				Ok(dest_code_hash) => {
-					let executable = nested.loader.load_main(&dest_code_hash)?;
-					let output = nested.vm
-						.execute(
-							&executable,
-							nested.new_call_context(caller, value),
-							input_data,
-							gas_meter,
-						)?;
-					Ok(output)
-				}
-				Err(storage::ContractAbsentError) => Ok(ExecReturnValue { flags: ReturnFlags::empty(), data: Vec::new() }),
-			}
+			let executable = nested.loader.load_main(&contract.code_hash)
+				.map_err(|_| Error::<T>::CodeNotFound)?;
+			let output = nested.vm.execute(
+				&executable,
+				nested.new_call_context(caller, value),
+				input_data,
+				gas_meter,
+			).map_err(|e| ExecError { error: e.error, origin: ErrorOrigin::Callee })?;
+			Ok(output)
 		})
 	}
 
@@ -369,16 +391,16 @@ where
 		gas_meter: &mut GasMeter<T>,
 		code_hash: &CodeHash<T>,
 		input_data: Vec<u8>,
-	) -> Result<(T::AccountId, ExecReturnValue), DispatchError> {
+	) -> Result<(T::AccountId, ExecReturnValue), ExecError> {
 		if self.depth == self.config.max_depth as usize {
-			Err("reached maximum depth, cannot instantiate")?
+			Err(Error::<T>::MaxCallDepthReached)?
 		}
 
 		if gas_meter
 			.charge(self.config, ExecFeeToken::Instantiate)
 			.is_out_of_gas()
 		{
-			Err("not enough gas to pay base instantiate fee")?
+			Err(Error::<T>::OutOfGas)?
 		}
 
 		let transactor_kind = self.transactor_kind();
@@ -416,21 +438,21 @@ where
 				nested,
 			)?;
 
-			let executable = nested.loader.load_init(&code_hash)?;
+			let executable = nested.loader.load_init(&code_hash)
+				.map_err(|_| Error::<T>::CodeNotFound)?;
 			let output = nested.vm
 				.execute(
 					&executable,
 					nested.new_call_context(caller.clone(), endowment),
 					input_data,
 					gas_meter,
-				)?;
+				).map_err(|e| ExecError { error: e.error, origin: ErrorOrigin::Callee })?;
 
-			// Error out if insufficient remaining balance.
 			// We need each contract that exists to be above the subsistence threshold
 			// in order to keep up the guarantuee that we always leave a tombstone behind
 			// with the exception of a contract that called `ext_terminate`.
-			if T::Currency::free_balance(&dest) < nested.config.subsistence_threshold() {
-				Err("insufficient remaining balance")?
+			if T::Currency::total_balance(&dest) < nested.config.subsistence_threshold() {
+				Err(Error::<T>::NewContractNotFunded)?
 			}
 
 			// Deposit an instantiation event.
@@ -569,7 +591,7 @@ fn transfer<'a, T: Trait, V: Vm<T>, L: Loader<T>>(
 	};
 
 	if gas_meter.charge(ctx.config, token).is_out_of_gas() {
-		Err("not enough gas to pay transfer fee")?
+		Err(Error::<T>::OutOfGas)?
 	}
 
 	// Only ext_terminate is allowed to bring the sender below the subsistence
@@ -580,13 +602,15 @@ fn transfer<'a, T: Trait, V: Vm<T>, L: Loader<T>>(
 			ensure!(
 				T::Currency::total_balance(transactor).saturating_sub(value) >=
 					ctx.config.subsistence_threshold(),
-				Error::<T>::InsufficientBalance,
+				Error::<T>::BelowSubsistenceThreshold,
 			);
 			ExistenceRequirement::KeepAlive
 		},
 		(_, PlainAccount) => ExistenceRequirement::KeepAlive,
 	};
-	T::Currency::transfer(transactor, dest, value, existence_requirement)?;
+
+	T::Currency::transfer(transactor, dest, value, existence_requirement)
+		.map_err(|_| Error::<T>::TransferFailed)?;
 
 	Ok(())
 }
@@ -653,7 +677,7 @@ where
 		endowment: BalanceOf<T>,
 		gas_meter: &mut GasMeter<T>,
 		input_data: Vec<u8>,
-	) -> Result<(AccountIdOf<T>, ExecReturnValue), DispatchError> {
+	) -> Result<(AccountIdOf<T>, ExecReturnValue), ExecError> {
 		self.ctx.instantiate(endowment, gas_meter, code_hash, input_data)
 	}
 
@@ -837,13 +861,13 @@ fn deposit_event<T: Trait>(
 mod tests {
 	use super::{
 		BalanceOf, Event, ExecFeeToken, ExecResult, ExecutionContext, Ext, Loader,
-		RawEvent, TransferFeeKind, TransferFeeToken, Vm, ReturnFlags,
+		RawEvent, TransferFeeKind, TransferFeeToken, Vm, ReturnFlags, ExecError, ErrorOrigin
 	};
 	use crate::{
 		gas::GasMeter, tests::{ExtBuilder, Test, MetaEvent},
 		exec::ExecReturnValue, CodeHash, Config,
 		gas::Gas,
-		storage,
+		storage, Error
 	};
 	use crate::tests::test_utils::{place_contract, set_balance, get_balance};
 	use sp_runtime::DispatchError;
@@ -999,11 +1023,19 @@ mod tests {
 
 			let mut gas_meter = GasMeter::<Test>::new(GAS_LIMIT);
 
-			let result = ctx.call(dest, 0, &mut gas_meter, vec![]);
+			let result = super::transfer(
+				&mut gas_meter,
+				super::TransferCause::Call,
+				super::TransactorKind::PlainAccount,
+				&origin,
+				&dest,
+				0,
+				&mut ctx,
+			);
 			assert_matches!(result, Ok(_));
 
 			let mut toks = gas_meter.tokens().iter();
-			match_tokens!(toks, ExecFeeToken::Call,);
+			match_tokens!(toks, TransferFeeToken { kind: TransferFeeKind::Transfer },);
 		});
 
 		// This test verifies that base fee for instantiation is taken.
@@ -1043,14 +1075,18 @@ mod tests {
 			set_balance(&origin, 100);
 			set_balance(&dest, 0);
 
-			let output = ctx.call(
-				dest,
+			let mut gas_meter = GasMeter::<Test>::new(GAS_LIMIT);
+
+			super::transfer(
+				&mut gas_meter,
+				super::TransferCause::Call,
+				super::TransactorKind::PlainAccount,
+				&origin,
+				&dest,
 				55,
-				&mut GasMeter::<Test>::new(GAS_LIMIT),
-				vec![],
+				&mut ctx,
 			).unwrap();
 
-			assert!(output.is_success());
 			assert_eq!(get_balance(&origin), 45);
 			assert_eq!(get_balance(&dest), 55);
 		});
@@ -1107,13 +1143,20 @@ mod tests {
 
 			let mut gas_meter = GasMeter::<Test>::new(GAS_LIMIT);
 
-			let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
+			let result = super::transfer(
+				&mut gas_meter,
+				super::TransferCause::Call,
+				super::TransactorKind::PlainAccount,
+				&origin,
+				&dest,
+				50,
+				&mut ctx,
+			);
 			assert_matches!(result, Ok(_));
 
 			let mut toks = gas_meter.tokens().iter();
 			match_tokens!(
 				toks,
-				ExecFeeToken::Call,
 				TransferFeeToken {
 					kind: TransferFeeKind::Transfer,
 				},
@@ -1132,13 +1175,20 @@ mod tests {
 
 			let mut gas_meter = GasMeter::<Test>::new(GAS_LIMIT);
 
-			let result = ctx.call(dest, 50, &mut gas_meter, vec![]);
+			let result = super::transfer(
+				&mut gas_meter,
+				super::TransferCause::Call,
+				super::TransactorKind::PlainAccount,
+				&origin,
+				&dest,
+				50,
+				&mut ctx,
+			);
 			assert_matches!(result, Ok(_));
 
 			let mut toks = gas_meter.tokens().iter();
 			match_tokens!(
 				toks,
-				ExecFeeToken::Call,
 				TransferFeeToken {
 					kind: TransferFeeKind::Transfer,
 				},
@@ -1189,16 +1239,19 @@ mod tests {
 			let mut ctx = ExecutionContext::top_level(origin, &cfg, &vm, &loader);
 			set_balance(&origin, 0);
 
-			let result = ctx.call(
-				dest,
-				100,
+			let result = super::transfer(
 				&mut GasMeter::<Test>::new(GAS_LIMIT),
-				vec![],
+				super::TransferCause::Call,
+				super::TransactorKind::PlainAccount,
+				&origin,
+				&dest,
+				100,
+				&mut ctx,
 			);
 
-			assert_matches!(
+			assert_eq!(
 				result,
-				Err(DispatchError::Module { message: Some("InsufficientBalance"), .. })
+				Err(Error::<Test>::TransferFailed.into())
 			);
 			assert_eq!(get_balance(&origin), 0);
 			assert_eq!(get_balance(&dest), 0);
@@ -1335,9 +1388,9 @@ mod tests {
 			if !*reached_bottom {
 				// We are first time here, it means we just reached bottom.
 				// Verify that we've got proper error and set `reached_bottom`.
-				assert_matches!(
+				assert_eq!(
 					r,
-					Err(DispatchError::Other("reached maximum depth, cannot make a call"))
+					Err(Error::<Test>::MaxCallDepthReached.into())
 				);
 				*reached_bottom = true;
 			} else {
@@ -1604,7 +1657,10 @@ mod tests {
 						ctx.gas_meter,
 						vec![]
 					),
-					Err(DispatchError::Other("It's a trap!"))
+					Err(ExecError {
+						error: DispatchError::Other("It's a trap!"),
+						origin: ErrorOrigin::Callee,
+					})
 				);
 
 				exec_success()
@@ -1648,14 +1704,14 @@ mod tests {
 				let mut ctx = ExecutionContext::top_level(ALICE, &cfg, &vm, &loader);
 				set_balance(&ALICE, 1000);
 
-				assert_matches!(
+				assert_eq!(
 					ctx.instantiate(
 						100,
 						&mut GasMeter::<Test>::new(GAS_LIMIT),
 						&terminate_ch,
 						vec![],
 					),
-					Err(DispatchError::Other("insufficient remaining balance"))
+					Err(Error::<Test>::NewContractNotFunded.into())
 				);
 
 				assert_eq!(

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -316,12 +316,12 @@ where
 		}
 	}
 
-	fn nested<'b, 'c: 'b>(&'c self, dest: T::AccountId, trie_id: Option<TrieId>)
+	fn nested<'b, 'c: 'b>(&'c self, dest: T::AccountId, trie_id: TrieId)
 		-> ExecutionContext<'b, T, V, L>
 	{
 		ExecutionContext {
 			caller: Some(self),
-			self_trie_id: trie_id,
+			self_trie_id: Some(trie_id),
 			self_account: dest,
 			depth: self.depth + 1,
 			config: self.config,
@@ -365,7 +365,7 @@ where
 		let transactor_kind = self.transactor_kind();
 		let caller = self.self_account.clone();
 
-		self.with_nested_context(dest.clone(), Some(contract.trie_id.clone()), |nested| {
+		self.with_nested_context(dest.clone(), contract.trie_id.clone(), |nested| {
 			if value > BalanceOf::<T>::zero() {
 				transfer(
 					gas_meter,
@@ -421,7 +421,7 @@ where
 		// Generate it now.
 		let dest_trie_id = <T as Trait>::TrieIdGenerator::trie_id(&dest);
 
-		let output = self.with_nested_context(dest.clone(), Some(dest_trie_id), |nested| {
+		let output = self.with_nested_context(dest.clone(), dest_trie_id, |nested| {
 			storage::place_contract::<T>(
 				&dest,
 				nested
@@ -486,7 +486,7 @@ where
 	}
 
 	/// Execute the given closure within a nested execution context.
-	fn with_nested_context<F>(&mut self, dest: T::AccountId, trie_id: Option<TrieId>, func: F)
+	fn with_nested_context<F>(&mut self, dest: T::AccountId, trie_id: TrieId, func: F)
 		-> ExecResult
 		where F: FnOnce(&mut ExecutionContext<T, V, L>) -> ExecResult
 	{

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -73,11 +73,12 @@ impl ExecReturnValue {
 
 /// Call or instantiate both call into other contracts and pass through errors happening
 /// in those to the caller. This enum is for  the caller to distinguish whether the error
-/// happened during the execution of the callee or during the supervisor code execution.
+/// happened during the execution of the callee or in the current execution context.
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub enum ErrorOrigin {
-	/// The error happened during the setup phase of the contract that is to be called.
-	Supervisor,
+	/// The error happened in the current exeuction context rather than in the one
+	/// of the contract that is called into.
+	Caller,
 	/// The error happened during execution of the called contract.
 	Callee,
 }
@@ -92,7 +93,7 @@ impl<T: Into<DispatchError>> From<T> for ExecError {
 	fn from(error: T) -> Self {
 		Self {
 			error: error.into(),
-			origin: ErrorOrigin::Supervisor,
+			origin: ErrorOrigin::Caller,
 		}
 	}
 }

--- a/frame/contracts/src/gas.rs
+++ b/frame/contracts/src/gas.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::Trait;
+use crate::{Trait, exec::ExecError};
 use sp_std::marker::PhantomData;
 use sp_runtime::traits::Zero;
 use frame_support::dispatch::{
-	DispatchError, DispatchResultWithPostInfo, PostDispatchInfo, DispatchErrorWithPostInfo,
+	DispatchResultWithPostInfo, PostDispatchInfo, DispatchErrorWithPostInfo,
 };
 
 #[cfg(test)]
@@ -189,8 +189,9 @@ impl<T: Trait> GasMeter<T> {
 	}
 
 	/// Turn this GasMeter into a DispatchResult that contains the actually used gas.
-	pub fn into_dispatch_result<R, E>(self, result: Result<R, E>) -> DispatchResultWithPostInfo where
-		E: Into<DispatchError>,
+	pub fn into_dispatch_result<R, E>(self, result: Result<R, E>) -> DispatchResultWithPostInfo
+	where
+		E: Into<ExecError>,
 	{
 		let post_info = PostDispatchInfo {
 			actual_weight: Some(self.gas_spent()),
@@ -199,7 +200,7 @@ impl<T: Trait> GasMeter<T> {
 
 		result
 			.map(|_| post_info)
-			.map_err(|e| DispatchErrorWithPostInfo { post_info, error: e.into() })
+			.map_err(|e| DispatchErrorWithPostInfo { post_info, error: e.into().error })
 	}
 
 	#[cfg(test)]

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -95,6 +95,7 @@ use crate::wasm::{WasmLoader, WasmVm};
 
 pub use crate::gas::{Gas, GasMeter};
 pub use crate::exec::{ExecResult, ExecReturnValue};
+pub use crate::wasm::ReturnCode as RuntimeReturnCode;
 
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -438,6 +438,10 @@ decl_error! {
 		CodeTooLarge,
 		/// No code could be found at the supplied code hash.
 		CodeNotFound,
+		/// A buffer outside of sandbox memory was passed to a contract API function.
+		OutOfBounds,
+		/// Input passed to a contract API function failed to decode as expected type.
+		DecodingFailed,
 	}
 }
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -442,6 +442,8 @@ decl_error! {
 		OutOfBounds,
 		/// Input passed to a contract API function failed to decode as expected type.
 		DecodingFailed,
+		/// Contract trapped during execution.
+		ContractTrapped,
 	}
 }
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -420,9 +420,24 @@ decl_error! {
 		/// the subsistence threshold. No transfer is allowed to do this in order to allow
 		/// for a tombstone to be created. Use `ext_terminate` to remove a contract without
 		/// leaving a tombstone behind.
-		InsufficientBalance,
+		BelowSubsistenceThreshold,
+		/// The newly created contract is below the subsistence threshold after executing
+		/// its contructor. No contracts are allowed to exist below that threshold.
+		NewContractNotFunded,
+		/// Performing the requested transfer failed for a reason originating in the
+		/// chosen currency implementation of the runtime. Most probably the balance is
+		/// too low or locks are placed on it.
+		TransferFailed,
+		/// Performing a call was denied because the calling depth reached the limit
+		/// of what is specified in the schedule.
+		MaxCallDepthReached,
+		/// The contract that was called is either no contract at all (a plain account)
+		/// or is a tombstone.
+		InvalidContractCalled,
 		/// The code supplied to `put_code` exceeds the limit specified in the current schedule.
 		CodeTooLarge,
+		/// No code could be found at the supplied code hash.
+		CodeNotFound,
 	}
 }
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -434,7 +434,7 @@ decl_error! {
 		MaxCallDepthReached,
 		/// The contract that was called is either no contract at all (a plain account)
 		/// or is a tombstone.
-		InvalidContractCalled,
+		NotCallable,
 		/// The code supplied to `put_code` exceeds the limit specified in the current schedule.
 		CodeTooLarge,
 		/// No code could be found at the supplied code hash.

--- a/frame/contracts/src/storage.rs
+++ b/frame/contracts/src/storage.rs
@@ -149,6 +149,7 @@ pub fn set_rent_allowance<T: Trait>(
 }
 
 /// Returns the code hash of the contract specified by `account` ID.
+#[cfg(test)]
 pub fn code_hash<T: Trait>(account: &AccountIdOf<T>) -> Result<CodeHash<T>, ContractAbsentError> {
 	<ContractInfoOf<T>>::get(account)
 		.and_then(|i| i.as_alive().map(|i| i.code_hash))

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -299,7 +299,7 @@ fn calling_plain_account_fails() {
 			Contracts::call(Origin::signed(ALICE), BOB, 0, GAS_LIMIT, Vec::new()),
 			Err(
 				DispatchErrorWithPostInfo {
-					error: Error::<Test>::InvalidContractCalled.into(),
+					error: Error::<Test>::NotCallable.into(),
 					post_info: PostDispatchInfo {
 						actual_weight: Some(67500000),
 						pays_fee: Default::default(),
@@ -999,7 +999,7 @@ fn call_removed_contract() {
 			// Calling contract should remove contract and fail.
 			assert_err_ignore_postinfo!(
 				Contracts::call(Origin::signed(ALICE), BOB, 0, GAS_LIMIT, call::null()),
-				Error::<Test>::InvalidContractCalled
+				Error::<Test>::NotCallable
 			);
 			// Calling a contract that is about to evict shall emit an event.
 			assert_eq!(System::events(), vec![
@@ -1013,7 +1013,7 @@ fn call_removed_contract() {
 			// Subsequent contract calls should also fail.
 			assert_err_ignore_postinfo!(
 				Contracts::call(Origin::signed(ALICE), BOB, 0, GAS_LIMIT, call::null()),
-				Error::<Test>::InvalidContractCalled
+				Error::<Test>::NotCallable
 			);
 		})
 }
@@ -1140,7 +1140,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 			// we expect that it will get removed leaving tombstone.
 			assert_err_ignore_postinfo!(
 				Contracts::call(Origin::signed(ALICE), BOB, 0, GAS_LIMIT, call::null()),
-				Error::<Test>::InvalidContractCalled
+				Error::<Test>::NotCallable
 			);
 			assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
 			assert_eq!(System::events(), vec![
@@ -1687,7 +1687,7 @@ fn call_return_code() {
 			GAS_LIMIT,
 			vec![0],
 		).0.unwrap();
-		assert_return_code!(result, RuntimeReturnCode::InvalidContractCalled);
+		assert_return_code!(result, RuntimeReturnCode::NotCallable);
 
 		assert_ok!(
 			Contracts::instantiate(

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1186,7 +1186,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 
 				assert_err_ignore_postinfo!(
 					perform_the_restoration(),
-					"contract trapped during execution"
+					Error::<Test>::ContractTrapped,
 				);
 
 				assert!(ContractInfoOf::<Test>::get(BOB).unwrap().get_tombstone().is_some());
@@ -1314,7 +1314,7 @@ fn storage_max_value_limit() {
 					GAS_LIMIT,
 					Encode::encode(&(self::MaxValueSize::get() + 1)),
 				),
-				"contract trapped during execution"
+				Error::<Test>::ContractTrapped,
 			);
 		});
 }
@@ -1427,7 +1427,7 @@ fn cannot_self_destruct_while_live() {
 					GAS_LIMIT,
 					vec![0],
 				),
-				"contract trapped during execution"
+				Error::<Test>::ContractTrapped,
 			);
 
 			// Check that BOB is still alive.

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -156,9 +156,8 @@ mod tests {
 	use crate::gas::{Gas, GasMeter};
 	use crate::tests::{Test, Call};
 	use crate::wasm::prepare::prepare_contract;
-	use crate::{CodeHash, BalanceOf};
+	use crate::{CodeHash, BalanceOf, Error};
 	use hex_literal::hex;
-	use assert_matches::assert_matches;
 	use sp_runtime::DispatchError;
 	use frame_support::weights::Weight;
 
@@ -1505,7 +1504,7 @@ mod tests {
 		// Checks that the runtime traps if there are more than `max_topic_events` topics.
 		let mut gas_meter = GasMeter::new(GAS_LIMIT);
 
-		assert_matches!(
+		assert_eq!(
 			execute(
 				CODE_DEPOSIT_EVENT_MAX_TOPICS,
 				vec![],
@@ -1513,7 +1512,7 @@ mod tests {
 				&mut gas_meter
 			),
 			Err(ExecError {
-				error: DispatchError::Other("contract trapped during execution"),
+				error: Error::<Test>::ContractTrapped.into(),
 				origin: ErrorOrigin::Supervisor,
 			})
 		);
@@ -1550,7 +1549,7 @@ mod tests {
 		// Checks that the runtime traps if there are duplicates.
 		let mut gas_meter = GasMeter::new(GAS_LIMIT);
 
-		assert_matches!(
+		assert_eq!(
 			execute(
 				CODE_DEPOSIT_EVENT_DUPLICATES,
 				vec![],
@@ -1558,7 +1557,7 @@ mod tests {
 				&mut gas_meter
 			),
 			Err(ExecError {
-				error: DispatchError::Other("contract trapped during execution"),
+				error: Error::<Test>::ContractTrapped.into(),
 				origin: ErrorOrigin::Supervisor,
 			})
 		);

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -1514,7 +1514,7 @@ mod tests {
 			),
 			Err(ExecError {
 				error: Error::<Test>::ContractTrapped.into(),
-				origin: ErrorOrigin::Supervisor,
+				origin: ErrorOrigin::Caller,
 			})
 		);
 	}
@@ -1559,7 +1559,7 @@ mod tests {
 			),
 			Err(ExecError {
 				error: Error::<Test>::ContractTrapped.into(),
-				origin: ErrorOrigin::Supervisor,
+				origin: ErrorOrigin::Caller,
 			})
 		);
 	}
@@ -1705,7 +1705,7 @@ mod tests {
 			result,
 			Err(ExecError {
 				error: Error::<Test>::OutOfBounds.into(),
-				origin: ErrorOrigin::Supervisor,
+				origin: ErrorOrigin::Caller,
 			})
 		);
 	}
@@ -1740,7 +1740,7 @@ mod tests {
 			result,
 			Err(ExecError {
 				error: Error::<Test>::DecodingFailed.into(),
-				origin: ErrorOrigin::Supervisor,
+				origin: ErrorOrigin::Caller,
 			})
 		);
 	}

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -36,6 +36,7 @@ use self::runtime::{to_execution_result, Runtime};
 use self::code_cache::load as load_code;
 
 pub use self::code_cache::save as save_code;
+pub use self::runtime::ReturnCode;
 
 /// A prepared wasm module ready for execution.
 #[derive(Clone, Encode, Decode)]

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -639,7 +639,7 @@ define_env!(Env, <E: Ext>,
 	// `ReturnCode::CalleeTrapped`
 	// `ReturnCode::BelowSubsistenceThreshold`
 	// `ReturnCode::TransferFailed`
-	// `ReturnCode::InvalidConractCalled`
+	// `ReturnCode::InvalidContractCalled`
 	ext_call(
 		ctx,
 		callee_ptr: u32,

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -62,7 +62,7 @@ pub enum ReturnCode {
 	CodeNotFound = 7,
 	/// The contract that was called is either no contract at all (a plain account)
 	/// or is a tombstone.
-	InvalidContractCalled = 8,
+	NotCallable = 8,
 }
 
 impl ConvertibleToWasm for ReturnCode {
@@ -433,14 +433,14 @@ fn err_into_return_code<T: Trait>(from: DispatchError) -> Result<ReturnCode, Dis
 	let transfer_failed = Error::<T>::TransferFailed.into();
 	let not_funded = Error::<T>::NewContractNotFunded.into();
 	let no_code = Error::<T>::CodeNotFound.into();
-	let invalid_contract = Error::<T>::InvalidContractCalled.into();
+	let invalid_contract = Error::<T>::NotCallable.into();
 
 	match from {
 		x if x == below_sub => Ok(BelowSubsistenceThreshold),
 		x if x == transfer_failed => Ok(TransferFailed),
 		x if x == not_funded => Ok(NewContractNotFunded),
 		x if x == no_code => Ok(CodeNotFound),
-		x if x == invalid_contract => Ok(InvalidContractCalled),
+		x if x == invalid_contract => Ok(NotCallable),
 		err => Err(err)
 	}
 }
@@ -646,7 +646,7 @@ define_env!(Env, <E: Ext>,
 	// `ReturnCode::CalleeTrapped`
 	// `ReturnCode::BelowSubsistenceThreshold`
 	// `ReturnCode::TransferFailed`
-	// `ReturnCode::InvalidContractCalled`
+	// `ReturnCode::NotCallable`
 	ext_call(
 		ctx,
 		callee_ptr: u32,

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -49,14 +49,14 @@ pub enum ReturnCode {
 	CalleeReverted = 2,
 	/// The passed key does not exist in storage.
 	KeyNotFound = 3,
-	/// Transfer failed because it would have brought the senders total balance below the
-	/// subsistence deposit.
+	/// Transfer failed because it would have brought the sender's total balance below the
+	/// subsistence threshold.
 	BelowSubsistenceThreshold = 4,
 	/// Transfer failed for other reasons. Most probably reserved or locked balance of the
 	/// sender prevents the transfer.
 	TransferFailed = 5,
 	/// The newly created contract is below the subsistence threshold after executing
-	// its contructor.
+	/// its constructor.
 	NewContractNotFunded = 6,
 	/// No code could be found at the supplied code hash.
 	CodeNotFound = 7,

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -36,7 +36,7 @@ use sp_io::hashing::{
 	sha2_256,
 };
 
-/// Every error that can be returned from a runtime API call.
+/// Every error that can be returned to a contract when it calls any of the host functions.
 #[repr(u32)]
 pub enum ReturnCode {
 	/// API call successful.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -18,7 +18,7 @@
 
 use crate::{Schedule, Trait, CodeHash, BalanceOf, Error};
 use crate::exec::{
-	Ext, ExecResult, ExecReturnValue, StorageKey, TopicOf, ReturnFlags,
+	Ext, ExecResult, ExecReturnValue, StorageKey, TopicOf, ReturnFlags, ExecError
 };
 use crate::gas::{Gas, GasMeter, Token, GasMeterResult};
 use crate::wasm::env_def::ConvertibleToWasm;
@@ -43,14 +43,26 @@ pub enum ReturnCode {
 	Success = 0,
 	/// The called function trapped and has its state changes reverted.
 	/// In this case no output buffer is returned.
-	/// Can only be returned from `ext_call` and `ext_instantiate`.
 	CalleeTrapped = 1,
 	/// The called function ran to completion but decided to revert its state.
 	/// An output buffer is returned when one was supplied.
-	/// Can only be returned from `ext_call` and `ext_instantiate`.
 	CalleeReverted = 2,
 	/// The passed key does not exist in storage.
 	KeyNotFound = 3,
+	/// Transfer failed because it would have brought the senders total balance below the
+	/// subsistence deposit.
+	BelowSubsistenceThreshold = 4,
+	/// Transfer failed for other reasons. Most probably reserved or locked balance of the
+	/// sender prevents the transfer.
+	TransferFailed = 5,
+	/// The newly created contract is below the subsistence threshold after executing
+	// its contructor.
+	NewContractNotFunded = 6,
+	/// No code could be found at the supplied code hash.
+	CodeNotFound = 7,
+	/// The contract that was called is either no contract at all (a plain account)
+	/// or is a tombstone.
+	InvalidContractCalled = 8,
 }
 
 impl ConvertibleToWasm for ReturnCode {
@@ -66,7 +78,7 @@ impl ConvertibleToWasm for ReturnCode {
 }
 
 impl From<ExecReturnValue> for ReturnCode {
-	fn from(from: ExecReturnValue) -> ReturnCode {
+	fn from(from: ExecReturnValue) -> Self {
 		if from.flags.contains(ReturnFlags::REVERT) {
 			Self::CalleeReverted
 		} else {
@@ -379,7 +391,7 @@ fn write_sandbox_output<E: Ext>(
 	let len: u32 = read_sandbox_memory_as(ctx, out_len_ptr, 4)?;
 
 	if len < buf_len {
-		Err(map_err(ctx, Error::<E::T>::OutputBufferTooSmall))?
+		Err(store_err(ctx, Error::<E::T>::OutputBufferTooSmall))?
 	}
 
 	charge_gas(
@@ -398,12 +410,80 @@ fn write_sandbox_output<E: Ext>(
 /// Stores a DispatchError returned from an Ext function into the trap_reason.
 ///
 /// This allows through supervisor generated errors to the caller.
-fn map_err<E, Error>(ctx: &mut Runtime<E>, err: Error) -> sp_sandbox::HostError where
+fn store_err<E, Error>(ctx: &mut Runtime<E>, err: Error) -> sp_sandbox::HostError where
 	E: Ext,
 	Error: Into<DispatchError>,
 {
 	ctx.trap_reason = Some(TrapReason::SupervisorError(err.into()));
 	sp_sandbox::HostError
+}
+
+/// Fallible conversion of `DispatchError` to `ReturnCode`.
+fn err_into_return_code<T: Trait>(from: DispatchError) -> Result<ReturnCode, DispatchError> {
+	use ReturnCode::*;
+
+	let below_sub = Error::<T>::BelowSubsistenceThreshold.into();
+	let transfer_failed = Error::<T>::TransferFailed.into();
+	let not_funded = Error::<T>::NewContractNotFunded.into();
+	let no_code = Error::<T>::CodeNotFound.into();
+	let invalid_contract = Error::<T>::InvalidContractCalled.into();
+
+	match from {
+		x if x == below_sub => Ok(BelowSubsistenceThreshold),
+		x if x == transfer_failed => Ok(TransferFailed),
+		x if x == not_funded => Ok(NewContractNotFunded),
+		x if x == no_code => Ok(CodeNotFound),
+		x if x == invalid_contract => Ok(InvalidContractCalled),
+		err => Err(err)
+	}
+}
+
+/// Fallible conversion of a `ExecResult` to `ReturnCode`.
+fn exec_into_return_code<T: Trait>(from: ExecResult) -> Result<ReturnCode, DispatchError> {
+	use crate::exec::ErrorOrigin::Callee;
+
+	let ExecError { error, origin } = match from {
+		Ok(retval) => return Ok(retval.into()),
+		Err(err) => err,
+	};
+
+	match (error, origin) {
+		(_, Callee) => Ok(ReturnCode::CalleeTrapped),
+		(err, _) => err_into_return_code::<T>(err)
+	}
+}
+
+/// Used by Runtime API that calls into other contracts.
+///
+/// Those need to transform the the `ExecResult` returned from the execution into
+/// a `ReturnCode`. If this conversion fails because the `ExecResult` constitutes a
+/// a fatal error then this error is stored in the `ExecutionContext` so it can be
+/// extracted for display in the UI.
+fn map_exec_result<E: Ext>(ctx: &mut Runtime<E>, result: ExecResult)
+	-> Result<ReturnCode, sp_sandbox::HostError>
+{
+	match exec_into_return_code::<E::T>(result) {
+		Ok(code) => Ok(code),
+		Err(err) => Err(store_err(ctx, err)),
+	}
+}
+
+/// Try to convert an error into a `ReturnCode`.
+///
+/// Used to decide between fatal and non-fatal errors.
+fn map_dispatch_result<T, E: Ext>(ctx: &mut Runtime<E>, result: Result<T, DispatchError>)
+	-> Result<ReturnCode, sp_sandbox::HostError>
+{
+	let err = if let Err(err) = result {
+		err
+	} else {
+		return Ok(ReturnCode::Success)
+	};
+
+	match err_into_return_code::<E::T>(err) {
+		Ok(code) => Ok(code),
+		Err(err) => Err(store_err(ctx, err)),
+	}
 }
 
 // ***********************************************************
@@ -412,6 +492,12 @@ fn map_err<E, Error>(ctx: &mut Runtime<E>, err: Error) -> sp_sandbox::HostError 
 
 // Define a function `fn init_env<E: Ext>() -> HostFunctionSet<E>` that returns
 // a function set which can be imported by an executed contract.
+//
+// # Note
+//
+// Any input that leads to a out of bound error (reading or writing) or failing to decode
+// data passed to the supervisor will lead to a trap. This is not documented explicitly
+// for every function.
 define_env!(Env, <E: Ext>,
 
 	// Account for used gas. Traps if gas used is greater than gas limit.
@@ -441,7 +527,7 @@ define_env!(Env, <E: Ext>,
 	// - `value_ptr`: pointer into the linear memory where the value to set is placed.
 	// - `value_len`: the length of the value in bytes.
 	//
-	// # Errors
+	// # Traps
 	//
 	// - If value length exceeds the configured maximum value length of a storage entry.
 	// - Upon trying to set an empty storage entry (value length is 0).
@@ -480,12 +566,7 @@ define_env!(Env, <E: Ext>,
 	//
 	// # Errors
 	//
-	// If there is no entry under the given key then this function will return
-	// `ReturnCode::KeyNotFound`.
-	//
-	// # Traps
-	//
-	// Traps if the supplied buffer length is smaller than the size of the stored value.
+	// `ReturnCode::KeyNotFound`
 	ext_get_storage(ctx, key_ptr: u32, out_ptr: u32, out_len_ptr: u32) -> ReturnCode => {
 		let mut key: StorageKey = [0; 32];
 		read_sandbox_memory_into_buf(ctx, key_ptr, &mut key)?;
@@ -508,24 +589,24 @@ define_env!(Env, <E: Ext>,
 	//   Should be decodable as a `T::Balance`. Traps otherwise.
 	// - value_len: length of the value buffer.
 	//
-	// # Traps
+	// # Errors
 	//
-	// Traps if the transfer wasn't succesful. This can happen when the value transfered
-	// brings the sender below the existential deposit. Use `ext_terminate` to remove
-	// the caller contract.
+	// `ReturnCode::BelowSubsistenceThreshold`
+	// `ReturnCode::TransferFailed`
 	ext_transfer(
 		ctx,
 		account_ptr: u32,
 		account_len: u32,
 		value_ptr: u32,
 		value_len: u32
-	) => {
+	) -> ReturnCode => {
 		let callee: <<E as Ext>::T as frame_system::Trait>::AccountId =
 			read_sandbox_memory_as(ctx, account_ptr, account_len)?;
 		let value: BalanceOf<<E as Ext>::T> =
 			read_sandbox_memory_as(ctx, value_ptr, value_len)?;
 
-		ctx.ext.transfer(&callee, value, ctx.gas_meter).map_err(|e| map_err(ctx, e))
+		let result = ctx.ext.transfer(&callee, value, ctx.gas_meter);
+		map_dispatch_result(ctx, result)
 	},
 
 	// Make a call to another contract.
@@ -551,17 +632,14 @@ define_env!(Env, <E: Ext>,
 	//
 	// # Errors
 	//
-	// `ReturnCode::CalleeReverted`: The callee ran to completion but decided to have its
-	//  changes reverted. The delivery of the output buffer is still possible.
-	// `ReturnCode::CalleeTrapped`: The callee trapped during execution. All changes are reverted
-	//  and no output buffer is delivered.
+	// An error means that the call wasn't succesful output buffer is returned unless
+	// stated otherwise.
 	//
-	// # Traps
-	//
-	// - Transfer of balance failed. This call can not bring the sender below the existential
-	//   deposit. Use `ext_terminate` to remove the caller.
-	// - Callee does not exist.
-	// - Supplied output buffer is too small.
+	// `ReturnCode::CalleeReverted`: Output buffer is returned.
+	// `ReturnCode::CalleeTrapped`
+	// `ReturnCode::BelowSubsistenceThreshold`
+	// `ReturnCode::TransferFailed`
+	// `ReturnCode::InvalidConractCalled`
 	ext_call(
 		ctx,
 		callee_ptr: u32,
@@ -594,22 +672,16 @@ define_env!(Env, <E: Ext>,
 						nested_meter,
 						input_data,
 					)
-					.map_err(|_| ())
 				}
 				// there is not enough gas to allocate for the nested call.
-				None => Err(()),
+				None => Err(Error::<<E as Ext>::T>::OutOfGas.into()),
 			}
 		});
 
-		match call_outcome {
-			Ok(output) => {
-				write_sandbox_output(ctx, output_ptr, output_len_ptr, &output.data, true)?;
-				Ok(output.into())
-			},
-			Err(_) => {
-				Ok(ReturnCode::CalleeTrapped)
-			},
+		if let Ok(output) = &call_outcome {
+			write_sandbox_output(ctx, output_ptr, output_len_ptr, &output.data, true)?;
 		}
+		map_exec_result(ctx, call_outcome)
 	},
 
 	// Instantiate a contract with the specified code hash.
@@ -643,19 +715,18 @@ define_env!(Env, <E: Ext>,
 	//
 	// # Errors
 	//
-	// `ReturnCode::CalleeReverted`: The callee's constructor ran to completion but decided to have
-	//		its changes reverted. The delivery of the output buffer is still possible but the
-	//		account was not created and no address is returned.
-	// `ReturnCode::CalleeTrapped`: The callee trapped during execution. All changes are reverted
-	//		and no output buffer is delivered. The accounts was not created and no address is
-	//		returned.
+	// Please consult the `ReturnCode` enum declaration for more information on those
+	// errors. Here we only note things specific to this function.
 	//
-	// # Traps
+	// An error means that the account wasn't created and no address or output buffer
+	// is returned unless stated otherwise.
 	//
-	// - Transfer of balance failed. This call can not bring the sender below the existential
-	//   deposit. Use `ext_terminate` to remove the caller.
-	// - Code hash does not exist.
-	// - Supplied output buffers are too small.
+	// `ReturnCode::CalleeReverted`: Output buffer is returned.
+	// `ReturnCode::CalleeTrapped`
+	// `ReturnCode::BelowSubsistenceThreshold`
+	// `ReturnCode::TransferFailed`
+	// `ReturnCode::NewContractNotFunded`
+	// `ReturnCode::CodeNotFound`
 	ext_instantiate(
 		ctx,
 		code_hash_ptr: u32,
@@ -690,26 +761,20 @@ define_env!(Env, <E: Ext>,
 						nested_meter,
 						input_data
 					)
-					.map_err(|_| ())
 				}
 				// there is not enough gas to allocate for the nested call.
-				None => Err(()),
+				None => Err(Error::<<E as Ext>::T>::OutOfGas.into()),
 			}
 		});
-		match instantiate_outcome {
-			Ok((address, output)) => {
-				if !output.flags.contains(ReturnFlags::REVERT) {
-					write_sandbox_output(
-						ctx, address_ptr, address_len_ptr, &address.encode(), true
-					)?;
-				}
-				write_sandbox_output(ctx, output_ptr, output_len_ptr, &output.data, true)?;
-				Ok(output.into())
-			},
-			Err(_) => {
-				Ok(ReturnCode::CalleeTrapped)
-			},
+		if let Ok((address, output)) = &instantiate_outcome {
+			if !output.flags.contains(ReturnFlags::REVERT) {
+				write_sandbox_output(
+					ctx, address_ptr, address_len_ptr, &address.encode(), true
+				)?;
+			}
+			write_sandbox_output(ctx, output_ptr, output_len_ptr, &output.data, true)?;
 		}
+		map_exec_result(ctx, instantiate_outcome.map(|(_id, retval)| retval))
 	},
 
 	// Remove the calling account and transfer remaining balance.
@@ -722,6 +787,10 @@ define_env!(Env, <E: Ext>,
 	//   where all remaining funds of the caller are transfered.
 	//   Should be decodable as an `T::AccountId`. Traps otherwise.
 	// - beneficiary_len: length of the address buffer.
+	//
+	// # Traps
+	//
+	// - The contract is live i.e is already on the call stack.
 	ext_terminate(
 		ctx,
 		beneficiary_ptr: u32,
@@ -939,6 +1008,11 @@ define_env!(Env, <E: Ext>,
 	// encodes the rent allowance that must be set in the case of successful restoration.
 	// `delta_ptr` is the pointer to the start of a buffer that has `delta_count` storage keys
 	// laid out sequentially.
+	//
+	// # Traps
+	//
+	// - Tombstone hashes do not match
+	// - Calling cantract is live i.e is already on the call stack.
 	ext_restore_to(
 		ctx,
 		dest_ptr: u32,

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -108,7 +108,7 @@ enum TrapReason {
 	SupervisorError(DispatchError),
 	/// Signals that trap was generated in response to call `ext_return` host function.
 	Return(ReturnData),
-	/// Signals that a trap was generated in response to a succesful call to the
+	/// Signals that a trap was generated in response to a successful call to the
 	/// `ext_terminate` host function.
 	Termination,
 	/// Signals that a trap was generated because of a successful restoration.
@@ -639,7 +639,7 @@ define_env!(Env, <E: Ext>,
 	//
 	// # Errors
 	//
-	// An error means that the call wasn't succesful output buffer is returned unless
+	// An error means that the call wasn't successful output buffer is returned unless
 	// stated otherwise.
 	//
 	// `ReturnCode::CalleeReverted`: Output buffer is returned.

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -190,7 +190,7 @@ pub(crate) fn to_execution_result<E: Ext>(
 			Err("validation error")?,
 		// Any other kind of a trap should result in a failure.
 		Err(sp_sandbox::Error::Execution) | Err(sp_sandbox::Error::OutOfBounds) =>
-			Err("contract trapped during execution")?,
+			Err(Error::<E::T>::ContractTrapped)?
 	}
 }
 


### PR DESCRIPTION
This started out as a small PR that should only fix the problem of `ext_instantiate` and `ext_call` reporting `CalleeTrapped` for every error despite its docs saying that it should trap on most errors. However, after looking at the current state of error reporting I decided to to some improvement as I was touching these parts anyways.

We have no proper errors for the most common errors instead of just using `DispatchError::Other` which have its message stripped when displayed on polkadot js or block explorers.

In addition to that `ext_call` no longer allows calling plain accounts. Allowing this predates `ext_transfer`. Having `ext_call` silently not calling any code when calling plain accounts does not seem useful and rather dangerous.

`ext_tranfer` now can return codes again. Removing those was based on the misconception that call and instantiate would trap on transfer errors which they never did.

cc @Robbepop