### PR TITLE
Don't close inbound notifications substreams immediately

### DIFF
--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -197,13 +197,14 @@
 //! handshake message can be of length 0, in which case the sender has to send a single `0`.
 //! - The receiver then either immediately closes the substream, or answers with its own
 //! LEB128-prefixed protocol-specific handshake response. The message can be of length 0, in which
-//! case a single `0` has to be sent back. The receiver is then encouraged to close its sending
-//! side.
+//! case a single `0` has to be sent back.
 //! - Once the handshake has completed, the notifications protocol is unidirectional. Only the
 //! node which initiated the substream can push notifications. If the remote wants to send
 //! notifications as well, it has to open its own undirectional substream.
 //! - Each notification must be prefixed with an LEB128-encoded length. The encoding of the
 //! messages is specific to each protocol.
+//! - Either party can signal that it doesn't want a notifications substream anymore by closing
+//! its writing side. The other party should respond by closing its own writing side soon after.
 //!
 //! The API of `sc-network` allows one to register user-defined notification protocols.
 //! `sc-network` automatically tries to open a substream towards each node for which the legacy

--- a/client/network/src/protocol/generic_proto/handler/notif_in.rs
+++ b/client/network/src/protocol/generic_proto/handler/notif_in.rs
@@ -163,11 +163,9 @@ impl ProtocolsHandler for NotifsInHandler {
 		}
 
 		// Note that we drop the existing substream, which will send an equivalent to a TCP "RST"
-		// to the remote and force-close the substream. It  might seem like an unclean way to get
+		// to the remote and force-close the substream. It might seem like an unclean way to get
 		// rid of a substream. However, keep in mind that it is invalid for the remote to open
-		// multiple such substreams, and therefore sending a "RST" is the correct thing to do.
-		// Also note that we have already closed our writing side during the initial handshake,
-		// and we can't close "more" than that anyway.
+		// multiple such substreams, and therefore sending a "RST" is not an incorrect thing to do.
 		self.substream = Some(proto);
 
 		self.events_queue.push_back(ProtocolsHandlerEvent::Custom(NotifsInHandlerOut::OpenRequest(msg)));


### PR DESCRIPTION
This PR slightly modifies the behaviour of notification substreams.

The current behaviour is:

- Node A opens a substream. Node A sends a handshake message.
- Node B either refuses the substream by immediately closing it, or accepts by sending back its own handshake message.
- After accepting the substream, node B closes its writing side.
- Node A can then send messages.

This PR removes step 3, where B closes its writing side.

The motivation behind this PR is that in the future nodes would signal that they no longer want a substream by closing their writing side.
In order for this to work, they should not immediately close it.

The mechanism where node A detects when node B closes its writing side and closes as well in return can't be implemented before we first deploy this PR, as otherwise the substreams would just get closed immediately.