### PR TITLE
Improve Benchmark Writer: Remove Unused Components, Remove Multiply by Zero, Files Split by Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,6 @@ dependencies = [
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
 dependencies = [
- "Inflector",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
 dependencies = [
+ "derive_more",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,6 @@ dependencies = [
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
 dependencies = [
- "derive_more",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",

--- a/Process.json
+++ b/Process.json
@@ -21,4 +21,9 @@
 	"project_name": "Smart Contracts",
 	"owner": "pepyakin",
 	"matrix_room_id": "!yBKstWVBkwzUkPslsp:matrix.parity.io"
+},
+{
+	"project_name": "Benchmarking and Weights",
+	"owner": "shawntabrizi",
+	"matrix_room_id": "!pZPWqCRLVtORZTEsEf:matrix.parity.io"
 }]

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -30,6 +30,13 @@ pub enum BenchmarkParameter {
 	a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z,
 }
 
+#[cfg(feature = "std")]
+impl std::fmt::Display for BenchmarkParameter {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", self)
+	}
+}
+
 /// The results of a single of benchmark.
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct BenchmarkBatch {

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -12,7 +12,6 @@ description = "CLI for benchmarking FRAME"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-Inflector = "0.11.4"
 frame-benchmarking = { version = "2.0.0-rc5", path = "../../../frame/benchmarking" }
 sp-core = { version = "2.0.0-rc5", path = "../../../primitives/core" }
 sc-service = { version = "0.8.0-rc5", default-features = false, path = "../../../client/service" }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -12,7 +12,6 @@ description = "CLI for benchmarking FRAME"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-derive_more = "0.99.2"
 frame-benchmarking = { version = "2.0.0-rc5", path = "../../../frame/benchmarking" }
 sp-core = { version = "2.0.0-rc5", path = "../../../primitives/core" }
 sc-service = { version = "0.8.0-rc5", default-features = false, path = "../../../client/service" }

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -12,6 +12,7 @@ description = "CLI for benchmarking FRAME"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+derive_more = "0.99.2"
 frame-benchmarking = { version = "2.0.0-rc5", path = "../../../frame/benchmarking" }
 sp-core = { version = "2.0.0-rc5", path = "../../../primitives/core" }
 sc-service = { version = "0.8.0-rc5", default-features = false, path = "../../../client/service" }

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -95,8 +95,7 @@ impl BenchmarkCmd {
 						let mut file = crate::writer::open_file("traits.rs")?;
 						crate::writer::write_trait(&mut file, batches.clone())?;
 					} else {
-						let mut file = crate::writer::open_file("benchmarks.rs")?;
-						crate::writer::write_results(&mut file, batches.clone())?;
+						crate::writer::write_results(&batches)?;
 					}
 				}
 

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -117,9 +117,6 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 			current_pallet = batch.pallet.clone()
 		}
 
-		// function name
-		write!(file, "\tfn {}(", benchmark_string).unwrap();
-
 		// Analysis results
 		let extrinsic_time = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::ExtrinsicTime).unwrap();
 		let reads = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Reads).unwrap();
@@ -153,11 +150,19 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 		used_components.sort();
 		used_components.dedup();
 
-		let components = &batch.results[0].components;
+		let mut components = batch.results[0].components
+			.iter()
+			.map(|(name, _)| -> String { return name.to_string() })
+			.collect::<Vec<String>>();
 		if components.len() != used_components.len() {
-			println!("SHAWN LEN DIFFERENT:\n{:?}\n{:?}", components, used_components)
+			// These are the components that were not used.
+			components.retain(|x| !used_components.contains(&x));
+			write!(file, "\t// WARNING! Some components were not used: {:?}\n", components).unwrap();
 		}
 
+		// function name
+		write!(file, "\tfn {}(", benchmark_string).unwrap();
+		// params
 		for component in used_components {
 			write!(file, "{}: u32, ", component).unwrap();
 		}

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -47,6 +47,11 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 
 		// only create new trait definitions when we go to a new pallet
 		if batch.pallet != current_pallet {
+			if !current_pallet.is_empty() {
+				// close trait
+				write!(file, "}}\n")?;
+			}
+
 			// trait wrapper
 			write!(file, "// {}\n", pallet_string)?;
 			write!(file, "pub trait WeightInfo {{\n")?;

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -22,11 +22,13 @@ use std::io::prelude::*;
 use frame_benchmarking::{BenchmarkBatch, BenchmarkSelector, Analysis};
 use sp_runtime::traits::Zero;
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 pub fn open_file(path: &str) -> Result<File, std::io::Error> {
 	OpenOptions::new()
 		.create(true)
 		.write(true)
-		.append(true)
+		.truncate(true)
 		.open(path)
 }
 
@@ -45,11 +47,6 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 
 		// only create new trait definitions when we go to a new pallet
 		if batch.pallet != current_pallet {
-			if !current_pallet.is_empty() {
-				// close trait
-				write!(file, "}}\n").unwrap();
-			}
-
 			// trait wrapper
 			write!(file, "// {}\n", pallet_string).unwrap();
 			write!(file, "pub trait WeightInfo {{\n").unwrap();
@@ -72,65 +69,24 @@ pub fn write_trait(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), 
 	// final close trait
 	write!(file, "}}\n").unwrap();
 
-	// Reset
-	current_pallet = Vec::<u8>::new();
-
-	for batch in &batches {
-		if batch.results.is_empty() { continue }
-
-		let benchmark_string = String::from_utf8(batch.benchmark.clone()).unwrap();
-
-		// only create new trait definitions when we go to a new pallet
-		if batch.pallet != current_pallet {
-			if !current_pallet.is_empty() {
-				// close trait
-				write!(file, "}}\n").unwrap();
-			}
-
-			// impl trait
-			write!(file, "\n").unwrap();
-			write!(file, "impl WeightInfo for () {{\n").unwrap();
-
-			current_pallet = batch.pallet.clone()
-		}
-
-		// function name
-		write!(file, "\tfn {}(", benchmark_string).unwrap();
-
-		// params
-		let components = &batch.results[0].components;
-		for component in components {
-			write!(file, "_{:?}: u32, ", component.0).unwrap();
-		}
-		// return value
-		write!(file, ") -> Weight {{ 1_000_000_000 }}\n").unwrap();
-	}
-
-	// final close trait
-	write!(file, "}}\n").unwrap();
-
 	Ok(())
 }
 
-pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<(), std::io::Error> {
+pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 	let mut current_pallet = Vec::<u8>::new();
 
 	// Skip writing if there are no batches
 	if batches.is_empty() { return Ok(()) }
 
-	// general imports
-	write!(
-		file,
-		"//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI\n\n"
-	).unwrap();
+	let mut batches_iter = batches.iter().peekable();
 
-	// general imports
-	write!(
-		file,
-		"use frame_support::weights::{{Weight, constants::RocksDbWeight as DbWeight}};\n\n"
+	let first_pallet = String::from_utf8(
+		batches_iter.peek().expect("we checked that batches is not empty").pallet.clone()
 	).unwrap();
+	let mut file = open_file(&(first_pallet + ".rs"))?;
 
-	for batch in &batches {
+
+	while let Some(batch) = batches_iter.next() {
 		// Skip writing if there are no results
 		if batch.results.is_empty() { continue }
 
@@ -139,10 +95,18 @@ pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<()
 
 		// only create new trait definitions when we go to a new pallet
 		if batch.pallet != current_pallet {
-			if !current_pallet.is_empty() {
-				// close trait
-				write!(file, "}}\n").unwrap();
-			}
+			// general imports
+			write!(
+				file,
+				"//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION {}\n\n",
+				 VERSION,
+			).unwrap();
+
+			// general imports
+			write!(
+				file,
+				"use frame_support::weights::{{Weight, constants::RocksDbWeight as DbWeight}};\n\n"
+			).unwrap();
 
 			// struct for weights
 			write!(file, "pub struct WeightInfo;\n").unwrap();
@@ -156,59 +120,96 @@ pub fn write_results(file: &mut File, batches: Vec<BenchmarkBatch>) -> Result<()
 		// function name
 		write!(file, "\tfn {}(", benchmark_string).unwrap();
 
-		// params
+		// Analysis results
+		let extrinsic_time = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::ExtrinsicTime).unwrap();
+		let reads = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Reads).unwrap();
+		let writes = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Writes).unwrap();
+
+		// Analysis data may include components that are not used, this filters out anything whose value is zero.
+		let mut used_components = Vec::new();
+		let mut used_extrinsic_time = Vec::new();
+		let mut used_reads = Vec::new();
+		let mut used_writes = Vec::new();
+		extrinsic_time.slopes.iter().zip(extrinsic_time.names.iter()).for_each(|(slope, name)| {
+			if !slope.is_zero() {
+				used_components.push(name);
+				used_extrinsic_time.push((slope, name));
+			}
+		});
+		reads.slopes.iter().zip(reads.names.iter()).for_each(|(slope, name)| {
+			if !slope.is_zero() {
+				used_components.push(name);
+				used_reads.push((slope, name));
+			}
+		});
+		writes.slopes.iter().zip(writes.names.iter()).for_each(|(slope, name)| {
+			if !slope.is_zero() {
+				used_components.push(name);
+				used_writes.push((slope, name));
+			}
+		});
+
+		// These are the final set of "used" components, i.e. only those that are used in the weight formula
+		used_components.sort();
+		used_components.dedup();
+
 		let components = &batch.results[0].components;
-		for component in components {
-			write!(file, "{:?}: u32, ", component.0).unwrap();
+		if components.len() != used_components.len() {
+			println!("SHAWN LEN DIFFERENT:\n{:?}\n{:?}", components, used_components)
+		}
+
+		for component in used_components {
+			write!(file, "{}: u32, ", component).unwrap();
 		}
 		// return value
 		write!(file, ") -> Weight {{\n").unwrap();
 
-		let extrinsic_time = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::ExtrinsicTime).unwrap();
 		if !extrinsic_time.base.is_zero() {
 			write!(file, "\t\t({} as Weight)\n", extrinsic_time.base.saturating_mul(1000)).unwrap();
 		}
-		extrinsic_time.slopes.iter().zip(extrinsic_time.names.iter()).for_each(|(slope, name)| {
-			if !slope.is_zero() {
-				write!(file, "\t\t\t.saturating_add(({} as Weight).saturating_mul({} as Weight))\n",
-					slope.saturating_mul(1000),
-					name,
-				).unwrap();
-			}
+		used_extrinsic_time.iter().for_each(|(slope, name)| {
+			write!(file, "\t\t\t.saturating_add(({} as Weight).saturating_mul({} as Weight))\n",
+				slope.saturating_mul(1000),
+				name,
+			).unwrap();
 		});
 
-		let reads = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Reads).unwrap();
 		if !reads.base.is_zero() {
 			write!(file, "\t\t\t.saturating_add(DbWeight::get().reads({} as Weight))\n", reads.base).unwrap();
 		}
-		reads.slopes.iter().zip(reads.names.iter()).for_each(|(slope, name)| {
-			if !slope.is_zero() {
-				write!(file, "\t\t\t.saturating_add(DbWeight::get().reads(({} as Weight).saturating_mul({} as Weight)))\n",
-					slope,
-					name,
-				).unwrap();
-			}
+		used_reads.iter().for_each(|(slope, name)| {
+			write!(file, "\t\t\t.saturating_add(DbWeight::get().reads(({} as Weight).saturating_mul({} as Weight)))\n",
+				slope,
+				name,
+			).unwrap();
 		});
 
-		let writes = Analysis::min_squares_iqr(&batch.results, BenchmarkSelector::Writes).unwrap();
 		if !writes.base.is_zero() {
 			write!(file, "\t\t\t.saturating_add(DbWeight::get().writes({} as Weight))\n", writes.base).unwrap();
 		}
-		writes.slopes.iter().zip(writes.names.iter()).for_each(|(slope, name)| {
-			if !slope.is_zero() {
-				write!(file, "\t\t\t.saturating_add(DbWeight::get().writes(({} as Weight).saturating_mul({} as Weight)))\n",
-					slope,
-					name,
-				).unwrap();
-			}
+		used_writes.iter().for_each(|(slope, name)| {
+			write!(file, "\t\t\t.saturating_add(DbWeight::get().writes(({} as Weight).saturating_mul({} as Weight)))\n",
+				slope,
+				name,
+			).unwrap();
 		});
 
 		// close function
 		write!(file, "\t}}\n").unwrap();
-	}
 
-	// final close trait
-	write!(file, "}}\n").unwrap();
+		// Check if this is the end of the iterator
+		if let Some(next) = batches_iter.peek() {
+			// Next pallet is different than current pallet, so we close up the file and open a new one.
+			if next.pallet != current_pallet {
+				write!(file, "}}\n").unwrap();
+				let next_pallet = String::from_utf8(next.pallet.clone()).unwrap();
+				file = open_file(&(next_pallet + ".rs"))?;
+			}
+		} else {
+			// This is the end of the iterator, so we close up the final file.
+			write!(file, "}}\n").unwrap();
+		}
+	}
 
 	Ok(())
 }

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -169,9 +169,7 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 		// return value
 		write!(file, ") -> Weight {{\n").unwrap();
 
-		if !extrinsic_time.base.is_zero() {
-			write!(file, "\t\t({} as Weight)\n", extrinsic_time.base.saturating_mul(1000)).unwrap();
-		}
+		write!(file, "\t\t({} as Weight)\n", extrinsic_time.base.saturating_mul(1000)).unwrap();
 		used_extrinsic_time.iter().for_each(|(slope, name)| {
 			write!(file, "\t\t\t.saturating_add(({} as Weight).saturating_mul({} as Weight))\n",
 				slope.saturating_mul(1000),

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -95,7 +95,7 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 
 		// only create new trait definitions when we go to a new pallet
 		if batch.pallet != current_pallet {
-			// general imports
+			// auto-generation note
 			write!(
 				file,
 				"//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION {}\n\n",

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -129,35 +129,31 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 		let mut used_writes = Vec::new();
 		extrinsic_time.slopes.iter().zip(extrinsic_time.names.iter()).for_each(|(slope, name)| {
 			if !slope.is_zero() {
-				used_components.push(name);
+				if !used_components.contains(&name) { used_components.push(name); }
 				used_extrinsic_time.push((slope, name));
 			}
 		});
 		reads.slopes.iter().zip(reads.names.iter()).for_each(|(slope, name)| {
 			if !slope.is_zero() {
-				used_components.push(name);
+				if !used_components.contains(&name) { used_components.push(name); }
 				used_reads.push((slope, name));
 			}
 		});
 		writes.slopes.iter().zip(writes.names.iter()).for_each(|(slope, name)| {
 			if !slope.is_zero() {
-				used_components.push(name);
+				if !used_components.contains(&name) { used_components.push(name); }
 				used_writes.push((slope, name));
 			}
 		});
 
-		// These are the final set of "used" components, i.e. only those that are used in the weight formula
-		used_components.sort();
-		used_components.dedup();
-
-		let mut components = batch.results[0].components
+		let mut all_components = batch.results[0].components
 			.iter()
 			.map(|(name, _)| -> String { return name.to_string() })
 			.collect::<Vec<String>>();
-		if components.len() != used_components.len() {
-			// These are the components that were not used.
-			components.retain(|x| !used_components.contains(&x));
-			write!(file, "\t// WARNING! Some components were not used: {:?}\n", components)?;
+		if all_components.len() != used_components.len() {
+			// `all_components` becomes the components that were not used.
+			all_components.retain(|x| !used_components.contains(&x));
+			write!(file, "\t// WARNING! Some components were not used: {:?}\n", all_components)?;
 		}
 
 		// function name

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -151,14 +151,14 @@ pub fn write_results(batches: &[BenchmarkBatch]) -> Result<(), std::io::Error> {
 			}
 		});
 
-		let mut all_components = batch.results[0].components
+		let all_components = batch.results[0].components
 			.iter()
 			.map(|(name, _)| -> String { return name.to_string() })
 			.collect::<Vec<String>>();
 		if all_components.len() != used_components.len() {
-			// `all_components` becomes the components that were not used.
-			all_components.retain(|x| !used_components.contains(&x));
-			write!(file, "\t// WARNING! Some components were not used: {:?}\n", all_components)?;
+			let mut unused_components = all_components;
+			unused_components.retain(|x| !used_components.contains(&x));
+			write!(file, "\t// WARNING! Some components were not used: {:?}\n", unused_components)?;
 		}
 
 		// function name


### PR DESCRIPTION
This PR updates the Benchmark Writer adding a number of features which should improve automation.

## Remove Unused Components

A benchmark may include components that do not end up effecting the weight of the function. We introduced "component-less" benchmarks, but in the case we want to keep the component in the benchmark to PROVE it does not need to be used, our benchmarking writer can now detect that the component is unused, and remove it from the function signature.

Example:

```
// WARNING! Some components were not used: ["z"]
fn as_multi_complete(s: u32, ) -> Weight {
	(65230000 as Weight)
		.saturating_add((70000 as Weight).saturating_mul(s as Weight))
		.saturating_add(DbWeight::get().reads(3 as Weight))
		.saturating_add(DbWeight::get().writes(3 as Weight))
}
```

## Remove Multiply by Zero

There are times where a component has no effect on a part of the benchmark. In those cases, we dont write any lines:

Before:

```
fn execute(m: u32, b: u32, ) -> Weight {
	(25703000 as Weight)
		.saturating_add((109000 as Weight).saturating_mul(m as Weight))
		.saturating_add((4000 as Weight).saturating_mul(b as Weight))
		.saturating_add(DbWeight::get().reads(1 as Weight))
		.saturating_add(DbWeight::get().reads((0 as Weight).saturating_mul(m as Weight)))
		.saturating_add(DbWeight::get().reads((0 as Weight).saturating_mul(b as Weight)))
		.saturating_add(DbWeight::get().writes(0 as Weight))
		.saturating_add(DbWeight::get().writes((0 as Weight).saturating_mul(m as Weight)))
		.saturating_add(DbWeight::get().writes((0 as Weight).saturating_mul(b as Weight)))
}
```

After:

```
fn execute(m: u32, b: u32, ) -> Weight {
	(25703000 as Weight)
		.saturating_add((109000 as Weight).saturating_mul(m as Weight))
		.saturating_add((4000 as Weight).saturating_mul(b as Weight))
		.saturating_add(DbWeight::get().reads(1 as Weight))
}
```

## Split Files by Pallet

Final change supports creating a weight file per pallet:

<img width="369" alt="image" src="https://user-images.githubusercontent.com/1860335/89038721-25478300-d341-11ea-9603-de766502462d.png">

Name of the file is the same as the crate name as imported in the runtime.