### PR TITLE
pallet-evm: fix wrong logic in mutate_account_basic

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -441,11 +441,11 @@ impl<T: Trait> Module<T> {
 			}
 		}
 
-		if current.balance < new.balance {
-			let diff = new.balance - current.balance;
-			T::Currency::slash(&account_id, diff.low_u128().unique_saturated_into());
-		} else if current.balance > new.balance {
+		if current.balance > new.balance {
 			let diff = current.balance - new.balance;
+			T::Currency::slash(&account_id, diff.low_u128().unique_saturated_into());
+		} else if current.balance < new.balance {
+			let diff = new.balance - current.balance;
 			T::Currency::deposit_creating(&account_id, diff.low_u128().unique_saturated_into());
 		}
 	}

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -166,3 +166,23 @@ fn fail_call_return_ok() {
 		));
 	});
 }
+
+#[test]
+fn mutate_account_works() {
+	new_test_ext().execute_with(|| {
+		EVM::mutate_account_basic(
+			&H160::from_str("1000000000000000000000000000000000000001").unwrap(),
+			Account {
+				nonce: U256::from(10),
+				balance: U256::from(1000),
+			},
+		);
+
+		assert_eq!(EVM::account_basic(
+			&H160::from_str("1000000000000000000000000000000000000001").unwrap()
+		), Account {
+			nonce: U256::from(10),
+			balance: U256::from(1000),
+		});
+	});
+}


### PR DESCRIPTION
The sign should be reverse.