### PR TITLE
Fix transaction payment runtime api

### DIFF
--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -33,7 +33,6 @@
 use std::sync::Arc;
 
 use node_primitives::{Block, BlockNumber, AccountId, Index, Balance, Hash};
-use node_runtime::UncheckedExtrinsic;
 use sp_api::ProvideRuntimeApi;
 use sp_transaction_pool::TransactionPool;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
@@ -106,7 +105,7 @@ pub fn create_full<C, P, M, SC>(
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance, UncheckedExtrinsic>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BabeApi<Block>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1101,9 +1101,8 @@ impl_runtime_apis! {
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
 		Block,
 		Balance,
-		UncheckedExtrinsic,
 	> for Runtime {
-		fn query_info(uxt: UncheckedExtrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
+		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 	}

--- a/frame/transaction-payment/rpc/runtime-api/src/lib.rs
+++ b/frame/transaction-payment/rpc/runtime-api/src/lib.rs
@@ -56,11 +56,10 @@ fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(dese
 }
 
 sp_api::decl_runtime_apis! {
-	pub trait TransactionPaymentApi<Balance, Extrinsic> where
+	pub trait TransactionPaymentApi<Balance> where
 		Balance: Codec + MaybeDisplay + MaybeFromStr,
-		Extrinsic: Codec,
 	{
-		fn query_info(uxt: Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
+		fn query_info(uxt: Block::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance>;
 	}
 }
 

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -69,14 +69,13 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, Balance, Extrinsic> TransactionPaymentApi<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
-	for TransactionPayment<C, (Block, Extrinsic)>
+impl<C, Block, Balance> TransactionPaymentApi<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
+	for TransactionPayment<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-	C::Api: TransactionPaymentRuntimeApi<Block, Balance, Extrinsic>,
+	C::Api: TransactionPaymentRuntimeApi<Block, Balance>,
 	Balance: Codec + MaybeDisplay + MaybeFromStr,
-	Extrinsic: Codec + Send + Sync + 'static,
 {
 	fn query_info(
 		&self,
@@ -91,7 +90,7 @@ where
 
 		let encoded_len = encoded_xt.len() as u32;
 
-		let uxt: Extrinsic = Decode::decode(&mut &*encoded_xt).map_err(|e| RpcError {
+		let uxt: Block::Extrinsic = Decode::decode(&mut &*encoded_xt).map_err(|e| RpcError {
 			code: ErrorCode::ServerError(Error::DecodeError.into()),
 			message: "Unable to query dispatch info.".into(),
 			data: Some(format!("{:?}", e).into()),


### PR DESCRIPTION
The transaction payment runtime api used its own extrinsic generic
parameter. This is wrong, because this resulted in using always the
native extrinsic. If there was a runtime upgrade that changed the
extrinsic in some way, it would result in the api breaking. The correct
way is to use the `Extrinsic` from the `Block` parameter. This is on the
node side the opaque extrinsic and on the runtime side the real extrinsic.

polkadot companion: https://github.com/paritytech/polkadot/pull/1519
