### PR TITLE
seal: Change prefix and module name from "ext_" to "seal_" for contract callable functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,9 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
+checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
  "byteorder",
  "log",
@@ -9362,7 +9362,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.3.23",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -485,7 +485,7 @@ fn full_wasm_block_import_works() {
 
 const CODE_TRANSFER: &str = r#"
 (module
-;; ext_call(
+;; seal_call(
 ;;    callee_ptr: u32,
 ;;    callee_len: u32,
 ;;    gas: u64,
@@ -496,15 +496,15 @@ const CODE_TRANSFER: &str = r#"
 ;;    output_ptr: u32,
 ;;    output_len_ptr: u32
 ;; ) -> u32
-(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-(import "env" "ext_input" (func $ext_input (param i32 i32)))
+(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 (import "env" "memory" (memory 1 1))
 (func (export "deploy")
 )
 (func (export "call")
 	(block $fail
 		;; Load input data to contract memory
-		(call $ext_input
+		(call $seal_input
 			(i32.const 0)
 			(i32.const 52)
 		)
@@ -543,7 +543,7 @@ const CODE_TRANSFER: &str = r#"
 		)
 
 		(drop
-			(call $ext_call
+			(call $seal_call
 				(i32.const 4)  ;; Pointer to "callee" address.
 				(i32.const 32)  ;; Length of "callee" address.
 				(i64.const 0)  ;; How much gas to devote for the execution. 0 = all.

--- a/frame/contracts/COMPLEXITY.md
+++ b/frame/contracts/COMPLEXITY.md
@@ -284,19 +284,19 @@ given runtime.
 
 This is the list of getters:
 
-- ext_caller
-- ext_address
-- ext_weight_to_fee
-- ext_gas_left
-- ext_balance
-- ext_value_transferred
-- ext_now
-- ext_minimum_balance
-- ext_tombstone_deposit
-- ext_rent_allowance
-- ext_block_number
+- seal_caller
+- seal_address
+- seal_weight_to_fee
+- seal_gas_left
+- seal_balance
+- seal_value_transferred
+- seal_now
+- seal_minimum_balance
+- seal_tombstone_deposit
+- seal_rent_allowance
+- seal_block_number
 
-### ext_set_storage
+### seal_set_storage
 
 This function receives a `key` and `value` as arguments. It consists of the following steps:
 
@@ -305,7 +305,7 @@ This function receives a `key` and `value` as arguments. It consists of the foll
 
 **complexity**: Complexity is proportional to the size of the `value`. This function induces a DB write of size proportional to the `value` size (if flushed to the storage), so should be priced accordingly.
 
-### ext_clear_storage
+### seal_clear_storage
 
 This function receives a `key` as argument. It consists of the following steps:
 
@@ -315,7 +315,7 @@ This function receives a `key` as argument. It consists of the following steps:
 **complexity**: Complexity is constant. This function induces a DB write to clear the storage entry
 (upon being flushed to the storage) and should be priced accordingly.
 
-### ext_get_storage
+### seal_get_storage
 
 This function receives a `key` as an argument. It consists of the following steps:
 
@@ -330,7 +330,7 @@ performed. Moreover, the DB read has to be synchronous and no progress can be ma
 
 **complexity**: The memory and computing complexity is proportional to the size of the fetched value. This function performs a DB read.
 
-### ext_transfer
+### seal_transfer
 
 This function receives the following arguments:
 
@@ -345,7 +345,7 @@ It consists of the following steps:
 
 Loading of `account` and `value` buffers should be charged. This is because the sizes of buffers are specified by the calling code, even though marshaled representations are, essentially, of constant size. This can be fixed by assigning an upper bound for sizes of `AccountId` and `Balance`.
 
-### ext_call
+### seal_call
 
 This function receives the following arguments:
 
@@ -369,7 +369,7 @@ Loading `input_data` should be charged in any case.
 
 **complexity**: All complexity comes from loading and writing buffers and executing `call` executive function. The former component is proportional to the sizes of `callee`, `value`, `input_data` and `output_ptr` buffers. The latter component completely depends on the complexity of `call` executive function, and also dominated by it.
 
-### ext_instantiate
+### seal_instantiate
 
 This function receives the following arguments:
 
@@ -391,7 +391,7 @@ Loading `init_code` and `input_data` should be charged in any case.
 
 **complexity**: All complexity comes from loading buffers and executing `instantiate` executive function. The former component is proportional to the sizes of `init_code`, `value` and `input_data` buffers. The latter component completely depends on the complexity of `instantiate` executive function and also dominated by it.
 
-### ext_terminate
+### seal_terminate
 
 This function receives the following arguments:
 
@@ -405,13 +405,13 @@ Loading of the `beneficiary` buffer should be charged. This is because the sizes
 
 **complexity**: All complexity comes from loading buffers and executing `terminate` executive function. The former component is proportional to the size of the `beneficiary` buffer. The latter component completely depends on the complexity of `terminate` executive function and also dominated by it.
 
-### ext_input
+### seal_input
 
 This function receives a pointer to contract memory. It copies the input to the contract call to this location.
 
 **complexity**: The complextity is proportional to the size of the input buffer.
 
-### ext_return
+### seal_return
 
 This function receives a `data` buffer and `flags` arguments. Execution of the function consists of the following steps:
 
@@ -421,7 +421,7 @@ This function receives a `data` buffer and `flags` arguments. Execution of the f
 
 **complexity**: The complexity of this function is proportional to the size of the `data` buffer.
 
-### ext_deposit_event
+### seal_deposit_event
 
 This function receives a `data` buffer as an argument. Execution of the function consists of the following steps:
 
@@ -432,7 +432,7 @@ This function receives a `data` buffer as an argument. Execution of the function
 
 **complexity**: The complexity of this function is proportional to the size of the `data` buffer.
 
-### ext_set_rent_allowance
+### seal_set_rent_allowance
 
 This function receives the following argument:
 

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -19,7 +19,7 @@ frame-support = { version = "2.0.0-rc5", default-features = false, path = "../su
 frame-system = { version = "2.0.0-rc5", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "2.0.0-rc5", default-features = false, path = "common" }
 parity-wasm = { version = "0.41.0", default-features = false }
-pwasm-utils = { version = "0.12.0", default-features = false }
+pwasm-utils = { version = "0.14.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-core = { version = "2.0.0-rc5", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0-rc5", default-features = false, path = "../../primitives/runtime" }

--- a/frame/contracts/fixtures/call_return_code.wat
+++ b/frame/contracts/fixtures/call_return_code.wat
@@ -2,9 +2,9 @@
 ;; of this call to the output buffer.
 ;; It also forwards its input to the callee.
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) address of django
@@ -23,10 +23,10 @@
 	(func (export "deploy"))
 
 	(func (export "call")
-		(call $ext_input (i32.const 20) (i32.const 24))
+		(call $seal_input (i32.const 20) (i32.const 24))
 		(i32.store
 			(i32.const 16)
-			(call $ext_call
+			(call $seal_call
 				(i32.const 0) ;; Pointer to "callee" address.
 				(i32.const 8) ;; Length of "callee" address.
 				(i64.const 0) ;; How much gas to devote for the execution. 0 = all.
@@ -39,6 +39,6 @@
 			)
 		)
 		;; exit with success and take transfer return code to the output buffer
-		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+		(call $seal_return (i32.const 0) (i32.const 16) (i32.const 4))
 	)
 )

--- a/frame/contracts/fixtures/call_return_code.wat
+++ b/frame/contracts/fixtures/call_return_code.wat
@@ -2,9 +2,9 @@
 ;; of this call to the output buffer.
 ;; It also forwards its input to the callee.
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) address of django

--- a/frame/contracts/fixtures/caller_contract.wat
+++ b/frame/contracts/fixtures/caller_contract.wat
@@ -1,9 +1,9 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_balance" (func $ext_balance (param i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_println" (func $ext_println (param i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_println" (func $seal_println (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -20,7 +20,7 @@
 			(i32.sub (get_local $sp) (i32.const 16))
 			(i32.const 8)
 		)
-		(call $ext_balance
+		(call $seal_balance
 			(i32.sub (get_local $sp) (i32.const 8))
 			(i32.sub (get_local $sp) (i32.const 16))
 		)
@@ -41,7 +41,7 @@
 		(i32.store (i32.const 20) (i32.const 32))
 
 		;; Copy input to this contracts memory
-		(call $ext_input (i32.const 24) (i32.const 20))
+		(call $seal_input (i32.const 24) (i32.const 20))
 
 		;; Input data is the code hash of the contract to be deployed.
 		(call $assert
@@ -59,7 +59,7 @@
 
 		;; Fail to deploy the contract since it returns a non-zero exit status.
 		(set_local $exit_code
-			(call $ext_instantiate
+			(call $seal_instantiate
 				(i32.const 24)	;; Pointer to the code hash.
 				(i32.const 32)	;; Length of the code hash.
 				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -86,7 +86,7 @@
 
 		;; Fail to deploy the contract due to insufficient gas.
 		(set_local $exit_code
-			(call $ext_instantiate
+			(call $seal_instantiate
 				(i32.const 24)	;; Pointer to the code hash.
 				(i32.const 32)	;; Length of the code hash.
 				(i64.const 187500000) ;; Just enough to pay for the instantiate
@@ -119,7 +119,7 @@
 
 		;; Deploy the contract successfully.
 		(set_local $exit_code
-			(call $ext_instantiate
+			(call $seal_instantiate
 				(i32.const 24)	;; Pointer to the code hash.
 				(i32.const 32)	;; Length of the code hash.
 				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -167,7 +167,7 @@
 
 		;; Call the new contract and expect it to return failing exit code.
 		(set_local $exit_code
-			(call $ext_call
+			(call $seal_call
 				(i32.const 16)	;; Pointer to "callee" address.
 				(i32.const 8)	;; Length of "callee" address.
 				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -203,7 +203,7 @@
 
 		;; Fail to call the contract due to insufficient gas.
 		(set_local $exit_code
-			(call $ext_call
+			(call $seal_call
 				(i32.const 16)	;; Pointer to "callee" address.
 				(i32.const 8)	;; Length of "callee" address.
 				(i64.const 117500000) ;; Just enough to make the call
@@ -240,7 +240,7 @@
 
 		;; Call the contract successfully.
 		(set_local $exit_code
-			(call $ext_call
+			(call $seal_call
 				(i32.const 16)	;; Pointer to "callee" address.
 				(i32.const 8)	;; Length of "callee" address.
 				(i64.const 0)	;; How much gas to devote for the execution. 0 = all.

--- a/frame/contracts/fixtures/caller_contract.wat
+++ b/frame/contracts/fixtures/caller_contract.wat
@@ -1,9 +1,9 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_println" (func $seal_println (param i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_balance" (func $seal_balance (param i32 i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_println" (func $seal_println (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)

--- a/frame/contracts/fixtures/check_default_rent_allowance.wat
+++ b/frame/contracts/fixtures/check_default_rent_allowance.wat
@@ -1,5 +1,5 @@
 (module
-	(import "env" "seal_rent_allowance" (func $seal_rent_allowance (param i32 i32)))
+	(import "seal0" "seal_rent_allowance" (func $seal_rent_allowance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) reserved for $seal_rent_allowance output

--- a/frame/contracts/fixtures/check_default_rent_allowance.wat
+++ b/frame/contracts/fixtures/check_default_rent_allowance.wat
@@ -1,8 +1,8 @@
 (module
-	(import "env" "ext_rent_allowance" (func $ext_rent_allowance (param i32 i32)))
+	(import "env" "seal_rent_allowance" (func $seal_rent_allowance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
-	;; [0, 8) reserved for $ext_rent_allowance output
+	;; [0, 8) reserved for $seal_rent_allowance output
 
 	;; [8, 16) length of the buffer
 	(data (i32.const 8) "\08")
@@ -22,7 +22,7 @@
 
 	(func (export "deploy")
 		;; fill the buffer with the rent allowance.
-		(call $ext_rent_allowance (i32.const 0) (i32.const 8))
+		(call $seal_rent_allowance (i32.const 0) (i32.const 8))
 
 		;; assert len == 8
 		(call $assert

--- a/frame/contracts/fixtures/crypto_hashes.wat
+++ b/frame/contracts/fixtures/crypto_hashes.wat
@@ -1,11 +1,11 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 
-	(import "env" "seal_hash_sha2_256" (func $seal_hash_sha2_256 (param i32 i32 i32)))
-	(import "env" "seal_hash_keccak_256" (func $seal_hash_keccak_256 (param i32 i32 i32)))
-	(import "env" "seal_hash_blake2_256" (func $seal_hash_blake2_256 (param i32 i32 i32)))
-	(import "env" "seal_hash_blake2_128" (func $seal_hash_blake2_128 (param i32 i32 i32)))
+	(import "seal0" "seal_hash_sha2_256" (func $seal_hash_sha2_256 (param i32 i32 i32)))
+	(import "seal0" "seal_hash_keccak_256" (func $seal_hash_keccak_256 (param i32 i32 i32)))
+	(import "seal0" "seal_hash_blake2_256" (func $seal_hash_blake2_256 (param i32 i32 i32)))
+	(import "seal0" "seal_hash_blake2_128" (func $seal_hash_blake2_128 (param i32 i32 i32)))
 
 	(import "env" "memory" (memory 1 1))
 

--- a/frame/contracts/fixtures/crypto_hashes.wat
+++ b/frame/contracts/fixtures/crypto_hashes.wat
@@ -1,21 +1,21 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 
-	(import "env" "ext_hash_sha2_256" (func $ext_hash_sha2_256 (param i32 i32 i32)))
-	(import "env" "ext_hash_keccak_256" (func $ext_hash_keccak_256 (param i32 i32 i32)))
-	(import "env" "ext_hash_blake2_256" (func $ext_hash_blake2_256 (param i32 i32 i32)))
-	(import "env" "ext_hash_blake2_128" (func $ext_hash_blake2_128 (param i32 i32 i32)))
+	(import "env" "seal_hash_sha2_256" (func $seal_hash_sha2_256 (param i32 i32 i32)))
+	(import "env" "seal_hash_keccak_256" (func $seal_hash_keccak_256 (param i32 i32 i32)))
+	(import "env" "seal_hash_blake2_256" (func $seal_hash_blake2_256 (param i32 i32 i32)))
+	(import "env" "seal_hash_blake2_128" (func $seal_hash_blake2_128 (param i32 i32 i32)))
 
 	(import "env" "memory" (memory 1 1))
 
 	(type $hash_fn_sig (func (param i32 i32 i32)))
 	(table 8 funcref)
 	(elem (i32.const 1)
-		$ext_hash_sha2_256
-		$ext_hash_keccak_256
-		$ext_hash_blake2_256
-		$ext_hash_blake2_128
+		$seal_hash_sha2_256
+		$seal_hash_keccak_256
+		$seal_hash_blake2_256
+		$seal_hash_blake2_128
 	)
 	(data (i32.const 1) "20202010201008") ;; Output sizes of the hashes in order in hex.
 
@@ -56,7 +56,7 @@
 		(local.set $input_len_ptr (i32.const 256))
 		(local.set $input_ptr (i32.const 10))
 		(i32.store (local.get $input_len_ptr) (i32.const 246))
-		(call $ext_input (local.get $input_ptr) (local.get $input_len_ptr))
+		(call $seal_input (local.get $input_ptr) (local.get $input_len_ptr))
 		(local.set $chosen_hash_fn (i32.load8_u (local.get $input_ptr)))
 		(if (i32.gt_u (local.get $chosen_hash_fn) (i32.const 7))
 			;; We check that the chosen hash fn  identifier is within bounds: [0,7]
@@ -71,7 +71,7 @@
 			(local.get $input_ptr)
 			(local.get $chosen_hash_fn) ;; Which crypto hash function to execute.
 		)
-		(call $ext_return
+		(call $seal_return
 			(i32.const 0)
 			(local.get $input_ptr) ;; Linear memory location of the output buffer.
 			(local.get $output_len) ;; Number of output buffer bytes.

--- a/frame/contracts/fixtures/destroy_and_transfer.wat
+++ b/frame/contracts/fixtures/destroy_and_transfer.wat
@@ -1,10 +1,10 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_get_storage" (func $ext_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) Endowment to send when creating contract.
@@ -35,7 +35,7 @@
 
 	(func (export "deploy")
 		;; Input data is the code hash of the contract to be deployed.
-		(call $ext_input (i32.const 48) (i32.const 96))
+		(call $seal_input (i32.const 48) (i32.const 96))
 		(call $assert
 			(i32.eq
 				(i32.load (i32.const 96))
@@ -46,7 +46,7 @@
 		;; Deploy the contract with the provided code hash.
 		(call $assert
 			(i32.eq
-				(call $ext_instantiate
+				(call $seal_instantiate
 					(i32.const 48)	;; Pointer to the code hash.
 					(i32.const 32)	;; Length of the code hash.
 					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -72,7 +72,7 @@
 		)
 
 		;; Store the return address.
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 16)	;; Pointer to the key
 			(i32.const 80)	;; Pointer to the value
 			(i32.const 8)	;; Length of the value
@@ -83,7 +83,7 @@
 		;; Read address of destination contract from storage.
 		(call $assert
 			(i32.eq
-				(call $ext_get_storage
+				(call $seal_get_storage
 					(i32.const 16)	;; Pointer to the key
 					(i32.const 80)	;; Pointer to the value
 					(i32.const 88)	;; Pointer to the len of the value
@@ -101,7 +101,7 @@
 		;; Calling the destination contract with non-empty input data should fail.
 		(call $assert
 			(i32.eq
-				(call $ext_call
+				(call $seal_call
 					(i32.const 80)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
 					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -120,7 +120,7 @@
 		;; Call the destination contract regularly, forcing it to self-destruct.
 		(call $assert
 			(i32.eq
-				(call $ext_call
+				(call $seal_call
 					(i32.const 80)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
 					(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -140,7 +140,7 @@
 		;; does not keep the contract alive.
 		(call $assert
 			(i32.eq
-				(call $ext_transfer
+				(call $seal_transfer
 					(i32.const 80)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
 					(i32.const 0)	;; Pointer to the buffer with value to transfer

--- a/frame/contracts/fixtures/destroy_and_transfer.wat
+++ b/frame/contracts/fixtures/destroy_and_transfer.wat
@@ -1,10 +1,10 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) Endowment to send when creating contract.

--- a/frame/contracts/fixtures/drain.wat
+++ b/frame/contracts/fixtures/drain.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
-	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_balance" (func $seal_balance (param i32 i32)))
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) reserved for $seal_balance output

--- a/frame/contracts/fixtures/drain.wat
+++ b/frame/contracts/fixtures/drain.wat
@@ -1,9 +1,9 @@
 (module
-	(import "env" "ext_balance" (func $ext_balance (param i32 i32)))
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
+	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 
-	;; [0, 8) reserved for $ext_balance output
+	;; [0, 8) reserved for $seal_balance output
 
 	;; [8, 16) length of the buffer
 	(data (i32.const 8) "\08")
@@ -23,7 +23,7 @@
 
 	(func (export "call")
 		;; Send entire remaining balance to the 0 address.
-		(call $ext_balance (i32.const 0) (i32.const 8))
+		(call $seal_balance (i32.const 0) (i32.const 8))
 
 		;; Balance should be encoded as a u64.
 		(call $assert
@@ -36,7 +36,7 @@
 		;; Self-destruct by sending full balance to the 0 address.
 		(call $assert
 			(i32.eq
-				(call $ext_transfer
+				(call $seal_transfer
 					(i32.const 16)	;; Pointer to destination address
 					(i32.const 8)	;; Length of destination address
 					(i32.const 0)	;; Pointer to the buffer with value to transfer

--- a/frame/contracts/fixtures/instantiate_return_code.wat
+++ b/frame/contracts/fixtures/instantiate_return_code.wat
@@ -3,9 +3,9 @@
 ;; The first 32 byte of input is the code hash to instantiate
 ;; The rest of the input is forwarded to the constructor of the callee
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) address of django

--- a/frame/contracts/fixtures/instantiate_return_code.wat
+++ b/frame/contracts/fixtures/instantiate_return_code.wat
@@ -3,9 +3,9 @@
 ;; The first 32 byte of input is the code hash to instantiate
 ;; The rest of the input is forwarded to the constructor of the callee
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) address of django
@@ -24,10 +24,10 @@
 	(func (export "deploy"))
 
 	(func (export "call")
-		(call $ext_input (i32.const 24) (i32.const 20))
+		(call $seal_input (i32.const 24) (i32.const 20))
 		(i32.store
 			(i32.const 16)
-			(call $ext_instantiate
+			(call $seal_instantiate
 				(i32.const 24) ;; Pointer to the code hash.
 				(i32.const 32) ;; Length of the code hash.
 				(i64.const 0) ;; How much gas to devote for the execution. 0 = all.
@@ -42,6 +42,6 @@
 			)
 		)
 		;; exit with success and take transfer return code to the output buffer
-		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+		(call $seal_return (i32.const 0) (i32.const 16) (i32.const 4))
 	)
 )

--- a/frame/contracts/fixtures/ok_trap_revert.wat
+++ b/frame/contracts/fixtures/ok_trap_revert.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
     (func (export "deploy")

--- a/frame/contracts/fixtures/ok_trap_revert.wat
+++ b/frame/contracts/fixtures/ok_trap_revert.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
     (func (export "deploy")
@@ -13,7 +13,7 @@
 
     (func $ok_trap_revert
         (i32.store (i32.const 4) (i32.const 4))
-        (call $ext_input (i32.const 0) (i32.const 4))
+        (call $seal_input (i32.const 0) (i32.const 4))
         (block $IF_2
             (block $IF_1
                 (block $IF_0
@@ -26,7 +26,7 @@
                 return
             )
             ;; 1 = revert
-            (call $ext_return (i32.const 1) (i32.const 0) (i32.const 0))
+            (call $seal_return (i32.const 1) (i32.const 0) (i32.const 0))
             (unreachable)
         )
         ;; 2 = trap

--- a/frame/contracts/fixtures/restoration.wat
+++ b/frame/contracts/fixtures/restoration.wat
@@ -1,8 +1,8 @@
 (module
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_restore_to"
-		(func $ext_restore_to
+	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_restore_to"
+		(func $seal_restore_to
 			(param i32 i32 i32 i32 i32 i32 i32 i32)
 		)
 	)
@@ -19,7 +19,7 @@
 
 	(func (export "call")
 		;; copy code hash to contract memory
-		(call $ext_input (i32.const 264) (i32.const 304))
+		(call $seal_input (i32.const 264) (i32.const 304))
 		(call $assert
 			(i32.eq
 				(i32.load (i32.const 304))
@@ -27,7 +27,7 @@
 			)
 		)
 
-		(call $ext_restore_to
+		(call $seal_restore_to
 			;; Pointer and length of the encoded dest buffer.
 			(i32.const 256)
 			(i32.const 8)
@@ -45,14 +45,14 @@
 	)
 	(func (export "deploy")
 		;; Data to restore
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 0)
 			(i32.const 0)
 			(i32.const 4)
 		)
 
 		;; ACL
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 100)
 			(i32.const 0)
 			(i32.const 4)
@@ -68,7 +68,7 @@
 	;; Address of bob
 	(data (i32.const 256) "\02\00\00\00\00\00\00\00")
 
-	;; [264, 296) Code hash of SET_RENT (copied here by ext_input)
+	;; [264, 296) Code hash of SET_RENT (copied here by seal_input)
 
 	;; [296, 304) Rent allowance
 	(data (i32.const 296) "\32\00\00\00\00\00\00\00")

--- a/frame/contracts/fixtures/restoration.wat
+++ b/frame/contracts/fixtures/restoration.wat
@@ -1,7 +1,7 @@
 (module
-	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_restore_to"
+	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_restore_to"
 		(func $seal_restore_to
 			(param i32 i32 i32 i32 i32 i32 i32 i32)
 		)

--- a/frame/contracts/fixtures/return_from_start_fn.wat
+++ b/frame/contracts/fixtures/return_from_start_fn.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
-	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(start $start)

--- a/frame/contracts/fixtures/return_from_start_fn.wat
+++ b/frame/contracts/fixtures/return_from_start_fn.wat
@@ -1,17 +1,17 @@
 (module
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
-	(import "env" "ext_deposit_event" (func $ext_deposit_event (param i32 i32 i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(start $start)
 	(func $start
-		(call $ext_deposit_event
+		(call $seal_deposit_event
 			(i32.const 0) ;; The topics buffer
 			(i32.const 0) ;; The topics buffer's length
 			(i32.const 8) ;; The data buffer
 			(i32.const 4) ;; The data buffer's length
 		)
-		(call $ext_return
+		(call $seal_return
 			(i32.const 0)
 			(i32.const 8)
 			(i32.const 4)

--- a/frame/contracts/fixtures/return_with_data.wat
+++ b/frame/contracts/fixtures/return_with_data.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 128) buffer where input is copied

--- a/frame/contracts/fixtures/return_with_data.wat
+++ b/frame/contracts/fixtures/return_with_data.wat
@@ -1,6 +1,6 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 128) buffer where input is copied
@@ -16,11 +16,11 @@
 	;; Call reads the first 4 bytes (LE) as the exit status and returns the rest as output data.
 	(func $call (export "call")
 		;; Copy input into this contracts memory.
-		(call $ext_input (i32.const 0) (i32.const 128))
+		(call $seal_input (i32.const 0) (i32.const 128))
 
 		;; Copy all but the first 4 bytes of the input data as the output data.
 		;; Use the first byte as exit status
-		(call $ext_return
+		(call $seal_return
 			(i32.load8_u (i32.const 0))	;; Exit status
 			(i32.const 4)	;; Pointer to the data to return.
 			(i32.sub		;; Count of bytes to copy.

--- a/frame/contracts/fixtures/self_destruct.wat
+++ b/frame/contracts/fixtures/self_destruct.wat
@@ -1,8 +1,8 @@
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_address" (func $seal_address (param i32 i32)))
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_address" (func $seal_address (param i32 i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) reserved for $seal_address output

--- a/frame/contracts/fixtures/self_destruct.wat
+++ b/frame/contracts/fixtures/self_destruct.wat
@@ -1,11 +1,11 @@
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_address" (func $ext_address (param i32 i32)))
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_address" (func $seal_address (param i32 i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
-	;; [0, 8) reserved for $ext_address output
+	;; [0, 8) reserved for $seal_address output
 
 	;; [8, 16) length of the buffer
 	(data (i32.const 8) "\08")
@@ -13,7 +13,7 @@
 	;; [16, 24) Address of django
 	(data (i32.const 16) "\04\00\00\00\00\00\00\00")
 
-	;; [24, 32) reserved for output of $ext_input
+	;; [24, 32) reserved for output of $seal_input
 
 	;; [32, 36) length of the buffer
 	(data (i32.const 32) "\04")
@@ -36,10 +36,10 @@
 		;; This should trap instead of self-destructing since a contract cannot be removed live in
 		;; the execution stack cannot be removed. If the recursive call traps, then trap here as
 		;; well.
-		(call $ext_input (i32.const 24) (i32.const 32))
+		(call $seal_input (i32.const 24) (i32.const 32))
 		(if (i32.load (i32.const 32))
 			(then
-				(call $ext_address (i32.const 0) (i32.const 8))
+				(call $seal_address (i32.const 0) (i32.const 8))
 
 				;; Expect address to be 8 bytes.
 				(call $assert
@@ -52,7 +52,7 @@
 				;; Recursively call self with empty input data.
 				(call $assert
 					(i32.eq
-						(call $ext_call
+						(call $seal_call
 							(i32.const 0)	;; Pointer to own address
 							(i32.const 8)	;; Length of own address
 							(i64.const 0)	;; How much gas to devote for the execution. 0 = all.
@@ -69,11 +69,11 @@
 			)
 			(else
 				;; Try to terminate and give balance to django.
-				(call $ext_terminate
+				(call $seal_terminate
 					(i32.const 16)	;; Pointer to beneficiary address
 					(i32.const 8)	;; Length of beneficiary address
 				)
-				(unreachable) ;; ext_terminate never returns
+				(unreachable) ;; seal_terminate never returns
 			)
 		)
 	)

--- a/frame/contracts/fixtures/self_destructing_constructor.wat
+++ b/frame/contracts/fixtures/self_destructing_constructor.wat
@@ -1,5 +1,5 @@
 (module
-	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
+	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)
@@ -13,7 +13,7 @@
 
 	(func (export "deploy")
 		;; Self-destruct by sending full balance to the 0 address.
-		(call $ext_terminate
+		(call $seal_terminate
 			(i32.const 0)	;; Pointer to destination address
 			(i32.const 8)	;; Length of destination address
 		)

--- a/frame/contracts/fixtures/self_destructing_constructor.wat
+++ b/frame/contracts/fixtures/self_destructing_constructor.wat
@@ -1,5 +1,5 @@
 (module
-	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
+	(import "seal0" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func $assert (param i32)

--- a/frame/contracts/fixtures/set_empty_storage.wat
+++ b/frame/contracts/fixtures/set_empty_storage.wat
@@ -1,12 +1,12 @@
 ;; This module stores a KV pair into the storage
 (module
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
+	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
 	(import "env" "memory" (memory 16 16))
 
 	(func (export "call")
 	)
 	(func (export "deploy")
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 0)				;; Pointer to storage key
 			(i32.const 0)				;; Pointer to value
 			(i32.load (i32.const 0))	;; Size of value

--- a/frame/contracts/fixtures/set_empty_storage.wat
+++ b/frame/contracts/fixtures/set_empty_storage.wat
@@ -1,6 +1,6 @@
 ;; This module stores a KV pair into the storage
 (module
-	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
 	(import "env" "memory" (memory 16 16))
 
 	(func (export "call")

--- a/frame/contracts/fixtures/set_rent.wat
+++ b/frame/contracts/fixtures/set_rent.wat
@@ -1,9 +1,9 @@
 (module
-	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
-	(import "env" "seal_clear_storage" (func $seal_clear_storage (param i32)))
-	(import "env" "seal_set_rent_allowance" (func $seal_set_rent_allowance (param i32 i32)))
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "seal0" "seal_clear_storage" (func $seal_clear_storage (param i32)))
+	(import "seal0" "seal_set_rent_allowance" (func $seal_set_rent_allowance (param i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; insert a value of 4 bytes into storage

--- a/frame/contracts/fixtures/set_rent.wat
+++ b/frame/contracts/fixtures/set_rent.wat
@@ -1,14 +1,14 @@
 (module
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
-	(import "env" "ext_clear_storage" (func $ext_clear_storage (param i32)))
-	(import "env" "ext_set_rent_allowance" (func $ext_set_rent_allowance (param i32 i32)))
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
+	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "env" "seal_clear_storage" (func $seal_clear_storage (param i32)))
+	(import "env" "seal_set_rent_allowance" (func $seal_set_rent_allowance (param i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; insert a value of 4 bytes into storage
 	(func $call_0
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 1)
 			(i32.const 0)
 			(i32.const 4)
@@ -17,7 +17,7 @@
 
 	;; remove the value inserted by call_1
 	(func $call_1
-		(call $ext_clear_storage
+		(call $seal_clear_storage
 			(i32.const 1)
 		)
 	)
@@ -26,7 +26,7 @@
 	(func $call_2
 		(call $assert
 			(i32.eq
-				(call $ext_transfer (i32.const 68) (i32.const 8) (i32.const 76) (i32.const 8))
+				(call $seal_transfer (i32.const 68) (i32.const 8) (i32.const 76) (i32.const 8))
 				(i32.const 0)
 			)
 		)
@@ -48,7 +48,7 @@
 	(func (export "call")
 		(local $input_size i32)
 		(i32.store (i32.const 64) (i32.const 64))
-		(call $ext_input (i32.const 1024) (i32.const 64))
+		(call $seal_input (i32.const 1024) (i32.const 64))
 		(set_local $input_size
 			(i32.load (i32.const 64))
 		)
@@ -76,16 +76,16 @@
 	;; Set into storage a 4 bytes value
 	;; Set call set_rent_allowance with input
 	(func (export "deploy")
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 0)
 			(i32.const 0)
 			(i32.const 4)
 		)
-		(call $ext_input
+		(call $seal_input
 			(i32.const 0)
 			(i32.const 64)
 		)
-		(call $ext_set_rent_allowance
+		(call $seal_set_rent_allowance
 			(i32.const 0)
 			(i32.load (i32.const 64))
 		)

--- a/frame/contracts/fixtures/storage_size.wat
+++ b/frame/contracts/fixtures/storage_size.wat
@@ -1,7 +1,7 @@
 (module
-	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "seal0" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
 	(import "env" "memory" (memory 16 16))
 
 	;; [0, 32) storage key

--- a/frame/contracts/fixtures/storage_size.wat
+++ b/frame/contracts/fixtures/storage_size.wat
@@ -1,7 +1,7 @@
 (module
-	(import "env" "ext_get_storage" (func $ext_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "ext_set_storage" (func $ext_set_storage (param i32 i32 i32)))
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
+	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "env" "seal_set_storage" (func $seal_set_storage (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
 	(import "env" "memory" (memory 16 16))
 
 	;; [0, 32) storage key
@@ -12,10 +12,10 @@
 	;; [36, 40) size of the input buffer
 	(data (i32.const 36) "\04")
 
-	;; [40, 44) size of buffer for ext_get_storage set to max
+	;; [40, 44) size of buffer for seal_get_storage set to max
 	(data (i32.const 40) "\FF\FF\FF\FF")
 
-	;; [44, inf) ext_get_storage buffer
+	;; [44, inf) seal_get_storage buffer
 
 	(func $assert (param i32)
 		(block $ok
@@ -27,7 +27,7 @@
 	)
 
 	(func (export "call")
-		(call $ext_input (i32.const 32) (i32.const 36))
+		(call $seal_input (i32.const 32) (i32.const 36))
 
 		;; assert input size == 4
 		(call $assert
@@ -38,7 +38,7 @@
 		)
 
 		;; place a garbage value in storage, the size of which is specified by the call input.
-		(call $ext_set_storage
+		(call $seal_set_storage
 			(i32.const 0)		;; Pointer to storage key
 			(i32.const 0)		;; Pointer to value
 			(i32.load (i32.const 32))	;; Size of value
@@ -46,7 +46,7 @@
 
 		(call $assert
 			(i32.eq
-				(call $ext_get_storage
+				(call $seal_get_storage
 					(i32.const 0)		;; Pointer to storage key
 					(i32.const 44)		;; buffer where to copy result
 					(i32.const 40)		;; pointer to size of buffer

--- a/frame/contracts/fixtures/transfer_return_code.wat
+++ b/frame/contracts/fixtures/transfer_return_code.wat
@@ -1,8 +1,8 @@
 ;; This transfers 100 balance to the zero account and copies the return code
 ;; of this transfer to the output buffer.
 (module
-	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) zero-adress

--- a/frame/contracts/fixtures/transfer_return_code.wat
+++ b/frame/contracts/fixtures/transfer_return_code.wat
@@ -1,8 +1,8 @@
 ;; This transfers 100 balance to the zero account and copies the return code
 ;; of this transfer to the output buffer.
 (module
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 8) zero-adress
@@ -18,7 +18,7 @@
 	(func (export "call")
 		(i32.store
 			(i32.const 16)
-			(call $ext_transfer
+			(call $seal_transfer
 				(i32.const 0) ;; ptr to destination address
 				(i32.const 8) ;; length of destination address
 				(i32.const 8) ;; ptr to value to transfer
@@ -26,6 +26,6 @@
 			)
 		)
 		;; exit with success and take transfer return code to the output buffer
-		(call $ext_return (i32.const 0) (i32.const 16) (i32.const 4))
+		(call $seal_return (i32.const 0) (i32.const 16) (i32.const 4))
 	)
 )

--- a/frame/contracts/src/benchmarking.rs
+++ b/frame/contracts/src/benchmarking.rs
@@ -130,9 +130,9 @@ benchmarks! {
 
     // Instantiate uses a dummy contract constructor to measure the overhead of the instantiate.
     // The size of the data has no influence on the costs of this extrinsic as long as the contract
-    // won't call `ext_input` in its constructor to copy the data to contract memory.
+    // won't call `seal_input` in its constructor to copy the data to contract memory.
     // The dummy contract used here does not do this. The costs for the data copy is billed as
-    // part of `ext_input`.
+    // part of `seal_input`.
     instantiate {
         let data = vec![0u8; 128];
         let endowment = Config::<T>::subsistence_threshold_uncached();

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -58,9 +58,9 @@ pub enum TransactorKind {
 /// Output of a contract call or instantiation which ran to completion.
 #[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub struct ExecReturnValue {
-	/// Flags passed along by `ext_return`. Empty when `ext_return` was never called.
+	/// Flags passed along by `seal_return`. Empty when `seal_return` was never called.
 	pub flags: ReturnFlags,
-	/// Buffer passed along by `ext_return`. Empty when `ext_return` was never called.
+	/// Buffer passed along by `seal_return`. Empty when `seal_return` was never called.
 	pub data: Vec<u8>,
 }
 
@@ -355,7 +355,7 @@ where
 		// `collect_rent` will be done on first call and destination contract and balance
 		// cannot be changed before the first call
 		// We do not allow 'calling' plain accounts. For transfering value
-		// `ext_transfer` must be used.
+		// `seal_transfer` must be used.
 		let contract = if let Some(ContractInfo::Alive(info)) = rent::collect_rent::<T>(&dest) {
 			info
 		} else {
@@ -455,7 +455,7 @@ where
 
 			// We need each contract that exists to be above the subsistence threshold
 			// in order to keep up the guarantuee that we always leave a tombstone behind
-			// with the exception of a contract that called `ext_terminate`.
+			// with the exception of a contract that called `seal_terminate`.
 			if T::Currency::total_balance(&dest) < nested.config.subsistence_threshold() {
 				Err(Error::<T>::NewContractNotFunded)?
 			}
@@ -599,7 +599,7 @@ fn transfer<'a, T: Trait, V: Vm<T>, L: Loader<T>>(
 		Err(Error::<T>::OutOfGas)?
 	}
 
-	// Only ext_terminate is allowed to bring the sender below the subsistence
+	// Only seal_terminate is allowed to bring the sender below the subsistence
 	// threshold or even existential deposit.
 	let existence_requirement = match (cause, origin) {
 		(Terminate, _) => ExistenceRequirement::AllowDeath,

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -419,7 +419,7 @@ decl_error! {
 		OutputBufferTooSmall,
 		/// Performing the requested transfer would have brought the contract below
 		/// the subsistence threshold. No transfer is allowed to do this in order to allow
-		/// for a tombstone to be created. Use `ext_terminate` to remove a contract without
+		/// for a tombstone to be created. Use `seal_terminate` to remove a contract without
 		/// leaving a tombstone behind.
 		BelowSubsistenceThreshold,
 		/// The newly created contract is below the subsistence threshold after executing
@@ -768,7 +768,7 @@ impl<T: Trait> Config<T> {
 	/// Rent or any contract initiated balance transfer mechanism cannot make the balance lower
 	/// than the subsistence threshold in order to guarantee that a tombstone is created.
 	///
-	/// The only way to completely kill a contract without a tombstone is calling `ext_terminate`.
+	/// The only way to completely kill a contract without a tombstone is calling `seal_terminate`.
 	pub fn subsistence_threshold(&self) -> BalanceOf<T> {
 		self.existential_deposit.saturating_add(self.tombstone_deposit)
 	}
@@ -846,7 +846,7 @@ pub struct Schedule {
 	/// Maximum allowed size of a declared table.
 	pub max_table_size: u32,
 
-	/// Whether the `ext_println` function is allowed to be used contracts.
+	/// Whether the `seal_println` function is allowed to be used contracts.
 	/// MUST only be enabled for `dev` chains, NOT for production chains
 	pub enable_println: bool,
 

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -358,7 +358,7 @@ fn account_removal_does_not_remove_storage() {
 		//
 		// This does not remove the contract storage as we are not notified about a
 		// account removal. This cannot happen in reality because a contract can only
-		// remove itself by `ext_terminate`. There is no external event that can remove
+		// remove itself by `seal_terminate`. There is no external event that can remove
 		// the account appart from that.
 		assert_ok!(Balances::transfer(Origin::signed(ALICE), BOB, 20));
 
@@ -1546,7 +1546,7 @@ fn cannot_self_destruct_in_constructor() {
 			let _ = Balances::deposit_creating(&ALICE, 1_000_000);
 			assert_ok!(Contracts::put_code(Origin::signed(ALICE), wasm));
 
-			// Fail to instantiate the BOB because the contructor calls ext_terminate.
+			// Fail to instantiate the BOB because the contructor calls seal_terminate.
 			assert_err_ignore_postinfo!(
 				Contracts::instantiate(
 					Origin::signed(ALICE),

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -127,9 +127,9 @@ impl<'a, T: Trait> crate::exec::Vm<T> for WasmVm<'a> {
 				});
 
 		let mut imports = sp_sandbox::EnvironmentDefinitionBuilder::new();
-		imports.add_memory("env", "memory", memory.clone());
+		imports.add_memory(self::prepare::IMPORT_MODULE_MEMORY, "memory", memory.clone());
 		runtime::Env::impls(&mut |name, func_ptr| {
-			imports.add_host_func("env", name, func_ptr);
+			imports.add_host_func(self::prepare::IMPORT_MODULE_FN, name, func_ptr);
 		});
 
 		let mut runtime = Runtime::new(
@@ -483,7 +483,7 @@ mod tests {
 	;;    value_ptr: u32,
 	;;    value_len: u32,
 	;;) -> u32
-	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
@@ -541,7 +541,7 @@ mod tests {
 	;;    output_ptr: u32,
 	;;    output_len_ptr: u32
 	;;) -> u32
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
@@ -608,7 +608,7 @@ mod tests {
 	;;     output_ptr: u32,
 	;;     output_len_ptr: u32
 	;; ) -> u32
-	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
@@ -669,7 +669,7 @@ mod tests {
 	;;     beneficiary_ptr: u32,
 	;;     beneficiary_len: u32,
 	;; )
-	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
+	(import "seal0" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(call $seal_terminate
@@ -717,7 +717,7 @@ mod tests {
 	;;    output_ptr: u32,
 	;;    output_len_ptr: u32
 	;;) -> u32
-	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "seal0" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
@@ -770,8 +770,8 @@ mod tests {
 
 	const CODE_GET_STORAGE: &str = r#"
 (module
-	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 32) key for get storage
@@ -852,7 +852,7 @@ mod tests {
 	/// calls `seal_caller` and compares the result with the constant 42.
 	const CODE_CALLER: &str = r#"
 (module
-	(import "env" "seal_caller" (func $seal_caller (param i32 i32)))
+	(import "seal0" "seal_caller" (func $seal_caller (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -905,7 +905,7 @@ mod tests {
 	/// calls `seal_address` and compares the result with the constant 69.
 	const CODE_ADDRESS: &str = r#"
 (module
-	(import "env" "seal_address" (func $seal_address (param i32 i32)))
+	(import "seal0" "seal_address" (func $seal_address (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -957,7 +957,7 @@ mod tests {
 
 	const CODE_BALANCE: &str = r#"
 (module
-	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
+	(import "seal0" "seal_balance" (func $seal_balance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1009,7 +1009,7 @@ mod tests {
 
 	const CODE_GAS_PRICE: &str = r#"
 (module
-	(import "env" "seal_weight_to_fee" (func $seal_weight_to_fee (param i64 i32 i32)))
+	(import "seal0" "seal_weight_to_fee" (func $seal_weight_to_fee (param i64 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1061,8 +1061,8 @@ mod tests {
 
 	const CODE_GAS_LEFT: &str = r#"
 (module
-	(import "env" "seal_gas_left" (func $seal_gas_left (param i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_gas_left" (func $seal_gas_left (param i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1116,7 +1116,7 @@ mod tests {
 
 	const CODE_VALUE_TRANSFERRED: &str = r#"
 (module
-	(import "env" "seal_value_transferred" (func $seal_value_transferred (param i32 i32)))
+	(import "seal0" "seal_value_transferred" (func $seal_value_transferred (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1168,7 +1168,7 @@ mod tests {
 
 	const CODE_RETURN_FROM_START_FN: &str = r#"
 (module
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(start $start)
@@ -1204,7 +1204,7 @@ mod tests {
 
 	const CODE_TIMESTAMP_NOW: &str = r#"
 (module
-	(import "env" "seal_now" (func $seal_now (param i32 i32)))
+	(import "seal0" "seal_now" (func $seal_now (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1256,7 +1256,7 @@ mod tests {
 
 	const CODE_MINIMUM_BALANCE: &str = r#"
 (module
-	(import "env" "seal_minimum_balance" (func $seal_minimum_balance (param i32 i32)))
+	(import "seal0" "seal_minimum_balance" (func $seal_minimum_balance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1307,7 +1307,7 @@ mod tests {
 
 	const CODE_TOMBSTONE_DEPOSIT: &str = r#"
 (module
-	(import "env" "seal_tombstone_deposit" (func $seal_tombstone_deposit (param i32 i32)))
+	(import "seal0" "seal_tombstone_deposit" (func $seal_tombstone_deposit (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1358,8 +1358,8 @@ mod tests {
 
 	const CODE_RANDOM: &str = r#"
 (module
-	(import "env" "seal_random" (func $seal_random (param i32 i32 i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_random" (func $seal_random (param i32 i32 i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0,128) is reserved for the result of PRNG.
@@ -1433,7 +1433,7 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT: &str = r#"
 (module
-	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
+	(import "seal0" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
@@ -1475,7 +1475,7 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT_MAX_TOPICS: &str = r#"
 (module
-	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
+	(import "seal0" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
@@ -1521,7 +1521,7 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT_DUPLICATES: &str = r#"
 (module
-	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
+	(import "seal0" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
@@ -1567,7 +1567,7 @@ mod tests {
 	/// calls `seal_block_number` compares the result with the constant 121.
 	const CODE_BLOCK_NUMBER: &str = r#"
 (module
-	(import "env" "seal_block_number" (func $seal_block_number (param i32 i32)))
+	(import "seal0" "seal_block_number" (func $seal_block_number (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1619,8 +1619,8 @@ mod tests {
 
 	const CODE_RETURN_WITH_DATA: &str = r#"
 (module
-	(import "env" "seal_input" (func $seal_input (param i32 i32)))
-	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
+	(import "seal0" "seal_input" (func $seal_input (param i32 i32)))
+	(import "seal0" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 32) "\20")
@@ -1677,7 +1677,7 @@ mod tests {
 
 	const CODE_OUT_OF_BOUNDS_ACCESS: &str = r#"
 (module
-	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
+	(import "seal0" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "deploy"))
@@ -1712,7 +1712,7 @@ mod tests {
 
 	const CODE_DECODE_FAILURE: &str = r#"
 (module
-	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
+	(import "seal0" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "deploy"))

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -477,17 +477,17 @@ mod tests {
 
 	const CODE_TRANSFER: &str = r#"
 (module
-	;; ext_transfer(
+	;; seal_transfer(
 	;;    account_ptr: u32,
 	;;    account_len: u32,
 	;;    value_ptr: u32,
 	;;    value_len: u32,
 	;;) -> u32
-	(import "env" "ext_transfer" (func $ext_transfer (param i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_transfer" (func $seal_transfer (param i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
-			(call $ext_transfer
+			(call $seal_transfer
 				(i32.const 4)  ;; Pointer to "account" address.
 				(i32.const 8)  ;; Length of "account" address.
 				(i32.const 12) ;; Pointer to the buffer with value to transfer
@@ -530,7 +530,7 @@ mod tests {
 
 	const CODE_CALL: &str = r#"
 (module
-	;; ext_call(
+	;; seal_call(
 	;;    callee_ptr: u32,
 	;;    callee_len: u32,
 	;;    gas: u64,
@@ -541,11 +541,11 @@ mod tests {
 	;;    output_ptr: u32,
 	;;    output_len_ptr: u32
 	;;) -> u32
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
-			(call $ext_call
+			(call $seal_call
 				(i32.const 4)  ;; Pointer to "callee" address.
 				(i32.const 8)  ;; Length of "callee" address.
 				(i64.const 0)  ;; How much gas to devote for the execution. 0 = all.
@@ -594,7 +594,7 @@ mod tests {
 
 	const CODE_INSTANTIATE: &str = r#"
 (module
-	;; ext_instantiate(
+	;; seal_instantiate(
 	;;     code_ptr: u32,
 	;;     code_len: u32,
 	;;     gas: u64,
@@ -608,11 +608,11 @@ mod tests {
 	;;     output_ptr: u32,
 	;;     output_len_ptr: u32
 	;; ) -> u32
-	(import "env" "ext_instantiate" (func $ext_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_instantiate" (func $seal_instantiate (param i32 i32 i64 i32 i32 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
-			(call $ext_instantiate
+			(call $seal_instantiate
 				(i32.const 16)   ;; Pointer to `code_hash`
 				(i32.const 32)   ;; Length of `code_hash`
 				(i64.const 0)    ;; How much gas to devote for the execution. 0 = all.
@@ -665,14 +665,14 @@ mod tests {
 
 	const CODE_TERMINATE: &str = r#"
 (module
-	;; ext_terminate(
+	;; seal_terminate(
 	;;     beneficiary_ptr: u32,
 	;;     beneficiary_len: u32,
 	;; )
-	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
+	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
-		(call $ext_terminate
+		(call $seal_terminate
 			(i32.const 4)  ;; Pointer to "beneficiary" address.
 			(i32.const 8)  ;; Length of "beneficiary" address.
 		)
@@ -706,7 +706,7 @@ mod tests {
 
 	const CODE_TRANSFER_LIMITED_GAS: &str = r#"
 (module
-	;; ext_call(
+	;; seal_call(
 	;;    callee_ptr: u32,
 	;;    callee_len: u32,
 	;;    gas: u64,
@@ -717,11 +717,11 @@ mod tests {
 	;;    output_ptr: u32,
 	;;    output_len_ptr: u32
 	;;) -> u32
-	(import "env" "ext_call" (func $ext_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
+	(import "env" "seal_call" (func $seal_call (param i32 i32 i64 i32 i32 i32 i32 i32 i32) (result i32)))
 	(import "env" "memory" (memory 1 1))
 	(func (export "call")
 		(drop
-			(call $ext_call
+			(call $seal_call
 				(i32.const 4)  ;; Pointer to "callee" address.
 				(i32.const 8)  ;; Length of "callee" address.
 				(i64.const 228)  ;; How much gas to devote for the execution.
@@ -770,8 +770,8 @@ mod tests {
 
 	const CODE_GET_STORAGE: &str = r#"
 (module
-	(import "env" "ext_get_storage" (func $ext_get_storage (param i32 i32 i32) (result i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_get_storage" (func $seal_get_storage (param i32 i32 i32) (result i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0, 32) key for get storage
@@ -800,7 +800,7 @@ mod tests {
 		;; Load a storage value into contract memory.
 		(call $assert
 			(i32.eq
-				(call $ext_get_storage
+				(call $seal_get_storage
 					(i32.const 0)		;; The pointer to the storage key to fetch
 					(i32.const 36)		;; Pointer to the output buffer
 					(i32.const 32)		;; Pointer to the size of the buffer
@@ -818,13 +818,13 @@ mod tests {
 		)
 
 		;; Return the contents of the buffer
-		(call $ext_return
+		(call $seal_return
 			(i32.const 0)
 			(i32.const 36)
 			(get_local $buf_size)
 		)
 
-		;; env:ext_return doesn't return, so this is effectively unreachable.
+		;; env:seal_return doesn't return, so this is effectively unreachable.
 		(unreachable)
 	)
 
@@ -849,10 +849,10 @@ mod tests {
 		assert_eq!(output, ExecReturnValue { flags: ReturnFlags::empty(), data: [0x22; 32].to_vec() });
 	}
 
-	/// calls `ext_caller` and compares the result with the constant 42.
+	/// calls `seal_caller` and compares the result with the constant 42.
 	const CODE_CALLER: &str = r#"
 (module
-	(import "env" "ext_caller" (func $ext_caller (param i32 i32)))
+	(import "env" "seal_caller" (func $seal_caller (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -869,7 +869,7 @@ mod tests {
 
 	(func (export "call")
 		;; fill the buffer with the caller.
-		(call $ext_caller (i32.const 0) (i32.const 32))
+		(call $seal_caller (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -902,10 +902,10 @@ mod tests {
 		).unwrap();
 	}
 
-	/// calls `ext_address` and compares the result with the constant 69.
+	/// calls `seal_address` and compares the result with the constant 69.
 	const CODE_ADDRESS: &str = r#"
 (module
-	(import "env" "ext_address" (func $ext_address (param i32 i32)))
+	(import "env" "seal_address" (func $seal_address (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -922,7 +922,7 @@ mod tests {
 
 	(func (export "call")
 		;; fill the buffer with the self address.
-		(call $ext_address (i32.const 0) (i32.const 32))
+		(call $seal_address (i32.const 0) (i32.const 32))
 
 		;; assert size == 8
 		(call $assert
@@ -957,7 +957,7 @@ mod tests {
 
 	const CODE_BALANCE: &str = r#"
 (module
-	(import "env" "ext_balance" (func $ext_balance (param i32 i32)))
+	(import "env" "seal_balance" (func $seal_balance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -974,7 +974,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the balance in the buffer
-		(call $ext_balance (i32.const 0) (i32.const 32))
+		(call $seal_balance (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1009,7 +1009,7 @@ mod tests {
 
 	const CODE_GAS_PRICE: &str = r#"
 (module
-	(import "env" "ext_weight_to_fee" (func $ext_weight_to_fee (param i64 i32 i32)))
+	(import "env" "seal_weight_to_fee" (func $seal_weight_to_fee (param i64 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1026,7 +1026,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the gas price in the buffer
-		(call $ext_weight_to_fee (i64.const 2) (i32.const 0) (i32.const 32))
+		(call $seal_weight_to_fee (i64.const 2) (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1061,8 +1061,8 @@ mod tests {
 
 	const CODE_GAS_LEFT: &str = r#"
 (module
-	(import "env" "ext_gas_left" (func $ext_gas_left (param i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_gas_left" (func $seal_gas_left (param i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1079,7 +1079,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the gas left in the buffer
-		(call $ext_gas_left (i32.const 0) (i32.const 32))
+		(call $seal_gas_left (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1090,7 +1090,7 @@ mod tests {
 		)
 
 		;; return gas left
-		(call $ext_return (i32.const 0) (i32.const 0) (i32.const 8))
+		(call $seal_return (i32.const 0) (i32.const 0) (i32.const 8))
 
 		(unreachable)
 	)
@@ -1116,7 +1116,7 @@ mod tests {
 
 	const CODE_VALUE_TRANSFERRED: &str = r#"
 (module
-	(import "env" "ext_value_transferred" (func $ext_value_transferred (param i32 i32)))
+	(import "env" "seal_value_transferred" (func $seal_value_transferred (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1133,7 +1133,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the value transferred in the buffer
-		(call $ext_value_transferred (i32.const 0) (i32.const 32))
+		(call $seal_value_transferred (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1168,12 +1168,12 @@ mod tests {
 
 	const CODE_RETURN_FROM_START_FN: &str = r#"
 (module
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(start $start)
 	(func $start
-		(call $ext_return
+		(call $seal_return
 			(i32.const 0)
 			(i32.const 8)
 			(i32.const 4)
@@ -1204,7 +1204,7 @@ mod tests {
 
 	const CODE_TIMESTAMP_NOW: &str = r#"
 (module
-	(import "env" "ext_now" (func $ext_now (param i32 i32)))
+	(import "env" "seal_now" (func $seal_now (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1221,7 +1221,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the block timestamp in the buffer
-		(call $ext_now (i32.const 0) (i32.const 32))
+		(call $seal_now (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1256,7 +1256,7 @@ mod tests {
 
 	const CODE_MINIMUM_BALANCE: &str = r#"
 (module
-	(import "env" "ext_minimum_balance" (func $ext_minimum_balance (param i32 i32)))
+	(import "env" "seal_minimum_balance" (func $seal_minimum_balance (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1272,7 +1272,7 @@ mod tests {
 	)
 
 	(func (export "call")
-		(call $ext_minimum_balance (i32.const 0) (i32.const 32))
+		(call $seal_minimum_balance (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1307,7 +1307,7 @@ mod tests {
 
 	const CODE_TOMBSTONE_DEPOSIT: &str = r#"
 (module
-	(import "env" "ext_tombstone_deposit" (func $ext_tombstone_deposit (param i32 i32)))
+	(import "env" "seal_tombstone_deposit" (func $seal_tombstone_deposit (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1323,7 +1323,7 @@ mod tests {
 	)
 
 	(func (export "call")
-		(call $ext_tombstone_deposit (i32.const 0) (i32.const 32))
+		(call $seal_tombstone_deposit (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1358,8 +1358,8 @@ mod tests {
 
 	const CODE_RANDOM: &str = r#"
 (module
-	(import "env" "ext_random" (func $ext_random (param i32 i32 i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_random" (func $seal_random (param i32 i32 i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; [0,128) is reserved for the result of PRNG.
@@ -1384,7 +1384,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the block random seed in the buffer
-		(call $ext_random
+		(call $seal_random
 			(i32.const 128) ;; Pointer in memory to the start of the subject buffer
 			(i32.const 32) ;; The subject buffer's length
 			(i32.const 0) ;; Pointer to the output buffer
@@ -1400,7 +1400,7 @@ mod tests {
 		)
 
 		;; return the random data
-		(call $ext_return
+		(call $seal_return
 			(i32.const 0)
 			(i32.const 0)
 			(i32.const 32)
@@ -1433,11 +1433,11 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT: &str = r#"
 (module
-	(import "env" "ext_deposit_event" (func $ext_deposit_event (param i32 i32 i32 i32)))
+	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
-		(call $ext_deposit_event
+		(call $seal_deposit_event
 			(i32.const 32) ;; Pointer to the start of topics buffer
 			(i32.const 33) ;; The length of the topics buffer.
 			(i32.const 8) ;; Pointer to the start of the data buffer
@@ -1475,11 +1475,11 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT_MAX_TOPICS: &str = r#"
 (module
-	(import "env" "ext_deposit_event" (func $ext_deposit_event (param i32 i32 i32 i32)))
+	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
-		(call $ext_deposit_event
+		(call $seal_deposit_event
 			(i32.const 32) ;; Pointer to the start of topics buffer
 			(i32.const 161) ;; The length of the topics buffer.
 			(i32.const 8) ;; Pointer to the start of the data buffer
@@ -1521,11 +1521,11 @@ mod tests {
 
 	const CODE_DEPOSIT_EVENT_DUPLICATES: &str = r#"
 (module
-	(import "env" "ext_deposit_event" (func $ext_deposit_event (param i32 i32 i32 i32)))
+	(import "env" "seal_deposit_event" (func $seal_deposit_event (param i32 i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "call")
-		(call $ext_deposit_event
+		(call $seal_deposit_event
 			(i32.const 32) ;; Pointer to the start of topics buffer
 			(i32.const 129) ;; The length of the topics buffer.
 			(i32.const 8) ;; Pointer to the start of the data buffer
@@ -1564,10 +1564,10 @@ mod tests {
 		);
 	}
 
-	/// calls `ext_block_number` compares the result with the constant 121.
+	/// calls `seal_block_number` compares the result with the constant 121.
 	const CODE_BLOCK_NUMBER: &str = r#"
 (module
-	(import "env" "ext_block_number" (func $ext_block_number (param i32 i32)))
+	(import "env" "seal_block_number" (func $seal_block_number (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	;; size of our buffer is 32 bytes
@@ -1584,7 +1584,7 @@ mod tests {
 
 	(func (export "call")
 		;; This stores the block height in the buffer
-		(call $ext_block_number (i32.const 0) (i32.const 32))
+		(call $seal_block_number (i32.const 0) (i32.const 32))
 
 		;; assert len == 8
 		(call $assert
@@ -1619,8 +1619,8 @@ mod tests {
 
 	const CODE_RETURN_WITH_DATA: &str = r#"
 (module
-	(import "env" "ext_input" (func $ext_input (param i32 i32)))
-	(import "env" "ext_return" (func $ext_return (param i32 i32 i32)))
+	(import "env" "seal_input" (func $seal_input (param i32 i32)))
+	(import "env" "seal_return" (func $seal_return (param i32 i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(data (i32.const 32) "\20")
@@ -1633,13 +1633,13 @@ mod tests {
 	;; Call reads the first 4 bytes (LE) as the exit status and returns the rest as output data.
 	(func $call (export "call")
 		;; Copy input data this contract memory.
-		(call $ext_input
+		(call $seal_input
 			(i32.const 0)	;; Pointer where to store input
 			(i32.const 32)	;; Pointer to the length of the buffer
 		)
 
 		;; Copy all but the first 4 bytes of the input data as the output data.
-		(call $ext_return
+		(call $seal_return
 			(i32.load (i32.const 0))
 			(i32.const 4)
 			(i32.sub (i32.load (i32.const 32)) (i32.const 4))
@@ -1650,7 +1650,7 @@ mod tests {
 "#;
 
 	#[test]
-	fn ext_return_with_success_status() {
+	fn seal_return_with_success_status() {
 		let output = execute(
 			CODE_RETURN_WITH_DATA,
 			hex!("00000000445566778899").to_vec(),
@@ -1677,13 +1677,13 @@ mod tests {
 
 	const CODE_OUT_OF_BOUNDS_ACCESS: &str = r#"
 (module
-	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
+	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "deploy"))
 
 	(func (export "call")
-		(call $ext_terminate
+		(call $seal_terminate
 			(i32.const 65536)  ;; Pointer to "account" address (out of bound).
 			(i32.const 8)  ;; Length of "account" address.
 		)
@@ -1712,13 +1712,13 @@ mod tests {
 
 	const CODE_DECODE_FAILURE: &str = r#"
 (module
-	(import "env" "ext_terminate" (func $ext_terminate (param i32 i32)))
+	(import "env" "seal_terminate" (func $seal_terminate (param i32 i32)))
 	(import "env" "memory" (memory 1 1))
 
 	(func (export "deploy"))
 
 	(func (export "call")
-		(call $ext_terminate
+		(call $seal_terminate
 			(i32.const 0)  ;; Pointer to "account" address.
 			(i32.const 4)  ;; Length of "account" address (too small -> decode fail).
 		)

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -296,10 +296,10 @@ impl<'a> ContractModule<'a> {
 				.get(*type_idx as usize)
 				.ok_or_else(|| "validation: import entry points to a non-existent type")?;
 
-			// We disallow importing `ext_println` unless debug features are enabled,
+			// We disallow importing `seal_println` unless debug features are enabled,
 			// which should only be allowed on a dev chain
-			if !self.schedule.enable_println && import.field().as_bytes() == b"ext_println" {
-				return Err("module imports `ext_println` but debug features disabled");
+			if !self.schedule.enable_println && import.field().as_bytes() == b"seal_println" {
+				return Err("module imports `seal_println` but debug features disabled");
 			}
 
 			// We disallow importing `gas` function here since it is treated as implementation detail.
@@ -409,7 +409,7 @@ mod tests {
 
 		nop(_ctx, _unused: u64) => { unreachable!(); },
 
-		ext_println(_ctx, _ptr: u32, _len: u32) => { unreachable!(); },
+		seal_println(_ctx, _ptr: u32, _len: u32) => { unreachable!(); },
 	);
 
 	macro_rules! prepare_test {
@@ -679,24 +679,24 @@ mod tests {
 			Err("module imports a non-existent function")
 		);
 
-		prepare_test!(ext_println_debug_disabled,
+		prepare_test!(seal_println_debug_disabled,
 			r#"
 			(module
-				(import "env" "ext_println" (func $ext_println (param i32 i32)))
+				(import "env" "seal_println" (func $seal_println (param i32 i32)))
 
 				(func (export "call"))
 				(func (export "deploy"))
 			)
 			"#,
-			Err("module imports `ext_println` but debug features disabled")
+			Err("module imports `seal_println` but debug features disabled")
 		);
 
 		#[test]
-		fn ext_println_debug_enabled() {
+		fn seal_println_debug_enabled() {
 			let wasm = wat::parse_str(
 				r#"
 				(module
-					(import "env" "ext_println" (func $ext_println (param i32 i32)))
+					(import "env" "seal_println" (func $seal_println (param i32 i32)))
 
 					(func (export "call"))
 					(func (export "deploy"))

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -654,7 +654,7 @@ mod tests {
 			Err("module imports a non-existent function")
 		);
 
-		// nothing can be imported from arbitrary modules
+		// memory is in "env" and not in "seal0"
 		prepare_test!(memory_not_in_seal0,
 			r#"
 			(module
@@ -665,6 +665,45 @@ mod tests {
 			)
 			"#,
 			Err("Invalid module for imported memory")
+		);
+
+		// memory is in "env" and not in some arbitrary module
+		prepare_test!(memory_not_in_arbitrary_module,
+			r#"
+			(module
+				(import "any_module" "memory" (memory 1 1))
+
+				(func (export "call"))
+				(func (export "deploy"))
+			)
+			"#,
+			Err("Invalid module for imported memory")
+		);
+
+		// functions are in "env" and not in "seal0"
+		prepare_test!(function_not_in_env,
+			r#"
+			(module
+				(import "env" "nop" (func (param i64)))
+
+				(func (export "call"))
+				(func (export "deploy"))
+			)
+			"#,
+			Err("Invalid module for imported function")
+		);
+
+		// functions are in "seal0" and not in in some arbitrary module
+		prepare_test!(function_not_arbitrary_module,
+			r#"
+			(module
+				(import "any_module" "nop" (func (param i64)))
+
+				(func (export "call"))
+				(func (export "deploy"))
+			)
+			"#,
+			Err("Invalid module for imported function")
 		);
 
 		// wrong signature


### PR DESCRIPTION
## Prefix Rename
The word Ext is a overloaded term in the context of substrate. It usually is a trait which abstracts away access to external resources usually in order to mock them away for the purpose of tests. The contract module has its own `Ext` trait in addition the the substrate `Ext` which makes things even more confusing.

In order to differentiate the contract callable functions more clearly from this `Ext` concept we rename them to use the "seal_" prefix instead.

This should change no behaviour at all. This is a pure renaming commit. Contract generation (ink!, solang) need to apply this rename as well.

## Change wasm module name

Currently, the wasm module name for all imported functions is the generic default value `env`. This commit changes this prefix to `seal0`. Later, that module name might be used for versioning. Please note that the the imported memory module stays `env` and does not move to `seal0` because current compiler toolchains do not support specifying custom modules there.

## Examples

Before:

```wat
(import "env" "ext_input" (func (param i32 i32)))
```

```rust
mod seal {
    extern "C" {
        pub fn ext_input(ptr: u32, len_ptr: u32);
    }
}
```

After:
```wat
(import "seal0" "seal_input" (func (param i32 i32)))
```

```rust
mod seal {
    #[link(wasm_import_module = "seal0")]
    extern "C" {
        pub fn seal_input(ptr: u32, len_ptr: u32);
    }
}
```

cc @Robbepop 