### PR TITLE
Add ss58 address for Subsocial network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -446,6 +446,8 @@ ss58_address_format!(
 		(18, "darwinia", "Darwinia Chain mainnet, standard account (*25519).")
 	StafiAccount =>
 		(20, "stafi", "Stafi mainnet, standard account (*25519).")
+	SubsocialAccount =>
+		(28, "subsocial", "Subsocial network, standard account (*25519).")
 	RobonomicsAccount =>
 		(32, "robonomics", "Any Robonomics network standard account (*25519).")
 	DataHighwayAccount =>


### PR DESCRIPTION
This PR adds a new ss58 address `28` for [Subsocial network](http://subsocial.network/) in this file:
https://github.com/paritytech/substrate/blob/293bcd6059f1e4e3dd95aa64989dadef4234222d/primitives/core/src/crypto.rs#L414