### PR TITLE
service: don't use sysinfo on Linux for metric collection

### DIFF
--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,6 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.14.15"
 sc-keystore = { version = "2.0.0-rc5", path = "../keystore" }
 sp-io = { version = "2.0.0-rc5", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../primitives/runtime" }
@@ -78,6 +77,9 @@ parity-util-mem = { version = "0.7.0", default-features = false, features = ["pr
 
 [target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))'.dependencies]
 netstat2 = "0.8.1"
+
+[target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios"), not(target_os = "linux")))'.dependencies]
+sysinfo = "0.14.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = '0.7.8'

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -383,9 +383,9 @@ mod sysinfo {
 	}
 }
 
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(not(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios"))))]
 mod noop {
-	use super::ProcessInfo;
+	use super::{LoadAverage, ProcessInfo};
 
 	pub(crate) struct System;
 
@@ -413,7 +413,7 @@ type System = linux::System;
 	not(target_os = "linux")
 ))]
 type System = sysinfo::System;
-#[cfg(any(target_os = "android", target_os = "ios"))]
+#[cfg(not(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios"))))]
 type System = noop::System;
 
 pub struct MetricsService {

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -199,7 +199,7 @@ impl MetricsService {
 
 		Self {
 			metrics,
-			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
+			system: sysinfo::System::new(),
 			pid: Some(process.pid),
 		}
 	}
@@ -234,7 +234,7 @@ impl MetricsService {
 	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
 		Self {
 			metrics,
-			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
+			system: sysinfo::System::new(),
 			pid: sysinfo::get_current_pid().ok(),
 		}
 	}


### PR DESCRIPTION
This PR updates our metrics code to not use the `sysinfo` crate on Linux and instead get all of the data through `procfs`. 

Additionally it fixes an issue on platform that still use `sysinfo`: We were tracking metrics of all processes running in the node through `sysinfo` which in turn will cache file descriptors of all accesses to `/proc/<pid>/stat`. After this PR we will only collect metrics for the process of the node itself. Unfortunately `sysinfo` will still keep track of all threads spawned by the node and will keep a file descriptor for each `/proc/<pid>/task/<tid>/stat` and there is no way to avoid this currently. These will be bound by the number of threads we spawn though and they should not leak (i.e. they'll be collected after a given threads exits). Below you can see a plot on the number of file handles for a Kusama node before/after this change.

![Screenshot_2020-08-03_18-33-25](https://user-images.githubusercontent.com/123550/89210482-174f6780-d5b8-11ea-96a5-7b4740e89348.png)

