### PR TITLE
Add RPC Builder to Substrate Node Template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,6 +3828,7 @@ version = "2.0.0-rc5"
 dependencies = [
  "jsonrpc-core",
  "node-template-runtime",
+ "pallet-transaction-payment-rpc",
  "sc-basic-authorship",
  "sc-cli",
  "sc-client-api",
@@ -3870,6 +3871,7 @@ dependencies = [
  "pallet-template",
  "pallet-timestamp",
  "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
 name = "node-template"
 version = "2.0.0-rc5"
 dependencies = [
+ "jsonrpc-core",
  "node-template-runtime",
  "sc-basic-authorship",
  "sc-cli",
@@ -3834,8 +3835,13 @@ dependencies = [
  "sc-consensus-aura",
  "sc-executor",
  "sc-finality-grandpa",
+ "sc-rpc",
+ "sc-rpc-api",
  "sc-service",
  "sc-transaction-pool",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
@@ -3845,6 +3851,7 @@ dependencies = [
  "sp-transaction-pool",
  "structopt",
  "substrate-build-script-utils",
+ "substrate-frame-rpc-system",
 ]
 
 [[package]]
@@ -3854,6 +3861,7 @@ dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
+ "frame-system-rpc-runtime-api",
  "pallet-aura",
  "pallet-balances",
  "pallet-grandpa",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -17,6 +17,7 @@ name = "node-template"
 
 [dependencies]
 structopt = "0.3.8"
+jsonrpc-core = "14.0.3"
 
 sc-cli = { version = "0.8.0-rc5", path = "../../../client/cli", features = ["wasmtime"] }
 sp-core = { version = "2.0.0-rc5", path = "../../../primitives/core" }
@@ -31,9 +32,16 @@ sp-consensus = { version = "0.8.0-rc5", path = "../../../primitives/consensus/co
 sc-consensus = { version = "0.8.0-rc5", path = "../../../client/consensus/common" }
 sc-finality-grandpa = { version = "0.8.0-rc5", path = "../../../client/finality-grandpa" }
 sp-finality-grandpa = { version = "2.0.0-rc5", path = "../../../primitives/finality-grandpa" }
+sc-rpc = { version = "2.0.0-rc5", path = "../../../client/rpc" }
+sp-api = { version = "2.0.0-rc5", path = "../../../primitives/api" }
+sc-rpc-api = { version = "0.8.0-rc5", path = "../../../client/rpc-api" }
 sc-client-api = { version = "2.0.0-rc5", path = "../../../client/api" }
+
 sp-runtime = { version = "2.0.0-rc5", path = "../../../primitives/runtime" }
-sc-basic-authorship = { path = "../../../client/basic-authorship", version = "0.8.0-rc5"}
+sp-blockchain = { version = "2.0.0-rc5", path = "../../../primitives/blockchain" }
+sp-block-builder = { version = "2.0.0-rc5", path = "../../../primitives/block-builder" }
+sc-basic-authorship = { version = "0.8.0-rc5", path = "../../../client/basic-authorship" }
+substrate-frame-rpc-system = { version = "2.0.0-rc5", path = "../../../utils/frame/rpc/system" }
 
 node-template-runtime = { version = "2.0.0-rc5", path = "../runtime" }
 

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -43,6 +43,7 @@ sp-blockchain = { version = "2.0.0-rc5", path = "../../../primitives/blockchain"
 sp-block-builder = { version = "2.0.0-rc5", path = "../../../primitives/block-builder" }
 sc-basic-authorship = { version = "0.8.0-rc5", path = "../../../client/basic-authorship" }
 substrate-frame-rpc-system = { version = "2.0.0-rc5", path = "../../../utils/frame/rpc/system" }
+pallet-transaction-payment-rpc = { version = "2.0.0-rc5", path = "../../../frame/transaction-payment/rpc/" }
 
 node-template-runtime = { version = "2.0.0-rc5", path = "../runtime" }
 

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -17,7 +17,6 @@ name = "node-template"
 
 [dependencies]
 structopt = "0.3.8"
-jsonrpc-core = "14.0.3"
 
 sc-cli = { version = "0.8.0-rc5", path = "../../../client/cli", features = ["wasmtime"] }
 sp-core = { version = "2.0.0-rc5", path = "../../../primitives/core" }
@@ -32,12 +31,15 @@ sp-consensus = { version = "0.8.0-rc5", path = "../../../primitives/consensus/co
 sc-consensus = { version = "0.8.0-rc5", path = "../../../client/consensus/common" }
 sc-finality-grandpa = { version = "0.8.0-rc5", path = "../../../client/finality-grandpa" }
 sp-finality-grandpa = { version = "2.0.0-rc5", path = "../../../primitives/finality-grandpa" }
+sc-client-api = { version = "2.0.0-rc5", path = "../../../client/api" }
+sp-runtime = { version = "2.0.0-rc5", path = "../../../primitives/runtime" }
+
+
+# The dependencies listed below are used for the node-template's RPCs
+jsonrpc-core = "14.0.3"
 sc-rpc = { version = "2.0.0-rc5", path = "../../../client/rpc" }
 sp-api = { version = "2.0.0-rc5", path = "../../../primitives/api" }
 sc-rpc-api = { version = "0.8.0-rc5", path = "../../../client/rpc-api" }
-sc-client-api = { version = "2.0.0-rc5", path = "../../../client/api" }
-
-sp-runtime = { version = "2.0.0-rc5", path = "../../../primitives/runtime" }
 sp-blockchain = { version = "2.0.0-rc5", path = "../../../primitives/blockchain" }
 sp-block-builder = { version = "2.0.0-rc5", path = "../../../primitives/block-builder" }
 sc-basic-authorship = { version = "0.8.0-rc5", path = "../../../client/basic-authorship" }

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -34,8 +34,7 @@ sp-finality-grandpa = { version = "2.0.0-rc5", path = "../../../primitives/final
 sc-client-api = { version = "2.0.0-rc5", path = "../../../client/api" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../../primitives/runtime" }
 
-
-# The dependencies listed below are used for the node-template's RPCs
+# These dependencies are used for the node template's RPCs
 jsonrpc-core = "14.0.3"
 sc-rpc = { version = "2.0.0-rc5", path = "../../../client/rpc" }
 sp-api = { version = "2.0.0-rc5", path = "../../../primitives/api" }

--- a/bin/node-template/node/src/lib.rs
+++ b/bin/node-template/node/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod chain_spec;
 pub mod service;
+pub mod rpc;

--- a/bin/node-template/node/src/main.rs
+++ b/bin/node-template/node/src/main.rs
@@ -6,6 +6,7 @@ mod chain_spec;
 mod service;
 mod cli;
 mod command;
+mod rpc;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -57,7 +57,11 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-        //io.extend_with(NodeTemplateApi::to_delegate(....
+        // To expand upon the current RPC set using a custom written API, extend using the syntaxt
+        // listed below. YourRpcStruct is the struct with a reference to a client, which is needed
+        // to call into the runtime. More information on this can be found in the "Custom RPCs"
+        // recipe.
+        //io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
 
         io
 }

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use node_template_runtime::{opaque::Block, AccountId, Index};
+use node_template_runtime::{opaque::Block, AccountId, Balance, Index};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_block_builder::BlockBuilder;
@@ -33,10 +33,12 @@ pub fn create_full<C, P>(
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+        C::Api : pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
-{
+{ 
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
 	let FullDeps {
@@ -48,6 +50,10 @@ pub fn create_full<C, P>(
 	io.extend_with(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
+
+        io.extend_with(
+            TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone()))
+        );
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -1,0 +1,122 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A collection of node-specific RPC methods.
+//!
+//! Since `substrate` core functionality makes no assumptions
+//! about the modules used inside the runtime, so do
+//! RPC methods defined in `sc-rpc` crate.
+//! It means that `client/rpc` can't have any methods that
+//! need some strong assumptions about the particular runtime.
+//!
+//! The RPCs available in this crate however can make some assumptions
+//! about how the runtime is constructed and what FRAME pallets
+//! are part of it. Therefore all node-runtime-specific RPCs can
+//! be placed here or imported from corresponding FRAME RPC definitions.
+
+#![warn(missing_docs)]
+
+use std::sync::Arc;
+
+use node_template_runtime::{opaque::Block, AccountId, Index, Hash};
+use sp_api::ProvideRuntimeApi;
+use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
+use sp_consensus::SelectChain;
+use sp_block_builder::BlockBuilder;
+pub use sc_rpc_api::DenyUnsafe;
+use sp_transaction_pool::TransactionPool;
+
+/// Light client extra dependencies.
+pub struct LightDeps<C, F, P> {
+	/// The client instance to use.
+	pub client: Arc<C>,
+	/// Transaction pool instance.
+	pub pool: Arc<P>,
+	/// Remote access to the blockchain (async).
+	pub remote_blockchain: Arc<dyn sc_client_api::light::RemoteBlockchain<Block>>,
+	/// Fetcher instance.
+	pub fetcher: Arc<F>,
+}
+
+/// Full client dependencies.
+pub struct FullDeps<C, P, SC> {
+	/// The client instance to use.
+	pub client: Arc<C>,
+	/// Transaction pool instance.
+	pub pool: Arc<P>,
+	/// The SelectChain Strategy
+	pub select_chain: SC,
+	/// Whether to deny unsafe calls
+	pub deny_unsafe: DenyUnsafe,
+}
+
+/// Instantiate all Full RPC extensions.
+pub fn create_full<C, P, SC>(
+	deps: FullDeps<C, P, SC>,
+) -> jsonrpc_core::IoHandler<sc_rpc::Metadata> where
+	C: ProvideRuntimeApi<Block>,
+	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
+	C: Send + Sync + 'static,
+	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
+	C::Api: BlockBuilder<Block>,
+	P: TransactionPool + 'static,
+	SC: SelectChain<Block> +'static,
+{
+	use substrate_frame_rpc_system::{FullSystem, SystemApi};
+
+	let mut io = jsonrpc_core::IoHandler::default();
+	let FullDeps {
+		client,
+		pool,
+		select_chain,
+		deny_unsafe,
+	} = deps;
+
+	io.extend_with(
+		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
+	);
+
+        //io.extend_with(NodeTemplateApi::to_delegate(....
+
+        io
+}
+
+/// Instantiate all Light RPC extensions.
+pub fn create_light<C, P, M, F>(
+	deps: LightDeps<C, F, P>,
+) -> jsonrpc_core::IoHandler<M> where
+	C: sp_blockchain::HeaderBackend<Block>,
+	C: Send + Sync + 'static,
+	F: sc_client_api::light::Fetcher<Block> + 'static,
+	P: TransactionPool + 'static,
+	M: jsonrpc_core::Metadata + Default,
+{
+	use substrate_frame_rpc_system::{LightSystem, SystemApi};
+
+	let LightDeps {
+		client,
+		pool,
+		remote_blockchain,
+		fetcher
+	} = deps;
+	let mut io = jsonrpc_core::IoHandler::default();
+	io.extend_with(
+		SystemApi::<Hash, AccountId, Index>::to_delegate(LightSystem::new(client, remote_blockchain, fetcher, pool))
+	);
+
+	io
+}

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -82,7 +82,7 @@ pub fn create_full<C, P, SC>(
 	let FullDeps {
 		client,
 		pool,
-		select_chain,
+		select_chain: _,
 		deny_unsafe,
 	} = deps;
 

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -57,10 +57,9 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-        // To expand upon the current RPC set using a custom written API, extend using the syntaxt
-        // listed below. YourRpcStruct is the struct with a reference to a client, which is needed
-        // to call into the runtime. More information on this can be found in the "Custom RPCs"
-        // recipe.
+        // To expand upon the current RPC set using a custom written API, extend using the syntax
+        // listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
+        // to call into the runtime.
         //io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
 
         io

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -33,10 +33,10 @@ pub fn create_full<C, P>(
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-        C::Api : pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
-{ 
+{
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 
@@ -51,9 +51,9 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-        io.extend_with(
-            TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone()))
-        );
+	io.extend_with(
+		TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone()))
+	);
 
 	// Extend this RPC with a custom API by using the following syntax.
 	// `YourRpcStruct` should have a reference to a client, which is needed

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -25,7 +25,7 @@ pub struct FullDeps<C, P> {
 	pub deny_unsafe: DenyUnsafe,
 }
 
-/// Instantiate all Full RPC extensions.
+/// Instantiate all full RPC extensions.
 pub fn create_full<C, P>(
 	deps: FullDeps<C, P>,
 ) -> jsonrpc_core::IoHandler<sc_rpc::Metadata> where

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -1,15 +1,7 @@
 //! A collection of node-specific RPC methods.
-//!
-//! Since `substrate` core functionality makes no assumptions
-//! about the modules used inside the runtime, so do
-//! RPC methods defined in `sc-rpc` crate.
-//! It means that `client/rpc` can't have any methods that
-//! need some strong assumptions about the particular runtime.
-//!
-//! The RPCs available in this crate however can make some assumptions
-//! about how the runtime is constructed and what FRAME pallets
-//! are part of it. Therefore all node-runtime-specific RPCs can
-//! be placed here or imported from corresponding FRAME RPC definitions.
+//! Substrate provides the `sc-rpc` crate, which defines the core RPC layer
+//! used by Substrate nodes. This file extends those RPC definitions with
+//! capabilities that are specific to this project's runtime configuration.
 
 #![warn(missing_docs)]
 

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -41,6 +41,7 @@ pub use sc_rpc_api::DenyUnsafe;
 use sp_transaction_pool::TransactionPool;
 
 /// Light client extra dependencies.
+#[allow(dead_code)]
 pub struct LightDeps<C, F, P> {
 	/// The client instance to use.
 	pub client: Arc<C>,
@@ -96,6 +97,7 @@ pub fn create_full<C, P, SC>(
 }
 
 /// Instantiate all Light RPC extensions.
+#[allow(dead_code)]
 pub fn create_light<C, P, M, F>(
 	deps: LightDeps<C, F, P>,
 ) -> jsonrpc_core::IoHandler<M> where

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -1,20 +1,3 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2019-2020 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //! A collection of node-specific RPC methods.
 //!
 //! Since `substrate` core functionality makes no assumptions
@@ -32,42 +15,27 @@
 
 use std::sync::Arc;
 
-use node_template_runtime::{opaque::Block, AccountId, Index, Hash};
+use node_template_runtime::{opaque::Block, AccountId, Index};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
-use sp_consensus::SelectChain;
 use sp_block_builder::BlockBuilder;
 pub use sc_rpc_api::DenyUnsafe;
 use sp_transaction_pool::TransactionPool;
 
-/// Light client extra dependencies.
-#[allow(dead_code)]
-pub struct LightDeps<C, F, P> {
-	/// The client instance to use.
-	pub client: Arc<C>,
-	/// Transaction pool instance.
-	pub pool: Arc<P>,
-	/// Remote access to the blockchain (async).
-	pub remote_blockchain: Arc<dyn sc_client_api::light::RemoteBlockchain<Block>>,
-	/// Fetcher instance.
-	pub fetcher: Arc<F>,
-}
 
 /// Full client dependencies.
-pub struct FullDeps<C, P, SC> {
+pub struct FullDeps<C, P> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
-	/// The SelectChain Strategy
-	pub select_chain: SC,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
 }
 
 /// Instantiate all Full RPC extensions.
-pub fn create_full<C, P, SC>(
-	deps: FullDeps<C, P, SC>,
+pub fn create_full<C, P>(
+	deps: FullDeps<C, P>,
 ) -> jsonrpc_core::IoHandler<sc_rpc::Metadata> where
 	C: ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
@@ -75,7 +43,6 @@ pub fn create_full<C, P, SC>(
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
-	SC: SelectChain<Block> +'static,
 {
 	use substrate_frame_rpc_system::{FullSystem, SystemApi};
 
@@ -83,7 +50,6 @@ pub fn create_full<C, P, SC>(
 	let FullDeps {
 		client,
 		pool,
-		select_chain: _,
 		deny_unsafe,
 	} = deps;
 
@@ -94,31 +60,4 @@ pub fn create_full<C, P, SC>(
         //io.extend_with(NodeTemplateApi::to_delegate(....
 
         io
-}
-
-/// Instantiate all Light RPC extensions.
-#[allow(dead_code)]
-pub fn create_light<C, P, M, F>(
-	deps: LightDeps<C, F, P>,
-) -> jsonrpc_core::IoHandler<M> where
-	C: sp_blockchain::HeaderBackend<Block>,
-	C: Send + Sync + 'static,
-	F: sc_client_api::light::Fetcher<Block> + 'static,
-	P: TransactionPool + 'static,
-	M: jsonrpc_core::Metadata + Default,
-{
-	use substrate_frame_rpc_system::{LightSystem, SystemApi};
-
-	let LightDeps {
-		client,
-		pool,
-		remote_blockchain,
-		fetcher
-	} = deps;
-	let mut io = jsonrpc_core::IoHandler::default();
-	io.extend_with(
-		SystemApi::<Hash, AccountId, Index>::to_delegate(LightSystem::new(client, remote_blockchain, fetcher, pool))
-	);
-
-	io
 }

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -49,10 +49,10 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-	// To expand upon the current RPC set using a custom written API, extend using the syntax
-	// listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
+	// Extend this RPC with a custom API by using the following syntax.
+	// `YourRpcStruct` should have a reference to a client, which is needed
 	// to call into the runtime.
-	//io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
+	// `io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));`
 
 	io
 }

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -57,10 +57,10 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-        // To expand upon the current RPC set using a custom written API, extend using the syntax
-        // listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
-        // to call into the runtime.
-        //io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
+		// To expand upon the current RPC set using a custom written API, extend using the syntax
+		// listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
+		// to call into the runtime.
+		//io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
 
-        io
+		io
 }

--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -57,10 +57,10 @@ pub fn create_full<C, P>(
 		SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe))
 	);
 
-		// To expand upon the current RPC set using a custom written API, extend using the syntax
-		// listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
-		// to call into the runtime.
-		//io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
+	// To expand upon the current RPC set using a custom written API, extend using the syntax
+	// listed below. `YourRpcStruct` is the struct with a reference to a client, which is needed
+	// to call into the runtime.
+	//io.extend_with(YourRpcTrait::to_delegate(YourRpcStruct::new(ReferenceToClient, ...)));
 
-		io
+	io
 }

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -73,7 +73,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {	
+pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client, backend, mut task_manager, import_queue, keystore, select_chain, transaction_pool,
 		inherent_data_providers,
@@ -93,7 +93,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 			on_demand: None,
 			block_announce_validator_builder: None,
 			finality_proof_request_builder: None,
-			finality_proof_provider: Some(finality_proof_provider.clone()), 
+			finality_proof_provider: Some(finality_proof_provider.clone()),
 		})?;
 
 	if config.offchain_worker.enabled {
@@ -109,20 +109,20 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 	let prometheus_registry = config.prometheus_registry().cloned();
 	let telemetry_connection_sinks = sc_service::TelemetryConnectionSinks::default();
 
-        let rpc_extensions_builder = {
-            let client = client.clone();
-            let pool = transaction_pool.clone();
+	let rpc_extensions_builder = {
+		let client = client.clone();
+		let pool = transaction_pool.clone();
 
-            Box::new(move |deny_unsafe| {
-                let deps = crate::rpc::FullDeps {
-                    client: client.clone(),
-                    pool: pool.clone(),
-                    deny_unsafe,
-                };
+		Box::new(move |deny_unsafe| {
+			let deps = crate::rpc::FullDeps {
+				client: client.clone(),
+				pool: pool.clone(),
+				deny_unsafe,
+			};
 
-                crate::rpc::create_full(deps)
-            })
-        };
+			crate::rpc::create_full(deps)
+		})
+	};
 
 	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		network: network.clone(),
@@ -271,7 +271,7 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
 			&config, backend.clone(), task_manager.spawn_handle(), client.clone(), network.clone(),
 		);
 	}
-	
+
 	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		remote_blockchain: Some(backend.remote_blockchain()),
 		transaction_pool,
@@ -279,12 +279,12 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
 		on_demand: Some(on_demand),
 		rpc_extensions_builder: Box::new(|_| ()),
 		telemetry_connection_sinks: sc_service::TelemetryConnectionSinks::default(),
-		config, 
-		client, 
-		keystore, 
-		backend, 
-		network, 
-		network_status_sinks, 
+		config,
+		client,
+		keystore,
+		backend,
+		network,
+		network_status_sinks,
 		system_rpc_tx,
 	 })?;
 

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -18,11 +18,6 @@ native_executor_instance!(
 	node_template_runtime::native_version,
 );
 
-
-// TODO:: Please change this to crate, lrpc=localrpc
-#[path = "rpc.rs"]
-mod lrpc;
-
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
 type FullBackend = sc_service::TFullBackend<Block>;
 type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
@@ -114,21 +109,18 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 	let prometheus_registry = config.prometheus_registry().cloned();
 	let telemetry_connection_sinks = sc_service::TelemetryConnectionSinks::default();
 
-
         let rpc_extensions_builder = {
             let client = client.clone();
             let pool = transaction_pool.clone();
-            let select_chain = select_chain.clone();
 
             Box::new(move |deny_unsafe| {
-                let deps = lrpc::FullDeps {
+                let deps = crate::rpc::FullDeps {
                     client: client.clone(),
                     pool: pool.clone(),
-                    select_chain: select_chain.clone(),
                     deny_unsafe,
                 };
 
-                lrpc::create_full(deps)
+                crate::rpc::create_full(deps)
             })
         };
 

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -12,9 +12,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
-
-system-runtime-rpi = { default-features = false, package = "frame-system-rpc-runtime-api" , version = "2.0.0-rc5", path = "../../../frame/system/rpc/runtime-api/" }
-
 aura = { version = "2.0.0-rc5", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }
 balances = { version = "2.0.0-rc5", default-features = false, package = "pallet-balances", path = "../../../frame/balances" }
 frame-support = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/support" }
@@ -37,6 +34,9 @@ sp-session = { version = "2.0.0-rc5", default-features = false, path = "../../..
 sp-std = { version = "2.0.0-rc5", default-features = false, path = "../../../primitives/std" }
 sp-transaction-pool = { version = "2.0.0-rc5", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "2.0.0-rc5", default-features = false, path = "../../../primitives/version" }
+
+# The dependency listed below is used for node-template's RPCs
+frame-system-rpc-runtime-api = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
 
 template = { version = "2.0.0-rc5", default-features = false, path = "../pallets/template", package = "pallet-template" }
 
@@ -69,6 +69,6 @@ std = [
 	"system/std",
 	"timestamp/std",
 	"transaction-payment/std",
+  "frame-system-rpc-runtime-api/std",
 	"template/std",
-  "system-runtime-rpi/std",
 ]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -13,6 +13,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 
+system-runtime-rpi = { default-features = false, package = "frame-system-rpc-runtime-api" , version = "2.0.0-rc5", path = "../../../frame/system/rpc/runtime-api/" }
+
 aura = { version = "2.0.0-rc5", default-features = false, package = "pallet-aura", path = "../../../frame/aura" }
 balances = { version = "2.0.0-rc5", default-features = false, package = "pallet-balances", path = "../../../frame/balances" }
 frame-support = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/support" }
@@ -68,4 +70,5 @@ std = [
 	"timestamp/std",
 	"transaction-payment/std",
 	"template/std",
+  "system-runtime-rpi/std",
 ]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -35,7 +35,7 @@ sp-std = { version = "2.0.0-rc5", default-features = false, path = "../../../pri
 sp-transaction-pool = { version = "2.0.0-rc5", default-features = false, path = "../../../primitives/transaction-pool" }
 sp-version = { version = "2.0.0-rc5", default-features = false, path = "../../../primitives/version" }
 
-# The dependency listed below is used for node-template's RPCs
+# Used for the node template's RPCs
 frame-system-rpc-runtime-api = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
 
 template = { version = "2.0.0-rc5", default-features = false, path = "../pallets/template", package = "pallet-template" }

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -37,6 +37,7 @@ sp-version = { version = "2.0.0-rc5", default-features = false, path = "../../..
 
 # Used for the node template's RPCs
 frame-system-rpc-runtime-api = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
+pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0-rc5", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
 
 template = { version = "2.0.0-rc5", default-features = false, path = "../pallets/template", package = "pallet-template" }
 
@@ -70,5 +71,6 @@ std = [
 	"timestamp/std",
 	"transaction-payment/std",
   "frame-system-rpc-runtime-api/std",
+  "pallet-transaction-payment-rpc-runtime-api/std",
 	"template/std",
 ]

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -422,13 +422,11 @@ impl_runtime_apis! {
 		fn account_nonce(account: AccountId) -> Index {
 			System::account_nonce(account)
 		}
-	}	
-           // crate::generic::block::traits::Extrinsic
-           // frame_support::inherent::Extrinsic
-           // sp_runtime::traits::Extrinsic
-        impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
-            fn query_info(uxt: <Block as BlockT>::Extrinsic , len: u32) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-                TransactionPayment::query_info(uxt, len)
-            }
-        }
+	}
+
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+		fn query_info(uxt: <Block as BlockT>::Extrinsic , len: u32) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_info(uxt, len)
+		}
+	}
 }

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -425,7 +425,10 @@ impl_runtime_apis! {
 	}
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
-		fn query_info(uxt: <Block as BlockT>::Extrinsic , len: u32) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+		fn query_info(
+			uxt: <Block as BlockT>::Extrinsic,
+			len: u32,
+		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 	}

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -418,9 +418,9 @@ impl_runtime_apis! {
 		}
 	}
 
-        impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
-            fn account_nonce(account: AccountId) -> Index {
-                System::account_nonce(account)
-            }
-        }
+	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
+		fn account_nonce(account: AccountId) -> Index {
+			System::account_nonce(account)
+		}
+	}
 }

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -422,5 +422,13 @@ impl_runtime_apis! {
 		fn account_nonce(account: AccountId) -> Index {
 			System::account_nonce(account)
 		}
-	}
+	}	
+           // crate::generic::block::traits::Extrinsic
+           // frame_support::inherent::Extrinsic
+           // sp_runtime::traits::Extrinsic
+        impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+            fn query_info(uxt: <Block as BlockT>::Extrinsic , len: u32) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+                TransactionPayment::query_info(uxt, len)
+            }
+        }
 }

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -417,4 +417,10 @@ impl_runtime_apis! {
 			None
 		}
 	}
+
+        impl system_runtime_rpi::AccountNonceApi<Block, AccountId, Index> for Runtime {
+            fn account_nonce(account: AccountId) -> Index {
+                System::account_nonce(account)
+            }
+        }
 }

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -418,7 +418,7 @@ impl_runtime_apis! {
 		}
 	}
 
-        impl system_runtime_rpi::AccountNonceApi<Block, AccountId, Index> for Runtime {
+        impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
             fn account_nonce(account: AccountId) -> Index {
                 System::account_nonce(account)
             }


### PR DESCRIPTION
Allows for and gives a concrete example on how to implement custom RPCs (with its implementation in the template's service.rs file). I've tried to keep everything minimal, but since I don't understand everything I can almost guarantee that there's room for improvements- not sure if allowed but I added 2 TODO's stating where these can be added. Note that the builder is only implemented for the full client. I've fully tested this and it works, perhaps if needed- could somebody point me towards some documentation which shows me how to write test-cases for RPCs? Thanks and sorry if I made a mess.