### PR TITLE
Update Benchmarks and Weights for Delayed Proxy

### DIFF
--- a/bin/node/runtime/src/weights/pallet_proxy.rs
+++ b/bin/node/runtime/src/weights/pallet_proxy.rs
@@ -20,65 +20,65 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 pub struct WeightInfo;
 impl pallet_proxy::WeightInfo for WeightInfo {
 	fn proxy(p: u32, ) -> Weight {
-		(27855000 as Weight)
-			.saturating_add((202000 as Weight).saturating_mul(p as Weight))
+		(26127000 as Weight)
+			.saturating_add((214000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 	}
 	fn proxy_announced(a: u32, p: u32, ) -> Weight {
-		(54594000 as Weight)
-			.saturating_add((771000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((221000 as Weight).saturating_mul(p as Weight))
+		(55405000 as Weight)
+			.saturating_add((774000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((209000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn remove_announcement(a: u32, p: u32, ) -> Weight {
-		(35575000 as Weight)
-			.saturating_add((792000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((23000 as Weight).saturating_mul(p as Weight))
+		(35879000 as Weight)
+			.saturating_add((783000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((20000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn reject_announcement(a: u32, p: u32, ) -> Weight {
-		(35551000 as Weight)
-			.saturating_add((777000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((27000 as Weight).saturating_mul(p as Weight))
+		(36097000 as Weight)
+			.saturating_add((780000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((12000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn announce(a: u32, p: u32, ) -> Weight {
-		(53119000 as Weight)
-			.saturating_add((670000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((222000 as Weight).saturating_mul(p as Weight))
+		(53769000 as Weight)
+			.saturating_add((675000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((214000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn add_proxy(p: u32, ) -> Weight {
-		(35704000 as Weight)
+		(36082000 as Weight)
 			.saturating_add((234000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxy(p: u32, ) -> Weight {
-		(32512000 as Weight)
-			.saturating_add((261000 as Weight).saturating_mul(p as Weight))
+		(32885000 as Weight)
+			.saturating_add((267000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxies(p: u32, ) -> Weight {
-		(31302000 as Weight)
-			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
+		(31735000 as Weight)
+			.saturating_add((215000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn anonymous(p: u32, ) -> Weight {
-		(50021000 as Weight)
-			.saturating_add((57000 as Weight).saturating_mul(p as Weight))
+		(50907000 as Weight)
+			.saturating_add((61000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(33528000 as Weight)
-			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
+		(33926000 as Weight)
+			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}

--- a/bin/node/runtime/src/weights/pallet_proxy.rs
+++ b/bin/node/runtime/src/weights/pallet_proxy.rs
@@ -20,61 +20,65 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 pub struct WeightInfo;
 impl pallet_proxy::WeightInfo for WeightInfo {
 	fn proxy(p: u32, ) -> Weight {
-		(27894000 as Weight)
-			.saturating_add((196000 as Weight).saturating_mul(p as Weight))
+		(27855000 as Weight)
+			.saturating_add((202000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 	}
-	fn proxy_announced(p: u32, ) -> Weight {
-		(78353000 as Weight)
-			.saturating_add((201000 as Weight).saturating_mul(p as Weight))
+	fn proxy_announced(a: u32, p: u32, ) -> Weight {
+		(54594000 as Weight)
+			.saturating_add((771000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((221000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn remove_announcement(p: u32, ) -> Weight {
-		(60264000 as Weight)
-			.saturating_add((4000 as Weight).saturating_mul(p as Weight))
+	fn remove_announcement(a: u32, p: u32, ) -> Weight {
+		(35575000 as Weight)
+			.saturating_add((792000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((23000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn reject_announcement(p: u32, ) -> Weight {
-		(60141000 as Weight)
-			.saturating_add((10000 as Weight).saturating_mul(p as Weight))
+	fn reject_announcement(a: u32, p: u32, ) -> Weight {
+		(35551000 as Weight)
+			.saturating_add((777000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((27000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn announce(p: u32, ) -> Weight {
-		(74751000 as Weight)
-			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
+	fn announce(a: u32, p: u32, ) -> Weight {
+		(53119000 as Weight)
+			.saturating_add((670000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((222000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn add_proxy(p: u32, ) -> Weight {
-		(36250000 as Weight)
-			.saturating_add((223000 as Weight).saturating_mul(p as Weight))
+		(35704000 as Weight)
+			.saturating_add((234000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxy(p: u32, ) -> Weight {
-		(32843000 as Weight)
-			.saturating_add((258000 as Weight).saturating_mul(p as Weight))
+		(32512000 as Weight)
+			.saturating_add((261000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxies(p: u32, ) -> Weight {
-		(31834000 as Weight)
-			.saturating_add((203000 as Weight).saturating_mul(p as Weight))
+		(31302000 as Weight)
+			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn anonymous(p: u32, ) -> Weight {
-		(50947000 as Weight)
-			.saturating_add((44000 as Weight).saturating_mul(p as Weight))
+		(50021000 as Weight)
+			.saturating_add((57000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(34213000 as Weight)
-			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
+		(33528000 as Weight)
+			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -85,6 +85,7 @@ benchmarks! {
 	}
 
 	proxy {
+		let a in 0 .. T::MaxPending::get();
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("target", p - 1, SEED);
@@ -92,13 +93,14 @@ benchmarks! {
 		// ... and "real" is the traditional caller. This is not a typo.
 		let real: T::AccountId = account("caller", 0, SEED);
 		let call: <T as Trait>::Call = frame_system::Call::<T>::remark(vec![]).into();
-		add_announcements::<T>(T::MaxPending::get(), Some(caller.clone()), None)?;
+		add_announcements::<T>(a, Some(caller.clone()), None)?;
 	}: _(RawOrigin::Signed(caller), real, Some(T::ProxyType::default()), Box::new(call))
 	verify {
 		assert_last_event::<T>(RawEvent::ProxyExecuted(Ok(())).into())
 	}
 
 	proxy_announced {
+		let a in 0 .. T::MaxPending::get() - 1;
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("anonymous", 0, SEED);
@@ -112,13 +114,14 @@ benchmarks! {
 			real.clone(),
 			T::CallHasher::hash_of(&call),
 		)?;
-		add_announcements::<T>(T::MaxPending::get() - 1, Some(delegate.clone()), None)?;
+		add_announcements::<T>(a, Some(delegate.clone()), None)?;
 	}: _(RawOrigin::Signed(caller), delegate, real, Some(T::ProxyType::default()), Box::new(call))
 	verify {
 		assert_last_event::<T>(RawEvent::ProxyExecuted(Ok(())).into())
 	}
 
 	remove_announcement {
+		let a in 0 .. T::MaxPending::get() - 1;
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("target", p - 1, SEED);
@@ -131,14 +134,15 @@ benchmarks! {
 			real.clone(),
 			T::CallHasher::hash_of(&call),
 		)?;
-		add_announcements::<T>(T::MaxPending::get() - 1, Some(caller.clone()), None)?;
+		add_announcements::<T>(a, Some(caller.clone()), None)?;
 	}: _(RawOrigin::Signed(caller.clone()), real, T::CallHasher::hash_of(&call))
 	verify {
 		let (announcements, _) = Announcements::<T>::get(&caller);
-		assert_eq!(announcements.len() as u32, T::MaxPending::get() - 1);
+		assert_eq!(announcements.len() as u32, a);
 	}
 
 	reject_announcement {
+		let a in 0 .. T::MaxPending::get() - 1;
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("target", p - 1, SEED);
@@ -151,21 +155,22 @@ benchmarks! {
 			real.clone(),
 			T::CallHasher::hash_of(&call),
 		)?;
-		add_announcements::<T>(T::MaxPending::get() - 1, Some(caller.clone()), None)?;
+		add_announcements::<T>(a, Some(caller.clone()), None)?;
 	}: _(RawOrigin::Signed(real), caller.clone(), T::CallHasher::hash_of(&call))
 	verify {
 		let (announcements, _) = Announcements::<T>::get(&caller);
-		assert_eq!(announcements.len() as u32, T::MaxPending::get() - 1);
+		assert_eq!(announcements.len() as u32, a);
 	}
 
 	announce {
+		let a in 0 .. T::MaxPending::get() - 1;
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("target", p - 1, SEED);
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// ... and "real" is the traditional caller. This is not a typo.
 		let real: T::AccountId = account("caller", 0, SEED);
-		add_announcements::<T>(T::MaxPending::get() - 1, Some(caller.clone()), None)?;
+		add_announcements::<T>(a, Some(caller.clone()), None)?;
 		let call: <T as Trait>::Call = frame_system::Call::<T>::remark(vec![]).into();
 		let call_hash = T::CallHasher::hash_of(&call);
 	}: _(RawOrigin::Signed(caller.clone()), real.clone(), call_hash)

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -85,7 +85,6 @@ benchmarks! {
 	}
 
 	proxy {
-		let a in 0 .. T::MaxPending::get();
 		let p in ...;
 		// In this case the caller is the "target" proxy
 		let caller: T::AccountId = account("target", p - 1, SEED);
@@ -93,7 +92,6 @@ benchmarks! {
 		// ... and "real" is the traditional caller. This is not a typo.
 		let real: T::AccountId = account("caller", 0, SEED);
 		let call: <T as Trait>::Call = frame_system::Call::<T>::remark(vec![]).into();
-		add_announcements::<T>(a, Some(caller.clone()), None)?;
 	}: _(RawOrigin::Signed(caller), real, Some(T::ProxyType::default()), Box::new(call))
 	verify {
 		assert_last_event::<T>(RawEvent::ProxyExecuted(Ok(())).into())

--- a/frame/proxy/src/default_weight.rs
+++ b/frame/proxy/src/default_weight.rs
@@ -19,61 +19,65 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
 impl crate::WeightInfo for () {
 	fn proxy(p: u32, ) -> Weight {
-		(27894000 as Weight)
-			.saturating_add((196000 as Weight).saturating_mul(p as Weight))
+		(27855000 as Weight)
+			.saturating_add((202000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 	}
-	fn proxy_announced(p: u32, ) -> Weight {
-		(78353000 as Weight)
-			.saturating_add((201000 as Weight).saturating_mul(p as Weight))
+	fn proxy_announced(a: u32, p: u32, ) -> Weight {
+		(54594000 as Weight)
+			.saturating_add((771000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((221000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn remove_announcement(p: u32, ) -> Weight {
-		(60264000 as Weight)
-			.saturating_add((4000 as Weight).saturating_mul(p as Weight))
+	fn remove_announcement(a: u32, p: u32, ) -> Weight {
+		(35575000 as Weight)
+			.saturating_add((792000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((23000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn reject_announcement(p: u32, ) -> Weight {
-		(60141000 as Weight)
-			.saturating_add((10000 as Weight).saturating_mul(p as Weight))
+	fn reject_announcement(a: u32, p: u32, ) -> Weight {
+		(35551000 as Weight)
+			.saturating_add((777000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((27000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
-	fn announce(p: u32, ) -> Weight {
-		(74751000 as Weight)
-			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
+	fn announce(a: u32, p: u32, ) -> Weight {
+		(53119000 as Weight)
+			.saturating_add((670000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((222000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn add_proxy(p: u32, ) -> Weight {
-		(36250000 as Weight)
-			.saturating_add((223000 as Weight).saturating_mul(p as Weight))
+		(35704000 as Weight)
+			.saturating_add((234000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxy(p: u32, ) -> Weight {
-		(32843000 as Weight)
-			.saturating_add((258000 as Weight).saturating_mul(p as Weight))
+		(32512000 as Weight)
+			.saturating_add((261000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxies(p: u32, ) -> Weight {
-		(31834000 as Weight)
-			.saturating_add((203000 as Weight).saturating_mul(p as Weight))
+		(31302000 as Weight)
+			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn anonymous(p: u32, ) -> Weight {
-		(50947000 as Weight)
-			.saturating_add((44000 as Weight).saturating_mul(p as Weight))
+		(50021000 as Weight)
+			.saturating_add((57000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(34213000 as Weight)
-			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
+		(33528000 as Weight)
+			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}

--- a/frame/proxy/src/default_weight.rs
+++ b/frame/proxy/src/default_weight.rs
@@ -19,65 +19,65 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
 impl crate::WeightInfo for () {
 	fn proxy(p: u32, ) -> Weight {
-		(27855000 as Weight)
-			.saturating_add((202000 as Weight).saturating_mul(p as Weight))
+		(26127000 as Weight)
+			.saturating_add((214000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 	}
 	fn proxy_announced(a: u32, p: u32, ) -> Weight {
-		(54594000 as Weight)
-			.saturating_add((771000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((221000 as Weight).saturating_mul(p as Weight))
+		(55405000 as Weight)
+			.saturating_add((774000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((209000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn remove_announcement(a: u32, p: u32, ) -> Weight {
-		(35575000 as Weight)
-			.saturating_add((792000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((23000 as Weight).saturating_mul(p as Weight))
+		(35879000 as Weight)
+			.saturating_add((783000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((20000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn reject_announcement(a: u32, p: u32, ) -> Weight {
-		(35551000 as Weight)
-			.saturating_add((777000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((27000 as Weight).saturating_mul(p as Weight))
+		(36097000 as Weight)
+			.saturating_add((780000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((12000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn announce(a: u32, p: u32, ) -> Weight {
-		(53119000 as Weight)
-			.saturating_add((670000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((222000 as Weight).saturating_mul(p as Weight))
+		(53769000 as Weight)
+			.saturating_add((675000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((214000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(3 as Weight))
 			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn add_proxy(p: u32, ) -> Weight {
-		(35704000 as Weight)
+		(36082000 as Weight)
 			.saturating_add((234000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxy(p: u32, ) -> Weight {
-		(32512000 as Weight)
-			.saturating_add((261000 as Weight).saturating_mul(p as Weight))
+		(32885000 as Weight)
+			.saturating_add((267000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn remove_proxies(p: u32, ) -> Weight {
-		(31302000 as Weight)
-			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
+		(31735000 as Weight)
+			.saturating_add((215000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn anonymous(p: u32, ) -> Weight {
-		(50021000 as Weight)
-			.saturating_add((57000 as Weight).saturating_mul(p as Weight))
+		(50907000 as Weight)
+			.saturating_add((61000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(2 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn kill_anonymous(p: u32, ) -> Weight {
-		(33528000 as Weight)
-			.saturating_add((207000 as Weight).saturating_mul(p as Weight))
+		(33926000 as Weight)
+			.saturating_add((208000 as Weight).saturating_mul(p as Weight))
 			.saturating_add(DbWeight::get().reads(1 as Weight))
 			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -425,9 +425,7 @@ decl_module! {
 		/// account whose `anonymous` call has corresponding parameters.
 		///
 		/// # <weight>
-		/// P is the number of proxies the user has
-		/// - Base weight: 15.65 + .137 * P µs
-		/// - DB weight: 1 storage read and write.
+		/// Weight is a function of the number of proxies the user has (P).
 		/// # </weight>
 		#[weight = T::WeightInfo::kill_anonymous(T::MaxProxies::get().into())]
 		fn kill_anonymous(origin,
@@ -464,7 +462,9 @@ decl_module! {
 		/// - `call_hash`: The hash of the call to be made by the `real` account.
 		///
 		/// # <weight>
-		/// Weight is a function of the number of proxies the user has (P).
+		/// Weight is a function of:
+		/// - A: the number of announcements made.
+		/// - P: the number of proxies the user has.
 		/// # </weight>
 		#[weight = T::WeightInfo::announce(T::MaxPending::get(), T::MaxProxies::get().into())]
 		fn announce(origin, real: T::AccountId, call_hash: CallHashOf<T>) {
@@ -504,6 +504,12 @@ decl_module! {
 		/// Parameters:
 		/// - `real`: The account that the proxy will make a call on behalf of.
 		/// - `call_hash`: The hash of the call to be made by the `real` account.
+		///
+		/// # <weight>
+		/// Weight is a function of:
+		/// - A: the number of announcements made.
+		/// - P: the number of proxies the user has.
+		/// # </weight>
 		#[weight = T::WeightInfo::remove_announcement(T::MaxPending::get(), T::MaxProxies::get().into())]
 		fn remove_announcement(origin, real: T::AccountId, call_hash: CallHashOf<T>) {
 			let who = ensure_signed(origin)?;
@@ -520,6 +526,12 @@ decl_module! {
 		/// Parameters:
 		/// - `delegate`: The account that previously announced the call.
 		/// - `call_hash`: The hash of the call to be made.
+		///
+		/// # <weight>
+		/// Weight is a function of:
+		/// - A: the number of announcements made.
+		/// - P: the number of proxies the user has.
+		/// # </weight>
 		#[weight = T::WeightInfo::reject_announcement(T::MaxPending::get(), T::MaxProxies::get().into())]
 		fn reject_announcement(origin, delegate: T::AccountId, call_hash: CallHashOf<T>) {
 			let who = ensure_signed(origin)?;
@@ -539,7 +551,9 @@ decl_module! {
 		/// - `call`: The call to be made by the `real` account.
 		///
 		/// # <weight>
-		/// Weight is a function of the number of proxies the user has (P).
+		/// Weight is a function of:
+		/// - A: the number of announcements made.
+		/// - P: the number of proxies the user has.
 		/// # </weight>
 		#[weight = {
 			let di = call.get_dispatch_info();


### PR DESCRIPTION
This PR updates the benchmarks and weights for delayed proxy in order to include announcements into the weight formula as a parameter