### PR TITLE
Better default balances weights

### DIFF
--- a/frame/balances/src/default_weight.rs
+++ b/frame/balances/src/default_weight.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Weights for the Balances Pallet
+
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+
+impl crate::WeightInfo for () {
+	fn transfer() -> Weight {
+		(65949000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn transfer_keep_alive() -> Weight {
+		(46665000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_balance_creating() -> Weight {
+		(27086000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn set_balance_killing() -> Weight {
+		(33424000 as Weight)
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn force_transfer() -> Weight {
+		(65343000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+}

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -154,6 +154,7 @@ mod tests;
 mod tests_local;
 mod tests_composite;
 mod benchmarking;
+mod default_weight;
 
 use sp_std::prelude::*;
 use sp_std::{cmp, result, mem, fmt::Debug, ops::BitOr, convert::Infallible};
@@ -185,14 +186,6 @@ pub trait WeightInfo {
 	fn set_balance_creating() -> Weight;
 	fn set_balance_killing() -> Weight;
 	fn force_transfer() -> Weight;
-}
-
-impl WeightInfo for () {
-	fn transfer() -> Weight { 1_000_000_000 }
-	fn transfer_keep_alive() -> Weight { 1_000_000_000 }
-	fn set_balance_creating() -> Weight { 1_000_000_000 }
-	fn set_balance_killing() -> Weight { 1_000_000_000 }
-	fn force_transfer() -> Weight { 1_000_000_000 }
 }
 
 pub trait Subtrait<I: Instance = DefaultInstance>: frame_system::Trait {


### PR DESCRIPTION
This sets the "default" balances weight to the weight we have measured when benchmarking the Substrate node using our benchmarking machine.

This means by default, if a user does not specify their own weights, they will use our weights which are safe in the context of how Substrate is configured by default.

This is basically backwards compatible with any existing substrate chains who already use our default weights by using our pallets.

This follows the pattern we will be using moving forward