### PR TITLE
Dynamic Benchmarking DB Whitelist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "sp-std",
+ "sp-storage",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8048,6 +8048,7 @@ dependencies = [
  "sp-runtime-interface-test-wasm",
  "sp-state-machine",
  "sp-std",
+ "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
  "static_assertions",
@@ -8177,6 +8178,7 @@ name = "sp-storage"
 version = "2.0.0-rc5"
 dependencies = [
  "impl-serde 0.2.3",
+ "parity-scale-codec",
  "ref-cast",
  "serde",
  "sp-debug-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ version = "2.0.0-rc5"
 dependencies = [
  "frame-support",
  "frame-system",
+ "hex-literal",
  "linregress",
  "parity-scale-codec",
  "paste",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1130,7 +1130,7 @@ impl_runtime_apis! {
 			repeat: u32,
 			extra: bool,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
 			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
 			// To get around that, we separated the Session benchmarks into its own crate, which is why
 			// we need these two lines below.
@@ -1142,19 +1142,19 @@ impl_runtime_apis! {
 			impl pallet_offences_benchmarking::Trait for Runtime {}
 			impl frame_system_benchmarking::Trait for Runtime {}
 
-			let whitelist: Vec<Vec<u8>> = vec![
+			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
 				// Total Issuance
-				hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),
+				hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
 				// Execution Phase
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
 				// Event Count
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
 				// System Events
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
 				// Treasury Account
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec(),
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1153,8 +1153,6 @@ impl_runtime_apis! {
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
 				// System Events
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec(),
-				// Caller 0 Account
-				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da946c154ffd9992e395af90b5b13cc6f295c77033fce8a9045824a6690bbf99c6db269502f0a8d1d2a008542d5690a0749").to_vec(),
 				// Treasury Account
 				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec(),
 			];

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -432,7 +432,7 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 	}
 
 	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
-		self.whitelist.borrow_mut().to_vec()
+		self.whitelist.borrow().to_vec()
 	}
 
 	fn set_whitelist(&self, new: Vec<TrackedStorageKey>) {

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -426,6 +426,10 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 		self.wipe_tracker()
 	}
 
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		self.whitelist.borrow_mut().to_vec()
+	}
+
 	fn set_whitelist(&self, new: Vec<Vec<u8>>) {
 		*self.whitelist.borrow_mut() = new;
 	}

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -24,7 +24,10 @@ use std::collections::HashMap;
 
 use hash_db::{Prefix, Hasher};
 use sp_trie::{MemoryDB, prefixed_key};
-use sp_core::{storage::ChildInfo, hexdisplay::HexDisplay};
+use sp_core::{
+	storage::{ChildInfo, TrackedStorageKey},
+	hexdisplay::HexDisplay
+};
 use sp_runtime::traits::{Block as BlockT, HashFor};
 use sp_runtime::Storage;
 use sp_state_machine::{DBValue, backend::Backend as StateBackend, StorageCollection};
@@ -93,9 +96,9 @@ pub struct BenchmarkingState<B: BlockT> {
 	genesis: HashMap<Vec<u8>, (Vec<u8>, i32)>,
 	record: Cell<Vec<Vec<u8>>>,
 	shared_cache: SharedCache<B>, // shared cache is always empty
-	key_tracker: RefCell<HashMap<Vec<u8>, KeyTracker>>,
+	key_tracker: RefCell<HashMap<Vec<u8>, TrackedStorageKey>>,
 	read_write_tracker: RefCell<ReadWriteTracker>,
-	whitelist: RefCell<Vec<Vec<u8>>>,
+	whitelist: RefCell<Vec<TrackedStorageKey>>,
 }
 
 impl<B: BlockT> BenchmarkingState<B> {
@@ -426,11 +429,11 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 		self.wipe_tracker()
 	}
 
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		self.whitelist.borrow_mut().to_vec()
 	}
 
-	fn set_whitelist(&self, new: Vec<Vec<u8>>) {
+	fn set_whitelist(&self, new: Vec<TrackedStorageKey>) {
 		*self.whitelist.borrow_mut() = new;
 	}
 

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use frame_system::RawOrigin;
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 use sp_runtime::traits::Bounded;
 
 use crate::Module as Balances;
@@ -40,7 +40,7 @@ benchmarks! {
 	// * Transfer will create the recipient account.
 	transfer {
 		let existential_deposit = T::ExistentialDeposit::get();
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 
 		// Give some multiple of the existential deposit + creation fee + transfer fee
 		let balance = existential_deposit.saturating_mul(ED_MULTIPLIER.into());
@@ -60,7 +60,7 @@ benchmarks! {
 	// * Both accounts exist and will continue to exist.
 	#[extra]
 	transfer_best_case {
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		let recipient: T::AccountId = account("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 
@@ -80,7 +80,7 @@ benchmarks! {
 	// Benchmark `transfer_keep_alive` with the worst possible condition:
 	// * The recipient account is created.
 	transfer_keep_alive {
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		let recipient: T::AccountId = account("recipient", 0, SEED);
 		let recipient_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(recipient.clone());
 

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -24,6 +24,9 @@ sp-storage = { version = "2.0.0-rc5", path = "../../primitives/storage", default
 frame-support = { version = "2.0.0-rc5", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc5", default-features = false, path = "../system" }
 
+[dev-dependencies]
+hex-literal = "0.2.1"
+
 [features]
 default = [ "std" ]
 std = [

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -20,6 +20,7 @@ sp-runtime-interface = { version = "2.0.0-rc5", path = "../../primitives/runtime
 sp-runtime = { version = "2.0.0-rc5", path = "../../primitives/runtime", default-features = false }
 sp-std = { version = "2.0.0-rc5", path = "../../primitives/std", default-features = false }
 sp-io = { version = "2.0.0-rc5", path = "../../primitives/io", default-features = false }
+sp-storage = { version = "2.0.0-rc5", path = "../../primitives/storage", default-features = false }
 frame-support = { version = "2.0.0-rc5", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc5", default-features = false, path = "../system" }
 

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -287,7 +287,6 @@ macro_rules! benchmarks_iter {
 					Call::<T $(, $instance)? >::$dispatch($($arg),*), $origin.into()
 				)?;
 			}
-			{ frame_system::RawOrigin::Root } // Additionally pass origin
 			verify $postcode
 			$( $rest )*
 		}
@@ -300,7 +299,6 @@ macro_rules! benchmarks_iter {
 		( $( $names:tt )* )
 		( $( $names_extra:tt )* )
 		$name:ident { $( $code:tt )* }: $eval:block
-		{ $origin:expr }
 		verify $postcode:block
 		$( $rest:tt )*
 	) => {
@@ -313,7 +311,6 @@ macro_rules! benchmarks_iter {
 			{ $eval }
 			{ $( $code )* }
 			$postcode
-			{ $origin }
 		}
 
 		#[cfg(test)]
@@ -433,7 +430,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -447,7 +443,6 @@ macro_rules! benchmark_backend {
 			{ $eval }
 			{ $( $rest )* }
 			$postcode
-			{ $origin }
 		}
 	};
 	(
@@ -462,7 +457,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -476,7 +470,6 @@ macro_rules! benchmark_backend {
 			{ $eval }
 			{ $( $rest )* }
 			$postcode
-			{ $origin }
 		}
 	};
 	// mutation arm to look after defaulting to a common param
@@ -492,7 +485,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -509,7 +501,6 @@ macro_rules! benchmark_backend {
 				$( $rest )*
 			}
 			$postcode
-			{ $origin }
 		}
 	};
 	// mutation arm to look after defaulting only the range to common param
@@ -525,7 +516,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -542,7 +532,6 @@ macro_rules! benchmark_backend {
 				$( $rest )*
 			}
 			$postcode
-			{ $origin }
 		}
 	};
 	// mutation arm to look after a single tt for param_from.
@@ -558,7 +547,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -572,7 +560,6 @@ macro_rules! benchmark_backend {
 				$( $rest )*
 			}
 			$postcode
-			{ $origin }
 		}
 	};
 	// mutation arm to look after the default tail of `=> ()`
@@ -588,7 +575,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -602,7 +588,6 @@ macro_rules! benchmark_backend {
 				$( $rest )*
 			}
 			$postcode
-			{ $origin }
 		}
 	};
 	// mutation arm to look after `let _ =`
@@ -618,7 +603,6 @@ macro_rules! benchmark_backend {
 			$( $rest:tt )*
 		}
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		$crate::benchmark_backend! {
 			{ $( $instance)? }
@@ -632,7 +616,6 @@ macro_rules! benchmark_backend {
 				$( $rest )*
 			}
 			$postcode
-			{ $origin }
 		}
 	};
 	// actioning arm
@@ -648,7 +631,6 @@ macro_rules! benchmark_backend {
 		{ $eval:block }
 		{ $( $post:tt )* }
 		$postcode:block
-		{ $origin:expr }
 	) => {
 		#[allow(non_camel_case_types)]
 		struct $name;
@@ -705,10 +687,6 @@ macro_rules! benchmark_backend {
 				$( $post )*
 
 				Ok(Box::new(move || -> Result<(), &'static str> { $eval; $postcode; Ok(()) }))
-			}
-
-			fn origin(&self) -> T::Origin {
-				$origin.into()
 			}
 		}
 	};
@@ -779,10 +757,6 @@ macro_rules! selected_benchmark {
 						>::verify(&$bench, components),
 					)*
 				}
-			}
-
-			fn origin(&self) -> T::Origin {
-				frame_system::RawOrigin::Root.into()
 			}
 		}
 	};

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1032,7 +1032,8 @@ macro_rules! impl_benchmark_test {
 ///
 /// For values that should be skipped entirely, we can just pass `key.into()`. For example:
 ///
-/// ```ignore
+/// ```
+/// use frame_benchmarking::TrackedStorageKey;
 /// let whitelist: Vec<TrackedStorageKey> = vec![
 /// 	// Block Number
 /// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
@@ -1043,6 +1044,7 @@ macro_rules! impl_benchmark_test {
 /// 	// Event Count
 /// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
 /// ];
+/// ```
 ///
 /// Then define a mutable local variable to hold your `BenchmarkBatch` object:
 ///

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1018,7 +1018,8 @@ macro_rules! impl_benchmark_test {
 /// let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
 /// ```
 ///
-/// For the `whitelist`, we use a vector of `TrackedStorageKeys`. This is a simple struct used set
+/// The `whitelist` is a parameter you pass to control the DB read/write tracking.
+/// We use a vector of `TrackedStorageKeys`, which is a simple struct used to set
 /// if a key has been read or written to:
 ///
 /// ```ignore
@@ -1029,18 +1030,18 @@ macro_rules! impl_benchmark_test {
 /// }
 /// ```
 ///
-/// For values that should be skipped entirely, we can just pass the `key`. For example:
+/// For values that should be skipped entirely, we can just pass `key.into()`. For example:
 ///
 /// ```ignore
 /// let whitelist: Vec<TrackedStorageKey> = vec![
 /// 	// Block Number
-/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
+/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
 /// 	// Total Issuance
-/// 	hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),
+/// 	hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
 /// 	// Execution Phase
-/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec(),
+/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
 /// 	// Event Count
-/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
+/// 	hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
 /// ];
 ///
 /// Then define a mutable local variable to hold your `BenchmarkBatch` object:

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -638,7 +638,7 @@ macro_rules! benchmark_backend {
 		#[allow(unused_variables)]
 		impl<T: Trait $( <$instance>, I: Instance)? >
 			$crate::BenchmarkingSetup<T $(, $instance)? > for $name
-			where T: frame_system::Trait, $( $where_clause )*
+			where $( $where_clause )*
 		{
 			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
 				vec! [
@@ -724,7 +724,7 @@ macro_rules! selected_benchmark {
 		// Allow us to select a benchmark from the list of available benchmarks.
 		impl<T: Trait $( <$instance>, I: Instance )? >
 			$crate::BenchmarkingSetup<T $(, $instance )? > for SelectedBenchmark
-			where T: frame_system::Trait, $( $where_clause )*
+			where $( $where_clause )*
 		{
 			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
 				match self {

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1019,16 +1019,8 @@ macro_rules! impl_benchmark_test {
 /// ```
 ///
 /// The `whitelist` is a parameter you pass to control the DB read/write tracking.
-/// We use a vector of `TrackedStorageKey`, which is a simple struct used to set
-/// if a key has been read or written to:
-///
-/// ```ignore
-/// pub struct TrackedStorageKey {
-/// 	pub key: Vec<u8>,
-/// 	pub has_been_read: bool,
-/// 	pub has_been_written: bool,
-/// }
-/// ```
+/// We use a vector of [TrackedStorageKey](./struct.TrackedStorageKey.html), which is a simple struct used to set
+/// if a key has been read or written to.
 ///
 /// For values that should be skipped entirely, we can just pass `key.into()`. For example:
 ///

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -736,8 +736,14 @@ macro_rules! impl_benchmark {
 					_ => return Err("Could not find extrinsic."),
 				};
 
-				// Add whitelist to DB
-				$crate::benchmarking::set_whitelist(whitelist.to_vec());
+				// Add whitelist to DB including whitelisted caller
+				let mut whitelist = whitelist.to_vec();
+				let whitelisted_caller_key =
+					<frame_system::Account::<T> as frame_support::storage::StorageMap<_,_>>::hashed_key_for(
+						$crate::whitelisted_caller::<T::AccountId>()
+					);
+				whitelist.push(whitelisted_caller_key);
+				$crate::benchmarking::set_whitelist(whitelist);
 
 				// Warm up the DB
 				$crate::benchmarking::commit_db();

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1019,7 +1019,7 @@ macro_rules! impl_benchmark_test {
 /// ```
 ///
 /// The `whitelist` is a parameter you pass to control the DB read/write tracking.
-/// We use a vector of `TrackedStorageKeys`, which is a simple struct used to set
+/// We use a vector of `TrackedStorageKey`, which is a simple struct used to set
 /// if a key has been read or written to:
 ///
 /// ```ignore

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -637,7 +637,7 @@ macro_rules! benchmark_backend {
 		#[allow(unused_variables)]
 		impl<T: Trait $( <$instance>, I: Instance)? >
 			$crate::BenchmarkingSetup<T $(, $instance)? > for $name
-			where $( $where_clause )*
+			where T: frame_system::Trait, $( $where_clause )*
 		{
 			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
 				vec! [
@@ -723,7 +723,7 @@ macro_rules! selected_benchmark {
 		// Allow us to select a benchmark from the list of available benchmarks.
 		impl<T: Trait $( <$instance>, I: Instance )? >
 			$crate::BenchmarkingSetup<T $(, $instance )? > for SelectedBenchmark
-			where $( $where_clause )*
+			where T: frame_system::Trait, $( $where_clause )*
 		{
 			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
 				match self {

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -20,7 +20,6 @@
 #![cfg(test)]
 
 use super::*;
-use codec::Decode;
 use sp_std::prelude::*;
 use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::{H256, Header}};
 use frame_support::{
@@ -64,12 +63,10 @@ pub trait OtherTrait {
 	type OtherEvent;
 }
 
-pub trait Trait: OtherTrait where Self::OtherEvent: Into<Self::Event> {
+pub trait Trait: frame_system::Trait + OtherTrait
+	where Self::OtherEvent: Into<<Self as Trait>::Event>
+{
 	type Event;
-	type BlockNumber;
-	type AccountId: 'static + Default + Decode;
-	type Origin: From<frame_system::RawOrigin<Self::AccountId>> +
-		Into<Result<RawOrigin<Self::AccountId>, Self::Origin>>;
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -105,9 +102,6 @@ impl frame_system::Trait for Test {
 
 impl Trait for Test {
 	type Event = ();
-	type BlockNumber = u32;
-	type Origin = Origin;
-	type AccountId = u64;
 }
 
 impl OtherTrait for Test {

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -101,18 +101,38 @@ pub trait Benchmarking {
 		self.commit()
 	}
 
-	/// Get the read/write count
+	/// Get the read/write count.
 	fn read_write_count(&self) -> (u32, u32, u32, u32) {
 		self.read_write_count()
 	}
 
-	/// Reset the read/write count
+	/// Reset the read/write count.
 	fn reset_read_write_count(&mut self) {
 		self.reset_read_write_count()
 	}
 
+	/// Get the DB whitelist.
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		self.get_whitelist()
+	}
+
+	/// Set the DB whitelist.
 	fn set_whitelist(&mut self, new: Vec<Vec<u8>>) {
 		self.set_whitelist(new)
+	}
+
+	// Add a new item to the DB whitelist.
+	fn add_whitelist(&mut self, add: Vec<u8>) {
+		let mut whitelist = self.get_whitelist();
+		whitelist.push(add);
+		self.set_whitelist(whitelist);
+	}
+
+	// Remove an item from the DB whitelist.
+	fn remove_whitelist(&mut self, remove: Vec<u8>) {
+		let mut whitelist = self.get_whitelist();
+		whitelist.retain(|x| x != &remove);
+		self.set_whitelist(whitelist);
 	}
 }
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -169,7 +169,9 @@ pub trait Benchmarking<T> {
 ///
 /// Instance generic parameter is optional and can be used in order to capture unused generics for
 /// instantiable pallets.
-pub trait BenchmarkingSetup<T, I = ()> {
+pub trait BenchmarkingSetup<T, I = ()>
+	where T: frame_system::Trait
+{
 	/// Return the components and their ranges which should be tested in this benchmark.
 	fn components(&self) -> Vec<(BenchmarkParameter, u32, u32)>;
 
@@ -178,6 +180,9 @@ pub trait BenchmarkingSetup<T, I = ()> {
 
 	/// Set up the storage, and prepare a closure to test and verify the benchmark
 	fn verify(&self, components: &[(BenchmarkParameter, u32)]) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
+
+	/// The origin used when executing the extrinsic.
+	fn origin(&self) -> T::Origin;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -183,9 +183,7 @@ pub trait Benchmarking<T> {
 ///
 /// Instance generic parameter is optional and can be used in order to capture unused generics for
 /// instantiable pallets.
-pub trait BenchmarkingSetup<T, I = ()>
-	where T: frame_system::Trait
-{
+pub trait BenchmarkingSetup<T, I = ()> {
 	/// Return the components and their ranges which should be tested in this benchmark.
 	fn components(&self) -> Vec<(BenchmarkParameter, u32, u32)>;
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -124,8 +124,10 @@ pub trait Benchmarking {
 	// Add a new item to the DB whitelist.
 	fn add_whitelist(&mut self, add: Vec<u8>) {
 		let mut whitelist = self.get_whitelist();
-		whitelist.push(add);
-		self.set_whitelist(whitelist);
+		if !whitelist.contains(&add) {
+			whitelist.push(add);
+			self.set_whitelist(whitelist);
+		}
 	}
 
 	// Remove an item from the DB whitelist.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -123,7 +123,7 @@ pub trait Benchmarking {
 	}
 
 	// Add a new item to the DB whitelist.
-	fn add_whitelist(&mut self, add: TrackedStorageKey) {
+	fn add_to_whitelist(&mut self, add: TrackedStorageKey) {
 		let mut whitelist = self.get_whitelist();
 		match whitelist.iter_mut().find(|x| x.key == add.key) {
 			// If we already have this key in the whitelist, update to be the most constrained value.
@@ -143,7 +143,7 @@ pub trait Benchmarking {
 	}
 
 	// Remove an item from the DB whitelist.
-	fn remove_whitelist(&mut self, remove: Vec<u8>) {
+	fn remove_from_whitelist(&mut self, remove: Vec<u8>) {
 		let mut whitelist = self.get_whitelist();
 		whitelist.retain(|x| x.key != remove);
 		self.set_whitelist(whitelist);

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -185,3 +185,8 @@ pub fn account<AccountId: Decode + Default>(name: &'static str, index: u32, seed
 	let entropy = (name, index, seed).using_encoded(blake2_256);
 	AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 }
+
+/// This caller account is automatically whitelisted for DB reads/writes by the benchmarking macro.
+pub fn whitelisted_caller<AccountId: Decode + Default>() -> AccountId {
+	account::<AccountId>("whitelisted_caller", 0, 0)
+}

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -180,9 +180,6 @@ pub trait BenchmarkingSetup<T, I = ()>
 
 	/// Set up the storage, and prepare a closure to test and verify the benchmark
 	fn verify(&self, components: &[(BenchmarkParameter, u32)]) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
-
-	/// The origin used when executing the extrinsic.
-	fn origin(&self) -> T::Origin;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -21,6 +21,7 @@ use codec::{Encode, Decode};
 use sp_std::{vec::Vec, prelude::Box};
 use sp_io::hashing::blake2_256;
 use sp_runtime::RuntimeString;
+use sp_storage::TrackedStorageKey;
 
 /// An alphabet of possible parameters to use for benchmarking.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Debug)]
@@ -112,17 +113,17 @@ pub trait Benchmarking {
 	}
 
 	/// Get the DB whitelist.
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		self.get_whitelist()
 	}
 
 	/// Set the DB whitelist.
-	fn set_whitelist(&mut self, new: Vec<Vec<u8>>) {
+	fn set_whitelist(&mut self, new: Vec<TrackedStorageKey>) {
 		self.set_whitelist(new)
 	}
 
 	// Add a new item to the DB whitelist.
-	fn add_whitelist(&mut self, add: Vec<u8>) {
+	fn add_whitelist(&mut self, add: TrackedStorageKey) {
 		let mut whitelist = self.get_whitelist();
 		if !whitelist.contains(&add) {
 			whitelist.push(add);

--- a/frame/collective/src/benchmarking.rs
+++ b/frame/collective/src/benchmarking.rs
@@ -21,7 +21,7 @@ use super::*;
 
 use frame_system::RawOrigin as SystemOrigin;
 use frame_system::EventRecord;
-use frame_benchmarking::{benchmarks_instance, account};
+use frame_benchmarking::{benchmarks_instance, account, whitelisted_caller};
 use sp_runtime::traits::Bounded;
 use sp_std::mem::size_of;
 
@@ -123,7 +123,7 @@ benchmarks_instance! {
 			members.push(member);
 		}
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 
 		Collective::<T, _>::set_members(SystemOrigin::Root.into(), members, None, MAX_MEMBERS)?;
@@ -153,7 +153,7 @@ benchmarks_instance! {
 			members.push(member);
 		}
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 
 		Collective::<T, _>::set_members(SystemOrigin::Root.into(), members, None, MAX_MEMBERS)?;
@@ -184,7 +184,7 @@ benchmarks_instance! {
 			let member = account("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 		Collective::<T, _>::set_members(SystemOrigin::Root.into(), members, None, MAX_MEMBERS)?;
 
@@ -377,7 +377,7 @@ benchmarks_instance! {
 			let member = account("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 		Collective::<T, _>::set_members(SystemOrigin::Root.into(), members.clone(), None, MAX_MEMBERS)?;
 
@@ -458,7 +458,7 @@ benchmarks_instance! {
 			let member = account("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 		Collective::<T, _>::set_members(
 			SystemOrigin::Root.into(),
@@ -530,7 +530,7 @@ benchmarks_instance! {
 			let member = account("member", i, SEED);
 			members.push(member);
 		}
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		members.push(caller.clone());
 		Collective::<T, _>::set_members(
 			SystemOrigin::Root.into(),

--- a/frame/indices/src/benchmarking.rs
+++ b/frame/indices/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 use frame_system::RawOrigin;
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 use sp_runtime::traits::Bounded;
 
 use crate::Module as Indices;
@@ -35,7 +35,7 @@ benchmarks! {
 		// Index being claimed
 		let i in 0 .. 1000;
 		let account_index = T::AccountIndex::from(i);
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 	}: _(RawOrigin::Signed(caller.clone()), account_index)
 	verify {
@@ -47,7 +47,7 @@ benchmarks! {
 		let i in 0 .. 1000;
 		let account_index = T::AccountIndex::from(i);
 		// Setup accounts
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		let recipient: T::AccountId = account("recipient", i, SEED);
 		T::Currency::make_free_balance_be(&recipient, BalanceOf::<T>::max_value());
@@ -63,7 +63,7 @@ benchmarks! {
 		let i in 0 .. 1000;
 		let account_index = T::AccountIndex::from(i);
 		// Setup accounts
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(caller.clone()).into(), account_index)?;
@@ -93,7 +93,7 @@ benchmarks! {
 		let i in 0 .. 1000;
 		let account_index = T::AccountIndex::from(i);
 		// Setup accounts
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		// Claim the index
 		Indices::<T>::claim(RawOrigin::Signed(caller.clone()).into(), account_index)?;

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -474,7 +474,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: {
 		let result = <Staking<T>>::submit_election_solution(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -538,7 +538,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 
 		// submit a very bad solution on-chain
 		{
@@ -594,7 +594,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 
 		// submit a seq-phragmen with all the good stuff on chain.
 		{

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -474,7 +474,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: {
 		let result = <Staking<T>>::submit_election_solution(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -538,7 +538,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 
 		// submit a very bad solution on-chain
 		{
@@ -594,7 +594,7 @@ benchmarks! {
 
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 
 		// submit a seq-phragmen with all the good stuff on chain.
 		{

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -23,7 +23,7 @@ use testing_utils::*;
 
 use sp_runtime::traits::One;
 use frame_system::RawOrigin;
-pub use frame_benchmarking::{benchmarks, account};
+pub use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 const SEED: u32 = 0;
 const MAX_SPANS: u32 = 100;
 const MAX_VALIDATORS: u32 = 1000;
@@ -280,7 +280,7 @@ benchmarks! {
 		let validator = create_validator_with_nominators::<T>(n, T::MaxNominatorRewardedPerValidator::get() as u32, true)?;
 
 		let current_era = CurrentEra::get().unwrap();
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);
 	}: _(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
@@ -294,7 +294,7 @@ benchmarks! {
 		let validator = create_validator_with_nominators::<T>(n, T::MaxNominatorRewardedPerValidator::get() as u32, false)?;
 
 		let current_era = CurrentEra::get().unwrap();
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
@@ -419,7 +419,7 @@ benchmarks! {
 		let total_payout = T::Currency::minimum_balance() * 1000.into();
 		<ErasValidatorReward<T>>::insert(current_era, total_payout);
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 	}: {
 		for arg in payout_calls_arg {
 			<Staking<T>>::payout_stakers(RawOrigin::Signed(caller.clone()).into(), arg.0, arg.1)?;
@@ -471,6 +471,10 @@ benchmarks! {
 
 		let era = <Staking<T>>::current_era().unwrap_or(0);
 		let caller: T::AccountId = account("caller", n, SEED);
+
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: {
 		let result = <Staking<T>>::submit_election_solution(
 			RawOrigin::Signed(caller.clone()).into(),
@@ -532,6 +536,10 @@ benchmarks! {
 		let era = <Staking<T>>::current_era().unwrap_or(0);
 		let caller: T::AccountId = account("caller", n, SEED);
 
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+
 		// submit a very bad solution on-chain
 		{
 			// this is needed to fool the chain to accept this solution.
@@ -583,6 +591,10 @@ benchmarks! {
 		<EraElectionStatus<T>>::put(ElectionStatus::Open(T::BlockNumber::from(1u32)));
 		let caller: T::AccountId = account("caller", n, SEED);
 		let era = <Staking<T>>::current_era().unwrap_or(0);
+
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 
 		// submit a seq-phragmen with all the good stuff on chain.
 		{

--- a/frame/system/benchmarking/src/lib.rs
+++ b/frame/system/benchmarking/src/lib.rs
@@ -24,13 +24,11 @@ use sp_std::vec;
 use sp_std::prelude::*;
 use sp_core::{ChangesTrieConfiguration, storage::well_known_keys};
 use sp_runtime::traits::Hash;
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::storage::{self, StorageMap};
 use frame_system::{Module as System, Call, RawOrigin, DigestItemOf, AccountInfo};
 
 mod mock;
-
-const SEED: u32 = 0;
 
 pub struct Module<T: Trait>(System<T>);
 pub trait Trait: frame_system::Trait {}
@@ -42,7 +40,7 @@ benchmarks! {
 		// # of Bytes
 		let b in 0 .. 16_384;
 		let remark_message = vec![1; b as usize];
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 	}: _(RawOrigin::Signed(caller), remark_message)
 
 	set_heap_pages {
@@ -142,7 +140,7 @@ benchmarks! {
 
 	suicide {
 		let n in 1 .. 1000;
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		let account_info = AccountInfo::<T::Index, T::AccountData> {
 			nonce: n.into(),
 			refcount: 0,

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -34,8 +34,10 @@ benchmarks! {
 
 	set {
 		let t in 1 .. MAX_TIME;
+		// Ignore write to `DidUpdate` since it transient.
+		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
+		frame_benchmarking::benchmarking::add_whitelist(did_update_key);
 	}: _(RawOrigin::None, t.into())
-
 	verify {
 		ensure!(Timestamp::<T>::now() == t.into(), "Time was not set.");
 	}
@@ -44,8 +46,10 @@ benchmarks! {
 		let t in 1 .. MAX_TIME;
 		Timestamp::<T>::set(RawOrigin::None.into(), t.into())?;
 		ensure!(DidUpdate::exists(), "Time was not set.");
+		// Ignore read/write to `DidUpdate` since it transient.
+		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
+		frame_benchmarking::benchmarking::add_whitelist(did_update_key);
 	}: { Timestamp::<T>::on_finalize(t.into()); }
-
 	verify {
 		ensure!(!DidUpdate::exists(), "Time was not removed.");
 	}

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -23,7 +23,7 @@ use super::*;
 use sp_std::prelude::*;
 use frame_system::RawOrigin;
 use frame_support::{ensure, traits::OnFinalize};
-use frame_benchmarking::benchmarks;
+use frame_benchmarking::{benchmarks, TrackedStorageKey};
 
 use crate::Module as Timestamp;
 
@@ -36,7 +36,11 @@ benchmarks! {
 		let t in 1 .. MAX_TIME;
 		// Ignore write to `DidUpdate` since it transient.
 		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
-		frame_benchmarking::benchmarking::add_whitelist(did_update_key);
+		frame_benchmarking::benchmarking::add_whitelist(TrackedStorageKey {
+			key: did_update_key,
+			has_been_read: false,
+			has_been_written: true,
+		});
 	}: _(RawOrigin::None, t.into())
 	verify {
 		ensure!(Timestamp::<T>::now() == t.into(), "Time was not set.");
@@ -48,7 +52,7 @@ benchmarks! {
 		ensure!(DidUpdate::exists(), "Time was not set.");
 		// Ignore read/write to `DidUpdate` since it transient.
 		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
-		frame_benchmarking::benchmarking::add_whitelist(did_update_key);
+		frame_benchmarking::benchmarking::add_whitelist(did_update_key.into());
 	}: { Timestamp::<T>::on_finalize(t.into()); }
 	verify {
 		ensure!(!DidUpdate::exists(), "Time was not removed.");

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -36,7 +36,7 @@ benchmarks! {
 		let t in 1 .. MAX_TIME;
 		// Ignore write to `DidUpdate` since it transient.
 		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
-		frame_benchmarking::benchmarking::add_whitelist(TrackedStorageKey {
+		frame_benchmarking::benchmarking::add_to_whitelist(TrackedStorageKey {
 			key: did_update_key,
 			has_been_read: false,
 			has_been_written: true,
@@ -52,7 +52,7 @@ benchmarks! {
 		ensure!(DidUpdate::exists(), "Time was not set.");
 		// Ignore read/write to `DidUpdate` since it is transient.
 		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
-		frame_benchmarking::benchmarking::add_whitelist(did_update_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(did_update_key.into());
 	}: { Timestamp::<T>::on_finalize(t.into()); }
 	verify {
 		ensure!(!DidUpdate::exists(), "Time was not removed.");

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -50,7 +50,7 @@ benchmarks! {
 		let t in 1 .. MAX_TIME;
 		Timestamp::<T>::set(RawOrigin::None.into(), t.into())?;
 		ensure!(DidUpdate::exists(), "Time was not set.");
-		// Ignore read/write to `DidUpdate` since it transient.
+		// Ignore read/write to `DidUpdate` since it is transient.
 		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
 		frame_benchmarking::benchmarking::add_whitelist(did_update_key.into());
 	}: { Timestamp::<T>::on_finalize(t.into()); }

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use frame_system::RawOrigin;
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 use frame_support::traits::OnInitialize;
 
 use crate::Module as Treasury;
@@ -45,7 +45,7 @@ fn setup_proposal<T: Trait>(u: u32) -> (
 
 // Create the pre-requisite information needed to create a `report_awesome`.
 fn setup_awesome<T: Trait>(length: u32) -> (T::AccountId, Vec<u8>, T::AccountId) {
-	let caller = account("caller", 0, SEED);
+	let caller = whitelisted_caller();
 	let value = T::TipReportDepositBase::get()
 		+ T::TipReportDepositPerByte::get() * length.into()
 		+ T::Currency::minimum_balance();
@@ -116,6 +116,9 @@ benchmarks! {
 	propose_spend {
 		let u in 0 .. 1000;
 		let (caller, value, beneficiary_lookup) = setup_proposal::<T>(u);
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), value, beneficiary_lookup)
 
 	reject_proposal {
@@ -143,6 +146,9 @@ benchmarks! {
 	report_awesome {
 		let r in 0 .. MAX_BYTES;
 		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), reason, awesome_person)
 
 	retract_tip {
@@ -155,6 +161,12 @@ benchmarks! {
 		)?;
 		let reason_hash = T::Hashing::hash(&reason[..]);
 		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), hash)
 
 	tip_new {
@@ -162,6 +174,9 @@ benchmarks! {
 		let t in 1 .. MAX_TIPPERS;
 
 		let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), reason, beneficiary, value)
 
 	tip {
@@ -179,6 +194,9 @@ benchmarks! {
 		ensure!(Tips::<T>::contains_key(hash), "tip does not exist");
 		create_tips::<T>(t - 1, hash.clone(), value)?;
 		let caller = account("member", t - 1, SEED);
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), hash, value)
 
 	close_tip {
@@ -206,6 +224,9 @@ benchmarks! {
 		create_tips::<T>(t, hash.clone(), value)?;
 
 		let caller = account("caller", t, SEED);
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), hash)
 
 	on_initialize {

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -118,7 +118,7 @@ benchmarks! {
 		let (caller, value, beneficiary_lookup) = setup_proposal::<T>(u);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), value, beneficiary_lookup)
 
 	reject_proposal {
@@ -148,7 +148,7 @@ benchmarks! {
 		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), reason, awesome_person)
 
 	retract_tip {
@@ -163,7 +163,7 @@ benchmarks! {
 		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash)
 
 	tip_new {
@@ -173,7 +173,7 @@ benchmarks! {
 		let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), reason, beneficiary, value)
 
 	tip {
@@ -193,7 +193,7 @@ benchmarks! {
 		let caller = account("member", t - 1, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash, value)
 
 	close_tip {
@@ -223,7 +223,7 @@ benchmarks! {
 		let caller = account("caller", t, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash)
 
 	on_initialize {

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -164,9 +164,6 @@ benchmarks! {
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
 		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
-		// Whitelist caller account from further DB operations.
-		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash)
 
 	tip_new {

--- a/frame/treasury/src/benchmarking.rs
+++ b/frame/treasury/src/benchmarking.rs
@@ -118,7 +118,7 @@ benchmarks! {
 		let (caller, value, beneficiary_lookup) = setup_proposal::<T>(u);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), value, beneficiary_lookup)
 
 	reject_proposal {
@@ -148,7 +148,7 @@ benchmarks! {
 		let (caller, reason, awesome_person) = setup_awesome::<T>(r);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), reason, awesome_person)
 
 	retract_tip {
@@ -163,10 +163,10 @@ benchmarks! {
 		let hash = T::Hashing::hash_of(&(&reason_hash, &awesome_person));
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash)
 
 	tip_new {
@@ -176,7 +176,7 @@ benchmarks! {
 		let (caller, reason, beneficiary, value) = setup_tip::<T>(r, t)?;
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), reason, beneficiary, value)
 
 	tip {
@@ -196,7 +196,7 @@ benchmarks! {
 		let caller = account("member", t - 1, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash, value)
 
 	close_tip {
@@ -226,7 +226,7 @@ benchmarks! {
 		let caller = account("caller", t, SEED);
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), hash)
 
 	on_initialize {

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -55,7 +55,7 @@ benchmarks! {
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), u as u16, call)
 }
 

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -55,7 +55,7 @@ benchmarks! {
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
 		// Whitelist caller account from further DB operations.
 		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
-		frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
+		frame_benchmarking::benchmarking::add_to_whitelist(caller_key.into());
 	}: _(RawOrigin::Signed(caller), u as u16, call)
 }
 

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 use frame_system::{RawOrigin, EventRecord};
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 
 const SEED: u32 = 0;
 
@@ -43,7 +43,7 @@ benchmarks! {
 			let call = frame_system::Call::remark(vec![]).into();
 			calls.push(call);
 		}
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 	}: _(RawOrigin::Signed(caller), calls)
 	verify {
 		assert_last_event::<T>(Event::BatchCompleted.into())
@@ -53,6 +53,9 @@ benchmarks! {
 		let u in 0 .. 1000;
 		let caller = account("caller", u, SEED);
 		let call = Box::new(frame_system::Call::remark(vec![]).into());
+		// Whitelist caller account from further DB operations.
+		let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
+		frame_benchmarking::benchmarking::add_whitelist(caller_key);
 	}: _(RawOrigin::Signed(caller), u as u16, call)
 }
 

--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use frame_system::{RawOrigin, Module as System};
-use frame_benchmarking::{benchmarks, account};
+use frame_benchmarking::{benchmarks, account, whitelisted_caller};
 use sp_runtime::traits::Bounded;
 
 use crate::Module as Vesting;
@@ -64,7 +64,7 @@ benchmarks! {
 	vest_locked {
 		let l in 0 .. MAX_LOCKS;
 
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		add_locks::<T>(&caller, l as u8);
 		add_vesting_schedule::<T>(&caller)?;
@@ -88,7 +88,7 @@ benchmarks! {
 	vest_unlocked {
 		let l in 0 .. MAX_LOCKS;
 
-		let caller = account("caller", 0, SEED);
+		let caller = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		add_locks::<T>(&caller, l as u8);
 		add_vesting_schedule::<T>(&caller)?;
@@ -125,7 +125,7 @@ benchmarks! {
 			"Vesting schedule not added",
 		);
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 	}: vest_other(RawOrigin::Signed(caller.clone()), other_lookup)
 	verify {
 		// Nothing happened since everything is still vested.
@@ -152,7 +152,7 @@ benchmarks! {
 			"Vesting schedule still active",
 		);
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 	}: vest_other(RawOrigin::Signed(caller.clone()), other_lookup)
 	verify {
 		// Vesting schedule is removed!
@@ -166,7 +166,7 @@ benchmarks! {
 	vested_transfer {
 		let l in 0 .. MAX_LOCKS;
 
-		let caller: T::AccountId = account("caller", 0, SEED);
+		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		let target: T::AccountId = account("target", 0, SEED);
 		let target_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(target.clone());

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -252,6 +252,13 @@ pub trait Externalities: ExtensionStore {
 	/// Benchmarking related functionality and shouldn't be used anywhere else!
 	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	///
+	/// Gets the current DB tracking whitelist.
+	fn get_whitelist(&self) -> Vec<Vec<u8>>;
+
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	/// Benchmarking related functionality and shouldn't be used anywhere else!
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	///
 	/// Adds new storage keys to the DB tracking whitelist.
 	fn set_whitelist(&mut self, new: Vec<Vec<u8>>);
 }

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -25,7 +25,7 @@
 
 use std::any::{Any, TypeId};
 
-use sp_storage::ChildInfo;
+use sp_storage::{ChildInfo, TrackedStorageKey};
 
 pub use scope_limited::{set_and_run_with_externalities, with_externalities};
 pub use extensions::{Extension, Extensions, ExtensionStore};
@@ -253,14 +253,14 @@ pub trait Externalities: ExtensionStore {
 	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	///
 	/// Gets the current DB tracking whitelist.
-	fn get_whitelist(&self) -> Vec<Vec<u8>>;
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey>;
 
 	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	/// Benchmarking related functionality and shouldn't be used anywhere else!
 	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 	///
 	/// Adds new storage keys to the DB tracking whitelist.
-	fn set_whitelist(&mut self, new: Vec<Vec<u8>>);
+	fn set_whitelist(&mut self, new: Vec<TrackedStorageKey>);
 }
 
 /// Extension for the [`Externalities`] trait.

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -21,6 +21,7 @@ sp-externalities = { version = "0.8.0-rc5", optional = true, path = "../external
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 static_assertions = "1.0.0"
 primitive-types = { version = "0.7.0", default-features = false }
+sp-storage = { version = "2.0.0-rc5", default-features = false, path = "../storage" }
 
 [dev-dependencies]
 sp-runtime-interface-test-wasm = { version = "2.0.0-rc5", path = "test-wasm" }

--- a/primitives/runtime-interface/src/impls.rs
+++ b/primitives/runtime-interface/src/impls.rs
@@ -537,3 +537,7 @@ impl PassBy for sp_wasm_interface::ValueType {
 impl PassBy for sp_wasm_interface::Value {
 	type PassBy = Codec<sp_wasm_interface::Value>;
 }
+
+impl PassBy for sp_storage::TrackedStorageKey {
+	type PassBy = Codec<Self>;
+}

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -19,7 +19,10 @@
 
 use hash_db::Hasher;
 use codec::{Decode, Encode};
-use sp_core::{traits::RuntimeCode, storage::{ChildInfo, well_known_keys}};
+use sp_core::{
+	traits::RuntimeCode,
+	storage::{ChildInfo, well_known_keys, TrackedStorageKey}
+};
 use crate::{
 	trie_backend::TrieBackend,
 	trie_backend_essence::TrieBackendStorage,
@@ -227,12 +230,12 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 	}
 
 	/// Get the whitelist for tracking db reads/writes
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		Default::default()
 	}
 
 	/// Update the whitelist for tracking db reads/writes
-	fn set_whitelist(&self, _: Vec<Vec<u8>>) {}
+	fn set_whitelist(&self, _: Vec<TrackedStorageKey>) {}
 }
 
 impl<'a, T: Backend<H>, H: Hasher> Backend<H> for &'a T {

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -226,10 +226,13 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 		unimplemented!()
 	}
 
-	/// Update the whitelist for tracking db reads/writes
-	fn set_whitelist(&self, _: Vec<Vec<u8>>) {
-		unimplemented!()
+	/// Get the whitelist for tracking db reads/writes
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		Default::default()
 	}
+
+	/// Update the whitelist for tracking db reads/writes
+	fn set_whitelist(&self, _: Vec<Vec<u8>>) {}
 }
 
 impl<'a, T: Backend<H>, H: Hasher> Backend<H> for &'a T {

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -325,6 +325,10 @@ impl Externalities for BasicExternalities {
 		unimplemented!("reset_read_write_count is not supported in Basic")
 	}
 
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		unimplemented!("get_whitelist is not supported in Basic")
+	}
+
 	fn set_whitelist(&mut self, _: Vec<Vec<u8>>) {
 		unimplemented!("set_whitelist is not supported in Basic")
 	}

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -27,7 +27,7 @@ use sp_trie::trie_types::Layout;
 use sp_core::{
 	storage::{
 		well_known_keys::is_child_storage_key, Storage,
-		ChildInfo, StorageChild,
+		ChildInfo, StorageChild, TrackedStorageKey,
 	},
 	traits::Externalities, Blake2Hasher,
 };
@@ -325,11 +325,11 @@ impl Externalities for BasicExternalities {
 		unimplemented!("reset_read_write_count is not supported in Basic")
 	}
 
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		unimplemented!("get_whitelist is not supported in Basic")
 	}
 
-	fn set_whitelist(&mut self, _: Vec<Vec<u8>>) {
+	fn set_whitelist(&mut self, _: Vec<TrackedStorageKey>) {
 		unimplemented!("set_whitelist is not supported in Basic")
 	}
 }

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -609,6 +609,10 @@ where
 		self.backend.reset_read_write_count()
 	}
 
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		self.backend.get_whitelist()
+	}
+
 	fn set_whitelist(&mut self, new: Vec<Vec<u8>>) {
 		self.backend.set_whitelist(new)
 	}

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -26,7 +26,7 @@ use crate::{
 use hash_db::Hasher;
 use sp_core::{
 	offchain::storage::OffchainOverlayedChanges,
-	storage::{well_known_keys::is_child_storage_key, ChildInfo},
+	storage::{well_known_keys::is_child_storage_key, ChildInfo, TrackedStorageKey},
 	traits::Externalities, hexdisplay::HexDisplay,
 };
 use sp_trie::{trie_types::Layout, empty_child_trie_root};
@@ -609,11 +609,11 @@ where
 		self.backend.reset_read_write_count()
 	}
 
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		self.backend.get_whitelist()
 	}
 
-	fn set_whitelist(&mut self, new: Vec<Vec<u8>>) {
+	fn set_whitelist(&mut self, new: Vec<TrackedStorageKey>) {
 		self.backend.set_whitelist(new)
 	}
 }

--- a/primitives/state-machine/src/read_only.rs
+++ b/primitives/state-machine/src/read_only.rs
@@ -24,7 +24,7 @@ use std::{
 use crate::{Backend, StorageKey, StorageValue};
 use hash_db::Hasher;
 use sp_core::{
-	storage::ChildInfo,
+	storage::{ChildInfo, TrackedStorageKey},
 	traits::Externalities, Blake2Hasher,
 };
 use codec::Encode;
@@ -194,11 +194,11 @@ impl<'a, H: Hasher, B: 'a + Backend<H>> Externalities for ReadOnlyExternalities<
 		unimplemented!("reset_read_write_count is not supported in ReadOnlyExternalities")
 	}
 
-	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+	fn get_whitelist(&self) -> Vec<TrackedStorageKey> {
 		unimplemented!("get_whitelist is not supported in ReadOnlyExternalities")
 	}
 
-	fn set_whitelist(&mut self, _: Vec<Vec<u8>>) {
+	fn set_whitelist(&mut self, _: Vec<TrackedStorageKey>) {
 		unimplemented!("set_whitelist is not supported in ReadOnlyExternalities")
 	}
 }

--- a/primitives/state-machine/src/read_only.rs
+++ b/primitives/state-machine/src/read_only.rs
@@ -194,6 +194,10 @@ impl<'a, H: Hasher, B: 'a + Backend<H>> Externalities for ReadOnlyExternalities<
 		unimplemented!("reset_read_write_count is not supported in ReadOnlyExternalities")
 	}
 
+	fn get_whitelist(&self) -> Vec<Vec<u8>> {
+		unimplemented!("get_whitelist is not supported in ReadOnlyExternalities")
+	}
+
 	fn set_whitelist(&mut self, _: Vec<Vec<u8>>) {
 		unimplemented!("set_whitelist is not supported in ReadOnlyExternalities")
 	}

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -18,7 +18,8 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 impl-serde = { version = "0.2.3", optional = true }
 ref-cast = "1.0.0"
 sp-debug-derive = { version = "2.0.0-rc5", path = "../debug-derive" }
+codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 
 [features]
 default = [ "std" ]
-std = [ "sp-std/std", "serde", "impl-serde" ]
+std = [ "sp-std/std", "serde", "impl-serde", "codec/std" ]

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -25,6 +25,7 @@ use sp_debug_derive::RuntimeDebug;
 
 use sp_std::{vec::Vec, ops::{Deref, DerefMut}};
 use ref_cast::RefCast;
+use codec::{Encode, Decode};
 
 /// Storage key.
 #[derive(PartialEq, Eq, RuntimeDebug)]
@@ -35,12 +36,23 @@ pub struct StorageKey(
 );
 
 /// Storage key with read/write tracking information.
-#[derive(PartialEq, Eq, RuntimeDebug, Clone)]
+#[derive(PartialEq, Eq, RuntimeDebug, Clone, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Hash, PartialOrd, Ord))]
 pub struct TrackedStorageKey {
 	pub key: Vec<u8>,
 	pub has_been_read: bool,
 	pub has_been_written: bool,
+}
+
+// Easily convert a key to a `TrackedStorageKey` that has been read and written to.
+impl From<Vec<u8>> for TrackedStorageKey {
+	fn from(key: Vec<u8>) -> Self {
+		Self {
+			key: key,
+			has_been_read: true,
+			has_been_written: true,
+		}
+	}
 }
 
 /// Storage key of a child trie, it contains the prefix to the key.

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -34,6 +34,15 @@ pub struct StorageKey(
 	pub Vec<u8>,
 );
 
+/// Storage key with read/write tracking information.
+#[derive(PartialEq, Eq, RuntimeDebug, Clone)]
+#[cfg_attr(feature = "std", derive(Hash, PartialOrd, Ord))]
+pub struct TrackedStorageKey {
+	pub key: Vec<u8>,
+	pub has_been_read: bool,
+	pub has_been_written: bool,
+}
+
 /// Storage key of a child trie, it contains the prefix to the key.
 #[derive(PartialEq, Eq, RuntimeDebug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, PartialOrd, Ord, Clone))]


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/1612

This PR introduces a new `get_whitelist` host function. In combination with `set_whitelist`, we are able to create helper functions `add_whitelist` and `remove_whitelist` which can be called from a benchmark to dynamically introduce or remove items from the benchmarking whitelist.

Additionally, this PR updates the format of the whitelist to use a new struct `TrackedStorageKey`:

```rust
pub struct TrackedStorageKey {
	pub key: Vec<u8>,
	pub has_been_read: bool,
	pub has_been_written: bool,
}
```

Which includes the storage key, and whether this storage key has been read from or written to. This allows us to whitelist a key for a read, write, or both.

Here are some explicit examples of how you would use this:

## Ignore Read, Track Write

Let's say that you have some storage value that is read each block, so you are able to ignore reads to that variable introduced by an extrinsic, but you still want to track the first write. For example, the `LaunchPeriod` of the democracy module may be placed as a storage item, and every `on_initialize`, we check if the block would trigger a launch period (reading it every block), but if we had an extrinsic to update the launch period, we would still want to track writes to this value.  To your benchmark you would add the following:

```rust
// Ignore reads to `LaunchPeriod` since it read every `on_initialize`. But still track writes to this value.
let launch_period_key = crate::LaunchPeriod::hashed_key().to_vec();
frame_benchmarking::benchmarking::add_whitelist(TrackedStorageKey {
	key: launch_period_key,
	has_been_read: true,
	has_been_written: false,
});
```

## Track Read, Ignore Write

In some more unique scenarios, you may want to track the first read of a storage item, but ignore any writes to it. For example the Timestamp pallet has the `DidUpdate` variable which is transient (created and destroyed within one block), but before we create the value, we make sure it doesn't already exist. This `exist` lookup should be counted as a storage read, but us writing to the value should not be counted because it will be removed at the end of the block, ultimately not committing anything to the DB. You would represent this like so:

```rust
// Ignore write to `DidUpdate` since it transient.
let did_update_key = crate::DidUpdate::hashed_key().to_vec();
frame_benchmarking::benchmarking::add_whitelist(TrackedStorageKey {
	key: did_update_key,
	has_been_read: false,
	has_been_written: true,
});
```

## Ignore Read and Write

Finally, the most common scenario is to simply ignore both reads and writes to a storage key. For example, use a unique caller account, and want to make sure that reads/writes to the `System.Account` of that caller are not accounted for as they are already included in the base weight of an extrinsic. For this, we can use a shorthand to construct the `TrackedStorageKey` by simply converting with `key.into()`, like so:

```rust
// Whitelist caller account from further DB operations.
let caller_key = frame_system::Account::<T>::hashed_key_for(&caller);
frame_benchmarking::benchmarking::add_whitelist(caller_key.into());
```

fixes #6802 