### PR TITLE
Warn in tests when no events are being emitted

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -940,7 +940,7 @@ impl<T: Trait> Module<T> {
 		if block_number.is_zero() {
 			// Print a message only in tests warning users about this behavior.
 			#[cfg(test)]
-			println!("The block number is zero, so events are not being deposited.")
+			println!("The block number is zero, so events are not being deposited.");
 
 			return
 		}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -937,7 +937,13 @@ impl<T: Trait> Module<T> {
 	pub fn deposit_event_indexed(topics: &[T::Hash], event: T::Event) {
 		let block_number = Self::block_number();
 		// Don't populate events on genesis.
-		if block_number.is_zero() { return }
+		if block_number.is_zero() {
+			// Print a message only in tests warning users about this behavior.
+			#[cfg(test)]
+			println!("The block number is zero, so events are not being deposited.")
+
+			return
+		}
 
 		let phase = ExecutionPhase::get().unwrap_or_default();
 		let event = EventRecord {


### PR DESCRIPTION
In Substrate, we don't emit events on block zero to prevent genesis construction from creating a ton of events.

See https://github.com/paritytech/substrate/pull/5463

This nuance occasionally comes up as an issue when people are writing runtime tests, since they would need to know to set the block number to greater than zero in order to start emitting events.

If a user does not set the block number, they may wonder why their tests are failing, for example when trying to inspect the last event being emitted.

This PR adds a simple `println` statement which is emitted only during tests. Thus, if a test would fail, a user would see this error message, and hopefully understand this behavior and fix it by increasing the block number.