### PR TITLE
service: remove collection of system/process metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
 dependencies = [
  "approx",
  "num-complex",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -235,8 +235,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "log",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.6",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -686,7 +686,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "js-sys",
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
  "time",
  "wasm-bindgen",
 ]
@@ -927,7 +927,7 @@ dependencies = [
  "itertools 0.8.2",
  "lazy_static",
  "libc",
- "num-traits 0.2.11",
+ "num-traits",
  "rand_core 0.3.1",
  "rand_os",
  "rand_xoshiro",
@@ -953,7 +953,7 @@ dependencies = [
  "csv",
  "itertools 0.8.2",
  "lazy_static",
- "num-traits 0.2.11",
+ "num-traits",
  "oorandom",
  "plotters",
  "rayon",
@@ -1096,8 +1096,8 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
 dependencies = [
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1136,8 +1136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1219,8 +1219,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1259,17 +1259,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
-name = "enum-primitive-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
-dependencies = [
- "num-traits 0.1.43",
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,8 +1274,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed9afacaea0301eefb738c9deea725e6d53938004597cdc518a8cf9a7aa2f03"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1450,8 +1439,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "synstructure",
 ]
 
@@ -1502,7 +1491,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-timer 2.0.2",
  "log",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.9.0",
  "rand 0.6.5",
@@ -1648,8 +1637,8 @@ version = "2.0.0-rc5"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1659,8 +1648,8 @@ dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1668,8 +1657,8 @@ name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1885,8 +1874,8 @@ checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2431,8 +2420,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2571,8 +2560,8 @@ checksum = "0fadf6945e227246825a583514534d864554e9f23d80b3c77d034b10983db5ef"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2785,18 +2774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
-
-[[package]]
 name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,8 +2861,8 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "515c4a7cba5d321bb88ed3ed803997bdd5634ce35c9c5e8e9ace9c512e57eceb"
 dependencies = [
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3467,7 +3444,7 @@ dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-rational",
- "num-traits 0.2.11",
+ "num-traits",
  "rand 0.6.5",
  "typenum",
 ]
@@ -3490,20 +3467,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "netstat2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29449d242064c48d3057a194b049a2bdcccadda16faa18a91468677b44e8d422"
-dependencies = [
- "bitflags",
- "byteorder",
- "enum-primitive-derive",
- "libc",
- "num-traits 0.2.11",
- "thiserror",
 ]
 
 [[package]]
@@ -3947,15 +3910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26e041cd983acbc087e30fcba770380cfa352d0e392e175b2344ebaf7ea0602"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,7 +3917,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -3973,7 +3927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -3983,7 +3937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -3995,16 +3949,7 @@ dependencies = [
  "autocfg 1.0.0",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.11",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -4824,9 +4769,9 @@ version = "2.0.0-rc5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
+ "quote",
  "sp-runtime",
- "syn 1.0.33",
+ "syn",
 ]
 
 [[package]]
@@ -5026,8 +4971,8 @@ checksum = "cd20ff7e0399b274a5f5bb37b712fccb5b3a64b9128200d1c3cc40fe709cb073"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5093,7 +5038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.33",
+ "syn",
  "synstructure",
 ]
 
@@ -5186,8 +5131,8 @@ checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5250,8 +5195,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5285,7 +5230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
 dependencies = [
  "js-sys",
- "num-traits 0.2.11",
+ "num-traits",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -5383,8 +5328,8 @@ checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -5395,8 +5340,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "syn-mid",
  "version_check",
 ]
@@ -5419,22 +5364,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
- "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "procfs"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe50036aa1b71e553a4a0c48ab7baabf8aa8c7a5a61aae06bf38c2eab7430475"
-dependencies = [
- "bitflags",
- "byteorder",
- "chrono",
- "hex",
- "lazy_static",
- "libc",
- "libflate",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -5487,8 +5417,8 @@ dependencies = [
  "anyhow",
  "itertools 0.8.2",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5540,12 +5470,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -5849,8 +5773,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5929,8 +5853,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5964,12 +5888,6 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rlp"
@@ -6071,8 +5989,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6205,8 +6123,8 @@ version = "2.0.0-rc5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6383,7 +6301,7 @@ dependencies = [
  "merlin",
  "num-bigint",
  "num-rational",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "pdqselect",
@@ -7015,12 +6933,10 @@ dependencies = [
  "jsonrpc-pubsub",
  "lazy_static",
  "log",
- "netstat2",
  "parity-scale-codec",
  "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
  "pin-project",
- "procfs",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -7061,7 +6977,6 @@ dependencies = [
  "sp-version",
  "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
- "sysinfo",
  "tempfile",
  "tokio 0.2.21",
  "tracing",
@@ -7267,8 +7182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7372,8 +7287,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7505,8 +7420,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7624,8 +7539,8 @@ dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7675,7 +7590,7 @@ version = "2.0.0-rc5"
 dependencies = [
  "criterion 0.3.1",
  "integer-sqrt",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-scale-codec",
  "primitive-types",
  "rand 0.7.3",
@@ -7691,7 +7606,7 @@ version = "2.0.0-rc5"
 dependencies = [
  "honggfuzz",
  "num-bigint",
- "num-traits 0.2.11",
+ "num-traits",
  "primitive-types",
  "sp-arithmetic",
 ]
@@ -7860,7 +7775,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-scale-codec",
  "parity-util-mem 0.7.0",
  "parking_lot 0.10.2",
@@ -7901,8 +7816,8 @@ name = "sp-debug-derive"
 version = "2.0.0-rc5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8000,8 +7915,8 @@ version = "2.0.0-rc5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8092,8 +8007,8 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8184,7 +8099,7 @@ dependencies = [
  "hex-literal",
  "itertools 0.9.0",
  "log",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "pretty_assertions",
@@ -8392,8 +8307,8 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8413,8 +8328,8 @@ checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8710,24 +8625,13 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "unicode-xid 0.2.0",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8737,17 +8641,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -8757,24 +8652,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
- "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2983daff11a197c7c406b130579bc362177aa54cf2cc1f34d6ac88fccaa6a5e1"
-dependencies = [
- "cfg-if",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi 0.3.8",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -8820,8 +8700,8 @@ checksum = "a605baa797821796a751f4a959e1206079b24a4b7e1ed302b7d785d81a9276c9"
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -8850,8 +8730,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca972988113b7715266f91250ddb98070d033c62a011fa0fcc57434a649310dd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -9056,8 +8936,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -9257,8 +9137,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -9420,12 +9300,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -9611,8 +9485,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -9634,7 +9508,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
- "quote 1.0.6",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -9645,8 +9519,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9678,7 +9552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2f86cd78a2aa7b1fb4bb6ed854eccb7f9263089c79542dca1576a1518a8467"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
+ "quote",
 ]
 
 [[package]]
@@ -9718,7 +9592,7 @@ dependencies = [
  "libc",
  "memory_units",
  "num-rational",
- "num-traits 0.2.11",
+ "num-traits",
  "parity-wasm 0.41.0",
  "wasmi-validation",
 ]
@@ -10060,8 +9934,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.6",
- "syn 1.0.33",
+ "quote",
+ "syn",
  "synstructure",
 ]
 

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -39,7 +39,6 @@ pin-project = "0.4.8"
 hash-db = "0.15.2"
 serde = "1.0.101"
 serde_json = "1.0.41"
-sysinfo = "0.14.15"
 sc-keystore = { version = "2.0.0-rc5", path = "../keystore" }
 sp-io = { version = "2.0.0-rc5", path = "../../primitives/io" }
 sp-runtime = { version = "2.0.0-rc5", path = "../../primitives/runtime" }
@@ -75,12 +74,6 @@ prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../..
 sc-tracing = { version = "2.0.0-rc5", path = "../tracing" }
 tracing = "0.1.10"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
-
-[target.'cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))'.dependencies]
-netstat2 = "0.8.1"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-procfs = '0.7.8'
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 tempfile = "3.1.0"

--- a/client/service/src/metrics.rs
+++ b/client/service/src/metrics.rs
@@ -19,7 +19,7 @@
 use std::{convert::TryFrom, time::SystemTime};
 
 use crate::{NetworkStatus, config::Configuration};
-use prometheus_endpoint::{register, Gauge, U64, F64, Registry, PrometheusError, Opts, GaugeVec};
+use prometheus_endpoint::{register, Gauge, U64, Registry, PrometheusError, Opts, GaugeVec};
 use sc_telemetry::{telemetry, SUBSTRATE_INFO};
 use sp_runtime::traits::{NumberFor, Block, SaturatedConversion, UniqueSaturatedInto};
 use sp_transaction_pool::PoolStatus;
@@ -27,28 +27,7 @@ use sp_utils::metrics::register_globals;
 use sc_client_api::ClientInfo;
 use sc_network::config::Role;
 
-use sysinfo::{self, ProcessExt, SystemExt};
-
-#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-use netstat2::{
-	TcpState, ProtocolSocketInfo, iterate_sockets_info, AddressFamilyFlags, ProtocolFlags,
-};
-
 struct PrometheusMetrics {
-	// system
-	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-	load_avg: GaugeVec<F64>,
-
-	// process
-	cpu_usage_percentage: Gauge<F64>,
-	memory_usage_bytes: Gauge<U64>,
-	threads: Gauge<U64>,
-	open_files: GaugeVec<U64>,
-
-	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-	netstat: GaugeVec<U64>,
-
-	// -- inner counters
 	// generic info
 	block_height: GaugeVec<U64>,
 	number_leaves: Gauge<U64>,
@@ -62,9 +41,12 @@ struct PrometheusMetrics {
 }
 
 impl PrometheusMetrics {
-	fn setup(registry: &Registry, name: &str, version: &str, roles: u64)
-		-> Result<Self, PrometheusError>
-	{
+	fn setup(
+		registry: &Registry,
+		name: &str,
+		version: &str,
+		roles: u64,
+	) -> Result<Self, PrometheusError> {
 		register(Gauge::<U64>::with_opts(
 			Opts::new(
 				"build_info",
@@ -88,39 +70,6 @@ impl PrometheusMetrics {
 		)?, registry)?.set(start_time_since_epoch.as_secs());
 
 		Ok(Self {
-			// system
-			#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-			load_avg: register(GaugeVec::new(
-				Opts::new("load_avg", "System load average"),
-				&["over"]
-			)?, registry)?,
-
-			// process
-			memory_usage_bytes: register(Gauge::new(
-				"memory_usage_bytes", "Process memory (resident set size) usage",
-			)?, registry)?,
-
-			cpu_usage_percentage: register(Gauge::new(
-				"cpu_usage_percentage", "Process CPU usage, percentage per core summed over all cores",
-			)?, registry)?,
-
-			#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-			netstat: register(GaugeVec::new(
-				Opts::new("netstat_tcp", "Number of TCP sockets of the process"),
-				&["status"]
-			)?, registry)?,
-
-			threads: register(Gauge::new(
-				"threads", "Number of threads used by the process",
-			)?, registry)?,
-
-			open_files: register(GaugeVec::new(
-				Opts::new("open_file_handles", "Number of open file handlers held by the process"),
-				&["fd_type"]
-			)?, registry)?,
-
-			// --- internal
-
 			// generic internals
 			block_height: register(GaugeVec::new(
 				Opts::new("block_height", "Block height info of the chain"),
@@ -154,116 +103,19 @@ impl PrometheusMetrics {
 	}
 }
 
-#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-#[derive(Default)]
-struct ConnectionsCount {
-	listen: u64,
-	established: u64,
-	starting: u64,
-	closing: u64,
-	closed: u64,
-	other: u64
-}
-
-#[derive(Default)]
-struct FdCounter {
-	paths: u64,
-	sockets: u64,
-	net: u64,
-	pipes: u64,
-	anon_inode: u64,
-	mem: u64,
-	other: u64,
-}
-
-#[derive(Default)]
-struct ProcessInfo {
-	cpu_usage: f64,
-	memory: u64,
-	threads: Option<u64>,
-	open_fd: Option<FdCounter>,
-}
-
 pub struct MetricsService {
 	metrics: Option<PrometheusMetrics>,
-	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-	system: sysinfo::System,
-	pid: Option<sysinfo::Pid>,
 }
 
-#[cfg(target_os = "linux")]
 impl MetricsService {
-	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
-		let process = procfs::process::Process::myself()
-			.expect("Procfs doesn't fail on unix. qed");
-
-		Self {
-			metrics,
-			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
-			pid: Some(process.pid),
-		}
+	pub fn new() -> Self {
+		MetricsService { metrics: None }
 	}
 
-	fn process_info(&mut self) -> ProcessInfo {
-		let pid = self.pid.clone().expect("unix always has a pid. qed");
-		let mut info = self.process_info_for(&pid);
-		let process = procfs::process::Process::new(pid).expect("Our process exists. qed.");
-		info.threads = process.stat().ok().map(|s|
-			u64::try_from(s.num_threads).expect("There are no negative thread counts. qed"),
-		);
-		info.open_fd = process.fd().ok().map(|i|
-			i.into_iter().fold(FdCounter::default(), |mut f, info| {
-				match info.target {
-					procfs::process::FDTarget::Path(_) => f.paths += 1,
-					procfs::process::FDTarget::Socket(_) => f.sockets += 1,
-					procfs::process::FDTarget::Net(_) => f.net += 1,
-					procfs::process::FDTarget::Pipe(_) => f.pipes += 1,
-					procfs::process::FDTarget::AnonInode(_) => f.anon_inode += 1,
-					procfs::process::FDTarget::MemFD(_) => f.mem += 1,
-					procfs::process::FDTarget::Other(_,_) => f.other += 1,
-				};
-				f
-			})
-		);
-		info
-	}
-}
-
-#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios"), not(target_os = "linux")))]
-impl MetricsService {
-	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
-		Self {
-			metrics,
-			system: sysinfo::System::new_with_specifics(sysinfo::RefreshKind::new().with_processes()),
-			pid: sysinfo::get_current_pid().ok(),
-		}
-	}
-
-	fn process_info(&mut self) -> ProcessInfo {
-		self.pid.map(|pid| self.process_info_for(&pid)).unwrap_or_default()
-	}
-}
-
-
-#[cfg(not(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios"))))]
-impl MetricsService {
-	fn inner_new(metrics: Option<PrometheusMetrics>) -> Self {
-		Self {
-			metrics,
-			pid: None,
-		}
-	}
-
-	fn process_info(&mut self) -> ProcessInfo {
-		ProcessInfo::default()
-	}
-}
-
-
-impl MetricsService {
-	pub fn with_prometheus(registry: &Registry, config: &Configuration)
-		-> Result<Self, PrometheusError>
-	{
+	pub fn with_prometheus(
+		registry: &Registry,
+		config: &Configuration,
+	) -> Result<Self, PrometheusError> {
 		let role_bits = match config.role {
 			Role::Full => 1u64,
 			Role::Light => 2u64,
@@ -271,57 +123,13 @@ impl MetricsService {
 			Role::Authority { .. } => 4u64,
 		};
 
-		PrometheusMetrics::setup(registry, &config.network.node_name, &config.impl_version, role_bits).map(|p| {
-			Self::inner_new(Some(p))
-		})
-	}
-
-	pub fn new() -> Self {
-		Self::inner_new(None)
-	}
-
-	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-	fn process_info_for(&mut self, pid: &sysinfo::Pid) -> ProcessInfo {
-		let mut info = ProcessInfo::default();
-		self.system.refresh_process(*pid);
-		self.system.get_process(*pid).map(|prc| {
-			info.cpu_usage = prc.cpu_usage().into();
-			info.memory = prc.memory();
-		});
-		info
-	}
-
-	#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-	fn connections_info(&self) -> Option<ConnectionsCount> {
-		self.pid.as_ref().and_then(|pid| {
-			let af_flags = AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
-			let proto_flags = ProtocolFlags::TCP;
-			let netstat_pid = *pid as u32;
-
-			iterate_sockets_info(af_flags, proto_flags).ok().map(|iter|
-				iter.filter_map(|r|
-					r.ok().and_then(|s| {
-						match s.protocol_socket_info {
-							ProtocolSocketInfo::Tcp(info)
-								if s.associated_pids.contains(&netstat_pid) => Some(info.state),
-							_ => None
-						}
-					})
-				).fold(ConnectionsCount::default(), |mut counter, socket_state| {
-					match socket_state {
-						TcpState::Listen => counter.listen += 1,
-						TcpState::Established => counter.established += 1,
-						TcpState::Closed => counter.closed += 1,
-						TcpState::SynSent | TcpState::SynReceived => counter.starting += 1,
-						TcpState::FinWait1 | TcpState::FinWait2 | TcpState::CloseWait
-						| TcpState::Closing | TcpState::LastAck => counter.closing += 1,
-						_ => counter.other += 1
-					}
-
-					counter
-				})
-			)
-		})
+		PrometheusMetrics::setup(
+			registry,
+			&config.network.node_name,
+			&config.impl_version,
+			role_bits,
+		)
+		.map(|p| MetricsService { metrics: Some(p) })
 	}
 
 	pub fn tick<T: Block>(
@@ -330,16 +138,15 @@ impl MetricsService {
 		txpool_status: &PoolStatus,
 		net_status: &NetworkStatus<T>,
 	) {
-
 		let best_number = info.chain.best_number.saturated_into::<u64>();
 		let best_hash = info.chain.best_hash;
 		let num_peers = net_status.num_connected_peers;
 		let finalized_number: u64 = info.chain.finalized_number.saturated_into::<u64>();
 		let bandwidth_download = net_status.average_download_per_sec;
 		let bandwidth_upload = net_status.average_upload_per_sec;
-		let best_seen_block = net_status.best_seen_block
+		let best_seen_block = net_status
+			.best_seen_block
 			.map(|num: NumberFor<T>| num.unique_saturated_into() as u64);
-		let process_info = self.process_info();
 
 		telemetry!(
 			SUBSTRATE_INFO;
@@ -348,8 +155,6 @@ impl MetricsService {
 			"height" => best_number,
 			"best" => ?best_hash,
 			"txcount" => txpool_status.ready,
-			"cpu" => process_info.cpu_usage,
-			"memory" => process_info.memory,
 			"finalized_height" => finalized_number,
 			"finalized_hash" => ?info.chain.finalized_hash,
 			"bandwidth_download" => bandwidth_download,
@@ -369,34 +174,23 @@ impl MetricsService {
 		);
 
 		if let Some(metrics) = self.metrics.as_ref() {
-			metrics.cpu_usage_percentage.set(process_info.cpu_usage as f64);
-			// `sysinfo::Process::memory` returns memory usage in KiB and not bytes.
-			metrics.memory_usage_bytes.set(process_info.memory * 1024);
+			metrics
+				.network_per_sec_bytes
+				.with_label_values(&["download"])
+				.set(net_status.average_download_per_sec);
+			metrics
+				.network_per_sec_bytes
+				.with_label_values(&["upload"])
+				.set(net_status.average_upload_per_sec);
+			metrics
+				.block_height
+				.with_label_values(&["finalized"])
+				.set(finalized_number);
+			metrics
+				.block_height
+				.with_label_values(&["best"])
+				.set(best_number);
 
-			if let Some(threads) = process_info.threads {
-				metrics.threads.set(threads);
-			}
-
-			if let Some(fd_info) = process_info.open_fd {
-				metrics.open_files.with_label_values(&["paths"]).set(fd_info.paths);
-				metrics.open_files.with_label_values(&["mem"]).set(fd_info.mem);
-				metrics.open_files.with_label_values(&["sockets"]).set(fd_info.sockets);
-				metrics.open_files.with_label_values(&["net"]).set(fd_info.net);
-				metrics.open_files.with_label_values(&["pipe"]).set(fd_info.pipes);
-				metrics.open_files.with_label_values(&["anon_inode"]).set(fd_info.anon_inode);
-				metrics.open_files.with_label_values(&["other"]).set(fd_info.other);
-			}
-
-
-			metrics.network_per_sec_bytes.with_label_values(&["download"]).set(
-				net_status.average_download_per_sec,
-			);
-			metrics.network_per_sec_bytes.with_label_values(&["upload"]).set(
-				net_status.average_upload_per_sec,
-			);
-
-			metrics.block_height.with_label_values(&["finalized"]).set(finalized_number);
-			metrics.block_height.with_label_values(&["best"]).set(best_number);
 			if let Ok(leaves) = u64::try_from(info.chain.number_leaves) {
 				metrics.number_leaves.set(leaves);
 			}
@@ -420,23 +214,6 @@ impl MetricsService {
 				metrics.state_db.with_label_values(&["pinned"]).set(
 					info.memory.state_db.pinned.as_bytes() as u64,
 				);
-			}
-
-			#[cfg(all(any(unix, windows), not(target_os = "android"), not(target_os = "ios")))]
-			{
-				let load = self.system.get_load_average();
-				metrics.load_avg.with_label_values(&["1min"]).set(load.one);
-				metrics.load_avg.with_label_values(&["5min"]).set(load.five);
-				metrics.load_avg.with_label_values(&["15min"]).set(load.fifteen);
-
-				if let Some(conns) = self.connections_info() {
-					metrics.netstat.with_label_values(&["listen"]).set(conns.listen);
-					metrics.netstat.with_label_values(&["established"]).set(conns.established);
-					metrics.netstat.with_label_values(&["starting"]).set(conns.starting);
-					metrics.netstat.with_label_values(&["closing"]).set(conns.closing);
-					metrics.netstat.with_label_values(&["closed"]).set(conns.closed);
-					metrics.netstat.with_label_values(&["other"]).set(conns.other);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up to #6805.

We will no longer be collecting system/process metrics, instead anyone that needs these metrics can collect them externally with software like: [node_exporter](https://github.com/prometheus/node_exporter), [process-exporter](https://github.com/ncabatoff/process-exporter) or [cadvisor](https://github.com/google/cadvisor). This makes our life easier as we don't have to deal with platform-specific code.

Closes #6806.