### PR TITLE
Fix legacy substream fallback not working

### DIFF
--- a/client/network/src/protocol/generic_proto/handler/group.rs
+++ b/client/network/src/protocol/generic_proto/handler/group.rs
@@ -600,11 +600,7 @@ impl ProtocolsHandler for NotifsHandler {
 						message
 					} => {
 						for (handler, _) in &mut self.out_handlers {
-							if handler.protocol_name() != &protocol_name[..] {
-								continue;
-							}
-
-							if handler.is_open() {
+							if handler.protocol_name() == &protocol_name[..] && handler.is_open() {
 								handler.send_or_discard(message);
 								continue 'poll_notifs_sink;
 							}

--- a/client/network/src/protocol/generic_proto/handler/group.rs
+++ b/client/network/src/protocol/generic_proto/handler/group.rs
@@ -606,9 +606,8 @@ impl ProtocolsHandler for NotifsHandler {
 
 							if handler.is_open() {
 								handler.send_or_discard(message);
+								continue 'poll_notifs_sink;
 							}
-
-							continue 'poll_notifs_sink;
 						}
 
 						self.legacy.inject_event(LegacyProtoHandlerIn::SendCustomMessage {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/paritytech/substrate/pull/6692
This `continue` was misplaced.

If a notifications substream isn't open, before this PR we would silently discard the message, while after this PR we're sending it on the legacy substream as intended.

This manifests itself in three situations:

- If a node doesn't support notifications substreams (unlikely nowadays).
- If the legacy substream is opened well in advance compared to the notifications substream.
- If two nodes connect before `register_notifications_protocol` has been called.

Points 2 and 3 typically happens only on a local testnet, and is how this issue got detected.
