### PR TITLE
Fix `wait_for_blocks` counting blocks that didn't go through consensus

### DIFF
--- a/test-utils/client/src/lib.rs
+++ b/test-utils/client/src/lib.rs
@@ -384,9 +384,11 @@ where
 
 		Box::pin(async move {
 			while let Some(notification) = import_notification_stream.next().await {
-				blocks.insert(notification.hash);
-				if blocks.len() == count {
-					break;
+				if notification.is_new_best {
+					blocks.insert(notification.hash);
+					if blocks.len() == count {
+						break;
+					}
 				}
 			}
 		})


### PR DESCRIPTION
After checking the logs of the integration test on cumulus I realized that there was an issue but the block counting did manage to count nevertheless. This will fix that latter issue (and break the integration test as it should :grin: )