### PR TITLE
Combine default values used at initialization in a trait

### DIFF
--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -64,7 +64,6 @@ pub enum Subcommand {
 	ExportState(ExportStateCmd),
 }
 
-// TODO: move to config.rs?
 /// Macro that helps implement CliConfiguration on an enum of subcommand automatically
 ///
 /// # Example
@@ -189,17 +188,24 @@ macro_rules! substrate_cli_subcommands {
 
 			fn network_config(
 				&self,
-				chain_spec: &::std::boxed::Box<dyn ::sc_service::ChainSpec>,
+				chain_spec: &std::boxed::Box<dyn sc_service::ChainSpec>,
 				is_dev: bool,
-				net_config_dir: ::std::path::PathBuf,
+				net_config_dir: std::path::PathBuf,
 				client_id: &str,
 				node_name: &str,
-				node_key: ::sc_service::config::NodeKeyConfig,
+				node_key: sc_service::config::NodeKeyConfig,
+				default_listen_port: u16,
 			) -> $crate::Result<::sc_service::config::NetworkConfiguration> {
 				match self {
 					$(
 						$enum::$variant(cmd) => cmd.network_config(
-							chain_spec, is_dev, net_config_dir, client_id, node_name, node_key
+							chain_spec,
+							is_dev,
+							net_config_dir,
+							client_id,
+							node_name,
+							node_key,
+							default_listen_port,
 						)
 					),*
 				}
@@ -291,15 +297,21 @@ macro_rules! substrate_cli_subcommands {
 				}
 			}
 
-			fn rpc_http(&self) -> $crate::Result<::std::option::Option<::std::net::SocketAddr>> {
+			fn rpc_http(
+				&self,
+				default_listen_port: u16,
+			) -> $crate::Result<std::option::Option<std::net::SocketAddr>> {
 				match self {
-					$($enum::$variant(cmd) => cmd.rpc_http()),*
+					$($enum::$variant(cmd) => cmd.rpc_http(default_listen_port)),*
 				}
 			}
 
-			fn rpc_ws(&self) -> $crate::Result<::std::option::Option<::std::net::SocketAddr>> {
+			fn rpc_ws(
+				&self,
+				default_listen_port: u16,
+			) -> $crate::Result<std::option::Option<std::net::SocketAddr>> {
 				match self {
-					$($enum::$variant(cmd) => cmd.rpc_ws()),*
+					$($enum::$variant(cmd) => cmd.rpc_ws(default_listen_port)),*
 				}
 			}
 
@@ -316,23 +328,23 @@ macro_rules! substrate_cli_subcommands {
 			}
 
 			fn rpc_cors(&self, is_dev: bool)
-			-> $crate::Result<::std::option::Option<::std::vec::Vec<String>>> {
+			-> $crate::Result<std::option::Option<std::vec::Vec<String>>> {
 				match self {
 					$($enum::$variant(cmd) => cmd.rpc_cors(is_dev)),*
 				}
 			}
 
-			fn prometheus_config(&self)
-			-> $crate::Result<::std::option::Option<::sc_service::config::PrometheusConfig>> {
+			fn prometheus_config(&self, default_listen_port: u16)
+			-> $crate::Result<std::option::Option<sc_service::config::PrometheusConfig>> {
 				match self {
-					$($enum::$variant(cmd) => cmd.prometheus_config()),*
+					$($enum::$variant(cmd) => cmd.prometheus_config(default_listen_port)),*
 				}
 			}
 
 			fn telemetry_endpoints(
 				&self,
-				chain_spec: &Box<dyn ::sc_service::ChainSpec>,
-			) -> $crate::Result<::std::option::Option<::sc_service::config::TelemetryEndpoints>> {
+				chain_spec: &Box<dyn sc_service::ChainSpec>,
+			) -> $crate::Result<std::option::Option<sc_service::config::TelemetryEndpoints>> {
 				match self {
 					$($enum::$variant(cmd) => cmd.telemetry_endpoints(chain_spec)),*
 				}

--- a/client/cli/src/commands/run_cmd.rs
+++ b/client/cli/src/commands/run_cmd.rs
@@ -382,7 +382,7 @@ impl CliConfiguration for RunCmd {
 		Ok(self.shared_params.dev || self.force_authoring)
 	}
 
-	fn prometheus_config(&self) -> Result<Option<PrometheusConfig>> {
+	fn prometheus_config(&self, default_listen_port: u16) -> Result<Option<PrometheusConfig>> {
 		Ok(if self.no_prometheus {
 			None
 		} else {
@@ -393,7 +393,10 @@ impl CliConfiguration for RunCmd {
 			};
 
 			Some(PrometheusConfig::new_with_default_registry(
-				SocketAddr::new(interface.into(), self.prometheus_port.unwrap_or(9615))
+				SocketAddr::new(
+					interface.into(),
+					self.prometheus_port.unwrap_or(default_listen_port),
+				)
 			))
 		})
 	}
@@ -427,7 +430,7 @@ impl CliConfiguration for RunCmd {
 			.into())
 	}
 
-	fn rpc_http(&self) -> Result<Option<SocketAddr>> {
+	fn rpc_http(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
 		let interface = rpc_interface(
 			self.rpc_external,
 			self.unsafe_rpc_external,
@@ -435,22 +438,22 @@ impl CliConfiguration for RunCmd {
 			self.validator
 		)?;
 
-		Ok(Some(SocketAddr::new(interface, self.rpc_port.unwrap_or(9933))))
+		Ok(Some(SocketAddr::new(interface, self.rpc_port.unwrap_or(default_listen_port))))
 	}
 
 	fn rpc_ipc(&self) -> Result<Option<String>> {
 		Ok(self.ipc_path.clone())
 	}
 
-	fn rpc_ws(&self) -> Result<Option<SocketAddr>> {
+	fn rpc_ws(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
 		let interface = rpc_interface(
 			self.ws_external,
 			self.unsafe_ws_external,
 			self.rpc_methods,
-			self.validator
+			self.validator,
 		)?;
 
-		Ok(Some(SocketAddr::new(interface, self.ws_port.unwrap_or(9944))))
+		Ok(Some(SocketAddr::new(interface, self.ws_port.unwrap_or(default_listen_port))))
 	}
 
 	fn rpc_methods(&self) -> Result<sc_service::config::RpcMethods> {

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -209,7 +209,7 @@ pub trait SubstrateCli: Sized {
 	}
 
 	/// Only create a Configuration for the command provided in argument
-	fn create_configuration<T: CliConfiguration>(
+	fn create_configuration<T: CliConfiguration<DVC>, DVC: DefaultConfigurationValues>(
 		&self,
 		command: &T,
 		task_executor: TaskExecutor,

--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -114,8 +114,9 @@ impl NetworkParams {
 		client_id: &str,
 		node_name: &str,
 		node_key: NodeKeyConfig,
+		default_listen_port: u16,
 	) -> NetworkConfiguration {
-		let port = self.port.unwrap_or(30333);
+		let port = self.port.unwrap_or(default_listen_port);
 
 		let listen_addresses = if self.listen_addr.is_empty() {
 			vec![


### PR DESCRIPTION
This moves default values used in the Substrate code base when
initializing a service into a common trait. Currently this trait only
contains listen ports, but this could be extended in the future.
Essentially this will make overriding these values much easier for
Cumulus, where we have 2 nodes running in one binary.

I'm open for any ideas on how to improve the name of the trait, because it sounds awful. 