### PR TITLE
Remove minimum_validator_count stale const

### DIFF
--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -55,8 +55,6 @@ pub fn create_validator_with_nominators<T: Trait>(
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
-	MinimumValidatorCount::put(0);
-
 	let (v_stash, v_controller) = create_stash_controller::<T>(0, 100)?;
 	let validator_prefs = ValidatorPrefs {
 		commission: Perbill::from_percent(50),
@@ -356,7 +354,7 @@ benchmarks! {
 	new_era {
 		let v in 1 .. 10;
 		let n in 1 .. 100;
-		MinimumValidatorCount::put(0);
+
 		create_validators_with_nominators_for_era::<T>(v, n, MAX_NOMINATIONS, false, None)?;
 		let session_index = SessionIndex::one();
 	}: {
@@ -393,7 +391,6 @@ benchmarks! {
 	payout_all {
 		let v in 1 .. 10;
 		let n in 1 .. 100;
-		MinimumValidatorCount::put(0);
 		create_validators_with_nominators_for_era::<T>(v, n, MAX_NOMINATIONS, false, None)?;
 		// Start a new Era
 		let new_validators = Staking::<T>::new_era(SessionIndex::one()).unwrap();
@@ -577,7 +574,6 @@ benchmarks! {
 		// number of nominator intent
 		let n in 1000 .. 2000;
 
-		MinimumValidatorCount::put(0);
 		create_validators_with_nominators_for_era::<T>(v, n, MAX_NOMINATIONS, false, None)?;
 
 		// needed for the solution to be generates.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -330,7 +330,6 @@ use sp_npos_elections::{
 	is_score_better, VotingLimit, SupportMap, VoteWeight,
 };
 
-const DEFAULT_MINIMUM_VALIDATOR_COUNT: u32 = 4;
 const STAKING_ID: LockIdentifier = *b"staking ";
 pub const MAX_UNLOCKING_CHUNKS: usize = 32;
 pub const MAX_NOMINATIONS: usize = <CompactAssignments as VotingLimit>::LIMIT;
@@ -1032,8 +1031,7 @@ decl_storage! {
 		pub ValidatorCount get(fn validator_count) config(): u32;
 
 		/// Minimum number of staking participants before emergency conditions are imposed.
-		pub MinimumValidatorCount get(fn minimum_validator_count) config():
-			u32 = DEFAULT_MINIMUM_VALIDATOR_COUNT;
+		pub MinimumValidatorCount get(fn minimum_validator_count) config(): u32;
 
 		/// Any validators that may never be slashed or forcibly kicked. It's a Vec since they're
 		/// easy to initialize and the performance hit is minimal (we expect no more than four


### PR DESCRIPTION
This is just a relic of the testing days or even earlier. There is no reason to enforce 4 here; The default is 0, which is then translated to `.max(1)` in the code, meaning that the logical minimum is 1, which is much more sensible than just 4 for no apparent reason. 

Actually, both polkadot and kusama now have 4 in their storage for this value, which should also be fixed, but I want to do that as https://github.com/paritytech/substrate/issues/2494 which needs more research and consideration. 