### PR TITLE
grandpa: change some logging from trace to debug

### DIFF
--- a/client/finality-grandpa/src/communication/gossip.rs
+++ b/client/finality-grandpa/src/communication/gossip.rs
@@ -922,7 +922,7 @@ impl<Block: BlockT> Inner<Block> {
 			PendingCatchUp::Processing { .. } => {
 				self.pending_catch_up = PendingCatchUp::None;
 			},
-			state => trace!(target: "afg",
+			state => debug!(target: "afg",
 				"Noted processed catch up message when state was: {:?}",
 				state,
 			),
@@ -1043,7 +1043,7 @@ impl<Block: BlockT> Inner<Block> {
 				let (catch_up_allowed, catch_up_report) = self.note_catch_up_request(who, &request);
 
 				if catch_up_allowed {
-					trace!(target: "afg", "Sending catch-up request for round {} to {}",
+					debug!(target: "afg", "Sending catch-up request for round {} to {}",
 						   round,
 						   who,
 					);

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -527,7 +527,7 @@ impl<BE, Block: BlockT, Client, SC> BlockImport<Block>
 			},
 			None => {
 				if needs_justification {
-					trace!(
+					debug!(
 						target: "afg",
 						"Imported unjustified block #{} that enacts authority set change, waiting for finality for enactment.",
 						number,

--- a/client/finality-grandpa/src/import.rs
+++ b/client/finality-grandpa/src/import.rs
@@ -18,7 +18,7 @@
 
 use std::{sync::Arc, collections::HashMap};
 
-use log::{debug, trace};
+use log::debug;
 use parity_scale_codec::Encode;
 use parking_lot::RwLockWriteGuard;
 


### PR DESCRIPTION
Running grandpa with trace logging generates a lot of data, mainly due to this: https://github.com/paritytech/finality-grandpa/blob/master/src/voter/voting_round.rs#L182

This PR changes some log statements, that are useful enough and don't happen that often, from `trace` to `debug`.