### PR TITLE
add runtime migrations to release notes/changelog

### DIFF
--- a/.maintain/gitlab/generate_changelog.sh
+++ b/.maintain/gitlab/generate_changelog.sh
@@ -11,6 +11,7 @@ runtime_changes=""
 api_changes=""
 client_changes=""
 changes=""
+migrations=""
 
 while IFS= read -r line; do
   pr_id=$(echo "$line" | sed -E 's/.*#([0-9]+)\)$/\1/')
@@ -31,12 +32,17 @@ $line"
     runtime_changes="$runtime_changes
 $line"
   fi
+  if has_label 'paritytech/substrate' "$pr_id" 'D1-runtime-migration'; then
+    migrations="$migrations
+$line"
+  fi
 done <<< "$all_changes"
 
 # Make the substrate section if there are any substrate changes
 if [ -n "$runtime_changes" ] ||
    [ -n "$api_changes" ] ||
-   [ -n "$client_changes" ]; then
+   [ -n "$client_changes" ] ||
+   [ -n "$migrations" ]; then
   changes=$(cat << EOF
 Substrate changes
 -----------------
@@ -67,6 +73,13 @@ $api_changes"
   release_text="$release_text
 
 $changes"
+fi
+if [ -n "$migrations" ]; then
+  changes="$changes
+
+Runtime Migrations
+------------------
+$migrations"
 fi
 
 echo "$changes"


### PR DESCRIPTION
This PR appends PRs that include runtime migrations to a new category "Runtime Migrations" in the release notes.

related to #6482
