### PR TITLE
Make `HexDisplay` useable in `no_std`

### DIFF
--- a/primitives/core/src/hexdisplay.rs
+++ b/primitives/core/src/hexdisplay.rs
@@ -67,7 +67,7 @@ impl AsBytesRef for [u8] {
 	fn as_bytes_ref(&self) -> &[u8] { &self }
 }
 
-impl AsBytesRef for Vec<u8> {
+impl AsBytesRef for sp_std::vec::Vec<u8> {
 	fn as_bytes_ref(&self) -> &[u8] { &self }
 }
 
@@ -84,6 +84,7 @@ impl_non_endians!([u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7],
 	[u8; 48], [u8; 56], [u8; 64], [u8; 65], [u8; 80], [u8; 96], [u8; 112], [u8; 128]);
 
 /// Format into ASCII + # + hex, suitable for storage key preimages.
+#[cfg(feature = "std")]
 pub fn ascii_format(asciish: &[u8]) -> String {
 	let mut r = String::new();
 	let mut latch = false;

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -52,7 +52,6 @@ pub use impl_serde::serialize as bytes;
 pub mod hashing;
 #[cfg(feature = "full_crypto")]
 pub use hashing::{blake2_128, blake2_256, twox_64, twox_128, twox_256, keccak_256};
-#[cfg(feature = "std")]
 pub mod hexdisplay;
 pub mod crypto;
 


### PR DESCRIPTION
Actually I use this quite often when debugging some WASM bugs and there
is no harm in enabling it by default. Before I just always copied it
everytime I needed it.
