### PR TITLE
Crystalin add evm log

### DIFF
--- a/frame/evm/src/backend.rs
+++ b/frame/evm/src/backend.rs
@@ -6,7 +6,7 @@ use codec::{Encode, Decode};
 use sp_core::{U256, H256, H160};
 use sp_runtime::traits::UniqueSaturatedInto;
 use frame_support::traits::Get;
-use frame_support::storage::{StorageMap, StorageDoubleMap};
+use frame_support::{debug, storage::{StorageMap, StorageDoubleMap}};
 use sha3::{Keccak256, Digest};
 use evm::backend::{Backend as BackendT, ApplyBackend, Apply};
 use crate::{Trait, AccountStorages, AccountCodes, Module, Event};
@@ -147,6 +147,12 @@ impl<'vicinity, T: Trait> ApplyBackend for Backend<'vicinity, T> {
 					});
 
 					if let Some(code) = code {
+						debug::debug!(
+							target: "evm",
+							"Inserting code ({} bytes) at {:?}",
+							code.len(),
+							address
+						);
 						AccountCodes::insert(address, code);
 					}
 
@@ -156,8 +162,21 @@ impl<'vicinity, T: Trait> ApplyBackend for Backend<'vicinity, T> {
 
 					for (index, value) in storage {
 						if value == H256::default() {
+							debug::debug!(
+								target: "evm",
+								"Removing storage for {:?} [index: {:?}]",
+								address,
+								index
+							);
 							AccountStorages::remove(address, index);
 						} else {
+							debug::debug!(
+								target: "evm",
+								"Updating storage for {:?} [index: {:?}, value: {:?}]",
+								address,
+								index,
+								value
+							);
 							AccountStorages::insert(address, index, value);
 						}
 					}
@@ -167,12 +186,26 @@ impl<'vicinity, T: Trait> ApplyBackend for Backend<'vicinity, T> {
 					}
 				},
 				Apply::Delete { address } => {
+					debug::debug!(
+						target: "evm",
+						"Deleting account at {:?}",
+						address
+					);
 					Module::<T>::remove_account(&address)
 				},
 			}
 		}
 
 		for log in logs {
+			debug::trace!(
+				target: "evm",
+				"Inserting log for {:?}, topics ({}) {:?}, data ({}): {:?}]",
+				log.address,
+				log.topics.len(),
+				log.topics,
+				log.data.len(),
+				log.data
+			);
 			Module::<T>::deposit_event(Event::<T>::Log(Log {
 				address: log.address,
 				topics: log.topics,

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -32,7 +32,7 @@ use sp_std::vec::Vec;
 use codec::{Encode, Decode};
 #[cfg(feature = "std")]
 use serde::{Serialize, Deserialize};
-use frame_support::{ensure, decl_module, decl_storage, decl_event, decl_error};
+use frame_support::{debug, ensure, decl_module, decl_storage, decl_event, decl_error};
 use frame_support::weights::{Weight, Pays};
 use frame_support::traits::{Currency, ExistenceRequirement, Get};
 use frame_support::dispatch::DispatchResultWithPostInfo;
@@ -617,6 +617,16 @@ impl<T: Trait> Module<T> {
 
 		let used_gas = U256::from(executor.used_gas());
 		let actual_fee = executor.fee(gas_price);
+		debug::debug!(
+			target: "evm",
+			"Execution {:?} [source: {:?}, value: {}, gas_limit: {}, used_gas: {}, actual_fee: {}]",
+			retv,
+			source,
+			value,
+			gas_limit,
+			used_gas,
+			actual_fee
+		);
 		executor.deposit(source, total_fee.saturating_sub(actual_fee));
 
 		if apply_state {


### PR DESCRIPTION
This PR only adds debug logs for the EVM frame, providing some information for easier troubleshooting.

Example of output:
```
2020-06-27 13:10:03.088 tokio-blocking-driver DEBUG evm  Execution Succeed(Returned) [source: 0x6be02d1d3665660d22ff9624b7be0551ee1ac91b, value: 0, gas_limit: 1048576, used_gas: 890864, actual_fee: 0]
2020-06-27 13:10:03.088 tokio-blocking-driver DEBUG evm  Updating state of 0x6be02d1d3665660d22ff9624b7be0551ee1ac91b [value: 123456122109135999863044, nonce: 10]
2020-06-27 13:10:03.089 tokio-blocking-driver DEBUG evm  Updating state of 0xdc552396caec809752fed0c5e23fd3983766e758 [value: 0, nonce: 1]
2020-06-27 13:10:03.089 tokio-blocking-driver DEBUG evm  Inserting code (3642 bytes) at 0xdc552396caec809752fed0c5e23fd3983766e758
2020-06-27 13:10:03.089 tokio-blocking-driver DEBUG evm  Updating storage for 0xdc552396caec809752fed0c5e23fd3983766e758 [index: 0x0000000000000000000000000000000000000000000000000000000000000002, value: 0x0000000000000000000000000000000000000000000000000000000000026160]   
2020-06-27 13:10:03.089 tokio-blocking-driver DEBUG evm  Updating storage for 0xdc552396caec809752fed0c5e23fd3983766e758 [index: 0x72045beb6bfbe6197e6cbe54e7341ffbeaf432433d0457a5de91cb6e7ffd69a7, value: 0x0000000000000000000000000000000000000000000000000000000000026160]   
2020-06-27 13:10:03.089 tokio-blocking-driver TRACE evm  Inserting log for 0xdc552396caec809752fed0c5e23fd3983766e758, topics (3) [0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, 0x0000000000000000000000000000000000000000000000000000000000000000, 0x0000000000000000000000006be02d1d3665660d22ff9624b7be0551ee1ac91b], data (32): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 97, 96]]
```
