### PR TITLE
Add support for sourced metrics.

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1201,7 +1201,6 @@ impl MetricSource for BandwidthCounters {
 }
 
 impl Metrics {
-
 	fn register(registry: &Registry) -> Result<Self, PrometheusError> {
 		Ok(Self {
 			// This list is ordered alphabetically

--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -31,6 +31,9 @@ use std::net::SocketAddr;
 
 #[cfg(not(target_os = "unknown"))]
 mod networking;
+mod sourced;
+
+pub use sourced::{SourcedCounter, SourcedGauge, MetricSource};
 
 #[cfg(target_os = "unknown")]
 pub use unknown_os::init_prometheus;

--- a/utils/prometheus/src/sourced.rs
+++ b/utils/prometheus/src/sourced.rs
@@ -86,6 +86,7 @@ impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
 				}
 			}
 
+			debug_assert_eq!(self.desc.variable_labels.len(), label_values.len());
 			match self.desc.variable_labels.len().cmp(&label_values.len()) {
 				Ordering::Greater =>
 					log::warn!("Missing label values for sourced metric {}", self.desc.fq_name),

--- a/utils/prometheus/src/sourced.rs
+++ b/utils/prometheus/src/sourced.rs
@@ -38,8 +38,8 @@ pub enum Gauge {}
 /// instead of being independently recorded.
 #[derive(Debug, Clone)]
 pub struct SourcedMetric<T, S> {
-    source: S,
-    desc: Desc,
+	source: S,
+	desc: Desc,
 	_type: PhantomData<T>,
 }
 
@@ -53,18 +53,18 @@ pub trait MetricSource: Sync + Send + Clone {
 
 impl<T: SourcedType, S: MetricSource> SourcedMetric<T, S> {
 	/// Creates a new metric that obtains its values from the given source.
-    pub fn new(opts: &Opts, source: S) -> prometheus::Result<Self> {
+	pub fn new(opts: &Opts, source: S) -> prometheus::Result<Self> {
 		let desc = opts.describe()?;
-        Ok(Self { source, desc, _type: PhantomData })
-    }
+		Ok(Self { source, desc, _type: PhantomData })
+	}
 }
 
 impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
-    fn desc(&self) -> Vec<&Desc> {
-        vec![&self.desc]
-    }
+	fn desc(&self) -> Vec<&Desc> {
+		vec![&self.desc]
+	}
 
-    fn collect(&self) -> Vec<proto::MetricFamily> {
+	fn collect(&self) -> Vec<proto::MetricFamily> {
 		let mut counters = Vec::new();
 
 		self.source.collect(|label_values, value| {
@@ -107,14 +107,14 @@ impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
 			counters.push(m);
 		});
 
-        let mut m = proto::MetricFamily::default();
-        m.set_name(self.desc.fq_name.clone());
-        m.set_help(self.desc.help.clone());
-        m.set_field_type(T::proto());
-        m.set_metric(counters);
+		let mut m = proto::MetricFamily::default();
+		m.set_name(self.desc.fq_name.clone());
+		m.set_help(self.desc.help.clone());
+		m.set_field_type(T::proto());
+		m.set_metric(counters);
 
-        vec![m]
-    }
+		vec![m]
+	}
 }
 
 /// Types of metrics that can obtain their values from an existing source.

--- a/utils/prometheus/src/sourced.rs
+++ b/utils/prometheus/src/sourced.rs
@@ -21,6 +21,10 @@ use prometheus::proto;
 use std::{cmp::Ordering, marker::PhantomData};
 
 /// A counter whose values are obtained from an existing source.
+///
+/// > **Note*: The counter values provided by the source `S`
+/// > must be monotonically increasing. Otherwise use a
+/// > [`SourcedGauge`] instead.
 pub type SourcedCounter<S> = SourcedMetric<Counter, S>;
 
 /// A gauge whose values are obtained from an existing source.

--- a/utils/prometheus/src/sourced.rs
+++ b/utils/prometheus/src/sourced.rs
@@ -1,0 +1,138 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Metrics that are collected from existing sources.
+
+use prometheus::core::{Collector, Desc, Describer, Number, Opts};
+use prometheus::proto;
+use std::{cmp::Ordering, marker::PhantomData};
+
+/// A counter whose values are obtained from an existing source.
+pub type SourcedCounter<S> = SourcedMetric<Counter, S>;
+
+/// A gauge whose values are obtained from an existing source.
+pub type SourcedGauge<S> = SourcedMetric<Gauge, S>;
+
+/// The type of a sourced counter.
+#[derive(Copy, Clone)]
+pub enum Counter {}
+
+/// The type of a sourced gauge.
+#[derive(Copy, Clone)]
+pub enum Gauge {}
+
+/// A metric whose values are obtained from an existing source,
+/// instead of being independently recorded.
+#[derive(Debug, Clone)]
+pub struct SourcedMetric<T, S> {
+    source: S,
+    desc: Desc,
+	_type: PhantomData<T>,
+}
+
+/// A source of values for a [`SourcedMetric`].
+pub trait MetricSource: Sync + Send + Clone {
+	/// The type of the collected values.
+	type N: Number;
+	/// Collects the current values of the metrics from the source.
+	fn collect(&self, set: impl FnMut(&[&str], Self::N));
+}
+
+impl<T: SourcedType, S: MetricSource> SourcedMetric<T, S> {
+	/// Creates a new metric that obtains its values from the given source.
+    pub fn new(opts: &Opts, source: S) -> prometheus::Result<Self> {
+		let desc = opts.describe()?;
+        Ok(Self { source, desc, _type: PhantomData })
+    }
+}
+
+impl<T: SourcedType, S: MetricSource> Collector for SourcedMetric<T, S> {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+		let mut counters = Vec::new();
+
+		self.source.collect(|label_values, value| {
+			let mut m = proto::Metric::default();
+
+			match T::proto() {
+				proto::MetricType::COUNTER => {
+					let mut c = proto::Counter::default();
+					c.set_value(value.into_f64());
+					m.set_counter(c);
+				}
+				proto::MetricType::GAUGE => {
+					let mut g = proto::Gauge::default();
+					g.set_value(value.into_f64());
+					m.set_gauge(g);
+				}
+				t => {
+					log::error!("Unsupported sourced metric type: {:?}", t);
+				}
+			}
+
+			match self.desc.variable_labels.len().cmp(&label_values.len()) {
+				Ordering::Greater =>
+					log::warn!("Missing label values for sourced metric {}", self.desc.fq_name),
+				Ordering::Less =>
+					log::warn!("Too many label values for sourced metric {}", self.desc.fq_name),
+				Ordering::Equal => {}
+			}
+
+			m.set_label(self.desc.variable_labels.iter().zip(label_values)
+				.map(|(l_name, l_value)| {
+					let mut l = proto::LabelPair::default();
+					l.set_name(l_name.to_string());
+					l.set_value(l_value.to_string());
+					l
+				})
+				.chain(self.desc.const_label_pairs.iter().cloned())
+				.collect::<Vec<_>>());
+
+			counters.push(m);
+		});
+
+        let mut m = proto::MetricFamily::default();
+        m.set_name(self.desc.fq_name.clone());
+        m.set_help(self.desc.help.clone());
+        m.set_field_type(T::proto());
+        m.set_metric(counters);
+
+        vec![m]
+    }
+}
+
+/// Types of metrics that can obtain their values from an existing source.
+pub trait SourcedType: private::Sealed + Sync + Send {
+	#[doc(hidden)]
+	fn proto() -> proto::MetricType;
+}
+
+impl SourcedType for Counter {
+	fn proto() -> proto::MetricType { proto::MetricType::COUNTER }
+}
+
+impl SourcedType for Gauge {
+	fn proto() -> proto::MetricType { proto::MetricType::GAUGE }
+}
+
+mod private {
+	pub trait Sealed {}
+	impl Sealed for super::Counter {}
+	impl Sealed for super::Gauge {}
+}


### PR DESCRIPTION
This is a little follow-up to the suggestion in https://github.com/paritytech/substrate/pull/6870 for [custom metric collectors](https://github.com/paritytech/substrate/pull/6870/files#r469152168). This PR introduces what I dubbed "sourced" counters or gauges via a custom collector.  A sourced counter or gauge is a metric that obtains its values from an existing source, i.e. not from a `prometheus`-crate metric. It thus allows feeding existing counters and gauges into prometheus without having to duplicate them as `prometheus`-crate counters or gauges and without having to declare counters as gauges or making extra gymnastics with the counter API (i.e. get() + compute diff + `inc_by()` or `reset()` + `inc_by()` for every update). The first use-case are the bandwidth counters from libp2p. I hope I understood and incorporated the labeling mechanisms from the `prometheus`-crate correctly. This is how the libp2p bandwidth counters show up in the localhost `/metrics` endpoint:
```
# TYPE substrate_sub_libp2p_network_bytes_total counter
substrate_sub_libp2p_network_bytes_total{direction="in"} 1808817
substrate_sub_libp2p_network_bytes_total{direction="out"} 36561
```
