### PR TITLE
Distribute the network future polling time more evenly

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1384,7 +1384,7 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 		// worker sometimes takes a long time to process the loop below. When that happens, the
 		// rest of the polling is frozen. In order to avoid negative side-effects caused by this
 		// freeze, a limit to the number of iterations is enforced below. If the limit is reached,
-		// the task is scheduled again.
+		// the task is interrupted then scheduled again.
 		//
 		// This allows for a more even distribution in the time taken by each sub-part of the
 		// polling.


### PR DESCRIPTION
At the moment, it's been diagnosed that these two `loop`s, especially the second, sometimes take a long time to be processed, up to more than a minute. During this processing, the rest of the polling isn't reached. In particular, the Prometheus metrics aren't updated, which in turn causes alarms to ring.

This change looks a bit like a hack, but I do believe that it is a fundamentally correct change (if you exclude the fact that the number of iterations is completely arbitrary), as we are kind of emulating something similar to `select`.

I've actually been willing to make this change for a while now, but have always tried to avoid doing so because reducing the load of the network worker was the primary way to fix this. However, it is indeed possible, even when everything is working normally, for this `loop` to take an infinite amount of time. As such, this change is, as mentioned, I think, fundamentally correct.
