### PR TITLE
Fix benchmark read/write key tracker for keys in child storages.

### DIFF
--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -509,7 +509,6 @@ mod test {
 
 	#[test]
 	fn read_to_main_and_child_tries() {
-
 		let bench_state = BenchmarkingState::<crate::tests::Block>::new(Default::default(), None)
 			.unwrap();
 

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -509,6 +509,7 @@ mod test {
 
 	#[test]
 	fn read_to_main_and_child_tries() {
+
 		let bench_state = BenchmarkingState::<crate::tests::Block>::new(Default::default(), None)
 			.unwrap();
 

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -23,7 +23,7 @@ use sp_core::{traits::RuntimeCode, storage::{ChildInfo, well_known_keys}};
 use crate::{
 	trie_backend::TrieBackend,
 	trie_backend_essence::TrieBackendStorage,
-	UsageInfo, StorageKey, StorageValue, StorageCollection,
+	UsageInfo, StorageKey, StorageValue, StorageCollection, ChildStorageCollection,
 };
 
 /// A state backend is used to read state data and can have changes committed
@@ -212,7 +212,13 @@ pub trait Backend<H: Hasher>: std::fmt::Debug {
 	}
 
 	/// Commit given transaction to storage.
-	fn commit(&self, _: H::Out, _: Self::Transaction, _: StorageCollection) -> Result<(), Self::Error> {
+	fn commit(
+		&self,
+		_: H::Out,
+		_: Self::Transaction,
+		_: StorageCollection,
+		_: ChildStorageCollection,
+	) -> Result<(), Self::Error> {
 		unimplemented!()
 	}
 

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -594,6 +594,7 @@ where
 			changes.transaction_storage_root,
 			changes.transaction,
 			changes.main_storage_changes,
+			changes.child_storage_changes,
 		).expect(EXT_NOT_ALLOWED_TO_FAIL);
 		self.mark_dirty();
 		self.overlay


### PR DESCRIPTION
This fix the issues related to count read and write in child tries:
* every write into a child trie will now be counted
* the same key read from different trie won't be counted as repeat

TODO:
* [x] implement some tests
* [x] maybe better log: are current log used in some script or can I just break them ? @shawntabrizi 
* [ ] maybe think if child trie read/writes should be priced differently (should be done in another PR)