### PR TITLE
Derive Clone for AlwaysCanAuthor, NeverCanAuthor, CanAuthorWithNativeVersion

### DIFF
--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -212,6 +212,7 @@ pub trait CanAuthorWith<Block: BlockT> {
 
 /// Checks if the node can author blocks by using
 /// [`NativeVersion::can_author_with`](sp_version::NativeVersion::can_author_with).
+#[derive(Clone)]
 pub struct CanAuthorWithNativeVersion<T>(T);
 
 impl<T> CanAuthorWithNativeVersion<T> {
@@ -239,6 +240,7 @@ impl<T: sp_version::GetRuntimeVersion<Block>, Block: BlockT> CanAuthorWith<Block
 }
 
 /// Returns always `true` for `can_author_with`. This is useful for tests.
+#[derive(Clone)]
 pub struct AlwaysCanAuthor;
 
 impl<Block: BlockT> CanAuthorWith<Block> for AlwaysCanAuthor {
@@ -248,6 +250,7 @@ impl<Block: BlockT> CanAuthorWith<Block> for AlwaysCanAuthor {
 }
 
 /// Never can author.
+#[derive(Clone)]
 pub struct NeverCanAuthor;
 
 impl<Block: BlockT> CanAuthorWith<Block> for NeverCanAuthor {


### PR DESCRIPTION
Derive Clone for those structs so that they can be used in places where Clone is required.