### PR TITLE
Import `IterableStorage*` traits by `decl_storage!`

### DIFF
--- a/frame/support/procedural/src/storage/mod.rs
+++ b/frame/support/procedural/src/storage/mod.rs
@@ -416,6 +416,8 @@ pub fn decl_storage_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 			StorageMap as _,
 			StorageDoubleMap as _,
 			StoragePrefixedMap as _,
+			IterableStorageMap as _,
+			IterableStorageDoubleMap as _,
 		};
 
 		#scrate_decl


### PR DESCRIPTION
Import `IterableStorageMap` and `IterableStorageDoubleMap` automatically
by `decl_storage!` as the other storage traits.