### PR TITLE
Try un-ignore flaky test

### DIFF
--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -346,9 +346,7 @@ fn lots_of_incoming_peers_works() {
 	});
 }
 
-// TODO: this test is at the moment ignored because of https://github.com/paritytech/substrate/issues/6766
 #[test]
-#[ignore]
 fn notifications_back_pressure() {
 	// Node 1 floods node 2 with notifications. Random sleeps are done on node 2 to simulate the
 	// node being busy. We make sure that all notifications are received.


### PR DESCRIPTION
Close https://github.com/paritytech/substrate/issues/6766

The main hypothesis why this test was flaky is that the legacy substream fallback wasn't working.
https://github.com/paritytech/substrate/pull/6826 fixes this problem, but we haven't tried un-ignoring the test so far.

I wanted to un-ignore it as part of https://github.com/paritytech/substrate/pull/6821, but we're having some trouble figuring out why the tests of https://github.com/paritytech/substrate/pull/6821 are failing.
By opening this PR that simply un-ignores the test, I want to check whether https://github.com/paritytech/substrate/pull/6821 introduces a regression, or if the problem is still there in the first place.
