### PR TITLE
Revert wabt-sys upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9846,9 +9846,9 @@ dependencies = [
 
 [[package]]
 name = "wabt-sys"
-version = "0.7.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c695f98f7eb81fd4e2f6b65301ccc916a950dc2265eeefc4d376b34ce666df"
+checksum = "23d7043ebb3e5d96fad7a8d3ca22ee9880748ff8c3e18092cfb2a49d3b8f9084"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
Upgrading to `wabt-sys=0.7.2` breaks Ubuntu 18.04 compatibility and what's more that version is actually yanked on crates.io.
