### PR TITLE
Enable verification logic when executing benchmarks

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1133,6 +1133,7 @@ impl_runtime_apis! {
 			highest_range_values: Vec<u32>,
 			steps: Vec<u32>,
 			repeat: u32,
+			verify: bool,
 			extra: bool,
 		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
@@ -1163,7 +1164,17 @@ impl_runtime_apis! {
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
-			let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist, extra);
+			let params = (
+				&pallet,
+				&benchmark,
+				&lowest_range_values,
+				&highest_range_values,
+				&steps,
+				repeat,
+				&whitelist,
+				verify,
+				extra,
+			);
 
 			add_benchmark!(params, batches, pallet_babe, Babe);
 			add_benchmark!(params, batches, pallet_balances, Balances);

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1126,9 +1126,9 @@ impl_runtime_apis! {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
-		fn dispatch_benchmark(config: frame_benchmarking::BenchmarkConfig)
-			-> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString>
-		{
+		fn dispatch_benchmark(
+			config: frame_benchmarking::BenchmarkConfig
+		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
 			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
 			// To get around that, we separated the Session benchmarks into its own crate, which is why

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 257,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1126,16 +1126,9 @@ impl_runtime_apis! {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
-		fn dispatch_benchmark(
-			pallet: Vec<u8>,
-			benchmark: Vec<u8>,
-			lowest_range_values: Vec<u32>,
-			highest_range_values: Vec<u32>,
-			steps: Vec<u32>,
-			repeat: u32,
-			verify: bool,
-			extra: bool,
-		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+		fn dispatch_benchmark(config: frame_benchmarking::BenchmarkConfig)
+			-> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString>
+		{
 			use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
 			// Trying to add benchmarks directly to the Session Pallet caused cyclic dependency issues.
 			// To get around that, we separated the Session benchmarks into its own crate, which is why
@@ -1164,17 +1157,7 @@ impl_runtime_apis! {
 			];
 
 			let mut batches = Vec::<BenchmarkBatch>::new();
-			let params = (
-				&pallet,
-				&benchmark,
-				&lowest_range_values,
-				&highest_range_values,
-				&steps,
-				repeat,
-				&whitelist,
-				verify,
-				extra,
-			);
+			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, pallet_babe, Babe);
 			add_benchmark!(params, batches, pallet_balances, Balances);

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -53,7 +53,7 @@ benchmarks! {
 	}: transfer(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount)
 	verify {
 		assert_eq!(Balances::<T>::free_balance(&caller), Zero::zero());
-		assert_eq!(Balances::<T>::free_balance(&recipient), Zero::zero());
+		assert_eq!(Balances::<T>::free_balance(&recipient), transfer_amount);
 	}
 
 	// Benchmark `transfer` with the best possible condition:

--- a/frame/balances/src/benchmarking.rs
+++ b/frame/balances/src/benchmarking.rs
@@ -53,7 +53,7 @@ benchmarks! {
 	}: transfer(RawOrigin::Signed(caller.clone()), recipient_lookup, transfer_amount)
 	verify {
 		assert_eq!(Balances::<T>::free_balance(&caller), Zero::zero());
-		assert_eq!(Balances::<T>::free_balance(&recipient), transfer_amount);
+		assert_eq!(Balances::<T>::free_balance(&recipient), Zero::zero());
 	}
 
 	// Benchmark `transfer` with the best possible condition:

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -648,9 +648,11 @@ macro_rules! benchmark_backend {
 				]
 			}
 
-			fn instance(&self, components: &[($crate::BenchmarkParameter, u32)], verify: bool)
-				-> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>
-			{
+			fn instance(
+				&self,
+				components: &[($crate::BenchmarkParameter, u32)],
+				verify: bool
+			) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
 				$(
 					let $common = $common_from;
 				)*
@@ -721,9 +723,11 @@ macro_rules! selected_benchmark {
 				}
 			}
 
-			fn instance(&self, components: &[($crate::BenchmarkParameter, u32)], verify: bool)
-				-> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>
-			{
+			fn instance(
+				&self,
+				components: &[($crate::BenchmarkParameter, u32)],
+				verify: bool
+			) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
 				match self {
 					$(
 						Self::$bench => <

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1058,19 +1058,19 @@ macro_rules! add_benchmark {
 			repeat,
 			verify,
 			extra,
-		} = config.clone();
+		} = config;
 		if &pallet[..] == &name_string[..] || &pallet[..] == &b"*"[..] {
 			if &pallet[..] == &b"*"[..] || &benchmark[..] == &b"*"[..] {
-				for benchmark in $( $location )*::benchmarks(extra).into_iter() {
+				for benchmark in $( $location )*::benchmarks(*extra).into_iter() {
 					$batches.push($crate::BenchmarkBatch {
 						results: $( $location )*::run_benchmark(
 							benchmark,
 							&lowest_range_values[..],
 							&highest_range_values[..],
 							&steps[..],
-							repeat,
+							*repeat,
 							whitelist,
-							verify,
+							*verify,
 						)?,
 						pallet: name_string.to_vec(),
 						benchmark: benchmark.to_vec(),
@@ -1083,9 +1083,9 @@ macro_rules! add_benchmark {
 						&lowest_range_values[..],
 						&highest_range_values[..],
 						&steps[..],
-						repeat,
+						*repeat,
 						whitelist,
-						verify,
+						*verify,
 					)?,
 					pallet: name_string.to_vec(),
 					benchmark: benchmark.clone(),

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -918,7 +918,7 @@ macro_rules! impl_benchmark {
 								// If `--verify` is used, run the benchmark once to verify it would complete.
 								repeat_benchmark(1, Default::default(), &mut Vec::new(), true)?;
 							}
-							repeat_benchmark(repeat, c, &mut results, verify)?;
+							repeat_benchmark(repeat, c, &mut results, false)?;
 						}
 					}
 				}

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1004,7 +1004,7 @@ macro_rules! impl_benchmark_test {
 /// First create an object that holds in the input parameters for the benchmark:
 ///
 /// ```ignore
-/// let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
+/// let params = (&config, &whitelist);
 /// ```
 ///
 /// The `whitelist` is a parameter you pass to control the DB read/write tracking.
@@ -1048,16 +1048,17 @@ macro_rules! impl_benchmark_test {
 macro_rules! add_benchmark {
 	( $params:ident, $batches:ident, $name:ident, $( $location:tt )* ) => (
 		let name_string = stringify!($name).as_bytes();
-		let (pallet,
+		let (config, whitelist) = $params;
+		let $crate::BenchmarkConfig {
+			pallet,
 			benchmark,
 			lowest_range_values,
 			highest_range_values,
 			steps,
 			repeat,
-			whitelist,
 			verify,
 			extra,
-		) = $params;
+		} = config.clone();
 		if &pallet[..] == &name_string[..] || &pallet[..] == &b"*"[..] {
 			if &pallet[..] == &b"*"[..] || &benchmark[..] == &b"*"[..] {
 				for benchmark in $( $location )*::benchmarks(extra).into_iter() {

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -176,10 +176,11 @@ fn benchmarks_macro_works() {
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
 		&selected,
 		&[(BenchmarkParameter::b, 1)],
+		true,
 	).expect("failed to create closure");
 
 	new_test_ext().execute_with(|| {
-		assert_eq!(closure(), Ok(()));
+		assert_ok!(closure());
 	});
 }
 
@@ -193,6 +194,7 @@ fn benchmarks_macro_rename_works() {
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
 		&selected,
 		&[(BenchmarkParameter::b, 1)],
+		true,
 	).expect("failed to create closure");
 
 	new_test_ext().execute_with(|| {
@@ -210,9 +212,10 @@ fn benchmarks_macro_works_for_non_dispatchable() {
 	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
 		&selected,
 		&[(BenchmarkParameter::x, 1)],
+		true,
 	).expect("failed to create closure");
 
-	assert_eq!(closure(), Ok(()));
+	assert_ok!(closure());
 }
 
 #[test]
@@ -220,13 +223,27 @@ fn benchmarks_macro_verify_works() {
 	// Check postcondition for benchmark `set_value` is valid.
 	let selected = SelectedBenchmark::set_value;
 
-	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::verify(
+	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
 		&selected,
 		&[(BenchmarkParameter::b, 1)],
+		true,
 	).expect("failed to create closure");
 
 	new_test_ext().execute_with(|| {
 		assert_ok!(closure());
+	});
+
+	// Check postcondition for benchmark `bad_verify` is invalid.
+	let selected = SelectedBenchmark::bad_verify;
+
+	let closure = <SelectedBenchmark as BenchmarkingSetup<Test>>::instance(
+		&selected,
+		&[(BenchmarkParameter::x, 10000)],
+		true,
+	).expect("failed to create closure");
+
+	new_test_ext().execute_with(|| {
+		assert_err!(closure(), "You forgot to sort!");
 	});
 }
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -202,8 +202,11 @@ pub trait BenchmarkingSetup<T, I = ()> {
 	fn components(&self) -> Vec<(BenchmarkParameter, u32, u32)>;
 
 	/// Set up the storage, and prepare a closure to run the benchmark.
-	fn instance(&self, components: &[(BenchmarkParameter, u32)], verify: bool)
-		-> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
+	fn instance(
+		&self,
+		components: &[(BenchmarkParameter, u32)],
+		verify: bool
+	) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -63,6 +63,19 @@ pub struct BenchmarkResults {
 	pub repeat_writes: u32,
 }
 
+/// Configuration used to setup and run runtime benchmarks.
+#[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
+pub struct BenchmarkConfig {
+	pub pallet: Vec<u8>,
+	pub benchmark: Vec<u8>,
+	pub lowest_range_values: Vec<u32>,
+	pub highest_range_values: Vec<u32>,
+	pub steps: Vec<u32>,
+	pub repeat: u32,
+	pub verify: bool,
+	pub extra: bool,
+}
+
 sp_api::decl_runtime_apis! {
 	/// Runtime api for benchmarking a FRAME runtime.
 	pub trait Benchmark {
@@ -74,6 +87,7 @@ sp_api::decl_runtime_apis! {
 			highest_range_values: Vec<u32>,
 			steps: Vec<u32>,
 			repeat: u32,
+			verify: bool,
 			extra: bool,
 		) -> Result<Vec<BenchmarkBatch>, RuntimeString>;
 	}
@@ -175,7 +189,8 @@ pub trait Benchmarking<T> {
 		highest_range_values: &[u32],
 		steps: &[u32],
 		repeat: u32,
-		whitelist: &[TrackedStorageKey]
+		whitelist: &[TrackedStorageKey],
+		verify: bool,
 	) -> Result<Vec<T>, &'static str>;
 }
 
@@ -188,10 +203,8 @@ pub trait BenchmarkingSetup<T, I = ()> {
 	fn components(&self) -> Vec<(BenchmarkParameter, u32, u32)>;
 
 	/// Set up the storage, and prepare a closure to run the benchmark.
-	fn instance(&self, components: &[(BenchmarkParameter, u32)]) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
-
-	/// Set up the storage, and prepare a closure to test and verify the benchmark
-	fn verify(&self, components: &[(BenchmarkParameter, u32)]) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
+	fn instance(&self, components: &[(BenchmarkParameter, u32)], verify: bool)
+		-> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str>;
 }
 
 /// Grab an account, seeded by a name and index.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -80,16 +80,7 @@ sp_api::decl_runtime_apis! {
 	/// Runtime api for benchmarking a FRAME runtime.
 	pub trait Benchmark {
 		/// Dispatch the given benchmark.
-		fn dispatch_benchmark(
-			pallet: Vec<u8>,
-			benchmark: Vec<u8>,
-			lowest_range_values: Vec<u32>,
-			highest_range_values: Vec<u32>,
-			steps: Vec<u32>,
-			repeat: u32,
-			verify: bool,
-			extra: bool,
-		) -> Result<Vec<BenchmarkBatch>, RuntimeString>;
+		fn dispatch_benchmark(config: BenchmarkConfig) -> Result<Vec<BenchmarkBatch>, RuntimeString>;
 	}
 }
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -66,13 +66,21 @@ pub struct BenchmarkResults {
 /// Configuration used to setup and run runtime benchmarks.
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug)]
 pub struct BenchmarkConfig {
+	/// The encoded name of the pallet to benchmark.
 	pub pallet: Vec<u8>,
+	/// The encoded name of the benchmark/extrinsic to run.
 	pub benchmark: Vec<u8>,
+	/// An optional manual override to the lowest values used in the `steps` range.
 	pub lowest_range_values: Vec<u32>,
+	/// An optional manual override to the highest values used in the `steps` range.
 	pub highest_range_values: Vec<u32>,
+	/// The number of samples to take across the range of values for components.
 	pub steps: Vec<u32>,
+	/// The number of times to repeat a benchmark.
 	pub repeat: u32,
+	/// Enable an extra benchmark iteration which runs the verification logic for a benchmark.
 	pub verify: bool,
+	/// Enable benchmarking of "extra" extrinsics, i.e. those that are not directly used in a pallet.
 	pub extra: bool,
 }
 

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -715,7 +715,8 @@ mod tests {
 			let closure_to_benchmark =
 				<SelectedBenchmark as frame_benchmarking::BenchmarkingSetup<Test>>::instance(
 					&selected_benchmark,
-					&c
+					&c,
+					true
 				).unwrap();
 
 			assert_ok!(closure_to_benchmark());

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -75,6 +75,7 @@ impl BenchmarkCmd {
 				self.highest_range_values.clone(),
 				self.steps.clone(),
 				self.repeat,
+				self.verify,
 				self.extra,
 			).encode(),
 			extensions,

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -75,7 +75,7 @@ impl BenchmarkCmd {
 				self.highest_range_values.clone(),
 				self.steps.clone(),
 				self.repeat,
-				self.verify,
+				!self.no_verify,
 				self.extra,
 			).encode(),
 			extensions,

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -72,12 +72,9 @@ pub struct BenchmarkCmd {
 	#[structopt(long)]
 	pub heap_pages: Option<u64>,
 
-	/// Run verification logic in addition to the benchmarks.
-	///
-	/// WARNING: The verification logic will be included as part of the extrinsic timing! This
-	/// should only be used for sanity checking your benchmarks are valid.
+	/// Disable verification logic when running benchmarks.
 	#[structopt(long)]
-	pub verify: bool,
+	pub no_verify: bool,
 
 	/// Display and run extra benchmarks that would otherwise not be needed for weight construction.
 	#[structopt(long)]

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -72,6 +72,13 @@ pub struct BenchmarkCmd {
 	#[structopt(long)]
 	pub heap_pages: Option<u64>,
 
+	/// Run verification logic in addition to the benchmarks.
+	///
+	/// WARNING: The verification logic will be included as part of the extrinsic timing! This
+	/// should only be used for sanity checking your benchmarks are valid.
+	#[structopt(long)]
+	pub verify: bool,
+
 	/// Display and run extra benchmarks that would otherwise not be needed for weight construction.
 	#[structopt(long)]
 	pub extra: bool,


### PR DESCRIPTION
This PR enables verification logic to run when executing benchmarks. Before, verification logic was only used in the runtime tests, but this will allow users who execute benchmarks on their actual runtime to verify the end state of their benchmarks.

This feature will not effect the results of your benchmarks, but will increase the overall execution time of benchmarks by S * extrinsic where S is the number of steps used for running your benchmark.

To disable this feature, simply pass the `--no-verify` flag.