### PR TITLE
babe: fix report_equivocation weight

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 257,
+	spec_version: 258,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -255,7 +255,7 @@ decl_module! {
 		/// the equivocation proof and validate the given key ownership proof
 		/// against the extracted offender. If both are valid, the offence will
 		/// be reported.
-		#[weight = weight::weight_for_report_equivocation::<T>()]
+		#[weight = weight_for::report_equivocation::<T>(key_owner_proof.validator_count())]
 		fn report_equivocation(
 			origin,
 			equivocation_proof: EquivocationProof<T::Header>,
@@ -278,7 +278,7 @@ decl_module! {
 		/// block authors will call it (validated in `ValidateUnsigned`), as such
 		/// if the block author is defined it will be defined as the equivocation
 		/// reporter.
-		#[weight = weight::weight_for_report_equivocation::<T>()]
+		#[weight = weight_for::report_equivocation::<T>(key_owner_proof.validator_count())]
 		fn report_equivocation_unsigned(
 			origin,
 			equivocation_proof: EquivocationProof<T::Header>,
@@ -295,24 +295,35 @@ decl_module! {
 	}
 }
 
-mod weight {
+mod weight_for {
 	use frame_support::{
 		traits::Get,
-		weights::{constants::WEIGHT_PER_MICROS, Weight},
+		weights::{
+			constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS},
+			Weight,
+		},
 	};
 
-	pub fn weight_for_report_equivocation<T: super::Trait>() -> Weight {
+	pub fn report_equivocation<T: super::Trait>(validator_count: u32) -> Weight {
+		// we take the validator set count from the membership proof to
+		// calculate the weight but we set a floor of 100 validators.
+		let validator_count = validator_count.min(100) as u64;
+
+		// worst case we are considering is that the given offender
+		// is backed by 200 nominators
+		const MAX_NOMINATORS: u64 = 200;
+
 		// checking membership proof
 		(35 * WEIGHT_PER_MICROS)
+			.saturating_add((175 * WEIGHT_PER_NANOS).saturating_mul(validator_count))
 			.saturating_add(T::DbWeight::get().reads(5))
 			// check equivocation proof
 			.saturating_add(110 * WEIGHT_PER_MICROS)
 			// report offence
 			.saturating_add(110 * WEIGHT_PER_MICROS)
-			// worst case we are considering is that the given offender
-			// is backed by 200 nominators
-			.saturating_add(T::DbWeight::get().reads(14 + 3 * 200))
-			.saturating_add(T::DbWeight::get().writes(10 + 3 * 200))
+			.saturating_add(25 * WEIGHT_PER_MICROS * MAX_NOMINATORS)
+			.saturating_add(T::DbWeight::get().reads(14 + 3 * MAX_NOMINATORS))
+			.saturating_add(T::DbWeight::get().writes(10 + 3 * MAX_NOMINATORS))
 	}
 }
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -307,7 +307,7 @@ mod weight_for {
 	pub fn report_equivocation<T: super::Trait>(validator_count: u32) -> Weight {
 		// we take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.
-		let validator_count = validator_count.min(100) as u64;
+		let validator_count = validator_count.max(100) as u64;
 
 		// worst case we are considering is that the given offender
 		// is backed by 200 nominators

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -585,3 +585,26 @@ fn report_equivocation_validate_unsigned_prevents_duplicates() {
 		);
 	});
 }
+
+#[test]
+fn report_equivocation_has_valid_weight() {
+	// the weight depends on the size of the validator set,
+	// but there's a lower bound of 100 validators.
+	assert!(
+		(1..=100)
+			.map(weight_for::report_equivocation::<Test>)
+			.collect::<Vec<_>>()
+			.windows(2)
+			.all(|w| w[0] == w[1])
+	);
+
+	// after 100 validators the weight should keep increasing
+	// with every extra validator.
+	assert!(
+		(100..=1000)
+			.map(weight_for::report_equivocation::<Test>)
+			.collect::<Vec<_>>()
+			.windows(2)
+			.all(|w| w[0] < w[1])
+	);
+}

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -376,7 +376,7 @@ mod weight_for {
 	pub fn report_equivocation<T: super::Trait>(validator_count: u32) -> Weight {
 		// we take the validator set count from the membership proof to
 		// calculate the weight but we set a floor of 100 validators.
-		let validator_count = validator_count.min(100) as u64;
+		let validator_count = validator_count.max(100) as u64;
 
 		// worst case we are considering is that the given offender
 		// is backed by 200 nominators

--- a/frame/grandpa/src/tests.rs
+++ b/frame/grandpa/src/tests.rs
@@ -842,3 +842,26 @@ fn always_schedules_a_change_on_new_session_when_stalled() {
 		assert_eq!(Grandpa::current_set_id(), 2);
 	});
 }
+
+#[test]
+fn report_equivocation_has_valid_weight() {
+	// the weight depends on the size of the validator set,
+	// but there's a lower bound of 100 validators.
+	assert!(
+		(1..=100)
+			.map(weight_for::report_equivocation::<Test>)
+			.collect::<Vec<_>>()
+			.windows(2)
+			.all(|w| w[0] == w[1])
+	);
+
+	// after 100 validators the weight should keep increasing
+	// with every extra validator.
+	assert!(
+		(100..=1000)
+			.map(weight_for::report_equivocation::<Test>)
+			.collect::<Vec<_>>()
+			.windows(2)
+			.all(|w| w[0] < w[1])
+	);
+}


### PR DESCRIPTION
This wasn't using the correct formula as extracted from the benchmarks model (was missing the components that scale with the number of validators).