### PR TITLE
Dynamically generate CHT roots on a full client

### DIFF
--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -540,15 +540,18 @@ pub fn changes_tries_state_at_block<'a, Block: BlockT>(
 /// Provide CHT roots. These are stored on a light client and generated dynamically on a full
 /// client.
 pub trait ProvideChtRoots<Block: BlockT> {
-	/// Get headers CHT root for given block. Returns None if the block is not a part of any CHT.
+	/// Get headers CHT root for given block.
+	/// * On a light client: Returns None if the block is not pruned (not a part of any CHT).
+	/// * On a full client: Returns None if the block is the genesis block.
 	fn header_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
 
-	/// Get changes trie CHT root for given block. Returns None if the block is not a part of any
-	/// CHT.
+	/// Get changes trie CHT root for given block.
+	/// * On a light client: Returns None if the block is not pruned (not a part of any CHT).
+	/// * On a full client: Returns None if the block is the genesis block.
 	fn changes_trie_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -540,18 +540,14 @@ pub fn changes_tries_state_at_block<'a, Block: BlockT>(
 /// Provide CHT roots. These are stored on a light client and generated dynamically on a full
 /// client.
 pub trait ProvideChtRoots<Block: BlockT> {
-	/// Get headers CHT root for given block.
-	/// * On a light client: Returns None if the block is not pruned (not a part of any CHT).
-	/// * On a full client: Returns None if the block is the genesis block.
+	/// Get headers CHT root for given block. Returns None if the block is not a part of any CHT.
 	fn header_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
 
-	/// Get changes trie CHT root for given block.
-	/// * On a light client: Returns None if the block is not pruned (not a part of any CHT).
-	/// * On a full client: Returns None if the block is the genesis block.
+	/// Get changes trie CHT root for given block. Returns None if the block is not a part of any CHT.
 	fn changes_trie_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -537,16 +537,18 @@ pub fn changes_tries_state_at_block<'a, Block: BlockT>(
 	}
 }
 
-/// Provide CHT roots. These are stored on a light client and generated dynamically on a full client.
+/// Provide CHT roots. These are stored on a light client and generated dynamically on a full
+/// client.
 pub trait ProvideChtRoots<Block: BlockT> {
-	/// Get headers CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
+	/// Get headers CHT root for given block. Returns None if the block is not a part of any CHT.
 	fn header_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,
 		block: NumberFor<Block>,
 	) -> sp_blockchain::Result<Option<Block::Hash>>;
 
-	/// Get changes trie CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
+	/// Get changes trie CHT root for given block. Returns None if the block is not a part of any
+	/// CHT.
 	fn changes_trie_cht_root(
 		&self,
 		cht_size: NumberFor<Block>,

--- a/client/api/src/backend.rs
+++ b/client/api/src/backend.rs
@@ -536,3 +536,20 @@ pub fn changes_tries_state_at_block<'a, Block: BlockT>(
 		None => Ok(None),
 	}
 }
+
+/// Provide CHT roots. These are stored on a light client and generated dynamically on a full client.
+pub trait ProvideChtRoots<Block: BlockT> {
+	/// Get headers CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
+	fn header_cht_root(
+		&self,
+		cht_size: NumberFor<Block>,
+		block: NumberFor<Block>,
+	) -> sp_blockchain::Result<Option<Block::Hash>>;
+
+	/// Get changes trie CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
+	fn changes_trie_cht_root(
+		&self,
+		cht_size: NumberFor<Block>,
+		block: NumberFor<Block>,
+	) -> sp_blockchain::Result<Option<Block::Hash>>;
+}

--- a/client/api/src/in_mem.rs
+++ b/client/api/src/in_mem.rs
@@ -35,7 +35,7 @@ use sp_state_machine::{
 use sp_blockchain::{CachedHeaderMetadata, HeaderMetadata};
 
 use crate::{
-	backend::{self, NewBlockState},
+	backend::{self, NewBlockState, ProvideChtRoots},
 	blockchain::{
 		self, BlockStatus, HeaderBackend, well_known_cache_keys::Id as CacheKeyId
 	},
@@ -456,7 +456,7 @@ impl<Block: BlockT> light::Storage<Block> for Blockchain<Block>
 	}
 }
 
-impl<Block: BlockT> light::ChtRootStorage<Block> for Blockchain<Block> {
+impl<Block: BlockT> ProvideChtRoots<Block> for Blockchain<Block> {
 	fn header_cht_root(
 		&self,
 		_cht_size: NumberFor<Block>,

--- a/client/api/src/light.rs
+++ b/client/api/src/light.rs
@@ -32,7 +32,7 @@ use sp_blockchain::{
 	HeaderMetadata, well_known_cache_keys, HeaderBackend, Cache as BlockchainCache,
 	Error as ClientError, Result as ClientResult,
 };
-use crate::{backend::{AuxStore, NewBlockState}, UsageInfo};
+use crate::{backend::{AuxStore, NewBlockState}, UsageInfo, ProvideChtRoots};
 
 /// Remote call request.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -233,7 +233,7 @@ pub trait FetchChecker<Block: BlockT>: Send + Sync {
 
 /// Light client blockchain storage.
 pub trait Storage<Block: BlockT>: AuxStore + HeaderBackend<Block>
-	+ HeaderMetadata<Block, Error=ClientError> + ChtRootStorage<Block>
+	+ HeaderMetadata<Block, Error=ClientError> + ProvideChtRoots<Block>
 {
 	/// Store new header. Should refuse to revert any finalized blocks.
 	///
@@ -261,23 +261,6 @@ pub trait Storage<Block: BlockT>: AuxStore + HeaderBackend<Block>
 
 	/// Get storage usage statistics.
 	fn usage_info(&self) -> Option<UsageInfo>;
-}
-
-/// Light client CHT root storage.
-pub trait ChtRootStorage<Block: BlockT> {
-	/// Get headers CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
-	fn header_cht_root(
-		&self,
-		cht_size: NumberFor<Block>,
-		block: NumberFor<Block>,
-	) -> ClientResult<Option<Block::Hash>>;
-
-	/// Get changes trie CHT root for given block. Returns None if the block is not pruned (not a part of any CHT).
-	fn changes_trie_cht_root(
-		&self,
-		cht_size: NumberFor<Block>,
-		block: NumberFor<Block>,
-	) -> ClientResult<Option<Block::Hash>>;
 }
 
 /// Remote header.

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -2405,9 +2405,12 @@ pub(crate) mod tests {
 
 		let blockchain = backend.blockchain();
 
-		let cht_root_1 = blockchain.header_cht_root(cht_size, cht::start_number(cht_size, 0)).unwrap().unwrap();
-		let cht_root_2 = blockchain.header_cht_root(cht_size, cht::start_number(cht_size, 0) + cht_size / 2).unwrap().unwrap();
-		let cht_root_3 = blockchain.header_cht_root(cht_size, cht::end_number(cht_size, 0)).unwrap().unwrap();
+		let cht_root_1 = blockchain.header_cht_root(cht_size, cht::start_number(cht_size, 0))
+			.unwrap().unwrap();
+		let cht_root_2 = blockchain.header_cht_root(cht_size, cht::start_number(cht_size, 0) + cht_size / 2)
+			.unwrap().unwrap();
+		let cht_root_3 = blockchain.header_cht_root(cht_size, cht::end_number(cht_size, 0))
+			.unwrap().unwrap();
 		assert_eq!(cht_root_1, cht_root_2);
 		assert_eq!(cht_root_2, cht_root_3);
 	}

--- a/client/db/src/light.rs
+++ b/client/db/src/light.rs
@@ -23,11 +23,11 @@ use std::convert::TryInto;
 use parking_lot::RwLock;
 
 use sc_client_api::{
-	cht, backend::{AuxStore, NewBlockState}, UsageInfo,
+	cht, backend::{AuxStore, NewBlockState, ProvideChtRoots}, UsageInfo,
 	blockchain::{
 		BlockStatus, Cache as BlockchainCache, Info as BlockchainInfo,
 	},
-	Storage, ChtRootStorage,
+	Storage,
 };
 use sp_blockchain::{
 	CachedHeaderMetadata, HeaderMetadata, HeaderMetadataCache,
@@ -596,7 +596,7 @@ impl<Block> Storage<Block> for LightStorage<Block>
 	}
 }
 
-impl<Block> ChtRootStorage<Block> for LightStorage<Block>
+impl<Block> ProvideChtRoots<Block> for LightStorage<Block>
 	where Block: BlockT,
 {
 	fn header_cht_root(

--- a/client/light/src/blockchain.rs
+++ b/client/light/src/blockchain.rs
@@ -29,7 +29,7 @@ use sp_blockchain::{
 };
 pub use sc_client_api::{
 	backend::{
-		AuxStore, NewBlockState
+		AuxStore, NewBlockState, ProvideChtRoots,
 	},
 	blockchain::{
 		Backend as BlockchainBackend, BlockStatus, Cache as BlockchainCache,
@@ -171,5 +171,23 @@ impl<S, Block: BlockT> RemoteBlockchain<Block> for Blockchain<S>
 			block: number,
 			retry_count: None,
 		}))
+	}
+}
+
+impl<S: Storage<Block>, Block: BlockT> ProvideChtRoots<Block> for Blockchain<S> {
+	fn header_cht_root(
+		&self,
+		cht_size: NumberFor<Block>,
+		block: NumberFor<Block>,
+	) -> sp_blockchain::Result<Option<Block::Hash>> {
+		self.storage().header_cht_root(cht_size, block)
+	}
+
+	fn changes_trie_cht_root(
+		&self,
+		cht_size: NumberFor<Block>,
+		block: NumberFor<Block>,
+	) -> sp_blockchain::Result<Option<Block::Hash>> {
+		self.storage().changes_trie_cht_root(cht_size, block)
 	}
 }

--- a/client/service/test/src/client/light.rs
+++ b/client/service/test/src/client/light.rs
@@ -42,7 +42,7 @@ use sc_executor::{NativeExecutor, WasmExecutionMethod, RuntimeVersion, NativeVer
 use sp_core::{H256, NativeOrEncoded, testing::TaskExecutor};
 use sc_client_api::{
 	blockchain::Info, backend::NewBlockState, Backend as ClientBackend, ProofProvider,
-	in_mem::{Backend as InMemBackend, Blockchain as InMemoryBlockchain}, ChtRootStorage,
+	in_mem::{Backend as InMemBackend, Blockchain as InMemoryBlockchain}, ProvideChtRoots,
 	AuxStore, Storage, CallExecutor, cht, ExecutionStrategy, StorageProof, BlockImportOperation,
 	RemoteCallRequest, StorageProvider, ChangesProof, RemoteBodyRequest, RemoteReadRequest,
 	RemoteChangesRequest, FetchChecker, RemoteReadChildRequest, RemoteHeaderRequest, BlockBackend,
@@ -173,7 +173,7 @@ impl Storage<Block> for DummyStorage {
 	}
 }
 
-impl ChtRootStorage<Block> for DummyStorage {
+impl ProvideChtRoots<Block> for DummyStorage {
 	fn header_cht_root(&self, _cht_size: u64, _block: u64) -> ClientResult<Option<Hash>> {
 		Err(ClientError::Backend("Test error".into()))
 	}


### PR DESCRIPTION
Currently, CHT roots are only generated on a light client, but CHT roots also need to be generated on full clients so that proofs can be sent to light clients.