### PR TITLE
.maintain/monitoring/alerting-rules: Add fd alert

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -110,6 +110,19 @@ groups:
       than 15 minutes'
 
   ##############################################################################
+  # System
+  ##############################################################################
+
+  - alert: HighNumberOfFileDescriptors
+    expr: 'node_filefd_allocated{domain=~"kusama|polkadot"} > 10000'
+    for: 3m
+    labels:
+      severity: warning
+    annotations:
+      message: 'The node {{ $labels.instance }} has more than 10_000 file
+      descriptors allocated for more than 3 minutes'
+
+  ##############################################################################
   # Others
   ##############################################################################
 


### PR DESCRIPTION
Alert on high file descriptor allocation.

This is not so much about the file descriptor limit itself, which is usually within the range of millions. Much rather this should show us when something suspicious is happening, e.g. https://github.com/paritytech/substrate/pull/6805 or high number of connections through https://github.com/libp2p/rust-libp2p/pull/1698.

Related to https://github.com/paritytech/polkadot/issues/1544.