### PR TITLE
Update tracing attribute in cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9395,9 +9395,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
the command `cargo +stable test -p frame-support-test` fails on master, updating tracing-attribute in cargo.lock fix the issue,
I'm not sure if this is the proper fix.