### PR TITLE
client/cli/src/config: Warn on low file descriptor limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,9 +1486,9 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 
 [[package]]
 name = "fdlimit"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da54a593b34c71b889ee45f5b5bb900c74148c5f7f8c6a9479ee7899f69603c"
+checksum = "47bc6e222b8349b2bd0acb85a1d16d22852376b3ceed2a7f09c2692c3d8a78d0"
 dependencies = [
  "libc",
 ]
@@ -9546,7 +9546,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.5.6",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -22,7 +22,7 @@ ansi_term = "0.12.1"
 lazy_static = "1.4.0"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"
-fdlimit = "0.1.4"
+fdlimit = "0.2.0"
 libp2p = "0.24.0"
 parity-scale-codec = "1.3.0"
 hex = "0.4.2"

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -24,6 +24,7 @@ use crate::{
 	init_logger, DatabaseParams, ImportParams, KeystoreParams, NetworkParams, NodeKeyParams,
 	OffchainWorkerParams, PruningParams, SharedParams, SubstrateCli,
 };
+use log::warn;
 use names::{Generator, Name};
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use sc_service::config::{
@@ -38,8 +39,11 @@ use std::path::PathBuf;
 /// The maximum number of characters for a node name.
 pub(crate) const NODE_NAME_MAX_LENGTH: usize = 64;
 
-/// default sub directory to store network config
+/// Default sub directory to store network config.
 pub(crate) const DEFAULT_NETWORK_CONFIG_PATH: &'static str = "network";
+
+/// The recommended open file descriptor limit to be configured for the process.
+const RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT: u64 = 10_000;
 
 /// Default configuration values used by Substrate
 ///
@@ -531,16 +535,25 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	///
 	/// This method:
 	///
-	/// 1. Set the panic handler
-	/// 2. Raise the FD limit
-	/// 3. Initialize the logger
+	/// 1. Sets the panic handler
+	/// 2. Initializes the logger
+	/// 3. Raises the FD limit
 	fn init<C: SubstrateCli>(&self) -> Result<()> {
 		let logger_pattern = self.log_filters()?;
 
 		sp_panic_handler::set(&C::support_url(), &C::impl_version());
 
-		fdlimit::raise_fd_limit();
 		init_logger(&logger_pattern);
+
+		if let Some(new_limit) = fdlimit::raise_fd_limit() {
+			if new_limit < RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT {
+				warn!(
+					"Low open file descriptor limit configured for the process. \
+					 Current value: {:?}, recommended value: {:?}.",
+					new_limit, RECOMMENDED_OPEN_FILE_DESCRIPTOR_LIMIT,
+				);
+			}
+		}
 
 		Ok(())
 	}

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -18,7 +18,7 @@ tokio = "0.1.22"
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
 env_logger = "0.7.0"
-fdlimit = "0.1.4"
+fdlimit = "0.2.0"
 parking_lot = "0.10.0"
 sc-light = { version = "2.0.0-rc6", path = "../../light" }
 sp-blockchain = { version = "2.0.0-rc6", path = "../../../primitives/blockchain" }


### PR DESCRIPTION
Substrate sets the soft file descriptor limit to the hard limit at
startup. In the case of the latter being low already (< 10_000) a
Substrate node under high demand might run into issues e.g. when opening
up new TCP connections or persisting data to the database.

With this commit a warn message is printed to stderr.

---

I am suggesting to only warn for now. In future releases we can still error
adding an optional `--ignore-fd-limit` flag to ignore the limit.

This is blocked on a new release of `fdlimit` that includes https://github.com/paritytech/fdlimit/pull/4.