### PR TITLE
Fix unwraps and other issues with benchmarks

### DIFF
--- a/frame/contracts/src/benchmarking.rs
+++ b/frame/contracts/src/benchmarking.rs
@@ -138,9 +138,7 @@ benchmarks! {
 		let endowment = Config::<T>::subsistence_threshold_uncached();
 		let caller = create_funded_user::<T>("caller", 0);
 		let (binary, hash) = load_module!("dummy");
-		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())
-			.unwrap();
-
+		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())?;
 	}: _(
 			RawOrigin::Signed(caller.clone()),
 			endowment,
@@ -164,15 +162,14 @@ benchmarks! {
 		let caller = create_funded_user::<T>("caller", 0);
 		let (binary, hash) = load_module!("dummy");
 		let addr = T::DetermineContractAddress::contract_address_for(&hash, &[], &caller);
-		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())
-			.unwrap();
+		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())?;
 		Contracts::<T>::instantiate(
 			RawOrigin::Signed(caller.clone()).into(),
 			endowment,
 			Weight::max_value(),
 			hash,
 			vec![],
-		).unwrap();
+		)?;
 	}: _(
 			RawOrigin::Signed(caller.clone()),
 			T::Lookup::unlookup(addr),
@@ -187,7 +184,7 @@ benchmarks! {
 		)
 	}
 
-	// We benchmark the costs for sucessfully evicting an empty contract.
+	// We benchmark the costs for successfully evicting an empty contract.
 	// The actual costs are depending on how many storage items the evicted contract
 	// does have. However, those costs are not to be payed by the sender but
 	// will be distributed over multiple blocks using a scheduler. Otherwise there is
@@ -199,18 +196,18 @@ benchmarks! {
 		let caller = create_funded_user::<T>("caller", 0);
 		let (binary, hash) = load_module!("dummy");
 		let addr = T::DetermineContractAddress::contract_address_for(&hash, &[], &caller);
-		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())
-			.unwrap();
+		Contracts::<T>::put_code(RawOrigin::Signed(caller.clone()).into(), binary.to_vec())?;
 		Contracts::<T>::instantiate(
 			RawOrigin::Signed(caller.clone()).into(),
 			endowment,
 			Weight::max_value(),
 			hash,
 			vec![],
-		).unwrap();
+		)?;
 
 		// instantiate should leave us with an alive contract
-		ContractInfoOf::<T>::get(addr.clone()).unwrap().get_alive().unwrap();
+		let contract_info = ContractInfoOf::<T>::get(addr.clone()).ok_or("Could not get contract info")?;
+		contract_info.get_alive().ok_or("Could not verify alive")?;
 
 		// generate some rent
 		advance_block::<T>(<T as Trait>::SignedClaimHandicap::get() + 1.into());
@@ -218,7 +215,8 @@ benchmarks! {
 	}: _(RawOrigin::Signed(caller.clone()), addr.clone(), None)
 	verify {
 		// the claim surcharge should have evicted the contract
-		ContractInfoOf::<T>::get(addr.clone()).unwrap().get_tombstone().unwrap();
+		let contract_info = ContractInfoOf::<T>::get(addr.clone()).ok_or("Could not get contract info.")?;
+		let _tombstone = contract_info.get_tombstone().ok_or("Could not get tombstone.")?;
 
 		// the caller should get the reward for being a good snitch
 		assert_eq!(


### PR DESCRIPTION
This PR generally improves the benchmarking code to avoid unnecessary panics, and instead handle errors more gracefully.

Additionally it:

* Executes no code when `repeat == 0`, ensuring you are always able to list available benchmarks.
* Pass by reference w/ Vec.
* Pass component when running verification code with components.