### PR TITLE
update kvdb-rocksdb to 0.9.1 and rocksdb to 6.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.3"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
+checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -2735,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c341ef15cfb1f923fa3b5138bfbd2d4813a2c1640b473727a53351c7f0b0fa2"
+checksum = "44947dd392f09475af614d740fe0320b66d01cb5b977f664bbbb5e45a70ea4c1"
 dependencies = [
  "fs-swap",
  "kvdb",
@@ -3246,9 +3246,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.7.4"
+version = "6.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
 dependencies = [
  "bindgen",
  "cc",
@@ -6096,9 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
+checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -9546,7 +9546,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.5.6",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.41"
 structopt = "0.3"
 derive_more = "0.99.2"
 kvdb = "0.7"
-kvdb-rocksdb = "0.9"
+kvdb-rocksdb = "0.9.1"
 sp-trie = { version = "2.0.0-rc6", path = "../../../primitives/trie" }
 sp-core = { version = "2.0.0-rc6", path = "../../../primitives/core" }
 sp-consensus = { version = "0.8.0-rc6", path = "../../../primitives/consensus/common" }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 parking_lot = "0.10.0"
 log = "0.4.8"
 kvdb = "0.7.0"
-kvdb-rocksdb = { version = "0.9", optional = true }
+kvdb-rocksdb = { version = "0.9.1", optional = true }
 kvdb-memorydb = "0.7.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
@@ -42,7 +42,7 @@ sp-keyring = { version = "2.0.0-rc6", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0-rc6", path = "../../test-utils/runtime/client" }
 env_logger = "0.7.0"
 quickcheck = "0.9"
-kvdb-rocksdb = "0.9"
+kvdb-rocksdb = "0.9.1"
 tempfile = "3"
 
 [features]


### PR DESCRIPTION
* rocksdb 6.11.4 (compared to 6.7.4) contains some fixes that might have caused corruption issues like #6797.
* updated default rocksdb format_version to 5 (https://github.com/paritytech/parity-common/pull/395), this might bring some perf speedup for dbs synced from scratch

polkadot companion: https://github.com/paritytech/polkadot/pull/1647