### PR TITLE
Update command to inspect key

### DIFF
--- a/bin/utils/subkey/README.adoc
+++ b/bin/utils/subkey/README.adoc
@@ -19,7 +19,7 @@ Will output a mnemonic phrase and give you the seed, public key, and address of 
 You can inspect a given URI (mnemonic, seed, public key, or address) and recover the public key and the address.
 
 ```bash
-subkey inspect <mnemonic,seed,pubkey,address>
+subkey inspect-key <mnemonic,seed,pubkey,address>
 
 OUTPUT:
   Public key (hex): 0x461edcf1ba99e43f50dec4bdeb3d1a2cf521ad7c3cd0eeee5cd3314e50fd424c


### PR DESCRIPTION
The original command
```
subkey inspect 
```
Produces this error
```
error: The subcommand 'inspect' wasn't recognized
	Did you mean 'inspect-key'?
```
The new updated command resolves this and works successfully.

Thank you for your Pull Request!

Before you submitting, please check that:

- [ ] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://wiki.parity.io/Substrate-Style-Guide)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
