### PR TITLE
Silence the error about non-registered protocols

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -648,7 +648,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 						messages: vec![(msg.engine_id, From::from(msg.data))],
 					}
 				} else {
-					warn!(target: "sync", "Received message on non-registered protocol: {:?}", msg.engine_id);
+					debug!(target: "sync", "Received message on non-registered protocol: {:?}", msg.engine_id);
 					CustomMessageOutcome::None
 				},
 			GenericMessage::ConsensusBatch(messages) => {
@@ -658,7 +658,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 						if self.protocol_name_by_engine.contains_key(&msg.engine_id) {
 							Some((msg.engine_id, From::from(msg.data)))
 						} else {
-							warn!(target: "sync", "Received message on non-registered protocol: {:?}", msg.engine_id);
+							debug!(target: "sync", "Received message on non-registered protocol: {:?}", msg.engine_id);
 							None
 						}
 					})

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1797,7 +1797,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 						}
 					}
 					None => {
-						error!(target: "sub-libp2p", "Received notification from unknown protocol {:?}", protocol_name);
+						debug!(target: "sub-libp2p", "Received notification from unknown protocol {:?}", protocol_name);
 						CustomMessageOutcome::None
 					}
 				}


### PR DESCRIPTION
This warning is supposed to indicate a critical problem in the node, but in practice it is frequently triggered in two situations:

- Light clients don't register the GrandPa protocol, as they are not interested in GrandPa messages, but still receive GrandPa notifications.
- More importantly: we're removed the old prototype of Polkadot-specific networking protocol, but older nodes still send notifications on this protocol.

As a consequence of the latter, anyone who runs a node right now is constantly spammed with this error.
This PR takes the pragmatic approach of silencing it.
