### PR TITLE
fix pallet-evm features

### DIFF
--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -22,7 +22,7 @@ sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../primi
 sp-runtime = { version = "2.0.0-rc6", default-features = false, path = "../../primitives/runtime" }
 sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "2.0.0-rc6", default-features = false, path = "../../primitives/io" }
-primitive-types = { version = "0.7.0", default-features = false, features = ["rlp"] }
+primitive-types = { version = "0.7.0", default-features = false, features = ["rlp", "byteorder"] }
 rlp = { version = "0.4", default-features = false }
 evm = { version = "0.17", default-features = false }
 sha3 = { version = "0.8", default-features = false }


### PR DESCRIPTION
Getting error when trying to add pallet-evm.

To reproduce:

```
cd frame/evm
cargo check --no-default-features --target=wasm32-unknown-unknown
```