### PR TITLE
ci: deploy alerting rules: fix run on changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -735,7 +735,7 @@ deploy-kubernetes-alerting-rules:
       - master
     changes:
       - .gitlab-ci.yml
-      - .maintain/monitoring/alerting-rules/alerting-rules.yaml
+      - .maintain/monitoring/
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -734,7 +734,7 @@ deploy-kubernetes-alerting-rules:
     refs:
       - master
     changes:
-      - "${RULES}"
+      - .maintain/monitoring/alerting-rules/alerting-rules.yaml
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -734,6 +734,7 @@ deploy-kubernetes-alerting-rules:
     refs:
       - master
     changes:
+      - .gitlab-ci.yml
       - .maintain/monitoring/alerting-rules/alerting-rules.yaml
 
 


### PR DESCRIPTION
the ci job for deploying prometheus alerting rules isn't triggered on changes to the file .maintain/monitoring/alerting-rules/alerting-rules.yaml as it should. gitlab doesn't understand variables in it's yaml syntax at that place.