### PR TITLE
Fix compact npos solution edge count calculation

### DIFF
--- a/primitives/npos-elections/compact/src/lib.rs
+++ b/primitives/npos-elections/compact/src/lib.rs
@@ -157,7 +157,7 @@ fn struct_def(
 		)
 	}).collect::<TokenStream2>();
 
-	let edge_count_impl = (1..count).map(|c| {
+	let edge_count_impl = (1..=count).map(|c| {
 		let field_name = field_name_for(c);
 		quote!(
 			all_edges = all_edges.saturating_add(


### PR DESCRIPTION
This edge count is used for weighing, and it is somewhat trivial to review and verify that the current implementation was ignoring `votes16` field of the struct. As reminder, the struct is like this: 
```rust

struct Compact {
  votes1: ... ,
  votes2: ..., 
  ...,
  votes16: ...,
}
```

I already will fix this in https://github.com/paritytech/substrate/pull/7007, but since it might take a while, this one can go in asap and make it to the very next runtime.

I won't mark this as high priority because the weight function is not _terribly_ wrong, it is just a bit underestimated. 