### PR TITLE
Partial fix for transaction priority

### DIFF
--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -251,7 +251,6 @@ pub mod priority {
 	///
 	/// This only makes sure that any value created for the operational dispatch class is
 	/// incremented by [`LIMIT`].
-	#[derive(Clone, Copy)]
 	pub enum FrameTransactionPriority {
 		Normal(u64),
 		Operational(u64),

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -256,9 +256,9 @@ pub mod priority {
 		Operational(u64),
 	}
 
-	impl Into<u64> for FrameTransactionPriority {
-		fn into(self) -> u64 {
-			match self {
+	impl From<FrameTransactionPriority> for u64 {
+		fn from(priority: FrameTransactionPriority) -> Self {
+			match priority {
 				FrameTransactionPriority::Normal(inner) => inner,
 				FrameTransactionPriority::Operational(inner) => inner.saturating_add(LIMIT),
 			}

--- a/frame/support/src/weights.rs
+++ b/frame/support/src/weights.rs
@@ -242,6 +242,31 @@ impl Default for DispatchClass {
 	}
 }
 
+/// Primitives related to priority management of Frame.
+pub mod priority {
+	/// The starting point of all Operational transactions. 3/4 of u64::max_value().
+	pub const LIMIT: u64 = 13_835_058_055_282_163_711_u64;
+
+	/// Wrapper for priority of different dispatch classes.
+	///
+	/// This only makes sure that any value created for the operational dispatch class is
+	/// incremented by [`LIMIT`].
+	#[derive(Clone, Copy)]
+	pub enum FrameTransactionPriority {
+		Normal(u64),
+		Operational(u64),
+	}
+
+	impl Into<u64> for FrameTransactionPriority {
+		fn into(self) -> u64 {
+			match self {
+				FrameTransactionPriority::Normal(inner) => inner,
+				FrameTransactionPriority::Operational(inner) => inner.saturating_add(LIMIT),
+			}
+		}
+	}
+}
+
 /// A bundle of static information collected from the `#[weight = $x]` attributes.
 #[derive(Clone, Copy, Eq, PartialEq, Default, RuntimeDebug, Encode, Decode)]
 pub struct DispatchInfo {

--- a/frame/system/src/extensions/check_nonce.rs
+++ b/frame/system/src/extensions/check_nonce.rs
@@ -31,6 +31,9 @@ use sp_runtime::{
 use sp_std::vec;
 
 /// Nonce check and increment to give replay protection for transactions.
+///
+/// Note that this does not set any priority by default. Make sure that AT LEAST one of the signed
+/// extension sets some kind of priority upon validating transactions.
 #[derive(Encode, Decode, Clone, Eq, PartialEq)]
 pub struct CheckNonce<T: Trait>(#[codec(compact)] T::Index);
 

--- a/frame/system/src/extensions/check_nonce.rs
+++ b/frame/system/src/extensions/check_nonce.rs
@@ -25,7 +25,7 @@ use sp_runtime::{
 	traits::{SignedExtension, DispatchInfoOf, Dispatchable, One},
 	transaction_validity::{
 		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
-		TransactionLongevity, TransactionPriority,
+		TransactionLongevity,
 	},
 };
 use sp_std::vec;
@@ -90,7 +90,7 @@ impl<T: Trait> SignedExtension for CheckNonce<T> where
 		&self,
 		who: &Self::AccountId,
 		_call: &Self::Call,
-		info: &DispatchInfoOf<Self::Call>,
+		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
 	) -> TransactionValidity {
 		// check index
@@ -107,7 +107,7 @@ impl<T: Trait> SignedExtension for CheckNonce<T> where
 		};
 
 		Ok(ValidTransaction {
-			priority: info.weight as TransactionPriority,
+			priority: 0,
 			requires,
 			provides,
 			longevity: TransactionLongevity::max_value(),

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -502,7 +502,7 @@ mod tests {
 	}
 
 	#[test]
-	fn signed_ext() {
+	fn signed_ext_check_weight_works() {
 		new_test_ext().execute_with(|| {
 			let normal = DispatchInfo { weight: 100, class: DispatchClass::Normal, pays_fee: Pays::Yes };
 			let op = DispatchInfo { weight: 100, class: DispatchClass::Operational, pays_fee: Pays::Yes };
@@ -518,7 +518,7 @@ mod tests {
 				.validate(&1, CALL, &op, len)
 				.unwrap()
 				.priority;
-			assert_eq!(priority, u64::max_value() / 2);
+			assert_eq!(priority, frame_support::weights::priority::LIMIT + 100);
 		})
 	}
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -467,6 +467,20 @@ impl<T: Trait + Send + Sync> ChargeTransactionPayment<T> where
 			Err(_) => Err(InvalidTransaction::Payment.into()),
 		}
 	}
+
+	/// Get an appropriate priority for a transaction with the given length and info.
+	///
+	/// This will try and optimise the `fee/weight` `fee/length`, whichever is consuming more of the
+	/// maximum corresponding limit.
+	///
+	/// For example, if a transaction consumed 1/4th of the block length and half of the weight, its
+	/// final priority is `fee * 2`.
+	fn get_priority(len: usize, info: &DispatchInfoOf<T::Call>, final_fee: BalanceOf<T>) -> TransactionPriority {
+		let weight_saturation = T::MaximumBlockWeight::get() / info.weight.max(1);
+		let len_saturation = T::MaximumBlockLength::get() as u64 / (len as u64).max(1);
+		let coefficient: BalanceOf<T> = weight_saturation.min(len_saturation).saturated_into::<BalanceOf<T>>();
+		final_fee.saturating_mul(coefficient).saturated_into::<TransactionPriority>()
+	}
 }
 
 impl<T: Trait + Send + Sync> sp_std::fmt::Debug for ChargeTransactionPayment<T> {
@@ -499,12 +513,10 @@ impl<T: Trait + Send + Sync> SignedExtension for ChargeTransactionPayment<T> whe
 		len: usize,
 	) -> TransactionValidity {
 		let (fee, _) = self.withdraw_fee(who, info, len)?;
-
-		let mut r = ValidTransaction::default();
-		// NOTE: we probably want to maximize the _fee (of any type) per weight unit_ here, which
-		// will be a bit more than setting the priority to tip. For now, this is enough.
-		r.priority = fee.saturated_into::<TransactionPriority>();
-		Ok(r)
+		Ok(ValidTransaction {
+			priority: Self::get_priority(len, info, fee),
+			..Default::default()
+		})
 	}
 
 	fn pre_dispatch(

--- a/primitives/npos-elections/compact/src/lib.rs
+++ b/primitives/npos-elections/compact/src/lib.rs
@@ -157,7 +157,7 @@ fn struct_def(
 		)
 	}).collect::<TokenStream2>();
 
-	let edge_count_impl = (1..count).map(|c| {
+	let edge_count_impl = (1..=count).map(|c| {
 		let field_name = field_name_for(c);
 		quote!(
 			all_edges = all_edges.saturating_add(


### PR DESCRIPTION
Partially fixing https://github.com/paritytech/substrate/issues/5672 and a recent audit comment about priorities being too eagerly correlated with fees. 

1. As suggested, the priority set by the `TransactionPayment` is now `fee / max(weight/maxWeigh, len/maxLen)`.
2. From other signed extensions, I removed the weight that was being set by `CheckNonce` as I think it was not needed. 
3. The weight set by `CheckWeight` is almost the same, I just made it a bit more expressive. Previously, the minimum for operational was `u64::max() / 2`, now it is `u64::max() * 3 / 4` plus whatever was the weight.

I am not super happy with this enum (`FrameTransactionPriority`) as it is. It is slightly better, but I had other intentions in mind when I first created it: A wrapper to make sure that if a priority is `Normal(x)`, adding more `Normal(y)` to it would never exceed `LIMIT`. Furthermore, it would make sure that any variant created as `Operational(x)` would be `LIMIT + x`.

But this is not trivial because this addition logic is placed in `primitives/runtime` where `SignedExtension` is defined. And we cannot make assumptions about `DispatchClass` there. So I will leave this aspect of the issue open. 