### PR TITLE
Update the service tasks Grafana dashboard

### DIFF
--- a/.maintain/monitoring/grafana-dashboards/substrate-service-tasks.json
+++ b/.maintain/monitoring/grafana-dashboards/substrate-service-tasks.json
@@ -44,14 +44,14 @@
       {
         "datasource": "$data_source",
         "enable": true,
-        "expr": "increase(${metric_namespace}_tasks_ended_total{reason=\"panic\", instance=~\"${nodename}\"}[5m])",
+        "expr": "increase(${metric_namespace}_tasks_ended_total{reason=\"panic\", instance=~\"${nodename}\"}[10m])",
         "hide": true,
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
         "name": "Task panics",
         "rawQuery": "SELECT\n  extract(epoch from time_column) AS time,\n  text_column as text,\n  tags_column as tags\nFROM\n  metric_table\nWHERE\n  $__timeFilter(time_column)\n",
         "showIn": 0,
-        "step": "",
+        "step": "10m",
         "tags": [],
         "textFormat": "{{instance}} - {{task_name}}",
         "titleFormat": "Panic!",
@@ -60,12 +60,12 @@
       {
         "datasource": "$data_source",
         "enable": true,
-        "expr": "changes(${metric_namespace}_process_start_time_seconds{instance=~\"${nodename}\"}[5m])",
+        "expr": "changes(${metric_namespace}_process_start_time_seconds{instance=~\"${nodename}\"}[10m])",
         "hide": false,
         "iconColor": "#8AB8FF",
         "name": "Node reboots",
         "showIn": 0,
-        "step": "",
+        "step": "10m",
         "textFormat": "{{instance}}",
         "titleFormat": "Reboots"
       }
@@ -75,7 +75,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1594822742772,
+  "iteration": 1599471940817,
   "links": [],
   "panels": [
     {
@@ -86,220 +86,6 @@
         "w": 24,
         "x": 0,
         "y": 0
-      },
-      "id": 25,
-      "panels": [],
-      "title": "CPU & Memory",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$data_source",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "hiddenSeries": false,
-      "id": 9,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "stddev-above",
-          "fillBelowTo": "stddev-below",
-          "hideTooltip": true,
-          "lines": false
-        },
-        {
-          "alias": "stddev-below",
-          "hideTooltip": true,
-          "lines": false
-        }
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "avg(${metric_namespace}_cpu_usage_percentage{instance=~\"${nodename}\"})",
-          "interval": "",
-          "legendFormat": "cpu-usage",
-          "refId": "A"
-        },
-        {
-          "expr": "avg(${metric_namespace}_cpu_usage_percentage{instance=~\"${nodename}\"}) - stddev(${metric_namespace}_cpu_usage_percentage{instance=~\"${nodename}\"})",
-          "interval": "",
-          "legendFormat": "stddev-below",
-          "refId": "B"
-        },
-        {
-          "expr": "avg(${metric_namespace}_cpu_usage_percentage{instance=~\"${nodename}\"}) + stddev(${metric_namespace}_cpu_usage_percentage{instance=~\"${nodename}\"})",
-          "interval": "",
-          "legendFormat": "stddev-above",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average CPU usage and standard deviation",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "percent",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$data_source",
-      "fill": 0,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 7
-      },
-      "hiddenSeries": false,
-      "id": 20,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "${metric_namespace}_memory_usage_bytes{instance=~\"${nodename}\"}",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Memory usage",
-      "tooltip": {
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
       },
       "id": 29,
       "panels": [],
@@ -318,19 +104,23 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 1
       },
       "hiddenSeries": false,
       "id": 11,
       "interval": "1m",
       "legend": {
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 2,
@@ -348,7 +138,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "avg(increase(${metric_namespace}_tasks_polling_duration_sum{instance=~\"${nodename}\"}[$__interval])) by (task_name) * 1000 / $__interval_ms",
+          "expr": "avg(irate(${metric_namespace}_tasks_polling_duration_sum{instance=~\"${nodename}\"}[10m])) by (task_name)",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -407,7 +197,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 7
       },
       "hiddenSeries": false,
       "id": 30,
@@ -416,6 +206,8 @@
         "alignAsTable": true,
         "avg": true,
         "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
         "max": false,
         "min": false,
         "rightSide": true,
@@ -439,7 +231,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "avg(rate(${metric_namespace}_tasks_polling_duration_count{instance=~\"${nodename}\"}[5m])) by (task_name)",
+          "expr": "avg(irate(${metric_namespace}_tasks_polling_duration_count{instance=~\"${nodename}\"}[10m])) by (task_name)",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -498,7 +290,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 13
       },
       "hiddenSeries": false,
       "id": 31,
@@ -530,7 +322,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "max(rate(${metric_namespace}_tasks_polling_duration_count{instance=~\"${nodename}\"}[5m])) by (task_name)",
+          "expr": "max(irate(${metric_namespace}_tasks_polling_duration_count{instance=~\"${nodename}\"}[10m])) by (task_name)",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -589,21 +381,21 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 19
       },
       "hiddenSeries": false,
       "id": 15,
       "interval": "",
       "legend": {
-        "alignAsTable": false,
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
         "max": false,
         "min": false,
-        "rightSide": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -621,7 +413,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "avg by(task_name) (irate(${metric_namespace}_tasks_spawned_total{instance=~\"${nodename}\"}[5m]))",
+          "expr": "avg by(task_name) (irate(${metric_namespace}_tasks_spawned_total{instance=~\"${nodename}\"}[10m]))",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -680,21 +472,21 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 25
       },
       "hiddenSeries": false,
       "id": 16,
       "interval": "",
       "legend": {
-        "alignAsTable": false,
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
-        "rightSide": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -712,7 +504,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "max by(task_name) (irate(${metric_namespace}_tasks_spawned_total{instance=~\"${nodename}\"}[5m]))",
+          "expr": "max by(task_name) (irate(${metric_namespace}_tasks_spawned_total{instance=~\"${nodename}\"}[10m]))",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -771,21 +563,21 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 2,
       "interval": "",
       "legend": {
-        "alignAsTable": false,
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
         "max": false,
         "min": false,
-        "rightSide": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -862,21 +654,21 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 37
       },
       "hiddenSeries": false,
       "id": 3,
       "interval": "",
       "legend": {
-        "alignAsTable": false,
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
-        "rightSide": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -947,13 +739,14 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$data_source",
+      "decimals": null,
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 43
       },
       "hiddenSeries": false,
       "id": 7,
@@ -987,7 +780,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "avg(\n  rate(${metric_namespace}_tasks_polling_duration_bucket{instance=~\"${nodename}\", le=\"+Inf\"}[1m])\n    - ignoring(le)\n  rate(${metric_namespace}_tasks_polling_duration_bucket{instance=~\"${nodename}\", le=\"1.024\"}[1m])\n) by (task_name) > 0",
+          "expr": "avg(\n  irate(${metric_namespace}_tasks_polling_duration_bucket{instance=~\"${nodename}\", le=\"+Inf\"}[10m])\n    - ignoring(le)\n  irate(${metric_namespace}_tasks_polling_duration_bucket{instance=~\"${nodename}\", le=\"1.024\"}[10m])\n) by (task_name) > 0",
           "interval": "",
           "legendFormat": "{{task_name}}",
           "refId": "A"
@@ -1013,6 +806,7 @@
       },
       "yaxes": [
         {
+          "decimals": null,
           "format": "cps",
           "label": "Calls to `Future::poll`/second",
           "logBase": 1,
@@ -1041,7 +835,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 49
       },
       "id": 27,
       "panels": [],
@@ -1060,18 +854,20 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 50
       },
       "hiddenSeries": false,
-      "id": 23,
+      "id": 32,
       "legend": {
-        "avg": false,
+        "alignAsTable": true,
+        "avg": true,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
-        "show": false,
+        "rightSide": true,
+        "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -1089,17 +885,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "${metric_namespace}_threads{instance=~\"${nodename}\"}",
+          "expr": "avg(${metric_namespace}_unbounded_channel_len{instance=~\"${nodename}\", action = \"send\"} - ignoring(action) ${metric_namespace}_unbounded_channel_len{instance=~\"${nodename}\", action = \"received\"}) by (entity)",
           "interval": "",
-          "legendFormat": "{{instance}}",
-          "refId": "A"
+          "legendFormat": "{{entity}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Number of threads",
+      "title": "Unbounded channels size (average per node)",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1135,9 +931,99 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$data_source",
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "hiddenSeries": false,
+      "id": 33,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(irate(${metric_namespace}_unbounded_channel_len{instance=~\"${nodename}\", action = \"send\"}[10m])) by (entity)",
+          "interval": "",
+          "legendFormat": "{{entity}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Unbounded channels rate (average per node)",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "cps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "refresh": "30s",
+  "refresh": false,
   "schemaVersion": 22,
   "style": "dark",
   "tags": [],
@@ -1147,7 +1033,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$data_source",
-        "definition": "${metric_namespace}_cpu_usage_percentage",
+        "definition": "${metric_namespace}_process_start_time_seconds",
         "hide": 0,
         "includeAll": true,
         "index": -1,
@@ -1155,7 +1041,7 @@
         "multi": true,
         "name": "nodename",
         "options": [],
-        "query": "${metric_namespace}_cpu_usage_percentage",
+        "query": "${metric_namespace}_process_start_time_seconds",
         "refresh": 1,
         "regex": "/instance=\"(.*?)\"/",
         "skipUrlSync": false,
@@ -1228,5 +1114,5 @@
   "variables": {
     "list": []
   },
-  "version": 44
+  "version": 52
 }


### PR DESCRIPTION
Updates it for the removal of sysinfo (#6805)

Most importantly, the list of nodes was fetched from what the `cpu_percentage` metric reports, and would therefore show as empty.

As always, reading this JSON file is kind of complicated, and I'd expect anyone interested to instead actually import the dashboard to look at it and suggest changes.
