### PR TITLE
grandpa-rpc don't share subscription manager, only executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,7 +3747,6 @@ dependencies = [
  "futures 0.3.5",
  "hex-literal",
  "jsonrpc-core",
- "jsonrpc-pubsub",
  "log",
  "nix",
  "node-executor",
@@ -3881,7 +3880,6 @@ name = "node-rpc"
 version = "2.0.0-rc6"
 dependencies = [
  "jsonrpc-core",
- "jsonrpc-pubsub",
  "node-primitives",
  "node-runtime",
  "pallet-contracts-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3746,7 +3746,6 @@ dependencies = [
  "frame-system",
  "futures 0.3.5",
  "hex-literal",
- "jsonrpc-core",
  "log",
  "nix",
  "node-executor",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -39,7 +39,6 @@ serde = { version = "1.0.102", features = ["derive"] }
 futures = { version = "0.3.1", features = ["compat"] }
 hex-literal = "0.3.1"
 jsonrpc-core = "14.2.0"
-jsonrpc-pubsub = "14.2.0"
 log = "0.4.8"
 rand = "0.7.2"
 structopt = { version = "0.3.8", optional = true }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -38,7 +38,6 @@ codec = { package = "parity-scale-codec", version = "1.3.4" }
 serde = { version = "1.0.102", features = ["derive"] }
 futures = { version = "0.3.1", features = ["compat"] }
 hex-literal = "0.3.1"
-jsonrpc-core = "14.2.0"
 log = "0.4.8"
 rand = "0.7.2"
 structopt = { version = "0.3.8", optional = true }

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -119,7 +119,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		let select_chain = select_chain.clone();
 		let keystore = keystore.clone();
 
-		let rpc_extensions_builder = move |deny_unsafe, subscriptions| {
+		let rpc_extensions_builder = move |deny_unsafe, sub_task_executor| {
 			let deps = node_rpc::FullDeps {
 				client: client.clone(),
 				pool: pool.clone(),
@@ -134,7 +134,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 					shared_voter_state: shared_voter_state.clone(),
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),
-					subscriptions,
+					sub_task_executor,
 				},
 			};
 

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -51,7 +51,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 	(
 		impl Fn(
 			node_rpc::DenyUnsafe,
-			sc_rpc::SubscriptionTaskExecutor
+			sc_rpc::SubscriptionTaskExecutor,
 		) -> node_rpc::IoHandler,
 		(
 			sc_consensus_babe::BabeBlockImport<Block, FullClient, FullGrandpaBlockImport>,

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -119,7 +119,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		let select_chain = select_chain.clone();
 		let keystore = keystore.clone();
 
-		let rpc_extensions_builder = move |deny_unsafe, sub_task_executor| {
+		let rpc_extensions_builder = move |deny_unsafe, subscription_executor| {
 			let deps = node_rpc::FullDeps {
 				client: client.clone(),
 				pool: pool.clone(),
@@ -134,7 +134,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 					shared_voter_state: shared_voter_state.clone(),
 					shared_authority_set: shared_authority_set.clone(),
 					justification_stream: justification_stream.clone(),
-					sub_task_executor,
+					subscription_executor,
 				},
 			};
 

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -51,7 +51,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 	(
 		impl Fn(
 			node_rpc::DenyUnsafe,
-			jsonrpc_pubsub::manager::SubscriptionManager
+			sc_rpc::SubscriptionTaskExecutor
 		) -> node_rpc::IoHandler,
 		(
 			sc_consensus_babe::BabeBlockImport<Block, FullClient, FullGrandpaBlockImport>,

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -12,7 +12,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 jsonrpc-core = "14.2.0"
-jsonrpc-pubsub = "14.2.0"
 node-primitives = { version = "2.0.0-rc6", path = "../primitives" }
 node-runtime = { version = "2.0.0-rc6", path = "../runtime" }
 pallet-contracts-rpc = { version = "0.8.0-rc6", path = "../../../frame/contracts/rpc/" }

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -32,7 +32,6 @@
 
 use std::sync::Arc;
 
-use jsonrpc_pubsub::manager::SubscriptionManager;
 use node_primitives::{Block, BlockNumber, AccountId, Index, Balance, Hash};
 use sc_consensus_babe::{Config, Epoch};
 use sc_consensus_babe_rpc::BabeRpcHandler;
@@ -46,6 +45,7 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_consensus::SelectChain;
 use sp_consensus_babe::BabeApi;
+use sc_rpc::SubscriptionTaskExecutor;
 use sp_transaction_pool::TransactionPool;
 
 /// Light client extra dependencies.
@@ -78,8 +78,8 @@ pub struct GrandpaDeps {
 	pub shared_authority_set: SharedAuthoritySet<Hash, BlockNumber>,
 	/// Receives notifications about justification events from Grandpa.
 	pub justification_stream: GrandpaJustificationStream<Block>,
-	/// Subscription manager to keep track of pubsub subscribers.
-	pub subscriptions: SubscriptionManager,
+	/// Executor to drive the subscription manager in the Grandpa RPC handler.
+	pub sub_task_executor: SubscriptionTaskExecutor,
 }
 
 /// Full client dependencies.

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -79,7 +79,7 @@ pub struct GrandpaDeps {
 	/// Receives notifications about justification events from Grandpa.
 	pub justification_stream: GrandpaJustificationStream<Block>,
 	/// Executor to drive the subscription manager in the Grandpa RPC handler.
-	pub sub_task_executor: SubscriptionTaskExecutor,
+	pub subscription_executor: SubscriptionTaskExecutor,
 }
 
 /// Full client dependencies.
@@ -139,7 +139,7 @@ pub fn create_full<C, P, SC>(
 		shared_voter_state,
 		shared_authority_set,
 		justification_stream,
-		sub_task_executor,
+		subscription_executor,
 	} = grandpa;
 
 	io.extend_with(
@@ -172,7 +172,7 @@ pub fn create_full<C, P, SC>(
 				shared_authority_set,
 				shared_voter_state,
 				justification_stream,
-				sub_task_executor,
+				subscription_executor,
 			)
 		)
 	);

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -139,7 +139,7 @@ pub fn create_full<C, P, SC>(
 		shared_voter_state,
 		shared_authority_set,
 		justification_stream,
-		subscriptions,
+		sub_task_executor,
 	} = grandpa;
 
 	io.extend_with(
@@ -172,7 +172,7 @@ pub fn create_full<C, P, SC>(
 				shared_authority_set,
 				shared_voter_state,
 				justification_stream,
-				subscriptions,
+				sub_task_executor,
 			)
 		)
 	);

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -46,7 +46,7 @@ use sp_runtime::traits::{
 };
 use sp_api::{ProvideRuntimeApi, CallApiAt};
 use sc_executor::{NativeExecutor, NativeExecutionDispatch, RuntimeInfo};
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 use wasm_timer::SystemTime;
 use sc_telemetry::{telemetry, SUBSTRATE_INFO};
 use sp_transaction_pool::MaintainedTransactionPool;
@@ -729,14 +729,10 @@ fn gen_handler<TBl, TBackend, TExPool, TRpc, TCl>(
 	);
 	let system = system::System::new(system_info, system_rpc_tx, deny_unsafe);
 
-	let maybe_offchain_rpc = offchain_storage
-	.map(|storage| {
+	let maybe_offchain_rpc = offchain_storage.map(|storage| {
 		let offchain = sc_rpc::offchain::Offchain::new(storage, deny_unsafe);
-		// FIXME: Use plain Option (don't collect into HashMap) when we upgrade to jsonrpc 14.1
-		// https://github.com/paritytech/jsonrpc/commit/20485387ed06a48f1a70bf4d609a7cde6cf0accf
-		let delegate = offchain::OffchainApi::to_delegate(offchain);
-			delegate.into_iter().collect::<HashMap<_, _>>()
-	}).unwrap_or_default();
+		offchain::OffchainApi::to_delegate(offchain)
+	});
 
 	sc_rpc_server::rpc_handler((
 		state::StateApi::to_delegate(state),

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -73,9 +73,10 @@ pub trait RpcExtensionBuilder {
 
 	/// Returns an instance of the RPC extension for a particular `DenyUnsafe`
 	/// value, e.g. the RPC extension might not expose some unsafe methods.
-	fn build(&self,
+	fn build(
+		&self,
 		deny: sc_rpc::DenyUnsafe,
-		subscription_executor: sc_rpc::SubscriptionTaskExecutor
+		subscription_executor: sc_rpc::SubscriptionTaskExecutor,
 	) -> Self::Output;
 }
 
@@ -85,9 +86,10 @@ impl<F, R> RpcExtensionBuilder for F where
 {
 	type Output = R;
 
-	fn build(&self,
+	fn build(
+		&self,
 		deny: sc_rpc::DenyUnsafe,
-		subscription_executor: sc_rpc::SubscriptionTaskExecutor
+		subscription_executor: sc_rpc::SubscriptionTaskExecutor,
 	) -> Self::Output {
 		(*self)(deny, subscription_executor)
 	}
@@ -103,9 +105,10 @@ impl<R> RpcExtensionBuilder for NoopRpcExtensionBuilder<R> where
 {
 	type Output = R;
 
-	fn build(&self,
+	fn build(
+		&self,
 		_deny: sc_rpc::DenyUnsafe,
-		_subscription_executor: sc_rpc::SubscriptionTaskExecutor
+		_subscription_executor: sc_rpc::SubscriptionTaskExecutor,
 	) -> Self::Output {
 		self.0.clone()
 	}

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -75,7 +75,7 @@ pub trait RpcExtensionBuilder {
 	/// value, e.g. the RPC extension might not expose some unsafe methods.
 	fn build(&self,
 		deny: sc_rpc::DenyUnsafe,
-		sub_task_executor: sc_rpc::SubscriptionTaskExecutor
+		subscription_executor: sc_rpc::SubscriptionTaskExecutor
 	) -> Self::Output;
 }
 
@@ -87,9 +87,9 @@ impl<F, R> RpcExtensionBuilder for F where
 
 	fn build(&self,
 		deny: sc_rpc::DenyUnsafe,
-		sub_task_executor: sc_rpc::SubscriptionTaskExecutor
+		subscription_executor: sc_rpc::SubscriptionTaskExecutor
 	) -> Self::Output {
-		(*self)(deny, sub_task_executor)
+		(*self)(deny, subscription_executor)
 	}
 }
 
@@ -105,7 +105,7 @@ impl<R> RpcExtensionBuilder for NoopRpcExtensionBuilder<R> where
 
 	fn build(&self,
 		_deny: sc_rpc::DenyUnsafe,
-		_sub_task_executor: sc_rpc::SubscriptionTaskExecutor
+		_subscription_executor: sc_rpc::SubscriptionTaskExecutor
 	) -> Self::Output {
 		self.0.clone()
 	}


### PR DESCRIPTION
Instead of having `sc-finality-grandpa-rpc` share subscription manager with the client, only share executors.
Based on the idea that less sharing is better.

Part of: #6066 
polkadot companion: https://github.com/paritytech/polkadot/pull/1687