### PR TITLE
Downgrade wabt = 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9753,9 +9753,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wabt"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
+checksum = "94b5f5d6984ca42df66280baa8a15ac188a173ddaf4580b574a98931c01920e7"
 dependencies = [
  "serde",
  "serde_derive",
@@ -9765,9 +9765,9 @@ dependencies = [
 
 [[package]]
 name = "wabt-sys"
-version = "0.7.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c695f98f7eb81fd4e2f6b65301ccc916a950dc2265eeefc4d376b34ce666df"
+checksum = "b064c81821100adb4b71923cecfc67fef083db21c3bbd454b0162c7ffe63eeaa"
 dependencies = [
  "cc",
  "cmake",

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -41,7 +41,7 @@ sp-application-crypto = { version = "2.0.0-rc6", path = "../../../primitives/app
 sp-runtime = { version = "2.0.0-rc6", path = "../../../primitives/runtime" }
 sp-externalities = { version = "0.8.0-rc6", path = "../../../primitives/externalities" }
 substrate-test-client = { version = "2.0.0-rc6", path = "../../../test-utils/client" }
-wabt = "0.9.2"
+wabt = "0.9.1"
 
 [features]
 wasmtime = [

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -39,7 +39,7 @@ substrate-test-client = { version = "2.0.0-rc6", path = "../../../test-utils/cli
 pallet-timestamp = { version = "2.0.0-rc6", path = "../../../frame/timestamp" }
 pallet-transaction-payment = { version = "2.0.0-rc6", path = "../../../frame/transaction-payment" }
 pallet-treasury = { version = "2.0.0-rc6", path = "../../../frame/treasury" }
-wabt = "0.9.2"
+wabt = "0.9.1"
 sp-api = { version = "2.0.0-rc6", path = "../../../primitives/api" }
 sp-finality-tracker = { version = "2.0.0-rc6", default-features = false, path = "../../../primitives/finality-tracker" }
 sp-timestamp = { version = "2.0.0-rc6", default-features = false, path = "../../../primitives/timestamp" }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -37,7 +37,7 @@ libsecp256k1 = "0.3.4"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-wabt = "0.9.2"
+wabt = "0.9.1"
 hex-literal = "0.3.1"
 sc-runtime-test = { version = "2.0.0-rc6", path = "runtime-test" }
 substrate-test-runtime = { version = "2.0.0-rc6", path = "../../test-utils/runtime" }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -20,7 +20,7 @@ sp-wasm-interface = { version = "2.0.0-rc6", default-features = false, path = ".
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 
 [dev-dependencies]
-wabt = "0.9.2"
+wabt = "0.9.1"
 assert_matches = "1.3.0"
 
 [features]


### PR DESCRIPTION
superseeding #6928 – downgrading wabt to better be safe than sorry.

fixes #6945 