### PR TITLE
Make `--file` optional for `generate-node-key`

### DIFF
--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -31,7 +31,8 @@ use sp_core::crypto::Ss58Codec;
 	about = "Utility for generating and restoring with Substrate keys",
 )]
 pub enum Subkey {
-	/// Generate a random node libp2p key, save it to file and print its peer ID
+	/// Generate a random node libp2p key, save it to file or print it to stdout
+	/// and print its peer ID to stderr.
 	GenerateNodeKey(GenerateNodeKeyCmd),
 
 	/// Generate a random account

--- a/client/cli/src/commands/key.rs
+++ b/client/cli/src/commands/key.rs
@@ -28,10 +28,11 @@ use super::{
 	generate_node_key::GenerateNodeKeyCmd,
 };
 
-/// key utilities for the cli.
+/// Key utilities for the cli.
 #[derive(Debug, StructOpt)]
 pub enum KeySubcommand {
-	/// Generate a random node libp2p key, save it to file and print its peer ID
+	/// Generate a random node libp2p key, save it to file or print it to stdout
+	/// and print its peer ID to stderr.
 	GenerateNodeKey(GenerateNodeKeyCmd),
 
 	/// Generate a random account


### PR DESCRIPTION
This pr makes the `--file` argument optional to `generate-node-key`.
If the argument is not given, the secret node key will be printed to
`stdout`. The public node key will always be printed to `stderr`.

Fixes: https://github.com/paritytech/substrate/issues/7022