### PR TITLE
Revert "Fix broken link to democracy pallet."

### DIFF
--- a/frame/sudo/README.md
+++ b/frame/sudo/README.md
@@ -61,7 +61,7 @@ You need to set an initial superuser account as the sudo `key`.
 
 ## Related Modules
 
-* [Democracy](https://github.com/paritytech/substrate/blob/master/frame/democracy/README.md)
+* [Democracy](../pallet_democracy/index.html)
 
 [`Call`]: ./enum.Call.html
 [`Trait`]: ./trait.Trait.html


### PR DESCRIPTION
Reverts paritytech/substrate#7026

Doesn't fix anything that's actually broken and in any case should be a more general change if decided sensible.