### PR TITLE
Change wabt to wat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
- "glob 0.3.0",
+ "glob",
  "libc",
  "libloading",
 ]
@@ -783,15 +783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2089,12 +2080,6 @@ checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-
-[[package]]
-name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -3267,7 +3252,7 @@ checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
 dependencies = [
  "bindgen",
  "cc",
- "glob 0.3.0",
+ "glob",
  "libc",
 ]
 
@@ -3844,7 +3829,7 @@ dependencies = [
  "sp-trie",
  "substrate-test-client",
  "trie-root",
- "wabt",
+ "wat",
 ]
 
 [[package]]
@@ -4095,7 +4080,7 @@ dependencies = [
  "sp-timestamp",
  "substrate-test-client",
  "tempfile",
- "wabt",
+ "wat",
 ]
 
 [[package]]
@@ -6785,8 +6770,8 @@ dependencies = [
  "substrate-test-runtime",
  "test-case",
  "tracing",
- "wabt",
  "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -8387,8 +8372,8 @@ dependencies = [
  "sp-io",
  "sp-std",
  "sp-wasm-interface",
- "wabt",
  "wasmi",
+ "wat",
 ]
 
 [[package]]
@@ -9580,7 +9565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe777c4e2060f44d83892be1189f96200be8ed3d99569d5c2d5ee26e62c0ea9"
 dependencies = [
  "dissimilar",
- "glob 0.3.0",
+ "glob",
  "lazy_static",
  "serde",
  "serde_json",
@@ -9750,29 +9735,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wabt"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5f5d6984ca42df66280baa8a15ac188a173ddaf4580b574a98931c01920e7"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "wabt-sys",
-]
-
-[[package]]
-name = "wabt-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b064c81821100adb4b71923cecfc67fef083db21c3bbd454b0162c7ffe63eeaa"
-dependencies = [
- "cc",
- "cmake",
- "glob 0.2.11",
-]
 
 [[package]]
 name = "wait-timeout"
@@ -10354,7 +10316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
 dependencies = [
  "cc",
- "glob 0.3.0",
+ "glob",
  "itertools 0.9.0",
  "libc",
 ]

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -41,7 +41,7 @@ sp-application-crypto = { version = "2.0.0-rc6", path = "../../../primitives/app
 sp-runtime = { version = "2.0.0-rc6", path = "../../../primitives/runtime" }
 sp-externalities = { version = "0.8.0-rc6", path = "../../../primitives/externalities" }
 substrate-test-client = { version = "2.0.0-rc6", path = "../../../test-utils/client" }
-wabt = "0.9.1"
+wat = "1.0"
 
 [features]
 wasmtime = [

--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -36,7 +36,7 @@ use node_runtime::{
 	constants::currency::*,
 };
 use node_primitives::{Balance, Hash};
-use wabt;
+use wat;
 use node_testing::keyring::*;
 
 pub mod common;
@@ -580,7 +580,7 @@ const CODE_TRANSFER: &str = r#"
 
 #[test]
 fn deploying_wasm_contract_should_work() {
-	let transfer_code = wabt::wat2wasm(CODE_TRANSFER).unwrap();
+	let transfer_code = wat::parse_str(CODE_TRANSFER).unwrap();
 	let transfer_ch = <Runtime as frame_system::Trait>::Hashing::hash(&transfer_code);
 
 	let addr = <Runtime as pallet_contracts::Trait>::DetermineContractAddress::contract_address_for(

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -39,7 +39,7 @@ substrate-test-client = { version = "2.0.0-rc6", path = "../../../test-utils/cli
 pallet-timestamp = { version = "2.0.0-rc6", path = "../../../frame/timestamp" }
 pallet-transaction-payment = { version = "2.0.0-rc6", path = "../../../frame/transaction-payment" }
 pallet-treasury = { version = "2.0.0-rc6", path = "../../../frame/treasury" }
-wabt = "0.9.1"
+wat = "1.0"
 sp-api = { version = "2.0.0-rc6", path = "../../../primitives/api" }
 sp-finality-tracker = { version = "2.0.0-rc6", default-features = false, path = "../../../primitives/finality-tracker" }
 sp-timestamp = { version = "2.0.0-rc6", default-features = false, path = "../../../primitives/timestamp" }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -37,7 +37,7 @@ libsecp256k1 = "0.3.4"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
-wabt = "0.9.1"
+wat = "1.0"
 hex-literal = "0.3.1"
 sc-runtime-test = { version = "2.0.0-rc6", path = "runtime-test" }
 substrate-test-runtime = { version = "2.0.0-rc6", path = "../../test-utils/runtime" }

--- a/client/executor/src/integration_tests/sandbox.rs
+++ b/client/executor/src/integration_tests/sandbox.rs
@@ -21,7 +21,6 @@ use crate::WasmExecutionMethod;
 
 use codec::Encode;
 use test_case::test_case;
-use wabt;
 
 #[test_case(WasmExecutionMethod::Interpreted)]
 #[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
@@ -29,7 +28,7 @@ fn sandbox_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(import "env" "assert" (func $assert (param i32)))
 			(import "env" "inc_counter" (func $inc_counter (param i32) (result i32)))
@@ -67,7 +66,7 @@ fn sandbox_trap(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(import "env" "assert" (func $assert (param i32)))
 			(func (export "call")
@@ -94,7 +93,7 @@ fn start_called(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(import "env" "assert" (func $assert (param i32)))
 			(import "env" "inc_counter" (func $inc_counter (param i32) (result i32)))
@@ -138,7 +137,7 @@ fn invoke_args(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(import "env" "assert" (func $assert (param i32)))
 
@@ -178,7 +177,7 @@ fn return_val(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(func (export "call") (param $x i32) (result i32)
 				(i32.add
@@ -206,7 +205,7 @@ fn unlinkable_module(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(import "env" "non-existent" (func))
 
@@ -252,7 +251,7 @@ fn start_fn_ok(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(func (export "call")
 			)
@@ -281,7 +280,7 @@ fn start_fn_traps(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(func (export "call")
 			)
@@ -311,7 +310,7 @@ fn get_global_val_works(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
-	let code = wabt::wat2wasm(r#"
+	let code = wat::parse_str(r#"
 		(module
 			(global (export "test_global") i64 (i64.const 500))
 		)

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -20,7 +20,7 @@ sp-wasm-interface = { version = "2.0.0-rc6", default-features = false, path = ".
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 
 [dev-dependencies]
-wabt = "0.9.1"
+wat = "1.0"
 assert_matches = "1.3.0"
 
 [features]

--- a/primitives/sandbox/with_std.rs
+++ b/primitives/sandbox/with_std.rs
@@ -300,7 +300,6 @@ impl<T> Instance<T> {
 
 #[cfg(test)]
 mod tests {
-	use wabt;
 	use crate::{Error, Value, ReturnValue, HostError, EnvironmentDefinitionBuilder, Instance};
 	use assert_matches::assert_matches;
 
@@ -351,7 +350,7 @@ mod tests {
 
 	#[test]
 	fn invoke_args() {
-		let code = wabt::wat2wasm(r#"
+		let code = wat::parse_str(r#"
 		(module
 			(import "env" "assert" (func $assert (param i32)))
 
@@ -386,7 +385,7 @@ mod tests {
 
 	#[test]
 	fn return_value() {
-		let code = wabt::wat2wasm(r#"
+		let code = wat::parse_str(r#"
 		(module
 			(func (export "call") (param $x i32) (result i32)
 				(i32.add
@@ -408,7 +407,7 @@ mod tests {
 
 	#[test]
 	fn signatures_dont_matter() {
-		let code = wabt::wat2wasm(r#"
+		let code = wat::parse_str(r#"
 		(module
 			(import "env" "polymorphic_id" (func $id_i32 (param i32) (result i32)))
 			(import "env" "polymorphic_id" (func $id_i64 (param i64) (result i64)))
@@ -450,7 +449,7 @@ mod tests {
 		let mut env_builder = EnvironmentDefinitionBuilder::new();
 		env_builder.add_host_func("env", "returns_i32", env_returns_i32);
 
-		let code = wabt::wat2wasm(r#"
+		let code = wat::parse_str(r#"
 		(module
 			;; It's actually returns i32, but imported as if it returned i64
 			(import "env" "returns_i32" (func $returns_i32 (result i64)))


### PR DESCRIPTION
Using wat is more desired since it should be more lightweight, faster to compile and most importantly doesn't depend on C toolchain.