### PR TITLE
Improves EVM gas price check

### DIFF
--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -333,7 +333,7 @@ decl_module! {
 				input,
 				value,
 				gas_limit,
-				Some(gas_price),
+				gas_price,
 				nonce,
 				true,
 			)? {
@@ -367,7 +367,7 @@ decl_module! {
 				init,
 				value,
 				gas_limit,
-				Some(gas_price),
+				gas_price,
 				nonce,
 				true,
 			)? {
@@ -402,7 +402,7 @@ decl_module! {
 				salt,
 				value,
 				gas_limit,
-				Some(gas_price),
+				gas_price,
 				nonce,
 				true,
 			)? {
@@ -482,7 +482,7 @@ impl<T: Trait> Module<T> {
 		init: Vec<u8>,
 		value: U256,
 		gas_limit: u32,
-		gas_price: Option<U256>,
+		gas_price: U256,
 		nonce: Option<U256>,
 		apply_state: bool,
 	) -> Result<(ExitReason, H160, U256), Error<T>> {
@@ -514,7 +514,7 @@ impl<T: Trait> Module<T> {
 		salt: H256,
 		value: U256,
 		gas_limit: u32,
-		gas_price: Option<U256>,
+		gas_price: U256,
 		nonce: Option<U256>,
 		apply_state: bool,
 	) -> Result<(ExitReason, H160, U256), Error<T>> {
@@ -548,7 +548,7 @@ impl<T: Trait> Module<T> {
 		input: Vec<u8>,
 		value: U256,
 		gas_limit: u32,
-		gas_price: Option<U256>,
+		gas_price: U256,
 		nonce: Option<U256>,
 		apply_state: bool,
 	) -> Result<(ExitReason, Vec<u8>, U256), Error<T>> {
@@ -574,20 +574,18 @@ impl<T: Trait> Module<T> {
 		source: H160,
 		value: U256,
 		gas_limit: u32,
-		gas_price: Option<U256>,
+		gas_price: U256,
 		nonce: Option<U256>,
 		apply_state: bool,
 		f: F,
 	) -> Result<(ExitReason, R, U256), Error<T>> where
 		F: FnOnce(&mut StackExecutor<Backend<T>>) -> (ExitReason, R),
 	{
-		let gas_price = match gas_price {
-			Some(gas_price) => {
-				ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
-				gas_price
-			},
-			None => U256::zero(),
-		};
+
+		// Gas price check is skipped when performing a gas estimation.
+		if apply_state {
+			ensure!(gas_price >= T::FeeCalculator::min_gas_price(), Error::<T>::GasPriceTooLow);
+		}
 
 		let vicinity = Vicinity {
 			gas_price,


### PR DESCRIPTION
This PR allows using the EVM execution without verifying the gas price when doing a gas estimation.
It only verifies the gas price when the state after execution is supposed to be applied.