### PR TITLE
Disambiguate `BlockNumber` type in `decl_module`

### DIFF
--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1265,15 +1265,16 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_initialize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn on_initialize() -> $return:ty { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn on_initialize(_block_number_not_used: $trait_instance::BlockNumber) -> $return {
+			fn on_initialize(_block_number_not_used: <$trait_instance as $system::Trait>::BlockNumber) -> $return {
 				$crate::sp_tracing::enter_span!("on_initialize");
 				{ $( $impl )* }
 			}
@@ -1281,12 +1282,13 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_initialize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn on_initialize($param:ident : $param_ty:ty) -> $return:ty { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_initialize($param: $param_ty) -> $return {
@@ -1297,11 +1299,12 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_initialize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnInitialize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};
@@ -1362,15 +1365,16 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_finalize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn on_finalize() { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn on_finalize(_block_number_not_used: $trait_instance::BlockNumber) {
+			fn on_finalize(_block_number_not_used: <$trait_instance as $system::Trait>::BlockNumber) {
 				$crate::sp_tracing::enter_span!("on_finalize");
 				{ $( $impl )* }
 			}
@@ -1378,12 +1382,13 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_finalize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn on_finalize($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn on_finalize($param: $param_ty) {
@@ -1394,36 +1399,39 @@ macro_rules! decl_module {
 	};
 
 	(@impl_on_finalize
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OnFinalize<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 		}
 	};
 
 	(@impl_offchain
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn offchain_worker() { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
-			fn offchain_worker(_block_number_not_used: $trait_instance::BlockNumber) { $( $impl )* }
+			fn offchain_worker(_block_number_not_used: <$trait_instance as $system::Trait>::BlockNumber) { $( $impl )* }
 		}
 	};
 
 	(@impl_offchain
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 		fn offchain_worker($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
 			fn offchain_worker($param: $param_ty) { $( $impl )* }
@@ -1431,11 +1439,12 @@ macro_rules! decl_module {
 	};
 
 	(@impl_offchain
+		{ $system:ident }
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)?>
-			$crate::traits::OffchainWorker<$trait_instance::BlockNumber>
+		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
 	};
@@ -1635,6 +1644,7 @@ macro_rules! decl_module {
 
 		$crate::decl_module! {
 			@impl_on_initialize
+			{ $system }
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
 			{ $( $other_where_bounds )* }
 			$( $on_initialize )*
@@ -1649,6 +1659,7 @@ macro_rules! decl_module {
 
 		$crate::decl_module! {
 			@impl_on_finalize
+			{ $system }
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
 			{ $( $other_where_bounds )* }
 			$( $on_finalize )*
@@ -1656,6 +1667,7 @@ macro_rules! decl_module {
 
 		$crate::decl_module! {
 			@impl_offchain
+			{ $system }
 			$mod_type<$trait_instance: $trait_name $(<I>, $instance: $instantiable)?>;
 			{ $( $other_where_bounds )* }
 			$( $offchain )*
@@ -2345,9 +2357,7 @@ mod tests {
 		IntegrityTest,
 	};
 
-	pub trait Trait: system::Trait + Sized where Self::AccountId: From<u32> {
-		type BlockNumber: Into<u32>;
-	}
+	pub trait Trait: system::Trait + Sized where Self::AccountId: From<u32> { }
 
 	pub mod system {
 		use codec::{Encode, Decode};
@@ -2357,6 +2367,7 @@ mod tests {
 			type Call;
 			type BaseCallFilter;
 			type Origin: crate::traits::OriginTrait<Call = Self::Call>;
+			type BlockNumber: Into<u32>;
 		}
 
 		#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
@@ -2480,10 +2491,7 @@ mod tests {
 	];
 
 	pub struct TraitImpl {}
-
-	impl Trait for TraitImpl {
-		type BlockNumber = u32;
-	}
+	impl Trait for TraitImpl { }
 
 	type Test = Module<TraitImpl>;
 
@@ -2502,6 +2510,7 @@ mod tests {
 		type AccountId = u32;
 		type Call = OuterCall;
 		type BaseCallFilter = ();
+		type BlockNumber = u32;
 	}
 
 	#[test]

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1270,7 +1270,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn on_initialize() -> $return:ty { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1287,7 +1287,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn on_initialize($param:ident : $param_ty:ty) -> $return:ty { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1303,7 +1303,7 @@ macro_rules! decl_module {
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnInitialize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}
@@ -1370,7 +1370,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn on_finalize() { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1387,7 +1387,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn on_finalize($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1403,7 +1403,7 @@ macro_rules! decl_module {
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OnFinalize<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1416,7 +1416,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn offchain_worker() { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1430,7 +1430,7 @@ macro_rules! decl_module {
 		{ $( $other_where_bounds:tt )* }
 		fn offchain_worker($param:ident : $param_ty:ty) { $( $impl:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{
@@ -1443,7 +1443,7 @@ macro_rules! decl_module {
 		$module:ident<$trait_instance:ident: $trait_name:ident$(<I>, $instance:ident: $instantiable:path)?>;
 		{ $( $other_where_bounds:tt )* }
 	) => {
-		impl<$trait_instance: $trait_name$(<I>, $instance: $instantiable)? + $system::Trait>
+		impl<$trait_instance: $system::Trait + $trait_name$(<I>, $instance: $instantiable)?>
 			$crate::traits::OffchainWorker<<$trait_instance as $system::Trait>::BlockNumber>
 			for $module<$trait_instance$(, $instance)?> where $( $other_where_bounds )*
 		{}

--- a/frame/support/test/src/lib.rs
+++ b/frame/support/test/src/lib.rs
@@ -32,5 +32,5 @@ pub trait Trait {
 
 frame_support::decl_module! {
 	/// Some test module
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }

--- a/frame/support/test/tests/construct_runtime.rs
+++ b/frame/support/test/tests/construct_runtime.rs
@@ -40,7 +40,7 @@ mod module1 {
 
 	frame_support::decl_module! {
 		pub struct Module<T: Trait<I>, I: Instance = DefaultInstance> for enum Call
-			where origin: <T as system::Trait>::Origin
+			where origin: <T as system::Trait>::Origin, system=system
 		{
 			#[weight = 0]
 			pub fn fail(_origin) -> frame_support::dispatch::DispatchResult {
@@ -67,7 +67,7 @@ mod module2 {
 
 	frame_support::decl_module! {
 		pub struct Module<T: Trait> for enum Call
-			where origin: <T as system::Trait>::Origin
+			where origin: <T as system::Trait>::Origin, system=system
 		{
 			#[weight = 0]
 			pub fn fail(_origin) -> frame_support::dispatch::DispatchResult {

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.rs
@@ -1,5 +1,5 @@
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 		fn integrity_test() {}
 
 		fn integrity_test() {}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_integrity_test.stderr
@@ -2,7 +2,7 @@ error: `integrity_test` can only be passed once as input.
  --> $DIR/reserved_keyword_two_times_integrity_test.rs:1:1
   |
 1 | / frame_support::decl_module! {
-2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 3 | |         fn integrity_test() {}
 4 | |
 5 | |         fn integrity_test() {}
@@ -16,7 +16,7 @@ error[E0601]: `main` function not found in crate `$CRATE`
  --> $DIR/reserved_keyword_two_times_integrity_test.rs:1:1
   |
 1 | / frame_support::decl_module! {
-2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+2 | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 3 | |         fn integrity_test() {}
 4 | |
 5 | |         fn integrity_test() {}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.rs
@@ -1,5 +1,5 @@
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 		fn on_initialize() -> Weight {
 			0
 		}

--- a/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
+++ b/frame/support/test/tests/decl_module_ui/reserved_keyword_two_times_on_initialize.stderr
@@ -2,7 +2,7 @@ error: `on_initialize` can only be passed once as input.
   --> $DIR/reserved_keyword_two_times_on_initialize.rs:1:1
    |
 1  | / frame_support::decl_module! {
-2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 3  | |         fn on_initialize() -> Weight {
 4  | |             0
 ...  |
@@ -16,7 +16,7 @@ error[E0601]: `main` function not found in crate `$CRATE`
   --> $DIR/reserved_keyword_two_times_on_initialize.rs:1:1
    |
 1  | / frame_support::decl_module! {
-2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+2  | |     pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 3  | |         fn on_initialize() -> Weight {
 4  | |             0
 ...  |

--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -25,7 +25,7 @@ mod tests {
 	use codec::{Encode, Decode, EncodeLike};
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 	}
 
 	pub trait Trait {
@@ -420,7 +420,7 @@ mod test2 {
 	}
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 	}
 
 	type PairOf<T> = (T, T);
@@ -455,7 +455,7 @@ mod test3 {
 		type BlockNumber;
 	}
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 	}
 	frame_support::decl_storage! {
 		trait Store for Module<T: Trait> as Test {
@@ -485,7 +485,7 @@ mod test_append_and_len {
 	}
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 	}
 
 	#[derive(PartialEq, Eq, Clone, Encode, Decode)]

--- a/frame/support/test/tests/decl_storage_ui/config_duplicate.rs
+++ b/frame/support/test/tests/decl_storage_ui/config_duplicate.rs
@@ -21,7 +21,7 @@ pub trait Trait {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }
 
 frame_support::decl_storage!{

--- a/frame/support/test/tests/decl_storage_ui/config_get_duplicate.rs
+++ b/frame/support/test/tests/decl_storage_ui/config_get_duplicate.rs
@@ -21,7 +21,7 @@ pub trait Trait {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }
 
 frame_support::decl_storage!{

--- a/frame/support/test/tests/decl_storage_ui/get_duplicate.rs
+++ b/frame/support/test/tests/decl_storage_ui/get_duplicate.rs
@@ -21,7 +21,7 @@ pub trait Trait {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }
 
 frame_support::decl_storage!{

--- a/frame/support/test/tests/final_keys.rs
+++ b/frame/support/test/tests/final_keys.rs
@@ -29,7 +29,7 @@ mod no_instance {
 	}
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 	}
 
 	frame_support::decl_storage!{
@@ -50,11 +50,13 @@ mod no_instance {
 }
 
 mod instance {
+	use super::no_instance;
+
 	pub trait Trait<I = DefaultInstance>: super::no_instance::Trait {}
 
 	frame_support::decl_module! {
 		pub struct Module<T: Trait<I>, I: Instance = DefaultInstance>
-			for enum Call where origin: T::Origin {}
+			for enum Call where origin: T::Origin, system=no_instance {}
 	}
 
 	frame_support::decl_storage!{

--- a/frame/support/test/tests/genesisconfig.rs
+++ b/frame/support/test/tests/genesisconfig.rs
@@ -21,7 +21,7 @@ pub trait Trait {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }
 
 frame_support::decl_storage! {

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -184,7 +184,7 @@ mod module3 {
 	}
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: <T as system::Trait>::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: <T as system::Trait>::Origin, system=system {}
 	}
 }
 

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -84,7 +84,7 @@ mod module {
 	pub trait Trait: system::Trait {}
 
 	frame_support::decl_module! {
-		pub struct Module<T: Trait> for enum Call where origin: T::Origin {}
+		pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=system {}
 	}
 
 	#[derive(Encode, Decode, Copy, Clone, Serialize, Deserialize)]

--- a/frame/support/test/tests/reserved_keyword/on_initialize.rs
+++ b/frame/support/test/tests/reserved_keyword/on_initialize.rs
@@ -18,7 +18,7 @@ macro_rules! reserved {
 				}
 
 				frame_support::decl_module! {
-					pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+					pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 						#[weight = 0]
 						fn $reserved(_origin) -> dispatch::DispatchResult { unreachable!() }
 					}

--- a/frame/support/test/tests/storage_transaction.rs
+++ b/frame/support/test/tests/storage_transaction.rs
@@ -29,7 +29,7 @@ pub trait Trait {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 		#[weight = 0]
 		#[transactional]
 		fn value_commits(_origin, v: u32) {

--- a/frame/support/test/tests/system.rs
+++ b/frame/support/test/tests/system.rs
@@ -31,7 +31,7 @@ pub trait Trait: 'static + Eq + Clone {
 }
 
 frame_support::decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin, {}
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {}
 }
 
 impl<T: Trait> Module<T> {

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -517,7 +517,7 @@ decl_error! {
 }
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin, system=self {
 		type Error = Error<T>;
 
 		/// The maximum number of blocks to allow in mortal eras.


### PR DESCRIPTION
`decl_module!` generates the `on_initialize`, `on_finalize`, and `offchain_worker` functions which depend on `T::BlockNumber`. However, if for some crazy reason, there is another `BlockNumber` associated type in a pallet that would interfere with this type definition, then a user would run into ambiguity errors.

This PR uses the already defined `system` identifier to disambiguate use of the `BlockNumber` type.

(A user should probably avoid creating a type named `BlockNumber`, but this seems like the right solution anyway)