### PR TITLE
Make decoding of `compact<perthing>` saturating instead of invalid

### DIFF
--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -327,7 +327,7 @@ macro_rules! implement_per_thing {
 		pub struct $name($type);
 
 		/// Implementation makes any compact encoding of `PerThing::Inner` valid,
-		/// when decoding it will saturate up to `PerThing::ACCURACY`
+		/// when decoding it will saturate up to `PerThing::ACCURACY`.
 		impl CompactAs for $name {
 			type As = $type;
 			fn encode_as(&self) -> &Self::As {

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -334,6 +334,7 @@ macro_rules! implement_per_thing {
 				&self.0
 			}
 			fn decode_from(x: Self::As) -> Self {
+				// Saturates if `x` is more than `$max` internally. 
 				Self::from_parts(x)
 			}
 		}

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -1192,7 +1192,7 @@ macro_rules! implement_per_thing {
 
 				let p = Compact::<$name>::decode(&mut &Compact(<$type>::max_value()).encode()[..])
 					.unwrap();
-				assert_eq!(p.0.0, $max);
+				assert_eq!((p.0).0, $max);
 				assert_eq!($name::from(p), $name::max_value());
 			}
 		}

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -323,8 +323,26 @@ macro_rules! implement_per_thing {
 		///
 		#[doc = $title]
 		#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-		#[derive(Encode, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RuntimeDebug, CompactAs)]
+		#[derive(Encode, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, RuntimeDebug)]
 		pub struct $name($type);
+
+		/// Implementation makes any compact encoding of `PerThing::Inner` valid,
+		/// when decoding it will saturate up to `PerThing::ACCURACY`
+		impl CompactAs for $name {
+			type As = $type;
+			fn encode_as(&self) -> &Self::As {
+				&self.0
+			}
+			fn decode_from(x: Self::As) -> Self {
+				Self::from_parts(x)
+			}
+		}
+
+		impl From<codec::Compact<$name>> for $name {
+			fn from(x: codec::Compact<$name>) -> $name {
+				x.0
+			}
+		}
 
 		impl PerThing for $name {
 			type Inner = $type;
@@ -1165,6 +1183,17 @@ macro_rules! implement_per_thing {
 
 				// deconstruct is also const, hence it can be called in const rhs.
 				const C5: bool = C1.deconstruct() == 0;
+			}
+
+			#[test]
+			fn compact_decoding_saturate_when_beyond_accuracy() {
+				use num_traits::Bounded;
+				use codec::Compact;
+
+				let p = Compact::<$name>::decode(&mut &Compact(<$type>::max_value()).encode()[..])
+					.unwrap();
+				assert_eq!(p.0.0, $max);
+				assert_eq!($name::from(p), $name::max_value());
 			}
 		}
 	};


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/5462

BREAKING CHANGE: more a fix than a breaking change: decoding a compact encoding of perthing will saturate the perthing to perthing::max instead of returning an invalid perthing variable when maximum overflowed.

by implementing CompactAs manually we can saturate the given inner type so it doesn't overflow perthing accuracy.

This means that any compact encoding of the perthing::Inner type are valid, just they will saturate when decoding them.
