### PR TITLE
[CI] Increase poll interval in the 'Check Polkadot Companion and Label' workflow

### DIFF
--- a/.github/workflows/polkadot-companion-labels.yml
+++ b/.github/workflows/polkadot-companion-labels.yml
@@ -16,9 +16,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           contexts: 'continuous-integration/gitlab-check-polkadot-companion-build'
           timeout: 1800
-          notPresentTimeout: 3600 # It can take quite a while before the job starts...
+          notPresentTimeout: 3600 # It can take quite a while before the job starts on Gitlab when the CI queue is large
           failureStates: failure
           interruptedStates: error # Error = job was probably cancelled. We don't want to label the PR in that case
+          pollInterval: 30
       - name: Label success
         uses: andymckay/labeler@master
         if: steps.check-companion-status.outputs.result == 'success'


### PR DESCRIPTION
Hopefully this will mitigate the `API rate limit exceeded for installation ID 5177796.` errors. Examples of errors:
https://github.com/paritytech/substrate/actions/runs/246456201
https://github.com/paritytech/substrate/actions/runs/246444243