### PR TITLE
Split manual consensus into sealing and finality parts

### DIFF
--- a/client/consensus/manual-seal/src/finalize_block.rs
+++ b/client/consensus/manual-seal/src/finalize_block.rs
@@ -16,7 +16,7 @@
 
 //! Block finalization utilities
 
-use crate::rpc;
+use crate::manual_finality_rpc;
 use sp_runtime::{
 	Justification,
 	traits::Block as BlockT,
@@ -31,7 +31,7 @@ pub struct FinalizeBlockParams<B: BlockT, F, CB> {
 	/// hash of the block
 	pub hash: <B as BlockT>::Hash,
 	/// sender to report errors/success to the rpc.
-	pub sender: rpc::Sender<()>,
+	pub sender: manual_finality_rpc::Sender<()>,
 	/// finalization justification
 	pub justification: Option<Justification>,
 	/// Finalizer trait object.
@@ -59,11 +59,11 @@ pub async fn finalize_block<B, F, CB>(params: FinalizeBlockParams<B, F, CB>)
 	match finalizer.finalize_block(BlockId::Hash(hash), justification, true) {
 		Err(e) => {
 			log::warn!("Failed to finalize block {:?}", e);
-			rpc::send_result(&mut sender, Err(e.into()))
+			manual_finality_rpc::send_result(&mut sender, Err(e.into()))
 		}
 		Ok(()) => {
 			log::info!("✅ Successfully finalized block: {}", hash);
-			rpc::send_result(&mut sender, Ok(()))
+			manual_finality_rpc::send_result(&mut sender, Ok(()))
 		}
 	}
 }

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -129,7 +129,7 @@ pub struct ManualFinalityParams<B: BlockT, C: ProvideRuntimeApi<B>, CS> {
 	/// the authorship task.
 	pub commands_stream: CS,
 
-	_phantom: PhantomData<B>,
+	pub _phantom: PhantomData<B>,
 }
 
 /// Params required to start the manual sealing authorship task.

--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -121,22 +121,15 @@ pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpool
 }
 
 /// Params required to start the instant sealing authorship task.
-pub struct ManualFinalityParams<B: BlockT, C: ProvideRuntimeApi<B>, A: txpool::ChainApi, CS> {
+pub struct ManualFinalityParams<B: BlockT, C: ProvideRuntimeApi<B>, CS> {
 	/// Client instance
 	pub client: Arc<C>,
-
-	/// Shared reference to the transaction pool.
-	pub pool: Arc<txpool::Pool<A>>,
 
 	/// Stream<Item = EngineCommands>, Basically the receiving end of a channel for sending commands to
 	/// the authorship task.
 	pub commands_stream: CS,
 
-	/// Digest provider for inclusion in blocks.
-	pub consensus_data_provider: Option<Box<dyn ConsensusDataProvider<B, Transaction = TransactionFor<C, B>>>>,
-
-	/// Provider for inherents to include in blocks.
-	pub inherent_data_providers: InherentDataProviders,
+	_phantom: PhantomData<B>,
 }
 
 /// Params required to start the manual sealing authorship task.
@@ -218,18 +211,14 @@ pub async fn run_manual_seal<B, BI, CB, E, C, A, SC, CS>(
 }
 
 /// Creates the background finality task for the manual finality engine.
-pub async fn run_manual_finality<B, CB, C, A, CS>(
+pub async fn run_manual_finality<B, CB, C, CS>(
 	ManualFinalityParams {
 		client,
-		pool,
 		mut commands_stream,
-		inherent_data_providers,
-		consensus_data_provider,
 		..
-	}: ManualFinalityParams<B, C, A, CS>
+	}: ManualFinalityParams<B, C, CS>
 )
 	where
-		A: txpool::ChainApi<Block=B> + 'static,
 		B: BlockT + 'static,
 		C: HeaderBackend<B> + Finalizer<B, CB> + ProvideRuntimeApi<B> + 'static,
 		CB: ClientBackend<B> + 'static,

--- a/client/consensus/manual-seal/src/manual_finality_rpc.rs
+++ b/client/consensus/manual-seal/src/manual_finality_rpc.rs
@@ -14,9 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-//! RPC interface for the `ManualSeal` Engine.
+//! RPC interface for the `ManualFinality` Engine.
 
-use sp_consensus::ImportedAux;
 use jsonrpc_core::Error;
 use jsonrpc_derive::rpc;
 use futures::{
@@ -25,7 +24,6 @@ use futures::{
 	FutureExt,
 	SinkExt
 };
-use serde::{Deserialize, Serialize};
 use sp_runtime::Justification;
 pub use self::gen_client::Client as ManualSealClient;
 

--- a/client/consensus/manual-seal/src/manual_finality_rpc.rs
+++ b/client/consensus/manual-seal/src/manual_finality_rpc.rs
@@ -1,0 +1,105 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! RPC interface for the `ManualSeal` Engine.
+
+use sp_consensus::ImportedAux;
+use jsonrpc_core::Error;
+use jsonrpc_derive::rpc;
+use futures::{
+	channel::{mpsc, oneshot},
+	TryFutureExt,
+	FutureExt,
+	SinkExt
+};
+use serde::{Deserialize, Serialize};
+use sp_runtime::Justification;
+pub use self::gen_client::Client as ManualSealClient;
+
+/// Future's type for jsonrpc
+type FutureResult<T> = Box<dyn jsonrpc_core::futures::Future<Item = T, Error = Error> + Send>;
+/// sender passed to the authorship task to report errors or successes.
+pub type Sender<T> = Option<oneshot::Sender<std::result::Result<T, crate::Error>>>;
+
+/// Message that instructs the background finality task, to finalize a block.
+/// Usually sent over RPC
+pub struct FinalizeBlockCommand<Hash> {
+	/// Hash of the block to finalize
+	pub hash: Hash,
+	/// Channel to report errors/success to the rpc.
+	pub sender: Sender<()>,
+	/// Finalization justification
+	pub justification: Option<Justification>,
+}
+
+/// RPC trait that provides method for interacting with the manual-finality task over rpc.
+#[rpc]
+pub trait ManualFinalityApi<Hash> {
+	/// Instructs the manual finality task to finalize a block
+	#[rpc(name = "engine_finalizeBlock")]
+	fn finalize_block(
+		&self,
+		hash: Hash,
+		justification: Option<Justification>
+	) -> FutureResult<bool>;
+}
+
+/// A struct that implements the `ManualFinalityApi`.
+pub struct ManualFinality<Hash> {
+	finalize_block_channel: mpsc::Sender<FinalizeBlockCommand<Hash>>,
+}
+
+impl<Hash> ManualFinality<Hash> {
+	/// Create new `ManualSeal` with the given reference to the client.
+	pub fn new(finalize_block_channel: mpsc::Sender<FinalizeBlockCommand<Hash>>) -> Self {
+		Self { finalize_block_channel }
+	}
+}
+
+impl<Hash: Send + 'static> ManualFinalityApi<Hash> for ManualFinality<Hash> {
+	fn finalize_block(&self, hash: Hash, justification: Option<Justification>) -> FutureResult<bool> {
+		let mut sink = self.finalize_block_channel.clone();
+		let future = async move {
+			let (sender, receiver) = oneshot::channel();
+			sink.send(
+				FinalizeBlockCommand { hash, sender: Some(sender), justification }
+			).await?;
+
+			receiver.await?.map(|_| true)
+		};
+
+		Box::new(future.boxed().map_err(Error::from).compat())
+	}
+}
+
+/// report any errors or successes encountered by the authorship task back
+/// to the rpc
+pub fn send_result<T: std::fmt::Debug>(
+	sender: &mut Sender<T>,
+	result: std::result::Result<T, crate::Error>
+) {
+	if let Some(sender) = sender.take() {
+		if let Err(err) = sender.send(result) {
+			log::warn!("Server is shutting down: {:?}", err)
+		}
+	} else {
+		// instant seal doesn't report errors over rpc, simply log them.
+		match result {
+			Ok(r) => log::info!("Instant Seal success: {:?}", r),
+			Err(e) => log::error!("Instant Seal encountered an error: {}", e)
+		}
+	}
+}

--- a/client/consensus/manual-seal/src/manual_seal_rpc.rs
+++ b/client/consensus/manual-seal/src/manual_seal_rpc.rs
@@ -26,7 +26,6 @@ use futures::{
 	SinkExt
 };
 use serde::{Deserialize, Serialize};
-use sp_runtime::Justification;
 pub use self::gen_client::Client as ManualSealClient;
 
 /// Future's type for jsonrpc


### PR DESCRIPTION
This PR splits the existing manual seal consensus engine into two parts. One is responsible only for authoring blocks. The second, a finality gadget, is responsible for manual finality. This split better emphasizes the way that Substrate handles authoring and finality separately. It also allows for combinations Grandpa with manual seal or aura with manual finality, which are useful in educational settings.

This is a better and less-invasive approach to what I tried in #6949 

One of the tests is failing, but it is also failing on `master`.