### PR TITLE
pow: support uniform tie breaking in fork choice

### DIFF
--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -171,9 +171,12 @@ pub trait PowAlgorithm<B: BlockT> {
 	) -> Result<Option<bool>, Error<B>> {
 		Ok(None)
 	}
-	/// Break a fork choice tie. By default this chooses the earliest block seen. Using uniform tie
-	/// breaking algorithms will help to protect against selfish mining. Returns if the new seal
-	/// should be considered best block.
+	/// Break a fork choice tie. 
+	/// 
+	/// By default this chooses the earliest block seen. Using uniform tie
+	/// breaking algorithms will help to protect against selfish mining.
+	///
+	/// Returns if the new seal should be considered best block.
 	fn break_tie(
 		&self,
 		_own_seal: &Seal,


### PR DESCRIPTION
This adds support for uniform tie breaking for PoW fork choice. A new trait method is added `PowAlgorithm::break_tie`. Given an own seal and a new seal of the same total difficulty, it returns which seal should be chosen. By default it's always own seal -- the current behavior. An implementer can customize this function to be deterministic to support uniform tie breaking.