### PR TITLE
Fix `storage::read`

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -94,7 +94,7 @@ pub trait Storage {
 			let data = &value[value_offset.min(value.len())..];
 			let written = std::cmp::min(data.len(), value_out.len());
 			value_out[..written].copy_from_slice(&data[..written]);
-			value.len() as u32
+			data.len() as u32
 		})
 	}
 
@@ -235,7 +235,7 @@ pub trait DefaultChildStorage {
 				let data = &value[value_offset.min(value.len())..];
 				let written = std::cmp::min(data.len(), value_out.len());
 				value_out[..written].copy_from_slice(&data[..written]);
-				value.len() as u32
+				data.len() as u32
 			})
 	}
 
@@ -1243,17 +1243,18 @@ mod tests {
 
 	#[test]
 	fn read_storage_works() {
+		let value = b"\x0b\0\0\0Hello world".to_vec();
 		let mut t = BasicExternalities::new(Storage {
-			top: map![b":test".to_vec() => b"\x0b\0\0\0Hello world".to_vec()],
+			top: map![b":test".to_vec() => value.clone()],
 			children_default: map![],
 		});
 
 		t.execute_with(|| {
 			let mut v = [0u8; 4];
-			assert!(storage::read(b":test", &mut v[..], 0).unwrap() >= 4);
+			assert_eq!(storage::read(b":test", &mut v[..], 0).unwrap(), value.len() as u32);
 			assert_eq!(v, [11u8, 0, 0, 0]);
 			let mut w = [0u8; 11];
-			assert!(storage::read(b":test", &mut w[..], 4).unwrap() >= 11);
+			assert_eq!(storage::read(b":test", &mut w[..], 4).unwrap(), value.len() as u32 - 4);
 			assert_eq!(&w, b"Hello world");
 		});
 	}

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -1067,17 +1067,13 @@ fn test_read_storage() {
 	sp_io::storage::set(KEY, b"test");
 
 	let mut v = [0u8; 4];
-	let r = sp_io::storage::read(
-		KEY,
-		&mut v,
-		0
-	);
+	let r = sp_io::storage::read(KEY, &mut v, 0);
 	assert_eq!(r, Some(4));
 	assert_eq!(&v, b"test");
 
 	let mut v = [0u8; 4];
-	let r = sp_io::storage::read(KEY, &mut v, 8);
-	assert_eq!(r, Some(4));
+	let r = sp_io::storage::read(KEY, &mut v, 4);
+	assert_eq!(r, Some(0));
 	assert_eq!(&v, &[0, 0, 0, 0]);
 }
 
@@ -1107,7 +1103,7 @@ fn test_read_child_storage() {
 		&mut v,
 		8,
 	);
-	assert_eq!(r, Some(4));
+	assert_eq!(r, Some(0));
 	assert_eq!(&v, &[0, 0, 0, 0]);
 }
 


### PR DESCRIPTION
It should return the length of the storage item after the given offset.
Before it returned always the length of the full storage item.

The regression was introduced in: https://github.com/paritytech/substrate/pull/3589