### PR TITLE
babe: uniform tie breaking

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -1334,7 +1334,13 @@ impl<Block, Client, Inner> BlockImport<Block> for BabeBlockImport<Block, Client,
 			Some(ForkChoiceStrategy::Custom(if total_weight > last_best_weight {
 				true
 			} else if total_weight == last_best_weight {
-				number > last_best_number
+				if number > last_best_number {
+					true
+				} else if number < last_best_number {
+					false
+				} else {
+					hash > last_best
+				}
 			} else {
 				false
 			}))


### PR DESCRIPTION
This adds uniform tie breaking in BABE. Right now, if there is a tie (two primary slot generated by two different validators), we would do "selfish mining" and choose our own block. This gives large entities running multiple validators in a single datacenter a slight advantage, because the next block is slightly more likely to be authored by that entity, and if that happens, then all nodes will reorg to that block. This PR creates a uniform tie breaking by adding an additional check of the old and new block hash, in case if both weights and block numbers are the same.