### PR TITLE
client/network: Expose number of entries per Kademlia bucket

### DIFF
--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -211,9 +211,12 @@ impl<B: BlockT, H: ExHashT> Behaviour<B, H> {
 		self.discovery.add_known_address(peer_id, addr)
 	}
 
-	/// Returns the number of nodes that are in the Kademlia k-buckets.
-	pub fn num_kbuckets_entries(&mut self) -> impl ExactSizeIterator<Item = (&ProtocolId, usize)> {
-		self.discovery.num_kbuckets_entries()
+	/// Returns the number of nodes in each Kademlia kbucket for each Kademlia instance.
+	///
+	/// Identifies Kademlia instances by their [`ProtocolId`] and kbuckets by the base 2 logarithm
+	/// of their lower bound.
+	pub fn num_entries_per_kbucket(&mut self) -> impl ExactSizeIterator<Item = (&ProtocolId, Vec<(u32, usize)>)> {
+		self.discovery.num_entries_per_kbucket()
 	}
 
 	/// Returns the number of records in the Kademlia record stores.

--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -329,10 +329,18 @@ impl DiscoveryBehaviour {
 		}
 	}
 
-	/// Returns the number of nodes that are in the Kademlia k-buckets.
-	pub fn num_kbuckets_entries(&mut self) -> impl ExactSizeIterator<Item = (&ProtocolId, usize)> {
+	/// Returns the number of nodes in each Kademlia kbucket for each Kademlia instance.
+	///
+	/// Identifies Kademlia instances by their [`ProtocolId`] and kbuckets by the base 2 logarithm
+	/// of their lower bound.
+	pub fn num_entries_per_kbucket(&mut self) -> impl ExactSizeIterator<Item = (&ProtocolId, Vec<(u32, usize)>)> {
 		self.kademlias.iter_mut()
-			.map(|(id, kad)| (id, kad.kbuckets().map(|bucket| bucket.iter().count()).sum()))
+			.map(|(id, kad)| {
+				let buckets = kad.kbuckets()
+					.map(|bucket| (bucket.range().0.ilog2().unwrap_or(0), bucket.iter().count()))
+					.collect();
+				(id, buckets)
+			})
 	}
 
 	/// Returns the number of records in the Kademlia record stores.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -1670,8 +1670,12 @@ impl<B: BlockT + 'static, H: ExHashT> Future for NetworkWorker<B, H> {
 		this.is_major_syncing.store(is_major_syncing, Ordering::Relaxed);
 
 		if let Some(metrics) = this.metrics.as_ref() {
-			for (proto, num_entries) in this.network_service.num_kbuckets_entries() {
-				metrics.kbuckets_num_nodes.with_label_values(&[&proto.as_ref()]).set(num_entries as u64);
+			for (proto, buckets) in this.network_service.num_entries_per_kbucket() {
+				for (lower_ilog2_bucket_bound, num_entries) in buckets {
+					metrics.kbuckets_num_nodes
+						.with_label_values(&[&proto.as_ref(), &lower_ilog2_bucket_bound.to_string()])
+						.set(num_entries as u64);
+				}
 			}
 			for (proto, num_entries) in this.network_service.num_kademlia_records() {
 				metrics.kademlia_records_count.with_label_values(&[&proto.as_ref()]).set(num_entries as u64);

--- a/client/network/src/service/metrics.rs
+++ b/client/network/src/service/metrics.rs
@@ -171,9 +171,9 @@ impl Metrics {
 			kbuckets_num_nodes: prometheus::register(GaugeVec::new(
 				Opts::new(
 					"sub_libp2p_kbuckets_num_nodes",
-					"Number of nodes in the Kademlia k-buckets"
+					"Number of nodes per kbucket per Kademlia instance"
 				),
-				&["protocol"]
+				&["protocol", "lower_ilog2_bucket_bound"]
 			)?, registry)?,
 			listeners_local_addresses: prometheus::register(Gauge::new(
 				"sub_libp2p_listeners_local_addresses", "Number of local addresses we're listening on"
@@ -355,4 +355,3 @@ impl MetricSource for NumConnectedGauge {
 		set(&[], self.0.load(Ordering::Relaxed) as u64);
 	}
 }
-


### PR DESCRIPTION
Extend `sub_libp2p_kbuckets_num_nodes` Prometheus metric to expose the
number of nodes per bucket per Kademlia instance instead of only per
Kademlia instance.