### PR TITLE
fix js dependancy alert, bumping bl version

### DIFF
--- a/.maintain/chaostest/package-lock.json
+++ b/.maintain/chaostest/package-lock.json
@@ -941,9 +941,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",

--- a/.maintain/chaostest/package-lock.json
+++ b/.maintain/chaostest/package-lock.json
@@ -3836,9 +3836,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",


### PR DESCRIPTION
Bumping bl version from 4.0.2 to 4.0.3 based on npm audit report  <del>1 High severity</del>
Bumping lodash version from 4.17.15 to 4.17.0 based on npm audit report <del>23 Low severity</del>
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Remote Memory Exposure                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ bl                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @oclif/dev-cli [dev]                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @oclif/dev-cli > qqjs > tar-fs > tar-stream > bl             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1555                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```