### PR TITLE
Add MathChain SS58 address type

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -494,6 +494,10 @@ ss58_address_format!(
 		(33, "datahighway", "DataHighway mainnet, standard account (*25519).")
 	CentrifugeAccount =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
+	MathChainAccount =>
+		(39, "mathchain", "MathChain mainnet, standard account (*25519).")
+	MathChainTestAccount =>
+		(40, "mathchain-testnet", "MathChain testnet, standard account (*25519).")
 	SubstrateAccount =>
 		(42, "substrate", "Any Substrate network, standard account (*25519).")
 	Reserved43 =>


### PR DESCRIPTION
Taking 39 and 40 for mathchain mainnet and testnet

Signed-off-by: lei dongliang, dlleig@gmail.com