### PR TITLE
babe: use SelectChain for block import fork choice

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -54,7 +54,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 			sc_rpc::SubscriptionTaskExecutor,
 		) -> node_rpc::IoHandler,
 		(
-			sc_consensus_babe::BabeBlockImport<Block, FullClient, FullGrandpaBlockImport>,
+			sc_consensus_babe::BabeBlockImport<Block, FullClient, FullSelectChain, FullGrandpaBlockImport>,
 			grandpa::LinkHalf<Block, FullClient, FullSelectChain>,
 			sc_consensus_babe::BabeLink<Block>,
 		),
@@ -83,6 +83,7 @@ pub fn new_partial(config: &Configuration) -> Result<sc_service::PartialComponen
 		sc_consensus_babe::Config::get_or_compute(&*client)?,
 		grandpa_block_import,
 		client.clone(),
+		select_chain.clone(),
 	)?;
 
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
@@ -164,7 +165,7 @@ pub struct NewFullBase {
 pub fn new_full_base(
 	config: Configuration,
 	with_startup_data: impl FnOnce(
-		&sc_consensus_babe::BabeBlockImport<Block, FullClient, FullGrandpaBlockImport>,
+		&sc_consensus_babe::BabeBlockImport<Block, FullClient, FullSelectChain, FullGrandpaBlockImport>,
 		&sc_consensus_babe::BabeLink<Block>,
 	)
 ) -> Result<NewFullBase, ServiceError> {
@@ -380,6 +381,7 @@ pub fn new_light_base(config: Configuration) -> Result<(
 		sc_consensus_babe::Config::get_or_compute(&*client)?,
 		grandpa_block_import,
 		client.clone(),
+		select_chain.clone(),
 	)?;
 
 	let inherent_data_providers = sp_inherents::InherentDataProviders::new();
@@ -511,7 +513,7 @@ mod tests {
 					task_manager, inherent_data_providers, client, network, transaction_pool, ..
 				} = new_full_base(config,
 					|
-						block_import: &sc_consensus_babe::BabeBlockImport<Block, _, _>,
+						block_import: &sc_consensus_babe::BabeBlockImport<Block, _, _, _>,
 						babe_link: &sc_consensus_babe::BabeLink<Block>,
 					| {
 						setup_handles = Some((block_import.clone(), babe_link.clone()));

--- a/client/consensus/babe/rpc/src/lib.rs
+++ b/client/consensus/babe/rpc/src/lib.rs
@@ -264,6 +264,7 @@ mod tests {
 			config.clone(),
 			client.clone(),
 			client.clone(),
+			longest_chain.clone(),
 		).expect("can initialize block-import");
 
 		let epoch_changes = link.epoch_changes().clone();

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -39,6 +39,7 @@ use sc_network_test::{Block as TestBlock, PeersClient};
 use sc_network::config::{BoxFinalityProofRequestBuilder, ProtocolConfig};
 use sp_runtime::{generic::DigestItem, traits::{Block as BlockT, DigestFor}};
 use sc_client_api::{BlockchainEvents, backend::TransactionFor};
+use substrate_test_runtime_client::DefaultTestClientBuilderExt;
 use log::debug;
 use std::{time::Duration, cell::RefCell, task::Poll};
 use rand::RngCore;
@@ -273,11 +274,14 @@ impl TestNetFactory for BabeTestNet {
 		let client = client.as_full().expect("only full clients are tested");
 		let inherent_data_providers = InherentDataProviders::new();
 
+		let (_, longest_chain) = TestClientBuilder::new().build_with_longest_chain();
+
 		let config = Config::get_or_compute(&*client).expect("config available");
 		let (block_import, link) = crate::block_import(
 			config,
 			client.clone(),
 			client.clone(),
+			longest_chain.clone(),
 		).expect("can initialize block-import");
 
 		let block_import = PanickingBlockImport(block_import);
@@ -302,8 +306,6 @@ impl TestNetFactory for BabeTestNet {
 	)
 		-> Self::Verifier
 	{
-		use substrate_test_runtime_client::DefaultTestClientBuilderExt;
-
 		let client = client.as_full().expect("only full clients are used in test");
 		trace!(target: "babe", "Creating a verifier");
 


### PR DESCRIPTION
This switches to use `SelectChain` for fetching the best block header in block import.