### PR TITLE
Declare collect type

### DIFF
--- a/bin/node/bench/src/tempdb.rs
+++ b/bin/node/bench/src/tempdb.rs
@@ -119,7 +119,7 @@ impl Clone for TempDatabase {
 			self_dir.to_string_lossy(),
 			new_dir.path().to_string_lossy(),
 		);
-		let self_db_files = std::fs::read_dir(self_dir)
+		let self_db_files: Vec<std::path::PathBuf> = std::fs::read_dir(self_dir)
 			.expect("failed to list file in seed dir")
 			.map(|f_result|
 				f_result.expect("failed to read file in seed db")

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -112,7 +112,7 @@ impl Clone for BenchDb {
 			seed_dir.to_string_lossy(),
 			dir.path().to_string_lossy(),
 		);
-		let seed_db_files = std::fs::read_dir(seed_dir)
+		let seed_db_files: Vec<PathBuf> = std::fs::read_dir(seed_dir)
 			.expect("failed to list file in seed dir")
 			.map(|f_result|
 				f_result.expect("failed to read file in seed db")


### PR DESCRIPTION
Maybe it is because `copy_items` expects a type `P` instead of a concrete structure but for some reason, the compiler isn't able to infer the `collect` type on my machine and it is causing a building error.