### PR TITLE
Remove warning about deprecated PeerIds

### DIFF
--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -281,21 +281,8 @@ pub fn parse_str_addr(addr_str: &str) -> Result<(PeerId, Multiaddr), ParseErr> {
 /// Splits a Multiaddress into a Multiaddress and PeerId.
 pub fn parse_addr(mut addr: Multiaddr)-> Result<(PeerId, Multiaddr), ParseErr> {
 	let who = match addr.pop() {
-		Some(multiaddr::Protocol::P2p(key)) => {
-			if !matches!(key.algorithm(), multiaddr::multihash::Code::Identity) {
-				// (note: this is the "person bowing" emoji)
-				log::warn!(
-					"🙇 You are using the peer ID {}. This peer ID uses a legacy, deprecated \
-					representation that will no longer be supported in the future. \
-					Please refresh it by performing a RPC query to the appropriate node, \
-					by looking at its logs, or by using `subkey inspect-node-key` on its \
-					private key.",
-					bs58::encode(key.as_bytes()).into_string()
-				);
-			}
-
-			PeerId::from_multihash(key).map_err(|_| ParseErr::InvalidPeerId)?
-		},
+		Some(multiaddr::Protocol::P2p(key)) => PeerId::from_multihash(key)
+			.map_err(|_| ParseErr::InvalidPeerId)?,
 		_ => return Err(ParseErr::PeerIdMissing),
 	};
 


### PR DESCRIPTION
This warning is no longer relevant after #7077.