### PR TITLE
Update READMEs, fix links

### DIFF
--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet template for defining custom runtime logic."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -7,6 +7,7 @@ build = "build.rs"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [[bin]]
 path = "src/main.rs"

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate client interfaces."
 documentation = "https://docs.rs/sc-client-api"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate authority discovery."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/basic-authorship/Cargo.toml
+++ b/client/basic-authorship/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Basic implementation of block-authoring logic."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/block-builder/Cargo.toml
+++ b/client/block-builder/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate block builder"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate chain configurations."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/chain-spec/README.md
+++ b/client/chain-spec/README.md
@@ -4,7 +4,7 @@ This crate contains structs and utilities to declare
 a runtime-specific configuration file (a.k.a chain spec).
 
 Basic chain spec type containing all required parameters is
-[`ChainSpec`](./struct.ChainSpec.html). It can be extended with
+[`ChainSpec`](https://docs.rs/sc-chain-spec/latest/sc_chain_spec/struct.ChainSpec.html). It can be extended with
 additional options that contain configuration specific to your chain.
 Usually the extension is going to be an amalgamate of types exposed
 by Substrate core modules. To allow the core modules to retrieve
@@ -25,7 +25,7 @@ pub type MyChainSpec<G> = GenericChainSpec<G, MyExtension>;
 
 Some parameters may require different values depending on the
 current blockchain height (a.k.a. forks). You can use `ChainSpecGroup`
-macro and provided [`Forks`](./struct.Forks.html) structure to put
+macro and provided [`Forks`](https://docs.rs/sc-chain-spec/latest/sc_chain_spec/struct.Forks.html) structure to put
 such parameters to your chain spec.
 This will allow to override a single parameter starting at specific
 block number.

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-consensus-babe"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/babe/rpc/Cargo.toml
+++ b/client/consensus/babe/rpc/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Collection of common consensus specific imlementations for Substrate (client)"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/epochs/Cargo.toml
+++ b/client/consensus/epochs/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/manual-seal/Cargo.toml
+++ b/client/consensus/manual-seal/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/pow/Cargo.toml
+++ b/client/consensus/pow/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/slots/Cargo.toml
+++ b/client/consensus/slots/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/consensus/uncles/Cargo.toml
+++ b/client/consensus/uncles/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Client backend that uses RocksDB database as storage."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "A crate that provides means of executing/dispatching calls into the runtime."
 documentation = "https://docs.rs/sc-executor"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "A set of common definitions that are needed for defining execution engines."
 documentation = "https://docs.rs/sc-executor-common/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "This crate provides an implementation of `WasmRuntime` that is baked by wasmi."
 documentation = "https://docs.rs/sc-executor-wasmi"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Defines a `WasmRuntime` that uses the Wasmtime JIT to execute."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Integration of the GRANDPA finality gadget into substrate."
 documentation = "https://docs.rs/sc-finality-grandpa"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/finality-grandpa/rpc/Cargo.toml
+++ b/client/finality-grandpa/rpc/Cargo.toml
@@ -6,6 +6,7 @@ description = "RPC extensions for the GRANDPA finality gadget"
 repository = "https://github.com/paritytech/substrate/"
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+readme = "README.md"
 
 [dependencies]
 sc-finality-grandpa = { version = "0.8.0-rc6", path = "../" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/keystore/Cargo.toml
+++ b/client/keystore/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Keystore (and session key management) for ed25519 based chains like Polkadot."
 documentation = "https://docs.rs/sc-keystore"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/light/Cargo.toml
+++ b/client/light/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-light"
+readme = "README.md"
 
 [dependencies]
 parking_lot = "0.10.0"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-network-gossip"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-network"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-peerset"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/proposer-metrics/Cargo.toml
+++ b/client/proposer-metrics/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Basic metrics for block production."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc-api/Cargo.toml
+++ b/client/rpc-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate RPC interfaces."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate RPC servers."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate Client RPC"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate service. Starts a thread that spins up the network, client, and extrinsic pool. Manages communication between them."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "State database maintenance. Handles canonicalization and pruning in the database."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sc-telemetry"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Instrumentation implementation for substrate."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate transaction pool implementation."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Generic Transaction Pool"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME asset management pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/assets/README.md
+++ b/frame/assets/README.md
@@ -11,9 +11,9 @@ with a fixed supply, including:
 * Asset Transfer
 * Asset Destruction
 
-To use it in your runtime, you need to implement the assets [`Trait`](./trait.Trait.html).
+To use it in your runtime, you need to implement the assets [`Trait`](https://docs.rs/pallet-assets/latest/pallet_assets/trait.Trait.html).
 
-The supported dispatchable functions are documented in the [`Call`](./enum.Call.html) enum.
+The supported dispatchable functions are documented in the [`Call`](https://docs.rs/pallet-assets/latest/pallet_assets/enum.Call.html) enum.
 
 ### Terminology
 
@@ -43,7 +43,7 @@ the function caller's account (`origin`) to a `target` account.
 * `destroy` - Destroys the entire holding of a fungible asset `id` associated with the account
 that called the function.
 
-Please refer to the [`Call`](./enum.Call.html) enum and its associated variants for documentation on each function.
+Please refer to the [`Call`](https://docs.rs/pallet-assets/latest/pallet_assets/enum.Call.html) enum and its associated variants for documentation on each function.
 
 ### Public Functions
 <!-- Original author of descriptions: @gavofyork -->
@@ -51,7 +51,7 @@ Please refer to the [`Call`](./enum.Call.html) enum and its associated variants 
 * `balance` - Get the asset `id` balance of `who`.
 * `total_supply` - Get the total supply of an asset `id`.
 
-Please refer to the [`Module`](./struct.Module.html) struct for details on publicly available functions.
+Please refer to the [`Module`](https://docs.rs/pallet-assets/latest/pallet_assets/struct.Module.html) struct for details on publicly available functions.
 
 ## Usage
 
@@ -110,7 +110,7 @@ them are violated, the behavior of this module is undefined.
 
 ## Related Modules
 
-* [`System`](../frame_system/index.html)
-* [`Support`](../frame_support/index.html)
+* [`System`](https://docs.rs/frame-system)
+* [`Support`](https://docs.rs/frame-support)
 
 License: Apache-2.0

--- a/frame/assets/README.md
+++ b/frame/assets/README.md
@@ -110,7 +110,7 @@ them are violated, the behavior of this module is undefined.
 
 ## Related Modules
 
-* [`System`](https://docs.rs/frame-system)
-* [`Support`](https://docs.rs/frame-support)
+* [`System`](https://docs.rs/frame-system/latest/frame_system/)
+* [`Support`](https://docs.rs/frame-support/latest/frame_support/)
 
 License: Apache-2.0

--- a/frame/atomic-swap/Cargo.toml
+++ b/frame/atomic-swap/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME atomic swap pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/atomic-swap/README.md
+++ b/frame/atomic-swap/README.md
@@ -2,9 +2,9 @@
 
 A module for atomically sending funds.
 
-- [`atomic_swap::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`atomic_swap::Trait`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/struct.Module.html)
 
 ## Overview
 

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME AURA consensus pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/aura/README.md
+++ b/frame/aura/README.md
@@ -15,14 +15,14 @@ The Aura module extends Aura consensus by managing offline reporting.
 
 ## Related Modules
 
-- [Timestamp](https://docs.rs/pallet-timestamp): The Timestamp module is used in Aura to track
+- [Timestamp](https://docs.rs/pallet-timestamp/latest/pallet_timestamp/): The Timestamp module is used in Aura to track
 consensus rounds (via `slots`).
 
 ## References
 
 If you're interested in hacking on this module, it is useful to understand the interaction with
 `substrate/primitives/inherents/src/lib.rs` and, specifically, the required implementation of
-[`ProvideInherent`](https://docs.rs/sp-inherents/trait.ProvideInherent.html) and
-[`ProvideInherentData`](https://docs.rs/sp-inherents/trait.ProvideInherentData.html) to create and check inherents.
+[`ProvideInherent`](https://docs.rs/sp-inherents/latest/sp_inherents/trait.ProvideInherent.html) and
+[`ProvideInherentData`](https://docs.rs/sp-inherents/latest/sp_inherents/trait.ProvideInherentData.html) to create and check inherents.
 
 License: Apache-2.0

--- a/frame/aura/README.md
+++ b/frame/aura/README.md
@@ -1,7 +1,7 @@
 # Aura Module
 
-- [`aura::Trait`](./trait.Trait.html)
-- [`Module`](./struct.Module.html)
+- [`aura::Trait`](https://docs.rs/pallet-aura/latest/pallet_aura/trait.Trait.html)
+- [`Module`](https://docs.rs/pallet-aura/latest/pallet_aura/struct.Module.html)
 
 ## Overview
 
@@ -15,14 +15,14 @@ The Aura module extends Aura consensus by managing offline reporting.
 
 ## Related Modules
 
-- [Timestamp](../pallet_timestamp/index.html): The Timestamp module is used in Aura to track
+- [Timestamp](https://docs.rs/pallet-timestamp): The Timestamp module is used in Aura to track
 consensus rounds (via `slots`).
 
 ## References
 
 If you're interested in hacking on this module, it is useful to understand the interaction with
 `substrate/primitives/inherents/src/lib.rs` and, specifically, the required implementation of
-[`ProvideInherent`](../sp_inherents/trait.ProvideInherent.html) and
-[`ProvideInherentData`](../sp_inherents/trait.ProvideInherentData.html) to create and check inherents.
+[`ProvideInherent`](https://docs.rs/sp-inherents/trait.ProvideInherent.html) and
+[`ProvideInherentData`](https://docs.rs/sp-inherents/trait.ProvideInherentData.html) to create and check inherents.
 
 License: Apache-2.0

--- a/frame/authority-discovery/Cargo.toml
+++ b/frame/authority-discovery/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for authority discovery"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/babe/Cargo.toml
+++ b/frame/babe/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Consensus extension module for BABE consensus. Collects on-chain randomness from VRF outputs and manages epoch transitions."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet to manage balances"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/balances/README.md
+++ b/frame/balances/README.md
@@ -2,9 +2,9 @@
 
 The Balances module provides functionality for handling accounts and balances.
 
-- [`balances::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`balances::Trait`](https://docs.rs/pallet-balances/latest/pallet_balances/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-balances/latest/pallet_balances/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-balances/latest/pallet_balances/struct.Module.html)
 
 ## Overview
 
@@ -53,16 +53,16 @@ locks always operate over the same funds, so they "overlay" rather than "stack".
 The Balances module provides implementations for the following traits. If these traits provide the functionality
 that you need, then you can avoid coupling with the Balances module.
 
-- [`Currency`](../frame_support/traits/trait.Currency.html): Functions for dealing with a
+- [`Currency`](https://docs.rs/frame-support/traits/trait.Currency.html): Functions for dealing with a
 fungible assets system.
-- [`ReservableCurrency`](../frame_support/traits/trait.ReservableCurrency.html):
+- [`ReservableCurrency`](https://docs.rs/frame-support/traits/trait.ReservableCurrency.html):
 Functions for dealing with assets that can be reserved from an account.
-- [`LockableCurrency`](../frame_support/traits/trait.LockableCurrency.html): Functions for
+- [`LockableCurrency`](https://docs.rs/frame-support/traits/trait.LockableCurrency.html): Functions for
 dealing with accounts that allow liquidity restrictions.
-- [`Imbalance`](../frame_support/traits/trait.Imbalance.html): Functions for handling
+- [`Imbalance`](https://docs.rs/frame-support/traits/trait.Imbalance.html): Functions for handling
 imbalances between total issuance in the system and account balances. Must be used when a function
 creates new funds (e.g. a reward) or destroys some funds (e.g. a system fee).
-- [`IsDeadAccount`](../frame_system/trait.IsDeadAccount.html): Determiner to say whether a
+- [`IsDeadAccount`](https://docs.rs/frame-system/trait.IsDeadAccount.html): Determiner to say whether a
 given account is unused.
 
 ## Interface
@@ -113,7 +113,7 @@ fn update_ledger<T: Trait>(
 
 ## Genesis config
 
-The Balances module depends on the [`GenesisConfig`](./struct.GenesisConfig.html).
+The Balances module depends on the [`GenesisConfig`](https://docs.rs/pallet-balances/latest/pallet_balances/struct.GenesisConfig.html).
 
 ## Assumptions
 

--- a/frame/balances/README.md
+++ b/frame/balances/README.md
@@ -53,16 +53,16 @@ locks always operate over the same funds, so they "overlay" rather than "stack".
 The Balances module provides implementations for the following traits. If these traits provide the functionality
 that you need, then you can avoid coupling with the Balances module.
 
-- [`Currency`](https://docs.rs/frame-support/traits/trait.Currency.html): Functions for dealing with a
+- [`Currency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.Currency.html): Functions for dealing with a
 fungible assets system.
-- [`ReservableCurrency`](https://docs.rs/frame-support/traits/trait.ReservableCurrency.html):
+- [`ReservableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.ReservableCurrency.html):
 Functions for dealing with assets that can be reserved from an account.
-- [`LockableCurrency`](https://docs.rs/frame-support/traits/trait.LockableCurrency.html): Functions for
+- [`LockableCurrency`](https://docs.rs/frame-support/latest/frame_support/traits/trait.LockableCurrency.html): Functions for
 dealing with accounts that allow liquidity restrictions.
-- [`Imbalance`](https://docs.rs/frame-support/traits/trait.Imbalance.html): Functions for handling
+- [`Imbalance`](https://docs.rs/frame-support/latest/frame_support/traits/trait.Imbalance.html): Functions for handling
 imbalances between total issuance in the system and account balances. Must be used when a function
 creates new funds (e.g. a reward) or destroys some funds (e.g. a system fee).
-- [`IsDeadAccount`](https://docs.rs/frame-system/trait.IsDeadAccount.html): Determiner to say whether a
+- [`IsDeadAccount`](https://docs.rs/frame-system/latest/frame_system/trait.IsDeadAccount.html): Determiner to say whether a
 given account is unused.
 
 ## Interface

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Macro for benchmarking a FRAME runtime."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/collective/Cargo.toml
+++ b/frame/collective/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Collective system: Members of a set of account IDs can make their collective feelings known through dispatched calls from one of two specialized origins."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/collective/README.md
+++ b/frame/collective/README.md
@@ -3,11 +3,14 @@ through dispatched calls from one of two specialized origins.
 
 The membership can be provided in one of two ways: either directly, using the Root-dispatchable
 function `set_members`, or indirectly, through implementing the `ChangeMembers`.
-The pallet assumes that the amount of members stays at or below `MAX_MEMBERS` for its weight
+The pallet assumes that the amount of members stays at or below `MaxMembers` for its weight
 calculations, but enforces this neither in `set_members` nor in `change_members_sorted`.
 
-A "prime" member may be set allowing their vote to act as the default vote in case of any
-abstentions after the voting period.
+A "prime" member may be set to help determine the default vote behavior based on chain
+config. If `PreimDefaultVote` is used, the prime vote acts as the default vote in case of any
+abstentions after the voting period. If `MoreThanMajorityThenPrimeDefaultVote` is used, then
+abstentations will first follow the majority of the collective voting, and then the prime
+member.
 
 Voting happens through motions comprising a proposal (i.e. a curried dispatchable) plus a
 number of approvals required for it to pass and be called. Motions are open for members to

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for WASM contracts"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/README.md
+++ b/frame/contracts/README.md
@@ -2,8 +2,8 @@
 
 The Contract module provides functionality for the runtime to deploy and execute WebAssembly smart-contracts.
 
-- [`contract::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`contract::Trait`](https://docs.rs/pallet-contracts/latest/pallet_contracts/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-contracts/latest/pallet_contracts/enum.Call.html)
 
 ## Overview
 
@@ -59,6 +59,6 @@ WebAssembly based smart contracts in the Rust programming language. This is a wo
 
 ## Related Modules
 
-* [Balances](../pallet_balances/index.html)
+* [Balances](https://docs.rs/pallet-balances)
 
 License: Apache-2.0

--- a/frame/contracts/README.md
+++ b/frame/contracts/README.md
@@ -59,6 +59,6 @@ WebAssembly based smart contracts in the Rust programming language. This is a wo
 
 ## Related Modules
 
-* [Balances](https://docs.rs/pallet-balances)
+* [Balances](https://docs.rs/pallet-balances/latest/pallet_balances/)
 
 License: Apache-2.0

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "A crate that hosts a common definitions that are relevant for the pallet-contracts."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Node-specific RPC methods for interaction with contracts."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Runtime API definition required by Contracts RPC extensions."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/democracy/Cargo.toml
+++ b/frame/democracy/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for democracy"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/democracy/README.md
+++ b/frame/democracy/README.md
@@ -1,7 +1,7 @@
 # Democracy Pallet
 
-- [`democracy::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`democracy::Trait`](https://docs.rs/pallet-democracy/latest/pallet_democracy/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-democracy/latest/pallet_democracy/enum.Call.html)
 
 ## Overview
 

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "pallet-elections-phragmen"
-version = "2.0.0-rc6"
+version = "2.0.0-rc7"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet based on seq-Phragmén election method."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -20,13 +21,6 @@ frame-support = { version = "2.0.0-rc6", default-features = false, path = "../su
 frame-system = { version = "2.0.0-rc6", default-features = false, path = "../system" }
 sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../primitives/std" }
 frame-benchmarking = { version = "2.0.0-rc6", default-features = false, path = "../benchmarking", optional = true }
-
-[dev-dependencies]
-sp-io = { version = "2.0.0-rc6", path = "../../primitives/io" }
-hex-literal = "0.3.1"
-pallet-balances = { version = "2.0.0-rc6", path = "../balances" }
-sp-core = { version = "2.0.0-rc6", path = "../../primitives/core" }
-substrate-test-utils = { version = "2.0.0-rc6", path = "../../test-utils" }
 
 [features]
 default = ["std"]

--- a/frame/elections-phragmen/Cargo.toml
+++ b/frame/elections-phragmen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-elections-phragmen"
-version = "2.0.0-rc7"
+version = "2.0.0-rc6"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,6 +21,13 @@ frame-support = { version = "2.0.0-rc6", default-features = false, path = "../su
 frame-system = { version = "2.0.0-rc6", default-features = false, path = "../system" }
 sp-std = { version = "2.0.0-rc6", default-features = false, path = "../../primitives/std" }
 frame-benchmarking = { version = "2.0.0-rc6", default-features = false, path = "../benchmarking", optional = true }
+
+[dev-dependencies]
+sp-io = { version = "2.0.0-rc6", path = "../../primitives/io" }
+hex-literal = "0.3.1"
+pallet-balances = { version = "2.0.0-rc6", path = "../balances" }
+sp-core = { version = "2.0.0-rc6", path = "../../primitives/core" }
+substrate-test-utils = { version = "2.0.0-rc6", path = "../../test-utils" }
 
 [features]
 default = ["std"]

--- a/frame/elections-phragmen/README.md
+++ b/frame/elections-phragmen/README.md
@@ -60,8 +60,8 @@ being re-elected at the end of each round.
 
 ### Module Information
 
-- [`election_sp_phragmen::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`election_sp_phragmen::Trait`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/struct.Module.html)
 
 License: Apache-2.0

--- a/frame/elections/Cargo.toml
+++ b/frame/elections/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for elections"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/evm/Cargo.toml
+++ b/frame/evm/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME EVM contracts pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example-offchain-worker/Cargo.toml
+++ b/frame/example-offchain-worker/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet for offchain worker"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example-offchain-worker/README.md
+++ b/frame/example-offchain-worker/README.md
@@ -6,9 +6,9 @@ concepts, APIs and structures common to most offchain workers.
 Run `cargo doc --package pallet-example-offchain-worker --open` to view this module's
 documentation.
 
-- [`pallet_example_offchain_worker::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`pallet_example_offchain_worker::Trait`](https://docs.rs/pallet-example-offchain-worker/latest/pallet_example_offchain_worker/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-example-offchain-worker/latest/pallet_example_offchain_worker/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-example-offchain-worker/latest/pallet_example_offchain_worker/struct.Module.html)
 
 
 ## Overview

--- a/frame/example/Cargo.toml
+++ b/frame/example/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/example/README.md
+++ b/frame/example/README.md
@@ -45,9 +45,9 @@ Copy and paste this template from frame/example/src/lib.rs into file
 // Include the following links that shows what trait needs to be implemented to use the pallet
 // and the supported dispatchables that are documented in the Call enum.
 
-- \[`<INSERT_CUSTOM_PALLET_NAME>::Trait`](./trait.Trait.html)
-- \[`Call`](./enum.Call.html)
-- \[`Module`](./struct.Module.html)
+- \[`<INSERT_CUSTOM_PALLET_NAME>::Trait`](https://docs.rs/pallet-example/latest/pallet_example/trait.Trait.html)
+- \[`Call`](https://docs.rs/pallet-example/latest/pallet_example/enum.Call.html)
+- \[`Module`](https://docs.rs/pallet-example/latest/pallet_example/struct.Module.html)
 
 \## Overview
 

--- a/frame/executive/Cargo.toml
+++ b/frame/executive/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME executives engine"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/executive/README.md
+++ b/frame/executive/README.md
@@ -7,7 +7,7 @@ extrinsic calls to the respective modules in the runtime.
 
 The executive module is not a typical pallet providing functionality around a specific feature.
 It is a cross-cutting framework component for the FRAME. It works in conjunction with the
-[FRAME System module](../frame_system/index.html) to perform these cross-cutting functions.
+[FRAME System module](https://docs.rs/frame-system) to perform these cross-cutting functions.
 
 The Executive module provides functions to:
 
@@ -27,7 +27,7 @@ The Executive module provides the following implementations:
 
 ## Usage
 
-The default Substrate node template declares the [`Executive`](./struct.Executive.html) type in its library.
+The default Substrate node template declares the [`Executive`](https://docs.rs/frame-executive/latest/frame_executive/struct.Executive.html) type in its library.
 
 ### Example
 

--- a/frame/executive/README.md
+++ b/frame/executive/README.md
@@ -7,7 +7,7 @@ extrinsic calls to the respective modules in the runtime.
 
 The executive module is not a typical pallet providing functionality around a specific feature.
 It is a cross-cutting framework component for the FRAME. It works in conjunction with the
-[FRAME System module](https://docs.rs/frame-system) to perform these cross-cutting functions.
+[FRAME System module](https://docs.rs/frame-system/latest/frame_system/) to perform these cross-cutting functions.
 
 The Executive module provides functions to:
 

--- a/frame/finality-tracker/Cargo.toml
+++ b/frame/finality-tracker/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME Pallet that tracks the last finalized block, as perceived by block authors."
 documentation = "https://docs.rs/pallet-finality-tracker"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/grandpa/Cargo.toml
+++ b/frame/grandpa/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for GRANDPA finality gadget"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/identity/Cargo.toml
+++ b/frame/identity/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME identity management pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/identity/README.md
+++ b/frame/identity/README.md
@@ -1,7 +1,7 @@
 # Identity Module
 
-- [`identity::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`identity::Trait`](https://docs.rs/pallet-identity/latest/pallet_identity/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-identity/latest/pallet_identity/enum.Call.html)
 
 ## Overview
 

--- a/frame/im-online/Cargo.toml
+++ b/frame/im-online/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME's I'm online pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/im-online/README.md
+++ b/frame/im-online/README.md
@@ -10,12 +10,12 @@ in the current era or session.
 
 The heartbeat is a signed transaction, which was signed using the session key
 and includes the recent best block number of the local validators chain as well
-as the [NetworkState](../../client/offchain/struct.NetworkState.html).
+as the [NetworkState](https://docs.rs/../client/offchain/struct.NetworkState.html).
 It is submitted as an Unsigned Transaction via off-chain workers.
 
-- [`im_online::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`im_online::Trait`](https://docs.rs/pallet-im-online/latest/pallet_im_online/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-im-online/latest/pallet_im_online/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-im-online/latest/pallet_im_online/struct.Module.html)
 
 ## Interface
 
@@ -46,6 +46,6 @@ decl_module! {
 
 ## Dependencies
 
-This module depends on the [Session module](../pallet_session/index.html).
+This module depends on the [Session module](https://docs.rs/pallet-session).
 
 License: Apache-2.0

--- a/frame/im-online/README.md
+++ b/frame/im-online/README.md
@@ -10,7 +10,7 @@ in the current era or session.
 
 The heartbeat is a signed transaction, which was signed using the session key
 and includes the recent best block number of the local validators chain as well
-as the [NetworkState](https://docs.rs/../client/offchain/struct.NetworkState.html).
+as the [NetworkState](https://docs.rs/../latest/../client/offchain/struct.NetworkState.html).
 It is submitted as an Unsigned Transaction via off-chain workers.
 
 - [`im_online::Trait`](https://docs.rs/pallet-im-online/latest/pallet_im_online/trait.Trait.html)
@@ -46,6 +46,6 @@ decl_module! {
 
 ## Dependencies
 
-This module depends on the [Session module](https://docs.rs/pallet-session).
+This module depends on the [Session module](https://docs.rs/pallet-session/latest/pallet_session/).
 
 License: Apache-2.0

--- a/frame/im-online/README.md
+++ b/frame/im-online/README.md
@@ -10,7 +10,7 @@ in the current era or session.
 
 The heartbeat is a signed transaction, which was signed using the session key
 and includes the recent best block number of the local validators chain as well
-as the [NetworkState](https://docs.rs/../latest/../client/offchain/struct.NetworkState.html).
+as the `NetworkState`.
 It is submitted as an Unsigned Transaction via off-chain workers.
 
 - [`im_online::Trait`](https://docs.rs/pallet-im-online/latest/pallet_im_online/trait.Trait.html)

--- a/frame/indices/Cargo.toml
+++ b/frame/indices/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME indices management pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/membership/Cargo.toml
+++ b/frame/membership/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME membership management pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/metadata/Cargo.toml
+++ b/frame/metadata/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Decodable variant of the RuntimeMetadata."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/multisig/Cargo.toml
+++ b/frame/multisig/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME multi-signature dispatch pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/multisig/README.md
+++ b/frame/multisig/README.md
@@ -1,8 +1,8 @@
 # Multisig Module
 A module for doing multisig dispatch.
 
-- [`multisig::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`multisig::Trait`](https://docs.rs/pallet-multisig/latest/pallet_multisig/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-multisig/latest/pallet_multisig/enum.Call.html)
 
 ## Overview
 

--- a/frame/nicks/Cargo.toml
+++ b/frame/nicks/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for nick management"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/nicks/README.md
+++ b/frame/nicks/README.md
@@ -1,12 +1,14 @@
 # Nicks Module
 
-- [`nicks::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`nicks::Trait`](https://docs.rs/pallet-nicks/latest/pallet_nicks/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-nicks/latest/pallet_nicks/enum.Call.html)
 
 ## Overview
 
-Nicks is a trivial module for keeping track of account names on-chain. It makes no effort to
-create a name hierarchy, be a DNS replacement or provide reverse lookups.
+Nicks is an example module for keeping track of account names on-chain. It makes no effort to
+create a name hierarchy, be a DNS replacement or provide reverse lookups. Furthermore, the
+weights attached to this module's dispatchable functions are for demonstration purposes only and
+have not been designed to be economically secure. Do not use this pallet as-is in production.
 
 ## Interface
 

--- a/frame/offences/Cargo.toml
+++ b/frame/offences/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME offences pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/offences/benchmarking/Cargo.toml
+++ b/frame/offences/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME offences pallet benchmarking"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/proxy/Cargo.toml
+++ b/frame/proxy/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME proxying pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/proxy/README.md
+++ b/frame/proxy/README.md
@@ -2,8 +2,12 @@
 A module allowing accounts to give permission to other accounts to dispatch types of calls from
 their signed origin.
 
-- [`proxy::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+The accounts to which permission is delegated may be requied to announce the action that they
+wish to execute some duration prior to execution happens. In this case, the target account may
+reject the announcement and in doing so, veto the execution.
+
+- [`proxy::Trait`](https://docs.rs/pallet-proxy/latest/pallet_proxy/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-proxy/latest/pallet_proxy/enum.Call.html)
 
 ## Overview
 

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME randomness collective flip pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/randomness-collective-flip/README.md
+++ b/frame/randomness-collective-flip/README.md
@@ -1,6 +1,6 @@
 # Randomness Module
 
-The Randomness Collective Flip module provides a [`random`](./struct.Module.html#method.random)
+The Randomness Collective Flip module provides a [`random`](https://docs.rs/pallet-randomness-collective-flip/latest/pallet_randomness_collective_flip/struct.Module.html#method.random)
 function that generates low-influence random values based on the block hashes from the previous
 `81` blocks. Low-influence randomness can be useful when defending against relatively weak
 adversaries. Using this pallet as a randomness source is advisable primarily in low-security
@@ -8,7 +8,7 @@ situations like testing.
 
 ## Public Functions
 
-See the [`Module`](./struct.Module.html) struct for details of publicly available functions.
+See the [`Module`](https://docs.rs/pallet-randomness-collective-flip/latest/pallet_randomness_collective_flip/struct.Module.html) struct for details of publicly available functions.
 
 ## Usage
 

--- a/frame/recovery/Cargo.toml
+++ b/frame/recovery/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME account recovery pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/recovery/README.md
+++ b/frame/recovery/README.md
@@ -1,7 +1,7 @@
 # Recovery Pallet
 
-- [`recovery::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`recovery::Trait`](https://docs.rs/pallet-recovery/latest/pallet_recovery/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-recovery/latest/pallet_recovery/enum.Call.html)
 
 ## Overview
 

--- a/frame/scheduler/Cargo.toml
+++ b/frame/scheduler/Cargo.toml
@@ -7,6 +7,7 @@ license = "Unlicense"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME example pallet"
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true }

--- a/frame/scheduler/README.md
+++ b/frame/scheduler/README.md
@@ -1,9 +1,9 @@
 # Scheduler
 A module for scheduling dispatches.
 
-- [`scheduler::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`scheduler::Trait`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/struct.Module.html)
 
 ## Overview
 

--- a/frame/scored-pool/Cargo.toml
+++ b/frame/scored-pool/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for scored pools"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/scored-pool/README.md
+++ b/frame/scored-pool/README.md
@@ -20,9 +20,9 @@ time. If an entity is currently a member, this results in removal
 from the `Pool` and `Members`; the entity is immediately replaced
 by the next highest scoring candidate in the pool, if available.
 
-- [`scored_pool::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`scored_pool::Trait`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/struct.Module.html)
 
 ## Interface
 
@@ -61,6 +61,6 @@ decl_module! {
 
 ## Dependencies
 
-This module depends on the [System module](../frame_system/index.html).
+This module depends on the [System module](https://docs.rs/frame-system).
 
 License: Apache-2.0

--- a/frame/scored-pool/README.md
+++ b/frame/scored-pool/README.md
@@ -61,6 +61,6 @@ decl_module! {
 
 ## Dependencies
 
-This module depends on the [System module](https://docs.rs/frame-system).
+This module depends on the [System module](https://docs.rs/frame-system/latest/frame_system/).
 
 License: Apache-2.0

--- a/frame/session/Cargo.toml
+++ b/frame/session/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME sessions pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/session/README.md
+++ b/frame/session/README.md
@@ -3,9 +3,9 @@
 The Session module allows validators to manage their session keys, provides a function for changing
 the session length, and handles session rotation.
 
-- [`session::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`session::Trait`](https://docs.rs/pallet-session/latest/pallet_session/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-session/latest/pallet_session/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-session/latest/pallet_session/struct.Module.html)
 
 ## Overview
 
@@ -66,7 +66,7 @@ for next session rotation.
 
 ### Example from the FRAME
 
-The [Staking pallet](../pallet_staking/index.html) uses the Session pallet to get the validator set.
+The [Staking pallet](https://docs.rs/pallet-staking) uses the Session pallet to get the validator set.
 
 ```rust
 use pallet_session as session;
@@ -78,6 +78,6 @@ fn validators<T: pallet_session::Trait>() -> Vec<<T as pallet_session::Trait>::V
 
 ## Related Modules
 
-- [Staking](../pallet_staking/index.html)
+- [Staking](https://docs.rs/pallet-staking)
 
 License: Apache-2.0

--- a/frame/session/README.md
+++ b/frame/session/README.md
@@ -66,7 +66,7 @@ for next session rotation.
 
 ### Example from the FRAME
 
-The [Staking pallet](https://docs.rs/pallet-staking) uses the Session pallet to get the validator set.
+The [Staking pallet](https://docs.rs/pallet-staking/latest/pallet_staking/) uses the Session pallet to get the validator set.
 
 ```rust
 use pallet_session as session;
@@ -78,6 +78,6 @@ fn validators<T: pallet_session::Trait>() -> Vec<<T as pallet_session::Trait>::V
 
 ## Related Modules
 
-- [Staking](https://docs.rs/pallet-staking)
+- [Staking](https://docs.rs/pallet-staking/latest/pallet_staking/)
 
 License: Apache-2.0

--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME sessions pallet benchmarking"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/society/Cargo.toml
+++ b/frame/society/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME society pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/society/README.md
+++ b/frame/society/README.md
@@ -1,7 +1,7 @@
 # Society Module
 
-- [`society::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`society::Trait`](https://docs.rs/pallet-society/latest/pallet_society/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-society/latest/pallet_society/enum.Call.html)
 
 ## Overview
 

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet staking"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -184,7 +184,7 @@ they received during the era. Points are added to a validator using
 [`reward_by_indices`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.reward_by_indices).
 
 [`Module`](./struct.Module.html) implements
-[`pallet_authorship::EventHandler`](https://docs.rs/pallet-authorship/trait.EventHandler.html) to add reward
+[`pallet_authorship::EventHandler`](https://docs.rs/pallet-authorship/latest/pallet_authorship/trait.EventHandler.html) to add reward
 points to block producer and block producer of referenced uncles.
 
 The validator and its nominator split their reward as following:
@@ -242,8 +242,8 @@ The Staking module depends on the [`GenesisConfig`](https://docs.rs/pallet-staki
 
 ## Related Modules
 
-- [Balances](https://docs.rs/pallet-balances): Used to manage values at stake.
-- [Session](https://docs.rs/pallet-session): Used to manage sessions. Also, a list of new
+- [Balances](https://docs.rs/pallet-balances/latest/pallet_balances/): Used to manage values at stake.
+- [Session](https://docs.rs/pallet-session/latest/pallet_session/): Used to manage sessions. Also, a list of new
   validators is stored in the Session module's `Validators` at the end of each era.
 
 License: Apache-2.0

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -2,9 +2,9 @@
 
 The Staking module is used to manage funds at stake by network maintainers.
 
-- [`staking::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`staking::Trait`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Module.html)
 
 ## Overview
 
@@ -48,16 +48,16 @@ which holds some or all of the funds that become frozen in place as part of the 
 is paired with an active **controller** account, which issues instructions on how they shall be
 used.
 
-An account pair can become bonded using the [`bond`](./enum.Call.html#variant.bond) call.
+An account pair can become bonded using the [`bond`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.bond) call.
 
 Stash accounts can change their associated controller using the
-[`set_controller`](./enum.Call.html#variant.set_controller) call.
+[`set_controller`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.set_controller) call.
 
 There are three possible roles that any staked account pair can be in: `Validator`, `Nominator`
-and `Idle` (defined in [`StakerStatus`](./enum.StakerStatus.html)). There are three
+and `Idle` (defined in [`StakerStatus`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.StakerStatus.html)). There are three
 corresponding instructions to change between roles, namely:
-[`validate`](./enum.Call.html#variant.validate),
-[`nominate`](./enum.Call.html#variant.nominate), and [`chill`](./enum.Call.html#variant.chill).
+[`validate`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.validate),
+[`nominate`](./enum.Call.html#variant.nominate), and [`chill`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.chill).
 
 #### Validating
 
@@ -69,7 +69,7 @@ _might_ get elected at the _next era_ as a validator. The result of the election
 by nominators and their votes.
 
 An account can become a validator candidate via the
-[`validate`](./enum.Call.html#variant.validate) call.
+[`validate`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.validate) call.
 
 #### Nomination
 
@@ -157,7 +157,7 @@ decl_module! {
 ### Era payout
 
 The era payout is computed using yearly inflation curve defined at
-[`T::RewardCurve`](./trait.Trait.html#associatedtype.RewardCurve) as such:
+[`T::RewardCurve`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html#associatedtype.RewardCurve) as such:
 
 ```nocompile
 staker_payout = yearly_inflation(npos_token_staked / total_tokens) * total_tokens / era_per_year
@@ -168,7 +168,7 @@ This payout is used to reward stakers as defined in next section
 remaining_payout = max_yearly_inflation * total_tokens / era_per_year - staker_payout
 ```
 The remaining reward is send to the configurable end-point
-[`T::RewardRemainder`](./trait.Trait.html#associatedtype.RewardRemainder).
+[`T::RewardRemainder`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html#associatedtype.RewardRemainder).
 
 ### Reward Calculation
 
@@ -180,28 +180,28 @@ defined staking rate. The full specification can be found
 
 Total reward is split among validators and their nominators depending on the number of points
 they received during the era. Points are added to a validator using
-[`reward_by_ids`](./enum.Call.html#variant.reward_by_ids) or
-[`reward_by_indices`](./enum.Call.html#variant.reward_by_indices).
+[`reward_by_ids`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.reward_by_ids) or
+[`reward_by_indices`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.reward_by_indices).
 
 [`Module`](./struct.Module.html) implements
-[`pallet_authorship::EventHandler`](../pallet_authorship/trait.EventHandler.html) to add reward
+[`pallet_authorship::EventHandler`](https://docs.rs/pallet-authorship/trait.EventHandler.html) to add reward
 points to block producer and block producer of referenced uncles.
 
 The validator and its nominator split their reward as following:
 
 The validator can declare an amount, named
-[`commission`](./struct.ValidatorPrefs.html#structfield.commission), that does not get shared
+[`commission`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.ValidatorPrefs.html#structfield.commission), that does not get shared
 with the nominators at each reward payout through its
-[`ValidatorPrefs`](./struct.ValidatorPrefs.html). This value gets deducted from the total reward
+[`ValidatorPrefs`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.ValidatorPrefs.html). This value gets deducted from the total reward
 that is paid to the validator and its nominators. The remaining portion is split among the
 validator and all of the nominators that nominated the validator, proportional to the value
 staked behind this validator (_i.e._ dividing the
-[`own`](./struct.Exposure.html#structfield.own) or
-[`others`](./struct.Exposure.html#structfield.others) by
-[`total`](./struct.Exposure.html#structfield.total) in [`Exposure`](./struct.Exposure.html)).
+[`own`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Exposure.html#structfield.own) or
+[`others`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Exposure.html#structfield.others) by
+[`total`](./struct.Exposure.html#structfield.total) in [`Exposure`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Exposure.html)).
 
 All entities who receive a reward have the option to choose their reward destination through the
-[`Payee`](./struct.Payee.html) storage item (see
+[`Payee`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Payee.html) storage item (see
 [`set_payee`](enum.Call.html#variant.set_payee)), to be one of the following:
 
 - Controller account, (obviously) not increasing the staked value.
@@ -214,9 +214,9 @@ Any funds already placed into stash can be the target of the following operation
 
 The controller account can free a portion (or all) of the funds using the
 [`unbond`](enum.Call.html#variant.unbond) call. Note that the funds are not immediately
-accessible. Instead, a duration denoted by [`BondingDuration`](./struct.BondingDuration.html)
+accessible. Instead, a duration denoted by [`BondingDuration`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.BondingDuration.html)
 (in number of eras) must pass until the funds can actually be removed. Once the
-`BondingDuration` is over, the [`withdraw_unbonded`](./enum.Call.html#variant.withdraw_unbonded)
+`BondingDuration` is over, the [`withdraw_unbonded`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.withdraw_unbonded)
 call can be used to actually withdraw the funds.
 
 Note that there is a limitation to the number of fund-chunks that can be scheduled to be
@@ -237,13 +237,13 @@ threshold.
 
 ## GenesisConfig
 
-The Staking module depends on the [`GenesisConfig`](./struct.GenesisConfig.html). The
+The Staking module depends on the [`GenesisConfig`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.GenesisConfig.html). The
 `GenesisConfig` is optional and allow to set some initial stakers.
 
 ## Related Modules
 
-- [Balances](../pallet_balances/index.html): Used to manage values at stake.
-- [Session](../pallet_session/index.html): Used to manage sessions. Also, a list of new
+- [Balances](https://docs.rs/pallet-balances): Used to manage values at stake.
+- [Session](https://docs.rs/pallet-session): Used to manage sessions. Also, a list of new
   validators is stored in the Session module's `Validators` at the end of each era.
 
 License: Apache-2.0

--- a/frame/sudo/Cargo.toml
+++ b/frame/sudo/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for sudo"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/sudo/README.md
+++ b/frame/sudo/README.md
@@ -61,7 +61,7 @@ You need to set an initial superuser account as the sudo `key`.
 
 ## Related Modules
 
-* [Democracy](https://docs.rs/pallet-democracy)
+* [Democracy](https://docs.rs/pallet-democracy/latest/pallet_democracy/)
 
 [`Call`]: ./enum.Call.html
 [`Trait`]: ./trait.Trait.html

--- a/frame/sudo/README.md
+++ b/frame/sudo/README.md
@@ -1,7 +1,7 @@
 # Sudo Module
 
-- [`sudo::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`sudo::Trait`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
 
 ## Overview
 
@@ -56,12 +56,12 @@ decl_module! {
 
 ## Genesis Config
 
-The Sudo module depends on the [`GenesisConfig`](./struct.GenesisConfig.html).
+The Sudo module depends on the [`GenesisConfig`](https://docs.rs/pallet-sudo/latest/pallet_sudo/struct.GenesisConfig.html).
 You need to set an initial superuser account as the sudo `key`.
 
 ## Related Modules
 
-* [Democracy](../pallet_democracy/index.html)
+* [Democracy](https://docs.rs/pallet-democracy)
 
 [`Call`]: ./enum.Call.html
 [`Trait`]: ./trait.Trait.html

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Support code for the runtime."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/system/Cargo.toml
+++ b/frame/system/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME system module"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/system/README.md
+++ b/frame/system/README.md
@@ -3,12 +3,12 @@
 The System module provides low-level access to core types and cross-cutting utilities.
 It acts as the base layer for other pallets to interact with the Substrate framework components.
 
-- [`system::Trait`](./trait.Trait.html)
+- [`system::Trait`](https://docs.rs/frame-system/latest/frame_system/trait.Trait.html)
 
 ## Overview
 
 The System module defines the core data types used in a Substrate runtime.
-It also provides several utility functions (see [`Module`](./struct.Module.html)) for other FRAME pallets.
+It also provides several utility functions (see [`Module`](https://docs.rs/frame-system/latest/frame_system/struct.Module.html)) for other FRAME pallets.
 
 In addition, it manages the storage items for extrinsics data, indexes, event records, and digest items,
 among other things that support the execution of the current block.
@@ -24,7 +24,7 @@ The System module does not implement any dispatchable functions.
 
 ### Public Functions
 
-See the [`Module`](./struct.Module.html) struct for details of publicly available functions.
+See the [`Module`](https://docs.rs/frame-system/latest/frame_system/struct.Module.html) struct for details of publicly available functions.
 
 ### Signed Extensions
 

--- a/frame/system/benchmarking/Cargo.toml
+++ b/frame/system/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME System benchmarking"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/system/rpc/runtime-api/Cargo.toml
+++ b/frame/system/rpc/runtime-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Runtime API definition required by System RPC extensions."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/timestamp/Cargo.toml
+++ b/frame/timestamp/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME Timestamp Module"
 documentation = "https://docs.rs/pallet-timestamp"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/timestamp/README.md
+++ b/frame/timestamp/README.md
@@ -2,9 +2,9 @@
 
 The Timestamp module provides functionality to get and set the on-chain time.
 
-- [`timestamp::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
-- [`Module`](./struct.Module.html)
+- [`timestamp::Trait`](https://docs.rs/pallet-timestamppallet-timestamp/latest/pallet_timestamp/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-timestamppallet-timestamp/latest/pallet_timestamp/enum.Call.html)
+- [`Module`](https://docs.rs/pallet-timestamppallet-timestamp/latest/pallet_timestamp/struct.Module.html)
 
 ## Overview
 
@@ -69,6 +69,6 @@ the Timestamp module for session management.
 
 ## Related Modules
 
-* [Session](../pallet_session/index.html)
+* [Session](https://docs.rs/pallet-timestamppallet-session)
 
 License: Apache-2.0

--- a/frame/timestamp/README.md
+++ b/frame/timestamp/README.md
@@ -69,6 +69,6 @@ the Timestamp module for session management.
 
 ## Related Modules
 
-* [Session](https://docs.rs/pallet-timestamppallet-session)
+* [Session](https://docs.rs/pallet-timestamppallet-session/latest/pallet_session/)
 
 License: Apache-2.0

--- a/frame/transaction-payment/Cargo.toml
+++ b/frame/transaction-payment/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet to manage transaction payments"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/transaction-payment/rpc/Cargo.toml
+++ b/frame/transaction-payment/rpc/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "RPC interface for the transaction payment module."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/transaction-payment/rpc/runtime-api/Cargo.toml
+++ b/frame/transaction-payment/rpc/runtime-api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "RPC runtime API for transaction payment FRAME pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/treasury/Cargo.toml
+++ b/frame/treasury/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet to manage treasury"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/treasury/README.md
+++ b/frame/treasury/README.md
@@ -3,8 +3,8 @@
 The Treasury module provides a "pot" of funds that can be managed by stakeholders in the
 system and a structure for making spending proposals from this pot.
 
-- [`treasury::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`treasury::Trait`](https://docs.rs/pallet-treasury/latest/pallet_treasury/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-treasury/latest/pallet_treasury/enum.Call.html)
 
 ## Overview
 
@@ -27,6 +27,23 @@ entered where any remaining members can declare their tip amounts also. After th
 countdown period, the median of all declared tips is paid to the reported beneficiary, along
 with any finders fee, in case of a public (and bonded) original report.
 
+### Bounty
+
+A Bounty Spending is a reward for a specified body of work - or specified set of objectives - that
+needs to be executed for a predefined Treasury amount to be paid out. A curator is assigned after
+the bounty is approved and funded by Council, to be delegated
+with the responsibility of assigning a payout address once the specified set of objectives is completed.
+
+After the Council has activated a bounty, it delegates the work that requires expertise to a curator
+in exchange of a deposit. Once the curator accepts the bounty, they
+get to close the Active bounty. Closing the Active bounty enacts a delayed payout to the payout
+address, the curator fee and the return of the curator deposit. The
+delay allows for intervention through regular democracy. The Council gets to unassign the curator,
+resulting in a new curator election. The Council also gets to cancel
+the bounty if deemed necessary before assigning a curator or once the bounty is active or payout
+is pending, resulting in the slash of the curator's deposit.
+
+
 ### Terminology
 
 - **Proposal:** A suggestion to allocate funds from the pot to a beneficiary.
@@ -47,6 +64,22 @@ Tipping protocol:
 - **Finders Fee:** Some proportion of the tip amount that is paid to the reporter of the tip,
   rather than the main beneficiary.
 
+Bounty:
+- **Bounty spending proposal:** A proposal to reward a predefined body of work upon completion by
+the Treasury.
+- **Proposer:** An account proposing a bounty spending.
+- **Curator:** An account managing the bounty and assigning a payout address receiving the reward
+for the completion of work.
+- **Deposit:** The amount held on deposit for placing a bounty proposal plus the amount held on
+deposit per byte within the bounty description.
+- **Curator deposit:** The payment from a candidate willing to curate an approved bounty. The deposit
+is returned when/if the bounty is completed.
+- **Bounty value:** The total amount that should be paid to the Payout Address if the bounty is
+rewarded.
+- **Payout address:** The account to which the total or part of the bounty is assigned to.
+- **Payout Delay:** The delay period for which a bounty beneficiary needs to wait before claiming.
+- **Curator fee:** The reserved upfront payment for a curator for work related to the bounty.
+
 ## Interface
 
 ### Dispatchable Functions
@@ -65,8 +98,21 @@ Tipping protocol:
 - `tip` - Declare or redeclare an amount to tip for a particular reason.
 - `close_tip` - Close and pay out a tip.
 
+Bounty protocol:
+- `propose_bounty` - Propose a specific treasury amount to be earmarked for a predefined set of
+tasks and stake the required deposit.
+- `approve_bounty` - Accept a specific treasury amount to be earmarked for a predefined body of work.
+- `propose_curator` - Assign an account to a bounty as candidate curator.
+- `accept_curator` - Accept a bounty assignment from the Council, setting a curator deposit.
+- `extend_bounty_expiry` - Extend the expiry block number of the bounty and stay active.
+- `award_bounty` - Close and pay out the specified amount for the completed work.
+- `claim_bounty` - Claim a specific bounty amount from the Payout Address.
+- `unassign_curator` - Unassign an accepted curator from a specific earmark.
+- `close_bounty` - Cancel the earmark for a specific treasury amount and close the bounty.
+
+
 ## GenesisConfig
 
-The Treasury module depends on the [`GenesisConfig`](./struct.GenesisConfig.html).
+The Treasury module depends on the [`GenesisConfig`](https://docs.rs/pallet-treasury/latest/pallet_treasury/struct.GenesisConfig.html).
 
 License: Apache-2.0

--- a/frame/utility/Cargo.toml
+++ b/frame/utility/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME utilities pallet"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/utility/README.md
+++ b/frame/utility/README.md
@@ -1,8 +1,8 @@
 # Utility Module
 A stateless module with helpers for dispatch management which does no re-authentication.
 
-- [`utility::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`utility::Trait`](https://docs.rs/pallet-utility/latest/pallet_utility/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-utility/latest/pallet_utility/enum.Call.html)
 
 ## Overview
 

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for manage vesting"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/vesting/README.md
+++ b/frame/vesting/README.md
@@ -1,7 +1,7 @@
 # Vesting Module
 
-- [`vesting::Trait`](./trait.Trait.html)
-- [`Call`](./enum.Call.html)
+- [`vesting::Trait`](https://docs.rs/pallet-vesting/latest/pallet_vesting/trait.Trait.html)
+- [`Call`](https://docs.rs/pallet-vesting/latest/pallet_vesting/enum.Call.html)
 
 ## Overview
 

--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Collection of allocator implementations."
 documentation = "https://docs.rs/sp-allocator"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate runtime api primitives"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sp-application-crypto"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Minimal fixed point arithmetic primitives and types for runtime."
 documentation = "https://docs.rs/sp-arithmetic"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "The block builder runtime api."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/blockchain/Cargo.toml
+++ b/primitives/blockchain/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate blockchain traits and primitives."
 documentation = "https://docs.rs/sp-blockchain"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/chain-spec/Cargo.toml
+++ b/primitives/chain-spec/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate chain configurations types."
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0.101", features = ["derive"] }

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Common utilities for building and using consensus engines in substrate."
 documentation = "https://docs.rs/sp-consensus/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/slots/Cargo.toml
+++ b/primitives/consensus/slots/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/substrate/"
 homepage = "https://substrate.dev"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/database/Cargo.toml
+++ b/primitives/database/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate database trait."
 documentation = "https://docs.rs/sp-database"
+readme = "README.md"
 
 [dependencies]
 parking_lot = "0.10.0"

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate externalities abstraction"
 documentation = "https://docs.rs/sp-externalities"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Primitives for GRANDPA integration, suitable for WASM compilation."
 documentation = "https://docs.rs/sp-finality-grandpa"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME module that tracks the last finalized block, as perceived by block authors."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Provides types and traits for creating and checking inherents."
 documentation = "https://docs.rs/sp-inherents"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "I/O for Substrate runtimes"
 documentation = "https://docs.rs/sp-io"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/keyring/Cargo.toml
+++ b/primitives/keyring/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Keyring support code for the runtime. A set of test accounts."
 documentation = "https://docs.rs/sp-keyring"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "NPoS election algorithm primitives"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/panic-handler/Cargo.toml
+++ b/primitives/panic-handler/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Custom panic hook with bug report link"
 documentation = "https://docs.rs/sp-panic-handler"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/rpc/Cargo.toml
+++ b/primitives/rpc/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate RPC primitives and utilities."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate runtime interface"
 documentation = "https://docs.rs/sp-runtime-interface/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -19,7 +19,7 @@ sp-io = { version = "2.0.0-rc6", default-features = false, path = "../../io" }
 sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../core" }
 
 [build-dependencies]
-wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
+wasm-builder-runner = { version = "1.0.6-rc6", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
 
 [features]
 default = [ "std" ]

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -19,7 +19,7 @@ sp-io = { version = "2.0.0-rc6", default-features = false, path = "../../io" }
 sp-core = { version = "2.0.0-rc6", default-features = false, path = "../../core" }
 
 [build-dependencies]
-wasm-builder-runner = { version = "1.0.6-rc6", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
+wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
 
 [features]
 default = [ "std" ]

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -31,6 +31,11 @@ parity-util-mem = { version = "0.7.0", default-features = false, features = ["pr
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 either = { version = "1.5", default-features = false }
 
+[dev-dependencies]
+serde_json = "1.0.41"
+rand = "0.7.2"
+sp-state-machine = { version = "0.8.0-rc6", path = "../../primitives/state-machine" }
+
 [features]
 bench = []
 runtime-benchmarks = []

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Runtime Modules shared primitive types."
 documentation = "https://docs.rs/sp-runtime"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -29,11 +30,6 @@ sp-inherents = { version = "2.0.0-rc6", default-features = false, path = "../inh
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 either = { version = "1.5", default-features = false }
-
-[dev-dependencies]
-serde_json = "1.0.41"
-rand = "0.7.2"
-sp-state-machine = { version = "0.8.0-rc6", path = "../../primitives/state-machine" }
 
 [features]
 bench = []

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "This crate provides means to instantiate and execute wasm modules."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/serializer/Cargo.toml
+++ b/primitives/serializer/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate customizable serde serializer."
 documentation = "https://docs.rs/sp-serializer"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Primitives for sessions"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "A crate which contains primitives that are useful for implementation that uses staking approaches in general. Definitions related to sessions, slashing, etc go here."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sp-state-machine"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/paritytech/substrate/"
 
 description = "Lowest-abstraction level for the Substrate runtime: just exports useful primitives from std or client/alloc to be used with any code that depends on the runtime."
 documentation = "https://docs.rs/sp-std"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 documentation = "https://docs.rs/sp-storage/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Substrate core types and inherents for timestamps."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Instrumentation primitives and macros for Substrate."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 # let's default to wasm32

--- a/primitives/tracing/README.md
+++ b/primitives/tracing/README.md
@@ -1,6 +1,6 @@
 Substrate tracing primitives and macros.
 
-To trace functions or invidual code in Substrate, this crate provides [`tracing_span`]
+To trace functions or invidual code in Substrate, this crate provides [`within_span`]
 and [`enter_span`]. See the individual docs for how to use these macros.
 
 Note that to allow traces from wasm execution environment there are

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Transaction pool primitives types & Runtime API."
 documentation = "https://docs.rs/sp-transaction-pool"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 edition = "2018"
 homepage = "https://substrate.dev"
 documentation = "https://docs.rs/sp-trie"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/utils/Cargo.toml
+++ b/primitives/utils/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "I/O for Substrate runtimes"
+readme = "README.md"
 
 [dependencies]
 futures = "0.3.4"

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Version module for the Substrate runtime; Provides a function that returns the runtime version."
 documentation = "https://docs.rs/sp-version"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Types and traits for interfacing between the host and the wasm runtime."
 documentation = "https://docs.rs/sp-wasm-interface"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/build-script-utils/Cargo.toml
+++ b/utils/build-script-utils/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Crate with utility functions for `build.rs` scripts."
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/fork-tree/Cargo.toml
+++ b/utils/fork-tree/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Utility library for managing tree-like ordered data with logic for pruning the tree while finalizing nodes."
 documentation = "https://docs.rs/fork-tree"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "CLI for benchmarking FRAME"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "cli interface for FRAME"
 documentation = "https://docs.rs/substrate-frame-cli"
+readme = "README.md"
 
 [dependencies]
 sp-core = { version = "2.0.0-rc6", path = "../../../primitives/core" }

--- a/utils/frame/rpc/system/Cargo.toml
+++ b/utils/frame/rpc/system/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME's system exposed over Substrate RPC"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/utils/prometheus/Cargo.toml
+++ b/utils/prometheus/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
+readme = "README.md"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Re-generated READMEs with latest `cargo-unleash` to:
- fix doc links (rewrite relative links to point them to docs.rs).
- Set readme field in package manifests (so they're rendered on crates.io).

Fixes #7146 