### PR TITLE
expose add_proxy and remove_proxy

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
 	spec_version: 259,
-	impl_version: 0,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 };

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -156,11 +156,11 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Proxy {
 		/// The set of account proxies. Maps the account which has delegated to the accounts
 		/// which are being delegated to, together with the amount held on deposit.
-		pub Proxies: map hasher(twox_64_concat) T::AccountId
+		pub Proxies get(fn proxies): map hasher(twox_64_concat) T::AccountId
 			=> (Vec<ProxyDefinition<T::AccountId, T::ProxyType, T::BlockNumber>>, BalanceOf<T>);
 
 		/// The announcements made by the proxy (key).
-		pub Announcements: map hasher(twox_64_concat) T::AccountId
+		pub Announcements get(fn announcements): map hasher(twox_64_concat) T::AccountId
 			=> (Vec<Announcement<T::AccountId, CallHashOf<T>, T::BlockNumber>>, BalanceOf<T>);
 	}
 }

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -282,6 +282,8 @@ decl_module! {
 		/// Parameters:
 		/// - `proxy`: The account that the `caller` would like to make a proxy.
 		/// - `proxy_type`: The permissions allowed for this proxy account.
+		/// - `delay`: The announcement period required of the initial proxy. Will generally be
+		/// zero.
 		///
 		/// # <weight>
 		/// Weight is a function of the number of proxies the user has (P).
@@ -549,6 +551,18 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
+
+	/// Calculate the address of an anonymous account.
+	///
+	/// - `who`: The spawner account.
+	/// - `proxy_type`: The type of the proxy that the sender will be registered as over the
+	/// new account. This will almost always be the most permissive `ProxyType` possible to
+	/// allow for maximum flexibility.
+	/// - `index`: A disambiguation index, in case this is called multiple times in the same
+	/// transaction (e.g. with `utility::batch`). Unless you're using `batch` you probably just
+	/// want to use `0`.
+	/// - `maybe_when`: The block height and extrinsic index of when the anonymous account was
+	/// created. None to use current block height and extrinsic index.
 	pub fn anonymous_account(
 		who: &T::AccountId,
 		proxy_type: &T::ProxyType,
@@ -564,6 +578,14 @@ impl<T: Trait> Module<T> {
 		T::AccountId::decode(&mut &entropy[..]).unwrap_or_default()
 	}
 
+	/// Register a proxy account for the delegator that is able to make calls on its behalf.
+	///
+	/// Parameters:
+	/// - `delegator`: The delegator account.
+	/// - `delegatee`: The account that the `delegator` would like to make a proxy.
+	/// - `proxy_type`: The permissions allowed for this proxy account.
+	/// - `delay`: The announcement period required of the initial proxy. Will generally be
+	/// zero.
 	pub fn add_proxy_delegate(
 		delegator: &T::AccountId,
 		delegatee: T::AccountId,
@@ -586,6 +608,14 @@ impl<T: Trait> Module<T> {
 		})
 	}
 
+	/// Unregister a proxy account for the delegator.
+	///
+	/// Parameters:
+	/// - `delegator`: The delegator account.
+	/// - `delegatee`: The account that the `delegator` would like to make a proxy.
+	/// - `proxy_type`: The permissions allowed for this proxy account.
+	/// - `delay`: The announcement period required of the initial proxy. Will generally be
+	/// zero.
 	pub fn remove_proxy_delegate(
 		delegator: &T::AccountId,
 		delegatee: T::AccountId,

--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -575,7 +575,7 @@ impl<T: Trait> Module<T> {
 			let proxy_def = ProxyDefinition { delegate: delegatee, proxy_type, delay };
 			let i = proxies.binary_search(&proxy_def).err().ok_or(Error::<T>::Duplicate)?;
 			proxies.insert(i, proxy_def);
-			let new_deposit =Self::deposit(proxies.len() as u32);
+			let new_deposit = Self::deposit(proxies.len() as u32);
 			if new_deposit > *deposit {
 				T::Currency::reserve(delegator, new_deposit - *deposit)?;
 			} else if new_deposit < *deposit {


### PR DESCRIPTION
Closes #7139

Can't figure out a good way to remove the deposit requirement for `add_proxy` without introducing inconsistency so provide a way to check deposit requirement instead.

I don't like on the name of `add_proxy_delegate` and `remove_proxy_delegate` but can't think a better one.