### PR TITLE
Add doc for auto-generated code

### DIFF
--- a/utils/wasm-builder-runner/src/lib.rs
+++ b/utils/wasm-builder-runner/src/lib.rs
@@ -403,7 +403,7 @@ fn create_project(
 		project_folder.join("src/main.rs"),
 		format!(
 			r#"
-				//! WASM builder
+				//! This is automatically generated code by `substrate-wasm-builder`.
 
 				use substrate_wasm_builder::build_project_with_default_rustflags;
 

--- a/utils/wasm-builder-runner/src/lib.rs
+++ b/utils/wasm-builder-runner/src/lib.rs
@@ -403,6 +403,8 @@ fn create_project(
 		project_folder.join("src/main.rs"),
 		format!(
 			r#"
+				//! WASM builder
+
 				use substrate_wasm_builder::build_project_with_default_rustflags;
 
 				fn main() {{


### PR DESCRIPTION
`RUSTFLAGS='-D missing_docs' cargo build` doesn't work with anything that uses `substrate-wasm-builder-runner` because there isn't a top-level documentation for the auto-generated code and this PR only adds a placeholder to make the lint happy.