### PR TITLE
client/network: Stop sending noise legacy handshake

### DIFF
--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -86,7 +86,6 @@ pub fn build_transport(
 
 		// Legacy noise configurations for backward compatibility.
 		let mut noise_legacy = noise::LegacyConfig::default();
-		noise_legacy.send_legacy_handshake = true;
 		noise_legacy.recv_legacy_handshake = true;
 
 		let mut xx_config = noise::NoiseConfig::xx(noise_keypair_spec);


### PR DESCRIPTION
Stop sending noise legacy handshake payloads, i.e. length-prefixed protobuf
payloads inside a length-prefixed noise frame. Receiving of such legacy
handshakes is still supported, thus backwards compatibility is given.

Fixes https://github.com/paritytech/substrate/issues/7175.

Release note suggestion:

> Stop sending noise legacy handshake payloads, i.e. length-prefixed protobuf payloads inside a length-prefixed noise frame. Receiving of such legacy handshakes is still supported, thus backwards compatibility is given to all clients running with libp2p `>= v0.22.0`. Clients previously running with libp2p `< v0.22.0` should first update to previous Substrate versions, which support the new handshake format, before updating to this Substrate version.