### PR TITLE
permit setting treasury pallet initial funding through genesis

### DIFF
--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -396,10 +396,14 @@ decl_storage! {
 	add_extra_genesis {
 		build(|_config| {
 			// Create Treasury account
-			let _ = T::Currency::make_free_balance_be(
-				&<Module<T, I>>::account_id(),
-				T::Currency::minimum_balance(),
-			);
+			let account_id = <Module<T, I>>::account_id();
+			let min = T::Currency::minimum_balance();
+			if T::Currency::free_balance(&account_id) < min {
+				let _ = T::Currency::make_free_balance_be(
+					&account_id,
+					min,
+				);
+			}
 		});
 	}
 }

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -1148,3 +1148,20 @@ fn test_last_reward_migration() {
 		);
 	});
 }
+
+#[test]
+fn genesis_funding_works() {
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let initial_funding = 100;
+	pallet_balances::GenesisConfig::<Test>{
+		// Total issuance will be 200 with treasury account initialized with 100.
+		balances: vec![(0, 100), (Treasury::account_id(), initial_funding)],
+	}.assimilate_storage(&mut t).unwrap();
+	GenesisConfig::default().assimilate_storage::<Test, _>(&mut t).unwrap();
+	let mut t: sp_io::TestExternalities = t.into();
+
+	t.execute_with(|| {
+		assert_eq!(Balances::free_balance(Treasury::account_id()), initial_funding);
+		assert_eq!(Treasury::pot(), initial_funding - Balances::minimum_balance());
+	});
+}


### PR DESCRIPTION
Treasury pallet will set initial balances to account ED, this will cause conflict if we want to set treasury initial funding in genesis, the change is to add a check before setting treasury balances to  ED (only when balance is lower than ED)