### PR TITLE
Send initial Sync Status to Telemetry Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6916,6 +6916,7 @@ dependencies = [
  "sc-block-builder",
  "sc-client-api",
  "sc-peerset",
+ "sc-telemetry",
  "serde",
  "serde_json",
  "slog",

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -57,6 +57,7 @@ sp-consensus = { version = "0.8.0", path = "../../primitives/consensus/common" }
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils" }
+sc-telemetry = { version = "2.0.0", path = "../telemetry" }
 thiserror = "1"
 unsigned-varint = { version = "0.4.0", features = ["futures", "futures-codec"] }
 void = "1.0.2"

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -34,6 +34,7 @@ use sp_consensus::{BlockOrigin, BlockStatus,
 	block_validation::{BlockAnnounceValidator, Validation},
 	import_queue::{IncomingBlock, BlockImportResult, BlockImportError}
 };
+use sc_telemetry::{telemetry, CONSENSUS_TRACE};
 use crate::{
 	config::BoxFinalityProofRequestBuilder,
 	protocol::message::{self, generic::FinalityProofRequest, BlockAnnounce, BlockAttributes, BlockRequest, BlockResponse,
@@ -887,6 +888,9 @@ impl<B: BlockT> ChainSync<B> {
 			};
 
 		if let Some((h, n)) = new_blocks.last().and_then(|b| b.header.as_ref().map(|h| (&b.hash, *h.number()))) {
+			if origin == BlockOrigin::NetworkInitialSync {
+				telemetry!(CONSENSUS_TRACE; "initial_sync.status"; "to_sync" => new_blocks.len());
+			}
 			trace!(target:"sync", "Accepted {} blocks ({:?}) with origin {:?}", new_blocks.len(), h, origin);
 			self.on_block_queued(h, n)
 		}

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -32,7 +32,7 @@ use sp_core::{
 	storage::{well_known_keys, ChildInfo, PrefixedStorageKey, StorageData, StorageKey},
 	ChangesTrieConfiguration, ExecutionContext, NativeOrEncoded,
 };
-use sc_telemetry::{telemetry, SUBSTRATE_INFO};
+use sc_telemetry::{telemetry, SUBSTRATE_INFO, CONSENSUS_TRACE};
 use sp_runtime::{
 	Justification, BuildStorage,
 	generic::{BlockId, SignedBlock, DigestItem},
@@ -656,6 +656,9 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 
 		if let Ok(ImportResult::Imported(ref aux)) = result {
 			if aux.is_new_best {
+				if origin == BlockOrigin::NetworkInitialSync {
+					telemetry!(CONSENSUS_TRACE; "initial_sync.status"; "current" => height);
+				}
 				// don't send telemetry block import events during initial sync for every
 				// block to avoid spamming the telemetry server, these events will be randomly
 				// sent at a rate of 1/10.


### PR DESCRIPTION
Currently, there is no way to inspect the Initial Sync Status, that's really a big issue when using the client on mobile devices (like `light-client`) since the sync status may take a very long time until it fully synced.

This PR adds a new telemetry event `initial_sync.status` which reports first how many blocks will be synced and then the current synced block, that way in the UI of a mobile application for example we could show a progress bar of the sync status.

> PS: We have built a small embed telemetry server inside the mobile application, so we could make use of this event.

Here is a simple scenario of what will happen when the client starts for the first time:

`=>` `initial_sync.status` => `{ "to_sync": X }`
Then after that, it will send the current block,
`=>` `initial_sync.status` => `{ "current": Y }`
`=>` `initial_sync.status` => `{ "current": Z0 }`
`=>` `initial_sync.status` => `{ "current": Z1 }`

and to calculate the current sync status in percent simply we do:
```py
to_sync = X
first_block = Y
current_block = Z1 # changes everytime
status = (current_block / (first_block + to_sync)) * 100
```
