### PR TITLE
WIP: remove deprecated only/except clauses

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,50 +76,43 @@ default:
   tags:
     - linux-docker
 
-.docker-env-only:                       &docker-env-only
-  only:
-    - master
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-    - schedules
-    - web
-    - /^[0-9]+$/                   # PRs
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH
 
-.build-only:                       &build-only
-  only:
-    - master
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-    - /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/
-    - web
+.docker-env-rules:                 &docker-env-rules
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
 
-.build-rules:                       &build-rules
+.build-rules:                      &build-rules
   rules:
     - if: '$DEPLOY_TAG'
       when: never
-    - if: $CI_COMMIT_REF_NAME=="master"
-      when: always
-    - if: $CI_PIPELINE_SOURCE=="web"
-      when: always
-    - if: $CI_COMMIT_REF_NAME=~ /^v[0-9]+\.[0-9]+.*$/
-      when: always
-    - if: $CI_COMMIT_REF_NAME=~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/
-      when: always
-    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME=~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
-      when: always
-    - when: never
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ "/^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/"'  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
+           && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
 
 .chaos-only:                       &chaos-only
-  only:
-    variables:
-      - '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME=~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
+  rules:
+    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
+           && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
 
 #### stage:                       .pre
 
 skip-if-draft:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  stage:                          .pre
-  only:
-    - /^[0-9]+$/                  # Pull requests
+  stage:                           .pre
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
   script:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
@@ -133,8 +126,8 @@ check-runtime:
   stage:                           check
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  only:
-    - /^[0-9]+$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
   variables:
     <<:                            *default-vars
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
@@ -147,9 +140,9 @@ check-signed-tag:
   stage:                           check
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  only:
-    - /^ci-release-.*$/
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
   script:
     - ./.maintain/gitlab/check_signed.sh
 
@@ -157,8 +150,8 @@ check-line-width:
   stage:                           check
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  only:
-    - /^[0-9]+$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
   script:
     - ./.maintain/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -167,9 +160,9 @@ test-dependency-rules:
   stage:                           check
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  except:
-    variables:
-      - $DEPLOY_TAG
+  rules:
+    - if: $DEPLOY_TAG
+      when: never
   script:
     - .maintain/ensure-deps.sh
 
@@ -178,9 +171,13 @@ test-dependency-rules:
 cargo-audit:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
-  except:
-    - /^[0-9]+$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     - cargo audit
   allow_failure:                   true
@@ -188,14 +185,15 @@ cargo-audit:
 cargo-deny:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
-  only:
-    - schedules
-    - tags
-    - web
-  except:
-    variables:
-      - $CI_COMMIT_MESSAGE =~ /skip-checks/
+  rules:
+    - if: '$CI_COMMIT_MESSAGE =~ "/skip-checks/"'
+      when: never
+      # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
   after_script:
@@ -211,7 +209,7 @@ cargo-deny:
 cargo-check-benches:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   script:
     - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
     - cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small
@@ -221,7 +219,7 @@ cargo-check-benches:
 cargo-check-subkey:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   script:
     - cd ./bin/utils/subkey
     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
@@ -230,12 +228,17 @@ cargo-check-subkey:
 test-deterministic-wasm:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
   variables:
     <<:                            *default-vars
-  except:
-    variables:
-      - $DEPLOY_TAG
+  rules:
+    - if: $DEPLOY_TAG
+      when: never
+  # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     # build runtime
     - WASM_BUILD_NO_COLOR=1 cargo build --verbose --release -p node-runtime
@@ -252,7 +255,6 @@ test-deterministic-wasm:
 test-linux-stable:                 &test-linux
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -260,9 +262,15 @@ test-linux-stable:                 &test-linux
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
-  except:
-    variables:
-      - $DEPLOY_TAG
+  rules:
+    - if: $DEPLOY_TAG
+      when: never
+  # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
@@ -272,13 +280,15 @@ test-linux-stable:                 &test-linux
 unleash-check:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
-  only:
-    - master
-    - tags
-  except:
-    variables:
-      - $CI_COMMIT_MESSAGE =~ /skip-checks/
+  rules:
+    - if: '$CI_COMMIT_MESSAGE =~ "/skip-checks/"'
+      when: never
+      # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
@@ -287,16 +297,21 @@ test-frame-examples-compile-to-wasm:
   # into one job
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  rules:
+    - if: $DEPLOY_TAG
+      when: never
+  # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
     RUSTFLAGS: -Cdebug-assertions=y
     RUST_BACKTRACE: 1
-  except:
-    variables:
-      - $DEPLOY_TAG
   script:
     - cd frame/example-offchain-worker/
     - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
@@ -306,9 +321,6 @@ test-frame-examples-compile-to-wasm:
 
 test-linux-stable-int:
   <<:                              *test-linux
-  except:
-    variables:
-      - $DEPLOY_TAG
   script:
     - echo "___Logs will be partly shown at the end in case of failure.___"
     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
@@ -329,7 +341,7 @@ test-linux-stable-int:
 check-web-wasm:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   script:
     # WASM support is in progress. As more and more crates support WASM, we
     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
@@ -350,16 +362,21 @@ check-web-wasm:
 test-full-crypto-feature:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  rules:
+    - if: $DEPLOY_TAG
+      when: never
+  # .docker-env-rules
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
     RUSTFLAGS: -Cdebug-assertions=y
     RUST_BACKTRACE: 1
-  except:
-    variables:
-      - $DEPLOY_TAG
   script:
     - cd primitives/core/
     - time cargo +nightly build --verbose --no-default-features --features full_crypto
@@ -371,7 +388,7 @@ cargo-check-macos:
   stage:                           test
   # shell runner on mac ignores the image set in *docker-env
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   script:
     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
     - sccache -s
@@ -392,15 +409,15 @@ check-polkadot-companion-status:
   stage:                           build
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  only:
-    - /^[0-9]+$/                   # PRs
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                        # PRs
   script:
     - ./.maintain/gitlab/check_polkadot_companion_status.sh
 
 check-polkadot-companion-build:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   needs:
     - job:                         test-linux-stable-int
       artifacts:                   false
@@ -413,7 +430,7 @@ check-polkadot-companion-build:
 test-browser-node:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   needs:
     - job:                         check-web-wasm
       artifacts:                   false
@@ -457,8 +474,7 @@ build-linux-subkey:                &build-subkey
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *docker-env-only
-  <<:                              *build-only
+  <<:                              *build-rules
   needs:
     - job:                         cargo-check-subkey
       artifacts:                   false
@@ -479,16 +495,16 @@ build-linux-subkey:                &build-subkey
 
 build-macos-subkey:
   <<:                              *build-subkey
-  only:
-    - master
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'             # i.e. v1.0, v2.1rc1
   tags:
     - osx
 
 build-rust-doc:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-only
+  <<:                              *docker-env-rules
   allow_failure:                   true
   variables:
     <<:                            *default-vars
@@ -520,12 +536,14 @@ trigger-contracts-ci:
     project:                       parity/srml-contracts-waterfall
     branch:                        master
     strategy:                      depend
-  only:
-    - master
-    - schedules
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_COMMIT_REF_NAME == "master"'
 
 #### stage:                        docker
-docker-build-chaos:                &docker-build-chaos
+
+docker-build-chaos:
   <<:                              *chaos-only
   stage:                           docker
   needs:
@@ -594,7 +612,7 @@ chaos-test-singlenodeheight:
 #### stage:                        publish
 
 .build-push-docker-image:          &build-push-docker-image
-  <<:                              *build-only
+  <<:                              *build-rules
   <<:                              *kubernetes-build
   image:                           docker:stable
   services:
@@ -655,7 +673,7 @@ publish-docker-subkey:
 
 publish-s3-release:
   stage:                           publish
-  <<:                              *build-only
+  <<:                              *build-rules
   <<:                              *kubernetes-build
   needs:
     - job:                         build-linux-substrate
@@ -683,7 +701,7 @@ publish-s3-doc:
   needs:
     - job:                         build-rust-doc
       artifacts:                   true
-  <<:                              *build-only
+  <<:                              *build-rules
   <<:                              *kubernetes-build
   variables:
     GIT_STRATEGY:                  none
@@ -703,9 +721,9 @@ publish-s3-doc:
 publish-draft-release:
   stage:                           publish
   image:                           paritytech/tools:latest
-  only:
-    - /^ci-release-.*$/
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
   script:
     - ./.maintain/gitlab/publish_draft_release.sh
   allow_failure:                   true
@@ -713,10 +731,10 @@ publish-draft-release:
 publish-to-crates-io:
   stage:                           publish
   <<:                              *docker-env
-  <<:                              *docker-env-only
-  only:
-    - /^ci-release-.*$/
-    - /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+  <<:                              *docker-env-rules
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
@@ -741,25 +759,35 @@ deploy-kubernetes-alerting-rules:
     - echo "deploying prometheus alerting rules"
     - kubectl -n ${NAMESPACE} patch prometheusrule ${PROMETHEUSRULE}
         --type=merge --patch "$(sed 's/^/  /;1s/^/spec:\n/' ${RULES})"
-  only:
-    refs:
-      - master
-    changes:
-      - .gitlab-ci.yml
-      - .maintain/monitoring/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - changes:
+        - .gitlab-ci.yml
+        - .maintain/monitoring/
 
 
 
 .validator-deploy:                 &validator-deploy
-  <<:                              *build-only
   stage:                           flaming-fir
+  rules:
+    # .build-rules, but manual
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+      when: manual
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+      when: manual
+    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+      when: manual
+    - if: '$CI_COMMIT_REF_NAME =~ "/^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/"'  # i.e. pre-v1.0, pre-v2.1rc1
+      when: manual
+    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
+            && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
+      when: manual
   needs:
     # script will fail if there is no artifacts/substrate/VERSION
     - job:                         publish-docker-substrate
       artifacts:                   true
   image:                           parity/azure-ansible:v1
   allow_failure:                   true
-  when:                            manual
   interruptible:                   true
   tags:
     - linux-docker
@@ -790,7 +818,7 @@ check-labels:
   stage:                          .post
   image:                          paritytech/tools:latest
   <<:                             *kubernetes-build
-  only:
-    - /^[0-9]+$/
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                        # PRs
   script:
     - ./.maintain/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,13 +86,15 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .build-rules:                      &build-rules
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
     - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
@@ -182,11 +184,10 @@ cargo-deny:
   rules:
     - if: $CI_COMMIT_MESSAGE =~ /skip-checks/
       when: never
-      # .docker-env-rules
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
@@ -225,15 +226,16 @@ test-deterministic-wasm:
   <<:                              *docker-env-rules
   variables:
     <<:                            *default-vars
+    WASM_BUILD_NO_COLOR:           1
   script:
     # build runtime
-    - WASM_BUILD_NO_COLOR=1 cargo build --verbose --release -p node-runtime
+    - cargo build --verbose --release -p node-runtime
     # make checksum
     - sha256sum target/release/wbuild/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
     # clean up – FIXME: can we reuse some of the artifacts?
     - cargo clean
     # build again
-    - WASM_BUILD_NO_COLOR=1 cargo build --verbose --release -p node-runtime
+    - cargo build --verbose --release -p node-runtime
     # confirm checksum
     - sha256sum -c checksum.sha256
     - sccache -s
@@ -249,10 +251,11 @@ test-linux-stable:                 &test-linux
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
+    SUBSTRATE_TEST_TIMEOUT:        1
   script:
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    - WASM_BUILD_NO_COLOR=1 SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+    - time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
     - sccache -s
 
 unleash-check:
@@ -262,10 +265,8 @@ unleash-check:
     - if: $CI_COMMIT_MESSAGE =~ /skip-checks/
       when: never
       # .docker-env-rules
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
@@ -431,7 +432,6 @@ build-linux-substrate:             &build-binary
     - cp -r .maintain/docker/substrate.Dockerfile ./artifacts/substrate/
     - sccache -s
 
-
 build-linux-subkey:                &build-subkey
   stage:                           build
   <<:                              *collect-artifacts
@@ -544,6 +544,7 @@ docker-build-chaos:
     - docker logout
 
 #### stage:                        chaos
+
 chaos-test-singlenodeheight:
   <<:                              *chaos-only
   stage:                           chaos
@@ -655,7 +656,6 @@ publish-s3-release:
     - aws s3 ls s3://${BUCKET}/${PREFIX}/latest/
         --recursive --human-readable --summarize
 
-
 publish-s3-doc:
   stage:                           publish
   image:                           paritytech/awscli:latest
@@ -702,8 +702,6 @@ publish-to-crates-io:
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
   allow_failure:                   true
 
-
-
 deploy-kubernetes-alerting-rules:
   stage:                           deploy
   interruptible:                   true
@@ -726,8 +724,6 @@ deploy-kubernetes-alerting-rules:
     - changes:
         - .gitlab-ci.yml
         - .maintain/monitoring/
-
-
 
 .validator-deploy:                 &validator-deploy
   stage:                           flaming-fir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -705,13 +705,6 @@ publish-to-crates-io:
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
-    # .docker-env-rules
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == "tags"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,25 +83,25 @@ workflow:
 
 .docker-env-rules:                 &docker-env-rules
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .build-rules:                      &build-rules
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
-    - if: '$CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/'  # i.e. pre-v1.0, pre-v2.1rc1
-    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
 
 .chaos-only:                       &chaos-only
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
 
 #### stage:                       .pre
 
@@ -110,7 +110,7 @@ skip-if-draft:
   <<:                              *kubernetes-build
   stage:                           .pre
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
   script:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
@@ -124,7 +124,7 @@ check-runtime:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
   variables:
     <<:                            *default-vars
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
@@ -138,8 +138,8 @@ check-signed-tag:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
+    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/gitlab/check_signed.sh
 
@@ -148,7 +148,7 @@ check-line-width:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
   script:
     - ./.maintain/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -166,12 +166,12 @@ cargo-audit:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
       when: never
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo audit
   allow_failure:                   true
@@ -180,14 +180,14 @@ cargo-deny:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ /skip-checks/'
+    - if: $CI_COMMIT_MESSAGE =~ /skip-checks/
       when: never
       # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
   after_script:
@@ -259,14 +259,14 @@ unleash-check:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ /skip-checks/'
+    - if: $CI_COMMIT_MESSAGE =~ /skip-checks/
       when: never
       # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
@@ -372,7 +372,7 @@ check-polkadot-companion-status:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                        # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                        # PRs
   script:
     - ./.maintain/gitlab/check_polkadot_companion_status.sh
 
@@ -458,8 +458,8 @@ build-linux-subkey:                &build-subkey
 build-macos-subkey:
   <<:                              *build-subkey
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'             # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
   tags:
     - osx
 
@@ -499,9 +499,9 @@ trigger-contracts-ci:
     branch:                        master
     strategy:                      depend
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
 
 #### stage:                        docker
 
@@ -684,8 +684,8 @@ publish-draft-release:
   stage:                           publish
   image:                           paritytech/tools:latest
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
+    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - ./.maintain/gitlab/publish_draft_release.sh
   allow_failure:                   true
@@ -695,8 +695,8 @@ publish-to-crates-io:
   <<:                              *docker-env
   <<:                              *docker-env-rules
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
+    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
@@ -722,7 +722,7 @@ deploy-kubernetes-alerting-rules:
     - kubectl -n ${NAMESPACE} patch prometheusrule ${PROMETHEUSRULE}
         --type=merge --patch "$(sed 's/^/  /;1s/^/spec:\n/' ${RULES})"
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: $CI_COMMIT_REF_NAME == "master"
     - changes:
         - .gitlab-ci.yml
         - .maintain/monitoring/
@@ -733,16 +733,16 @@ deploy-kubernetes-alerting-rules:
   stage:                           flaming-fir
   rules:
     # .build-rules, but manual
-    - if: '$CI_COMMIT_REF_NAME == "master"'
+    - if: $CI_COMMIT_REF_NAME == "master"
       when: manual
-    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: $CI_PIPELINE_SOURCE == "web"
       when: manual
-    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
       when: manual
-    - if: '$CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/'  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
       when: manual
-    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
       when: manual
   needs:
     # script will fail if there is no artifacts/substrate/VERSION
@@ -781,6 +781,6 @@ check-labels:
   image:                          paritytech/tools:latest
   <<:                             *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                        # PRs
+    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                        # PRs
   script:
     - ./.maintain/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -438,7 +438,16 @@ build-linux-subkey:                &build-subkey
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-refs
+  rules:
+    # .build-refs with manual on PRs
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: manual
+      allow_failure: true
   needs:
     - job:                         cargo-check-subkey
       artifacts:                   false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@
 #   allow_failure:                   true # Allow the pipeline to continue if this job fails (default: false)
 #   needs:
 #   - job:                           test-linux # Any jobs that are required to run before this job (optional)
-#     - build-rust-doc 
+#     - build-rust-doc
 #   variables:
 #     MY_ENVIRONMENT_VARIABLE:       "some useful value" # Environment variables passed to the job (optional)
 #   script:
@@ -112,7 +112,7 @@ skip-if-draft:
   <<:                              *kubernetes-build
   stage:                           .pre
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
@@ -126,7 +126,7 @@ check-runtime:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   variables:
     <<:                            *default-vars
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
@@ -150,7 +150,7 @@ check-line-width:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
     - ./.maintain/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -251,11 +251,10 @@ test-linux-stable:                 &test-linux
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
-    SUBSTRATE_TEST_TIMEOUT:        1
   script:
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    - time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+    - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
     - sccache -s
 
 unleash-check:
@@ -373,7 +372,7 @@ check-polkadot-companion-status:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
     - ./.maintain/gitlab/check_polkadot_companion_status.sh
 
@@ -693,10 +692,16 @@ publish-draft-release:
 publish-to-crates-io:
   stage:                           publish
   <<:                              *docker-env
-  <<:                              *docker-env-rules
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+    # .docker-env-rules
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
@@ -777,6 +782,6 @@ check-labels:
   image:                          paritytech/tools:latest
   <<:                             *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   script:
     - ./.maintain/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -739,7 +739,7 @@ deploy-kubernetes-alerting-rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       changes:
         - .gitlab-ci.yml
-        - .maintain/monitoring/
+        - .maintain/monitoring/**/*
 
 .validator-deploy:                 &validator-deploy
   stage:                           flaming-fir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ stages:
   - test
   - build
   - post-build-test
-  - docker
+  - chaos-env
   - chaos
   - publish
   - deploy
@@ -81,7 +81,7 @@ workflow:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH
 
-.docker-env-rules:                 &docker-env-rules
+.test-refs:                        &test-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -90,20 +90,13 @@ workflow:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
-.build-rules:                      &build-rules
+.build-refs:                       &build-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
-    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
-
-.chaos-only:                       &chaos-only
-  rules:
-    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
 
 #### stage:                       .pre
 
@@ -204,7 +197,7 @@ cargo-deny:
 cargo-check-benches:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   script:
     - BUILD_DUMMY_WASM_BINARY=1 time cargo +nightly check --benches --all
     - cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small
@@ -214,7 +207,7 @@ cargo-check-benches:
 cargo-check-subkey:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   script:
     - cd ./bin/utils/subkey
     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
@@ -223,7 +216,7 @@ cargo-check-subkey:
 test-deterministic-wasm:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   variables:
     <<:                            *default-vars
     WASM_BUILD_NO_COLOR:           1
@@ -243,7 +236,7 @@ test-deterministic-wasm:
 test-linux-stable:                 &test-linux
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -263,7 +256,7 @@ unleash-check:
   rules:
     - if: $CI_COMMIT_MESSAGE =~ /skip-checks/
       when: never
-      # .docker-env-rules
+      # .test-refs
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
@@ -275,7 +268,7 @@ test-frame-examples-compile-to-wasm:
   # into one job
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -311,7 +304,7 @@ test-linux-stable-int:
 check-web-wasm:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   script:
     # WASM support is in progress. As more and more crates support WASM, we
     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
@@ -332,7 +325,7 @@ check-web-wasm:
 test-full-crypto-feature:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -350,7 +343,7 @@ cargo-check-macos:
   stage:                           test
   # shell runner on mac ignores the image set in *docker-env
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   script:
     - BUILD_DUMMY_WASM_BINARY=1 time cargo check --release
     - sccache -s
@@ -379,7 +372,7 @@ check-polkadot-companion-status:
 check-polkadot-companion-build:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   needs:
     - job:                         test-linux-stable-int
       artifacts:                   false
@@ -392,7 +385,7 @@ check-polkadot-companion-build:
 test-browser-node:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   needs:
     - job:                         check-web-wasm
       artifacts:                   false
@@ -409,16 +402,16 @@ build-linux-substrate:             &build-binary
   <<:                              *collect-artifacts
   <<:                              *docker-env
   rules:
-    # .build-rules with manual on PRs
+    # .build-refs with manual on PRs and chaos
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
-    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
+      allow_failure: true
   needs:
     - job:                         test-linux-stable
       artifacts:                   false
@@ -445,7 +438,7 @@ build-linux-subkey:                &build-subkey
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-rules
+  <<:                              *build-refs
   needs:
     - job:                         cargo-check-subkey
       artifacts:                   false
@@ -475,7 +468,7 @@ build-macos-subkey:
 build-rust-doc:
   stage:                           build
   <<:                              *docker-env
-  <<:                              *docker-env-rules
+  <<:                              *test-refs
   allow_failure:                   true
   variables:
     <<:                            *default-vars
@@ -512,11 +505,18 @@ trigger-contracts-ci:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
 
-#### stage:                        docker
+#### stage:                        chaos-env
 
-docker-build-chaos:
-  <<:                              *chaos-only
-  stage:                           docker
+build-chaos-docker:
+  stage:                           chaos-env
+  rules:
+    # .build-refs with chaos
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
   needs:
     - job:                         build-linux-substrate
   image:                           docker:stable
@@ -555,11 +555,18 @@ docker-build-chaos:
 #### stage:                        chaos
 
 chaos-test-singlenodeheight:
-  <<:                              *chaos-only
   stage:                           chaos
+  rules:
+    # .build-refs with chaos
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
   image:                           parity/chaostools:latest
   needs:
-    - job:                         docker-build-chaos
+    - job:                         build-chaos-docker
   tags:
     - parity-chaos
   variables:
@@ -584,7 +591,7 @@ chaos-test-singlenodeheight:
 #### stage:                        publish
 
 .build-push-docker-image:          &build-push-docker-image
-  <<:                              *build-rules
+  <<:                              *build-refs
   <<:                              *kubernetes-build
   image:                           docker:stable
   services:
@@ -645,7 +652,7 @@ publish-docker-subkey:
 
 publish-s3-release:
   stage:                           publish
-  <<:                              *build-rules
+  <<:                              *build-refs
   <<:                              *kubernetes-build
   needs:
     - job:                         build-linux-substrate
@@ -672,7 +679,7 @@ publish-s3-doc:
   needs:
     - job:                         build-rust-doc
       artifacts:                   true
-  <<:                              *build-rules
+  <<:                              *build-refs
   <<:                              *kubernetes-build
   variables:
     GIT_STRATEGY:                  none
@@ -729,14 +736,14 @@ deploy-kubernetes-alerting-rules:
         --type=merge --patch "$(sed 's/^/  /;1s/^/spec:\n/' ${RULES})"
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
-    - changes:
+      changes:
         - .gitlab-ci.yml
         - .maintain/monitoring/
 
 .validator-deploy:                 &validator-deploy
   stage:                           flaming-fir
   rules:
-    # .build-rules, but manual
+    # .build-refs, but manual
     - if: $CI_COMMIT_REF_NAME == "master"
       when: manual
     - if: $CI_PIPELINE_SOURCE == "web"
@@ -744,9 +751,6 @@ deploy-kubernetes-alerting-rules:
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
-      when: manual
-    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
-            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
       when: manual
   needs:
     # script will fail if there is no artifacts/substrate/VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,8 +11,9 @@
 #   stage:                           test # One of the stages listed below this job (required)
 #   image:                           paritytech/tools:latest # Any docker image (required)
 #   allow_failure:                   true # Allow the pipeline to continue if this job fails (default: false)
-#   dependencies:
-#     - build-rust-doc # Any jobs that are required to run before this job (optional)
+#   needs:
+#   - job:                           test-linux # Any jobs that are required to run before this job (optional)
+#     - build-rust-doc 
 #   variables:
 #     MY_ENVIRONMENT_VARIABLE:       "some useful value" # Environment variables passed to the job (optional)
 #   script:
@@ -85,7 +86,8 @@ workflow:
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    # - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME == "7229"'                         # PRs
     - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
 
 .build-rules:                      &build-rules

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,23 +86,22 @@ workflow:
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    # - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME == "7229"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
 
 .build-rules:                      &build-rules
   rules:
     - if: '$CI_COMMIT_REF_NAME == "master"'
     - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
-    - if: '$CI_COMMIT_REF_NAME =~ "/^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/"'  # i.e. pre-v1.0, pre-v2.1rc1
-    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
-           && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/'  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
 
 .chaos-only:                       &chaos-only
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
-           && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
+    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+           && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
 
 #### stage:                       .pre
 
@@ -111,7 +110,7 @@ skip-if-draft:
   <<:                              *kubernetes-build
   stage:                           .pre
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
   script:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
@@ -125,7 +124,7 @@ check-runtime:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
   variables:
     <<:                            *default-vars
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
@@ -139,8 +138,8 @@ check-signed-tag:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
   script:
     - ./.maintain/gitlab/check_signed.sh
 
@@ -149,7 +148,7 @@ check-line-width:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'     # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'     # PRs
   script:
     - ./.maintain/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -167,12 +166,12 @@ cargo-audit:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
       when: never
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
   script:
     - cargo audit
   allow_failure:                   true
@@ -181,14 +180,14 @@ cargo-deny:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ "/skip-checks/"'
+    - if: '$CI_COMMIT_MESSAGE =~ /skip-checks/'
       when: never
       # .docker-env-rules
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
   script:
     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
   after_script:
@@ -260,14 +259,14 @@ unleash-check:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: '$CI_COMMIT_MESSAGE =~ "/skip-checks/"'
+    - if: '$CI_COMMIT_MESSAGE =~ /skip-checks/'
       when: never
       # .docker-env-rules
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                         # PRs
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
@@ -373,7 +372,7 @@ check-polkadot-companion-status:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                        # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                        # PRs
   script:
     - ./.maintain/gitlab/check_polkadot_companion_status.sh
 
@@ -460,7 +459,7 @@ build-macos-subkey:
   <<:                              *build-subkey
   rules:
     - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'             # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'             # i.e. v1.0, v2.1rc1
   tags:
     - osx
 
@@ -685,8 +684,8 @@ publish-draft-release:
   stage:                           publish
   image:                           paritytech/tools:latest
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
   script:
     - ./.maintain/gitlab/publish_draft_release.sh
   allow_failure:                   true
@@ -696,8 +695,8 @@ publish-to-crates-io:
   <<:                              *docker-env
   <<:                              *docker-env-rules
   rules:
-    - if: '$CI_COMMIT_REF_NAME =~ "/^ci-release-.*$/"'
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+\.[0-9]+.*$/"'
+    - if: '$CI_COMMIT_REF_NAME =~ /^ci-release-.*$/'
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/'
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
@@ -738,12 +737,12 @@ deploy-kubernetes-alerting-rules:
       when: manual
     - if: '$CI_PIPELINE_SOURCE == "web"'
       when: manual
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/'              # i.e. v1.0, v2.1rc1
       when: manual
-    - if: '$CI_COMMIT_REF_NAME =~ "/^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/"'  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: '$CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/'  # i.e. pre-v1.0, pre-v2.1rc1
       when: manual
-    - if: '$CI_COMMIT_MESSAGE =~ "/\[chaos:(basic|medium|large)\]/"
-            && $CI_COMMIT_REF_NAME =~ "/^[0-9]+$/"'  # i.e add [chaos:basic] in commit message to trigger
+    - if: '$CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/'  # i.e add [chaos:basic] in commit message to trigger
       when: manual
   needs:
     # script will fail if there is no artifacts/substrate/VERSION
@@ -782,6 +781,6 @@ check-labels:
   image:                          paritytech/tools:latest
   <<:                             *kubernetes-build
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                        # PRs
+    - if: '$CI_COMMIT_REF_NAME == /^[0-9]+$/'                        # PRs
   script:
     - ./.maintain/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,10 +76,10 @@ default:
   tags:
     - linux-docker
 
-workflow:
-  rules:
-    - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH
+# workflow:
+#   rules:
+#     - if: $CI_COMMIT_TAG
+#     - if: $CI_COMMIT_BRANCH
 
 .docker-env-rules:                 &docker-env-rules
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,6 @@
 # substrate
 #
 # pipelines can be triggered manually in the web
-# setting DEPLOY_TAG will only deploy the tagged image
 
 # SAMPLE JOB TEMPLATE - This is not a complete example but is enough to build a
 # simple CI job. For full documentation, visit https://docs.gitlab.com/ee/ci/yaml/
@@ -91,8 +90,6 @@ workflow:
 
 .build-rules:                      &build-rules
   rules:
-    - if: '$DEPLOY_TAG'
-      when: never
     - if: '$CI_COMMIT_REF_NAME == "master"'
     - if: '$CI_PIPELINE_SOURCE == "web"'
     - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
@@ -117,7 +114,6 @@ skip-if-draft:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
      - echo "pipeline source is ${CI_PIPELINE_SOURCE}"
-     - echo "deploy tag is ${DEPLOY_TAG}"
      - ./.maintain/gitlab/skip_if_draft.sh
 
 #### stage:                        check
@@ -160,9 +156,6 @@ test-dependency-rules:
   stage:                           check
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
-  rules:
-    - if: $DEPLOY_TAG
-      when: never
   script:
     - .maintain/ensure-deps.sh
 
@@ -228,17 +221,9 @@ cargo-check-subkey:
 test-deterministic-wasm:
   stage:                           test
   <<:                              *docker-env
+  <<:                              *docker-env-rules
   variables:
     <<:                            *default-vars
-  rules:
-    - if: $DEPLOY_TAG
-      when: never
-  # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     # build runtime
     - WASM_BUILD_NO_COLOR=1 cargo build --verbose --release -p node-runtime
@@ -255,6 +240,7 @@ test-deterministic-wasm:
 test-linux-stable:                 &test-linux
   stage:                           test
   <<:                              *docker-env
+  <<:                              *docker-env-rules
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -262,15 +248,6 @@ test-linux-stable:                 &test-linux
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
     RUST_BACKTRACE:                1
     WASM_BUILD_NO_COLOR:           1
-  rules:
-    - if: $DEPLOY_TAG
-      when: never
-  # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
   script:
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
@@ -297,15 +274,7 @@ test-frame-examples-compile-to-wasm:
   # into one job
   stage:                           test
   <<:                              *docker-env
-  rules:
-    - if: $DEPLOY_TAG
-      when: never
-  # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+  <<:                              *docker-env-rules
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
@@ -362,15 +331,7 @@ check-web-wasm:
 test-full-crypto-feature:
   stage:                           test
   <<:                              *docker-env
-  rules:
-    - if: $DEPLOY_TAG
-      when: never
-  # .docker-env-rules
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-    - if: '$CI_COMMIT_REF_NAME == "/^[0-9]+$/"'                         # PRs
-    - if: '$CI_COMMIT_REF_NAME =~ "/^v[0-9]+\.[0-9]+.*$/"'              # i.e. v1.0, v2.1rc1
+  <<:                              *docker-env-rules
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,17 +76,17 @@ default:
   tags:
     - linux-docker
 
-# workflow:
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#     - if: $CI_COMMIT_BRANCH
+workflow:
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH
 
 .docker-env-rules:                 &docker-env-rules
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .build-rules:                      &build-rules
@@ -110,7 +110,7 @@ skip-if-draft:
   <<:                              *kubernetes-build
   stage:                           .pre
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
   script:
      - echo "Commit message is ${CI_COMMIT_MESSAGE}"
      - echo "Ref is ${CI_COMMIT_REF_NAME}"
@@ -124,7 +124,7 @@ check-runtime:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
   variables:
     <<:                            *default-vars
     GITLAB_API:                    "https://gitlab.parity.io/api/v4"
@@ -148,7 +148,7 @@ check-line-width:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/     # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/     # PRs
   script:
     - ./.maintain/gitlab/check_line_width.sh
   allow_failure:                   true
@@ -166,7 +166,7 @@ cargo-audit:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: never
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -186,7 +186,7 @@ cargo-deny:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
@@ -265,7 +265,7 @@ unleash-check:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
@@ -372,7 +372,7 @@ check-polkadot-companion-status:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                        # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
   script:
     - ./.maintain/gitlab/check_polkadot_companion_status.sh
 
@@ -781,6 +781,6 @@ check-labels:
   image:                          paritytech/tools:latest
   <<:                             *kubernetes-build
   rules:
-    - if: $CI_COMMIT_REF_NAME == /^[0-9]+$/                        # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
   script:
     - ./.maintain/gitlab/check_labels.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,7 +96,6 @@ workflow:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
 
 #### stage:                       .pre
 
@@ -407,7 +406,6 @@ build-linux-substrate:             &build-binary
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
     - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
@@ -444,7 +442,6 @@ build-linux-subkey:                &build-subkey
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: manual
       allow_failure: true
@@ -524,7 +521,6 @@ build-chaos-docker:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
     - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
   needs:
     - job:                         build-linux-substrate
@@ -571,7 +567,6 @@ chaos-test-singlenodeheight:
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
     - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/ && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
   image:                           parity/chaostools:latest
   needs:
@@ -758,8 +753,6 @@ deploy-kubernetes-alerting-rules:
     - if: $CI_PIPELINE_SOURCE == "web"
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: manual
-    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
       when: manual
   needs:
     # script will fail if there is no artifacts/substrate/VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,7 @@
 #   image:                           paritytech/tools:latest # Any docker image (required)
 #   allow_failure:                   true # Allow the pipeline to continue if this job fails (default: false)
 #   needs:
-#   - job:                           test-linux # Any jobs that are required to run before this job (optional)
-#     - build-rust-doc
+#     - job:                         test-linux # Any jobs that are required to run before this job (optional)
 #   variables:
 #     MY_ENVIRONMENT_VARIABLE:       "some useful value" # Environment variables passed to the job (optional)
 #   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -465,9 +465,6 @@ build-linux-subkey:                &build-subkey
 
 build-macos-subkey:
   <<:                              *build-subkey
-  rules:
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/             # i.e. v1.0, v2.1rc1
   tags:
     - osx
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -408,7 +408,17 @@ build-linux-substrate:             &build-binary
   stage:                           build
   <<:                              *collect-artifacts
   <<:                              *docker-env
-  <<:                              *build-rules
+  rules:
+    # .build-rules with manual on PRs
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_REF_NAME =~ /^pre-v[0-9]+\.[0-9]+-[0-9a-f]+$/  # i.e. pre-v1.0, pre-v2.1rc1
+    - if: $CI_COMMIT_MESSAGE =~ /\[chaos:(basic|medium|large)\]/
+            && $CI_COMMIT_REF_NAME =~ /^[0-9]+$/  # i.e add [chaos:basic] in commit message to trigger
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      when: manual
   needs:
     - job:                         test-linux-stable
       artifacts:                   false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.51"
+version = "0.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f085725a5828d7e959f014f624773094dfe20acc91be310ef106923c30594bc"
+checksum = "832bac18a82ec7d6c21887daa8616b238fe90d5d5e762d0d4b9372cdaa9e097f"
 dependencies = [
  "arbitrary",
  "lazy_static",


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/1769

- changes somewhat broken/deprecated `only` and `accept` keys to not very readable `rules`. The upside is without `only`, DAGs will be accessible.
- removes unused `DEPLOY_TAG`
- build binaries for substrate and subkey (both mac and linux) is now manually available in PRs

example of a pipeline for a regular PR https://gitlab.parity.io/parity/substrate/-/pipelines/109099
example of a pipeline with `[chaos:basic]` in commit text https://gitlab.parity.io/parity/substrate/-/pipelines/109101