### PR TITLE
No longer display the legacy representation of the PeerId

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -59,7 +59,7 @@ use sp_runtime::{
 };
 use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnboundedSender};
 use std::{
-	borrow::{Borrow, Cow},
+	borrow::Cow,
 	collections::{HashMap, HashSet},
 	fs,
 	marker::PhantomData,
@@ -233,12 +233,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		let local_identity = params.network_config.node_key.clone().into_keypair()?;
 		let local_public = local_identity.public();
 		let local_peer_id = local_public.clone().into_peer_id();
-		let local_peer_id_legacy = bs58::encode(Borrow::<[u8]>::borrow(&local_peer_id)).into_string();
 		info!(
 			target: "sub-libp2p",
-			"🏷 Local node identity is: {} (legacy representation: {})",
+			"🏷 Local node identity is: {}",
 			local_peer_id.to_base58(),
-			local_peer_id_legacy
 		);
 
 		let checker = params.on_demand.as_ref()


### PR DESCRIPTION
Despite #7077, I thought it might still be useful to see the legacy representation of the `PeerId`.

However, since `Borrow::borrow` no longer returns a hashed version of the `PeerId`, the log message touched in this PR ends up printing the same string twice.

Rather than going through complicated means to properly show the legacy `PeerId`, I propose to just remove it.
