### PR TITLE
WIP: Automatic Validator count adjust with dampening

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -416,6 +416,7 @@ parameter_types! {
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const MaxIterations: u32 = 10;
+	pub const AdjustValidatorCount: bool = false;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
 	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
 }
@@ -445,6 +446,7 @@ impl pallet_staking::Trait for Runtime {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+	type ValidatorCountAdjust = AdjustValidatorCount;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type WeightInfo = ();
 }

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -416,7 +416,7 @@ parameter_types! {
 	pub const MaxNominatorRewardedPerValidator: u32 = 64;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const MaxIterations: u32 = 10;
-	pub const AdjustValidatorCount: bool = false;
+	pub const ValidatorCountAdjust: bool = false;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.
 	pub MinSolutionScoreBump: Perbill = Perbill::from_rational_approximation(5u32, 10_000);
 }
@@ -446,7 +446,7 @@ impl pallet_staking::Trait for Runtime {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
-	type ValidatorCountAdjust = AdjustValidatorCount;
+	type ValidatorCountAdjust = ValidatorCountAdjust;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type WeightInfo = ();
 }

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -193,6 +193,7 @@ impl pallet_staking::Trait for Test {
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = ();
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
+	type ValidatorCountAdjust = ();
 	type UnsignedPriority = ();
 	type WeightInfo = ();
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2917,9 +2917,6 @@ impl<T: Trait> Module<T> {
 
 			if T::ValidatorCountAdjust::get() {
 				let new_validator_count = Self::update_target_validators(exposure_totals);
-				sp_std::if_std!{
-					println!("New validator count: {}", new_validator_count);
-				}
 				ValidatorCount::put(new_validator_count);
 			}
 			// Insert current era staking information
@@ -3164,8 +3161,8 @@ impl<T: Trait> Module<T> {
 		if one_percent_average > Percent::from_percent(40) * global_average {
 			return (current_validator_count + one_percent_count).min(MaximumValidatorCount::get())
 		} else if current_validator_count > 1 {
-			let two_percent_count = one_percent_count.saturating_mul(2);
-			let two_percent_average = average(&exposures[0..(two_percent_count as usize)]);
+			let one_percent_times_two_count = one_percent_count.saturating_mul(2);
+			let two_percent_average = average(&exposures[0..(one_percent_times_two_count as usize)]);
 			// Rule 2: If the bottom 2% of validators (more precisely, 2 ceil(0.01 k) validators) have
 			// an average stake value strictly below 20% of the global average, in the next era decrease
 			// the number of active validators by 1%, i.e. k <-- max{min_limit, k - ceil(0.01 k)}.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3148,7 +3148,7 @@ impl<T: Trait> Module<T> {
 		};
 		// Current validator count should never be zero.
 		let current_validator_count = Self::validator_count().max(1);
-		let one_percent_count = (1 + (current_validator_count - 1) / 100);
+		let one_percent_count = 1 + (current_validator_count - 1) / 100;
 		let global_average = average(&exposures);
 		// Sort exposures by balance
 		exposures.sort();
@@ -3159,8 +3159,8 @@ impl<T: Trait> Module<T> {
 		let one_percent_average = average(&exposures[0..(one_percent_count as usize)]);
 		if one_percent_average > Percent::from_percent(40) * global_average {
 			return (current_validator_count + one_percent_count).min(MaximumValidatorCount::get())
-		} else {
-			let two_percent_count = (1 + (current_validator_count - 1) / 50);
+		} else if current_validator_count > 1 {
+			let two_percent_count = one_percent_count.saturating_mul(2);
 			let two_percent_average = average(&exposures[0..(two_percent_count as usize)]);
 			// Rule 2: If the bottom 2% of validators (more precisely, 2 ceil(0.01 k) validators) have
 			// an average stake value strictly below 20% of the global average, in the next era decrease

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3142,10 +3142,11 @@ impl<T: Trait> Module<T> {
 	/// Use a damping function to update the target number of validators for the next selection.
 	fn update_target_validators(mut exposure_totals: Vec<BalanceOf<T>>) -> u32 {
 		let average = |all: &[BalanceOf<T>]| -> BalanceOf<T> {
+			let all_len = all.len().max(1) as u32;
 			all.iter().fold(Zero::zero(), |total: BalanceOf<T>, x: &BalanceOf<T>| {
-				// `total` should never saturate since total issuance fits inside `Balance`
+				// `total` should never saturate since total issuance fits inside `Balance`		
 				total.saturating_add(*x)
-			}) / BalanceOf::<T>::saturated_from(all.len() as u128)
+			}) / BalanceOf::<T>::from(all_len)
 		};
 		// Current validator count should never be zero.
 		let current_validator_count = Self::validator_count().max(1);

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3148,7 +3148,7 @@ impl<T: Trait> Module<T> {
 		};
 		// Current validator count should never be zero.
 		let current_validator_count = Self::validator_count().max(1);
-		let one_percent_count = (current_validator_count / 100).max(1);
+		let one_percent_count = (1 + (current_validator_count - 1) / 100);
 		let global_average = average(&exposures);
 		// Sort exposures by balance
 		exposures.sort();
@@ -3160,7 +3160,7 @@ impl<T: Trait> Module<T> {
 		if one_percent_average > Percent::from_percent(40) * global_average {
 			return (current_validator_count + one_percent_count).min(MaximumValidatorCount::get())
 		} else {
-			let two_percent_count = (current_validator_count / 50).max(1);
+			let two_percent_count = (1 + (current_validator_count - 1) / 50);
 			let two_percent_average = average(&exposures[0..(two_percent_count as usize)]);
 			// Rule 2: If the bottom 2% of validators (more precisely, 2 ceil(0.01 k) validators) have
 			// an average stake value strictly below 20% of the global average, in the next era decrease

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -973,6 +973,9 @@ pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// their reward. This used to limit the i/o cost for the nominator payout.
 	type MaxNominatorRewardedPerValidator: Get<u32>;
 
+	/// Automaticly adjust the validator count.
+	type ValidatorCountAdjust: Get<bool>;
+
 	/// A configuration for base priority of unsigned transactions.
 	///
 	/// This is exposed so that it can be tuned for particular runtime, when
@@ -2912,12 +2915,13 @@ impl<T: Trait> Module<T> {
 				<ErasStakersClipped<T>>::insert(&current_era, &stash, exposure_clipped);
 			});
 
-			let new_validator_count = Self::update_target_validators(exposure_totals);
-			sp_std::if_std!{
-				println!("New validator count: {}", new_validator_count);
+			if T::ValidatorCountAdjust::get() {
+				let new_validator_count = Self::update_target_validators(exposure_totals);
+				sp_std::if_std!{
+					println!("New validator count: {}", new_validator_count);
+				}
+				ValidatorCount::put(new_validator_count);
 			}
-			// ValidatorCount::put(new_validator_count);
-
 			// Insert current era staking information
 			<ErasTotalStake<T>>::insert(&current_era, total_stake);
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -357,14 +357,64 @@ fn maximum_validator_set() {
 }
 
 #[test]
-fn validator_adjust() {
+fn validator_adjust_up() {
 	ExtBuilder::default()
 		.minimum_validator_count(1)
 		.maximum_validator_count(4)
+		.has_stakers(false)
 		.validator_adjust(true)
+		.validator_count(2)
 		.build()
 		.execute_with(|| {
-			bond_validator(8,9,1000 as Balance);
+			let balance_1 = 1000;
+			let balance_2 = 2000;
+		    // Validator count was 2 make it so it is adjusted to 3, 1% is above 40% average exposure
+			bond_validator(11, 10, balance_1); 
+			bond_validator(21, 20, balance_2);
+			mock::start_era(1); //adjust count
+			assert_eq!(Staking::validator_count(), 3);
+		})
+}
+
+#[test]
+fn validator_adjust_down() {
+	ExtBuilder::default()
+		.minimum_validator_count(1)
+		.maximum_validator_count(4)
+		.has_stakers(false)
+		.validator_adjust(true)
+		.validator_count(3)
+		.build()
+		.execute_with(|| {
+			let balance_1 = 100;
+			let balance_2 = 200;
+			let balance_3 = 3000;
+		    // Validator count was 3 make it so it is adjusted to 2, 2*1% is below 20% average exposure
+			bond_validator(11, 10, balance_1); 
+			bond_validator(21, 20, balance_2);
+			bond_validator(31, 30, balance_3);
+			mock::start_era(1); //adjust count
+			assert_eq!(Staking::validator_count(), 2);
+		})
+}
+
+#[test]
+fn validator_no_adjust() {
+	ExtBuilder::default()
+		.minimum_validator_count(1)
+		.maximum_validator_count(4)
+		.has_stakers(false)
+		.validator_adjust(true)
+		.validator_count(2)
+		.build()
+		.execute_with(|| {
+			let balance_1 = 500;
+			let balance_2 = 2000;
+		    // Validator count is 2 but no adjustments should be made.
+			bond_validator(11, 10, balance_1); 
+			bond_validator(21, 20, balance_2);
+			mock::start_era(1); //adjust count
+			assert_eq!(Staking::validator_count(), 2);
 		})
 }
 

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -346,15 +346,6 @@ fn staking_should_work() {
 		});
 }
 
-#[test]
-fn maximum_validator_set() {
-	ExtBuilder::default()
-		.maximum_validator_count(4)
-		.build()
-		.execute_with(|| {
-			assert_eq!(Staking::maximum_validator_count(), 4);
-		});
-}
 
 #[test]
 fn validator_adjust_up() {

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -347,6 +347,28 @@ fn staking_should_work() {
 }
 
 #[test]
+fn maximum_validator_set() {
+	ExtBuilder::default()
+		.maximum_validator_count(4)
+		.build()
+		.execute_with(|| {
+			assert_eq!(Staking::maximum_validator_count(), 4);
+		});
+}
+
+#[test]
+fn validator_adjust() {
+	ExtBuilder::default()
+		.minimum_validator_count(1)
+		.maximum_validator_count(4)
+		.validator_adjust(true)
+		.build()
+		.execute_with(|| {
+			bond_validator(8,9,1000 as Balance);
+		})
+}
+
+#[test]
 fn less_than_needed_candidates_works() {
 	ExtBuilder::default()
 		.minimum_validator_count(1)


### PR DESCRIPTION
This PR build on top of the previous work of @shawntabrizi. It implements the features in #6997. The goal is to have an automatic adjustment of the validator count when a new era starts if certain conditions are matched.
It also adds a flag to turn on/off the use of the dampening function and it adds an extra MaxValidatorCount storage item.
On top of that I added mocks and a few tests, to test the basic functioning of the dampening function.

I think a few test could be added so it would be helpfull if someone can add them. Also validation of the rules is still needed.