### PR TITLE
Improve Payout Benchmarks in Staking

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -436,7 +436,7 @@ parameter_types! {
 	pub const BondingDuration: pallet_staking::EraIndex = 24 * 28;
 	pub const SlashDeferDuration: pallet_staking::EraIndex = 24 * 7; // 1/4 the bonding duration.
 	pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
-	pub const MaxNominatorRewardedPerValidator: u32 = 64;
+	pub const MaxNominatorRewardedPerValidator: u32 = 256;
 	pub const ElectionLookahead: BlockNumber = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const MaxIterations: u32 = 10;
 	// 0.05%. The higher the value, the more strict solution acceptance becomes.

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -71,7 +71,12 @@ benchmarks! {
 
 	purge_keys {
 		let n = MAX_NOMINATIONS as u32;
-		let (v_stash, _) = create_validator_with_nominators::<T>(n, MAX_NOMINATIONS as u32, false, RewardDestination::Staked)?;
+		let (v_stash, _) = create_validator_with_nominators::<T>(
+			n,
+			MAX_NOMINATIONS as u32,
+			false,
+			RewardDestination::Staked
+		)?;
 		let v_controller = pallet_staking::Module::<T>::bonded(&v_stash).ok_or("not stash")?;
 		let keys = T::Keys::default();
 		let proof: Vec<u8> = vec![0,1,2,3];

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -55,7 +55,7 @@ benchmarks! {
 
 	set_keys {
 		let n = MAX_NOMINATIONS as u32;
-		let (v_stash, _) = create_validator_with_nominators::<T>(
+		let v_stash = create_validator_with_nominators::<T>(
 			n,
 			MAX_NOMINATIONS as u32,
 			false,
@@ -71,7 +71,7 @@ benchmarks! {
 
 	purge_keys {
 		let n = MAX_NOMINATIONS as u32;
-		let (v_stash, _) = create_validator_with_nominators::<T>(n, MAX_NOMINATIONS as u32, false, RewardDestination::Staked)?;
+		let v_stash = create_validator_with_nominators::<T>(n, MAX_NOMINATIONS as u32, false, RewardDestination::Staked)?;
 		let v_controller = pallet_staking::Module::<T>::bonded(&v_stash).ok_or("not stash")?;
 		let keys = T::Keys::default();
 		let proof: Vec<u8> = vec![0,1,2,3];

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -55,7 +55,7 @@ benchmarks! {
 
 	set_keys {
 		let n = MAX_NOMINATIONS as u32;
-		let v_stash = create_validator_with_nominators::<T>(
+		let (v_stash, _) = create_validator_with_nominators::<T>(
 			n,
 			MAX_NOMINATIONS as u32,
 			false,
@@ -71,7 +71,7 @@ benchmarks! {
 
 	purge_keys {
 		let n = MAX_NOMINATIONS as u32;
-		let v_stash = create_validator_with_nominators::<T>(n, MAX_NOMINATIONS as u32, false, RewardDestination::Staked)?;
+		let (v_stash, _) = create_validator_with_nominators::<T>(n, MAX_NOMINATIONS as u32, false, RewardDestination::Staked)?;
 		let v_controller = pallet_staking::Module::<T>::bonded(&v_stash).ok_or("not stash")?;
 		let keys = T::Keys::default();
 		let proof: Vec<u8> = vec![0,1,2,3];

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -46,13 +46,13 @@ fn add_slashing_spans<T: Trait>(who: &T::AccountId, spans: u32) {
 }
 
 // This function generates one validator being nominated by n nominators, and returns the validator
-// stash account and the nominators' stash and controller. It also starts an era and creates pending payouts.
+// stash account. It also starts an era and creates pending payouts.
 pub fn create_validator_with_nominators<T: Trait>(
 	n: u32,
 	upper_bound: u32,
 	dead: bool,
 	destination: RewardDestination<T::AccountId>
-) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
+) -> Result<T::AccountId, &'static str> {
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
@@ -66,18 +66,15 @@ pub fn create_validator_with_nominators<T: Trait>(
 	points_total += 10;
 	points_individual.push((v_stash.clone(), 10));
 
-	let mut nominators = Vec::new();
-
 	// Give the validator n nominators, but keep total users in the system the same.
 	for i in 0 .. upper_bound {
-		let (n_stash, n_controller) = if !dead {
+		let (_n_stash, n_controller) = if !dead {
 			create_stash_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		} else {
 			create_stash_and_dead_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		};
 		if i < n {
 			Staking::<T>::nominate(RawOrigin::Signed(n_controller.clone()).into(), vec![stash_lookup.clone()])?;
-			nominators.push((n_stash, n_controller));
 		}
 	}
 
@@ -103,7 +100,7 @@ pub fn create_validator_with_nominators<T: Trait>(
 		.saturating_mul(1000.into());
 	<ErasValidatorReward<T>>::insert(current_era, total_payout);
 
-	Ok((v_stash, nominators))
+	Ok(v_stash)
 }
 
 const USER_SEED: u32 = 999666;
@@ -285,7 +282,7 @@ benchmarks! {
 
 	payout_stakers_dead_controller {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let (validator, nominators) = create_validator_with_nominators::<T>(
+		let validator = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			true,
@@ -299,10 +296,6 @@ benchmarks! {
 		let caller = whitelisted_caller();
 		let validator_controller = <Bonded<T>>::get(&validator).unwrap();
 		let balance_before = T::Currency::free_balance(&validator_controller);
-		for (_, controller) in &nominators {
-			let balance = T::Currency::free_balance(&controller);
-			assert!(balance.is_zero(), "Controller has balance, but should be dead.");
-		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator_controller);
@@ -311,16 +304,11 @@ benchmarks! {
 			"Balance of controller {:?} should have increased after payout.",
 			validator,
 		);
-
-		for (_, controller) in &nominators {
-			let balance = T::Currency::free_balance(&controller);
-			assert!(!balance.is_zero(), "Payout not given to controller.");
-		}
 	}
 
 	payout_stakers_alive_staked {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let (validator, nominators) = create_validator_with_nominators::<T>(
+		let validator = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			false,
@@ -333,11 +321,6 @@ benchmarks! {
 
 		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);
-		let mut nominator_balances_before = Vec::new();
-		for (stash, _) in &nominators {
-			let balance = T::Currency::free_balance(&stash);
-			nominator_balances_before.push(balance);
-		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator);
@@ -346,14 +329,6 @@ benchmarks! {
 			"Balance of stash {:?} should have increased after payout.",
 			validator,
 		);
-		for ((stash, _), balance_before) in nominators.iter().zip(nominator_balances_before.iter()) {
-			let balance_after = T::Currency::free_balance(&stash);
-			assert!(
-				balance_before < &balance_after,
-				"Balance of nominator stash {:?} should have increased after payout.",
-				stash,
-			);
-		}
 	}
 
 	rebond {
@@ -727,14 +702,12 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let (validator_stash, nominators) = create_validator_with_nominators::<Test>(
+			let validator_stash = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,
 				RewardDestination::Staked,
 			).unwrap();
-
-			assert_eq!(nominators.len() as u32, n);
 
 			let current_era = CurrentEra::get().unwrap();
 
@@ -751,7 +724,7 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let (validator_stash, _nominators) = create_validator_with_nominators::<Test>(
+			let validator_stash = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -46,13 +46,13 @@ fn add_slashing_spans<T: Trait>(who: &T::AccountId, spans: u32) {
 }
 
 // This function generates one validator being nominated by n nominators, and returns the validator
-// stash account. It also starts an era and creates pending payouts.
+// stash account and the nominators' stash and controller. It also starts an era and creates pending payouts.
 pub fn create_validator_with_nominators<T: Trait>(
 	n: u32,
 	upper_bound: u32,
 	dead: bool,
 	destination: RewardDestination<T::AccountId>
-) -> Result<T::AccountId, &'static str> {
+) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
@@ -66,15 +66,18 @@ pub fn create_validator_with_nominators<T: Trait>(
 	points_total += 10;
 	points_individual.push((v_stash.clone(), 10));
 
+	let mut nominators = Vec::new();
+
 	// Give the validator n nominators, but keep total users in the system the same.
 	for i in 0 .. upper_bound {
-		let (_n_stash, n_controller) = if !dead {
+		let (n_stash, n_controller) = if !dead {
 			create_stash_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		} else {
 			create_stash_and_dead_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		};
 		if i < n {
 			Staking::<T>::nominate(RawOrigin::Signed(n_controller.clone()).into(), vec![stash_lookup.clone()])?;
+			nominators.push((n_stash, n_controller));
 		}
 	}
 
@@ -95,10 +98,12 @@ pub fn create_validator_with_nominators<T: Trait>(
 	ErasRewardPoints::<T>::insert(current_era, reward);
 
 	// Create reward pool
-	let total_payout = T::Currency::minimum_balance() * 1000.into();
+	let total_payout = T::Currency::minimum_balance()
+		.saturating_mul(upper_bound.into())
+		.saturating_mul(1000.into());
 	<ErasValidatorReward<T>>::insert(current_era, total_payout);
 
-	Ok(v_stash)
+	Ok((v_stash, nominators))
 }
 
 const USER_SEED: u32 = 999666;
@@ -280,7 +285,7 @@ benchmarks! {
 
 	payout_stakers_dead_controller {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let validator = create_validator_with_nominators::<T>(
+		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			true,
@@ -294,6 +299,10 @@ benchmarks! {
 		let caller = whitelisted_caller();
 		let validator_controller = <Bonded<T>>::get(&validator).unwrap();
 		let balance_before = T::Currency::free_balance(&validator_controller);
+		for (_, controller) in &nominators {
+			let balance = T::Currency::free_balance(&controller);
+			assert!(balance.is_zero(), "Controller has balance, but should be dead.");
+		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator_controller);
@@ -302,11 +311,16 @@ benchmarks! {
 			"Balance of controller {:?} should have increased after payout.",
 			validator,
 		);
+
+		for (_, controller) in &nominators {
+			let balance = T::Currency::free_balance(&controller);
+			assert!(!balance.is_zero(), "Payout not given to controller.");
+		}
 	}
 
 	payout_stakers_alive_staked {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let validator = create_validator_with_nominators::<T>(
+		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			false,
@@ -319,6 +333,11 @@ benchmarks! {
 
 		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);
+		let mut nominator_balances_before = Vec::new();
+		for (stash, _) in &nominators {
+			let balance = T::Currency::free_balance(&stash);
+			nominator_balances_before.push(balance);
+		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator);
@@ -327,6 +346,14 @@ benchmarks! {
 			"Balance of stash {:?} should have increased after payout.",
 			validator,
 		);
+		for ((stash, _), balance_before) in nominators.iter().zip(nominator_balances_before.iter()) {
+			let balance_after = T::Currency::free_balance(&stash);
+			assert!(
+				balance_before < &balance_after,
+				"Balance of nominator stash {:?} should have increased after payout.",
+				stash,
+			);
+		}
 	}
 
 	rebond {
@@ -700,12 +727,14 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let validator_stash = create_validator_with_nominators::<Test>(
+			let (validator_stash, nominators) = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,
 				RewardDestination::Staked,
 			).unwrap();
+
+			assert_eq!(nominators.len() as u32, n);
 
 			let current_era = CurrentEra::get().unwrap();
 
@@ -722,7 +751,7 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let validator_stash = create_validator_with_nominators::<Test>(
+			let (validator_stash, _nominators) = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -46,13 +46,13 @@ fn add_slashing_spans<T: Trait>(who: &T::AccountId, spans: u32) {
 }
 
 // This function generates one validator being nominated by n nominators, and returns the validator
-// stash account. It also starts an era and creates pending payouts.
+// stash account and the nominators' stash and controller. It also starts an era and creates pending payouts.
 pub fn create_validator_with_nominators<T: Trait>(
 	n: u32,
 	upper_bound: u32,
 	dead: bool,
 	destination: RewardDestination<T::AccountId>
-) -> Result<T::AccountId, &'static str> {
+) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
@@ -66,15 +66,18 @@ pub fn create_validator_with_nominators<T: Trait>(
 	points_total += 10;
 	points_individual.push((v_stash.clone(), 10));
 
+	let mut nominators = Vec::new();
+
 	// Give the validator n nominators, but keep total users in the system the same.
 	for i in 0 .. upper_bound {
-		let (_n_stash, n_controller) = if !dead {
+		let (n_stash, n_controller) = if !dead {
 			create_stash_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		} else {
 			create_stash_and_dead_controller::<T>(u32::max_value() - i, 100, destination.clone())?
 		};
 		if i < n {
 			Staking::<T>::nominate(RawOrigin::Signed(n_controller.clone()).into(), vec![stash_lookup.clone()])?;
+			nominators.push((n_stash, n_controller));
 		}
 	}
 
@@ -100,7 +103,7 @@ pub fn create_validator_with_nominators<T: Trait>(
 		.saturating_mul(1000.into());
 	<ErasValidatorReward<T>>::insert(current_era, total_payout);
 
-	Ok(v_stash)
+	Ok((v_stash, nominators))
 }
 
 const USER_SEED: u32 = 999666;
@@ -282,7 +285,7 @@ benchmarks! {
 
 	payout_stakers_dead_controller {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let validator = create_validator_with_nominators::<T>(
+		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			true,
@@ -296,6 +299,10 @@ benchmarks! {
 		let caller = whitelisted_caller();
 		let validator_controller = <Bonded<T>>::get(&validator).unwrap();
 		let balance_before = T::Currency::free_balance(&validator_controller);
+		for (_, controller) in &nominators {
+			let balance = T::Currency::free_balance(&controller);
+			assert!(balance.is_zero(), "Controller has balance, but should be dead.");
+		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator_controller);
@@ -304,11 +311,16 @@ benchmarks! {
 			"Balance of controller {:?} should have increased after payout.",
 			validator,
 		);
+
+		for (_, controller) in &nominators {
+			let balance = T::Currency::free_balance(&controller);
+			assert!(!balance.is_zero(), "Payout not given to controller.");
+		}
 	}
 
 	payout_stakers_alive_staked {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		let validator = create_validator_with_nominators::<T>(
+		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
 			false,
@@ -321,6 +333,11 @@ benchmarks! {
 
 		let caller = whitelisted_caller();
 		let balance_before = T::Currency::free_balance(&validator);
+		let mut nominator_balances_before = Vec::new();
+		for (stash, _) in &nominators {
+			let balance = T::Currency::free_balance(&stash);
+			nominator_balances_before.push(balance);
+		}
 	}: payout_stakers(RawOrigin::Signed(caller), validator.clone(), current_era)
 	verify {
 		let balance_after = T::Currency::free_balance(&validator);
@@ -329,6 +346,14 @@ benchmarks! {
 			"Balance of stash {:?} should have increased after payout.",
 			validator,
 		);
+		for ((stash, _), balance_before) in nominators.iter().zip(nominator_balances_before.iter()) {
+			let balance_after = T::Currency::free_balance(&stash);
+			assert!(
+				balance_before < &balance_after,
+				"Balance of nominator stash {:?} should have increased after payout.",
+				stash,
+			);
+		}
 	}
 
 	rebond {
@@ -702,12 +727,14 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let validator_stash = create_validator_with_nominators::<Test>(
+			let (validator_stash, nominators) = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,
 				RewardDestination::Staked,
 			).unwrap();
+
+			assert_eq!(nominators.len() as u32, n);
 
 			let current_era = CurrentEra::get().unwrap();
 
@@ -724,7 +751,7 @@ mod tests {
 		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
 			let n = 10;
 
-			let validator_stash = create_validator_with_nominators::<Test>(
+			let (validator_stash, _nominators) = create_validator_with_nominators::<Test>(
 				n,
 				<Test as Trait>::MaxNominatorRewardedPerValidator::get() as u32,
 				false,


### PR DESCRIPTION
This PR solves an issue I found when doing final weights on Polkadot around the payouts code.
https://github.com/paritytech/polkadot/pull/1761

The main issue was that the validator we set up to test was not being selected as the validator in the benchmark.
I have updated the test to add a bunch more assertion statements about the benchmark doing what we actually expect
and i have added an additional line in the benchmark to make sure to clean up old state.

I can confirm this fixes bad results I was finding in Polkadot, and should be one of the last things I need to merge my Polkadot weight update pr: https://github.com/paritytech/polkadot/pull/1761

Note the correct DB weight information below

```
pub struct WeightInfo<T>(PhantomData<T>);
impl<T: frame_system::Trait> pallet_staking::WeightInfo for WeightInfo<T> {
	fn payout_stakers_alive_staked(n: u32, ) -> Weight {
		(1_561_135_000 as Weight)
			.saturating_add((411_183_000 as Weight).saturating_mul(n as Weight))
			.saturating_add(T::DbWeight::get().reads(12 as Weight))
			.saturating_add(T::DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
			.saturating_add(T::DbWeight::get().writes(3 as Weight))
			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
	}
}