### PR TITLE
client/cli: Update to fdlimit 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,9 +1433,9 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 
 [[package]]
 name = "fdlimit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bc6e222b8349b2bd0acb85a1d16d22852376b3ceed2a7f09c2692c3d8a78d0"
+checksum = "2c4c9e43643f5a3be4ca5b67d26b98031ff9db6806c3440ae32e02e3ceac3f1b"
 dependencies = [
  "libc",
 ]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -22,7 +22,7 @@ ansi_term = "0.12.1"
 lazy_static = "1.4.0"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"
-fdlimit = "0.2.0"
+fdlimit = "0.2.1"
 libp2p = "0.28.1"
 parity-scale-codec = "1.3.0"
 hex = "0.4.2"

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -17,7 +17,7 @@ tempfile = "3.1.0"
 tokio = "0.1.22"
 futures01 = { package = "futures", version = "0.1.29" }
 log = "0.4.8"
-fdlimit = "0.2.0"
+fdlimit = "0.2.1"
 parking_lot = "0.10.0"
 sc-light = { version = "2.0.0", path = "../../light" }
 sp-blockchain = { version = "2.0.0", path = "../../../primitives/blockchain" }


### PR DESCRIPTION
fdlimit 0.2.1 contains a small patch allowing compilation on platforms
where libc represents rlimits as u32.

See https://github.com/paritytech/fdlimit/pull/6 for details.
