### PR TITLE
.maintain/monitoring: Add alert when continuous task ends

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -127,22 +127,8 @@ groups:
   ##############################################################################
 
   - alert: ContinuousTaskEnded
-    expr: 'polkadot_tasks_ended_total{task_name=~"
-      authority-discovery-worker
-      |babe
-      |basic-block-import-worker
-      |grandpa-voter
-      |informant
-      |network-worker
-      |offchain-notifications
-      |on-transaction-imported
-      |prometheus-endpoint
-      |telemetry-periodic-network-state
-      |telemetry-periodic-send
-      |telemetry-worker
-      |txpool-background
-      |txpool-notifications
-    "} > 0'
+    expr: '(polkadot_tasks_spawned_total == 1) - on(instance, task_name)
+    (polkadot_tasks_ended_total == 1)'
     for: 5m
     labels:
       severity: warning

--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -126,6 +126,30 @@ groups:
   # Others
   ##############################################################################
 
+  - alert: ContinuousTaskEnded
+    expr: 'polkadot_tasks_ended_total{task_name=~"
+      authority-discovery-worker
+      |babe
+      |basic-block-import-worker
+      |grandpa-voter
+      |informant
+      |network-worker
+      |offchain-notifications
+      |on-transaction-imported
+      |prometheus-endpoint
+      |telemetry-periodic-network-state
+      |telemetry-periodic-send
+      |telemetry-worker
+      |txpool-background
+      |txpool-notifications
+    "} > 0'
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      message: 'Continuous task {{ $labels.task_name }} on node
+      {{ $labels.instance }} ended unexpectedly.'
+
   - alert: AuthorityDiscoveryDiscoveryFailureHigh
     expr: 'polkadot_authority_discovery_handle_value_found_event_failure /
     ignoring(name)


### PR DESCRIPTION
Through the `polkadot_tasks_ended_total` Prometheus metric one can tell
when a task ended. Use this metric to alert when specific
known-to-be-continuous tasks end on a node.

This would catch bugs like https://github.com/paritytech/substrate/pull/7000/#discussion_r498387783.