### PR TITLE
Rework `InspectState`

### DIFF
--- a/bin/node/bench/src/import.rs
+++ b/bin/node/bench/src/import.rs
@@ -133,8 +133,10 @@ impl core::Benchmark for ImportBenchmark {
 		let elapsed = start.elapsed();
 
 		// Sanity checks.
-		context.client.state_at(&BlockId::number(1)).expect("state_at failed for block#1")
-			.inspect_with(|| {
+		context.client
+			.state_at(&BlockId::number(1))
+			.expect("state_at failed for block#1")
+			.inspect_state(|| {
 				match self.block_type {
 					BlockType::RandomTransfersKeepAlive => {
 						// should be 5 per signed extrinsic + 1 per unsigned

--- a/primitives/state-machine/src/read_only.rs
+++ b/primitives/state-machine/src/read_only.rs
@@ -37,11 +37,13 @@ pub trait InspectState<H: Hasher, B: Backend<H>> {
 	///
 	/// Self will be set as read-only externalities and inspection
 	/// closure will be run against it.
-	fn inspect_with<F: FnOnce()>(&self, f: F);
+	///
+	/// Returns the result of the closure.
+	fn inspect_state<F: FnOnce() -> R, R>(&self, f: F) -> R;
 }
 
 impl<H: Hasher, B: Backend<H>> InspectState<H, B> for B {
-	fn inspect_with<F: FnOnce()>(&self, f: F) {
+	fn inspect_state<F: FnOnce() -> R, R>(&self, f: F) -> R {
 		ReadOnlyExternalities::from(self).execute_with(f)
 	}
 }


### PR DESCRIPTION
Reworks `InspectState` in two ways:
- Renames `inspect_with` to `inspect_state` to reflect the trait name.
- Make `inspect_state` return the result of the closure
