### PR TITLE
use runtime-wasm feature instead of assuming no_std to be wasm

### DIFF
--- a/primitives/allocator/Cargo.toml
+++ b/primitives/allocator/Cargo.toml
@@ -22,6 +22,7 @@ derive_more = { version = "0.99.2", optional = true }
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-std/std",
 	"sp-core/std",

--- a/primitives/allocator/src/error.rs
+++ b/primitives/allocator/src/error.rs
@@ -29,7 +29,7 @@ pub enum Error {
 	Other(&'static str)
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::error::Error for Error {
 	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
 		match self {

--- a/primitives/api/Cargo.toml
+++ b/primitives/api/Cargo.toml
@@ -27,6 +27,7 @@ sp-test-primitives = { version = "2.0.0", path = "../test-primitives" }
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-core/std",

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -26,4 +26,5 @@ proc-macro-crate = "0.1.4"
 # Required for the doc tests
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = []

--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -148,7 +148,7 @@ fn generate_dispatch_function(impls: &[ItemImpl]) -> Result<TokenStream> {
 		});
 
 	Ok(quote!(
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		pub fn dispatch(method: &str, mut #data: &[u8]) -> Option<Vec<u8>> {
 			match method {
 				#( #impl_calls )*
@@ -172,7 +172,7 @@ fn generate_wasm_interface(impls: &[ItemImpl]) -> Result<TokenStream> {
 
 			quote!(
 				#( #attrs )*
-				#[cfg(not(feature = "std"))]
+				#[cfg(feature = "runtime-wasm")]
 				#[no_mangle]
 				pub unsafe fn #fn_name(input_data: *mut u8, input_len: usize) -> u64 {
 					let mut #input = if input_len == 0 {
@@ -757,7 +757,7 @@ mod tests {
 
 	#[test]
 	fn filter_non_cfg_attributes() {
-		let cfg_std: Attribute = parse_quote!(#[cfg(feature = "std")]);
+		let cfg_std: Attribute = parse_quote!(#[cfg(not(feature = "runtime-wasm"))]);
 		let cfg_benchmarks: Attribute = parse_quote!(#[cfg(feature = "runtime-benchmarks")]);
 
 		let attrs = vec![

--- a/primitives/api/src/lib.rs
+++ b/primitives/api/src/lib.rs
@@ -37,20 +37,20 @@
 extern crate self as sp_api;
 
 #[doc(hidden)]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use sp_state_machine::{
 	OverlayedChanges, StorageProof, Backend as StateBackend, ChangesTrieState, InMemoryBackend,
 };
 #[doc(hidden)]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use sp_core::NativeOrEncoded;
 #[doc(hidden)]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use hash_db::Hasher;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use sp_core::offchain::storage::OffchainOverlayedChanges;
 #[doc(hidden)]
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 pub use sp_core::to_substrate_wasm_fn_return_value;
 #[doc(hidden)]
 pub use sp_runtime::{
@@ -66,12 +66,12 @@ pub use sp_core::{offchain, ExecutionContext};
 pub use sp_version::{ApiId, RuntimeVersion, ApisVec, create_apis_vec};
 #[doc(hidden)]
 pub use sp_std::{slice, mem};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_std::result;
 #[doc(hidden)]
 pub use codec::{Encode, Decode, DecodeLimit};
 use sp_core::OpaqueMetadata;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::{panic::UnwindSafe, cell::RefCell};
 
 /// Maximum nesting level for extrinsics.
@@ -304,17 +304,17 @@ pub use sp_api_proc_macro::impl_runtime_apis;
 pub use sp_api_proc_macro::mock_impl_runtime_apis;
 
 /// A type that records all accessed trie nodes and generates a proof out of it.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type ProofRecorder<B> = sp_state_machine::ProofRecorder<HashFor<B>>;
 
 /// A type that is used as cache for the storage transactions.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type StorageTransactionCache<Block, Backend> =
 	sp_state_machine::StorageTransactionCache<
 		<Backend as StateBackend<HashFor<Block>>>::Transaction, HashFor<Block>, NumberFor<Block>
 	>;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type StorageChanges<SBackend, Block> =
 	sp_state_machine::StorageChanges<
 		<SBackend as StateBackend<HashFor<Block>>>::Transaction,
@@ -323,17 +323,17 @@ pub type StorageChanges<SBackend, Block> =
 	>;
 
 /// Extract the state backend type for a type that implements `ProvideRuntimeApi`.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type StateBackendFor<P, Block> =
 	<<P as ProvideRuntimeApi<Block>>::Api as ApiExt<Block>>::StateBackend;
 
 /// Extract the state backend transaction type for a type that implements `ProvideRuntimeApi`.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type TransactionFor<P, Block> =
 	<StateBackendFor<P, Block> as StateBackend<HashFor<Block>>>::Transaction;
 
 /// Something that can be constructed to a runtime api.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait ConstructRuntimeApi<Block: BlockT, C: CallApiAt<Block>> {
 	/// The actual runtime api that will be constructed.
 	type RuntimeApi: ApiExt<Block>;
@@ -344,14 +344,14 @@ pub trait ConstructRuntimeApi<Block: BlockT, C: CallApiAt<Block>> {
 
 /// Extends the runtime api traits with an associated error type. This trait is given as super
 /// trait to every runtime api trait.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait ApiErrorExt {
 	/// Error type used by the runtime apis.
 	type Error: std::fmt::Debug + From<String>;
 }
 
 /// Extends the runtime api implementation with some common functionality.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait ApiExt<Block: BlockT>: ApiErrorExt {
 	/// The state backend that is used to store the block states.
 	type StateBackend: StateBackend<HashFor<Block>>;
@@ -408,7 +408,7 @@ pub trait ApiExt<Block: BlockT>: ApiErrorExt {
 ///
 /// `call_api_at` is instructed by this enum to do the initialization or to skip
 /// it.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Clone, Copy)]
 pub enum InitializeBlock<'a, Block: BlockT> {
 	/// Skip initializing the runtime for a given block.
@@ -422,7 +422,7 @@ pub enum InitializeBlock<'a, Block: BlockT> {
 }
 
 /// Parameters for [`CallApiAt::call_api_at`].
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct CallApiAtParams<'a, Block: BlockT, C, NC, Backend: StateBackend<HashFor<Block>>> {
 	/// A reference to something that implements the [`Core`] api.
 	pub core_api: &'a C,
@@ -453,7 +453,7 @@ pub struct CallApiAtParams<'a, Block: BlockT, C, NC, Backend: StateBackend<HashF
 }
 
 /// Something that can call into the an api at a given block.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait CallApiAt<Block: BlockT> {
 	/// Error type used by the implementation.
 	type Error: std::fmt::Debug + From<String>;
@@ -478,17 +478,17 @@ pub trait CallApiAt<Block: BlockT> {
 }
 
 /// Auxiliary wrapper that holds an api instance and binds it to the given lifetime.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct ApiRef<'a, T>(T, std::marker::PhantomData<&'a ()>);
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, T> From<T> for ApiRef<'a, T> {
 	fn from(api: T) -> Self {
 		ApiRef(api, Default::default())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, T> std::ops::Deref for ApiRef<'a, T> {
 	type Target = T;
 
@@ -497,7 +497,7 @@ impl<'a, T> std::ops::Deref for ApiRef<'a, T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, T> std::ops::DerefMut for ApiRef<'a, T> {
 	fn deref_mut(&mut self) -> &mut T {
 		&mut self.0
@@ -505,7 +505,7 @@ impl<'a, T> std::ops::DerefMut for ApiRef<'a, T> {
 }
 
 /// Something that provides a runtime api.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait ProvideRuntimeApi<Block: BlockT> {
 	/// The concrete type that provides the api.
 	type Api: ApiExt<Block>;
@@ -519,7 +519,7 @@ pub trait ProvideRuntimeApi<Block: BlockT> {
 }
 
 /// Something that provides information about a runtime api.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait RuntimeApiInfo {
 	/// The identifier of the runtime api.
 	const ID: [u8; 8];
@@ -528,7 +528,7 @@ pub trait RuntimeApiInfo {
 }
 
 /// Extracts the `Api::Error` for a type that provides a runtime api.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type ApiErrorFor<T, Block> = <<T as ProvideRuntimeApi<Block>>::Api as ApiErrorExt>::Error;
 
 #[derive(codec::Encode, codec::Decode)]

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -36,4 +36,5 @@ harness = false
 # We only need this to generate the correct code.
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = []

--- a/primitives/application-crypto/Cargo.toml
+++ b/primitives/application-crypto/Cargo.toml
@@ -23,6 +23,7 @@ sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [ "full_crypto", "sp-core/std", "codec/std", "serde", "sp-std/std", "sp-io/std" ]
 
 # This feature enables all crypto primitives for `no_std` builds like microcontrollers

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -31,7 +31,7 @@ pub use sp_core::crypto::{KeyTypeId, CryptoTypeId, key_types};
 #[doc(hidden)]
 pub use codec;
 #[doc(hidden)]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use serde;
 #[doc(hidden)]
 pub use sp_std::{
@@ -158,7 +158,7 @@ macro_rules! app_crypto_pair {
 
 /// Implements functions for the `Pair` trait when `feature = "std"` is enabled.
 #[doc(hidden)]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[macro_export]
 macro_rules! app_crypto_pair_functions_if_std {
 	($pair:ty) => {
@@ -176,7 +176,7 @@ macro_rules! app_crypto_pair_functions_if_std {
 }
 
 #[doc(hidden)]
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[macro_export]
 macro_rules! app_crypto_pair_functions_if_std {
 	($pair:ty) => {}
@@ -327,7 +327,7 @@ macro_rules! app_crypto_public_common {
 }
 
 /// Implements traits for the public key type if `feature = "std"` is enabled.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_public_common_if_std {
@@ -368,7 +368,7 @@ macro_rules! app_crypto_public_common_if_std {
 	}
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! app_crypto_public_common_if_std {

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -29,7 +29,8 @@ serde_json = "1.0"
 primitive-types = "0.7.0"
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"num-traits/std",

--- a/primitives/arithmetic/src/biguint.rs
+++ b/primitives/arithmetic/src/biguint.rs
@@ -430,7 +430,7 @@ impl BigUint {
 }
 
 impl sp_std::fmt::Debug for BigUint {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(
 			f,
@@ -440,7 +440,7 @@ impl sp_std::fmt::Debug for BigUint {
 		)
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		Ok(())
 	}

--- a/primitives/arithmetic/src/per_things.rs
+++ b/primitives/arithmetic/src/per_things.rs
@@ -185,7 +185,7 @@ pub trait PerThing:
 	fn from_parts(parts: Self::Inner) -> Self;
 
 	/// Converts a fraction into `Self`.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_fraction(x: f64) -> Self;
 
 	/// Approximate the fraction `p/q` into a per-thing fraction. This will never overflow.
@@ -358,7 +358,7 @@ macro_rules! implement_per_thing {
 			fn from_parts(parts: Self::Inner) -> Self { Self(parts.min($max)) }
 
 			/// NOTE: saturate to 0 or 1 if x is beyond `[0, 1]`
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			fn from_fraction(x: f64) -> Self {
 				Self::from_parts((x.max(0.).min(1.) * $max as f64) as Self::Inner)
 			}
@@ -459,7 +459,7 @@ macro_rules! implement_per_thing {
 			}
 
 			/// See [`PerThing::from_fraction`].
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			pub fn from_fraction(x: f64) -> Self {
 				<Self as PerThing>::from_fraction(x)
 			}

--- a/primitives/arithmetic/src/rational.rs
+++ b/primitives/arithmetic/src/rational.rs
@@ -92,14 +92,14 @@ impl From<Rational128> for RationalInfinite {
 #[derive(Clone, Copy, Default, Eq)]
 pub struct Rational128(u128, u128);
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl sp_std::fmt::Debug for Rational128 {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(f, "Rational128({:.4})", self.0 as f32 / self.1 as f32)
 	}
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 impl sp_std::fmt::Debug for Rational128 {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(f, "Rational128(..)")

--- a/primitives/authority-discovery/Cargo.toml
+++ b/primitives/authority-discovery/Cargo.toml
@@ -20,7 +20,8 @@ sp-api = { version = "2.0.0", default-features = false, path = "../api" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-application-crypto/std",
 	"codec/std",

--- a/primitives/authorship/Cargo.toml
+++ b/primitives/authorship/Cargo.toml
@@ -20,6 +20,7 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-std/std",

--- a/primitives/authorship/src/lib.rs
+++ b/primitives/authorship/src/lib.rs
@@ -56,20 +56,20 @@ impl<H: Decode> UnclesInherentData<H> for InherentData {
 }
 
 /// Provider for inherent data.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct InherentDataProvider<F, H> {
 	inner: F,
 	_marker: std::marker::PhantomData<H>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<F, H> InherentDataProvider<F, H> {
 	pub fn new(uncles_oracle: F) -> Self {
 		InherentDataProvider { inner: uncles_oracle, _marker: Default::default() }
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<F, H: Encode + std::fmt::Debug> sp_inherents::ProvideInherentData for InherentDataProvider<F, H>
 where F: Fn() -> Vec<H>
 {

--- a/primitives/block-builder/Cargo.toml
+++ b/primitives/block-builder/Cargo.toml
@@ -21,6 +21,7 @@ sp-inherents = { version = "2.0.0", default-features = false, path = "../inheren
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-runtime/std",
 	"codec/std",

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -22,7 +22,8 @@ sp-inherents = { version = "2.0.0", default-features = false, path = "../../inhe
 sp-timestamp = { version = "2.0.0", default-features = false, path = "../../timestamp" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-application-crypto/std",
 	"codec/std",

--- a/primitives/consensus/aura/src/inherents.rs
+++ b/primitives/consensus/aura/src/inherents.rs
@@ -19,7 +19,7 @@
 
 use sp_inherents::{InherentIdentifier, InherentData, Error};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_inherents::{InherentDataProviders, ProvideInherentData};
 
 /// The Aura inherent identifier.
@@ -48,12 +48,12 @@ impl AuraInherentData for InherentData {
 }
 
 /// Provides the slot duration inherent data for `Aura`.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct InherentDataProvider {
 	slot_duration: u64,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl InherentDataProvider {
 	pub fn new(slot_duration: u64) -> Self {
 		Self {
@@ -62,7 +62,7 @@ impl InherentDataProvider {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl ProvideInherentData for InherentDataProvider {
 	fn on_register(
 		&self,

--- a/primitives/consensus/babe/Cargo.toml
+++ b/primitives/consensus/babe/Cargo.toml
@@ -27,7 +27,8 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../../runtim
 sp-timestamp = { version = "2.0.0", default-features = false, path = "../../timestamp" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-application-crypto/std",
 	"codec/std",

--- a/primitives/consensus/babe/src/inherents.rs
+++ b/primitives/consensus/babe/src/inherents.rs
@@ -18,12 +18,12 @@
 //! Inherents for BABE
 
 use sp_inherents::{Error, InherentData, InherentIdentifier};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_inherents::{InherentDataProviders, ProvideInherentData};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_timestamp::TimestampInherentData;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use codec::Decode;
 use sp_std::result::Result;
 
@@ -52,12 +52,12 @@ impl BabeInherentData for InherentData {
 }
 
 /// Provides the slot duration inherent data for BABE.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct InherentDataProvider {
 	slot_duration: u64,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl InherentDataProvider {
 	/// Constructs `Self`
 	pub fn new(slot_duration: u64) -> Self {
@@ -65,7 +65,7 @@ impl InherentDataProvider {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl ProvideInherentData for InherentDataProvider {
 	fn on_register(&self, providers: &InherentDataProviders) -> Result<(), Error> {
 		if !providers.has_provider(&sp_timestamp::INHERENT_IDENTIFIER) {

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -29,7 +29,7 @@ pub use sp_consensus_vrf::schnorrkel::{
 };
 
 use codec::{Decode, Encode};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_core::vrf::{VRFTranscriptData, VRFTranscriptValue};
 use sp_runtime::{traits::Header, ConsensusEngineId, RuntimeDebug};
 use sp_std::vec::Vec;
@@ -52,7 +52,7 @@ pub static BABE_VRF_INOUT_CONTEXT: &[u8] = b"BabeVRFInOutContext";
 
 /// A Babe authority keypair. Necessarily equivalent to the schnorrkel public key used in
 /// the main Babe module. If that ever changes, then this must, too.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type AuthorityPair = app::Pair;
 
 /// A Babe authority signature.
@@ -104,7 +104,7 @@ pub fn make_transcript(
 }
 
 /// Make a VRF transcript data container
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn make_transcript_data(
 	randomness: &Randomness,
 	slot_number: u64,
@@ -238,7 +238,7 @@ impl AllowedSlots {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl sp_consensus::SlotData for BabeGenesisConfiguration {
 	fn slot_duration(&self) -> u64 {
 		self.slot_duration

--- a/primitives/consensus/pow/Cargo.toml
+++ b/primitives/consensus/pow/Cargo.toml
@@ -20,7 +20,8 @@ sp-core = { version = "2.0.0", default-features = false, path = "../../core" }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-std/std",
 	"sp-api/std",

--- a/primitives/consensus/slots/Cargo.toml
+++ b/primitives/consensus/slots/Cargo.toml
@@ -17,7 +17,8 @@ codec = { package = "parity-scale-codec", version = "1.3.0", default-features = 
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-runtime/std",

--- a/primitives/consensus/vrf/Cargo.toml
+++ b/primitives/consensus/vrf/Cargo.toml
@@ -20,7 +20,8 @@ sp-core = { version = "2.0.0", path = "../../core", default-features = false }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"schnorrkel/std",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -71,7 +71,8 @@ harness = false
 bench = false
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"full_crypto",
 	"log/std",

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -23,19 +23,19 @@ use crate::{sr25519, ed25519};
 use sp_std::hash::Hash;
 use sp_std::vec::Vec;
 use sp_std::str;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_std::convert::TryInto;
 use sp_std::convert::TryFrom;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use parking_lot::Mutex;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use rand::{RngCore, rngs::OsRng};
 use codec::{Encode, Decode};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use regex::Regex;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use base58::{FromBase58, ToBase58};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use crate::hexdisplay::HexDisplay;
 #[doc(hidden)]
 pub use sp_std::ops::Deref;
@@ -45,7 +45,7 @@ pub use zeroize::Zeroize;
 /// Trait for accessing reference to `SecretString`.
 pub use secrecy::ExposeSecret;
 /// A store for sensitive data.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use secrecy::SecretString;
 
 /// The root phrase for our publicly known keys.
@@ -224,7 +224,7 @@ pub enum PublicError {
 #[cfg(feature = "full_crypto")]
 pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	/// Some if the string is a properly encoded SS58Check address.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_ss58check(s: &str) -> Result<Self, PublicError> {
 		Self::from_ss58check_with_version(s)
 			.and_then(|(r, v)| match v {
@@ -234,7 +234,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 			})
 	}
 	/// Some if the string is a properly encoded SS58Check address.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_ss58check_with_version(s: &str) -> Result<(Self, Ss58AddressFormat), PublicError> {
 		let mut res = Self::default();
 		let len = res.as_mut().len();
@@ -254,7 +254,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	}
 	/// Some if the string is a properly encoded SS58Check address, optionally with
 	/// a derivation path following.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_string(s: &str) -> Result<Self, PublicError> {
 		Self::from_string_with_version(s)
 			.and_then(|(r, v)| match v {
@@ -265,7 +265,7 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	}
 
 	/// Return the ss58-check string for this key.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn to_ss58check_with_version(&self, version: Ss58AddressFormat) -> String {
 		let mut v = vec![version.into()];
 		v.extend(self.as_ref());
@@ -275,12 +275,12 @@ pub trait Ss58Codec: Sized + AsMut<[u8]> + AsRef<[u8]> + Default {
 	}
 
 	/// Return the ss58-check string for this key.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn to_ss58check(&self) -> String { self.to_ss58check_with_version(*DEFAULT_VERSION.lock()) }
 
 	/// Some if the string is a properly encoded SS58Check address, optionally with
 	/// a derivation path following.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_string_with_version(s: &str) -> Result<(Self, Ss58AddressFormat), PublicError> {
 		Self::from_ss58check_with_version(s)
 	}
@@ -291,16 +291,16 @@ pub trait Derive: Sized {
 	/// Derive a child key from a series of given junctions.
 	///
 	/// Will be `None` for public keys if there are any hard junctions in there.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn derive<Iter: Iterator<Item=DeriveJunction>>(&self, _path: Iter) -> Option<Self> {
 		None
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 const PREFIX: &[u8] = b"SS58PRE";
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 	let mut context = blake2_rfc::blake2b::Blake2b::new(64);
 	context.update(PREFIX);
@@ -308,7 +308,7 @@ fn ss58hash(data: &[u8]) -> blake2_rfc::blake2b::Blake2bResult {
 	context.finalize()
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 lazy_static::lazy_static! {
 	static ref DEFAULT_VERSION: Mutex<Ss58AddressFormat>
 		= Mutex::new(Ss58AddressFormat::SubstrateAccount);
@@ -325,7 +325,7 @@ macro_rules! ss58_address_format {
 			Custom(u8),
 		}
 
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		impl std::fmt::Display for Ss58AddressFormat {
 			fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 				match self {
@@ -379,13 +379,13 @@ macro_rules! ss58_address_format {
 				match x {
 					$($number => Ok(Ss58AddressFormat::$identifier)),*,
 					_ => {
-						#[cfg(feature = "std")]
+						#[cfg(not(feature = "runtime-wasm"))]
 						match Ss58AddressFormat::default() {
 							Ss58AddressFormat::Custom(n) if n == x => Ok(Ss58AddressFormat::Custom(x)),
 							_ => Err(()),
 						}
 
-						#[cfg(not(feature = "std"))]
+						#[cfg(feature = "runtime-wasm")]
 						Err(())
 					},
 				}
@@ -408,7 +408,7 @@ macro_rules! ss58_address_format {
 			}
 		}
 
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		impl std::str::FromStr for Ss58AddressFormat {
 			type Err = ParseError;
 
@@ -417,21 +417,21 @@ macro_rules! ss58_address_format {
 			}
 		}
 
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		impl std::fmt::Display for ParseError {
 			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 				write!(f, "failed to parse network value as u8")
 			}
 		}
 
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		impl Default for Ss58AddressFormat {
 			fn default() -> Self {
 				*DEFAULT_VERSION.lock()
 			}
 		}
 
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		impl From<Ss58AddressFormat> for String {
 			fn from(x: Ss58AddressFormat) -> String {
 				x.to_string()
@@ -514,12 +514,12 @@ ss58_address_format!(
 /// encoding and decoding SS58 addresses. If an unknown version is provided then it fails.
 ///
 /// See `ss58_address_format!` for all current known "versions".
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn set_default_ss58_version(version: Ss58AddressFormat) {
 	*DEFAULT_VERSION.lock() = version
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<T: Sized + AsMut<[u8]> + AsRef<[u8]> + Default + Derive> Ss58Codec for T {
 	fn from_string(s: &str) -> Result<Self, PublicError> {
 		let re = Regex::new(r"^(?P<ss58>[\w\d ]+)?(?P<path>(//?[^/]+)*)$")
@@ -605,7 +605,7 @@ impl UncheckedFrom<crate::hash::H256> for AccountId32 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Ss58Codec for AccountId32 {}
 
 impl AsRef<[u8]> for AccountId32 {
@@ -669,7 +669,7 @@ impl From<ed25519::Public> for AccountId32 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Display for AccountId32 {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
@@ -677,26 +677,26 @@ impl std::fmt::Display for AccountId32 {
 }
 
 impl sp_std::fmt::Debug for AccountId32 {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let s = self.to_ss58check();
 		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.0), &s[0..8])
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl serde::Serialize for AccountId32 {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		serializer.serialize_str(&self.to_ss58check())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> serde::Deserialize<'de> for AccountId32 {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
 		Ss58Codec::from_ss58check(&String::deserialize(deserializer)?)
@@ -704,7 +704,7 @@ impl<'de> serde::Deserialize<'de> for AccountId32 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl sp_std::str::FromStr for AccountId32 {
 	type Err = &'static str;
 
@@ -721,10 +721,10 @@ impl sp_std::str::FromStr for AccountId32 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use self::dummy::*;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod dummy {
 	use super::*;
 
@@ -753,7 +753,7 @@ mod dummy {
 
 	impl Public for Dummy {
 		fn from_slice(_: &[u8]) -> Self { Self }
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		fn to_raw_vec(&self) -> Vec<u8> { vec![] }
 		fn as_slice(&self) -> &[u8] { b"" }
 		fn to_public_crypto_pair(&self) -> CryptoTypePublicPair {
@@ -768,9 +768,9 @@ mod dummy {
 		type Seed = Dummy;
 		type Signature = Dummy;
 		type DeriveError = ();
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		fn generate_with_phrase(_: Option<&str>) -> (Self, String, Self::Seed) { Default::default() }
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		fn from_phrase(_: &str, _: Option<&str>)
 			-> Result<(Self, Self::Seed), SecretStringError>
 		{
@@ -812,7 +812,7 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 	///
 	/// This is only for ephemeral keys really, since you won't have access to the secret key
 	/// for storage. If you want a persistent key pair, use `generate_with_phrase` instead.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn generate() -> (Self, Self::Seed) {
 		let mut seed = Self::Seed::default();
 		OsRng.fill_bytes(seed.as_mut());
@@ -825,11 +825,11 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 	///
 	/// This is generally slower than `generate()`, so prefer that unless you need to persist
 	/// the key from the current session.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn generate_with_phrase(password: Option<&str>) -> (Self, String, Self::Seed);
 
 	/// Returns the KeyPair from the English BIP39 seed `phrase`, or `None` if it's invalid.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_phrase(phrase: &str, password: Option<&str>) -> Result<(Self, Self::Seed), SecretStringError>;
 
 	/// Derive a child key from a series of given junctions.
@@ -891,7 +891,7 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 	/// be equivalent to no password at all.
 	///
 	/// `None` is returned if no matches are found.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_string_with_seed(s: &str, password_override: Option<&str>)
 		-> Result<(Self, Option<Self::Seed>), SecretStringError>
 	{
@@ -929,7 +929,7 @@ pub trait Pair: CryptoType + Sized + Clone + Send + Sync + 'static {
 	/// Interprets the string `s` in order to generate a key pair.
 	///
 	/// See [`from_string_with_seed`](Pair::from_string_with_seed) for more extensive documentation.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_string(s: &str, password_override: Option<&str>) -> Result<Self, SecretStringError> {
 		Self::from_string_with_seed(s, password_override).map(|x| x.0)
 	}
@@ -1026,7 +1026,7 @@ pub struct CryptoTypeId(pub [u8; 4]);
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Encode, Decode)]
 pub struct CryptoTypePublicPair(pub CryptoTypeId, pub Vec<u8>);
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl sp_std::fmt::Display for CryptoTypePublicPair {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let id = match str::from_utf8(&(self.0).0[..]) {

--- a/primitives/core/src/ed25519.rs
+++ b/primitives/core/src/ed25519.rs
@@ -31,15 +31,15 @@ use blake2_rfc;
 use core::convert::TryFrom;
 #[cfg(feature = "full_crypto")]
 use ed25519_dalek::{Signer as _, Verifier as _};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use substrate_bip39::seed_from_entropy;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use bip39::{Mnemonic, Language, MnemonicType};
 #[cfg(feature = "full_crypto")]
 use crate::crypto::{Pair as TraitPair, DeriveJunction, SecretStringError};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use crate::crypto::Ss58Codec;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{de, Serializer, Serialize, Deserializer, Deserialize};
 use crate::crypto::{Public as TraitPublic, CryptoTypePublicPair, UncheckedFrom, CryptoType, Derive, CryptoTypeId};
 use sp_runtime_interface::pass_by::PassByInner;
@@ -133,7 +133,7 @@ impl From<Public> for H256 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::str::FromStr for Public {
 	type Err = crate::crypto::PublicError;
 
@@ -154,7 +154,7 @@ impl UncheckedFrom<H256> for Public {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Display for Public {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
@@ -162,26 +162,26 @@ impl std::fmt::Display for Public {
 }
 
 impl sp_std::fmt::Debug for Public {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let s = self.to_ss58check();
 		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.0), &s[0..8])
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Serialize for Public {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
 		serializer.serialize_str(&self.to_ss58check())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> Deserialize<'de> for Public {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		Public::from_ss58check(&String::deserialize(deserializer)?)
@@ -207,14 +207,14 @@ impl sp_std::convert::TryFrom<&[u8]> for Signature {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Serialize for Signature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
 		serializer.serialize_str(&hex::encode(self))
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> Deserialize<'de> for Signature {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
@@ -277,12 +277,12 @@ impl AsMut<[u8]> for Signature {
 }
 
 impl sp_std::fmt::Debug for Signature {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "{}", crate::hexdisplay::HexDisplay::from(&self.0))
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
@@ -324,7 +324,7 @@ impl Signature {
 }
 
 /// A localized signature also contains sender information.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
 pub struct LocalizedSignature {
 	/// The signer of the signature.
@@ -334,7 +334,7 @@ pub struct LocalizedSignature {
 }
 
 /// An error type for SS58 decoding.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub enum PublicError {
 	/// Bad alphabet.
@@ -427,7 +427,7 @@ impl TraitPair for Pair {
 	/// Generate new secure (random) key pair and provide the recovery phrase.
 	///
 	/// You can recover the same key later with `from_phrase`.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn generate_with_phrase(password: Option<&str>) -> (Pair, String, Seed) {
 		let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
 		let phrase = mnemonic.phrase();
@@ -441,7 +441,7 @@ impl TraitPair for Pair {
 	}
 
 	/// Generate key pair from given recovery phrase and password.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_phrase(phrase: &str, password: Option<&str>) -> Result<(Pair, Seed), SecretStringError> {
 		let big_seed = seed_from_entropy(
 			Mnemonic::from_phrase(phrase, Language::English)
@@ -541,7 +541,7 @@ impl Pair {
 
 	/// Exactly as `from_string` except that if no matches are found then, the the first 32
 	/// characters are taken (padded with spaces as necessary) and used as the MiniSecretKey.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	pub fn from_legacy_string(s: &str, password_override: Option<&str>) -> Pair {
 		Self::from_string(s, password_override).unwrap_or_else(|_| {
 			let mut padded_seed: Seed = [' ' as u8; 32];

--- a/primitives/core/src/hexdisplay.rs
+++ b/primitives/core/src/hexdisplay.rs
@@ -84,7 +84,7 @@ impl_non_endians!([u8; 1], [u8; 2], [u8; 3], [u8; 4], [u8; 5], [u8; 6], [u8; 7],
 	[u8; 48], [u8; 56], [u8; 64], [u8; 65], [u8; 80], [u8; 96], [u8; 112], [u8; 128]);
 
 /// Format into ASCII + # + hex, suitable for storage key preimages.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn ascii_format(asciish: &[u8]) -> String {
 	let mut r = String::new();
 	let mut latch = false;

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -37,16 +37,16 @@ use sp_std::prelude::*;
 use sp_std::ops::Deref;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Serialize, Deserialize};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use serde;
 #[doc(hidden)]
 pub use codec::{Encode, Decode};
 
 pub use sp_debug_derive::RuntimeDebug;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use impl_serde::serialize as bytes;
 
 #[cfg(feature = "full_crypto")]
@@ -63,16 +63,16 @@ pub mod ed25519;
 pub mod sr25519;
 pub mod ecdsa;
 pub mod hash;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod hasher;
 pub mod offchain;
 pub mod sandbox;
 pub mod uint;
 mod changes_trie;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod traits;
 pub mod testing;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod vrf;
 
 pub use self::hash::{H160, H256, H512, convert_hash};
@@ -82,9 +82,9 @@ pub use changes_trie::{ChangesTrieConfiguration, ChangesTrieConfigurationRange};
 pub use crypto::{DeriveJunction, Pair, Public};
 
 pub use hash_db::Hasher;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use self::hasher::blake2::Blake2Hasher;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use self::hasher::keccak::KeccakHasher;
 
 pub use sp_storage as storage;
@@ -149,7 +149,7 @@ impl Deref for Bytes {
 	fn deref(&self) -> &[u8] { &self.0[..] }
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl sp_std::str::FromStr for Bytes {
 	type Err = bytes::FromHexError;
 
@@ -190,7 +190,7 @@ impl OpaquePeerId {
 }
 
 /// Something that is either a native or an encoded value.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub enum NativeOrEncoded<R> {
 	/// The native representation.
 	Native(R),
@@ -198,14 +198,14 @@ pub enum NativeOrEncoded<R> {
 	Encoded(Vec<u8>)
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<R: codec::Encode> sp_std::fmt::Debug for NativeOrEncoded<R> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		hexdisplay::HexDisplay::from(&self.as_encoded().as_ref()).fmt(f)
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<R: codec::Encode> NativeOrEncoded<R> {
 	/// Return the value as the encoded format.
 	pub fn as_encoded(&self) -> Cow<'_, [u8]> {
@@ -224,7 +224,7 @@ impl<R: codec::Encode> NativeOrEncoded<R> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<R: PartialEq + codec::Decode> PartialEq for NativeOrEncoded<R> {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
@@ -239,11 +239,11 @@ impl<R: PartialEq + codec::Decode> PartialEq for NativeOrEncoded<R> {
 
 /// A value that is never in a native representation.
 /// This is type is useful in conjunction with `NativeOrEncoded`.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(PartialEq)]
 pub enum NeverNativeValue {}
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl codec::Encode for NeverNativeValue {
 	fn encode(&self) -> Vec<u8> {
 		// The enum is not constructable, so this function should never be callable!
@@ -251,10 +251,10 @@ impl codec::Encode for NeverNativeValue {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl codec::EncodeLike for NeverNativeValue {}
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl codec::Decode for NeverNativeValue {
 	fn decode<I: codec::Input>(_: &mut I) -> Result<Self, codec::Error> {
 		Err("`NeverNativeValue` should never be decoded".into())
@@ -328,7 +328,7 @@ impl From<LogLevel> for log::Level {
 /// from the Wasm blob. The return value of this signature is always a `u64`.
 /// This `u64` stores the pointer to the encoded return value and the length of this encoded value.
 /// The low `32bits` are reserved for the pointer, followed by `32bit` for the length.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 pub fn to_substrate_wasm_fn_return_value(value: &impl Encode) -> u64 {
 	let encoded = value.encode();
 
@@ -375,15 +375,15 @@ macro_rules! impl_maybe_marker {
 	) => {
 		$(
 			$(#[$doc])+
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			pub trait $trait_name: $( $trait_bound + )+ {}
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			impl<T: $( $trait_bound + )+> $trait_name for T {}
 
 			$(#[$doc])+
-			#[cfg(not(feature = "std"))]
+			#[cfg(feature = "runtime-wasm")]
 			pub trait $trait_name {}
-			#[cfg(not(feature = "std"))]
+			#[cfg(feature = "runtime-wasm")]
 			impl<T> $trait_name for T {}
 		)+
 	}

--- a/primitives/core/src/offchain/mod.rs
+++ b/primitives/core/src/offchain/mod.rs
@@ -24,9 +24,9 @@ use sp_runtime_interface::pass_by::{PassByCodec, PassByInner, PassByEnum};
 
 pub use crate::crypto::KeyTypeId;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod storage;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod testing;
 
 /// Local storage prefix used by the Offchain Worker API to
@@ -705,13 +705,13 @@ impl<T: Externalities> Externalities for LimitedExternalities<T> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 sp_externalities::decl_extension! {
 	/// The offchain extension that will be registered at the Substrate externalities.
 	pub struct OffchainExt(Box<dyn Externalities>);
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl OffchainExt {
 	/// Create a new instance of `Self`.
 	pub fn new<O: Externalities + 'static>(offchain: O) -> Self {
@@ -724,7 +724,7 @@ impl OffchainExt {
 /// This trait is currently used within the `ExternalitiesExtension`
 /// to provide offchain calls with access to the transaction pool without
 /// tight coupling with any pool implementation.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait TransactionPool {
 	/// Submit transaction.
 	///
@@ -732,13 +732,13 @@ pub trait TransactionPool {
 	fn submit_transaction(&mut self, extrinsic: Vec<u8>) -> Result<(), ()>;
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 sp_externalities::decl_extension! {
 	/// An externalities extension to submit transactions to the pool.
 	pub struct TransactionPoolExt(Box<dyn TransactionPool + Send>);
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl TransactionPoolExt {
 	/// Create a new instance of `TransactionPoolExt`.
 	pub fn new<O: TransactionPool + Send + 'static>(pool: O) -> Self {

--- a/primitives/core/src/sr25519.rs
+++ b/primitives/core/src/sr25519.rs
@@ -27,17 +27,17 @@ use sp_std::vec::Vec;
 use schnorrkel::{signing_context, ExpansionMode, Keypair, SecretKey, MiniSecretKey, PublicKey,
 	derive::{Derivation, ChainCode, CHAIN_CODE_LENGTH}
 };
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::convert::TryFrom;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use substrate_bip39::mini_secret_from_entropy;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use bip39::{Mnemonic, Language, MnemonicType};
 #[cfg(feature = "full_crypto")]
 use crate::crypto::{
 	Pair as TraitPair, DeriveJunction, Infallible, SecretStringError
 };
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use crate::crypto::Ss58Codec;
 
 use crate::crypto::{Public as TraitPublic, CryptoTypePublicPair, UncheckedFrom, CryptoType, Derive, CryptoTypeId};
@@ -45,7 +45,7 @@ use crate::hash::{H256, H512};
 use codec::{Encode, Decode};
 use sp_std::ops::Deref;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "full_crypto")]
 use schnorrkel::keys::{MINI_SECRET_KEY_LENGTH, SECRET_KEY_LENGTH};
@@ -116,7 +116,7 @@ impl From<Public> for H256 {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::str::FromStr for Public {
 	type Err = crate::crypto::PublicError;
 
@@ -151,7 +151,7 @@ impl UncheckedFrom<H256> for Public {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Display for Public {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		write!(f, "{}", self.to_ss58check())
@@ -159,26 +159,26 @@ impl std::fmt::Display for Public {
 }
 
 impl sp_std::fmt::Debug for Public {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		let s = self.to_ss58check();
 		write!(f, "{} ({}...)", crate::hexdisplay::HexDisplay::from(&self.0), &s[0..8])
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Serialize for Public {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
 		serializer.serialize_str(&self.to_ss58check())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> Deserialize<'de> for Public {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		Public::from_ss58check(&String::deserialize(deserializer)?)
@@ -206,14 +206,14 @@ impl sp_std::convert::TryFrom<&[u8]> for Signature {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Serialize for Signature {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
 		serializer.serialize_str(&hex::encode(self))
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> Deserialize<'de> for Signature {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
 		let signature_hex = hex::decode(&String::deserialize(deserializer)?)
@@ -283,12 +283,12 @@ impl From<schnorrkel::Signature> for Signature {
 }
 
 impl sp_std::fmt::Debug for Signature {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "{}", crate::hexdisplay::HexDisplay::from(&self.0))
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
@@ -303,7 +303,7 @@ impl sp_std::hash::Hash for Signature {
 
 /// A localized signature also contains sender information.
 /// NOTE: Encode and Decode traits are supported in ed25519 but not possible for now here.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct LocalizedSignature {
 	/// The signer of the signature.
@@ -346,7 +346,7 @@ impl Derive for Public {
 	/// Derive a child key from a series of given junctions.
 	///
 	/// `None` if there are any hard junctions in there.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn derive<Iter: Iterator<Item=DeriveJunction>>(&self, path: Iter) -> Option<Public> {
 		let mut acc = PublicKey::from_bytes(self.as_ref()).ok()?;
 		for j in path {
@@ -410,14 +410,14 @@ impl From<&Public> for CryptoTypePublicPair {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl From<MiniSecretKey> for Pair {
 	fn from(sec: MiniSecretKey) -> Pair {
 		Pair(sec.expand_to_keypair(ExpansionMode::Ed25519))
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl From<SecretKey> for Pair {
 	fn from(sec: SecretKey) -> Pair {
 		Pair(Keypair::from(sec))
@@ -502,7 +502,7 @@ impl TraitPair for Pair {
 			_ => Err(SecretStringError::InvalidSeedLength)
 		}
 	}
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn generate_with_phrase(password: Option<&str>) -> (Pair, String, Seed) {
 		let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
 		let phrase = mnemonic.phrase();
@@ -514,7 +514,7 @@ impl TraitPair for Pair {
 			seed,
 		)
 	}
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn from_phrase(phrase: &str, password: Option<&str>) -> Result<(Pair, Seed), SecretStringError> {
 		Mnemonic::from_phrase(phrase, Language::English)
 			.map_err(|_| SecretStringError::InvalidPhrase)
@@ -572,7 +572,7 @@ impl TraitPair for Pair {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Pair {
 	/// Make a new key pair from binary data derived from a valid seed phrase.
 	///
@@ -621,7 +621,7 @@ impl CryptoType for Pair {
 /// `messages`, `signatures` and `pub_keys` should all have equal length.
 ///
 /// Returns `true` if all signatures are correct, `false` otherwise.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn verify_batch(
 	messages: Vec<&[u8]>,
 	signatures: Vec<&Signature>,

--- a/primitives/core/src/testing.rs
+++ b/primitives/core/src/testing.rs
@@ -18,14 +18,14 @@
 //! Types that should only be used for testing!
 
 use crate::crypto::KeyTypeId;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use crate::{
 	crypto::{Pair, Public, CryptoTypePublicPair},
 	ed25519, sr25519, ecdsa,
 	traits::Error,
 	vrf::{VRFTranscriptData, VRFSignature, make_transcript},
 };
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::collections::HashSet;
 
 /// Key type for generic Ed25519 key.
@@ -36,14 +36,14 @@ pub const SR25519: KeyTypeId = KeyTypeId(*b"sr25");
 pub const ECDSA: KeyTypeId = KeyTypeId(*b"ecds");
 
 /// A keystore implementation usable in tests.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Default)]
 pub struct KeyStore {
 	/// `KeyTypeId` maps to public keys and public keys map to private keys.
 	keys: std::collections::HashMap<KeyTypeId, std::collections::HashMap<Vec<u8>, String>>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl KeyStore {
 	/// Creates a new instance of `Self`.
 	pub fn new() -> crate::traits::BareCryptoStorePtr {
@@ -76,7 +76,7 @@ impl KeyStore {
 
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl crate::traits::BareCryptoStore for KeyStore {
 	fn keys(&self, id: KeyTypeId) -> Result<Vec<CryptoTypePublicPair>, Error> {
 		self.keys
@@ -265,7 +265,7 @@ impl crate::traits::BareCryptoStore for KeyStore {
 /// The input parameters are expected to be SCALE encoded and will be automatically decoded for you.
 /// The output value is also SCALE encoded when returned back to the host.
 ///
-/// The functions are feature-gated with `#[cfg(not(feature = "std"))]`, so they are only available
+/// The functions are feature-gated with `#[cfg(feature = "runtime-wasm")]`, so they are only available
 /// from within wasm.
 ///
 /// # Example
@@ -308,7 +308,7 @@ macro_rules! wasm_export_functions {
 	) => {
 		#[no_mangle]
 		#[allow(unreachable_code)]
-		#[cfg(not(feature = "std"))]
+		#[cfg(feature = "runtime-wasm")]
 		pub fn $name(input_data: *mut u8, input_len: usize) -> u64 {
 			let input: &[u8] = if input_len == 0 {
 				&[0u8; 0]
@@ -336,7 +336,7 @@ macro_rules! wasm_export_functions {
 	) => {
 		#[no_mangle]
 		#[allow(unreachable_code)]
-		#[cfg(not(feature = "std"))]
+		#[cfg(feature = "runtime-wasm")]
 		pub fn $name(input_data: *mut u8, input_len: usize) -> u64 {
 			let input: &[u8] = if input_len == 0 {
 				&[0u8; 0]
@@ -363,11 +363,11 @@ macro_rules! wasm_export_functions {
 ///
 /// Internally this just wraps a `ThreadPool` with a pool size of `8`. This
 /// should ensure that we have enough threads in tests for spawning blocking futures.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Clone)]
 pub struct TaskExecutor(futures::executor::ThreadPool);
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl TaskExecutor {
 	/// Create a new instance of `Self`.
 	pub fn new() -> Self {
@@ -376,7 +376,7 @@ impl TaskExecutor {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl crate::traits::SpawnNamed for TaskExecutor {
 	fn spawn_blocking(&self, _: &'static str, future: futures::future::BoxFuture<'static, ()>) {
 		self.0.spawn_ok(future);

--- a/primitives/debug-derive/src/impls.rs
+++ b/primitives/debug-derive/src/impls.rs
@@ -43,7 +43,7 @@ pub fn debug_derive(ast: DeriveInput) -> proc_macro::TokenStream {
 	gen.into()
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 mod implementation {
 	use super::*;
 
@@ -58,7 +58,7 @@ mod implementation {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod implementation {
 	use super::*;
 	use proc_macro2::Span;

--- a/primitives/externalities/Cargo.toml
+++ b/primitives/externalities/Cargo.toml
@@ -20,7 +20,8 @@ environmental = { version = "1.1.2", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"environmental/std",

--- a/primitives/finality-grandpa/Cargo.toml
+++ b/primitives/finality-grandpa/Cargo.toml
@@ -26,7 +26,8 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" 
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-application-crypto/std",
 	"codec/std",

--- a/primitives/finality-grandpa/src/lib.rs
+++ b/primitives/finality-grandpa/src/lib.rs
@@ -19,20 +19,20 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 extern crate alloc;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::Serialize;
 
 use codec::{Encode, Decode, Input, Codec};
 use sp_runtime::{ConsensusEngineId, RuntimeDebug, traits::NumberFor};
 use sp_std::borrow::Cow;
 use sp_std::vec::Vec;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_core::traits::BareCryptoStorePtr;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use log::debug;
 
 /// Key type for GRANDPA module.
@@ -362,7 +362,7 @@ where
 	let valid = id.verify(&buf, signature);
 
 	if !valid {
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		debug!(target: "afg", "Bad signature on message from {:?}", id);
 	}
 
@@ -370,7 +370,7 @@ where
 }
 
 /// Localizes the message to the given set and round and signs the payload.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn sign_message<H, N>(
 	keystore: &BareCryptoStorePtr,
 	message: grandpa::Message<H, N>,

--- a/primitives/finality-tracker/Cargo.toml
+++ b/primitives/finality-tracker/Cargo.toml
@@ -18,7 +18,8 @@ sp-inherents = { version = "2.0.0", default-features = false, path = "../../prim
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-std/std",

--- a/primitives/finality-tracker/src/lib.rs
+++ b/primitives/finality-tracker/src/lib.rs
@@ -22,7 +22,7 @@
 use sp_inherents::{InherentIdentifier, InherentData, Error};
 use codec::Decode;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use codec::Encode;
 
 /// The identifier for the `finalnum` inherent.
@@ -42,20 +42,20 @@ impl<N: Decode> FinalizedInherentData<N> for InherentData {
 }
 
 /// Provider for inherent data.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct InherentDataProvider<F, N> {
 	inner: F,
 	_marker: std::marker::PhantomData<N>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<F, N> InherentDataProvider<F, N> {
 	pub fn new(final_oracle: F) -> Self {
 		InherentDataProvider { inner: final_oracle, _marker: Default::default() }
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<F, N: Encode> sp_inherents::ProvideInherentData for InherentDataProvider<F, N>
 	where F: Fn() -> Result<N, Error>
 {

--- a/primitives/inherents/Cargo.toml
+++ b/primitives/inherents/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = { version = "0.99.2", optional = true }
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"parking_lot",
 	"sp-std/std",

--- a/primitives/inherents/src/lib.rs
+++ b/primitives/inherents/src/lib.rs
@@ -38,25 +38,25 @@ use codec::{Encode, Decode};
 
 use sp_std::{collections::btree_map::{BTreeMap, IntoIter, Entry}, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use parking_lot::RwLock;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::{sync::Arc, format};
 
 /// An error that can occur within the inherent data system.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Debug, Encode, Decode, derive_more::Display)]
 pub struct Error(String);
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<T: Into<String>> From<T> for Error {
 	fn from(data: T) -> Error {
 		Self(data.into())
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl Error {
 	/// Convert this error into a `String`.
 	pub fn into_string(self) -> String {
@@ -66,10 +66,10 @@ impl Error {
 
 /// An error that can occur within the inherent data system.
 #[derive(Encode, sp_core::RuntimeDebug)]
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 pub struct Error(&'static str);
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 impl From<&'static str> for Error {
 	fn from(data: &'static str) -> Error {
 		Self(data)
@@ -247,7 +247,7 @@ impl CheckInherentsResult {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl PartialEq for CheckInherentsResult {
 	fn eq(&self, other: &Self) -> bool {
 		self.fatal_error == other.fatal_error &&
@@ -257,13 +257,13 @@ impl PartialEq for CheckInherentsResult {
 }
 
 /// All `InherentData` providers.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Clone, Default)]
 pub struct InherentDataProviders {
 	providers: Arc<RwLock<Vec<Box<dyn ProvideInherentData + Send + Sync>>>>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl InherentDataProviders {
 	/// Create a new instance.
 	pub fn new() -> Self {
@@ -337,7 +337,7 @@ impl InherentDataProviders {
 }
 
 /// Something that provides inherent data.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait ProvideInherentData {
 	/// Is called when this inherent data provider is registered at the given
 	/// `InherentDataProviders`.
@@ -360,7 +360,7 @@ pub trait ProvideInherentData {
 }
 
 /// A fallback function, if the decoding of an error fails.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 fn error_to_string_fallback(identifier: &InherentIdentifier) -> String {
 	format!(
 		"Error while checking inherent of type \"{}\", but error could not be decoded.",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -33,7 +33,7 @@ tracing = { version = "0.1.19", default-features = false }
 tracing-core = { version = "0.1.15", default-features = false}
 
 [features]
-default = ["std"]
+default = [ "std" ]
 runtime-wasm = []
 std = [
 	"sp-core/std",

--- a/primitives/io/Cargo.toml
+++ b/primitives/io/Cargo.toml
@@ -34,6 +34,7 @@ tracing-core = { version = "0.1.15", default-features = false}
 
 [features]
 default = ["std"]
+runtime-wasm = []
 std = [
 	"sp-core/std",
 	"codec/std",

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -32,10 +32,10 @@ use sp_std::vec::Vec;
 #[cfg(feature = "std")]
 use sp_std::ops::Deref;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use tracing;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_core::{
 	crypto::Pair,
 	traits::{KeystoreExt, CallInWasmExt, TaskExecutorExt},
@@ -51,7 +51,7 @@ use sp_core::{
 	},
 };
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_trie::{TrieConfiguration, trie_types::Layout};
 
 use sp_runtime_interface::{runtime_interface, Pointer};
@@ -59,13 +59,13 @@ use sp_runtime_interface::pass_by::PassBy;
 
 use codec::{Encode, Decode};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_externalities::{ExternalitiesExt, Externalities};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod batch_verifier;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use batch_verifier::BatchVerifier;
 
 /// Error verifying ECDSA signature
@@ -760,7 +760,7 @@ pub trait OffchainIndex {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 sp_externalities::decl_extension! {
 	/// The keystore extension to register/retrieve from the externalities.
 	pub struct VerificationExt(BatchVerifier);
@@ -1247,14 +1247,14 @@ pub trait Sandbox {
 }
 
 /// Allocator used by Substrate when executing the Wasm runtime.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 struct WasmAllocator;
 
 #[cfg(all(not(feature = "disable_allocator"), not(feature = "std")))]
 #[global_allocator]
 static ALLOCATOR: WasmAllocator = WasmAllocator;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 mod allocator_impl {
 	use super::*;
 	use core::alloc::{GlobalAlloc, Layout};
@@ -1293,13 +1293,13 @@ pub fn oom(_: core::alloc::Layout) -> ! {
 }
 
 /// Type alias for Externalities implementation used in tests.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type TestExternalities = sp_state_machine::TestExternalities<sp_core::Blake2Hasher, u64>;
 
 /// The host functions Substrate provides for the Wasm runtime environment.
 ///
 /// All these host functions will be callable from inside the Wasm environment.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type SubstrateHostFunctions = (
 	storage::HostFunctions,
 	default_child_storage::HostFunctions,

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -29,7 +29,7 @@
 
 use sp_std::vec::Vec;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_std::ops::Deref;
 
 #[cfg(not(feature = "runtime-wasm"))]

--- a/primitives/npos-elections/Cargo.toml
+++ b/primitives/npos-elections/Cargo.toml
@@ -25,7 +25,8 @@ rand = "0.7.3"
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 bench = []
 std = [
 	"codec/std",

--- a/primitives/npos-elections/src/lib.rs
+++ b/primitives/npos-elections/src/lib.rs
@@ -82,9 +82,9 @@ use sp_arithmetic::{
 	traits::{Zero, Bounded},
 };
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Serialize, Deserialize};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use codec::{Encode, Decode};
 
 #[cfg(test)]
@@ -205,7 +205,7 @@ pub struct Edge<AccountId> {
 	weight: ExtendedBalance,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<A: IdentifierT> sp_std::fmt::Debug for Edge<A> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(f, "Edge({:?}, weight = {:?})", self.who, self.weight)
@@ -225,7 +225,7 @@ pub struct Voter<AccountId> {
 	load: Rational128,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<A: IdentifierT> std::fmt::Debug for Voter<A> {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(f, "Voter({:?}, budget = {}, edges = {:?})", self.who, self.budget, self.edges)

--- a/primitives/npos-elections/src/node.rs
+++ b/primitives/npos-elections/src/node.rs
@@ -48,7 +48,7 @@ impl<A> NodeId<A> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<A: fmt::Debug> sp_std::fmt::Debug for NodeId<A> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> sp_std::fmt::Result {
 		write!(
@@ -81,7 +81,7 @@ impl<A: PartialEq> PartialEq for Node<A> {
 
 impl<A: PartialEq> Eq for Node<A> {}
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<A: fmt::Debug + Clone> fmt::Debug for Node<A> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(

--- a/primitives/npos-elections/src/reduce.rs
+++ b/primitives/npos-elections/src/reduce.rs
@@ -404,7 +404,7 @@ fn reduce_all<A: IdentifierT>(assignments: &mut Vec<StakedAssignment<A>>) -> u32
 				let common_count = trailing_common(&voter_root_path, &target_root_path);
 
 				// because roots are the same.
-				#[cfg(feature = "std")]
+				#[cfg(not(feature = "runtime-wasm"))]
 				debug_assert_eq!(
 					target_root_path.last().unwrap(),
 					voter_root_path.last().unwrap()
@@ -428,7 +428,7 @@ fn reduce_all<A: IdentifierT>(assignments: &mut Vec<StakedAssignment<A>>) -> u32
 					.collect::<Vec<NodeRef<A>>>();
 
 				// a cycle's length shall always be multiple of two.
-				#[cfg(feature = "std")]
+				#[cfg(not(feature = "runtime-wasm"))]
 				debug_assert_eq!(cycle.len() % 2, 0);
 
 				// find minimum of cycle.

--- a/primitives/offchain/Cargo.toml
+++ b/primitives/offchain/Cargo.toml
@@ -21,7 +21,8 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" 
 sp-state-machine = { version = "0.8.0", default-features = false, path = "../state-machine" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-core/std",
 	"sp-api/std",

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -34,6 +34,7 @@ trybuild = "1.0.23"
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-wasm-interface/std",
 	"sp-std/std",

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/bare_function_interface.rs
@@ -104,7 +104,7 @@ fn function_no_std_impl(method: &TraitItemMethod) -> Result<TokenStream> {
 
 	Ok(
 		quote! {
-			#[cfg(not(feature = "std"))]
+			#[cfg(feature = "runtime-wasm")]
 			#( #attrs )*
 			pub fn #function_name( #( #args, )* ) #return_value {
 				// Call the host function
@@ -129,7 +129,7 @@ fn function_std_latest_impl(
 	let latest_function_name = create_function_ident_with_version(&method.sig.ident, latest_version);
 
 	Ok(quote_spanned! { method.span() =>
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		#( #attrs )*
 		pub fn #function_name( #( #args, )* ) #return_value {
 			#latest_function_name(
@@ -181,7 +181,7 @@ fn function_std_impl(
 
 	Ok(
 		quote_spanned! { method.span() =>
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			#( #attrs )*
 			fn #function_name( #( #args, )* ) #return_value {
 				#call_to_trait

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/host_function_interface.rs
@@ -64,7 +64,7 @@ pub fn generate(trait_def: &ItemTrait, is_wasm_only: bool) -> Result<TokenStream
 			/// The implementations of the extern host functions. This special implementation module
 			/// is required to change the extern host functions signature to
 			/// `unsafe fn name(args) -> ret` to make the function implementations exchangeable.
-			#[cfg(not(feature = "std"))]
+			#[cfg(feature = "runtime-wasm")]
 			mod extern_host_function_impls {
 				use super::*;
 
@@ -146,7 +146,7 @@ fn generate_exchangeable_host_function(method: &TraitItemMethod) -> Result<Token
 
 	Ok(
 		quote! {
-			#[cfg(not(feature = "std"))]
+			#[cfg(feature = "runtime-wasm")]
 			#[allow(non_upper_case_globals)]
 			#[doc = #doc_string]
 			pub static #exchangeable_function : #crate_::wasm::ExchangeableFunction<
@@ -171,10 +171,10 @@ fn generate_host_functions_struct(trait_def: &ItemTrait, is_wasm_only: bool) -> 
 	Ok(
 		quote! {
 			/// Provides implementations for the extern host functions.
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			pub struct HostFunctions;
 
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			impl #crate_::sp_wasm_interface::HostFunctions for HostFunctions {
 				fn host_functions() -> Vec<&'static dyn #crate_::sp_wasm_interface::Function> {
 					vec![ #( #host_functions ),* ]

--- a/primitives/runtime-interface/proc-macro/src/runtime_interface/trait_decl_impl.rs
+++ b/primitives/runtime-interface/proc-macro/src/runtime_interface/trait_decl_impl.rs
@@ -174,7 +174,7 @@ fn impl_trait_for_externalities(trait_def: &ItemTrait, is_wasm_only: bool) -> Re
 
 	Ok(
 		quote! {
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			impl #trait_ for #impl_type {
 				#( #methods )*
 			}

--- a/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm-deprecated/Cargo.toml
@@ -23,4 +23,5 @@ wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-run
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [ "sp-runtime-interface/std", "sp-std/std", "sp-core/std", "sp-io/std" ]

--- a/primitives/runtime-interface/test-wasm-deprecated/src/lib.rs
+++ b/primitives/runtime-interface/test-wasm-deprecated/src/lib.rs
@@ -23,10 +23,10 @@ use sp_core::wasm_export_functions;
 use sp_runtime_interface::runtime_interface;
 
 // Include the WASM binary
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 /// Wasm binary unwrapped. If built with `BUILD_DUMMY_WASM_BINARY`, the function panics.
 pub fn wasm_binary_unwrap() -> &'static [u8] {
 	WASM_BINARY.expect("Development wasm binary is not available. Testing is only \
@@ -35,7 +35,7 @@ pub fn wasm_binary_unwrap() -> &'static [u8] {
 
 /// This function is not used, but we require it for the compiler to include `sp-io`.
 /// `sp-io` is required for its panic and oom handler.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[no_mangle]
 pub fn import_sp_io() {
 	sp_io::misc::print_utf8(&[]);

--- a/primitives/runtime-interface/test-wasm/Cargo.toml
+++ b/primitives/runtime-interface/test-wasm/Cargo.toml
@@ -23,4 +23,5 @@ wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-run
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [ "sp-runtime-interface/std", "sp-std/std", "sp-core/std", "sp-io/std" ]

--- a/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -21,16 +21,16 @@
 
 use sp_runtime_interface::runtime_interface;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 use sp_std::{prelude::*, mem, convert::TryFrom};
 
 use sp_core::{sr25519::Public, wasm_export_functions};
 
 // Include the WASM binary
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 /// Wasm binary unwrapped. If built with `BUILD_DUMMY_WASM_BINARY`, the function panics.
 pub fn wasm_binary_unwrap() -> &'static [u8] {
 	WASM_BINARY.expect("Development wasm binary is not available. Testing is only \

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -39,7 +39,8 @@ sp-state-machine = { version = "0.8.0", path = "../../primitives/state-machine" 
 [features]
 bench = []
 runtime-benchmarks = []
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-application-crypto/std",
 	"sp-arithmetic/std",

--- a/primitives/runtime/src/generic/block.rs
+++ b/primitives/runtime/src/generic/block.rs
@@ -17,10 +17,10 @@
 
 //! Generic implementation of a block and associated items.
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::fmt;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Deserialize, Serialize};
 
 use sp_std::prelude::*;
@@ -58,7 +58,7 @@ impl<Block: BlockT> BlockId<Block> {
 
 impl<Block: BlockT> Copy for BlockId<Block> {}
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<Block: BlockT> fmt::Display for BlockId<Block> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{:?}", self)

--- a/primitives/runtime/src/generic/digest.rs
+++ b/primitives/runtime/src/generic/digest.rs
@@ -17,7 +17,7 @@
 
 //! Generic implementation of a digest.
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Deserialize, Serialize};
 
 use sp_std::prelude::*;
@@ -135,7 +135,7 @@ pub enum ChangesTrieSignal {
 	NewConfiguration(Option<ChangesTrieConfiguration>),
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<Hash: Encode> serde::Serialize for DigestItem<Hash> {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		self.using_encoded(|bytes| {
@@ -144,7 +144,7 @@ impl<Hash: Encode> serde::Serialize for DigestItem<Hash> {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, Hash: Decode> serde::Deserialize<'a> for DigestItem<Hash> {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error> where
 		D: serde::Deserializer<'a>,

--- a/primitives/runtime/src/generic/era.rs
+++ b/primitives/runtime/src/generic/era.rs
@@ -17,7 +17,7 @@
 
 //! Generic implementation of an unchecked (pre-verification) extrinsic.
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Serialize, Deserialize};
 
 use crate::codec::{Decode, Encode, Input, Output, Error};

--- a/primitives/runtime/src/generic/header.rs
+++ b/primitives/runtime/src/generic/header.rs
@@ -17,7 +17,7 @@
 
 //! Generic implementation of a block header.
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Deserialize, Serialize};
 use crate::codec::{Decode, Encode, Codec, Input, Output, HasCompact, EncodeAsRef, Error};
 use crate::traits::{
@@ -53,7 +53,7 @@ pub struct Header<Number: Copy + Into<U256> + TryFrom<U256>, Hash: HashT> {
 	pub digest: Digest<Hash::Output>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<Number, Hash> parity_util_mem::MallocSizeOf for Header<Number, Hash>
 where
 	Number: Copy + Into<U256> + TryFrom<U256> + parity_util_mem::MallocSizeOf,
@@ -69,7 +69,7 @@ where
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn serialize_number<S, T: Copy + Into<U256> + TryFrom<U256>>(
 	val: &T, s: S,
 ) -> Result<S::Ok, S::Error> where S: serde::Serializer {
@@ -77,7 +77,7 @@ pub fn serialize_number<S, T: Copy + Into<U256> + TryFrom<U256>>(
 	serde::Serialize::serialize(&u256, s)
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn deserialize_number<'a, D, T: Copy + Into<U256> + TryFrom<U256>>(
 	d: D,
 ) -> Result<T, D::Error> where D: serde::Deserializer<'a> {
@@ -148,7 +148,7 @@ impl<Number, Hash> traits::Header for Header<Number, Hash> where
 	fn digest(&self) -> &Digest<Self::Hash> { &self.digest }
 
 	fn digest_mut(&mut self) -> &mut Digest<Self::Hash> {
-		#[cfg(feature = "std")]
+		#[cfg(not(feature = "runtime-wasm"))]
 		log::debug!(target: "header", "Retrieving mutable reference to digest");
 		&mut self.digest
 	}

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -48,7 +48,7 @@ where
 	pub function: Call,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<Address, Call, Signature, Extra> parity_util_mem::MallocSizeOf
 	for UncheckedExtrinsic<Address, Call, Signature, Extra>
 where
@@ -279,7 +279,7 @@ where
 	Extra: SignedExtension,
 {}
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> serde::Serialize
 	for UncheckedExtrinsic<Address, Call, Signature, Extra>
 {
@@ -288,7 +288,7 @@ impl<Address: Encode, Signature: Encode, Call: Encode, Extra: SignedExtension> s
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, Address: Decode, Signature: Decode, Call: Decode, Extra: SignedExtension> serde::Deserialize<'a>
 	for UncheckedExtrinsic<Address, Call, Signature, Extra>
 {

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -26,7 +26,7 @@
 
 #[doc(hidden)]
 pub use codec;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[doc(hidden)]
 pub use serde;
 #[doc(hidden)]
@@ -38,7 +38,7 @@ pub use paste;
 #[doc(hidden)]
 pub use sp_application_crypto as app_crypto;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use sp_core::storage::{Storage, StorageChild};
 
 use sp_std::prelude::*;
@@ -50,7 +50,7 @@ use codec::{Encode, Decode};
 pub mod curve;
 pub mod generic;
 pub mod offchain;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod testing;
 pub mod traits;
 pub mod transaction_validity;
@@ -103,12 +103,12 @@ impl TypeId for ModuleId {
 	const TYPE_ID: [u8; 4] = *b"modl";
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use serde::{Serialize, Deserialize, de::DeserializeOwned};
 use crate::traits::IdentifyAccount;
 
 /// Complex storage builder stuff.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait BuildStorage {
 	/// Build the storage out of this builder.
 	fn build_storage(&self) -> Result<sp_core::storage::Storage, String> {
@@ -124,7 +124,7 @@ pub trait BuildStorage {
 }
 
 /// Something that can build the genesis storage of a module.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait BuildModuleGenesisStorage<T, I>: Sized {
 	/// Create the module genesis storage into the given `storage` and `child_storage`.
 	fn build_module_genesis_storage(
@@ -133,7 +133,7 @@ pub trait BuildModuleGenesisStorage<T, I>: Sized {
 	) -> Result<(), String>;
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl BuildStorage for sp_core::storage::Storage {
 	fn assimilate_storage(
 		&self,
@@ -155,7 +155,7 @@ impl BuildStorage for sp_core::storage::Storage {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl BuildStorage for () {
 	fn assimilate_storage(
 		&self,
@@ -311,7 +311,7 @@ impl TryFrom<MultiSigner> for ecdsa::Public {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Display for MultiSigner {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match *self {
@@ -699,7 +699,7 @@ macro_rules! impl_outer_config {
 /// # }
 /// ```
 #[macro_export]
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 macro_rules! assert_eq_error_rate {
 	($x:expr, $y:expr, $error:expr $(,)?) => {
 		assert!(
@@ -724,7 +724,7 @@ impl OpaqueExtrinsic {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl parity_util_mem::MallocSizeOf for OpaqueExtrinsic {
 	fn size_of(&self, ops: &mut parity_util_mem::MallocSizeOfOps) -> usize {
 		self.0.size_of(ops)
@@ -732,26 +732,26 @@ impl parity_util_mem::MallocSizeOf for OpaqueExtrinsic {
 }
 
 impl sp_std::fmt::Debug for OpaqueExtrinsic {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn fmt(&self, fmt: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(fmt, "{}", sp_core::hexdisplay::HexDisplay::from(&self.0))
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn fmt(&self, _fmt: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		Ok(())
 	}
 }
 
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl ::serde::Serialize for OpaqueExtrinsic {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
 		codec::Encode::using_encoded(&self.0, |bytes| ::sp_core::bytes::serialize(bytes, seq))
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a> ::serde::Deserialize<'a> for OpaqueExtrinsic {
 	fn deserialize<D>(de: D) -> Result<Self, D::Error> where D: ::serde::Deserializer<'a> {
 		let r = ::sp_core::bytes::deserialize(de)?;

--- a/primitives/runtime/src/offchain/http.rs
+++ b/primitives/runtime/src/offchain/http.rs
@@ -50,7 +50,7 @@
 
 use sp_std::str;
 use sp_std::prelude::Vec;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 use sp_std::prelude::vec;
 use sp_core::RuntimeDebug;
 use sp_core::offchain::{
@@ -377,7 +377,7 @@ pub struct ResponseBody {
 	deadline: Option<Timestamp>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Debug for ResponseBody {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
 		fmt.debug_struct("ResponseBody")

--- a/primitives/runtime/src/runtime_string.rs
+++ b/primitives/runtime/src/runtime_string.rs
@@ -25,10 +25,10 @@ pub enum RuntimeString {
 	/// The borrowed mode that wraps a `&'static str`.
 	Borrowed(&'static str),
 	/// The owned mode that wraps a `String`.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	Owned(String),
 	/// The owned mode that wraps a `Vec<u8>`.
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	Owned(Vec<u8>),
 }
 
@@ -38,7 +38,7 @@ impl From<&'static str> for RuntimeString {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl From<RuntimeString> for String {
 	fn from(string: RuntimeString) -> Self {
 		match string {
@@ -84,7 +84,7 @@ impl Decode for RuntimeString {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl std::fmt::Display for RuntimeString {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match self {
@@ -94,7 +94,7 @@ impl std::fmt::Display for RuntimeString {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl serde::Serialize for RuntimeString {
 	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
 		match self {
@@ -104,7 +104,7 @@ impl serde::Serialize for RuntimeString {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'de> serde::Deserialize<'de> for RuntimeString {
 	fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
 		String::deserialize(de).map(Self::Owned)

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -20,11 +20,11 @@
 use sp_std::prelude::*;
 use sp_std::{self, marker::PhantomData, convert::{TryFrom, TryInto}, fmt::Debug};
 use sp_io;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::fmt::Display;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::str::FromStr;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Serialize, Deserialize, de::DeserializeOwned};
 use sp_core::{self, Hasher, TypeId, RuntimeDebug};
 use crate::codec::{Codec, Encode, Decode};
@@ -410,7 +410,7 @@ pub trait CheckEqual {
 }
 
 impl CheckEqual for sp_core::H256 {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn check_equal(&self, other: &Self) {
 		use sp_core::hexdisplay::HexDisplay;
 		if self != other {
@@ -422,7 +422,7 @@ impl CheckEqual for sp_core::H256 {
 		}
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn check_equal(&self, other: &Self) {
 		if self != other {
 			"Hash not equal".print();
@@ -433,14 +433,14 @@ impl CheckEqual for sp_core::H256 {
 }
 
 impl<H: PartialEq + Eq + Debug> CheckEqual for super::generic::DigestItem<H> where H: Encode {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	fn check_equal(&self, other: &Self) {
 		if self != other {
 			println!("DigestItem: given={:?}, expected={:?}", self, other);
 		}
 	}
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	fn check_equal(&self, other: &Self) {
 		if self != other {
 			"DigestItem not equal".print();
@@ -884,7 +884,7 @@ impl<AccountId, Call: Dispatchable> SignedExtension for Tuple {
 }
 
 /// Only for bare bone testing when you don't care about signed extensions at all.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl SignedExtension for () {
 	type AccountId = u64;
 	type AdditionalSigned = ();
@@ -1331,7 +1331,7 @@ impl Printable for Tuple {
 }
 
 /// Something that can convert a [`BlockId`](crate::generic::BlockId) to a number or a hash.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait BlockIdTo<Block: self::Block> {
 	/// The error type that will be returned by the functions.
 	type Error: std::fmt::Debug;

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -25,7 +25,8 @@ wat = "1.0"
 assert_matches = "1.3.0"
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"wasmi",
 	"sp-core/std",

--- a/primitives/sandbox/src/lib.rs
+++ b/primitives/sandbox/src/lib.rs
@@ -44,10 +44,10 @@ pub use sp_core::sandbox::HostError;
 pub use sp_wasm_interface::{Value, ReturnValue};
 
 mod imp {
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	include!("../with_std.rs");
 
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	include!("../without_std.rs");
 }
 

--- a/primitives/session/Cargo.toml
+++ b/primitives/session/Cargo.toml
@@ -22,6 +22,7 @@ sp-runtime = { version = "2.0.0", optional = true, path = "../runtime" }
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-api/std",

--- a/primitives/session/src/lib.rs
+++ b/primitives/session/src/lib.rs
@@ -21,9 +21,9 @@
 
 use codec::{Encode, Decode};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_api::ProvideRuntimeApi;
 
 use sp_core::RuntimeDebug;
@@ -108,7 +108,7 @@ impl GetValidatorCount for MembershipProof {
 
 /// Generate the initial session keys with the given seeds, at the given block and store them in
 /// the client's keystore.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub fn generate_initial_session_keys<Block, T>(
 	client: std::sync::Arc<T>,
 	at: &BlockId<Block>,

--- a/primitives/staking/Cargo.toml
+++ b/primitives/staking/Cargo.toml
@@ -18,7 +18,8 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" 
 sp-std = { version = "2.0.0", default-features = false, path = "../std" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"sp-runtime/std",

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -35,7 +35,8 @@ sp-runtime = { version = "2.0.0", path = "../runtime" }
 pretty_assertions = "0.6.1"
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec/std",
 	"hash-db/std",

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -28,7 +28,7 @@ use crate::{
 	UsageInfo, StorageKey, StorageValue, StorageCollection, ChildStorageCollection,
 };
 use sp_std::vec::Vec;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_core::traits::RuntimeCode;
 
 /// A state backend is used to read state data and can have changes committed
@@ -377,13 +377,13 @@ pub(crate) fn insert_into_memory_db<H, I>(mdb: &mut sp_trie::MemoryDB<H>, input:
 }
 
 /// Wrapper to create a [`RuntimeCode`] from a type that implements [`Backend`].
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct BackendRuntimeCode<'a, B, H> {
 	backend: &'a B,
 	_marker: std::marker::PhantomData<H>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, B: Backend<H>, H: Hasher> sp_core::traits::FetchRuntimeCode for
 	BackendRuntimeCode<'a, B, H>
 {
@@ -392,7 +392,7 @@ impl<'a, B: Backend<H>, H: Hasher> sp_core::traits::FetchRuntimeCode for
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<'a, B: Backend<H>, H: Hasher> BackendRuntimeCode<'a, B, H> where H::Out: Encode {
 	/// Create a new instance.
 	pub fn new(backend: &'a B) -> Self {

--- a/primitives/state-machine/src/lib.rs
+++ b/primitives/state-machine/src/lib.rs
@@ -21,36 +21,36 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod backend;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod in_memory_backend;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod changes_trie;
 mod error;
 mod ext;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod testing;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod basic;
 pub(crate) mod overlayed_changes;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod proving_backend;
 mod trie_backend;
 mod trie_backend_essence;
 mod stats;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod read_only;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use std_reexport::*;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use execution::*;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use log::{debug, warn, trace, error as log_error};
 
 /// In no_std we skip logs for state_machine, this macro
 /// is a noops.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[macro_export]
 macro_rules! warn {
 	(target: $target:expr, $($arg:tt)+) => (
@@ -63,7 +63,7 @@ macro_rules! warn {
 
 /// In no_std we skip logs for state_machine, this macro
 /// is a noops.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[macro_export]
 macro_rules! debug {
 	(target: $target:expr, $($arg:tt)+) => (
@@ -76,7 +76,7 @@ macro_rules! debug {
 
 /// In no_std we skip logs for state_machine, this macro
 /// is a noops.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[macro_export]
 macro_rules! trace {
 	(target: $target:expr, $($arg:tt)+) => (
@@ -89,7 +89,7 @@ macro_rules! trace {
 
 /// In no_std we skip logs for state_machine, this macro
 /// is a noops.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[macro_export]
 macro_rules! log_error {
 	(target: $target:expr, $($arg:tt)+) => (
@@ -101,14 +101,14 @@ macro_rules! log_error {
 }
 
 /// Default error type to use with state machine trie backend.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub type DefaultError = String;
 /// Error type to use with state machine trie backend.
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct DefaultError;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 impl sp_std::fmt::Display for DefaultError {
 	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
 		write!(f, "DefaultError")
@@ -127,7 +127,7 @@ pub use crate::stats::{UsageInfo, UsageUnit, StateMachineStats};
 pub use error::{Error, ExecutionError};
 pub use crate::ext::Ext;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 mod changes_trie {
 	/// Stub for change trie block number until
 	/// change trie move to no_std.
@@ -136,7 +136,7 @@ mod changes_trie {
 	impl<N> BlockNumber for N {}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod std_reexport {
 	pub use sp_trie::{trie_types::{Layout, TrieDBMut}, StorageProof, TrieMut, DBValue, MemoryDB};
 	pub use crate::testing::TestExternalities;
@@ -164,7 +164,7 @@ mod std_reexport {
 	pub use crate::in_memory_backend::new_in_mem;
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod execution {
 	use super::*;
 	use std::{fmt, result, collections::HashMap, panic::UnwindSafe};

--- a/primitives/state-machine/src/overlayed_changes/changeset.rs
+++ b/primitives/state-machine/src/overlayed_changes/changeset.rs
@@ -19,9 +19,9 @@
 
 use super::{StorageKey, StorageValue, Extrinsics};
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::collections::HashSet as Set;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 use sp_std::collections::btree_set::BTreeSet as Set;
 
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};

--- a/primitives/state-machine/src/stats.rs
+++ b/primitives/state-machine/src/stats.rs
@@ -17,7 +17,7 @@
 
 //! Usage statistics for state db
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::time::{Instant, Duration};
 use sp_std::cell::RefCell;
 
@@ -51,10 +51,10 @@ pub struct UsageInfo {
 	/// Memory used.
 	pub memory: usize,
 
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	/// Moment at which current statistics has been started being collected.
 	pub started: Instant,
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	/// Timespan of the statistics.
 	pub span: Duration,
 }
@@ -102,9 +102,9 @@ impl UsageInfo {
 			cache_reads: UsageUnit::default(),
 			modified_reads: UsageUnit::default(),
 			memory: 0,
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			started: Instant::now(),
-			#[cfg(feature = "std")]
+			#[cfg(not(feature = "runtime-wasm"))]
 			span: Default::default(),
 		}
 	}

--- a/primitives/state-machine/src/trie_backend_essence.rs
+++ b/primitives/state-machine/src/trie_backend_essence.rs
@@ -18,7 +18,7 @@
 //! Trie-based state machine backend essence used to read values
 //! from storage.
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::sync::Arc;
 use sp_std::{ops::Deref, boxed::Box, vec::Vec};
 use crate::{warn, debug};
@@ -31,7 +31,7 @@ use crate::{backend::Consolidate, StorageKey, StorageValue};
 use sp_core::storage::ChildInfo;
 use codec::Encode;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "runtime-wasm")]
 macro_rules! format {
 	($($arg:tt)+) => (
 		crate::DefaultError
@@ -351,7 +351,7 @@ pub trait TrieBackendStorage<H: Hasher>: Send + Sync {
 }
 
 // This implementation is used by normal storage trie clients.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<H: Hasher> TrieBackendStorage<H> for Arc<dyn Storage<H>> {
 	type Overlay = PrefixedMemoryDB<H>;
 

--- a/primitives/std/Cargo.toml
+++ b/primitives/std/Cargo.toml
@@ -15,5 +15,6 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = []

--- a/primitives/std/src/lib.rs
+++ b/primitives/std/src/lib.rs
@@ -99,6 +99,6 @@ pub mod prelude {
 
 	// Re-export `vec!` macro here, but not in `std` mode, since
 	// std's prelude already brings `vec!` into the scope.
-	#[cfg(not(feature = "std"))]
+	#[cfg(feature = "runtime-wasm")]
 	pub use crate::vec;
 }

--- a/primitives/storage/Cargo.toml
+++ b/primitives/storage/Cargo.toml
@@ -23,4 +23,5 @@ codec = { package = "parity-scale-codec", version = "1.3.1", default-features = 
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [ "sp-std/std", "serde", "impl-serde", "codec/std" ]

--- a/primitives/test-primitives/src/lib.rs
+++ b/primitives/test-primitives/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Extrinsic {
 	StorageChange(Vec<u8>, Option<Vec<u8>>),
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl serde::Serialize for Extrinsic {
 	fn serialize<S>(&self, seq: S) -> Result<S::Ok, S::Error> where S: ::serde::Serializer {
 		self.using_encoded(|bytes| seq.serialize_bytes(bytes))

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -23,6 +23,7 @@ wasm-timer = { version = "0.2", optional = true }
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-api/std",
 	"sp-std/std",

--- a/primitives/timestamp/src/lib.rs
+++ b/primitives/timestamp/src/lib.rs
@@ -20,9 +20,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::Encode;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use codec::Decode;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_inherents::ProvideInherentData;
 use sp_inherents::{InherentIdentifier, IsFatalError, InherentData};
 
@@ -55,7 +55,7 @@ impl IsFatalError for InherentError {
 
 impl InherentError {
 	/// Try to create an instance ouf of the given identifier and data.
-	#[cfg(feature = "std")]
+	#[cfg(not(feature = "runtime-wasm"))]
 	pub fn try_from(id: &InherentIdentifier, data: &[u8]) -> Option<Self> {
 		if id == &INHERENT_IDENTIFIER {
 			<InherentError as codec::Decode>::decode(&mut &data[..]).ok()
@@ -79,10 +79,10 @@ impl TimestampInherentData for InherentData {
 }
 
 /// Provide duration since unix epoch in millisecond for timestamp inherent.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub struct InherentDataProvider;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl ProvideInherentData for InherentDataProvider {
 	fn inherent_identifier(&self) -> &'static InherentIdentifier {
 		&INHERENT_IDENTIFIER

--- a/primitives/tracing/Cargo.toml
+++ b/primitives/tracing/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { version = "0.2.10", optional = true, features = ["tracing
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 with-tracing = [
     "codec/derive",
     "codec/full",

--- a/primitives/transaction-pool/Cargo.toml
+++ b/primitives/transaction-pool/Cargo.toml
@@ -25,6 +25,7 @@ sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" 
 
 [features]
 default = [ "std" ]
+runtime-wasm = []
 std = [
 	"codec",
 	"derive_more",

--- a/primitives/transaction-pool/src/lib.rs
+++ b/primitives/transaction-pool/src/lib.rs
@@ -21,12 +21,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod runtime_api;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub mod error;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod pool;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub use pool::*;
 
 pub use sp_runtime::transaction_validity::{

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -34,7 +34,8 @@ hex-literal = "0.3.1"
 sp-runtime = { version = "2.0.0", path = "../runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"sp-std/std",
 	"codec/std",

--- a/primitives/version/Cargo.toml
+++ b/primitives/version/Cargo.toml
@@ -22,7 +22,8 @@ sp-std = { version = "2.0.0", default-features = false, path = "../std" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../runtime" }
 
 [features]
-default = ["std"]
+default = [ "std" ]
+runtime-wasm = []
 std = [
 	"impl-serde",
 	"serde",

--- a/primitives/version/src/lib.rs
+++ b/primitives/version/src/lib.rs
@@ -19,11 +19,11 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use serde::{Serialize, Deserialize};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::fmt;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use std::collections::HashSet;
 
 use codec::{Encode, Decode};
@@ -32,7 +32,7 @@ pub use sp_runtime::create_runtime_str;
 #[doc(hidden)]
 pub use sp_std;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 use sp_runtime::{traits::Block as BlockT, generic::BlockId};
 
 /// The identity of a particular API interface that the runtime might provide.
@@ -107,7 +107,7 @@ pub struct RuntimeVersion {
 	pub transaction_version: u32,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl fmt::Display for RuntimeVersion {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{}-{} ({}-{}.tx{}.au{})",
@@ -121,7 +121,7 @@ impl fmt::Display for RuntimeVersion {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl RuntimeVersion {
 	/// Check if this version matches other version for calling into runtime.
 	pub fn can_call_with(&self, other: &RuntimeVersion) -> bool {
@@ -141,7 +141,7 @@ impl RuntimeVersion {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 #[derive(Debug)]
 pub struct NativeVersion {
 	/// Basic runtime version info.
@@ -150,7 +150,7 @@ pub struct NativeVersion {
 	pub can_author_with: HashSet<u32>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl NativeVersion {
 	/// Check if this version matches other version for authoring blocks.
 	///
@@ -181,7 +181,7 @@ impl NativeVersion {
 }
 
 /// Something that can provide the runtime version at a given block and the native runtime version.
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 pub trait GetRuntimeVersion<Block: BlockT> {
 	/// Returns the version of the native runtime.
 	fn native_version(&self) -> &NativeVersion;
@@ -190,7 +190,7 @@ pub trait GetRuntimeVersion<Block: BlockT> {
 	fn runtime_version(&self, at: &BlockId<Block>) -> Result<RuntimeVersion, String>;
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 impl<T: GetRuntimeVersion<Block>, Block: BlockT> GetRuntimeVersion<Block> for std::sync::Arc<T> {
 	fn native_version(&self) -> &NativeVersion {
 		(&**self).native_version()
@@ -201,7 +201,7 @@ impl<T: GetRuntimeVersion<Block>, Block: BlockT> GetRuntimeVersion<Block> for st
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "runtime-wasm"))]
 mod apis_serialize {
 	use super::*;
 	use impl_serde::serialize as bytes;


### PR DESCRIPTION
fixes #5547 

Main steps done:
1. replace `#[cfg(feature = "std")]` by `#[cfg(not(feature = "runtime-wasm"))]` and the logical opposite
```
find . -type f -name "*.rs" ! -path "./target/*" -print0 | xargs -0 sed -i 's/#\[cfg(feature = "std")\]/#\[cfg(not(feature = "runtime-wasm"))\]/g' 
find . -type f -name "*.rs" ! -path "./target/*" -print0 | xargs -0 sed -i 's/#\[cfg(not(feature = "std"))\]/#\[cfg(feature = "runtime-wasm")\]/g' 
```
2. introduce `runtime-wasm` feature in all tomls (probably that's too many as not all are needed for runtime)
```
find . -type f -name "*.toml" -print0 | xargs -0 sed -i 's/default = \[ "std" \]/default = \[ "std" \]\nruntime-wasm = \[\]/g' 
find . -type f -name "*.toml" -print0 | xargs -0 sed -i 's/default = \["std"\]/default = \[ "std" \]\nruntime-wasm = \[\]/g' 
```
3. let wasm-builder-runner add the `runtime-wasm` feature to rustc args
4. manual fixes, i.e. to gate `RuntimeDebug` derivation

this is WIP. not yet sure if the approach makes sense


