### PR TITLE
add ss58 id for nodle

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -496,6 +496,8 @@ ss58_address_format!(
 		(33, "datahighway", "DataHighway mainnet, standard account (*25519).")
 	CentrifugeAccount =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
+	NodleAccount =>
+		(37, "nodle", "Nodle Chain mainnet, standard account (*25519).")
 	SubstrateAccount =>
 		(42, "substrate", "Any Substrate network, standard account (*25519).")
 	Reserved43 =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -254,6 +254,15 @@
 			"website": "https://centrifuge.io/"
 		},
 		{
+			"prefix": 37,
+			"network": "nodle",
+			"displayName": "Nodle Chain",
+			"symbols": ["NODL"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://nodle.io/"
+		},
+		{
 			"prefix": 39,
 			"network": "mathchain",
 			"displayName": "MathChain mainnet",


### PR DESCRIPTION
This PR modifies the list of reserved SS58 IDs to include one for Nodle (37, we will keep 42 for Arcadia, our tesnet).
We'd then modify our node to include the reserved ID once this PR is merged.

✄ -----------------------------------------------------------------------------

Thank you for your Pull Request!

Before you submitting, please check that:

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://wiki.parity.io/Substrate-Style-Guide)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
