### PR TITLE
Allow `schedule_after(0, ...)` to work

### DIFF
--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -474,7 +474,8 @@ impl<T: Trait> Module<T> {
 
 		let when = match when {
 			DispatchTime::At(x) => x,
-			DispatchTime::After(x) => now.saturating_add(x)
+			// If the user does "after 0", just schedule it for the next block.
+			DispatchTime::After(x) => now.saturating_add(x.max(One::one()))
 		};
 
 		if when <= now {
@@ -894,7 +895,7 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			let call = Call::Logger(logger::Call::log(42, 1000));
 			assert!(!<Test as frame_system::Trait>::BaseCallFilter::filter(&call));
-			let _ = Scheduler::do_schedule(DispatchTime::At(4), None, 127, root(), call);
+			assert_ok!(Scheduler::do_schedule(DispatchTime::At(4), None, 127, root(), call));
 			run_to_block(3);
 			assert!(logger::log().is_empty());
 			run_to_block(4);
@@ -910,7 +911,7 @@ mod tests {
 			run_to_block(2);
 			let call = Call::Logger(logger::Call::log(42, 1000));
 			assert!(!<Test as frame_system::Trait>::BaseCallFilter::filter(&call));
-			let _ = Scheduler::do_schedule(DispatchTime::After(3), None, 127, root(), call);
+			assert_ok!(Scheduler::do_schedule(DispatchTime::After(3), None, 127, root(), call));
 			run_to_block(4);
 			assert!(logger::log().is_empty());
 			run_to_block(5);
@@ -921,12 +922,27 @@ mod tests {
 	}
 
 	#[test]
+	fn schedule_after_zero_works() {
+		new_test_ext().execute_with(|| {
+			run_to_block(2);
+			let call = Call::Logger(logger::Call::log(42, 1000));
+			assert!(!<Test as frame_system::Trait>::BaseCallFilter::filter(&call));
+			assert_ok!(Scheduler::do_schedule(DispatchTime::After(0), None, 127, root(), call));
+			// Will trigger on the next block.
+			run_to_block(3);
+			assert_eq!(logger::log(), vec![(root(), 42u32)]);
+			run_to_block(100);
+			assert_eq!(logger::log(), vec![(root(), 42u32)]);
+		});
+	}
+
+	#[test]
 	fn periodic_scheduling_works() {
 		new_test_ext().execute_with(|| {
 			// at #4, every 3 blocks, 3 times.
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4), Some((3, 3)), 127, root(), Call::Logger(logger::Call::log(42, 1000))
-			);
+			));
 			run_to_block(3);
 			assert!(logger::log().is_empty());
 			run_to_block(4);
@@ -1091,19 +1107,19 @@ mod tests {
 	#[test]
 	fn scheduler_respects_weight_limits() {
 		new_test_ext().execute_with(|| {
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				127,
 				root(),
 				Call::Logger(logger::Call::log(42, MaximumSchedulerWeight::get() / 2))
-			);
-			let _ = Scheduler::do_schedule(
+			));
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				127,
 				root(), Call::Logger(logger::Call::log(69, MaximumSchedulerWeight::get() / 2))
-			);
+			));
 			// 69 and 42 do not fit together
 			run_to_block(4);
 			assert_eq!(logger::log(), vec![(root(), 42u32)]);
@@ -1115,20 +1131,20 @@ mod tests {
 	#[test]
 	fn scheduler_respects_hard_deadlines_more() {
 		new_test_ext().execute_with(|| {
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				0,
 				root(),
 				Call::Logger(logger::Call::log(42, MaximumSchedulerWeight::get() / 2))
-			);
-			let _ = Scheduler::do_schedule(
+			));
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				0,
 				root(),
 				Call::Logger(logger::Call::log(69, MaximumSchedulerWeight::get() / 2))
-			);
+			));
 			// With base weights, 69 and 42 should not fit together, but do because of hard deadlines
 			run_to_block(4);
 			assert_eq!(logger::log(), vec![(root(), 42u32), (root(), 69u32)]);
@@ -1138,20 +1154,20 @@ mod tests {
 	#[test]
 	fn scheduler_respects_priority_ordering() {
 		new_test_ext().execute_with(|| {
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				1,
 				root(),
 				Call::Logger(logger::Call::log(42, MaximumSchedulerWeight::get() / 2))
-			);
-			let _ = Scheduler::do_schedule(
+			));
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				0,
 				root(),
 				Call::Logger(logger::Call::log(69, MaximumSchedulerWeight::get() / 2))
-			);
+			));
 			run_to_block(4);
 			assert_eq!(logger::log(), vec![(root(), 69u32), (root(), 42u32)]);
 		});
@@ -1160,24 +1176,24 @@ mod tests {
 	#[test]
 	fn scheduler_respects_priority_ordering_with_soft_deadlines() {
 		new_test_ext().execute_with(|| {
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				255,
 				root(), Call::Logger(logger::Call::log(42, MaximumSchedulerWeight::get() / 3))
-			);
-			let _ = Scheduler::do_schedule(
+			));
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				127,
 				root(), Call::Logger(logger::Call::log(69, MaximumSchedulerWeight::get() / 2))
-			);
-			let _ = Scheduler::do_schedule(
+			));
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(4),
 				None,
 				126,
 				root(), Call::Logger(logger::Call::log(2600, MaximumSchedulerWeight::get() / 2))
-			);
+			));
 
 			// 2600 does not fit with 69 or 42, but has higher priority, so will go through
 			run_to_block(4);
@@ -1204,21 +1220,21 @@ mod tests {
 				)
 			);
 			// Anon Periodic
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(1),
 				Some((1000, 3)),
 				128,
 				root(),
 				Call::Logger(logger::Call::log(42, MaximumSchedulerWeight::get() / 3))
-			);
+			));
 			// Anon
-			let _ = Scheduler::do_schedule(
+			assert_ok!(Scheduler::do_schedule(
 				DispatchTime::At(1),
 				None,
 				127,
 				root(),
 				Call::Logger(logger::Call::log(69, MaximumSchedulerWeight::get() / 2))
-			);
+			));
 			// Named Periodic
 			assert_ok!(Scheduler::do_schedule_named(
 				2u32.encode(), DispatchTime::At(1), Some((1000, 3)), 126, root(),


### PR DESCRIPTION
Right now, if a user puts `schedule_after(0, ...)`, the call will fail because there is a check that the scheduled block must be greater than the current block:

```
if when <= now {
	return Err(Error::<T>::TargetBlockNumberInPast.into())
}
```

This PR simply adds one additional block to any `schedule_after` call. So `schedule_after(0, ...)` will be the block **after** the current block, `schedule_after(1, ...)` will be the block after that, etc... So after this PR, all `schedule_after` will happen one block later. This allows `schedule_after` to always pass this check with any `after` input.

This is just a quality of life improvement which should capture the intention of the caller.

cc @xlc 