### PR TITLE
add_handlebar_template_to_benchmark_cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
  "byteorder 1.3.4",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -1535,11 +1535,14 @@ version = "2.0.0"
 dependencies = [
  "chrono",
  "frame-benchmarking",
+ "handlebars",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-db",
  "sc-executor",
  "sc-service",
+ "serde",
+ "serde_json",
  "sp-core",
  "sp-externalities",
  "sp-keystore",
@@ -2116,6 +2119,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
+name = "handlebars"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd1b5399b9884f9ae18b5d4105d180720c8f602aeb73d3ceae9d6b1d13a5fa7"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "quick-error 2.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,7 +2301,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -3340,6 +3357,12 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -5382,6 +5405,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,6 +5726,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quickcheck"
@@ -7540,9 +7612,9 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
@@ -7559,9 +7631,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7570,9 +7642,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -9593,6 +9665,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uint"

--- a/frame/benchmarking/README.md
+++ b/frame/benchmarking/README.md
@@ -163,14 +163,15 @@ Then you can run a benchmark like so:
 
 ```bash
 ./target/release/substrate benchmark \
-    --chain dev \               # Configurable Chain Spec
-    --execution=wasm \          # Always test with Wasm
-    --wasm-execution=compiled \ # Always used `wasm-time`
-    --pallet pallet_balances \  # Select the pallet
-    --extrinsic transfer \      # Select the extrinsic
-    --steps 50 \                # Number of samples across component ranges
-    --repeat 20 \               # Number of times we repeat a benchmark
-    --output \                  # Output benchmark results into a Rust file
+    --chain dev \                                     # Configurable Chain Spec
+    --execution=wasm \                                # Always test with Wasm
+    --wasm-execution=compiled \                       # Always used `wasm-time`
+    --pallet pallet_balances \                        # Select the pallet
+    --extrinsic transfer \                            # Select the extrinsic
+    --steps 50 \                                      # Number of samples across component ranges
+    --repeat 20 \                                     # Number of times we repeat a benchmark
+    --output \                                        # Output benchmark results into a Rust file
+    --handlebar-template .\\handlebar_test.hbs        # Path to Handlebar template file for benchmark results (Optional)
 ```
 
 This will output a file `pallet_name.rs` which implements the `WeightInfo` trait you should include

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -26,6 +26,9 @@ sp-state-machine = { version = "0.8.0", path = "../../../primitives/state-machin
 structopt = "0.3.8"
 codec = { version = "1.3.1", package = "parity-scale-codec" }
 chrono = "0.4"
+handlebars = "3.5.0"
+serde_json = "1.0.57"
+serde = "1.0.116"
 
 [features]
 default = ["db"]

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -50,6 +50,10 @@ impl BenchmarkCmd {
 			if !header_file.is_file() { return Err("Header file is invalid!".into()) };
 		}
 
+		if let Some(handlebar_template_file) = &self.handlebar_template {
+			if !handlebar_template_file.is_file() { return Err("Handlebar Template file is invalid!".into()) };
+		}
+		
 		let spec = config.chain_spec;
 		let wasm_method = self.wasm_method.into();
 		let strategy = self.execution.unwrap_or(ExecutionStrategy::Native);
@@ -99,23 +103,44 @@ impl BenchmarkCmd {
 
 		match results {
 			Ok(batches) => {
-				// If we are going to output results to a file...
 				if let Some(output_path) = &self.output {
-					if self.trait_def {
-						crate::writer::write_trait(&batches, output_path, &self.r#trait, self.spaces)?;
-					} else {
-						crate::writer::write_results(
-							&batches,
-							output_path,
-							&self.lowest_range_values,
-							&self.highest_range_values,
-							&self.steps,
-							self.repeat,
-							&self.header,
-							&self.r#struct,
-							&self.r#trait,
-							self.spaces
-						)?;
+					if let Some(handlebar_template) = &self.handlebar_template {
+						if self.trait_def {
+							println!("write_trait:  {:#?} ", &self.r#trait);
+							crate::writer::write_trait(&batches, output_path, &self.r#trait, self.spaces)?;
+						} else {
+							// If we are going to output results using a template to a file...
+							crate::writer::write_results_from_template(
+								&batches,
+								output_path,
+								&self.lowest_range_values,
+								&self.highest_range_values,
+								&self.steps,
+								self.repeat,
+								&self.header,
+								handlebar_template,
+								&self.r#struct,
+								&self.r#trait
+							)?;
+						}
+					}else{
+						if self.trait_def {
+							crate::writer::write_trait(&batches, output_path, &self.r#trait, self.spaces)?;
+						} else {
+							// If we are going to output results to a file...
+							crate::writer::write_results(
+								&batches,
+								output_path,
+								&self.lowest_range_values,
+								&self.highest_range_values,
+								&self.steps,
+								self.repeat,
+								&self.header,
+								&self.r#struct,
+								&self.r#trait,
+								self.spaces
+							)?;
+						}
 					}
 				}
 

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -68,6 +68,10 @@ pub struct BenchmarkCmd {
 	#[structopt(long)]
 	pub header: Option<std::path::PathBuf>,
 
+	/// Path to Handlebar template file for benchmark results (Optional)
+	#[structopt(long)]
+	pub handlebar_template: Option<std::path::PathBuf>,
+
 	/// Output the trait definition to a Rust file.
 	#[structopt(long)]
 	pub trait_def: bool,


### PR DESCRIPTION
PR Description: #7169  

- add benchmark-cli arg to take in a handlebar-template file

Test Command
`
 .\target\release\substrate.exe benchmark --chain dev --execution wasm --wasm-execution compiled --pallet pallet_timestamp --extrinsic * --steps 10 --repeat 20   --handlebar-template .\benchmark\handlebar_test.hbs --output .\benchmark\
`

Sample Handlebar template - handlebar_test.hbs
https://gist.github.com/zadmarbella/2bdc8a135b6ac22972e8e8d75999cf1a

@shawntabrizi @kianenigma looking for a review to merge these changes
