### PR TITLE
Add `CompactAs` derive for `Fixed*` types

### DIFF
--- a/primitives/arithmetic/src/fixed_point.rs
+++ b/primitives/arithmetic/src/fixed_point.rs
@@ -17,7 +17,7 @@
 //! Decimal Fixed Point implementations for Substrate runtime.
 
 use sp_std::{ops::{self, Add, Sub, Mul, Div}, fmt::Debug, prelude::*, convert::{TryInto, TryFrom}};
-use codec::{Encode, Decode};
+use codec::{Encode, Decode, CompactAs};
 use crate::{
 	helpers_128bit::multiply_by_rational, PerThing,
 	traits::{
@@ -342,7 +342,7 @@ macro_rules! implement_fixed {
 		/// A fixed point number representation in the range.
 		///
 		#[doc = $title]
-		#[derive(Encode, Decode, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+		#[derive(Encode, Decode, CompactAs, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 		pub struct $name($inner_type);
 
 		impl From<$inner_type> for $name {


### PR DESCRIPTION
Some associated types in pallets require `HasCompact` trait to be implemented, but if I, for example, want to use a newtype like `Balance(FixedU128)` I can't implement `CompactAs` for it, because it requires a reference to the inner `u128` in `FixedU128` or same implementation for the fixed. In this PR I've chosen the last variant to solve this problem.