### PR TITLE
Fixes bug in wasm-builder with cargo publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8906,7 +8906,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/bin/node-template/runtime/build.rs
+++ b/bin/node-template/runtime/build.rs
@@ -3,7 +3,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates("2.0.0")
+		.with_wasm_builder_from_crates("2.0.1")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/bin/node/runtime/build.rs
+++ b/bin/node/runtime/build.rs
@@ -20,7 +20,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/client/executor/runtime-test/build.rs
+++ b/client/executor/runtime-test/build.rs
@@ -20,7 +20,7 @@ fn main() {
 	// regular build
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
 		.build();
@@ -28,7 +28,7 @@ fn main() {
 	// and building with tracing activated
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
 		.set_file_name("wasm_binary_with_tracing.rs")

--- a/primitives/runtime-interface/test-wasm-deprecated/build.rs
+++ b/primitives/runtime-interface/test-wasm-deprecated/build.rs
@@ -20,7 +20,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/primitives/runtime-interface/test-wasm/build.rs
+++ b/primitives/runtime-interface/test-wasm/build.rs
@@ -20,7 +20,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/test-utils/runtime/build.rs
+++ b/test-utils/runtime/build.rs
@@ -20,7 +20,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates_or_path("2.0.0", "../../utils/wasm-builder")
+		.with_wasm_builder_from_crates_or_path("2.0.1", "../../utils/wasm-builder")
 		.export_heap_base()
 		// Note that we set the stack-size to 1MB explicitly even though it is set
 		// to this value by default. This is because some of our tests (`restoration_of_globals`)

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-wasm-builder"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Utility for building WASM binaries"
 edition = "2018"

--- a/utils/wasm-builder/src/lib.rs
+++ b/utils/wasm-builder/src/lib.rs
@@ -181,16 +181,16 @@ pub fn build_project_with_default_rustflags(
 	};
 
 	write_file_if_changed(
-			file_name.into(),
-			format!(
-				r#"
-					pub const WASM_BINARY: Option<&[u8]> = Some(include_bytes!("{wasm_binary}"));
-					pub const WASM_BINARY_BLOATY: Option<&[u8]> = Some(include_bytes!("{wasm_binary_bloaty}"));
-				"#,
-				wasm_binary = wasm_binary,
-				wasm_binary_bloaty = wasm_binary_bloaty,
-			),
-		);
+		file_name.into(),
+		format!(
+			r#"
+				pub const WASM_BINARY: Option<&[u8]> = Some(include_bytes!("{wasm_binary}"));
+				pub const WASM_BINARY_BLOATY: Option<&[u8]> = Some(include_bytes!("{wasm_binary_bloaty}"));
+			"#,
+			wasm_binary = wasm_binary,
+			wasm_binary_bloaty = wasm_binary_bloaty,
+		),
+	);
 }
 
 /// Checks if the build of the WASM binary should be skipped.

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -95,7 +95,7 @@ fn crate_metadata(cargo_manifest: &Path) -> Metadata {
 		.exec()
 		.expect("`cargo metadata` can not fail on project `Cargo.toml`; qed");
 
-	// If the `Cargo.lock` didn't existed, we need to remove it after
+	// If the `Cargo.lock` didn't exist, we need to remove it after
 	// calling `cargo metadata`. This is required to ensure that we don't change
 	// the build directory outside of the `target` folder. Commands like
 	// `cargo publish` require this.

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -84,6 +84,28 @@ impl Drop for WorkspaceLock {
 	}
 }
 
+fn crate_metadata(cargo_manifest: &Path) -> Metadata {
+	let mut cargo_lock = cargo_manifest.to_path_buf();
+	cargo_lock.set_file_name("Cargo.lock");
+
+	let cargo_lock_existed = cargo_lock.exists();
+
+	let crate_metadata = MetadataCommand::new()
+		.manifest_path(cargo_manifest)
+		.exec()
+		.expect("`cargo metadata` can not fail on project `Cargo.toml`; qed");
+
+	// If the `Cargo.lock` didn't existed, we need to remove it after
+	// calling `cargo metadata`. This is required to ensure that we don't change
+	// the build directory outside of the `target` folder. Commands like
+	// `cargo publish` require this.
+	if !cargo_lock_existed {
+		let _ = fs::remove_file(&cargo_lock);
+	}
+
+	crate_metadata
+}
+
 /// Creates the WASM project, compiles the WASM binary and compacts the WASM binary.
 ///
 /// # Returns
@@ -98,10 +120,7 @@ pub fn create_and_compile(
 	// Lock the workspace exclusively for us
 	let _lock = WorkspaceLock::new(&wasm_workspace_root);
 
-	let crate_metadata = MetadataCommand::new()
-		.manifest_path(cargo_manifest)
-		.exec()
-		.expect("`cargo metadata` can not fail on project `Cargo.toml`; qed");
+	let crate_metadata = crate_metadata(cargo_manifest);
 
 	let project = create_project(cargo_manifest, &wasm_workspace, &crate_metadata);
 	create_wasm_workspace_project(&wasm_workspace, &crate_metadata.workspace_root);


### PR DESCRIPTION
There was a bug in wasm-builder which resulted in generating a
`Cargo.lock` in the project directory because of running `cargo
metadata`. This resulted in commands like `cargo publish` to fail (if
there was no `Cargo.lock` before building), because it checks that the
project directory isn't modified.

Fixes: https://github.com/paritytech/substrate/issues/7116