### PR TITLE
[CI] bump matrix-message-action to v0.0.3

### DIFF
--- a/.github/workflows/burnin-label-notification.yml
+++ b/.github/workflows/burnin-label-notification.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Notify devops
         if: github.event.label.name == 'A1-needsburnin'
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ROOM_ID }}
           access_token: ${{ secrets.POLKADOT_DEVOPS_MATRIX_ACCESS_TOKEN }}

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send message
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}


### PR DESCRIPTION
Required for Github actions that send messages to Matrix/Element to continue working.