### PR TITLE
Add an system_syncState RPC method

### DIFF
--- a/client/rpc-api/src/system/helpers.rs
+++ b/client/rpc-api/src/system/helpers.rs
@@ -86,6 +86,21 @@ pub enum NodeRole {
 	Sentry,
 }
 
+/// The state of the syncing of the node.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncState<Number> {
+	/// Height of the block at which syncing started.
+	pub starting_block: Number,
+	/// Height of the current best block of the node.
+	pub current_block: Number,
+	/// Height of the highest block learned from the network. Missing if no block is known yet.
+	#[serde(default = "none", skip_serializing_if = "Option::is_none")]
+	pub highest_block: Option<Number>,
+}
+
+fn none<T>() -> Option<T> { None }
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -112,6 +127,27 @@ mod tests {
 				best_number: 6u32,
 			}).unwrap(),
 			r#"{"peerId":"2","roles":"a","bestHash":5,"bestNumber":6}"#,
+		);
+	}
+
+	#[test]
+	fn should_serialize_sync_state() {
+		assert_eq!(
+			::serde_json::to_string(&SyncState {
+				starting_block: 12u32,
+				current_block: 50u32,
+				highest_block: Some(128u32),
+			}).unwrap(),
+			r#"{"startingBlock":12,"currentBlock":50,"highestBlock":128}"#,
+		);
+
+		assert_eq!(
+			::serde_json::to_string(&SyncState {
+				starting_block: 12u32,
+				current_block: 50u32,
+				highest_block: None,
+			}).unwrap(),
+			r#"{"startingBlock":12,"currentBlock":50}"#,
 		);
 	}
 }

--- a/client/rpc-api/src/system/helpers.rs
+++ b/client/rpc-api/src/system/helpers.rs
@@ -95,12 +95,9 @@ pub struct SyncState<Number> {
 	/// Height of the current best block of the node.
 	pub current_block: Number,
 	/// Height of the highest block learned from the network. Missing if no block is known yet.
-	#[serde(default = "none", skip_serializing_if = "Option::is_none")]
+	#[serde(default = "Default::default", skip_serializing_if = "Option::is_none")]
 	pub highest_block: Option<Number>,
 }
-
-fn none<T>() -> Option<T> { None }
-
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -27,7 +27,7 @@ use futures::{future::BoxFuture, compat::Compat};
 
 use self::error::Result as SystemResult;
 
-pub use self::helpers::{SystemInfo, Health, PeerInfo, NodeRole};
+pub use self::helpers::{SystemInfo, Health, PeerInfo, NodeRole, SyncState};
 pub use self::gen_client::Client as SystemClient;
 
 /// Substrate system RPC API
@@ -103,4 +103,9 @@ pub trait SystemApi<Hash, Number> {
 	/// Returns the roles the node is running as.
 	#[rpc(name = "system_nodeRoles", returns = "Vec<NodeRole>")]
 	fn system_node_roles(&self) -> Receiver<Vec<NodeRole>>;
+
+	/// Returns the state of the syncing of the node: starting block, current best block, highest
+	/// known block.
+	#[rpc(name = "system_syncState", returns = "SyncState<Number>")]
+	fn system_sync_state(&self) -> Receiver<SyncState<Number>>;
 }

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -44,6 +44,7 @@ lazy_static = { version = "1.4.0", optional = true }
 [dev-dependencies]
 assert_matches = "1.3.0"
 futures01 = { package = "futures", version = "0.1.29" }
+lazy_static = "1.4.0"
 sc-network = { version = "0.8.0", path = "../network" }
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -104,6 +104,13 @@ fn api<T: Into<Option<Status>>>(sync: T) -> System<Block> {
 				Request::NodeRoles(sender) => {
 					let _ = sender.send(vec![NodeRole::Authority]);
 				}
+				Request::SyncState(sender) => {
+					let _ = sender.send(SyncState {
+						starting_block: 1,
+						current_block: 2,
+						highest_block: Some(3),
+					});
+				}
 			};
 
 			future::ready(())
@@ -288,6 +295,18 @@ fn system_node_roles() {
 	assert_eq!(
 		wait_receiver(api(None).system_node_roles()),
 		vec![NodeRole::Authority]
+	);
+}
+
+#[test]
+fn system_sync_state() {
+	assert_eq!(
+		wait_receiver(api(None).system_sync_state()),
+		SyncState {
+			starting_block: 1,
+			current_block: 2,
+			highest_block: Some(3),
+		}
 	);
 }
 


### PR DESCRIPTION
Fix #5727 

(I don't know who to ask for a review)

Example usage:

```
curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"system_syncState","params":[],"id":1}' localhost:9933
{"jsonrpc":"2.0","result":{"currentBlock":2903,"highestBlock":173020,"startingBlock":2738},"id":1}
```

The `highestBlock` field will be missing for a short duration after the node starts.