### PR TITLE
Make `run_node_until_exit` take a future

### DIFF
--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -126,9 +126,11 @@ pub fn run() -> sc_cli::Result<()> {
 		},
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node_until_exit(|config| match config.role {
-				Role::Light => service::new_light(config),
-				_ => service::new_full(config),
+			runner.run_node_until_exit(|config| async move {
+				match config.role {
+					Role::Light => service::new_light(config),
+					_ => service::new_full(config),
+				}
 			})
 		}
 	}

--- a/bin/node/cli/src/command.rs
+++ b/bin/node/cli/src/command.rs
@@ -72,9 +72,11 @@ pub fn run() -> Result<()> {
 	match &cli.subcommand {
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
-			runner.run_node_until_exit(|config| match config.role {
-				Role::Light => service::new_light(config),
-				_ => service::new_full(config),
+			runner.run_node_until_exit(|config| async move {
+				match config.role {
+					Role::Light => service::new_light(config),
+					_ => service::new_full(config),
+				}
 			})
 		}
 		Some(Subcommand::Inspect(cmd)) => {


### PR DESCRIPTION
The function takes a closure that resolved before to a `TaskManager`,
now it resolves to a `Future` which output is a `TaskManager`. This is
required for node setups that are async.

polkadot companion: https://github.com/paritytech/polkadot/pull/1810