### PR TITLE
Allow where clause in `decl_error!`

### DIFF
--- a/frame/support/src/error.rs
+++ b/frame/support/src/error.rs
@@ -77,6 +77,7 @@ macro_rules! decl_error {
 				$generic:ident: $trait:path
 				$(, $inst_generic:ident: $instance:path)?
 			>
+			$( where $( $where_ty:ty: $where_bound:path )* $(,)? )?
 		{
 			$(
 				$( #[doc = $doc_attr:tt] )*
@@ -86,7 +87,9 @@ macro_rules! decl_error {
 		}
 	) => {
 		$(#[$attr])*
-		pub enum $error<$generic: $trait $(, $inst_generic: $instance)?> {
+		pub enum $error<$generic: $trait $(, $inst_generic: $instance)?>
+		$( where $( $where_ty: $where_bound )* )?
+		{
 			#[doc(hidden)]
 			__Ignore(
 				$crate::sp_std::marker::PhantomData<($generic, $( $inst_generic)?)>,
@@ -100,13 +103,16 @@ macro_rules! decl_error {
 
 		impl<$generic: $trait $(, $inst_generic: $instance)?> $crate::sp_std::fmt::Debug
 			for $error<$generic $(, $inst_generic)?>
+		$( where $( $where_ty: $where_bound )* )?
 		{
 			fn fmt(&self, f: &mut $crate::sp_std::fmt::Formatter<'_>) -> $crate::sp_std::fmt::Result {
 				f.write_str(self.as_str())
 			}
 		}
 
-		impl<$generic: $trait $(, $inst_generic: $instance)?> $error<$generic $(, $inst_generic)?> {
+		impl<$generic: $trait $(, $inst_generic: $instance)?> $error<$generic $(, $inst_generic)?>
+		$( where $( $where_ty: $where_bound )* )?
+		{
 			fn as_u8(&self) -> u8 {
 				$crate::decl_error! {
 					@GENERATE_AS_U8
@@ -130,6 +136,7 @@ macro_rules! decl_error {
 
 		impl<$generic: $trait $(, $inst_generic: $instance)?> From<$error<$generic $(, $inst_generic)?>>
 			for &'static str
+		$( where $( $where_ty: $where_bound )* )?
 		{
 			fn from(err: $error<$generic $(, $inst_generic)?>) -> &'static str {
 				err.as_str()
@@ -138,6 +145,7 @@ macro_rules! decl_error {
 
 		impl<$generic: $trait $(, $inst_generic: $instance)?> From<$error<$generic $(, $inst_generic)?>>
 			for $crate::sp_runtime::DispatchError
+		$( where $( $where_ty: $where_bound )* )?
 		{
 			fn from(err: $error<$generic $(, $inst_generic)?>) -> Self {
 				let index = <$generic::PalletInfo as $crate::traits::PalletInfo>
@@ -154,6 +162,7 @@ macro_rules! decl_error {
 
 		impl<$generic: $trait $(, $inst_generic: $instance)?> $crate::error::ModuleErrorMetadata
 			for $error<$generic $(, $inst_generic)?>
+		$( where $( $where_ty: $where_bound )* )?
 		{
 			fn metadata() -> &'static [$crate::error::ErrorMetadata] {
 				&[

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -81,6 +81,13 @@ mod module1 {
 		}
 	}
 
+	frame_support::decl_error! {
+		pub enum Error for Module<T: Trait<I>, I: Instance> where T::BlockNumber: From<u32> {
+			/// Test
+			Test,
+		}
+	}
+
 	frame_support::decl_event! {
 		pub enum Event<T, I> where Phantom = std::marker::PhantomData<T> {
 			_Phantom(Phantom),


### PR DESCRIPTION
If a trait has some where clause then decl_error will fail to compile.

This PR solve it by allowing decl_error to specify some where clause.