### PR TITLE
Remove compact from staking.

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -145,7 +145,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	}
 }
 
-const AVERAGE_ON_INITIALIZE_WEIGHT: Perbill = Perbill::from_percent(10);
+const AVERAGE_ON_INITIALIZE_WEIGHT: Perbill = Perbill::from_percent(2);
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -145,7 +145,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
 	}
 }
 
-const AVERAGE_ON_INITIALIZE_WEIGHT: Perbill = Perbill::from_percent(2);
+const AVERAGE_ON_INITIALIZE_WEIGHT: Perbill = Perbill::from_perthousand(25);
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -469,7 +469,6 @@ impl pallet_staking::Trait for Runtime {
 	type RewardCurve = RewardCurve;
 	type NextNewSession = Session;
 	type ElectionLookahead = ElectionLookahead;
-	type Call = Call;
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;

--- a/bin/node/runtime/src/weights/pallet_staking.rs
+++ b/bin/node/runtime/src/weights/pallet_staking.rs
@@ -28,133 +28,133 @@ use sp_std::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Trait> pallet_staking::WeightInfo for WeightInfo<T> {
 	fn bond() -> Weight {
-		(101_255_000 as Weight)
+		(100_663_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 	fn bond_extra() -> Weight {
-		(79_012_000 as Weight)
+		(79_135_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn unbond() -> Weight {
-		(71_840_000 as Weight)
+		(71_690_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_update(s: u32, ) -> Weight {
-		(73_037_000 as Weight)
-			.saturating_add((65_000 as Weight).saturating_mul(s as Weight))
+		(72_725_000 as Weight)
+			.saturating_add((66_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_kill(s: u32, ) -> Weight {
-		(118_614_000 as Weight)
-			.saturating_add((3_972_000 as Weight).saturating_mul(s as Weight))
+		(118_747_000 as Weight)
+			.saturating_add((3_967_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn validate() -> Weight {
-		(25_589_000 as Weight)
+		(25_420_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn nominate(n: u32, ) -> Weight {
-		(35_452_000 as Weight)
-			.saturating_add((215_000 as Weight).saturating_mul(n as Weight))
+		(35_132_000 as Weight)
+			.saturating_add((218_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn chill() -> Weight {
-		(25_568_000 as Weight)
+		(24_983_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn set_payee() -> Weight {
-		(17_653_000 as Weight)
+		(17_454_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_controller() -> Weight {
-		(37_445_000 as Weight)
+		(37_176_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn set_validator_count() -> Weight {
-		(3_458_000 as Weight)
+		(3_526_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_no_eras() -> Weight {
-		(4_007_000 as Weight)
+		(3_910_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era() -> Weight {
-		(4_020_000 as Weight)
+		(3_933_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era_always() -> Weight {
-		(3_940_000 as Weight)
+		(3_926_000 as Weight)
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_invulnerables(v: u32, ) -> Weight {
-		(4_184_000 as Weight)
+		(4_080_000 as Weight)
 			.saturating_add((9_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_unstake(s: u32, ) -> Weight {
-		(82_034_000 as Weight)
-			.saturating_add((3_983_000 as Weight).saturating_mul(s as Weight))
+		(81_032_000 as Weight)
+			.saturating_add((4_002_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn cancel_deferred_slash(s: u32, ) -> Weight {
-		(5_832_405_000 as Weight)
-			.saturating_add((34_814_000 as Weight).saturating_mul(s as Weight))
+		(5_861_542_000 as Weight)
+			.saturating_add((34_654_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn payout_stakers_dead_controller(n: u32, ) -> Weight {
-		(146_733_000 as Weight)
-			.saturating_add((61_057_000 as Weight).saturating_mul(n as Weight))
+		(149_257_000 as Weight)
+			.saturating_add((60_209_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(T::DbWeight::get().reads(11 as Weight))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(n as Weight)))
 	}
 	fn payout_stakers_alive_staked(n: u32, ) -> Weight {
-		(184_098_000 as Weight)
-			.saturating_add((79_092_000 as Weight).saturating_mul(n as Weight))
+		(191_436_000 as Weight)
+			.saturating_add((79_168_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
 			.saturating_add(T::DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
 	}
 	fn rebond(l: u32, ) -> Weight {
-		(50_251_000 as Weight)
-			.saturating_add((107_000 as Weight).saturating_mul(l as Weight))
+		(50_148_000 as Weight)
+			.saturating_add((106_000 as Weight).saturating_mul(l as Weight))
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn set_history_depth(e: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((39_402_000 as Weight).saturating_mul(e as Weight))
+			.saturating_add((39_233_000 as Weight).saturating_mul(e as Weight))
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes((7 as Weight).saturating_mul(e as Weight)))
 	}
 	fn reap_stash(s: u32, ) -> Weight {
-		(102_745_000 as Weight)
-			.saturating_add((3_982_000 as Weight).saturating_mul(s as Weight))
+		(101_765_000 as Weight)
+			.saturating_add((3_959_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn new_era(v: u32, n: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((952_457_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add((117_987_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add((952_199_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add((117_926_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(T::DbWeight::get().reads(10 as Weight))
 			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
@@ -163,10 +163,10 @@ impl<T: frame_system::Trait> pallet_staking::WeightInfo for WeightInfo<T> {
 	}
 	fn submit_solution_better(v: u32, n: u32, a: u32, w: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((1_327_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add((584_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add((100_121_000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((7_994_000 as Weight).saturating_mul(w as Weight))
+			.saturating_add((733_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add((405_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add((100_431_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((7_279_000 as Weight).saturating_mul(w as Weight))
 			.saturating_add(T::DbWeight::get().reads(6 as Weight))
 			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(a as Weight)))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(w as Weight)))

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -200,7 +200,6 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type NextNewSession = Session;
 	type ElectionLookahead = ElectionLookahead;
-	type Call = Call;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -215,7 +215,6 @@ impl pallet_staking::Trait for Test {
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type NextNewSession = Session;
 	type ElectionLookahead = ElectionLookahead;
-	type Call = Call;
 	type UnsignedPriority = StakingUnsignedPriority;
 	type MaxIterations = ();
 	type MinSolutionScoreBump = ();

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -165,7 +165,6 @@ impl pallet_staking::Trait for Test {
 	type RewardCurve = RewardCurve;
 	type NextNewSession = Session;
 	type ElectionLookahead = ();
-	type Call = Call;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = ();
 	type MaxIterations = ();

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -173,7 +173,6 @@ impl pallet_staking::Trait for Test {
 	type RewardCurve = RewardCurve;
 	type NextNewSession = Session;
 	type ElectionLookahead = ();
-	type Call = Call;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;
 	type UnsignedPriority = UnsignedPriority;
 	type MaxIterations = ();

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -177,7 +177,6 @@ impl pallet_staking::Trait for Test {
 	type RewardCurve = RewardCurve;
 	type NextNewSession = Session;
 	type ElectionLookahead = ();
-	type Call = Call;
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = ();
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;

--- a/frame/staking/src/default_weights.rs
+++ b/frame/staking/src/default_weights.rs
@@ -23,6 +23,7 @@
 
 use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 use sp_std::marker::PhantomData;
+use frame_support::traits::Get;
 
 pub struct DefaultWeight<T>(PhantomData<T>);
 impl<T: frame_system::Trait> crate::WeightInfo for DefaultWeight<T> {

--- a/frame/staking/src/default_weights.rs
+++ b/frame/staking/src/default_weights.rs
@@ -22,6 +22,7 @@
 #![allow(unused_imports)]
 
 use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+use sp_std::marker::PhantomData;
 
 pub struct DefaultWeight<T>(PhantomData<T>);
 impl<T: frame_system::Trait> crate::WeightInfo for DefaultWeight<T> {

--- a/frame/staking/src/default_weights.rs
+++ b/frame/staking/src/default_weights.rs
@@ -25,141 +25,140 @@ use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 use sp_std::marker::PhantomData;
 use frame_support::traits::Get;
 
-pub struct DefaultWeight<T>(PhantomData<T>);
-impl<T: frame_system::Trait> crate::WeightInfo for DefaultWeight<T> {
+impl crate::WeightInfo for () {
 	fn bond() -> Weight {
 		(100_663_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
 	}
 	fn bond_extra() -> Weight {
 		(79_135_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn unbond() -> Weight {
 		(71_690_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_update(s: u32, ) -> Weight {
 		(72_725_000 as Weight)
 			.saturating_add((66_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_kill(s: u32, ) -> Weight {
 		(118_747_000 as Weight)
 			.saturating_add((3_967_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(DbWeight::get().reads(7 as Weight))
+			.saturating_add(DbWeight::get().writes(8 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn validate() -> Weight {
 		(25_420_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn nominate(n: u32, ) -> Weight {
 		(35_132_000 as Weight)
 			.saturating_add((218_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn chill() -> Weight {
 		(24_983_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 	fn set_payee() -> Weight {
 		(17_454_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_controller() -> Weight {
 		(37_176_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn set_validator_count() -> Weight {
 		(3_526_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn force_no_eras() -> Weight {
 		(3_910_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era() -> Weight {
 		(3_933_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era_always() -> Weight {
 		(3_926_000 as Weight)
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn set_invulnerables(v: u32, ) -> Weight {
 		(4_080_000 as Weight)
 			.saturating_add((9_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn force_unstake(s: u32, ) -> Weight {
 		(81_032_000 as Weight)
 			.saturating_add((4_002_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(8 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn cancel_deferred_slash(s: u32, ) -> Weight {
 		(5_861_542_000 as Weight)
 			.saturating_add((34_654_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().reads(1 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
 	}
 	fn payout_stakers_dead_controller(n: u32, ) -> Weight {
 		(149_257_000 as Weight)
 			.saturating_add((60_209_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(11 as Weight))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(DbWeight::get().reads(11 as Weight))
+			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(n as Weight)))
 	}
 	fn payout_stakers_alive_staked(n: u32, ) -> Weight {
 		(191_436_000 as Weight)
 			.saturating_add((79_168_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(12 as Weight))
-			.saturating_add(T::DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(DbWeight::get().reads(12 as Weight))
+			.saturating_add(DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
 	}
 	fn rebond(l: u32, ) -> Weight {
 		(50_148_000 as Weight)
 			.saturating_add((106_000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
 	}
 	fn set_history_depth(e: u32, ) -> Weight {
 		(0 as Weight)
 			.saturating_add((39_233_000 as Weight).saturating_mul(e as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes((7 as Weight).saturating_mul(e as Weight)))
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+			.saturating_add(DbWeight::get().writes((7 as Weight).saturating_mul(e as Weight)))
 	}
 	fn reap_stash(s: u32, ) -> Weight {
 		(101_765_000 as Weight)
 			.saturating_add((3_959_000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(T::DbWeight::get().reads(4 as Weight))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(8 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn new_era(v: u32, n: u32, ) -> Weight {
 		(0 as Weight)
 			.saturating_add((952_199_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add((117_926_000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(v as Weight)))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(DbWeight::get().reads(10 as Weight))
+			.saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(DbWeight::get().writes(8 as Weight))
+			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
 	fn submit_solution_better(v: u32, n: u32, a: u32, w: u32, ) -> Weight {
 		(0 as Weight)
@@ -167,9 +166,9 @@ impl<T: frame_system::Trait> crate::WeightInfo for DefaultWeight<T> {
 			.saturating_add((405_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add((100_431_000 as Weight).saturating_mul(a as Weight))
 			.saturating_add((7_279_000 as Weight).saturating_mul(w as Weight))
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(a as Weight)))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(w as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(DbWeight::get().reads(6 as Weight))
+			.saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(a as Weight)))
+			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(w as Weight)))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
 	}
 }

--- a/frame/staking/src/default_weights.rs
+++ b/frame/staking/src/default_weights.rs
@@ -23,147 +23,151 @@
 
 use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
-impl crate::WeightInfo for () {
+pub struct DefaultWeight<T>(PhantomData<T>);
+impl<T: frame_system::Trait> crate::WeightInfo for DefaultWeight<T> {
 	fn bond() -> Weight {
-		(144278000 as Weight)
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
+		(100_663_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 	fn bond_extra() -> Weight {
-		(110715000 as Weight)
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(79_135_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn unbond() -> Weight {
-		(99840000 as Weight)
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
+		(71_690_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_update(s: u32, ) -> Weight {
-		(100728000 as Weight)
-			.saturating_add((63000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
+		(72_725_000 as Weight)
+			.saturating_add((66_000 as Weight).saturating_mul(s as Weight))
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn withdraw_unbonded_kill(s: u32, ) -> Weight {
-		(168879000 as Weight)
-			.saturating_add((6666000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(DbWeight::get().reads(7 as Weight))
-			.saturating_add(DbWeight::get().writes(8 as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+		(118_747_000 as Weight)
+			.saturating_add((3_967_000 as Weight).saturating_mul(s as Weight))
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn validate() -> Weight {
-		(35539000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(25_420_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn nominate(n: u32, ) -> Weight {
-		(48596000 as Weight)
-			.saturating_add((308000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(35_132_000 as Weight)
+			.saturating_add((218_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn chill() -> Weight {
-		(35144000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+		(24_983_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	fn set_payee() -> Weight {
-		(24255000 as Weight)
-			.saturating_add(DbWeight::get().reads(1 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(17_454_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_controller() -> Weight {
-		(52294000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
+		(37_176_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn set_validator_count() -> Weight {
-		(5185000 as Weight)
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(3_526_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_no_eras() -> Weight {
-		(5907000 as Weight)
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(3_910_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era() -> Weight {
-		(5917000 as Weight)
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(3_933_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_new_era_always() -> Weight {
-		(5952000 as Weight)
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(3_926_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn set_invulnerables(v: u32, ) -> Weight {
-		(6324000 as Weight)
-			.saturating_add((9000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(4_080_000 as Weight)
+			.saturating_add((9_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn force_unstake(s: u32, ) -> Weight {
-		(119691000 as Weight)
-			.saturating_add((6681000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(8 as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+		(81_032_000 as Weight)
+			.saturating_add((4_002_000 as Weight).saturating_mul(s as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn cancel_deferred_slash(s: u32, ) -> Weight {
-		(5820201000 as Weight)
-			.saturating_add((34672000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(DbWeight::get().reads(1 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
+		(5_861_542_000 as Weight)
+			.saturating_add((34_654_000 as Weight).saturating_mul(s as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	fn payout_stakers_dead_controller(n: u32, ) -> Weight {
-		(0 as Weight)
-			.saturating_add((92486000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(n as Weight)))
+		(149_257_000 as Weight)
+			.saturating_add((60_209_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(T::DbWeight::get().reads(11 as Weight))
+			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(n as Weight)))
 	}
 	fn payout_stakers_alive_staked(n: u32, ) -> Weight {
-		(0 as Weight)
-			.saturating_add((117324000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
+		(191_436_000 as Weight)
+			.saturating_add((79_168_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(T::DbWeight::get().reads(12 as Weight))
+			.saturating_add(T::DbWeight::get().reads((5 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(n as Weight)))
 	}
 	fn rebond(l: u32, ) -> Weight {
-		(71316000 as Weight)
-			.saturating_add((142000 as Weight).saturating_mul(l as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
+		(50_148_000 as Weight)
+			.saturating_add((106_000 as Weight).saturating_mul(l as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	fn set_history_depth(e: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((51901000 as Weight).saturating_mul(e as Weight))
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-			.saturating_add(DbWeight::get().writes((7 as Weight).saturating_mul(e as Weight)))
+			.saturating_add((39_233_000 as Weight).saturating_mul(e as Weight))
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes((7 as Weight).saturating_mul(e as Weight)))
 	}
 	fn reap_stash(s: u32, ) -> Weight {
-		(147166000 as Weight)
-			.saturating_add((6661000 as Weight).saturating_mul(s as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(8 as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
+		(101_765_000 as Weight)
+			.saturating_add((3_959_000 as Weight).saturating_mul(s as Weight))
+			.saturating_add(T::DbWeight::get().reads(4 as Weight))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
 	fn new_era(v: u32, n: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((1440459000 as Weight).saturating_mul(v as Weight))
-			.saturating_add((182580000 as Weight).saturating_mul(n as Weight))
-			.saturating_add(DbWeight::get().reads(10 as Weight))
-			.saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(v as Weight)))
-			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(DbWeight::get().writes(8 as Weight))
-			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
+			.saturating_add((952_199_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add((117_926_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add(T::DbWeight::get().reads(10 as Weight))
+			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
+			.saturating_add(T::DbWeight::get().writes(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
 	fn submit_solution_better(v: u32, n: u32, a: u32, w: u32, ) -> Weight {
 		(0 as Weight)
-			.saturating_add((964000 as Weight).saturating_mul(v as Weight))
-			.saturating_add((432000 as Weight).saturating_mul(n as Weight))
-			.saturating_add((204294000 as Weight).saturating_mul(a as Weight))
-			.saturating_add((9546000 as Weight).saturating_mul(w as Weight))
-			.saturating_add(DbWeight::get().reads(6 as Weight))
-			.saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(a as Weight)))
-			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(w as Weight)))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
+			.saturating_add((733_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add((405_000 as Weight).saturating_mul(n as Weight))
+			.saturating_add((100_431_000 as Weight).saturating_mul(a as Weight))
+			.saturating_add((7_279_000 as Weight).saturating_mul(w as Weight))
+			.saturating_add(T::DbWeight::get().reads(6 as Weight))
+			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(a as Weight)))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(w as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -372,7 +372,6 @@ pub type RewardPoint = u32;
 
 // Note: Maximum nomination limit is set here -- 16.
 generate_solution_type!(
-	#[compact]
 	pub struct CompactAssignments::<NominatorIndex, ValidatorIndex, OffchainAccuracy>(16)
 );
 

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -343,7 +343,7 @@ macro_rules! log {
 	($level:tt, $patter:expr $(, $values:expr)* $(,)?) => {
 		frame_support::debug::$level!(
 			target: crate::LOG_TARGET,
-			$patter $(, $values)*
+			concat!("💸 ", $patter) $(, $values)*
 		)
 	};
 }
@@ -860,9 +860,6 @@ pub trait Trait: frame_system::Trait + SendTransactionTypes<Call<Self>> {
 	/// length of a session will be pointless.
 	type ElectionLookahead: Get<Self::BlockNumber>;
 
-	/// The overarching call type.
-	type Call: Dispatchable + From<Call<Self>> + IsSubType<Call<Self>> + Clone;
-
 	/// Maximum number of balancing iterations to run in the offchain submission.
 	///
 	/// If set to 0, balance_solution will not be executed at all.
@@ -1321,14 +1318,14 @@ decl_module! {
 									ElectionStatus::<T::BlockNumber>::Open(now)
 								);
 								add_weight(0, 1, 0);
-								log!(info, "💸 Election window is Open({:?}). Snapshot created", now);
+								log!(info, "Election window is Open({:?}). Snapshot created", now);
 							} else {
-								log!(warn, "💸 Failed to create snapshot at {:?}.", now);
+								log!(warn, "Failed to create snapshot at {:?}.", now);
 							}
 						}
 					}
 				} else {
-					log!(warn, "💸 Estimating next session change failed.");
+					log!(warn, "Estimating next session change failed.");
 				}
 				add_weight(0, 0, T::NextNewSession::weight(now))
 			}
@@ -1347,12 +1344,12 @@ decl_module! {
 			if Self::era_election_status().is_open_at(now) {
 				let offchain_status = set_check_offchain_execution_status::<T>(now);
 				if let Err(why) = offchain_status {
-					log!(warn, "💸 skipping offchain worker in open election window due to [{}]", why);
+					log!(warn, "skipping offchain worker in open election window due to [{}]", why);
 				} else {
 					if let Err(e) = compute_offchain_election::<T>() {
-						log!(error, "💸 Error in election offchain worker: {:?}", e);
+						log!(error, "Error in election offchain worker: {:?}", e);
 					} else {
-						log!(debug, "💸 Executed offchain worker thread without errors.");
+						log!(debug, "Executed offchain worker thread without errors.");
 					}
 				}
 			}
@@ -2232,7 +2229,7 @@ impl<T: Trait> Module<T> {
 		{
 			log!(
 				warn,
-				"💸 Snapshot size too big [{} <> {}][{} <> {}].",
+				"Snapshot size too big [{} <> {}][{} <> {}].",
 				num_validators,
 				MAX_VALIDATORS,
 				num_nominators,
@@ -2552,7 +2549,7 @@ impl<T: Trait> Module<T> {
 			validator_at,
 		).map_err(|e| {
 			// log the error since it is not propagated into the runtime error.
-			log!(warn, "💸 un-compacting solution failed due to {:?}", e);
+			log!(warn, "un-compacting solution failed due to {:?}", e);
 			Error::<T>::OffchainElectionBogusCompact
 		})?;
 
@@ -2567,7 +2564,7 @@ impl<T: Trait> Module<T> {
 				// all of the indices must map to either a validator or a nominator. If this is ever
 				// not the case, then the locking system of staking is most likely faulty, or we
 				// have bigger problems.
-				log!(error, "💸 detected an error in the staking locking and snapshot.");
+				log!(error, "detected an error in the staking locking and snapshot.");
 				// abort.
 				return Err(Error::<T>::OffchainElectionBogusNominator.into());
 			}
@@ -2629,7 +2626,7 @@ impl<T: Trait> Module<T> {
 		let exposures = Self::collect_exposure(supports);
 		log!(
 			info,
-			"💸 A better solution (with compute {:?} and score {:?}) has been validated and stored on chain.",
+			"A better solution (with compute {:?} and score {:?}) has been validated and stored on chain.",
 			compute,
 			submitted_score,
 		);
@@ -2826,7 +2823,7 @@ impl<T: Trait> Module<T> {
 
 			log!(
 				info,
-				"💸 new validator set of size {:?} has been elected via {:?} for era {:?}",
+				"new validator set of size {:?} has been elected via {:?} for era {:?}",
 				elected_stashes.len(),
 				compute,
 				current_era,
@@ -2882,7 +2879,7 @@ impl<T: Trait> Module<T> {
 			.map_err(|_|
 				log!(
 					error,
-					"💸 on-chain phragmen is failing due to a problem in the result. This must be a bug."
+					"on-chain phragmen is failing due to a problem in the result. This must be a bug."
 				)
 			)
 			.ok()?;
@@ -2949,7 +2946,7 @@ impl<T: Trait> Module<T> {
 
 		if all_validators.len() < Self::minimum_validator_count().max(1) as usize {
 			// If we don't have enough candidates, nothing to do.
-			log!(error, "💸 Chain does not have enough staking candidates to operate. Era {:?}.", Self::current_era());
+			log!(error, "Chain does not have enough staking candidates to operate. Era {:?}.", Self::current_era());
 			None
 		} else {
 			seq_phragmen::<_, Accuracy>(
@@ -3386,13 +3383,11 @@ impl<T: Trait> frame_support::unsigned::ValidateUnsigned for Module<T> {
 				let invalid = to_invalid(error_with_post_info);
 				log!(
 					debug,
-					"💸 validate unsigned pre dispatch checks failed due to error #{:?}.",
+					"validate unsigned pre dispatch checks failed due to error #{:?}.",
 					invalid,
 				);
 				return invalid.into();
 			}
-
-			log!(debug, "💸 validateUnsigned succeeded for a solution at era {}.", era);
 
 			ValidTransaction::with_tag_prefix("StakingOffchain")
 				// The higher the score[0], the better a solution is.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -294,7 +294,7 @@ use frame_support::{
 	weights::{Weight, constants::{WEIGHT_PER_MICROS, WEIGHT_PER_NANOS}},
 	storage::IterableStorageMap,
 	dispatch::{
-		IsSubType, DispatchResult, DispatchResultWithPostInfo, DispatchErrorWithPostInfo,
+		DispatchResult, DispatchResultWithPostInfo, DispatchErrorWithPostInfo,
 		WithPostDispatchInfo,
 	},
 	traits::{
@@ -308,7 +308,7 @@ use sp_runtime::{
 	curve::PiecewiseLinear,
 	traits::{
 		Convert, Zero, StaticLookup, CheckedSub, Saturating, SaturatedConversion,
-		AtLeast32BitUnsigned, Dispatchable,
+		AtLeast32BitUnsigned,
 	},
 	transaction_validity::{
 		TransactionValidityError, TransactionValidity, ValidTransaction, InvalidTransaction,

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -315,7 +315,6 @@ impl Trait for Test {
 	type RewardCurve = RewardCurve;
 	type NextNewSession = Session;
 	type ElectionLookahead = ElectionLookahead;
-	type Call = Call;
 	type MaxIterations = MaxIterations;
 	type MinSolutionScoreBump = MinSolutionScoreBump;
 	type MaxNominatorRewardedPerValidator = MaxNominatorRewardedPerValidator;

--- a/frame/staking/src/offchain_election.rs
+++ b/frame/staking/src/offchain_election.rs
@@ -127,7 +127,7 @@ pub(crate) fn compute_offchain_election<T: Trait>() -> Result<(), OffchainElecti
 
 	crate::log!(
 		info,
-		"💸 prepared a seq-phragmen solution with {} balancing iterations and score {:?}",
+		"prepared a seq-phragmen solution with {} balancing iterations and score {:?}",
 		iters,
 		score,
 	);
@@ -284,7 +284,7 @@ where
 				if compact.remove_voter(index) {
 					crate::log!(
 						trace,
-						"💸 removed a voter at index {} with stake {:?} from compact to reduce the size",
+						"removed a voter at index {} with stake {:?} from compact to reduce the size",
 						index,
 						_stake,
 					);
@@ -298,7 +298,7 @@ where
 
 			crate::log!(
 					warn,
-					"💸 {} nominators out of {} had to be removed from compact solution due to size limits.",
+					"{} nominators out of {} had to be removed from compact solution due to size limits.",
 					removed,
 					compact.len() + removed,
 				);
@@ -308,7 +308,7 @@ where
 			// nada, return as-is
 			crate::log!(
 				info,
-				"💸 Compact solution did not get trimmed due to block weight limits.",
+				"Compact solution did not get trimmed due to block weight limits.",
 			);
 			Ok(compact)
 		}
@@ -398,7 +398,7 @@ where
 	let maximum_allowed_voters =
 		maximum_compact_len::<T::WeightInfo>(winners.len() as u32, size, maximum_weight);
 
-	crate::log!(debug, "💸 Maximum weight = {:?} // current weight = {:?} // maximum voters = {:?} // current votes = {:?}",
+	crate::log!(debug, "Maximum weight = {:?} // current weight = {:?} // maximum voters = {:?} // current votes = {:?}",
 		maximum_weight,
 		T::WeightInfo::submit_solution_better(
 				size.validators.into(),


### PR DESCRIPTION
This PR introduces two changes that will be of help to polkadot with regards to nominators. 

1. The companion will deduce the average on initialize weight to 2.5%, 1/4th of the current value and based on a sampling from @shawntabrizi the real value is around 0.35%, so we are still safe. This will leave more room for the npos solutions. 

2. Remove the `#[compact]` attribute of the solution. This will increase the weight a wee bit, but should hopefully reduce the decoding time. We have to re-benchmark here and see what happens.  Essentially, we disable: https://github.com/paritytech/substrate/pull/6720

The regression on the length is as follows: 

```
/// Without compact
[2020-10-16T15:36:58Z INFO  staking_miner::offchain_miner] prepared a seq-phragmen solution with 10 balancing iterations and score ["27,552,369,270,134,705", "6,455,599,802,115,900,355", "209,722,308,278,769,244,421,375,166,777,465,483"] and weight = "1,444,783,774,000" and len = 38096

/// With compact
[2020-10-16T15:35:43Z INFO  staking_miner::offchain_miner] prepared a seq-phragmen solution with 10 balancing iterations and score ["27,552,369,270,134,705", "6,455,599,802,115,900,355", "209,722,308,278,769,244,421,375,166,777,465,483"] and weight = "1,444,783,774,000" and len = 25166
```

Both 25k and 38k solutions are way below limit, so we are cool. 

--- 

polkadot companion: https://github.com/paritytech/polkadot/pull/1827

- One might that it sucks that the specifications of the solution type (such as it being `#[compact]` or not) is encoded in the heart of pallet_staking. 
I could not agree more and my next PR on staking (https://github.com/paritytech/substrate/pull/7319) should address this among many other issues. 
- The `type Call` was not used so I also removed that while we're at it.