### PR TITLE
Adds support for inspecting a hex encoded public key

### DIFF
--- a/client/cli/src/commands/generate.rs
+++ b/client/cli/src/commands/generate.rs
@@ -70,7 +70,7 @@ impl GenerateCmd {
 				mnemonic.phrase(),
 				password,
 				self.network_scheme.network.clone(),
-				output
+				output,
 			)
 		);
 		Ok(())

--- a/client/cli/src/commands/key.rs
+++ b/client/cli/src/commands/key.rs
@@ -22,7 +22,7 @@ use structopt::StructOpt;
 
 use super::{
 	insert::InsertCmd,
-	inspect::InspectKeyCmd,
+	inspect_key::InspectKeyCmd,
 	generate::GenerateCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	generate_node_key::GenerateNodeKeyCmd,

--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -30,7 +30,7 @@ mod generate_node_key;
 mod generate;
 mod insert;
 mod inspect_node_key;
-mod inspect;
+mod inspect_key;
 mod key;
 pub mod utils;
 
@@ -44,7 +44,7 @@ pub use self::{
 	sign::SignCmd,
 	generate::GenerateCmd,
 	insert::InsertCmd,
-	inspect::InspectKeyCmd,
+	inspect_key::InspectKeyCmd,
 	generate_node_key::GenerateNodeKeyCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	key::KeySubcommand,

--- a/client/cli/src/commands/utils.rs
+++ b/client/cli/src/commands/utils.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! subcommand utilities
-use std::{io::Read, path::PathBuf};
+use std::{io::Read, path::PathBuf, convert::TryFrom};
 use sp_core::{
 	Pair, hexdisplay::HexDisplay,
 	crypto::{Ss58Codec, Ss58AddressFormat},
@@ -50,13 +50,23 @@ pub fn read_uri(uri: Option<&String>) -> error::Result<String> {
 	Ok(uri)
 }
 
-/// print formatted pair from uri
+/// Try to parse given `uri` and print relevant information.
+///
+/// 1. Try to construct the `Pair` while using `uri` as input for [`sp_core::Pair::from_phrase`].
+///
+/// 2. Try to construct the `Pair` while using `uri` as input for [`sp_core::Pair::from_string_with_seed`].
+///
+/// 3. Try to construct the `Pair::Public` while using `uri` as input for
+///    [`sp_core::Pair::Public::from_string_with_version`].
 pub fn print_from_uri<Pair>(
 	uri: &str,
 	password: Option<SecretString>,
 	network_override: Option<Ss58AddressFormat>,
 	output: OutputType,
-) where Pair: sp_core::Pair, Pair::Public: Into<MultiSigner> {
+) where
+	Pair: sp_core::Pair,
+	Pair::Public: Into<MultiSigner>,
+{
 	let password = password.as_ref().map(|s| s.expose_secret().as_str());
 	if let Ok((pair, seed)) = Pair::from_phrase(uri, password.clone()) {
 		let public_key = pair.public();
@@ -130,26 +140,72 @@ pub fn print_from_uri<Pair>(
 					"accountId": format_account_id::<Pair>(public_key.clone()),
 					"ss58Address": public_key.to_ss58check_with_version(network_override),
 				});
+
 				println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
 			},
 			OutputType::Text => {
 				println!(
 					"Public Key URI `{}` is account:\n  \
-					Network ID/version: {}\n  \
-					Public key (hex):   {}\n  \
-					Account ID:         {}\n  \
-					SS58 Address:       {}",
+					 Network ID/version: {}\n  \
+					 Public key (hex):   {}\n  \
+					 Account ID:         {}\n  \
+					 SS58 Address:       {}",
 					uri,
 					String::from(network_override),
 					format_public_key::<Pair>(public_key.clone()),
 					format_account_id::<Pair>(public_key.clone()),
 					public_key.to_ss58check_with_version(network_override),
 				);
-			},
+			}
 		}
 	} else {
 		println!("Invalid phrase/URI given");
 	}
+}
+
+/// Try to parse given `public` as hex encoded public key and print relevant information.
+pub fn print_from_public<Pair>(
+	public_str: &str,
+	network_override: Option<Ss58AddressFormat>,
+	output: OutputType,
+) -> Result<(), Error>
+where
+	Pair: sp_core::Pair,
+	Pair::Public: Into<MultiSigner>,
+{
+	let public = decode_hex(public_str)?;
+
+	let public_key = Pair::Public::try_from(&public)
+		.map_err(|_| "Failed to construct public key from given hex")?;
+
+	let network_override = network_override.unwrap_or_default();
+
+	match output {
+		OutputType::Json => {
+			let json = json!({
+				"networkId": String::from(network_override),
+				"publicKey": format_public_key::<Pair>(public_key.clone()),
+				"accountId": format_account_id::<Pair>(public_key.clone()),
+				"ss58Address": public_key.to_ss58check_with_version(network_override),
+			});
+
+			println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
+		},
+		OutputType::Text => {
+			println!(
+				"Network ID/version: {}\n  \
+				Public key (hex):   {}\n  \
+				Account ID:         {}\n  \
+				SS58 Address:       {}",
+				String::from(network_override),
+				format_public_key::<Pair>(public_key.clone()),
+				format_account_id::<Pair>(public_key.clone()),
+				public_key.to_ss58check_with_version(network_override),
+			);
+		}
+	}
+
+	Ok(())
 }
 
 /// generate a pair from suri

--- a/client/cli/src/commands/utils.rs
+++ b/client/cli/src/commands/utils.rs
@@ -194,9 +194,9 @@ where
 		OutputType::Text => {
 			println!(
 				"Network ID/version: {}\n  \
-				Public key (hex):   {}\n  \
-				Account ID:         {}\n  \
-				SS58 Address:       {}",
+				 Public key (hex):   {}\n  \
+				 Account ID:         {}\n  \
+				 SS58 Address:       {}",
 				String::from(network_override),
 				format_public_key::<Pair>(public_key.clone()),
 				format_account_id::<Pair>(public_key.clone()),

--- a/primitives/application-crypto/src/lib.rs
+++ b/primitives/application-crypto/src/lib.rs
@@ -323,6 +323,14 @@ macro_rules! app_crypto_public_common {
 				)
 			}
 		}
+
+		impl<'a> $crate::TryFrom<&'a [u8]> for Public {
+			type Error = ();
+
+			fn try_from(data: &'a [u8]) -> Result<Self, Self::Error> {
+				<$public>::try_from(data).map(Into::into)
+			}
+		}
 	}
 }
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -583,7 +583,17 @@ impl<T: Sized + AsMut<[u8]> + AsRef<[u8]> + Default + Derive> Ss58Codec for T {
 
 /// Trait suitable for typical cryptographic PKI key public type.
 pub trait Public:
-	AsRef<[u8]> + AsMut<[u8]> + Default + Derive + CryptoType + PartialEq + Eq + Clone + Send + Sync
+	AsRef<[u8]>
+	+ AsMut<[u8]>
+	+ Default
+	+ Derive
+	+ CryptoType
+	+ PartialEq
+	+ Eq
+	+ Clone
+	+ Send
+	+ Sync
+	+ for<'a> TryFrom<&'a [u8]>
 {
 	/// A new instance from the given slice.
 	///
@@ -748,6 +758,14 @@ mod dummy {
 				#[allow(mutable_transmutes)]
 				sp_std::mem::transmute::<_, &'static mut [u8]>(&b""[..])
 			}
+		}
+	}
+
+	impl<'a> TryFrom<&'a [u8]> for Dummy {
+		type Error = ();
+
+		fn try_from(_: &'a [u8]) -> Result<Self, ()> {
+			Ok(Self)
 		}
 	}
 
@@ -1106,6 +1124,13 @@ mod tests {
 	impl AsMut<[u8]> for TestPublic {
 		fn as_mut(&mut self) -> &mut [u8] {
 			&mut []
+		}
+	}
+	impl<'a> TryFrom<&'a [u8]> for TestPublic {
+		type Error = ();
+
+		fn try_from(_: &'a [u8]) -> Result<Self, ()> {
+			Ok(Self)
 		}
 	}
 	impl CryptoType for TestPublic {


### PR DESCRIPTION
This adds support for inspecting hex encoded public keys to subkey. The
command looks like:

`subkey inspect --public 0xPUBLICHEX`

Closes: https://github.com/paritytech/substrate/issues/7069