### PR TITLE
client/network: Make NetworkService::set_priority_group async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6216,6 +6216,7 @@ dependencies = [
 name = "sc-authority-discovery"
 version = "0.8.0"
 dependencies = [
+ "async-trait",
  "bytes 0.5.6",
  "derive_more",
  "either",

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -17,6 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 prost-build = "0.6.1"
 
 [dependencies]
+async-trait = "0.1"
 bytes = "0.5.0"
 codec = { package = "parity-scale-codec", default-features = false, version = "1.3.4" }
 derive_more = "0.99.2"

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -972,7 +972,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	///
 	/// Returns an `Err` if one of the given addresses is invalid or contains an
 	/// invalid peer ID (which includes the local peer ID).
-	pub fn set_priority_group(&self, group_id: String, peers: HashSet<Multiaddr>) -> Result<(), String> {
+	//
+	// NOTE: even though this function is currently sync, it's marked as async for
+	// future-proofing, see https://github.com/paritytech/substrate/pull/7247#discussion_r502263451.
+	pub async fn set_priority_group(&self, group_id: String, peers: HashSet<Multiaddr>) -> Result<(), String> {
 		let peers = self.split_multiaddr_and_peer_id(peers)?;
 
 		let peer_ids = peers.iter().map(|(peer_id, _addr)| peer_id.clone()).collect();


### PR DESCRIPTION
As done with `NetworkService::{add_to,remove_from}_priority_group`, make
`NetworkService::set_priority_group` async as well. This future-proofs
the API should we ever decide to use a bounded channel between
`NetworkService` and `NetworkWorker`.

See https://github.com/paritytech/substrate/pull/7247#discussion_r502263451 for past discussion.

Release note suggestion:

> Make `NetworkService::set_priority_group` `async`. Doing so for all methods would eventually allow to use a bounded channel between `NetworkService` and `NetworkWorker`.