### PR TITLE
client/network: Allow configuring Kademlia's disjoint query paths

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -102,6 +102,14 @@ pub struct NetworkParams {
 	/// By default this option is true for `--dev` and false otherwise.
 	#[structopt(long)]
 	pub discover_local: bool,
+
+	/// Require iterative Kademlia DHT queries to use disjoint paths for increased resiliency in the
+	/// presence of potentially adversarial nodes.
+	///
+	/// See the S/Kademlia paper for more information on the high level design as well as its
+	/// security improvements.
+	#[structopt(long)]
+	pub kademlia_disjoint_query_paths: bool,
 }
 
 impl NetworkParams {
@@ -162,6 +170,7 @@ impl NetworkParams {
 			},
 			max_parallel_downloads: self.max_parallel_downloads,
 			allow_non_globals_in_dht: self.discover_local || is_dev,
+			kademlia_disjoint_query_paths: self.kademlia_disjoint_query_paths,
 		}
 	}
 }

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -423,6 +423,9 @@ pub struct NetworkConfiguration {
 	pub max_parallel_downloads: u32,
 	/// Should we insert non-global addresses into the DHT?
 	pub allow_non_globals_in_dht: bool,
+	/// Require iterative Kademlia DHT queries to use disjoint paths for increased resiliency in the
+	/// presence of potentially adversarial nodes.
+	pub kademlia_disjoint_query_paths: bool,
 }
 
 impl NetworkConfiguration {
@@ -455,6 +458,7 @@ impl NetworkConfiguration {
 			},
 			max_parallel_downloads: 5,
 			allow_non_globals_in_dht: false,
+			kademlia_disjoint_query_paths: false,
 		}
 	}
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -292,6 +292,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				config.discovery_limit(u64::from(params.network_config.out_peers) + 15);
 				config.add_protocol(params.protocol_id.clone());
 				config.allow_non_globals_in_dht(params.network_config.allow_non_globals_in_dht);
+				config.use_kademlia_disjoint_query_paths(params.network_config.kademlia_disjoint_query_paths);
 
 				match params.network_config.transport {
 					TransportConfig::MemoryOnly => {


### PR DESCRIPTION
The Rust libp2p-kad implementation can require iterative queries to use
disjoint paths for increased resiliency in the presence of potentially
adversarial nodes.

Allow Substrate users to enable this feature via the
`--kademlia-disjoint-query-paths` flag.

Release note suggestion:
> Allow configuring Kademlia via the `--kademlia-disjoint-query-paths` flag  to require iterative DHT queries to use disjoint paths for increased resiliency in the presence of potentially adversarial nodes.