### PR TITLE
Make `decl_runtime_apis!` fail on methods with default implementation

### DIFF
--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -912,6 +912,13 @@ impl CheckTraitDecl {
 				.entry(method.sig.ident.clone())
 				.or_default()
 				.push(changed_in);
+
+			if method.default.is_some() {
+				self.errors.push(Error::new(
+					method.default.span(),
+					"A runtime api function can not have a default implementation!",
+				));
+			}
 		});
 
 		method_to_signature_changed.into_iter().for_each(|(f, changed)| {

--- a/primitives/api/proc-macro/src/decl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/decl_runtime_apis.rs
@@ -916,7 +916,7 @@ impl CheckTraitDecl {
 			if method.default.is_some() {
 				self.errors.push(Error::new(
 					method.default.span(),
-					"A runtime api function can not have a default implementation!",
+					"A runtime API function cannot have a default implementation!",
 				));
 			}
 		});

--- a/primitives/api/test/tests/ui/no_default_implementation.rs
+++ b/primitives/api/test/tests/ui/no_default_implementation.rs
@@ -1,0 +1,9 @@
+sp_api::decl_runtime_apis! {
+	pub trait Api {
+		fn test() {
+			println!("Hey, I'm a default implementation!");
+		}
+	}
+}
+
+fn main() {}

--- a/primitives/api/test/tests/ui/no_default_implementation.stderr
+++ b/primitives/api/test/tests/ui/no_default_implementation.stderr
@@ -1,0 +1,8 @@
+error: A runtime api function can not have a default implementation!
+ --> $DIR/no_default_implementation.rs:3:13
+  |
+3 |           fn test() {
+  |  ___________________^
+4 | |             println!("Hey, I'm a default implementation!");
+5 | |         }
+  | |_________^

--- a/primitives/api/test/tests/ui/no_default_implementation.stderr
+++ b/primitives/api/test/tests/ui/no_default_implementation.stderr
@@ -1,4 +1,4 @@
-error: A runtime api function can not have a default implementation!
+error: A runtime API function cannot have a default implementation!
  --> $DIR/no_default_implementation.rs:3:13
   |
 3 |           fn test() {


### PR DESCRIPTION
Runtime api functions are not allowed to have default implementations.
This fixes this by throwing an error when we detect such a function.

Fixes: https://github.com/paritytech/substrate/issues/7360