### PR TITLE
grandpa: don't send equivocation reports for local identities

### DIFF
--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -1813,3 +1813,49 @@ fn imports_justification_for_regular_blocks_on_import() {
 		client.justification(&BlockId::Hash(block_hash)).unwrap().is_some(),
 	);
 }
+
+#[test]
+fn grandpa_environment_doesnt_send_equivocation_reports_for_itself() {
+	let alice = Ed25519Keyring::Alice;
+	let voters = make_ids(&[alice]);
+
+	let environment = {
+		let mut net = GrandpaTestNet::new(TestApi::new(voters), 1);
+		let peer = net.peer(0);
+		let network_service = peer.network_service().clone();
+		let link = peer.data.lock().take().unwrap();
+		let (keystore, _keystore_path) = create_keystore(alice);
+		test_environment(&link, Some(keystore), network_service.clone(), ())
+	};
+
+	let signed_prevote = {
+		let prevote = finality_grandpa::Prevote {
+			target_hash: H256::random(),
+			target_number: 1,
+		};
+
+		let signed = alice.sign(&[]).into();
+		(prevote, signed)
+	};
+
+	let mut equivocation = finality_grandpa::Equivocation {
+		round_number: 1,
+		identity: alice.public().into(),
+		first: signed_prevote.clone(),
+		second: signed_prevote.clone(),
+	};
+
+	// reporting the equivocation should fail since the offender is a local
+	// authority (i.e. we have keys in our keystore for the given id)
+	let equivocation_proof = sp_finality_grandpa::Equivocation::Prevote(equivocation.clone());
+	assert!(matches!(
+		environment.report_equivocation(equivocation_proof),
+		Err(Error::Safety(_)),
+	));
+
+	// if we set the equivocation offender to another id for which we don't have
+	// keys it should work
+	equivocation.identity = Default::default();
+	let equivocation_proof = sp_finality_grandpa::Equivocation::Prevote(equivocation);
+	assert!(environment.report_equivocation(equivocation_proof).is_ok());
+}

--- a/client/finality-grandpa/src/tests.rs
+++ b/client/finality-grandpa/src/tests.rs
@@ -1850,7 +1850,7 @@ fn grandpa_environment_doesnt_send_equivocation_reports_for_itself() {
 	let equivocation_proof = sp_finality_grandpa::Equivocation::Prevote(equivocation.clone());
 	assert!(matches!(
 		environment.report_equivocation(equivocation_proof),
-		Err(Error::Safety(_)),
+		Err(Error::Safety(_))
 	));
 
 	// if we set the equivocation offender to another id for which we don't have


### PR DESCRIPTION
There's no need to send equivocation reports for keys that we control:
- If the equivocation went to the network then someone else will report it;
- Otherwise there was no harm done so the slash is unnecessary.

This can happen (and has happened) when node operators restore the database from a backup and lose the GRANDPA voter state. They might end up equivocating on an old round for which no one in the network is listening anymore (and therefore the equivocation is harmless and would go unreported), but they end up reporting themselves and getting slashed.