### PR TITLE
build: add nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let
+  mozillaOverlay =
+    import (builtins.fetchGit {
+      url = "https://github.com/mozilla/nixpkgs-mozilla.git";
+      rev = "57c8084c7ef41366993909c20491e359bbb90f54";
+    });
+  nixpkgs = import <nixpkgs> { overlays = [ mozillaOverlay ]; };
+  rust-nightly = with nixpkgs; ((rustChannelOf { date = "2020-10-01"; channel = "nightly"; }).rust.override {
+    targets = [ "wasm32-unknown-unknown" ];
+  });
+in
+with nixpkgs; pkgs.mkShell {
+  buildInputs = [
+    clang
+    cmake
+    pkg-config
+    rust-nightly
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
+  PROTOC = "${protobuf}/bin/protoc";
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+}


### PR DESCRIPTION
Adds a nix shell definition with everything required to build substrate. I'm OK with this not getting merged but I think it's a nice-to-have for any potential nix users that might clone our repo.