### PR TITLE
Made correction in sp-tracing macros to use level parameter #7348

### DIFF
--- a/primitives/tracing/src/lib.rs
+++ b/primitives/tracing/src/lib.rs
@@ -164,7 +164,7 @@ macro_rules! within_span {
 		$( $code:tt )*
 	) => {
 		{
-			$crate::within_span!($crate::span!($crate::Level::TRACE, $name); $( $code )*)
+			$crate::within_span!($crate::span!($lvl, $name); $( $code )*)
 		}
 	};
 }
@@ -233,6 +233,6 @@ macro_rules! enter_span {
 		let __tracing_guard__ = __within_span__.enter();
 	};
 	( $lvl:expr, $name:expr ) => {
-		$crate::enter_span!($crate::span!($crate::Level::TRACE, $name))
+		$crate::enter_span!($crate::span!($lvl, $name))
 	};
 }


### PR DESCRIPTION
In `in within_span` and `enter_span`, there was a parameter `$lvl:expr`, but it was not being used in macro implementation part, in implementation all is filled `TRACE `level.

As a part of this pull request, I have modified both macros to start using `$lvl` parameter in the implementation.

Fixes #7348 