### PR TITLE
Fix doc for ChangeMember trait

### DIFF
--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1268,8 +1268,8 @@ pub trait ChangeMembers<AccountId: Clone + Ord> {
 		Self::change_members_sorted(&incoming[..], &outgoing[..], &new_members);
 	}
 
-	/// Set the new members; they **must already be sorted**. This will compute the diff and use it to
-	/// call `change_members_sorted`.
+	/// Compute diff between new and old members; they **must already be sorted**. Returns incoming
+	/// and outgoing members.
 	fn compute_members_diff(
 		new_members: &[AccountId],
 		old_members: &[AccountId]

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1268,8 +1268,9 @@ pub trait ChangeMembers<AccountId: Clone + Ord> {
 		Self::change_members_sorted(&incoming[..], &outgoing[..], &new_members);
 	}
 
-	/// Compute diff between new and old members; they **must already be sorted**. Returns incoming
-	/// and outgoing members.
+	/// Compute diff between new and old members; they **must already be sorted**. 
+	///
+	/// Returns incoming and outgoing members.
 	fn compute_members_diff(
 		new_members: &[AccountId],
 		old_members: &[AccountId]


### PR DESCRIPTION
the default implementation and its usage in substrate doesn't follow the doc.

So I replace the doc, hopefully other user don't rely on the wrong spec but just on the function name.