### PR TITLE
Set ChainId and GasePrice in storage

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 260,
+	spec_version: 261,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -238,7 +238,17 @@ decl_storage! {
 
 	add_extra_genesis {
 		config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
+		config(chain_id): Option<u64>;
+		config(gas_price): Option<U256>;
 		build(|config: &GenesisConfig| {
+			match &config.chain_id {
+				Some(chain_id) => ChainId::put(chain_id),
+				_ => ChainId::put(42)
+			};
+			match &config.gas_price {
+				Some(gas_price) => GasPrice::put(gas_price),
+				_ => GasPrice::put(U256::zero())
+			};
 			for (address, account) in &config.accounts {
 				let account_id = T::AddressMapping::into_account_id(*address);
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -53,7 +53,7 @@ pub trait FeeCalculator {
 }
 
 impl FeeCalculator for () {
-	fn min_gas_price() -> U256 { U256::zero() }
+	fn min_gas_price() -> U256 { GasPrice::get() }
 }
 
 pub trait EnsureAddressOrigin<OuterOrigin> {

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -229,8 +229,8 @@ pub struct GenesisAccount {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as EVM {
-		ChainId get(fn chain_id): u64;
-		GasPrice get(fn gas_price): U256;
+		ChainId get(fn chain_id) config(): u64 = 42;
+		GasPrice get(fn gas_price) config(): U256;
 		AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
 		AccountStorages get(fn account_storages):
 			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;
@@ -238,17 +238,7 @@ decl_storage! {
 
 	add_extra_genesis {
 		config(accounts): std::collections::BTreeMap<H160, GenesisAccount>;
-		config(chain_id): Option<u64>;
-		config(gas_price): Option<U256>;
 		build(|config: &GenesisConfig| {
-			match &config.chain_id {
-				Some(chain_id) => ChainId::put(chain_id),
-				_ => ChainId::put(42)
-			};
-			match &config.gas_price {
-				Some(gas_price) => GasPrice::put(gas_price),
-				_ => GasPrice::put(U256::zero())
-			};
 			for (address, account) in &config.accounts {
 				let account_id = T::AddressMapping::into_account_id(*address);
 

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -204,8 +204,6 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 	/// Precompiles associated with this EVM engine.
 	type Precompiles: Precompiles;
-	/// Chain ID of EVM.
-	type ChainId: Get<u64>;
 	/// EVM execution runner.
 	type Runner: Runner<Self>;
 
@@ -231,6 +229,8 @@ pub struct GenesisAccount {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as EVM {
+		ChainId get(fn chain_id): u64;
+		GasPrice get(fn gas_price): U256;
 		AccountCodes get(fn account_codes): map hasher(blake2_128_concat) H160 => Vec<u8>;
 		AccountStorages get(fn account_storages):
 			double_map hasher(blake2_128_concat) H160, hasher(blake2_128_concat) H256 => H256;

--- a/frame/evm/src/runner/native.rs
+++ b/frame/evm/src/runner/native.rs
@@ -24,7 +24,7 @@ use sp_std::{
 use sp_core::{H160, U256, H256};
 use sp_runtime::{TransactionOutcome, traits::UniqueSaturatedInto};
 use frame_support::{
-	ensure, traits::{Get, Currency, ExistenceRequirement},
+	ensure, traits::{Currency, ExistenceRequirement},
 	storage::{StorageMap, StorageDoubleMap},
 };
 use sha3::{Keccak256, Digest};
@@ -491,7 +491,7 @@ impl<'vicinity, 'config, T: Trait> HandlerT for Handler<'vicinity, 'config, T> {
 	}
 
 	fn chain_id(&self) -> U256 {
-		U256::from(T::ChainId::get())
+		U256::from(<Module<T>>::chain_id())
 	}
 
 	fn exists(&self, _address: H160) -> bool {

--- a/frame/evm/src/runner/stack.rs
+++ b/frame/evm/src/runner/stack.rs
@@ -21,7 +21,7 @@ use sp_std::marker::PhantomData;
 use sp_std::vec::Vec;
 use sp_core::{U256, H256, H160};
 use sp_runtime::traits::UniqueSaturatedInto;
-use frame_support::{debug, ensure, traits::{Get, Currency}, storage::{StorageMap, StorageDoubleMap}};
+use frame_support::{debug, ensure, traits::Currency, storage::{StorageMap, StorageDoubleMap}};
 use sha3::{Keccak256, Digest};
 use sp_evm::{ExecutionInfo, CallInfo, CreateInfo, Account, Log, Vicinity};
 use evm::ExitReason;
@@ -267,7 +267,7 @@ impl<'vicinity, T: Trait> BackendT for Backend<'vicinity, T> {
 	}
 
 	fn chain_id(&self) -> U256 {
-		U256::from(T::ChainId::get())
+		U256::from(<Module<T>>::chain_id())
 	}
 
 	fn exists(&self, _address: H160) -> bool {


### PR DESCRIPTION
- Define `ChainId` and `GasPrice` storage values.
- Set an optional genesis config or fallback to default (ChainId `42` and GasPrice `zero`). 