### PR TITLE
First draft of a chain_getBlockWithTraces RPC

### DIFF
--- a/bin/node/runtime/build.rs
+++ b/bin/node/runtime/build.rs
@@ -23,5 +23,7 @@ fn main() {
 		.with_wasm_builder_from_crates_or_path("2.0.1", "../../../utils/wasm-builder")
 		.export_heap_base()
 		.import_memory()
+		// TODO dp: uncomment to turn traces collection on. Need to hook up to CLI?
+		// .append_to_rust_flags("--cfg feature=\\\"with-tracing\\\"")
 		.build()
 }

--- a/client/api/src/client.rs
+++ b/client/api/src/client.rs
@@ -21,7 +21,7 @@ use sp_core::storage::StorageKey;
 use sp_runtime::{
 	traits::{Block as BlockT, NumberFor},
 	generic::{BlockId, SignedBlock},
-	Justification,
+	Justification, Traces,
 };
 use sp_consensus::BlockOrigin;
 
@@ -85,11 +85,17 @@ pub trait BlockBackend<Block: BlockT> {
 	/// Get full block by id.
 	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>>;
 
+	/// Get full block by id including traces.
+	fn block_with_traces(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>>;
+
 	/// Get block status.
 	fn block_status(&self, id: &BlockId<Block>) -> sp_blockchain::Result<sp_consensus::BlockStatus>;
 
 	/// Get block justification set by id.
 	fn justification(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Justification>>;
+
+	/// Get block traces set by id.
+	fn traces(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Traces>>;
 
 	/// Get block hash by number.
 	fn block_hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<Block::Hash>>;

--- a/client/db/src/upgrade.rs
+++ b/client/db/src/upgrade.rs
@@ -27,6 +27,7 @@ use crate::utils::DatabaseType;
 const VERSION_FILE_NAME: &'static str = "db_version";
 
 /// Current db version.
+// TODO dp: need bump?
 const CURRENT_VERSION: u32 = 1;
 
 /// Upgrade database to current version.

--- a/client/db/src/utils.rs
+++ b/client/db/src/utils.rs
@@ -37,7 +37,7 @@ use crate::{DatabaseSettings, DatabaseSettingsSrc, Database, DbHash};
 /// Number of columns in the db. Must be the same for both full && light dbs.
 /// Otherwise RocksDb will fail to open database && check its type.
 #[cfg(any(feature = "with-kvdb-rocksdb", feature = "with-parity-db", feature = "test-helpers", test))]
-pub const NUM_COLUMNS: u32 = 11;
+pub const NUM_COLUMNS: u32 = 12;
 /// Meta column. The set of keys in the column is shared by full && light storages.
 pub const COLUMN_META: u32 = 0;
 

--- a/client/light/src/blockchain.rs
+++ b/client/light/src/blockchain.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use sp_runtime::{Justification, generic::BlockId};
+use sp_runtime::{Justification, generic::BlockId, Traces};
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor, Zero};
 
 use sp_blockchain::{
@@ -110,6 +110,10 @@ impl<S, Block> BlockchainBackend<Block> for Blockchain<S> where Block: BlockT, S
 	}
 
 	fn justification(&self, _id: BlockId<Block>) -> ClientResult<Option<Justification>> {
+		Err(ClientError::NotAvailableOnLightClient)
+	}
+
+	fn traces(&self, _id: BlockId<Block>) -> ClientResult<Option<Traces>> {
 		Err(ClientError::NotAvailableOnLightClient)
 	}
 

--- a/client/rpc-api/src/chain/mod.rs
+++ b/client/rpc-api/src/chain/mod.rs
@@ -42,6 +42,10 @@ pub trait ChainApi<Number, Hash, Header, SignedBlock> {
 	#[rpc(name = "chain_getBlock")]
 	fn block(&self, hash: Option<Hash>) -> FutureResult<Option<SignedBlock>>;
 
+	/// Get header and body of a relay chain block, including tracing data.
+	#[rpc(name = "chain_getBlockWithTraces")]
+	fn block_with_traces(&self, hash: Option<Hash>) -> FutureResult<Option<SignedBlock>>;
+
 	/// Get hash of the n-th block in the canon chain.
 	///
 	/// By default returns latest block hash.

--- a/client/rpc/src/chain/chain_full.rs
+++ b/client/rpc/src/chain/chain_full.rs
@@ -75,4 +75,13 @@ impl<Block, Client> ChainBackend<Client, Block> for FullChain<Block, Client> whe
 			.map_err(client_err)
 		))
 	}
+
+	fn block_with_traces(&self, hash: Option<Block::Hash>)
+		-> FutureResult<Option<SignedBlock<Block>>>
+	{
+		let block = self.client
+			.block_with_traces(&BlockId::Hash(self.unwrap_or_best(hash)))
+			.map_err(client_err);
+		Box::new(result(block))
+	}
 }

--- a/client/rpc/src/chain/chain_light.rs
+++ b/client/rpc/src/chain/chain_light.rs
@@ -105,6 +105,7 @@ impl<Block, Client, F> ChainBackend<Client, Block> for LightChain<Block, Client,
 					.map(move |body| Some(SignedBlock {
 						block: Block::new(header, body),
 						justification: None,
+						traces: None,
 					}))
 					.map_err(client_err)
 				),
@@ -112,5 +113,12 @@ impl<Block, Client, F> ChainBackend<Client, Block> for LightChain<Block, Client,
 			});
 
 		Box::new(block)
+	}
+
+	fn block_with_traces(&self, _hash: Option<Block::Hash>)
+		-> FutureResult<Option<SignedBlock<Block>>>
+	{
+		// TODO dp: what's the policy for Light Clients? I guess  they could get traces from their remote node, but... is that useful?
+		todo!("fetch from remote node?")
 	}
 }

--- a/client/rpc/src/chain/mod.rs
+++ b/client/rpc/src/chain/mod.rs
@@ -72,6 +72,9 @@ trait ChainBackend<Client, Block: BlockT>: Send + Sync + 'static
 	/// Get header and body of a relay chain block.
 	fn block(&self, hash: Option<Block::Hash>) -> FutureResult<Option<SignedBlock<Block>>>;
 
+	/// Get header and body of a relay chain block complete with all tracing data.
+	fn block_with_traces(&self, hash: Option<Block::Hash>) -> FutureResult<Option<SignedBlock<Block>>>;
+
 	/// Get hash of the n-th block in the canon chain.
 	///
 	/// By default returns latest block hash.
@@ -239,6 +242,11 @@ impl<Block, Client> ChainApi<NumberFor<Block>, Block::Hash, Block::Header, Signe
 	fn block(&self, hash: Option<Block::Hash>) -> FutureResult<Option<SignedBlock<Block>>>
 	{
 		self.backend.block(hash)
+	}
+
+	fn block_with_traces(&self, hash: Option<Block::Hash>) -> FutureResult<Option<SignedBlock<Block>>>
+	{
+		self.backend.block_with_traces(hash)
 	}
 
 	fn block_hash(

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -1904,7 +1904,15 @@ impl<B, E, Block, RA> BlockBackend<Block> for Client<B, E, Block, RA>
 	{
 		Ok(match (self.header(id)?, self.body(id)?, self.justification(id)?) {
 			(Some(header), Some(extrinsics), justification) =>
-				Some(SignedBlock { block: Block::new(header, extrinsics), justification }),
+				Some(SignedBlock { block: Block::new(header, extrinsics), justification, traces: None }),
+			_ => None,
+		})
+	}
+
+	fn block_with_traces(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>> {
+		Ok(match (self.header(id)?, self.body(id)?, self.justification(id)?, self.traces(id)?) {
+			(Some(header), Some(extrinsics), justification, traces) =>
+				Some(SignedBlock { block: Block::new(header, extrinsics), justification, traces }),
 			_ => None,
 		})
 	}
@@ -1934,6 +1942,10 @@ impl<B, E, Block, RA> BlockBackend<Block> for Client<B, E, Block, RA>
 
 	fn justification(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Justification>> {
 		self.backend.blockchain().justification(*id)
+	}
+
+	fn traces(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Justification>> {
+		self.backend.blockchain().traces(*id)
 	}
 
 	fn block_hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<Block::Hash>> {

--- a/primitives/blockchain/src/backend.rs
+++ b/primitives/blockchain/src/backend.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 use sp_runtime::generic::BlockId;
-use sp_runtime::Justification;
+use sp_runtime::{Justification, Traces};
 use log::warn;
 use parking_lot::RwLock;
 
@@ -86,6 +86,8 @@ pub trait Backend<Block: BlockT>: HeaderBackend<Block> + HeaderMetadata<Block, E
 	fn body(&self, id: BlockId<Block>) -> Result<Option<Vec<<Block as BlockT>::Extrinsic>>>;
 	/// Get block justification. Returns `None` if justification does not exist.
 	fn justification(&self, id: BlockId<Block>) -> Result<Option<Justification>>;
+	/// Get block traces. Returns `None` if no traces are available.
+	fn traces(&self, id: BlockId<Block>) -> Result<Option<Traces>>;
 	/// Get last finalized block hash.
 	fn last_finalized(&self) -> Result<Block::Hash>;
 	/// Returns data cache reference, if it is enabled on this backend.

--- a/primitives/runtime/src/generic/block.rs
+++ b/primitives/runtime/src/generic/block.rs
@@ -30,7 +30,7 @@ use crate::traits::{
 	self, Member, Block as BlockT, Header as HeaderT, MaybeSerialize, MaybeMallocSizeOf,
 	NumberFor,
 };
-use crate::Justification;
+use crate::{Justification, Traces};
 
 /// Something to identify a block.
 #[derive(PartialEq, Eq, Clone, RuntimeDebug)]
@@ -113,4 +113,7 @@ pub struct SignedBlock<Block> {
 	pub block: Block,
 	/// Block justification.
 	pub justification: Option<Justification>,
+	/// Execution traces.
+	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
+	pub traces: Option<Traces>,
 }

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -93,6 +93,10 @@ pub use either::Either;
 /// bypasses this problem.
 pub type Justification = Vec<u8>;
 
+/// Execution traces
+// TODO dp: not sure what the best storage format is for traces. Investigate (but for now just serialzie JSON to bytes and move on?).
+pub type Traces = Vec<u8>;
+
 use traits::{Verify, Lazy};
 
 /// A module identifier. These are per module and should be stored in a registry somewhere.

--- a/primitives/tracing/src/lib.rs
+++ b/primitives/tracing/src/lib.rs
@@ -198,12 +198,12 @@ macro_rules! enter_span {
 
 /// Enter a span.
 ///
-/// The span will be valid, until the scope is left. Use either level and name
-/// or pass in any valid `sp_tracing::Span` for extended usage. The span will
-/// be exited on drop – which is at the end of the block or to the next
-/// `enter_span!` calls, as this overwrites the local variable. For nested
-/// usage or to ensure the span closes at certain time either put it into a block
-/// or use `within_span!`
+/// The span will be valid for the duration of the current scope. Use either
+/// level and name or pass in any valid `sp_tracing::Span` for extended usage.
+/// The span will be exited on drop – which is at the end of the block or to the
+/// next `enter_span!` calls, as this overwrites the local variable. For nested
+/// usage or to ensure the span closes at certain time either put it into a
+/// block or use `within_span!`
 ///
 /// # Example
 ///


### PR DESCRIPTION
WIP

Add an RPC to retrieve a block with execution traces included. This PR adds the RPC and the database column, `TRACES`, and some other menial footwork.

Lots of things to sort out still.