### PR TITLE
Add Totem Live Accounting ss58 prefix Related #7439

### DIFF
--- a/frame/identity/src/benchmarking.rs
+++ b/frame/identity/src/benchmarking.rs
@@ -47,6 +47,7 @@ fn add_registrars<T: Trait>(r: u32) -> Result<(), &'static str> {
 		let fields = IdentityFields(
 			IdentityField::Display | IdentityField::Legal | IdentityField::Web | IdentityField::Riot
 			| IdentityField::Email | IdentityField::PgpFingerprint | IdentityField::Image | IdentityField::Twitter
+			| IdentityField::Totem
 		);
 		Identity::<T>::set_fields(RawOrigin::Signed(registrar.clone()).into(), i.into(), fields)?;
 	}
@@ -101,6 +102,7 @@ fn create_identity_info<T: Trait>(num_fields: u32) -> IdentityInfo {
 		pgp_fingerprint: Some([0; 20]),
 		image: data.clone(),
 		twitter: data.clone(),
+		totem: data.clone(),
 	};
 
 	return info
@@ -287,7 +289,8 @@ benchmarks! {
 		Identity::<T>::add_registrar(RawOrigin::Root.into(), caller.clone())?;
 		let fields = IdentityFields(
 			IdentityField::Display | IdentityField::Legal | IdentityField::Web | IdentityField::Riot
-			| IdentityField::Email | IdentityField::PgpFingerprint | IdentityField::Image | IdentityField::Twitter
+			| IdentityField::Email | IdentityField::PgpFingerprint | IdentityField::Image | IdentityField::Twitter 
+			| IdentityField::Totem
 		);
 		let registrars = Registrars::<T>::get();
 		ensure!(registrars[r as usize].as_ref().unwrap().fields == Default::default(), "fields already set.");

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -291,6 +291,7 @@ pub enum IdentityField {
 	PgpFingerprint = 0b0000000000000000000000000000000000000000000000000000000000100000,
 	Image          = 0b0000000000000000000000000000000000000000000000000000000001000000,
 	Twitter        = 0b0000000000000000000000000000000000000000000000000000000010000000,
+	Totem          = 0b0000000000000000000000000000000000000000000000000000000100000000,
 }
 
 /// Wrapper type for `BitFlags<IdentityField>` that implements `Codec`.
@@ -360,6 +361,9 @@ pub struct IdentityInfo {
 
 	/// The Twitter identity. The leading `@` character may be elided.
 	pub twitter: Data,
+
+	/// The Totem Live Accounting network messaging user identity. The leading `@` character may be elided.
+	pub totem: Data,
 }
 
 /// Information concerning the identity of the controller of an account.

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -470,6 +470,8 @@ ss58_address_format!(
 		(12, "polymath", "Polymath network, standard account (*25519).")
 	SubstraTeeAccount =>
 		(13, "substratee", "Any SubstraTEE off-chain network private account (*25519).")
+	TotemAccount =>
+		(14, "totem", "Any Totem Live Accounting network standard account (*25519).")
 	KulupuAccount =>
 		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
 	DarkAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -137,6 +137,15 @@
 			"website": "https://www.substratee.com"
 		},
 		{
+			"prefix": 14,
+			"network": "totem",
+			"displayName": "Totem",
+			"symbols": ["XTX"],
+			"decimals": [0],
+			"standardAccount": "*25519",
+			"website": "https://totemaccounting.com"
+		},
+		{
 			"prefix": 16,
 			"network": "kulupu",
 			"displayName": "Kulupu",


### PR DESCRIPTION
This pull request adds the ss58 prefix (14) for the Totem Live Accounting second test network (Totem Lego) which will go live shortly. It will also be used for Totem Live Accounting MainNet, and so does not make the distinction.

It changes the two files associated with config for the prefixes, and should not conflict with any other known changes at this time.

Please review.