### PR TITLE
Add Totem ss58 address

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -470,6 +470,8 @@ ss58_address_format!(
 		(12, "polymath", "Polymath network, standard account (*25519).")
 	SubstraTeeAccount =>
 		(13, "substratee", "Any SubstraTEE off-chain network private account (*25519).")
+	TotemAccount =>
+		(14, "totem", "Any Totem Live Accounting network standard account (*25519).")
 	KulupuAccount =>
 		(16, "kulupu", "Kulupu mainnet, standard account (*25519).")
 	DarkAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -137,6 +137,15 @@
 			"website": "https://www.substratee.com"
 		},
 		{
+			"prefix": 14,
+			"network": "totem",
+			"displayName": "Totem",
+			"symbols": ["XTX"],
+			"decimals": [0],
+			"standardAccount": "*25519",
+			"website": "https://totemaccounting.com"
+		},
+		{
 			"prefix": 16,
 			"network": "kulupu",
 			"displayName": "Kulupu",


### PR DESCRIPTION
This pull request adds the ss58 prefix (14) for the Totem Live Accounting second test network (Totem Lego) which will go live shortly. It will also be used for Totem Live Accounting MainNet, and so does not make the distinction.

It changes the two files associated with config for the prefixes, and should not conflict with any other known changes at this time.

It is related to #7439 
Please review.