### PR TITLE
Print an error if an unregistered notifications protocol is used

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -661,6 +661,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		if let Some(protocol_name) = protocol_name {
 			sink.send_sync_notification(protocol_name, message);
 		} else {
+			log::error!(
+				target: "sub-libp2p",
+				"Attempted to send notification on unknown protocol: {}", engine_id
+			);
 			return;
 		}
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -663,7 +663,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		} else {
 			log::error!(
 				target: "sub-libp2p",
-				"Attempted to send notification on unknown protocol: {}", engine_id
+				"Attempted to send notification on unknown protocol: {:?}", engine_id
 			);
 			return;
 		}

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -663,7 +663,8 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		} else {
 			log::error!(
 				target: "sub-libp2p",
-				"Attempted to send notification on unknown protocol: {:?}", engine_id
+				"Attempted to send notification on unknown protocol: {:?}",
+				engine_id,
 			);
 			return;
 		}


### PR DESCRIPTION
Adding this, as it would have detected a problem with the Polkadot testing.