### PR TITLE
contracts: Rework contracts_call RPC

### DIFF
--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -388,10 +388,10 @@ pub type DispatchResultWithInfo<T> = sp_std::result::Result<T, DispatchErrorWith
 
 /// Reason why a dispatch call failed.
 #[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug)]
-#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum DispatchError {
 	/// Some error occurred.
-	Other(#[codec(skip)] &'static str),
+	Other(#[codec(skip)] #[cfg_attr(feature = "std", serde(skip_deserializing))] &'static str),
 	/// Failed to lookup some data.
 	CannotLookup,
 	/// A bad origin.
@@ -404,6 +404,7 @@ pub enum DispatchError {
 		error: u8,
 		/// Optional error message.
 		#[codec(skip)]
+		#[cfg_attr(feature = "std", serde(skip_deserializing))]
 		message: Option<&'static str>,
 	},
 }


### PR DESCRIPTION
This changes the `contracts_call` RPC so that more information is returned. The following changes are made:

* `gas_consumed` is returned in any case and not only on success.
* On error the `DispatchError` is returned instead of nothing. Can be used by the UI to pre-run a contract call and show the user what is going wrong.
*  A `debug_message` is introduced that can be used to return dynamic information. In the future, the plan is to use the field to allow outputting more precise error messages and to support println debugging. Those messages will only be collected when called by RPC and will introduce no overhead when executed as transaction. This is currently unused and will return an empty string.

This will need changes in polkadot.js API @jacogr 

Also I needed to derive `Deserialize` for `DispatchError` because that is a requirement to use it in an RPC even though it is only used as a result.