### PR TITLE
Collective Close Operational

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -615,7 +615,7 @@ decl_module! {
 		/// Close a vote that is either approved, disapproved, or whose voting period has ended
 		/// with operational transaction priority.
 		///
-		/// May be called only by an active member close the proposal with operational priority.
+		/// May be called only by an active member to close the proposal with operational priority.
 		///
 		/// If called before the end of the voting period it will only close the vote if it is
 		/// has enough votes to be approved or disapproved.


### PR DESCRIPTION
This PR creates an explicit `close_operational` transaction that can only be called by collective members in order to close a vote with `Operational` priority. The original `close` extrinsic now has `Normal` priority and can be called by anyone.

This is just a little bit safer against spam attacks from irrational users who may want to waste their money in order to fill a block. In this case, the average user does not have access to generate arbitrary `Operational` transactions.