### PR TITLE
Add constant constructor to AccountId32

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -617,6 +617,16 @@ pub trait Public:
 #[cfg_attr(feature = "std", derive(Hash))]
 pub struct AccountId32([u8; 32]);
 
+impl AccountId32 {
+	/// Create a new instance from its raw inner byte value.
+	///
+	/// Equivalent to this types `From<[u8; 32]>` implementation. For the lack of const
+	/// support in traits we have this constructor.
+	pub const fn new(inner: [u8; 32]) -> Self {
+		Self(inner)
+	}
+}
+
 impl UncheckedFrom<crate::hash::H256> for AccountId32 {
 	fn unchecked_from(h: crate::hash::H256) -> Self {
 		AccountId32(h.into())
@@ -651,8 +661,8 @@ impl AsMut<[u8; 32]> for AccountId32 {
 }
 
 impl From<[u8; 32]> for AccountId32 {
-	fn from(x: [u8; 32]) -> AccountId32 {
-		AccountId32(x)
+	fn from(x: [u8; 32]) -> Self {
+		Self::new(x)
 	}
 }
 


### PR DESCRIPTION
This helps declaring some well known account ids as const in tests without resorting to `lazy_static` or `OnceCell`.