### PR TITLE
Fix Session Benchmarks

### DIFF
--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -45,16 +45,17 @@ fn add_slashing_spans<T: Trait>(who: &T::AccountId, spans: u32) {
 	SlashingSpans::<T>::insert(who, slashing_spans);
 }
 
-// This function generates one validator being nominated by n nominators, and returns the validator
-// stash account and the nominators' stash and controller. It also starts an era and creates pending payouts.
+// This function clears all existing validators and nominators from the set, and generates one new
+// validator being nominated by n nominators, and returns the validator stash account and the
+// nominators' stash and controller. It also starts an era and creates pending payouts.
 pub fn create_validator_with_nominators<T: Trait>(
 	n: u32,
 	upper_bound: u32,
 	dead: bool,
 	destination: RewardDestination<T::AccountId>
 ) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
-	// Clean up any existing validators.
-	Validators::<T>::remove_all();
+	// Clean up any existing state.
+	clear_validators_and_nominators::<T>();
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
@@ -706,7 +707,7 @@ mod tests {
 
 	#[test]
 	fn create_validators_with_nominators_for_era_works() {
-		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
+		ExtBuilder::default().has_stakers(true).build().execute_with(|| {
 			let v = 10;
 			let n = 100;
 
@@ -723,7 +724,7 @@ mod tests {
 
 	#[test]
 	fn create_validator_with_nominators_works() {
-		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
+		ExtBuilder::default().has_stakers(true).build().execute_with(|| {
 			let n = 10;
 
 			let (validator_stash, nominators) = create_validator_with_nominators::<Test>(
@@ -747,7 +748,7 @@ mod tests {
 
 	#[test]
 	fn add_slashing_spans_works() {
-		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
+		ExtBuilder::default().has_stakers(true).build().execute_with(|| {
 			let n = 10;
 
 			let (validator_stash, _nominators) = create_validator_with_nominators::<Test>(
@@ -778,7 +779,7 @@ mod tests {
 
 	#[test]
 	fn test_payout_all() {
-		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
+		ExtBuilder::default().has_stakers(true).build().execute_with(|| {
 			let v = 10;
 			let n = 100;
 
@@ -797,7 +798,7 @@ mod tests {
 
 	#[test]
 	fn test_benchmarks() {
-		ExtBuilder::default().has_stakers(false).build().execute_with(|| {
+		ExtBuilder::default().has_stakers(true).build().execute_with(|| {
 			assert_ok!(test_benchmark_bond::<Test>());
 			assert_ok!(test_benchmark_bond_extra::<Test>());
 			assert_ok!(test_benchmark_unbond::<Test>());

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -288,7 +288,6 @@ benchmarks! {
 
 	payout_stakers_dead_controller {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		// Clean up existing validators
 		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
@@ -322,7 +321,6 @@ benchmarks! {
 
 	payout_stakers_alive_staked {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
-		// Clean up existing validators
 		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -53,6 +53,8 @@ pub fn create_validator_with_nominators<T: Trait>(
 	dead: bool,
 	destination: RewardDestination<T::AccountId>
 ) -> Result<(T::AccountId, Vec<(T::AccountId, T::AccountId)>), &'static str> {
+	// Clean up any existing validators.
+	Validators::<T>::remove_all();
 	let mut points_total = 0;
 	let mut points_individual = Vec::new();
 
@@ -287,7 +289,6 @@ benchmarks! {
 	payout_stakers_dead_controller {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
 		// Clean up existing validators
-		Validators::<T>::remove_all();
 		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,
@@ -322,7 +323,6 @@ benchmarks! {
 	payout_stakers_alive_staked {
 		let n in 1 .. T::MaxNominatorRewardedPerValidator::get() as u32;
 		// Clean up existing validators
-		Validators::<T>::remove_all();
 		let (validator, nominators) = create_validator_with_nominators::<T>(
 			n,
 			T::MaxNominatorRewardedPerValidator::get() as u32,

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -28,6 +28,12 @@ use sp_npos_elections::*;
 
 const SEED: u32 = 0;
 
+/// This function removes all validators and nominators from storage.
+pub fn clear_validators_and_nominators<T: Trait>() {
+	Validators::<T>::remove_all();
+	Nominators::<T>::remove_all();
+}
+
 /// Grab a funded user.
 pub fn create_funded_user<T: Trait>(
 	string: &'static str,
@@ -97,6 +103,9 @@ pub fn create_validators<T: Trait>(
 /// This function generates validators and nominators who are randomly nominating
 /// `edge_per_nominator` random validators (until `to_nominate` if provided).
 ///
+/// NOTE: This function will remove any existing validators or nominators to ensure
+/// we are working with a clean state.
+///
 /// Parameters:
 /// - `validators`: number of bonded validators
 /// - `nominators`: number of bonded nominators.
@@ -113,6 +122,8 @@ pub fn create_validators_with_nominators_for_era<T: Trait>(
 	randomize_stake: bool,
 	to_nominate: Option<u32>,
 ) -> Result<Vec<<T::Lookup as StaticLookup>::Source>, &'static str> {
+	clear_validators_and_nominators::<T>();
+
 	let mut validators_stash: Vec<<T::Lookup as StaticLookup>::Source>
 		= Vec::with_capacity(validators as usize);
 	let mut rng = ChaChaRng::from_seed(SEED.using_encoded(blake2_256));


### PR DESCRIPTION
On Polkadot, the Session Benchmarks are failing because the validator we create in the benchmark isn't selected in the validator set.

This problem is caused because the Session benchmarking uses the `create_validator_with_nominators` function from Staking, but does not first clean up the existing list of validators from storage.

This PR simply moves the Validator cleanup logic into the `create_validator_with_nominators` function so anyone that uses it gets the expected outcome.

Confirmed this fix locally.