### PR TITLE
Exclude basic-authorship-proposer from the continuous tasks alert

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -127,8 +127,8 @@ groups:
   ##############################################################################
 
   - alert: ContinuousTaskEnded
-    expr: '(polkadot_tasks_spawned_total == 1) - on(instance, task_name)
-    (polkadot_tasks_ended_total == 1)'
+    expr: '(polkadot_tasks_spawned_total{task_name != "basic-authorship-proposer"} == 1)
+        - on(instance, task_name) (polkadot_tasks_ended_total == 1)'
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/7328 introduced a new task named `basic-authorship-proposer`.
This task is spawned whenever a slot is ready for the node to create a slot, and ends once the block has been created.

Unfortunately in https://github.com/paritytech/substrate/pull/7250 we made the assumption that a task that starts once, then ends once, then doesn't start again for 10 minutes, was actually probably supposed either to not end or to start again, and thus we raise an alert.

This means that if more than 10 minutes pass between the first time a node has a slot available to it and the second time a node has a slot available to it, an alert will be triggered.

In this PR I propose to special-case `basic-authorship-proposer` as a task that doesn't trigger this alert.
