### PR TITLE
Write pallet_evm README

### DIFF
--- a/frame/evm/README.md
+++ b/frame/evm/README.md
@@ -1,16 +1,20 @@
 # EVM Module
+
 The EVM module allows unmodified EVM code to be executed in a Substrate-based blockchain.
 - [`evm::Trait`](https://docs.rs/pallet-evm/2.0.0/pallet_evm/trait.Trait.html)
 
 ## EVM Engine
-The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm). In the future, we will want to allow users to swap out components like gasometer, and inject their own customized ones.
+
+The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm).
 
 ## Execution Lifecycle
+
 There are a separate set of accounts managed by the EVM module. Substrate based accounts can call the EVM Module to deposit or withdraw balance from the Substrate base-currency into a different balance managed and used by the EVM module. Once a user has populated their balance, they can create and call smart contracts using this module.
 
 There's one-to-one mapping from Substrate accounts and EVM external accounts that is defined by a conversion function.
 
 ## EVM Module vs Ethereum Network
+
 The EVM module should be able to produce nearly identical results compared to the Ethereum mainnet, including gas cost and balance changes.
 
 Observable differences include:
@@ -20,6 +24,6 @@ Observable differences include:
 
 We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
 
-The gas configurations are currently hard-coded to the Istanbul hard fork. It can later be expanded to support earlier hard fork configurations.
+The gas configurations are configurable. Right now, a pre-defined Istanbul hard fork configuration option is provided.
 
 License: Apache-2.0

--- a/frame/evm/README.md
+++ b/frame/evm/README.md
@@ -21,3 +21,5 @@ Observable differences include:
 We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
 
 The gas configurations are currently hard-coded to the Istanbul hard fork. It can later be expanded to support earlier hard fork configurations.
+
+License: Apache-2.0

--- a/frame/evm/README.md
+++ b/frame/evm/README.md
@@ -1,3 +1,23 @@
-EVM execution module for Substrate
+# EVM Module
+The EVM module allows unmodified EVM code to be executed in a Substrate-based blockchain.
+- [`evm::Trait`](https://docs.rs/pallet-evm/2.0.0/pallet_evm/trait.Trait.html)
 
-License: Apache-2.0
+## EVM Engine
+The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm). In the future, we will want to allow users to swap out components like gasometer, and inject their own customized ones.
+
+## Execution Lifecycle
+There are a separate set of accounts managed by the EVM module. Substrate based accounts can call the EVM Module to deposit or withdraw balance from the Substrate base-currency into a different balance managed and used by the EVM module. Once a user has populated their balance, they can create and call smart contracts using this module.
+
+There's one-to-one mapping from Substrate accounts and EVM external accounts that is defined by a conversion function.
+
+## EVM Module vs Ethereum Network
+The EVM module should be able to produce nearly identical results compared to the Ethereum mainnet, including gas cost and balance changes.
+
+Observable differences include:
+
+- The available length of block hashes may not be 256 depending on the configuration of the System module in the Substrate runtime.
+- Difficulty and coinbase, which do not make sense in this module and is currently hard coded to zero.
+
+We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
+
+The gas configurations are currently hard-coded to the Istanbul hard fork. It can later be expanded to support earlier hard fork configurations.

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -15,7 +15,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! EVM execution module for Substrate
+//! # EVM Module
+//!
+//! The EVM module allows unmodified EVM code to be executed in a Substrate-based blockchain.
+//! - [`evm::Trait`](https://docs.rs/pallet-evm/2.0.0/pallet_evm/trait.Trait.html)
+//!
+//! ## EVM Engine
+//!
+//! The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm). In the future, we will want to allow users to swap out components like gasometer, and inject their own customized ones.
+//!
+//! ## Execution Lifecycle
+//!
+//! There are a separate set of accounts managed by the EVM module. Substrate based accounts can call the EVM Module to deposit or withdraw balance from the Substrate base-currency into a different balance managed and used by the EVM module. Once a user has populated their balance, they can create and call smart contracts using this module.
+//!
+//! There's one-to-one mapping from Substrate accounts and EVM external accounts that is defined by a conversion function.
+//!
+//! ## EVM Module vs Ethereum Network
+//!
+//! The EVM module should be able to produce nearly identical results compared to the Ethereum mainnet, including gas cost and balance changes.
+//!
+//! Observable differences include:
+//!
+//! - The available length of block hashes may not be 256 depending on the configuration of the System module in the Substrate runtime.
+//! - Difficulty and coinbase, which do not make sense in this module and is currently hard coded to zero.
+//!
+//! We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
+//!
+//! The gas configurations are currently hard-coded to the Istanbul hard fork. It can later be expanded to support earlier hard fork configurations.
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
 //!
-//! The gas configurations are currently hard-coded to the Istanbul hard fork. It can later be expanded to support earlier hard fork configurations.
+//! The gas configurations are configurable. Right now, a pre-defined Istanbul hard fork configuration option is provided.
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ## EVM Engine
 //!
-//! The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm). In the future, we will want to allow users to swap out components like gasometer, and inject their own customized ones.
+//! The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm).
 //!
 //! ## Execution Lifecycle
 //!

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -18,7 +18,7 @@
 //! # EVM Module
 //!
 //! The EVM module allows unmodified EVM code to be executed in a Substrate-based blockchain.
-//! - [`evm::Trait`](https://docs.rs/pallet-evm/2.0.0/pallet_evm/trait.Trait.html)
+//! - [`evm::Trait`]
 //!
 //! ## EVM Engine
 //!

--- a/frame/evm/src/lib.rs
+++ b/frame/evm/src/lib.rs
@@ -22,24 +22,31 @@
 //!
 //! ## EVM Engine
 //!
-//! The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine. The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm).
+//! The EVM module uses [`SputnikVM`](https://github.com/rust-blockchain/evm) as the underlying EVM engine.
+//! The engine is overhauled so that it's [`modular`](https://github.com/corepaper/evm).
 //!
 //! ## Execution Lifecycle
 //!
-//! There are a separate set of accounts managed by the EVM module. Substrate based accounts can call the EVM Module to deposit or withdraw balance from the Substrate base-currency into a different balance managed and used by the EVM module. Once a user has populated their balance, they can create and call smart contracts using this module.
+//! There are a separate set of accounts managed by the EVM module. Substrate based accounts can call the EVM Module
+//! to deposit or withdraw balance from the Substrate base-currency into a different balance managed and used by
+//! the EVM module. Once a user has populated their balance, they can create and call smart contracts using this module.
 //!
 //! There's one-to-one mapping from Substrate accounts and EVM external accounts that is defined by a conversion function.
 //!
 //! ## EVM Module vs Ethereum Network
 //!
-//! The EVM module should be able to produce nearly identical results compared to the Ethereum mainnet, including gas cost and balance changes.
+//! The EVM module should be able to produce nearly identical results compared to the Ethereum mainnet,
+//! including gas cost and balance changes.
 //!
 //! Observable differences include:
 //!
-//! - The available length of block hashes may not be 256 depending on the configuration of the System module in the Substrate runtime.
+//! - The available length of block hashes may not be 256 depending on the configuration of the System module
+//! in the Substrate runtime.
 //! - Difficulty and coinbase, which do not make sense in this module and is currently hard coded to zero.
 //!
-//! We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
+//! We currently do not aim to make unobservable behaviors, such as state root, to be the same. We also don't aim to follow
+//! the exact same transaction / receipt format. However, given one Ethereum transaction and one Substrate account's
+//! private key, one should be able to convert any Ethereum transaction into a transaction compatible with this module.
 //!
 //! The gas configurations are configurable. Right now, a pre-defined Istanbul hard fork configuration option is provided.
 


### PR DESCRIPTION
I wanted to read pallet_evm source code but there was no README so I described pallet_evm README.
I put a link for the Rust documentation and wrote description according to [this page](https://substrate.dev/docs/en/knowledgebase/smart-contracts/evm-pallet).