### PR TITLE
[EVM] Make account basic trait

### DIFF
--- a/frame/evm/src/backend.rs
+++ b/frame/evm/src/backend.rs
@@ -9,7 +9,7 @@ use frame_support::traits::Get;
 use frame_support::{debug, storage::{StorageMap, StorageDoubleMap}};
 use sha3::{Keccak256, Digest};
 use evm::backend::{Backend as BackendT, ApplyBackend, Apply};
-use crate::{Trait, AccountStorages, AccountCodes, Module, Event};
+use crate::{Trait, AccountStorages, AccountCodes, Module, Event, AccountBasicMapping};
 
 #[derive(Clone, Eq, PartialEq, Encode, Decode, Default)]
 #[cfg_attr(feature = "std", derive(Debug, Serialize, Deserialize))]
@@ -100,7 +100,7 @@ impl<'vicinity, T: Trait> BackendT for Backend<'vicinity, T> {
 	}
 
 	fn basic(&self, address: H160) -> evm::backend::Basic {
-		let account = Module::<T>::account_basic(&address);
+		let account = T::AccountBasicMapping::account_basic(&address);
 
 		evm::backend::Basic {
 			balance: account.balance,
@@ -141,7 +141,7 @@ impl<'vicinity, T: Trait> ApplyBackend for Backend<'vicinity, T> {
 				Apply::Modify {
 					address, basic, code, storage, reset_storage,
 				} => {
-					Module::<T>::mutate_account_basic(&address, Account {
+					T::AccountBasicMapping::mutate_account_basic(&address, Account {
 						nonce: basic.nonce,
 						balance: basic.balance,
 					});

--- a/frame/evm/src/tests.rs
+++ b/frame/evm/src/tests.rs
@@ -103,6 +103,7 @@ impl Trait for Test {
 	type Event = Event<Test>;
 	type Precompiles = ();
 	type ChainId = SystemChainId;
+	type AccountBasicMapping = RawAccountBasicMapping<Test>;
 }
 
 type System = frame_system::Module<Test>;
@@ -171,7 +172,7 @@ fn fail_call_return_ok() {
 #[test]
 fn mutate_account_works() {
 	new_test_ext().execute_with(|| {
-		EVM::mutate_account_basic(
+		<Test as Trait>::AccountBasicMapping::mutate_account_basic(
 			&H160::from_str("1000000000000000000000000000000000000001").unwrap(),
 			Account {
 				nonce: U256::from(10),
@@ -179,7 +180,7 @@ fn mutate_account_works() {
 			},
 		);
 
-		assert_eq!(EVM::account_basic(
+		assert_eq!(<Test as Trait>::AccountBasicMapping::account_basic(
 			&H160::from_str("1000000000000000000000000000000000000001").unwrap()
 		), Account {
 			nonce: U256::from(10),


### PR DESCRIPTION
# Desc

In this PR, Make the `account_basic`, `mutate_account_basic` into one trait names `AccountBasicMapping`.

## The reason

Recently, in order to utilize ethereum development tools, such as metamask, remix, etc. we want to achieve this via integrate frontier and evm-pallet. However, we found that the balance model in our project is different from ethereum, which will cause the balance to be displayed in metamask tool incorrectly.  

To support handle such difference in runtime, make `AccountBasicMapping` as an associated type of pallet-evm.

For more info, please refer to:

https://github.com/darwinia-network/darwinia-common/issues/339


