### PR TITLE
Bump pallet-contracts version to 3.0.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "2.0.0"
+version = "3.0.0-rc1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "2.0.0"
+version = "3.0.0-rc1"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc"
-version = "0.8.0"
+version = "3.0.0-rc1"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0"
+version = "3.0.0-rc1"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -78,7 +78,7 @@ sc-authority-discovery = { version = "0.8.0",  path = "../../../client/authority
 # frame dependencies
 pallet-indices = { version = "2.0.0", path = "../../../frame/indices" }
 pallet-timestamp = { version = "2.0.0", default-features = false, path = "../../../frame/timestamp" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0-rc1", path = "../../../frame/contracts" }
 frame-system = { version = "2.0.0", path = "../../../frame/system" }
 pallet-balances = { version = "2.0.0", path = "../../../frame/balances" }
 pallet-transaction-payment = { version = "2.0.0", path = "../../../frame/transaction-payment" }

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -30,7 +30,7 @@ frame-support = { version = "2.0.0", path = "../../../frame/support" }
 frame-system = { version = "2.0.0", path = "../../../frame/system" }
 node-testing = { version = "2.0.0", path = "../testing" }
 pallet-balances = { version = "2.0.0", path = "../../../frame/balances" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0-rc1", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "2.0.0", path = "../../../frame/grandpa" }
 pallet-im-online = { version = "2.0.0", path = "../../../frame/im-online" }
 pallet-indices = { version = "2.0.0", path = "../../../frame/indices" }

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 jsonrpc-core = "15.1.0"
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "2.0.0", path = "../runtime" }
-pallet-contracts-rpc = { version = "0.8.0", path = "../../../frame/contracts/rpc/" }
+pallet-contracts-rpc = { version = "3.0.0-rc1", path = "../../../frame/contracts/rpc/" }
 pallet-transaction-payment-rpc = { version = "2.0.0", path = "../../../frame/transaction-payment/rpc/" }
 sc-client-api = { version = "2.0.0", path = "../../../client/api" }
 sc-consensus-babe = { version = "0.8.0", path = "../../../client/consensus/babe" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -48,9 +48,9 @@ pallet-authorship = { version = "2.0.0", default-features = false, path = "../..
 pallet-babe = { version = "2.0.0", default-features = false, path = "../../../frame/babe" }
 pallet-balances = { version = "2.0.0", default-features = false, path = "../../../frame/balances" }
 pallet-collective = { version = "2.0.0", default-features = false, path = "../../../frame/collective" }
-pallet-contracts = { version = "2.0.0", default-features = false, path = "../../../frame/contracts" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "../../../frame/contracts/common/" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
+pallet-contracts = { version = "3.0.0-rc1", default-features = false, path = "../../../frame/contracts" }
+pallet-contracts-primitives = { version = "3.0.0-rc1", default-features = false, path = "../../../frame/contracts/common/" }
+pallet-contracts-rpc-runtime-api = { version = "3.0.0-rc1", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
 pallet-democracy = { version = "2.0.0", default-features = false, path = "../../../frame/democracy" }
 pallet-elections-phragmen = { version = "2.0.0", default-features = false, path = "../../../frame/elections-phragmen" }
 pallet-grandpa = { version = "2.0.0", default-features = false, path = "../../../frame/grandpa" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -18,7 +18,7 @@ sc-service = { version = "0.8.0", features = ["test-helpers", "db"],  path = "..
 sc-client-db = { version = "0.8.0", path = "../../../client/db/", features = ["kvdb-rocksdb", "parity-db"] }
 sc-client-api = { version = "2.0.0", path = "../../../client/api/" }
 codec = { package = "parity-scale-codec", version = "1.3.4" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0-rc1", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "2.0.0", path = "../../../frame/grandpa" }
 pallet-indices = { version = "2.0.0", path = "../../../frame/indices" }
 sp-keyring = { version = "2.0.0", path = "../../../primitives/keyring" }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts"
-version = "2.0.0"
+version = "3.0.0-rc1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -17,7 +17,6 @@ codec = { package = "parity-scale-codec", version = "1.3.4", default-features = 
 frame-benchmarking = { version = "2.0.0", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "2.0.0", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0", default-features = false, path = "../system" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "common" }
 parity-wasm = { version = "0.41.0", default-features = false }
 pwasm-utils = { version = "0.14.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
@@ -27,6 +26,8 @@ sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 sp-sandbox = { version = "0.8.0", default-features = false, path = "../../primitives/sandbox" }
 wasmi-validation = { version = "0.3.0", default-features = false }
+
+pallet-contracts-primitives = { version = "3.0.0-rc1", default-features = false, path = "common" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-primitives"
-version = "2.0.0"
+version = "3.0.0-rc1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc"
-version = "0.8.0"
+version = "3.0.0-rc1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -23,8 +23,9 @@ sp-rpc = { version = "2.0.0", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
 sp-api = { version = "2.0.0", path = "../../../primitives/api" }
-pallet-contracts-primitives = { version = "2.0.0", path = "../common" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0", path = "./runtime-api" }
+
+pallet-contracts-primitives = { version = "3.0.0-rc1", path = "../common" }
+pallet-contracts-rpc-runtime-api = { version = "3.0.0-rc1", path = "./runtime-api" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0"
+version = "3.0.0-rc1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,7 +17,8 @@ sp-api = { version = "2.0.0", default-features = false, path = "../../../../prim
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0", default-features = false, path = "../../../../primitives/std" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../../../primitives/runtime" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "../../common" }
+
+pallet-contracts-primitives = { version = "3.0.0-rc1", default-features = false, path = "../../common" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This bump is performed in expectation of a new substrate release soon(TM). There are already breaking changes in master [[1](https://github.com/paritytech/substrate/pull/7409), [2](https://github.com/paritytech/substrate/pull/7468)] and more are expected [[1](https://github.com/paritytech/substrate/pull/7482), [2](https://github.com/paritytech/substrate/issues/6596)] before `3.0.0` can be released.

The `rcX` suffix is a workaround to not be forced to bump the major version in rapid succession in this phase of applying breaking changes before  we go over to a more stable period (after `3.0.0` release).

@Robbepop @seanyoung