### PR TITLE
Make the maximum block size configurable

### DIFF
--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -42,6 +42,11 @@ use std::marker::PhantomData;
 use prometheus_endpoint::Registry as PrometheusRegistry;
 use sc_proposer_metrics::MetricsLink as PrometheusMetrics;
 
+/// Default maximum block size in bytes used by [`Proposer`].
+///
+/// Can be overwritten by [`ProposerFactory::set_maxium_block_size`].
+pub const DEFAULT_MAX_BLOCK_SIZE: usize = 4 * 1024 * 1024 + 512;
+
 /// Proposer factory.
 pub struct ProposerFactory<A, B, C> {
 	spawn_handle: Box<dyn SpawnNamed>,
@@ -53,6 +58,7 @@ pub struct ProposerFactory<A, B, C> {
 	metrics: PrometheusMetrics,
 	/// phantom member to pin the `Backend` type.
 	_phantom: PhantomData<B>,
+	max_block_size: usize,
 }
 
 impl<A, B, C> ProposerFactory<A, B, C> {
@@ -68,7 +74,16 @@ impl<A, B, C> ProposerFactory<A, B, C> {
 			transaction_pool,
 			metrics: PrometheusMetrics::new(prometheus),
 			_phantom: PhantomData,
+			max_block_size: DEFAULT_MAX_BLOCK_SIZE,
 		}
+	}
+
+	/// Set the maximum block size in bytes.
+	///
+	/// The default value for the maximum block size is:
+	/// [`DEFAULT_MAX_BLOCK_SIZE`].
+	pub fn set_maximum_block_size(&mut self, size: usize) {
+		self.max_block_size = size;
 	}
 }
 
@@ -103,6 +118,7 @@ impl<B, Block, C, A> ProposerFactory<A, B, C>
 			now,
 			metrics: self.metrics.clone(),
 			_phantom: PhantomData,
+			max_block_size: self.max_block_size,
 		};
 
 		proposer
@@ -143,6 +159,7 @@ pub struct Proposer<B, Block: BlockT, C, A: TransactionPool> {
 	now: Box<dyn Fn() -> time::Instant + Send + Sync>,
 	metrics: PrometheusMetrics,
 	_phantom: PhantomData<B>,
+	max_block_size: usize,
 }
 
 impl<A, B, Block, C> sp_consensus::Proposer<Block> for
@@ -334,7 +351,12 @@ impl<A, B, Block, C> Proposer<B, Block, C, A>
 			error!("Failed to verify block encoding/decoding");
 		}
 
-		if let Err(err) = evaluation::evaluate_initial(&block, &self.parent_hash, self.parent_number) {
+		if let Err(err) = evaluation::evaluate_initial(
+			&block,
+			&self.parent_hash,
+			self.parent_number,
+			self.max_block_size,
+		) {
 			error!("Failed to evaluate authored block: {:?}", err);
 		}
 

--- a/client/basic-authorship/src/basic_authorship.rs
+++ b/client/basic-authorship/src/basic_authorship.rs
@@ -45,6 +45,10 @@ use sc_proposer_metrics::MetricsLink as PrometheusMetrics;
 /// Default maximum block size in bytes used by [`Proposer`].
 ///
 /// Can be overwritten by [`ProposerFactory::set_maxium_block_size`].
+///
+/// Be aware that there is also an upper packet size on what the networking code
+/// will accept. If the block doesn't fit in such a package, it can not be
+/// transferred to other nodes.
 pub const DEFAULT_MAX_BLOCK_SIZE: usize = 4 * 1024 * 1024 + 512;
 
 /// Proposer factory.

--- a/primitives/consensus/common/src/evaluation.rs
+++ b/primitives/consensus/common/src/evaluation.rs
@@ -58,7 +58,7 @@ pub fn evaluate_initial<Block: BlockT>(
 		.map_err(|e| Error::BadProposalFormat(e))?;
 
 	if encoded.len() > max_block_size {
-		return Err(Error::ProposalTooLarge{ max_block_size, block_size: encoded.len() })
+		return Err(Error::ProposalTooLarge { max_block_size, block_size: encoded.len() })
 	}
 
 	if *parent_hash != *proposal.header().parent_hash() {

--- a/primitives/consensus/common/src/lib.rs
+++ b/primitives/consensus/common/src/lib.rs
@@ -46,9 +46,6 @@ pub mod import_queue;
 pub mod evaluation;
 mod metrics;
 
-// block size limit.
-const MAX_BLOCK_SIZE: usize = 4 * 1024 * 1024 + 512;
-
 pub use self::error::Error;
 pub use block_import::{
 	BlockImport, BlockOrigin, ForkChoiceStrategy, ImportedAux, BlockImportParams, BlockCheckParams,


### PR DESCRIPTION
This pr makes the maximum block size configurable. The maximum block
size is used after proposing a new block to check if the new block is
not exceeding the maximum.

Closes: https://github.com/paritytech/substrate/issues/7492