### PR TITLE
Fix comments of indices pallet events

### DIFF
--- a/frame/indices/src/lib.rs
+++ b/frame/indices/src/lib.rs
@@ -80,11 +80,11 @@ decl_event!(
 		<T as frame_system::Trait>::AccountId,
 		<T as Trait>::AccountIndex
 	{
-		/// A account index was assigned. \[who, index\]
+		/// A account index was assigned. \[index, who\]
 		IndexAssigned(AccountId, AccountIndex),
 		/// A account index has been freed up (unassigned). \[index\]
 		IndexFreed(AccountIndex),
-		/// A account index has been frozen to its current account ID. \[who, index\]
+		/// A account index has been frozen to its current account ID. \[index, who\]
 		IndexFrozen(AccountIndex, AccountId),
 	}
 );


### PR DESCRIPTION
Arguments for IndexAssigned and IndexFrozen were inverted in comments.