### PR TITLE
[WIP] add prelude module to frame_support

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -22,6 +22,21 @@
 /// Export ourself as `frame_support` to make tests happy.
 extern crate self as frame_support;
 
+pub mod prelude {
+    pub use crate::debug;
+    pub use crate::dispatch::{DispatchError, DispatchResult, DispatchResultWithPostInfo};
+    pub use crate::storage;
+    pub use crate::traits::{
+        BalanceStatus, Currency, EnsureOrigin, ExistenceRequirement, Get, Randomness,
+        ReservableCurrency, WithdrawReasons,
+    };
+    pub use crate::weights::{DispatchClass, Pays, Weight};
+    pub use crate::{
+        decl_error, decl_event, decl_module, decl_storage, ensure, Parameter, RuntimeDebug,
+    };
+}
+
+
 #[doc(hidden)]
 pub use sp_tracing;
 


### PR DESCRIPTION
This PR adds a `prelude` module to `frame_support` for a more pleasant dev experience.

✄ -----------------------------------------------------------------------------

- [ ] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

