### PR TITLE
Skip slot lenience on first block in BABE

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -669,12 +669,17 @@ impl<B, C, E, I, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for BabeSlot
 
 	fn proposing_remaining_duration(
 		&self,
-		head: &B::Header,
+		parent_head: &B::Header,
 		slot_info: &SlotInfo,
 	) -> Option<std::time::Duration> {
 		let slot_remaining = self.slot_remaining_duration(slot_info);
 
-		let parent_slot = match find_pre_digest::<B>(head) {
+		// If parent is genesis block, we don't require any lenience factor.
+		if parent_head.number().is_zero() {
+			return Some(slot_remaining)
+		}
+
+		let parent_slot = match find_pre_digest::<B>(parent_head) {
 			Err(_) => return Some(slot_remaining),
 			Ok(d) => d.slot_number(),
 		};
@@ -682,7 +687,8 @@ impl<B, C, E, I, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for BabeSlot
 		if let Some(slot_lenience) =
 			sc_consensus_slots::slot_lenience_exponential(parent_slot, slot_info)
 		{
-			debug!(target: "babe",
+			debug!(
+				target: "babe",
 				"No block for {} slots. Applying exponential lenience of {}s",
 				slot_info.number.saturating_sub(parent_slot + 1),
 				slot_lenience.as_secs(),
@@ -697,8 +703,7 @@ impl<B, C, E, I, Error, SO> sc_consensus_slots::SimpleSlotWorker<B> for BabeSlot
 
 /// Extract the BABE pre digest from the given header. Pre-runtime digests are
 /// mandatory, the function will return `Err` if none is found.
-pub fn find_pre_digest<B: BlockT>(header: &B::Header) -> Result<PreDigest, Error<B>>
-{
+pub fn find_pre_digest<B: BlockT>(header: &B::Header) -> Result<PreDigest, Error<B>> {
 	// genesis block doesn't contain a pre digest so let's generate a
 	// dummy one to not break any invariants in the rest of the code
 	if header.number().is_zero() {


### PR DESCRIPTION
The genesis header doesn't have the BABE pre-digest and we insert `0` as
slot number. The slot lenience calculation will return the maximum in
this situation. Besides returning the maximum which is not bad at all,
it also prints some a debug message that can be confusing in the first
moment. To prevent printing this debug message, we now just return early
when we see that the parent block is the genesis block.

