### PR TITLE
Don't log with colors when we are writing to a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6226,9 +6226,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "region"
@@ -6549,6 +6549,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.5",
  "hex",
+ "lazy_static",
  "libp2p",
  "log",
  "names",
@@ -7075,6 +7076,7 @@ name = "sc-informant"
 version = "0.8.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "atty",
  "futures 0.3.5",
  "log",
  "parity-util-mem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,6 @@ dependencies = [
  "fdlimit",
  "futures 0.3.5",
  "hex",
- "lazy_static",
  "libp2p",
  "log",
  "names",
@@ -7076,7 +7075,6 @@ name = "sc-informant"
 version = "0.8.0"
 dependencies = [
  "ansi_term 0.12.1",
- "atty",
  "futures 0.3.5",
  "log",
  "parity-util-mem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,6 +6549,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.5",
  "hex",
+ "lazy_static",
  "libp2p",
  "log",
  "names",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.11"
 atty = "0.2.13"
 regex = "1.4.2"
+lazy_static = "1.4.0"
 ansi_term = "0.12.1"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -15,7 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = "0.4.11"
 atty = "0.2.13"
-regex = "1.3.4"
+regex = "1.4.2"
+lazy_static = "1.4.0"
 ansi_term = "0.12.1"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -16,7 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 log = "0.4.11"
 atty = "0.2.13"
 regex = "1.4.2"
-lazy_static = "1.4.0"
 ansi_term = "0.12.1"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"

--- a/client/cli/src/logging.rs
+++ b/client/cli/src/logging.rs
@@ -34,7 +34,7 @@ use regex::Regex;
 /// Span name used for the logging prefix. See macro `sc_cli::prefix_logs_with!`
 pub const PREFIX_LOG_SPAN: &str = "substrate-log-prefix";
 
-/// A writer that may writes to `inner_writer` with colors.
+/// A writer that may write to `inner_writer` with colors.
 ///
 /// This is used by [`EventFormat`] to kill colors when `enable_color` is `false`.
 ///

--- a/client/cli/src/logging.rs
+++ b/client/cli/src/logging.rs
@@ -16,8 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use std::fmt::{self, Write};
 use ansi_term::Colour;
-use std::fmt;
 use tracing::{span::Attributes, Event, Id, Level, Subscriber};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
@@ -29,16 +29,62 @@ use tracing_subscriber::{
 	registry::LookupSpan,
 	Layer,
 };
+use regex::Regex;
 
 /// Span name used for the logging prefix. See macro `sc_cli::prefix_logs_with!`
 pub const PREFIX_LOG_SPAN: &str = "substrate-log-prefix";
 
+/// A writer that may writes to `inner_writer` with colors.
+///
+/// This is used by [`EventFormat`] to kill colors when `enable_color` is `false`.
+///
+/// It is required to call [`MaybeColorWriter::write`] after all writes are done,
+/// because the content of these writes is buffered and will only be written to the
+/// `inner_writer` at this point.
+struct MaybeColorWriter<'a> {
+	enable_color: bool,
+	buffer: String,
+	inner_writer: &'a mut dyn fmt::Write,
+}
+
+impl<'a> fmt::Write for MaybeColorWriter<'a> {
+	fn write_str(&mut self, buf: &str) -> fmt::Result {
+		self.buffer.push_str(buf);
+		Ok(())
+	}
+}
+
+impl<'a> MaybeColorWriter<'a> {
+	/// Creates a new instance.
+	fn new(enable_color: bool, inner_writer: &'a mut dyn fmt::Write) -> Self {
+		Self {
+			enable_color,
+			inner_writer,
+			buffer: String::new(),
+		}
+	}
+
+	/// Write the buffered content to the `inner_writer`.
+	fn write(&mut self) -> fmt::Result {
+		lazy_static::lazy_static! {
+			static ref RE: Regex = Regex::new("\x1b\\[[^m]+m").expect("Error initializing color regex");
+		}
+
+		if !self.enable_color {
+			let replaced = RE.replace_all(&self.buffer, "");
+			self.inner_writer.write_str(&replaced)
+		} else {
+			self.inner_writer.write_str(&self.buffer)
+		}
+	}
+}
+
 pub(crate) struct EventFormat<T = SystemTime> {
 	pub(crate) timer: T,
-	pub(crate) ansi: bool,
 	pub(crate) display_target: bool,
 	pub(crate) display_level: bool,
 	pub(crate) display_thread_name: bool,
+	pub(crate) enable_color: bool,
 }
 
 // NOTE: the following code took inspiration from tracing-subscriber
@@ -56,12 +102,13 @@ where
 		writer: &mut dyn fmt::Write,
 		event: &Event,
 	) -> fmt::Result {
+		let writer = &mut MaybeColorWriter::new(self.enable_color, writer);
 		let normalized_meta = event.normalized_metadata();
 		let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
-		time::write(&self.timer, writer, self.ansi)?;
+		time::write(&self.timer, writer, self.enable_color)?;
 
 		if self.display_level {
-			let fmt_level = { FmtLevel::new(meta.level(), self.ansi) };
+			let fmt_level = { FmtLevel::new(meta.level(), self.enable_color) };
 			write!(writer, "{} ", fmt_level)?;
 		}
 
@@ -94,7 +141,9 @@ where
 			write!(writer, "{}:", meta.target())?;
 		}
 		ctx.format_fields(writer, event)?;
-		writeln!(writer)
+		writeln!(writer)?;
+
+		writer.write()
 	}
 }
 

--- a/client/cli/src/logging.rs
+++ b/client/cli/src/logging.rs
@@ -40,7 +40,7 @@ pub const PREFIX_LOG_SPAN: &str = "substrate-log-prefix";
 ///
 /// It is required to call [`MaybeColorWriter::write`] after all writes are done,
 /// because the content of these writes is buffered and will only be written to the
-/// `inner_writer` at this point.
+/// `inner_writer` at that point.
 struct MaybeColorWriter<'a> {
 	enable_color: bool,
 	buffer: String,

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -14,7 +14,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
-atty = "0.2.13"
 futures = "0.3.4"
 log = "0.4.8"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 ansi_term = "0.12.1"
+atty = "0.2.13"
 futures = "0.3.4"
 log = "0.4.8"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }

--- a/client/informant/src/lib.rs
+++ b/client/informant/src/lib.rs
@@ -35,7 +35,9 @@ mod display;
 /// The format to print telemetry output in.
 #[derive(Clone, Debug)]
 pub struct OutputFormat {
-	/// Enable color output in logs. True by default.
+	/// Enable color output in logs.
+	///
+	/// Is enabled by default.
 	pub enable_color: bool,
 }
 


### PR DESCRIPTION
This fixes a regression that was introduced by the switch to tracing.
Before we killed all colors before writing to a tty, this pr brings the
behaviour back.

Fixes: https://github.com/paritytech/substrate/issues/7521