### PR TITLE
MemoryId -> u32

### DIFF
--- a/client/executor/wasmtime/src/host.rs
+++ b/client/executor/wasmtime/src/host.rs
@@ -232,7 +232,7 @@ impl<'a> Sandbox for HostContext<'a> {
 			.map_err(|e| e.to_string())
 	}
 
-	fn memory_new(&mut self, initial: u32, maximum: MemoryId) -> sp_wasm_interface::Result<u32> {
+	fn memory_new(&mut self, initial: u32, maximum: u32) -> sp_wasm_interface::Result<u32> {
 		self.sandbox_store
 			.borrow_mut()
 			.new_memory(initial, maximum)


### PR DESCRIPTION
I think it's a typo.
The `memory_new` function uses a `u32` everywhere except here, and passing a `MemoryId` for what I assume is the maximum memory size doesn't really make sense to me.

Since `MemoryId` is an alias of `u32`, this doesn't change anything.
