### PR TITLE
Enable local addresses in DHT when chain type == `Local` | `Development`

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -94,7 +94,8 @@ pub struct NetworkParams {
 
 	/// Enable peer discovery on local networks.
 	///
-	/// By default this option is true for `--dev` and false otherwise.
+	/// By default this option is `true` for `--dev` or when the chain type is `Local`/`Development`
+	/// and false otherwise.
 	#[structopt(long)]
 	pub discover_local: bool,
 


### PR DESCRIPTION
This pr changes when to add local addresses to DHT. Instead of only
checking if `--discover-local` and `--dev` are present, we now also
check if the chain type is `Local` or `Development`.