### PR TITLE
Add slashing events to elections-phragmen.

### DIFF
--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1007,7 +1007,7 @@ impl<T: Trait> Module<T> {
 			// Burn outgoing bonds
 			to_burn_bond.into_iter().for_each(|x| {
 				let (imbalance, _) = T::Currency::slash_reserved(&x, T::CandidacyBond::get());
-				Self::deposit_event(RawEvent:: SeatHolderSlashed(x, T::CandidacyBond::get()));
+				Self::deposit_event(RawEvent::SeatHolderSlashed(x, T::CandidacyBond::get()));
 				T::LoserCandidate::on_unbalanced(imbalance);
 			});
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -684,7 +684,7 @@ decl_event!(
 		MemberKicked(AccountId),
 		/// A candidate was slashed due to failing to obtain a seat as member or runner-up
 		CandidateSlashed(AccountId, Balance),
-		/// A member/runner-up was slashed due to failing to retaining their position.
+		/// A seat holder (member or runner-up) was slashed due to failing to retaining their position.
 		SeatHolderSlashed(AccountId, Balance),
 		/// A \[member\] has renounced their candidacy.
 		MemberRenounced(AccountId),

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -682,6 +682,10 @@ decl_event!(
 		/// A \[member\] has been removed. This should always be followed by either `NewTerm` or
 		/// `EmptyTerm`.
 		MemberKicked(AccountId),
+		/// A candidate was slashed due to failing to obtain a seat as member or runner-up
+		CandidateSlashed(AccountId, Balance),
+		/// A member/runner-up was slashed due to failing to retaining their position.
+		MemberSlashed(AccountId, Balance),
 		/// A \[member\] has renounced their candidacy.
 		MemberRenounced(AccountId),
 		/// A voter was reported with the the report being successful or not.
@@ -995,6 +999,7 @@ impl<T: Trait> Module<T> {
 					new_runners_up_ids_sorted.binary_search(&c).is_err()
 				{
 					let (imbalance, _) = T::Currency::slash_reserved(&c, T::CandidacyBond::get());
+					Self::deposit_event(RawEvent::CandidateSlashed(c, T::CandidacyBond::get()));
 					T::LoserCandidate::on_unbalanced(imbalance);
 				}
 			});
@@ -1002,6 +1007,7 @@ impl<T: Trait> Module<T> {
 			// Burn outgoing bonds
 			to_burn_bond.into_iter().for_each(|x| {
 				let (imbalance, _) = T::Currency::slash_reserved(&x, T::CandidacyBond::get());
+				Self::deposit_event(RawEvent::MemberSlashed(c, T::CandidacyBond::get()));
 				T::LoserCandidate::on_unbalanced(imbalance);
 			});
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1007,7 +1007,7 @@ impl<T: Trait> Module<T> {
 			// Burn outgoing bonds
 			to_burn_bond.into_iter().for_each(|x| {
 				let (imbalance, _) = T::Currency::slash_reserved(&x, T::CandidacyBond::get());
-				Self::deposit_event(RawEvent::MemberSlashed(c, T::CandidacyBond::get()));
+				Self::deposit_event(RawEvent::MemberSlashed(x, T::CandidacyBond::get()));
 				T::LoserCandidate::on_unbalanced(imbalance);
 			});
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -685,7 +685,7 @@ decl_event!(
 		/// A candidate was slashed due to failing to obtain a seat as member or runner-up
 		CandidateSlashed(AccountId, Balance),
 		/// A member/runner-up was slashed due to failing to retaining their position.
-		MemberSlashed(AccountId, Balance),
+		SeatHolderSlashed(AccountId, Balance),
 		/// A \[member\] has renounced their candidacy.
 		MemberRenounced(AccountId),
 		/// A voter was reported with the the report being successful or not.
@@ -1007,7 +1007,7 @@ impl<T: Trait> Module<T> {
 			// Burn outgoing bonds
 			to_burn_bond.into_iter().for_each(|x| {
 				let (imbalance, _) = T::Currency::slash_reserved(&x, T::CandidacyBond::get());
-				Self::deposit_event(RawEvent::MemberSlashed(x, T::CandidacyBond::get()));
+				Self::deposit_event(RawEvent:: SeatHolderSlashed(x, T::CandidacyBond::get()));
 				T::LoserCandidate::on_unbalanced(imbalance);
 			});
 


### PR DESCRIPTION
As an aftermath of https://github.com/paritytech/substrate/pull/7384, it is sensible and very useful to exactly deposit events for slashing. This is an important event, and should not happen too often anymore. In the past there was no event so we had to rely on `Treasury::deposit` to guess which slashings happened. 