### PR TITLE
Relax std constraint of sp-runtime::testing

### DIFF
--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -50,7 +50,6 @@ use codec::{Encode, Decode};
 pub mod curve;
 pub mod generic;
 pub mod offchain;
-#[cfg(feature = "std")]
 pub mod testing;
 pub mod traits;
 pub mod transaction_validity;


### PR DESCRIPTION
Hand picks conditional `serde` or `std` features and frees everything else for `core` usage.