### PR TITLE
sc-network: update some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,12 +573,6 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
-
-[[package]]
-name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
@@ -2930,7 +2924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8186060d6bd415e4e928e6cb44c4fe7e7a7dd53437bd936ce7e5f421e45a51"
 dependencies = [
  "asn1_der",
- "bs58 0.4.0",
+ "bs58",
  "ed25519-dalek",
  "either",
  "fnv",
@@ -2952,7 +2946,7 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.5.0",
  "thiserror",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
  "zeroize",
 ]
@@ -3029,7 +3023,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2 0.9.2",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
@@ -3071,7 +3065,7 @@ dependencies = [
  "sha2 0.9.2",
  "smallvec 1.5.0",
  "uint",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
  "wasm-timer",
 ]
@@ -3113,7 +3107,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3166,7 +3160,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "void",
 ]
 
@@ -3200,7 +3194,7 @@ dependencies = [
  "minicbor",
  "rand 0.7.3",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "wasm-timer",
 ]
 
@@ -3665,7 +3659,7 @@ dependencies = [
  "sha-1 0.9.2",
  "sha2 0.9.2",
  "sha3",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3685,7 +3679,7 @@ dependencies = [
  "log",
  "pin-project 1.0.2",
  "smallvec 1.5.0",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5201,14 +5195,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
 dependencies = [
  "arrayref",
- "bs58 0.4.0",
+ "bs58",
  "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding 2.1.0",
  "serde",
  "static_assertions",
- "unsigned-varint 0.5.1",
+ "unsigned-varint",
  "url 2.2.0",
 ]
 
@@ -7091,7 +7085,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bitflags",
- "bs58 0.3.1",
+ "bs58",
  "bytes 0.5.6",
  "derive_more",
  "either",
@@ -7110,7 +7104,7 @@ dependencies = [
  "lru 0.6.1",
  "nohash-hasher",
  "parity-scale-codec",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "pin-project 0.4.27",
  "prost",
  "prost-build",
@@ -7123,7 +7117,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog_derive",
- "smallvec 0.6.13",
+ "smallvec 1.5.0",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -7138,7 +7132,7 @@ dependencies = [
  "substrate-test-runtime-client",
  "tempfile",
  "thiserror",
- "unsigned-varint 0.4.0",
+ "unsigned-varint",
  "void",
  "wasm-timer",
  "zeroize",
@@ -9813,18 +9807,6 @@ checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.4",
  "subtle 2.3.0",
-]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
-dependencies = [
- "bytes 0.5.6",
- "futures-io",
- "futures-util",
- "futures_codec",
 ]
 
 [[package]]

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -20,7 +20,7 @@ prost-build = "0.6.1"
 async-trait = "0.1"
 async-std = "1.6.5"
 bitflags = "1.2.0"
-bs58 = "0.3.1"
+bs58 = "0.4.0"
 bytes = "0.5.0"
 codec = { package = "parity-scale-codec", version = "1.3.4", features = ["derive"] }
 derive_more = "0.99.2"
@@ -38,7 +38,7 @@ linked_hash_set = "0.1.3"
 log = "0.4.8"
 lru = "0.6.1"
 nohash-hasher = "0.2.0"
-parking_lot = "0.10.0"
+parking_lot = "0.11.1"
 pin-project = "0.4.6"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0", path = "../../utils/prometheus" }
 prost = "0.6.1"
@@ -50,7 +50,7 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"
 slog = { version = "2.5.2", features = ["nested-values"] }
 slog_derive = "0.2.0"
-smallvec = "0.6.10"
+smallvec = "1.5.0"
 sp-arithmetic = { version = "2.0.0", path = "../../primitives/arithmetic" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.8.0", path = "../../primitives/consensus/common" }
@@ -58,7 +58,7 @@ sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils" }
 thiserror = "1"
-unsigned-varint = { version = "0.4.0", features = ["futures", "futures-codec"] }
+unsigned-varint = { version = "0.5.0", features = ["futures", "futures-codec"] }
 void = "1.0.2"
 wasm-timer = "0.2"
 zeroize = "1.0.0"

--- a/client/network/src/protocol/generic_proto/handler.rs
+++ b/client/network/src/protocol/generic_proto/handler.rs
@@ -715,7 +715,7 @@ impl ProtocolsHandler for NotifsHandler {
 			},
 
 			NotifsHandlerIn::Close => {
-				for mut substream in self.legacy_substreams.drain() {
+				for mut substream in self.legacy_substreams.drain(..) {
 					substream.shutdown();
 					self.legacy_shutdown.push(substream);
 				}


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

update some dependencies to prune some duplicated dependencies in dep graph.

It seems that dependabot can't detect duplicate dependencies?