### PR TITLE
Fix notifications sometimes not being sent

### DIFF
--- a/client/network/src/protocol/generic_proto/handler.rs
+++ b/client/network/src/protocol/generic_proto/handler.rs
@@ -971,6 +971,7 @@ impl ProtocolsHandler for NotifsHandler {
 						if let Some(pos) = self.out_protocols.iter().position(|(n, _)| *n == protocol_name) {
 							if let Some(substream) = out_substreams[pos].as_mut() {
 								let _ = substream.start_send_unpin(message);
+								cx.waker().wake_by_ref();
 								continue 'poll_notifs_sink;
 							}
 

--- a/client/network/src/protocol/generic_proto/handler.rs
+++ b/client/network/src/protocol/generic_proto/handler.rs
@@ -971,6 +971,15 @@ impl ProtocolsHandler for NotifsHandler {
 						if let Some(pos) = self.out_protocols.iter().position(|(n, _)| *n == protocol_name) {
 							if let Some(substream) = out_substreams[pos].as_mut() {
 								let _ = substream.start_send_unpin(message);
+								// Calling `start_send_unpin` only queues the message. Actually
+								// emitting the message is done with `poll_flush`. In order to
+								// not introduce too much complexity, this flushing is done earlier
+								// in the body of this `poll()` method. As such, we schedule a task
+								// wake-up now in order to guarantee that `poll()` will be called
+								// again and the flush happening.
+								// At the time of the writing of this comment, a rewrite of this
+								// code is being planned. If you find this comment in the wild and
+								// the rewrite didn't happen, please consider a refactor.
 								cx.waker().wake_by_ref();
 								continue 'poll_notifs_sink;
 							}


### PR DESCRIPTION
In the `poll` function of `handler.rs`, we first call `Sink::poll_flush` on all the outbound substreams, then only call `Sink::start_send`. This means that the actual flushing is only done the next time `poll` is called, which is in no way guaranteed to happen soon.

While this little fix might seem like a hack, and it would be preferable to change the order of operations in `poll`, doing so is a bit tricky to me because of having to handle state transitions when the substream errors. Since this code is undergoing another rewrite in #7374, I went for the easy solution.
