### PR TITLE
node-template: add aura to light block import pipeline

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -239,9 +239,14 @@ pub fn new_light(config: Configuration) -> Result<TaskManager, ServiceError> {
 		select_chain.clone(),
 	)?;
 
+	let aura_block_import = sc_consensus_aura::AuraBlockImport::<_, _, _, AuraPair>::new(
+		grandpa_block_import.clone(),
+		client.clone(),
+	);
+
 	let import_queue = sc_consensus_aura::import_queue::<_, _, _, AuraPair, _, _>(
 		sc_consensus_aura::slot_duration(&*client)?,
-		grandpa_block_import.clone(),
+		aura_block_import,
 		Some(Box::new(grandpa_block_import)),
 		client.clone(),
 		InherentDataProviders::new(),


### PR DESCRIPTION
When building the import pipeline for the light client we were not using the `AuraBlockImport` which meant that some aura-specific block validation logic was not being run.