### PR TITLE
network: don't force send block announcements

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1089,16 +1089,11 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 
 		let is_best = self.context_data.chain.info().best_hash == hash;
 		debug!(target: "sync", "Reannouncing block {:?} is_best: {}", hash, is_best);
-		self.send_announcement(&header, data, is_best, true)
-	}
-
-	fn send_announcement(&mut self, header: &B::Header, data: Vec<u8>, is_best: bool, force: bool) {
-		let hash = header.hash();
 
 		for (who, ref mut peer) in self.context_data.peers.iter_mut() {
-			trace!(target: "sync", "Announcing block {:?} to {}", hash, who);
 			let inserted = peer.known_blocks.insert(hash);
-			if inserted || force {
+			if inserted {
+				trace!(target: "sync", "Announcing block {:?} to {}", hash, who);
 				let message = message::BlockAnnounce {
 					header: header.clone(),
 					state: if is_best {


### PR DESCRIPTION
There are 2 situations where we send out block announcements:
- after importing a block
- after voting on a block in GRANDPA

Currently we are always force-sending the block announcement even if the peer already knows this block, which can lead to duplicating block announcements in the following situations:
- multiple GRANDPA votes on the same block (on prevote and precommit but also potentially across different rounds)
- we import a block from a peer and then re-announce it again to it

I think we can relax the force-sending of announcements. The only worry would be missing some fork that is needed to process some GRANDPA votes, but we already have the reverse mechanism where peers will actively try to sync these forks.