### PR TITLE
Use build script to make no-std work on stable Rust

### DIFF
--- a/primitives/io/build.rs
+++ b/primitives/io/build.rs
@@ -1,0 +1,24 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2017-2020 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
+fn main() { }
+
+#[cfg(not(feature = "std"))]
+fn main() {
+	println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+}


### PR DESCRIPTION
`RUSTC_BOOTSTRAP=1` would allow us building wasm binary using stable Rust. The drawback is however that it introduces it on the whole codebase, which may lead to unwanted introduction of usage of nightly features.

This PR, instead, sets the flag only in no-std build script, thus enabling it only for a crate when needed.