### PR TITLE
Add Key Subcommand to node-template

### DIFF
--- a/bin/node-template/node/src/cli.rs
+++ b/bin/node-template/node/src/cli.rs
@@ -12,6 +12,8 @@ pub struct Cli {
 
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
+	/// Key management cli utilities
+	Key(sc_cli::KeySubcommand),
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),
 

--- a/bin/node-template/node/src/command.rs
+++ b/bin/node-template/node/src/command.rs
@@ -66,6 +66,7 @@ pub fn run() -> sc_cli::Result<()> {
 	let cli = Cli::from_args();
 
 	match &cli.subcommand {
+		Some(Subcommand::Key(cmd)) => cmd.run(),
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))


### PR DESCRIPTION
as it says on the tin. Our node-template didn't have this integrated yet, which I found out when trying to use it. No reason to not just quickly add it (just copy-pasted).