### PR TITLE
fork-tree: fix tree rebalancing

### DIFF
--- a/client/finality-grandpa/src/authorities.rs
+++ b/client/finality-grandpa/src/authorities.rs
@@ -758,9 +758,10 @@ mod tests {
 		authorities.add_pending_change(change_d.clone(), &static_is_descendent_of(false)).unwrap();
 		authorities.add_pending_change(change_e.clone(), &static_is_descendent_of(false)).unwrap();
 
+		// ordered by subtree depth
 		assert_eq!(
 			authorities.pending_changes().collect::<Vec<_>>(),
-			vec![&change_b, &change_a, &change_c, &change_e, &change_d],
+			vec![&change_a, &change_c, &change_b, &change_e, &change_d],
 		);
 	}
 
@@ -798,7 +799,7 @@ mod tests {
 
 		assert_eq!(
 			authorities.pending_changes().collect::<Vec<_>>(),
-			vec![&change_b, &change_a],
+			vec![&change_a, &change_b],
 		);
 
 		// finalizing "hash_c" won't enact the change signaled at "hash_a" but it will prune out "hash_b"

--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -229,7 +229,10 @@ impl<H, N, V> ForkTree<H, N, V> where
 					number = n;
 					data = d;
 				},
-				None => return Ok(false),
+				None => {
+					self.rebalance();
+					return Ok(false);
+				},
 			}
 		}
 

--- a/utils/fork-tree/src/lib.rs
+++ b/utils/fork-tree/src/lib.rs
@@ -254,7 +254,9 @@ impl<H, N, V> ForkTree<H, N, V> where
 	}
 
 	fn node_iter(&self) -> impl Iterator<Item=&Node<H, N, V>> {
-		ForkTreeIterator { stack: self.roots.iter().collect() }
+		// we need to reverse the order of roots to maintain the expected
+		// ordering since the iterator uses a stack to track state.
+		ForkTreeIterator { stack: self.roots.iter().rev().collect() }
 	}
 
 	/// Iterates the nodes in the tree in pre-order.


### PR DESCRIPTION
We want to keep the fork tree nodes sorted by subtree depth, this is an heuristic since the deepest subtree will most likely translate to the longest chain, in which case any query on the tree will most likely want to target the longest branch. To this end, after inserting a new node in the tree we make sure it is rebalanced. Currently we were only triggering the rebalancing when the new node being inserted was a new root, and not when it was a leaf node part of an already existing subtree.

I also fixed the initial state of the tree iterator which would mess up the ordering.