### PR TITLE
`sudo_as` Returns a Result

### DIFF
--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -214,15 +214,9 @@ decl_module! {
 
 			let who = T::Lookup::lookup(who)?;
 
-			let res = match call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into()) {
-				Ok(_) => true,
-				Err(e) => {
-					sp_runtime::print(e);
-					false
-				}
-			};
+			let res = call.dispatch_bypass_filter(frame_system::RawOrigin::Signed(who).into());
 
-			Self::deposit_event(RawEvent::SudoAsDone(res));
+			Self::deposit_event(RawEvent::SudoAsDone(res.map(|_| ()).map_err(|e| e.error)));
 			// Sudo user does not pay a fee.
 			Ok(Pays::No.into())
 		}
@@ -236,7 +230,7 @@ decl_event!(
 		/// The \[sudoer\] just switched identity; the old key is supplied.
 		KeyChanged(AccountId),
 		/// A sudo just took place. \[result\]
-		SudoAsDone(bool),
+		SudoAsDone(DispatchResult),
 	}
 );
 

--- a/frame/sudo/src/tests.rs
+++ b/frame/sudo/src/tests.rs
@@ -163,7 +163,7 @@ fn sudo_as_emits_events_correctly() {
 		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
 		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
 		assert_ok!(Sudo::sudo_as(Origin::signed(1), 2, call));
-		let expected_event = TestEvent::sudo(RawEvent::SudoAsDone(true));
+		let expected_event = TestEvent::sudo(RawEvent::SudoAsDone(Ok(())));
 		assert!(System::events().iter().any(|a| a.event == expected_event));
 	});
 }


### PR DESCRIPTION
This is a super tiny PR which has the `SudoAsDone` event from the `sudo_as` extrinsic return a `Result` with the dispatch error rather than a bool.

The Result allows people to actually see what went wrong! (and is consistent with the more used `sudo` call.