### PR TITLE
Bump regex dep

### DIFF
--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -27,7 +27,7 @@ base58 = { version = "0.1.0", optional = true }
 rand = { version = "0.7.3", optional = true, features = ["small_rng"] }
 substrate-bip39 = { version = "0.4.2", optional = true }
 tiny-bip39 = { version = "0.8", optional = true }
-regex = { version = "1.3.1", optional = true }
+regex = { version = "1.4.2", optional = true }
 num-traits = { version = "0.2.8", default-features = false }
 zeroize = { version = "1.0.0", default-features = false }
 secrecy = { version = "0.7.0", default-features = false }


### PR DESCRIPTION
On behalf of dependabot, because we use 1.4.x somewhere in cli and it clashes with this.
