### PR TITLE
Renames of `Trait` to `Config` in README.md, weight templates and few minor ones

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -45,7 +45,7 @@ pub trait WeightInfo {
 
 /// Weights for {{pallet}} using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
-impl<T: frame_system::Trait> WeightInfo for SubstrateWeight<T> {
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	{{~#each benchmarks as |benchmark|}}
 	fn {{benchmark.name~}}
 	(

--- a/bin/node-template/README.md
+++ b/bin/node-template/README.md
@@ -157,7 +157,7 @@ Review the [FRAME runtime implementation](./runtime/src/lib.rs) included in this
 the following:
 
 -   This file configures several pallets to include in the runtime. Each pallet configuration is
-    defined by a code block that begins with `impl $PALLET_NAME::Trait for Runtime`.
+    defined by a code block that begins with `impl $PALLET_NAME::Config for Runtime`.
 -   The pallets are composed into a single runtime by way of the
     [`construct_runtime!`](https://crates.parity.io/frame_support/macro.construct_runtime.html)
     macro, which is part of the core
@@ -181,8 +181,8 @@ A FRAME pallet is compromised of a number of blockchain primitives:
 -   Events: Substrate uses [events](https://substrate.dev/docs/en/knowledgebase/runtime/events) to
     notify users of important changes in the runtime.
 -   Errors: When a dispatchable fails, it returns an error.
--   Trait: The `Trait` configuration interface is used to define the types and parameters upon which
-    a FRAME pallet depends.
+-   Config: The `Config` configuration interface is used to define the types and parameters upon
+    which a FRAME pallet depends.
 
 ## Generate a Custom Node Template
 

--- a/frame/assets/README.md
+++ b/frame/assets/README.md
@@ -11,7 +11,7 @@ with a fixed supply, including:
 * Asset Transfer
 * Asset Destruction
 
-To use it in your runtime, you need to implement the assets [`Trait`](https://docs.rs/pallet-assets/latest/pallet_assets/trait.Trait.html).
+To use it in your runtime, you need to implement the assets [`Config`](https://docs.rs/pallet-assets/latest/pallet_assets/trait.Config.html).
 
 The supported dispatchable functions are documented in the [`Call`](https://docs.rs/pallet-assets/latest/pallet_assets/enum.Call.html) enum.
 
@@ -72,10 +72,10 @@ use pallet_assets as assets;
 use frame_support::{decl_module, dispatch, ensure};
 use frame_system::ensure_signed;
 
-pub trait Trait: assets::Trait { }
+pub trait Config: assets::Config { }
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		pub fn issue_token_airdrop(origin) -> dispatch::DispatchResult {
 			let sender = ensure_signed(origin).map_err(|e| e.as_str())?;
 
@@ -106,7 +106,7 @@ Below are assumptions that must be held when using this module.  If any of
 them are violated, the behavior of this module is undefined.
 
 * The total count of assets should be less than
-  `Trait::AssetId::max_value()`.
+  `Config::AssetId::max_value()`.
 
 ## Related Modules
 

--- a/frame/atomic-swap/README.md
+++ b/frame/atomic-swap/README.md
@@ -2,7 +2,7 @@
 
 A module for atomically sending funds.
 
-- [`atomic_swap::Trait`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/trait.Trait.html)
+- [`atomic_swap::Config`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-atomic-swap/latest/pallet_atomic_swap/struct.Module.html)
 

--- a/frame/aura/README.md
+++ b/frame/aura/README.md
@@ -1,6 +1,6 @@
 # Aura Module
 
-- [`aura::Trait`](https://docs.rs/pallet-aura/latest/pallet_aura/trait.Trait.html)
+- [`aura::Config`](https://docs.rs/pallet-aura/latest/pallet_aura/trait.Config.html)
 - [`Module`](https://docs.rs/pallet-aura/latest/pallet_aura/struct.Module.html)
 
 ## Overview

--- a/frame/balances/README.md
+++ b/frame/balances/README.md
@@ -2,7 +2,7 @@
 
 The Balances module provides functionality for handling accounts and balances.
 
-- [`balances::Trait`](https://docs.rs/pallet-balances/latest/pallet_balances/trait.Trait.html)
+- [`balances::Config`](https://docs.rs/pallet-balances/latest/pallet_balances/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-balances/latest/pallet_balances/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-balances/latest/pallet_balances/struct.Module.html)
 
@@ -83,8 +83,8 @@ The Contract module uses the `Currency` trait to handle gas payment, and its typ
 ```rust
 use frame_support::traits::Currency;
 
-pub type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
-pub type NegativeImbalanceOf<T> = <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::NegativeImbalance;
+pub type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+pub type NegativeImbalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
 
 ```
 
@@ -93,11 +93,11 @@ The Staking module uses the `LockableCurrency` trait to lock a stash account's f
 ```rust
 use frame_support::traits::{WithdrawReasons, LockableCurrency};
 use sp_runtime::traits::Bounded;
-pub trait Trait: frame_system::Trait {
+pub trait Config: frame_system::Config {
 	type Currency: LockableCurrency<Self::AccountId, Moment=Self::BlockNumber>;
 }
 
-fn update_ledger<T: Trait>(
+fn update_ledger<T: Config>(
 	controller: &T::AccountId,
 	ledger: &StakingLedger<T>
 ) {
@@ -117,6 +117,6 @@ The Balances module depends on the [`GenesisConfig`](https://docs.rs/pallet-bala
 
 ## Assumptions
 
-* Total issued balanced of all accounts should be less than `Trait::Balance::max_value()`.
+* Total issued balanced of all accounts should be less than `Config::Balance::max_value()`.
 
 License: Apache-2.0

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -30,7 +30,7 @@ use frame_system::{RawOrigin, ensure_signed, ensure_none};
 
 decl_storage! {
 	trait Store for Module<T: Config> as Test where
-		<T as OtherTrait>::OtherEvent: Into<<T as Config>::Event>
+		<T as OtherConfig>::OtherEvent: Into<<T as Config>::Event>
 	{
 		Value get(fn value): Option<u32>;
 	}
@@ -38,7 +38,7 @@ decl_storage! {
 
 decl_module! {
 	pub struct Module<T: Config> for enum Call where
-		origin: T::Origin, <T as OtherTrait>::OtherEvent: Into<<T as Config>::Event>
+		origin: T::Origin, <T as OtherConfig>::OtherEvent: Into<<T as Config>::Event>
 	{
 		#[weight = 0]
 		fn set_value(origin, n: u32) -> DispatchResult {
@@ -59,11 +59,11 @@ impl_outer_origin! {
 	pub enum Origin for Test where system = frame_system {}
 }
 
-pub trait OtherTrait {
+pub trait OtherConfig {
 	type OtherEvent;
 }
 
-pub trait Config: frame_system::Config + OtherTrait
+pub trait Config: frame_system::Config + OtherConfig
 	where Self::OtherEvent: Into<<Self as Config>::Event>
 {
 	type Event;
@@ -104,7 +104,7 @@ impl Config for Test {
 	type Event = ();
 }
 
-impl OtherTrait for Test {
+impl OtherConfig for Test {
 	type OtherEvent = ();
 }
 
@@ -113,7 +113,7 @@ fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 benchmarks!{
-	where_clause { where <T as OtherTrait>::OtherEvent: Into<<T as Config>::Event> }
+	where_clause { where <T as OtherConfig>::OtherEvent: Into<<T as Config>::Event> }
 
 	_ {
 		// Define a common range for `b`.

--- a/frame/contracts/README.md
+++ b/frame/contracts/README.md
@@ -2,7 +2,7 @@
 
 The Contract module provides functionality for the runtime to deploy and execute WebAssembly smart-contracts.
 
-- [`contract::Trait`](https://docs.rs/pallet-contracts/latest/pallet_contracts/trait.Trait.html)
+- [`contract::Config`](https://docs.rs/pallet-contracts/latest/pallet_contracts/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-contracts/latest/pallet_contracts/enum.Call.html)
 
 ## Overview

--- a/frame/democracy/README.md
+++ b/frame/democracy/README.md
@@ -1,6 +1,6 @@
 # Democracy Pallet
 
-- [`democracy::Trait`](https://docs.rs/pallet-democracy/latest/pallet_democracy/trait.Trait.html)
+- [`democracy::Config`](https://docs.rs/pallet-democracy/latest/pallet_democracy/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-democracy/latest/pallet_democracy/enum.Call.html)
 
 ## Overview

--- a/frame/elections-phragmen/README.md
+++ b/frame/elections-phragmen/README.md
@@ -60,7 +60,7 @@ being re-elected at the end of each round.
 
 ### Module Information
 
-- [`election_sp_phragmen::Trait`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/trait.Trait.html)
+- [`election_sp_phragmen::Config`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-elections-phragmen/latest/pallet_elections_phragmen/struct.Module.html)
 

--- a/frame/example-offchain-worker/README.md
+++ b/frame/example-offchain-worker/README.md
@@ -7,7 +7,7 @@ concepts, APIs and structures common to most offchain workers.
 Run `cargo doc --package pallet-example-offchain-worker --open` to view this module's
 documentation.
 
-- [`pallet_example_offchain_worker::Trait`](./trait.Trait.html)
+- [`pallet_example_offchain_worker::Config`](./trait.Config.html)
 - [`Call`](./enum.Call.html)
 - [`Module`](./struct.Module.html)
 

--- a/frame/example/README.md
+++ b/frame/example/README.md
@@ -46,7 +46,7 @@ Copy and paste this template from frame/example/src/lib.rs into file
 // Include the following links that shows what trait needs to be implemented to use the pallet
 // and the supported dispatchables that are documented in the Call enum.
 
-- \[`<INSERT_CUSTOM_PALLET_NAME>::Trait`](https://docs.rs/pallet-example/latest/pallet_example/trait.Trait.html)
+- \[`<INSERT_CUSTOM_PALLET_NAME>::Config`](https://docs.rs/pallet-example/latest/pallet_example/trait.Config.html)
 - \[`Call`](https://docs.rs/pallet-example/latest/pallet_example/enum.Call.html)
 - \[`Module`](https://docs.rs/pallet-example/latest/pallet_example/struct.Module.html)
 
@@ -195,7 +195,7 @@ Copy and paste this template from frame/example/src/lib.rs into file
 \```rust
 use <INSERT_CUSTOM_PALLET_NAME>;
 
-pub trait Trait: <INSERT_CUSTOM_PALLET_NAME>::Trait { }
+pub trait Config: <INSERT_CUSTOM_PALLET_NAME>::Config { }
 \```
 
 \### Simple Code Snippet

--- a/frame/identity/README.md
+++ b/frame/identity/README.md
@@ -1,6 +1,6 @@
 # Identity Module
 
-- [`identity::Trait`](https://docs.rs/pallet-identity/latest/pallet_identity/trait.Trait.html)
+- [`identity::Config`](https://docs.rs/pallet-identity/latest/pallet_identity/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-identity/latest/pallet_identity/enum.Call.html)
 
 ## Overview
@@ -51,6 +51,6 @@ no state-bloat attack is viable.
 * `kill_identity` - Forcibly remove the associated identity; the deposit is lost.
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/frame/im-online/README.md
+++ b/frame/im-online/README.md
@@ -13,7 +13,7 @@ and includes the recent best block number of the local validators chain as well
 as the `NetworkState`.
 It is submitted as an Unsigned Transaction via off-chain workers.
 
-- [`im_online::Trait`](https://docs.rs/pallet-im-online/latest/pallet_im_online/trait.Trait.html)
+- [`im_online::Config`](https://docs.rs/pallet-im-online/latest/pallet_im_online/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-im-online/latest/pallet_im_online/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-im-online/latest/pallet_im_online/struct.Module.html)
 
@@ -30,10 +30,10 @@ use frame_support::{decl_module, dispatch};
 use frame_system::ensure_signed;
 use pallet_im_online::{self as im_online};
 
-pub trait Trait: im_online::Trait {}
+pub trait Config: im_online::Config {}
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
 		pub fn is_online(origin, authority_index: u32) -> dispatch::DispatchResult {
 			let _sender = ensure_signed(origin)?;

--- a/frame/multisig/README.md
+++ b/frame/multisig/README.md
@@ -1,7 +1,7 @@
 # Multisig Module
 A module for doing multisig dispatch.
 
-- [`multisig::Trait`](https://docs.rs/pallet-multisig/latest/pallet_multisig/trait.Trait.html)
+- [`multisig::Config`](https://docs.rs/pallet-multisig/latest/pallet_multisig/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-multisig/latest/pallet_multisig/enum.Call.html)
 
 ## Overview
@@ -24,6 +24,6 @@ not available or desired.
 * `cancel_as_multi` - Cancel a call from a composite origin.
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/frame/nicks/README.md
+++ b/frame/nicks/README.md
@@ -1,6 +1,6 @@
 # Nicks Module
 
-- [`nicks::Trait`](https://docs.rs/pallet-nicks/latest/pallet_nicks/trait.Trait.html)
+- [`nicks::Config`](https://docs.rs/pallet-nicks/latest/pallet_nicks/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-nicks/latest/pallet_nicks/enum.Call.html)
 
 ## Overview
@@ -20,6 +20,6 @@ have not been designed to be economically secure. Do not use this pallet as-is i
 * `kill_name` - Forcibly remove the associated name; the deposit is lost.
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -24,22 +24,22 @@ mod mock;
 use sp_std::prelude::*;
 use sp_std::vec;
 
-use frame_system::{RawOrigin, Module as System, Config as SystemTrait};
+use frame_system::{RawOrigin, Module as System, Config as SystemConfig};
 use frame_benchmarking::{benchmarks, account};
 use frame_support::traits::{Currency, OnInitialize};
 
 use sp_runtime::{Perbill, traits::{Convert, StaticLookup, Saturating, UniqueSaturatedInto}};
 use sp_staking::offence::{ReportOffence, Offence, OffenceDetails};
 
-use pallet_balances::{Config as BalancesTrait};
+use pallet_balances::{Config as BalancesConfig};
 use pallet_babe::BabeEquivocationOffence;
 use pallet_grandpa::{GrandpaEquivocationOffence, GrandpaTimeSlot};
-use pallet_im_online::{Config as ImOnlineTrait, Module as ImOnline, UnresponsivenessOffence};
-use pallet_offences::{Config as OffencesTrait, Module as Offences};
-use pallet_session::historical::{Config as HistoricalTrait, IdentificationTuple};
-use pallet_session::{Config as SessionTrait, SessionManager};
+use pallet_im_online::{Config as ImOnlineConfig, Module as ImOnline, UnresponsivenessOffence};
+use pallet_offences::{Config as OffencesConfig, Module as Offences};
+use pallet_session::historical::{Config as HistoricalConfig, IdentificationTuple};
+use pallet_session::{Config as SessionConfig, SessionManager};
 use pallet_staking::{
-	Module as Staking, Config as StakingTrait, RewardDestination, ValidatorPrefs,
+	Module as Staking, Config as StakingConfig, RewardDestination, ValidatorPrefs,
 	Exposure, IndividualExposure, ElectionStatus, MAX_NOMINATIONS, Event as StakingEvent
 };
 
@@ -53,32 +53,32 @@ const MAX_DEFERRED_OFFENCES: u32 = 100;
 pub struct Module<T: Config>(Offences<T>);
 
 pub trait Config:
-	SessionTrait
-	+ StakingTrait
-	+ OffencesTrait
-	+ ImOnlineTrait
-	+ HistoricalTrait
-	+ BalancesTrait
+	SessionConfig
+	+ StakingConfig
+	+ OffencesConfig
+	+ ImOnlineConfig
+	+ HistoricalConfig
+	+ BalancesConfig
 	+ IdTupleConvert<Self>
 {}
 
 /// A helper trait to make sure we can convert `IdentificationTuple` coming from historical
 /// and the one required by offences.
-pub trait IdTupleConvert<T: HistoricalTrait + OffencesTrait> {
+pub trait IdTupleConvert<T: HistoricalConfig + OffencesConfig> {
 	/// Convert identification tuple from `historical` trait to the one expected by `offences`.
-	fn convert(id: IdentificationTuple<T>) -> <T as OffencesTrait>::IdentificationTuple;
+	fn convert(id: IdentificationTuple<T>) -> <T as OffencesConfig>::IdentificationTuple;
 }
 
-impl<T: HistoricalTrait + OffencesTrait> IdTupleConvert<T> for T where
-	<T as OffencesTrait>::IdentificationTuple: From<IdentificationTuple<T>>
+impl<T: HistoricalConfig + OffencesConfig> IdTupleConvert<T> for T where
+	<T as OffencesConfig>::IdentificationTuple: From<IdentificationTuple<T>>
 {
-	fn convert(id: IdentificationTuple<T>) -> <T as OffencesTrait>::IdentificationTuple {
+	fn convert(id: IdentificationTuple<T>) -> <T as OffencesConfig>::IdentificationTuple {
 		id.into()
 	}
 }
 
-type LookupSourceOf<T> = <<T as SystemTrait>::Lookup as StaticLookup>::Source;
-type BalanceOf<T> = <<T as StakingTrait>::Currency as Currency<<T as SystemTrait>::AccountId>>::Balance;
+type LookupSourceOf<T> = <<T as SystemConfig>::Lookup as StaticLookup>::Source;
+type BalanceOf<T> = <<T as StakingConfig>::Currency as Currency<<T as SystemConfig>::AccountId>>::Balance;
 
 struct Offender<T: Config> {
 	pub controller: T::AccountId,
@@ -165,10 +165,10 @@ fn make_offenders<T: Config>(num_offenders: u32, num_nominators: u32) -> Result<
 
 	let id_tuples = offenders.iter()
 		.map(|offender|
-			<T as SessionTrait>::ValidatorIdOf::convert(offender.controller.clone())
+			<T as SessionConfig>::ValidatorIdOf::convert(offender.controller.clone())
 				.expect("failed to get validator id from account id"))
 		.map(|validator_id|
-			<T as HistoricalTrait>::FullIdentificationOf::convert(validator_id.clone())
+			<T as HistoricalConfig>::FullIdentificationOf::convert(validator_id.clone())
 			.map(|full_id| (validator_id, full_id))
 			.expect("failed to convert validator id to full identification"))
 		.collect::<Vec<IdentificationTuple<T>>>();
@@ -176,7 +176,7 @@ fn make_offenders<T: Config>(num_offenders: u32, num_nominators: u32) -> Result<
 }
 
 #[cfg(test)]
-fn check_events<T: Config, I: Iterator<Item = <T as SystemTrait>::Event>>(expected: I) {
+fn check_events<T: Config, I: Iterator<Item = <T as SystemConfig>::Event>>(expected: I) {
 	let events = System::<T>::events() .into_iter()
 		.map(|frame_system::EventRecord { event, .. }| event).collect::<Vec<_>>();
 	let expected = expected.collect::<Vec<_>>();
@@ -235,7 +235,7 @@ benchmarks! {
 		};
 		assert_eq!(System::<T>::event_count(), 0);
 	}: {
-		let _ = <T as ImOnlineTrait>::ReportUnresponsiveness::report_offence(
+		let _ = <T as ImOnlineConfig>::ReportUnresponsiveness::report_offence(
 			reporters.clone(),
 			offence
 		);
@@ -250,14 +250,14 @@ benchmarks! {
 			.flat_map(|offender| {
 				core::iter::once(offender.stash).chain(offender.nominator_stashes.into_iter())
 			})
-			.map(|stash| <T as StakingTrait>::Event::from(
+			.map(|stash| <T as StakingConfig>::Event::from(
 				StakingEvent::<T>::Slash(stash, BalanceOf::<T>::from(slash_amount))
 			))
 			.collect::<Vec<_>>();
 		let reward_events = reporters.into_iter()
 			.flat_map(|reporter| vec![
 				frame_system::Event::<T>::NewAccount(reporter.clone()).into(),
-				<T as BalancesTrait>::Event::from(
+				<T as BalancesConfig>::Event::from(
 					pallet_balances::Event::<T>::Endowed(reporter, (reward_amount / r).into())
 				).into()
 			]);
@@ -272,7 +272,7 @@ benchmarks! {
 				.chain(slash_events.into_iter().map(Into::into))
 				.chain(reward_events)
 				.chain(slash_rest.into_iter().map(Into::into))
-				.chain(std::iter::once(<T as OffencesTrait>::Event::from(
+				.chain(std::iter::once(<T as OffencesConfig>::Event::from(
 					pallet_offences::Event::Offence(
 						UnresponsivenessOffence::<T>::ID,
 						0_u32.to_le_bytes().to_vec(),

--- a/frame/proxy/README.md
+++ b/frame/proxy/README.md
@@ -6,7 +6,7 @@ The accounts to which permission is delegated may be requied to announce the act
 wish to execute some duration prior to execution happens. In this case, the target account may
 reject the announcement and in doing so, veto the execution.
 
-- [`proxy::Trait`](https://docs.rs/pallet-proxy/latest/pallet_proxy/trait.Trait.html)
+- [`proxy::Config`](https://docs.rs/pallet-proxy/latest/pallet_proxy/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-proxy/latest/pallet_proxy/enum.Call.html)
 
 ## Overview
@@ -16,6 +16,6 @@ reject the announcement and in doing so, veto the execution.
 ### Dispatchable Functions
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/frame/randomness-collective-flip/README.md
+++ b/frame/randomness-collective-flip/README.md
@@ -22,10 +22,10 @@ the system trait.
 ```rust
 use frame_support::{decl_module, dispatch, traits::Randomness};
 
-pub trait Trait: frame_system::Trait {}
+pub trait Config: frame_system::Config {}
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
 		pub fn random_module_example(origin) -> dispatch::DispatchResult {
 			let _random_value = <pallet_randomness_collective_flip::Module<T>>::random(&b"my context"[..]);

--- a/frame/recovery/README.md
+++ b/frame/recovery/README.md
@@ -1,6 +1,6 @@
 # Recovery Pallet
 
-- [`recovery::Trait`](https://docs.rs/pallet-recovery/latest/pallet_recovery/trait.Trait.html)
+- [`recovery::Config`](https://docs.rs/pallet-recovery/latest/pallet_recovery/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-recovery/latest/pallet_recovery/enum.Call.html)
 
 ## Overview

--- a/frame/scheduler/README.md
+++ b/frame/scheduler/README.md
@@ -1,7 +1,7 @@
 # Scheduler
 A module for scheduling dispatches.
 
-- [`scheduler::Trait`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/trait.Trait.html)
+- [`scheduler::Config`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-scheduler/latest/pallet_scheduler/struct.Module.html)
 
@@ -12,7 +12,7 @@ specified block number or at a specified period. These scheduled dispatches
 may be named or anonymous and may be canceled.
 
 **NOTE:** The scheduled calls will be dispatched with the default filter
-for the origin: namely `frame_system::Trait::BaseCallFilter` for all origin
+for the origin: namely `frame_system::Config::BaseCallFilter` for all origin
 except root which will get no filter. And not the filter contained in origin
 use to call `fn schedule`.
 

--- a/frame/scored-pool/README.md
+++ b/frame/scored-pool/README.md
@@ -20,7 +20,7 @@ time. If an entity is currently a member, this results in removal
 from the `Pool` and `Members`; the entity is immediately replaced
 by the next highest scoring candidate in the pool, if available.
 
-- [`scored_pool::Trait`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/trait.Trait.html)
+- [`scored_pool::Config`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-scored-pool/latest/pallet_scored_pool/struct.Module.html)
 
@@ -41,10 +41,10 @@ use frame_support::{decl_module, dispatch};
 use frame_system::ensure_signed;
 use pallet_scored_pool::{self as scored_pool};
 
-pub trait Trait: scored_pool::Trait {}
+pub trait Config: scored_pool::Config {}
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
 		pub fn candidate(origin) -> dispatch::DispatchResult {
 			let who = ensure_signed(origin)?;

--- a/frame/session/README.md
+++ b/frame/session/README.md
@@ -3,7 +3,7 @@
 The Session module allows validators to manage their session keys, provides a function for changing
 the session length, and handles session rotation.
 
-- [`session::Trait`](https://docs.rs/pallet-session/latest/pallet_session/trait.Trait.html)
+- [`session::Config`](https://docs.rs/pallet-session/latest/pallet_session/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-session/latest/pallet_session/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-session/latest/pallet_session/struct.Module.html)
 
@@ -71,7 +71,7 @@ The [Staking pallet](https://docs.rs/pallet-staking/latest/pallet_staking/) uses
 ```rust
 use pallet_session as session;
 
-fn validators<T: pallet_session::Trait>() -> Vec<<T as pallet_session::Trait>::ValidatorId> {
+fn validators<T: pallet_session::Config>() -> Vec<<T as pallet_session::Config>::ValidatorId> {
 	<pallet_session::Module<T>>::validators()
 }
 ```

--- a/frame/session/src/historical/offchain.rs
+++ b/frame/session/src/historical/offchain.rs
@@ -189,12 +189,12 @@ mod tests {
 	#[test]
 	fn encode_decode_roundtrip() {
 		use codec::{Decode, Encode};
-		use super::super::super::Config as SessionTrait;
-		use super::super::Config as HistoricalTrait;
+		use super::super::super::Config as SessionConfig;
+		use super::super::Config as HistoricalConfig;
 
 		let sample = (
-				22u32 as <Test as SessionTrait>::ValidatorId,
-				7_777_777 as <Test as HistoricalTrait>::FullIdentification);
+				22u32 as <Test as SessionConfig>::ValidatorId,
+				7_777_777 as <Test as HistoricalConfig>::FullIdentification);
 
 		let encoded = sample.encode();
 		let decoded = Decode::decode(&mut encoded.as_slice()).expect("Must decode");

--- a/frame/session/src/historical/onchain.rs
+++ b/frame/session/src/historical/onchain.rs
@@ -20,9 +20,9 @@
 use codec::Encode;
 use sp_runtime::traits::Convert;
 
-use super::super::Config as SessionTrait;
+use super::super::Config as SessionConfig;
 use super::super::{Module as SessionModule, SessionIndex};
-use super::Config as HistoricalTrait;
+use super::Config as HistoricalConfig;
 
 use super::shared;
 use sp_std::prelude::*;
@@ -35,14 +35,14 @@ use sp_std::prelude::*;
 /// `on_initialize(..)` or `on_finalization(..)`.
 /// **Must** be called during the session, which validator-set is to be stored for further
 /// off-chain processing. Otherwise the `FullIdentification` might not be available.
-pub fn store_session_validator_set_to_offchain<T: HistoricalTrait + SessionTrait>(
+pub fn store_session_validator_set_to_offchain<T: HistoricalConfig + SessionConfig>(
 	session_index: SessionIndex,
 ) {
 	let encoded_validator_list = <SessionModule<T>>::validators()
 		.into_iter()
-		.filter_map(|validator_id: <T as SessionTrait>::ValidatorId| {
+		.filter_map(|validator_id: <T as SessionConfig>::ValidatorId| {
 			let full_identification =
-				<<T as HistoricalTrait>::FullIdentificationOf>::convert(validator_id.clone());
+				<<T as HistoricalConfig>::FullIdentificationOf>::convert(validator_id.clone());
 			full_identification.map(|full_identification| (validator_id, full_identification))
 		})
 		.collect::<Vec<_>>();
@@ -57,6 +57,6 @@ pub fn store_session_validator_set_to_offchain<T: HistoricalTrait + SessionTrait
 ///
 /// See [`fn store_session_validator_set_...(..)`](Self::store_session_validator_set_to_offchain)
 /// for further information and restrictions.
-pub fn store_current_session_validator_set_to_offchain<T: HistoricalTrait + SessionTrait>() {
+pub fn store_current_session_validator_set_to_offchain<T: HistoricalConfig + SessionConfig>() {
 	store_session_validator_set_to_offchain::<T>(<SessionModule<T>>::current_index());
 }

--- a/frame/society/README.md
+++ b/frame/society/README.md
@@ -1,6 +1,6 @@
 # Society Module
 
-- [`society::Trait`](https://docs.rs/pallet-society/latest/pallet_society/trait.Trait.html)
+- [`society::Config`](https://docs.rs/pallet-society/latest/pallet_society/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-society/latest/pallet_society/enum.Call.html)
 
 ## Overview

--- a/frame/staking/README.md
+++ b/frame/staking/README.md
@@ -2,7 +2,7 @@
 
 The Staking module is used to manage funds at stake by network maintainers.
 
-- [`staking::Trait`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html)
+- [`staking::Config`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-staking/latest/pallet_staking/struct.Module.html)
 
@@ -90,7 +90,7 @@ valid behavior_ while _punishing any misbehavior or lack of availability_.
 
 Rewards must be claimed for each era before it gets too old by `$HISTORY_DEPTH` using the
 `payout_stakers` call. Any account can call `payout_stakers`, which pays the reward to the
-validator as well as its nominators. Only the [`Trait::MaxNominatorRewardedPerValidator`]
+validator as well as its nominators. Only the [`Config::MaxNominatorRewardedPerValidator`]
 biggest stakers can claim their reward. This is to limit the i/o cost to mutate storage for each
 nominator's account.
 
@@ -137,10 +137,10 @@ use frame_support::{decl_module, dispatch};
 use frame_system::ensure_signed;
 use pallet_staking::{self as staking};
 
-pub trait Trait: staking::Trait {}
+pub trait Config: staking::Config {}
 
 decl_module! {
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
         /// Reward a validator.
         #[weight = 0]
         pub fn reward_myself(origin) -> dispatch::DispatchResult {
@@ -157,7 +157,7 @@ decl_module! {
 ### Era payout
 
 The era payout is computed using yearly inflation curve defined at
-[`T::RewardCurve`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html#associatedtype.RewardCurve) as such:
+[`T::RewardCurve`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Config.html#associatedtype.RewardCurve) as such:
 
 ```nocompile
 staker_payout = yearly_inflation(npos_token_staked / total_tokens) * total_tokens / era_per_year
@@ -168,7 +168,7 @@ This payout is used to reward stakers as defined in next section
 remaining_payout = max_yearly_inflation * total_tokens / era_per_year - staker_payout
 ```
 The remaining reward is send to the configurable end-point
-[`T::RewardRemainder`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html#associatedtype.RewardRemainder).
+[`T::RewardRemainder`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Config.html#associatedtype.RewardRemainder).
 
 ### Reward Calculation
 
@@ -214,7 +214,7 @@ Any funds already placed into stash can be the target of the following operation
 
 The controller account can free a portion (or all) of the funds using the
 [`unbond`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.unbond) call. Note that the funds are not immediately
-accessible. Instead, a duration denoted by [`BondingDuration`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Trait.html#associatedtype.BondingDuration)
+accessible. Instead, a duration denoted by [`BondingDuration`](https://docs.rs/pallet-staking/latest/pallet_staking/trait.Config.html#associatedtype.BondingDuration)
 (in number of eras) must pass until the funds can actually be removed. Once the
 `BondingDuration` is over, the [`withdraw_unbonded`](https://docs.rs/pallet-staking/latest/pallet_staking/enum.Call.html#variant.withdraw_unbonded)
 call can be used to actually withdraw the funds.

--- a/frame/sudo/README.md
+++ b/frame/sudo/README.md
@@ -1,6 +1,6 @@
 # Sudo Module
 
-- [`sudo::Trait`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Trait.html)
+- [`sudo::Config`](https://docs.rs/pallet-sudo/latest/pallet_sudo/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-sudo/latest/pallet_sudo/enum.Call.html)
 
 ## Overview
@@ -38,10 +38,10 @@ This is an example of a module that exposes a privileged function:
 use frame_support::{decl_module, dispatch};
 use frame_system::ensure_root;
 
-pub trait Trait: frame_system::Trait {}
+pub trait Config: frame_system::Config {}
 
 decl_module! {
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+    pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
         pub fn privileged_function(origin) -> dispatch::DispatchResult {
             ensure_root(origin)?;
@@ -64,7 +64,7 @@ You need to set an initial superuser account as the sudo `key`.
 * [Democracy](https://docs.rs/pallet-democracy/latest/pallet_democracy/)
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 [`Origin`]: https://docs.substrate.dev/docs/substrate-types
 
 License: Apache-2.0

--- a/frame/system/README.md
+++ b/frame/system/README.md
@@ -3,7 +3,7 @@
 The System module provides low-level access to core types and cross-cutting utilities.
 It acts as the base layer for other pallets to interact with the Substrate framework components.
 
-- [`system::Trait`](https://docs.rs/frame-system/latest/frame_system/trait.Trait.html)
+- [`system::Config`](https://docs.rs/frame-system/latest/frame_system/trait.Config.html)
 
 ## Overview
 
@@ -57,10 +57,10 @@ Import the System module and derive your module's configuration trait from the s
 use frame_support::{decl_module, dispatch};
 use frame_system::{self as system, ensure_signed};
 
-pub trait Trait: system::Trait {}
+pub trait Config: system::Config {}
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
 		pub fn system_module_example(origin) -> dispatch::DispatchResult {
 			let _sender = ensure_signed(origin)?;

--- a/frame/timestamp/README.md
+++ b/frame/timestamp/README.md
@@ -2,7 +2,7 @@
 
 The Timestamp module provides functionality to get and set the on-chain time.
 
-- [`timestamp::Trait`](https://docs.rs/pallet-timestamp/latest/pallet_timestamp/trait.Trait.html)
+- [`timestamp::Config`](https://docs.rs/pallet-timestamp/latest/pallet_timestamp/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-timestamp/latest/pallet_timestamp/enum.Call.html)
 - [`Module`](https://docs.rs/pallet-timestamp/latest/pallet_timestamp/struct.Module.html)
 
@@ -29,7 +29,7 @@ because of cumulative calculation errors and hence should be avoided.
 * `get` - Gets the current time for the current block. If this function is called prior to
 setting the timestamp, it will return the timestamp of the previous block.
 
-### Trait Getters
+### Config Getters
 
 * `MinimumPeriod` - Gets the minimum (and advised) period between blocks for the chain.
 
@@ -48,10 +48,10 @@ trait from the timestamp trait.
 use frame_support::{decl_module, dispatch};
 use frame_system::ensure_signed;
 
-pub trait Trait: timestamp::Trait {}
+pub trait Config: timestamp::Config {}
 
 decl_module! {
-	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		#[weight = 0]
 		pub fn get_time(origin) -> dispatch::DispatchResult {
 			let _sender = ensure_signed(origin)?;

--- a/frame/transaction-payment/README.md
+++ b/frame/transaction-payment/README.md
@@ -8,9 +8,9 @@ transaction to be included. This includes:
     chance to be included by the transaction queue.
 
 Additionally, this module allows one to configure:
-  - The mapping between one unit of weight to one unit of fee via [`Trait::WeightToFee`].
+  - The mapping between one unit of weight to one unit of fee via [`Config::WeightToFee`].
   - A means of updating the fee for the next block, via defining a multiplier, based on the
     final state of the chain at the end of the previous block. This can be configured via
-    [`Trait::FeeMultiplierUpdate`]
+    [`Config::FeeMultiplierUpdate`]
 
 License: Apache-2.0

--- a/frame/treasury/README.md
+++ b/frame/treasury/README.md
@@ -3,7 +3,7 @@
 The Treasury module provides a "pot" of funds that can be managed by stakeholders in the
 system and a structure for making spending proposals from this pot.
 
-- [`treasury::Trait`](https://docs.rs/pallet-treasury/latest/pallet_treasury/trait.Trait.html)
+- [`treasury::Config`](https://docs.rs/pallet-treasury/latest/pallet_treasury/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-treasury/latest/pallet_treasury/enum.Call.html)
 
 ## Overview
@@ -21,7 +21,7 @@ A separate subsystem exists to allow for an agile "tipping" process, whereby a r
 given without first having a pre-determined stakeholder group come to consensus on how much
 should be paid.
 
-A group of `Tippers` is determined through the config `Trait`. After half of these have declared
+A group of `Tippers` is determined through the config `Config`. After half of these have declared
 some amount that they believe a particular reported reason deserves, then a countdown period is
 entered where any remaining members can declare their tip amounts also. After the close of the
 countdown period, the median of all declared tips is paid to the reported beneficiary, along

--- a/frame/utility/README.md
+++ b/frame/utility/README.md
@@ -1,7 +1,7 @@
 # Utility Module
 A stateless module with helpers for dispatch management which does no re-authentication.
 
-- [`utility::Trait`](https://docs.rs/pallet-utility/latest/pallet_utility/trait.Trait.html)
+- [`utility::Config`](https://docs.rs/pallet-utility/latest/pallet_utility/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-utility/latest/pallet_utility/enum.Call.html)
 
 ## Overview
@@ -33,6 +33,6 @@ filtered by any proxy.
 * `as_derivative` - Dispatch a call from a derivative signed origin.
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/frame/vesting/README.md
+++ b/frame/vesting/README.md
@@ -1,6 +1,6 @@
 # Vesting Module
 
-- [`vesting::Trait`](https://docs.rs/pallet-vesting/latest/pallet_vesting/trait.Trait.html)
+- [`vesting::Config`](https://docs.rs/pallet-vesting/latest/pallet_vesting/trait.Config.html)
 - [`Call`](https://docs.rs/pallet-vesting/latest/pallet_vesting/enum.Call.html)
 
 ## Overview
@@ -26,6 +26,6 @@ This module implements the `VestingSchedule` trait.
   "vested" so far.
 
 [`Call`]: ./enum.Call.html
-[`Trait`]: ./trait.Trait.html
+[`Config`]: ./trait.Config.html
 
 License: Apache-2.0

--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -410,7 +410,7 @@ fn extend_with_runtime_decl_path(mut trait_: Path) -> Path {
 			.segments
 			.last()
 			.as_ref()
-			.expect("Config path should always contain at least one item; qed")
+			.expect("Trait path should always contain at least one item; qed")
 			.ident;
 
 		generate_runtime_mod_name_for_trait(trait_name)

--- a/utils/frame/benchmarking-cli/src/template.hbs
+++ b/utils/frame/benchmarking-cli/src/template.hbs
@@ -18,7 +18,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions for {{pallet}}.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Trait> {{pallet}}::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
 	{{~#each benchmarks as |benchmark|}}
 	fn {{benchmark.name~}}
 	(


### PR DESCRIPTION
This PR does:

* commit 1:
  * some additional renames of stuff like SessionTrait to SessionConfig
  * I also fix a wrong rename in `primitives/api/proc-macro/src/impl_runtime_apis.rs` where Trait actually meant trait.
  * and fix the Trait to Config in the template used to generate weight
* commit 2: I expect README.md to be regenerated from rust inner doc before publishing but this PR rename Trait to Config in them anyway.
* commit 3: another weight template fixed

