### PR TITLE
Add Standard Error to Weight Template

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -54,6 +54,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	) -> Weight {
 		({{underscore benchmark.base_weight}} as Weight)
 			{{~#each benchmark.component_weight as |cw|}}
+			// Standard Error: {{underscore cw.error}}
 			.saturating_add(({{underscore cw.slope}} as Weight).saturating_mul({{cw.name}} as Weight))
 			{{~/each}}
 			{{~#if (ne benchmark.base_reads "0")}}
@@ -82,6 +83,7 @@ impl WeightInfo for () {
 	) -> Weight {
 		({{underscore benchmark.base_weight}} as Weight)
 			{{~#each benchmark.component_weight as |cw|}}
+			// Standard Error: {{underscore cw.error}}
 			.saturating_add(({{underscore cw.slope}} as Weight).saturating_mul({{cw.name}} as Weight))
 			{{~/each}}
 			{{~#if (ne benchmark.base_reads "0")}}

--- a/utils/frame/benchmarking-cli/src/template.hbs
+++ b/utils/frame/benchmarking-cli/src/template.hbs
@@ -27,6 +27,7 @@ impl<T: frame_system::Config> {{pallet}}::WeightInfo for WeightInfo<T> {
 	) -> Weight {
 		({{underscore benchmark.base_weight}} as Weight)
 			{{~#each benchmark.component_weight as |cw|}}
+			// Standard Error: {{underscore cw.error}}
 			.saturating_add(({{underscore cw.slope}} as Weight).saturating_mul({{cw.name}} as Weight))
 			{{~/each}}
 			{{~#if (ne benchmark.base_reads "0")}}

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -84,6 +84,8 @@ struct ComponentSlope {
 	name: String,
 	#[serde(serialize_with = "string_serialize")]
 	slope: u128,
+	#[serde(serialize_with = "string_serialize")]
+	error: u128,
 }
 
 // Small helper to create an `io::Error` from a string.
@@ -145,27 +147,45 @@ fn get_benchmark_data(batch: &BenchmarkBatch) -> BenchmarkData {
 	let mut used_reads = Vec::new();
 	let mut used_writes = Vec::new();
 
-	extrinsic_time.slopes.into_iter().zip(extrinsic_time.names.iter()).for_each(|(slope, name)| {
-		if !slope.is_zero() {
-			if !used_components.contains(&name) { used_components.push(name); }
-			used_extrinsic_time.push(ComponentSlope {
-				name: name.clone(),
-				slope: slope.saturating_mul(1000),
-			});
-		}
-	});
-	reads.slopes.into_iter().zip(reads.names.iter()).for_each(|(slope, name)| {
-		if !slope.is_zero() {
-			if !used_components.contains(&name) { used_components.push(name); }
-			used_reads.push(ComponentSlope { name: name.clone(), slope });
-		}
-	});
-	writes.slopes.into_iter().zip(writes.names.iter()).for_each(|(slope, name)| {
-		if !slope.is_zero() {
-			if !used_components.contains(&name) { used_components.push(name); }
-			used_writes.push(ComponentSlope { name: name.clone(), slope });
-		}
-	});
+	extrinsic_time.slopes.into_iter()
+		.zip(extrinsic_time.names.iter())
+		.zip(extrinsic_time.model.unwrap().se.regressor_values.iter())
+		.for_each(|((slope, name), error)| {
+			if !slope.is_zero() {
+				if !used_components.contains(&name) { used_components.push(name); }
+				used_extrinsic_time.push(ComponentSlope {
+					name: name.clone(),
+					slope: slope.saturating_mul(1000),
+					error: (*error as u128).saturating_mul(1000),
+				});
+			}
+		});
+	reads.slopes.into_iter()
+		.zip(reads.names.iter())
+		.zip(reads.model.unwrap().se.regressor_values.iter())
+		.for_each(|((slope, name), error)| {
+			if !slope.is_zero() {
+				if !used_components.contains(&name) { used_components.push(name); }
+				used_reads.push(ComponentSlope {
+					name: name.clone(),
+					slope,
+					error: *error as u128,
+				});
+			}
+		});
+	writes.slopes.into_iter()
+		.zip(writes.names.iter())
+		.zip(writes.model.unwrap().se.regressor_values.iter())
+		.for_each(|((slope, name), error)| {
+			if !slope.is_zero() {
+				if !used_components.contains(&name) { used_components.push(name); }
+				used_writes.push(ComponentSlope {
+					name: name.clone(),
+					slope,
+					error: *error as u128,
+				});
+			}
+		});
 
 	// This puts a marker on any component which is entirely unused in the weight formula.
 	let components = batch.results[0].components

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -399,18 +399,30 @@ mod test {
 		assert_eq!(benchmark.base_weight, base * 1_000);
 		assert_eq!(
 			benchmark.component_weight,
-			vec![ComponentSlope { name: component.to_string(), slope: slope * 1_000 }]
+			vec![ComponentSlope {
+				name: component.to_string(),
+				slope: slope * 1_000,
+				error: 0,
+			}]
 		);
 		// DB Reads/Writes are untouched
 		assert_eq!(benchmark.base_reads, base);
 		assert_eq!(
 			benchmark.component_reads,
-			vec![ComponentSlope { name: component.to_string(), slope: slope }]
+			vec![ComponentSlope {
+				name: component.to_string(),
+				slope,
+				error: 0,
+			}]
 		);
 		assert_eq!(benchmark.base_writes, base);
 		assert_eq!(
 			benchmark.component_writes,
-			vec![ComponentSlope { name: component.to_string(), slope: slope }]
+			vec![ComponentSlope {
+				name: component.to_string(),
+				slope,
+				error: 0,
+			}]
 		);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/7648

This PR extracts the Standard Error from the regression model in the Weight analysis and places that as a comment in the weight files.