### PR TITLE
*: Update to libp2p v0.31.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,9 +2780,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24966e73cc5624a6cf14b025365f67cb6da436b4d6337ed84d198063ba74451d"
+checksum = "724846a3194368fefcac7ebdab12e01b8ac382e3efe399ddbd28851ab34f396f"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d92fab5df60c9705e05750d9ecee6a5af15aed1e3fa86e09fd3dd07ec5dc8e"
+checksum = "cc9c96d3a606a696a3a6c0ad3c3352c57bda2082ec9090930f1bd9daf787039f"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3571,9 +3571,9 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e19fd46149acdd3600780ebaa09f6ae4e7f2ddbafec64aab54cf75aafd1746"
+checksum = "dda822043bba2d6da31c4e14041f9794f8fb130a5959289038d0b809d8888614"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.8",

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -23,7 +23,7 @@ derive_more = "0.99.2"
 either = "1.5.3"
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { version = "0.31.1", default-features = false, features = ["kad"] }
+libp2p = { version = "0.31.2", default-features = false, features = ["kad"] }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.8.0"}
 prost = "0.6.1"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -21,7 +21,7 @@ ansi_term = "0.12.1"
 tokio = { version = "0.2.21", features = [ "signal", "rt-core", "rt-threaded", "blocking" ] }
 futures = "0.3.4"
 fdlimit = "0.2.1"
-libp2p = "0.31.1"
+libp2p = "0.31.2"
 parity-scale-codec = "1.3.0"
 hex = "0.4.2"
 rand = "0.7.3"

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 futures = "0.3.4"
 futures-timer = "3.0.1"
-libp2p = { version = "0.31.1", default-features = false }
+libp2p = { version = "0.31.2", default-features = false }
 log = "0.4.8"
 lru = "0.6.1"
 sc-network = { version = "0.8.0", path = "../network" }

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -64,13 +64,13 @@ wasm-timer = "0.2"
 zeroize = "1.0.0"
 
 [dependencies.libp2p]
-version = "0.31.1"
+version = "0.31.2"
 default-features = false
 features = ["identify", "kad", "mdns-async-std", "mplex", "noise", "ping", "request-response", "tcp-async-std", "websocket", "yamux"]
 
 [dev-dependencies]
 assert_matches = "1.3"
-libp2p = { version = "0.31.1", default-features = false }
+libp2p = { version = "0.31.2", default-features = false }
 quickcheck = "0.9.0"
 rand = "0.7.2"
 sp-keyring = { version = "2.0.0", path = "../../primitives/keyring" }

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 rand = "0.7.2"
-libp2p = { version = "0.31.1", default-features = false }
+libp2p = { version = "0.31.2", default-features = false }
 sp-consensus = { version = "0.8.0", path = "../../../primitives/consensus/common" }
 sc-consensus = { version = "0.8.0", path = "../../../client/consensus/common" }
 sc-client-api = { version = "2.0.0", path = "../../api" }

--- a/client/peerset/Cargo.toml
+++ b/client/peerset/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 futures = "0.3.4"
-libp2p = { version = "0.31.1", default-features = false }
+libp2p = { version = "0.31.2", default-features = false }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils"}
 log = "0.4.8"
 serde_json = "1.0.41"

--- a/client/telemetry/Cargo.toml
+++ b/client/telemetry/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.10.0"
 futures = "0.3.4"
 futures-timer = "3.0.1"
 wasm-timer = "0.2.5"
-libp2p = { version = "0.31.1", default-features = false, features = ["dns", "tcp-async-std", "wasm-ext", "websocket"] }
+libp2p = { version = "0.31.2", default-features = false, features = ["dns", "tcp-async-std", "wasm-ext", "websocket"] }
 log = "0.4.8"
 pin-project = "0.4.6"
 rand = "0.7.2"

--- a/primitives/consensus/common/Cargo.toml
+++ b/primitives/consensus/common/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 thiserror = "1.0.21"
-libp2p = { version = "0.31.1", default-features = false }
+libp2p = { version = "0.31.2", default-features = false }
 log = "0.4.8"
 sp-core = { path= "../../core", version = "2.0.0"}
 sp-inherents = { version = "2.0.0", path = "../../inherents" }


### PR DESCRIPTION
Update libp2p to `v0.31.2` to include https://github.com/libp2p/rust-libp2p/pull/1871 which fixes https://github.com/paritytech/substrate/pull/7478#issuecomment-736803765.