### PR TITLE
Refactor `StorageInstance` trait to be usable more easily

### DIFF
--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -68,8 +68,7 @@ where
 	type Hasher1 = Hasher1;
 	type Hasher2 = Hasher2;
 	fn module_prefix() -> &'static [u8] {
-		<Prefix::PalletInfo as crate::traits::PalletInfo>::name::<Prefix::Pallet>()
-			.expect("Every active pallet has a name in the runtime; qed").as_bytes()
+		Prefix::pallet_prefix().as_bytes()
 	}
 	fn storage_prefix() -> &'static [u8] {
 		Prefix::STORAGE_PREFIX.as_bytes()
@@ -415,8 +414,7 @@ mod test {
 
 	struct Prefix;
 	impl StorageInstance for Prefix {
-		type Pallet = ();
-		type PalletInfo = ();
+		fn pallet_prefix() -> &'static str { "test" }
 		const STORAGE_PREFIX: &'static str = "foo";
 	}
 

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -34,7 +34,7 @@ use sp_std::vec::Vec;
 ///
 /// Each value is stored at:
 /// ```nocompile
-/// Twox128(<Prefix::Pallet as PalletInfo>::name())
+/// Twox128(Prefix::pallet_prefix())
 ///		++ Twox128(Prefix::STORAGE_PREFIX)
 ///		++ Hasher1(encode(key1))
 ///		++ Hasher2(encode(key2))

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -33,7 +33,7 @@ use sp_std::prelude::*;
 ///
 /// Each value is stored at:
 /// ```nocompile
-/// Twox128(<Prefix::Pallet as PalletInfo>::name())
+/// Twox128(Prefix::pallet_prefix())
 ///		++ Twox128(Prefix::STORAGE_PREFIX)
 ///		++ Hasher1(encode(key))
 /// ```

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -60,8 +60,7 @@ where
 	type Query = QueryKind::Query;
 	type Hasher = Hasher;
 	fn module_prefix() -> &'static [u8] {
-		<Prefix::PalletInfo as crate::traits::PalletInfo>::name::<Prefix::Pallet>()
-			.expect("Every active pallet has a name in the runtime; qed").as_bytes()
+		Prefix::pallet_prefix().as_bytes()
 	}
 	fn storage_prefix() -> &'static [u8] {
 		Prefix::STORAGE_PREFIX.as_bytes()
@@ -318,8 +317,7 @@ mod test {
 
 	struct Prefix;
 	impl StorageInstance for Prefix {
-		type Pallet = ();
-		type PalletInfo = ();
+		fn pallet_prefix() -> &'static str { "test" }
 		const STORAGE_PREFIX: &'static str = "foo";
 	}
 

--- a/frame/support/src/storage/types/value.rs
+++ b/frame/support/src/storage/types/value.rs
@@ -31,7 +31,7 @@ use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 ///
 /// Each value is stored at:
 /// ```nocompile
-/// Twox128(<Prefix::Pallet as PalletInfo>::name()) ++ Twox128(Prefix::STORAGE_PREFIX)
+/// Twox128(Prefix::pallet_prefix()) ++ Twox128(Prefix::STORAGE_PREFIX)
 /// ```
 pub struct StorageValue<Prefix, Value, QueryKind=OptionQuery, OnEmpty=GetDefault>(
 	core::marker::PhantomData<(Prefix, Value, QueryKind, OnEmpty)>

--- a/frame/support/src/storage/types/value.rs
+++ b/frame/support/src/storage/types/value.rs
@@ -47,8 +47,7 @@ where
 {
 	type Query = QueryKind::Query;
 	fn module_prefix() -> &'static [u8] {
-		<Prefix::PalletInfo as crate::traits::PalletInfo>::name::<Prefix::Pallet>()
-			.expect("Every active pallet has a name in the runtime; qed").as_bytes()
+		Prefix::pallet_prefix().as_bytes()
 	}
 	fn storage_prefix() -> &'static [u8] {
 		Prefix::STORAGE_PREFIX.as_bytes()
@@ -201,8 +200,7 @@ mod test {
 
 	struct Prefix;
 	impl StorageInstance for Prefix {
-		type Pallet = ();
-		type PalletInfo = ();
+		fn pallet_prefix() -> &'static str { "test" }
 		const STORAGE_PREFIX: &'static str = "foo";
 	}
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1731,12 +1731,19 @@ pub trait Instance: 'static {
 	const PREFIX: &'static str;
 }
 
-/// An instance of a storage.
+/// An instance of a storage in a pallet.
 ///
-/// It is required the the couple `(pallet_prefix(), STORAGE_PREFIX)` is unique.
-/// Any storage with same couple will collide.
+/// Define an instance for an individual storage inside a pallet.
+/// The pallet prefix is used to isolate the storage between pallets, and the storage prefix is
+/// used to isolate storages inside a pallet.
+///
+/// NOTE: These information can be used to define storages in pallet such as a `StorageMap` which
+/// can use keys after `twox_128(pallet_prefix())++twox_128(STORAGE_PREFIX)`
 pub trait StorageInstance {
+	/// Prefix given to a pallet to isolate from other pallets.
 	fn pallet_prefix() -> &'static str;
+
+	/// Prefix given to a storage to isolate from other storages in the pallet.
 	const STORAGE_PREFIX: &'static str;
 }
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1733,11 +1733,10 @@ pub trait Instance: 'static {
 
 /// An instance of a storage.
 ///
-/// It is required the the couple `(PalletInfo::name<Pallet>(), STORAGE_PREFIX)` is unique.
+/// It is required the the couple `(pallet_prefix(), STORAGE_PREFIX)` is unique.
 /// Any storage with same couple will collide.
 pub trait StorageInstance {
-	type Pallet: 'static;
-	type PalletInfo: PalletInfo;
+	fn pallet_prefix() -> &'static str;
 	const STORAGE_PREFIX: &'static str;
 }
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -1740,7 +1740,7 @@ pub trait Instance: 'static {
 /// NOTE: These information can be used to define storages in pallet such as a `StorageMap` which
 /// can use keys after `twox_128(pallet_prefix())++twox_128(STORAGE_PREFIX)`
 pub trait StorageInstance {
-	/// Prefix given to a pallet to isolate from other pallets.
+	/// Prefix of a pallet to isolate it from other pallets.
 	fn pallet_prefix() -> &'static str;
 
 	/// Prefix given to a storage to isolate from other storages in the pallet.


### PR DESCRIPTION
`StorageInstance` is introduced to be used alongside storage types. It was meant to be implemented by macro, thus I tried to make it as straightforward as possible to implement from the macro (just some associated type and constant). But this is a rather ugly trait and it is less usable then.

Thus this PR refactors it to make it more usable and idiomatic.