### PR TITLE
Fix #7629

### DIFF
--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -668,9 +668,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 				sink.clone()
 			} else {
 				// Notification silently discarded, as documented.
-				log::error!(
+				log::debug!(
 					target: "sub-libp2p",
-					"Attempted to send notification on unknown protocol: {:?}",
+					"Attempted to send notification on closed substream: {:?}",
 					protocol,
 				);
 				return;

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -670,7 +670,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 				// Notification silently discarded, as documented.
 				log::debug!(
 					target: "sub-libp2p",
-					"Attempted to send notification on closed substream: {:?}",
+					"Attempted to send notification on missing or closed substream: {:?}",
 					protocol,
 				);
 				return;


### PR DESCRIPTION
Fix #7629 

This downgrade the `error` into a `debug` log.

The error happens if we try to send a notification on a substream that has already been closed.
Considering that sending notifications happen in parallel of receiving events, this can happen in completely normal situations. It was a mistake to have it as an `error`.

Also cc #6756

