### PR TITLE
Update Transaction Payment Api to use Runtime Types

### DIFF
--- a/bin/node-template/node/src/rpc.rs
+++ b/bin/node-template/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use node_template_runtime::{opaque::Block, AccountId, Balance, Index};
+use node_template_runtime::{opaque::Block, AccountId, Balance, Index, DispatchClass, Weight};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{Error as BlockChainError, HeaderMetadata, HeaderBackend};
 use sp_block_builder::BlockBuilder;
@@ -33,7 +33,7 @@ pub fn create_full<C, P>(
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error=BlockChainError> + 'static,
 	C: Send + Sync + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Weight, DispatchClass, Balance>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,
 {

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -33,7 +33,7 @@ pub use frame_support::{
 	construct_runtime, parameter_types, StorageValue,
 	traits::{KeyOwnerProofSystem, Randomness},
 	weights::{
-		Weight, IdentityFee,
+		Weight, IdentityFee, DispatchClass,
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 	},
 };
@@ -440,11 +440,16 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
+		Block,
+		Weight,
+		DispatchClass,
+		Balance,
+	> for Runtime {
 		fn query_info(
 			uxt: <Block as BlockT>::Extrinsic,
 			len: u32,
-		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Weight, DispatchClass, Balance> {
 			TransactionPayment::query_info(uxt, len)
 		}
 	}

--- a/bin/node/rpc/src/lib.rs
+++ b/bin/node/rpc/src/lib.rs
@@ -33,6 +33,7 @@
 use std::sync::Arc;
 
 use sp_keystore::SyncCryptoStorePtr;
+use node_runtime::{DispatchClass, Weight};
 use node_primitives::{Block, BlockNumber, AccountId, Index, Balance, Hash};
 use sc_consensus_babe::{Config, Epoch};
 use sc_consensus_babe_rpc::BabeRpcHandler;
@@ -116,7 +117,7 @@ pub fn create_full<C, P, SC, B>(
 		HeaderMetadata<Block, Error=BlockChainError> + Sync + Send + 'static,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Index>,
 	C::Api: pallet_contracts_rpc::ContractsRuntimeApi<Block, AccountId, Balance, BlockNumber>,
-	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Weight, DispatchClass, Balance>,
 	C::Api: BabeApi<Block>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + 'static,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use sp_std::prelude::*;
 use frame_support::{
 	construct_runtime, parameter_types, debug, RuntimeDebug,
 	weights::{
-		Weight, IdentityFee,
+		Weight, IdentityFee, DispatchClass,
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 	},
 	traits::{
@@ -1158,9 +1158,13 @@ impl_runtime_apis! {
 
 	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<
 		Block,
+		Weight,
+		DispatchClass,
 		Balance,
 	> for Runtime {
-		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32) -> RuntimeDispatchInfo<Balance> {
+		fn query_info(uxt: <Block as BlockT>::Extrinsic, len: u32)
+			-> RuntimeDispatchInfo<Weight, DispatchClass, Balance>
+		{
 			TransactionPayment::query_info(uxt, len)
 		}
 	}

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use sp_std::prelude::*;
 use frame_support::{
 	construct_runtime, parameter_types, debug, RuntimeDebug,
 	weights::{
-		Weight, IdentityFee, DispatchClass,
+		IdentityFee,
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 	},
 	traits::{
@@ -35,6 +35,7 @@ use frame_support::{
 		U128CurrencyToVote,
 	},
 };
+pub use frame_support::weights::{Weight, DispatchClass};
 use frame_system::{EnsureRoot, EnsureOneOf};
 use frame_support::traits::InstanceFilter;
 use codec::{Encode, Decode};

--- a/frame/transaction-payment/rpc/src/lib.rs
+++ b/frame/transaction-payment/rpc/src/lib.rs
@@ -69,19 +69,24 @@ impl From<Error> for i64 {
 	}
 }
 
-impl<C, Block, Balance> TransactionPaymentApi<<Block as BlockT>::Hash, RuntimeDispatchInfo<Balance>>
+impl<C, Block, Weight, DispatchClass, Balance> TransactionPaymentApi<
+	<Block as BlockT>::Hash,
+	RuntimeDispatchInfo<Weight, DispatchClass, Balance>,
+>
 	for TransactionPayment<C, Block>
 where
 	Block: BlockT,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
-	C::Api: TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: TransactionPaymentRuntimeApi<Block, Weight, DispatchClass, Balance>,
+	Weight: Codec,
+	DispatchClass: Codec,
 	Balance: Codec + MaybeDisplay + MaybeFromStr,
 {
 	fn query_info(
 		&self,
 		encoded_xt: Bytes,
 		at: Option<<Block as BlockT>::Hash>
-	) -> Result<RuntimeDispatchInfo<Balance>> {
+	) -> Result<RuntimeDispatchInfo<Weight, DispatchClass, Balance>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(||
 			// If the block hash is not supplied assume the best block.

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 	traits::Get,
 	weights::{
 		Weight, DispatchInfo, PostDispatchInfo, GetDispatchInfo, Pays, WeightToFeePolynomial,
-		WeightToFeeCoefficient,
+		WeightToFeeCoefficient, DispatchClass,
 	},
 	dispatch::DispatchResult,
 };
@@ -310,7 +310,7 @@ impl<T: Config> Module<T> where
 	pub fn query_info<Extrinsic: GetDispatchInfo>(
 		unchecked_extrinsic: Extrinsic,
 		len: u32,
-	) -> RuntimeDispatchInfo<BalanceOf<T>>
+	) -> RuntimeDispatchInfo<Weight, DispatchClass, BalanceOf<T>>
 	where
 		T: Send + Sync,
 		BalanceOf<T>: Send + Sync,


### PR DESCRIPTION
Fixes: https://github.com/paritytech/substrate/issues/7689

This PR updates the Transaction Payment API to use types defined by the runtime, rather than the types defined in our libraries. The types in our libraries may get updated, while the runtime types should be the source of truth. (i.e. when native runtime is ahead of the wasm runtime)