### PR TITLE
feat: add jeager to configuration

### DIFF
--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -352,6 +352,13 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 		Ok(None)
 	}
 
+	/// Get the jaeger configuration (`None` if disabled)
+	///
+	/// By default this is `None`.
+	fn jaeger_config(&self, _default_listen_port: u16) -> Result<Option<JaegerConfig>> {
+		Ok(None)
+	}
+
 	/// Get the telemetry endpoints (if any)
 	///
 	/// By default this is retrieved from the chain spec loaded by `load_spec`.

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -82,6 +82,8 @@ pub struct Configuration {
 	pub rpc_methods: RpcMethods,
 	/// Prometheus endpoint configuration. `None` if disabled.
 	pub prometheus_config: Option<PrometheusConfig>,
+	/// Jaeger collection configuration. `None` if disabled.
+	pub jaeger_config: Option<JaegerConfig>,
 	/// Telemetry service URL. `None` if disabled.
 	pub telemetry_endpoints: Option<TelemetryEndpoints>,
 	/// External WASM transport for the telemetry. If `Some`, when connection to a telemetry
@@ -178,6 +180,27 @@ impl PrometheusConfig {
 			port,
 			registry: Registry::new_custom(Some("substrate".into()), None)
 				.expect("this can only fail if the prefix is empty")
+		}
+	}
+}
+
+/// Configuration of the Prometheus endpoint.
+#[derive(Debug, Clone)]
+pub struct JaegerConfig {
+	/// Destination of the jaeger collector.
+	pub addr: SocketAddr,
+	/// An additional prefix for all used strings.
+	pub prefix: String,
+}
+
+impl JaegerConfig {
+	/// Create a new config using the default registry.
+	///
+	/// The default registry prefixes metrics with `substrate`.
+	pub fn new_with_default_prefix(addr: SocketAddr) -> Self {
+		Self {
+			addr,
+			prefix: "substrate".to_owned()
 		}
 	}
 }


### PR DESCRIPTION
Add a configuration item to be able to properly configure `jaeger` based tracing. For substrate itself this is currently unused, for polkadot it'd be much appreciated ( https://github.com/paritytech/polkadot/pull/2047 ).