### PR TITLE
Pin md link checker's version

### DIFF
--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -3,5 +3,5 @@
 // not listed here, CI will fail.
 
 module.exports = [
-    'gaurav-nelson/github-action-markdown-link-check@b9ebf58cf4d8ad45e9ce45d9309812e1291c1a03', // gaurav-nelson/github-action-markdown-link-check@v1.0.2
+    'gaurav-nelson/github-action-markdown-link-check@e3c371c731b2f494f856dc5de7f61cea4d519907', // gaurav-nelson/github-action-markdown-link-check@v1.0.8
 ]

--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -1,0 +1,7 @@
+// This is a whitelist of GitHub Actions that are approved for use in this project.
+// If a new or existing workflow file is updated to use an action or action version
+// not listed here, CI will fail.
+
+module.exports = [
+    'gaurav-nelson/github-action-markdown-link-check@95d5f3b63d2ca8e93f527396308c41e70634e2e7', // gaurav-nelson/github-action-markdown-link-check@v1.0.7
+]

--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -3,5 +3,5 @@
 // not listed here, CI will fail.
 
 module.exports = [
-    'gaurav-nelson/github-action-markdown-link-check@28631ee73c4024e27af2a44ee611c97fe0012a34',
+    'gaurav-nelson/github-action-markdown-link-check@b9ebf58cf4d8ad45e9ce45d9309812e1291c1a03', // gaurav-nelson/github-action-markdown-link-check@v1.0.2
 ]

--- a/.github/allowed-actions.js
+++ b/.github/allowed-actions.js
@@ -3,5 +3,5 @@
 // not listed here, CI will fail.
 
 module.exports = [
-    'gaurav-nelson/github-action-markdown-link-check@95d5f3b63d2ca8e93f527396308c41e70634e2e7', // gaurav-nelson/github-action-markdown-link-check@v1.0.7
+    'gaurav-nelson/github-action-markdown-link-check@28631ee73c4024e27af2a44ee611c97fe0012a34',
 ]

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@b9ebf58cf4d8ad45e9ce45d9309812e1291c1a03
+    - uses: gaurav-nelson/github-action-markdown-link-check@e3c371c731b2f494f856dc5de7f61cea4d519907
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@95d5f3b63d2ca8e93f527396308c41e70634e2e7
+    - uses: gaurav-nelson/github-action-markdown-link-check@28631ee73c4024e27af2a44ee611c97fe0012a34
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@95d5f3b63d2ca8e93f527396308c41e70634e2e7
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: gaurav-nelson/github-action-markdown-link-check@28631ee73c4024e27af2a44ee611c97fe0012a34
+    - uses: gaurav-nelson/github-action-markdown-link-check@b9ebf58cf4d8ad45e9ce45d9309812e1291c1a03
       with:
         use-quiet-mode: 'yes'
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -3,5 +3,11 @@
         {
             "pattern": "^https://crates.io"
         }
+    ],
+    "replacementPatterns": [
+        {
+          "pattern": "%20",
+          "replacement": " "
+        }
     ]
 }


### PR DESCRIPTION
- pins the md link checker's version to the previous release as the current version, to mitigate [this](https://github.com/tcort/markdown-link-check/issues/142) issue
- introduces a whitelist with pinned versions, [as done](https://github.com/github/docs/blob/main/.github/allowed-actions.js) by github