### PR TITLE
CI: ignore %20 for md link checker

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,13 +1,8 @@
 {
     "ignorePatterns": [
         {
-            "pattern": "^https://crates.io"
-        }
-    ],
-    "replacementPatterns": [
-        {
-          "pattern": "%20",
-          "replacement": " "
+            "pattern": "^https://crates.io",
+            "pattern": "%20"
         }
     ]
 }


### PR DESCRIPTION
Avoids links with `%20` as it's bugged in the GitHub Action.