### PR TITLE
Fix polkadot benchmarks for remark.

### DIFF
--- a/frame/system/benchmarking/src/lib.rs
+++ b/frame/system/benchmarking/src/lib.rs
@@ -28,6 +28,7 @@ use frame_benchmarking::{benchmarks, whitelisted_caller};
 use frame_support::{
 	storage::{self, StorageMap},
 	traits::Get,
+	weights::DispatchClass,
 };
 use frame_system::{Module as System, Call, RawOrigin, DigestItemOf, AccountInfo};
 
@@ -40,7 +41,7 @@ benchmarks! {
 	_ { }
 
 	remark {
-		let b in 0 .. T::BlockWeights::get().max_block as u32;
+		let b in 0 .. *T::BlockLength::get().max.get(DispatchClass::Normal) as u32;
 		let remark_message = vec![1; b as usize];
 		let caller = whitelisted_caller();
 	}: _(RawOrigin::Signed(caller), remark_message)


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot/issues/2103

The code before #6629 was using `MaximumBlockLength` not weight. I don't really understand why the benchmarks worked just fine in the substrate repo, @shawntabrizi ?

CC @s3krit 