### PR TITLE
Prevent dust in staking by disallowing cheap bond_extra

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1586,7 +1586,7 @@ decl_module! {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}
 
-			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active < T::Balances::minimum_balance() {
+			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active < T::Currency::minimum_balance() {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1479,7 +1479,7 @@ decl_module! {
 				ledger.total += extra;
 				ledger.active += extra;
 				// last check: the new active amount of ledger must be more than ED.
-				ensure!(ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+				ensure!(ledger.active >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
 
 				Self::deposit_event(RawEvent::Bonded(stash, extra));
 				Self::update_ledger(&controller, &ledger);
@@ -1588,7 +1588,7 @@ decl_module! {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}
 
-			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active < T::Currency::minimum_balance() {
+			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active <= T::Currency::minimum_balance() {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.
@@ -1976,7 +1976,7 @@ decl_module! {
 
 			let ledger = ledger.rebond(value);
 			// last check: the new active amount of ledger must be more than ED.
-			ensure!(ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+			ensure!(ledger.active >= T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
 
 			Self::update_ledger(&controller, &ledger);
 			Ok(Some(

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1586,7 +1586,7 @@ decl_module! {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}
 
-			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active.is_zero() {
+			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active < T::Balances::minimum_balance() {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1476,9 +1476,11 @@ decl_module! {
 			let stash_balance = T::Currency::free_balance(&stash);
 			if let Some(extra) = stash_balance.checked_sub(&ledger.total) {
 				let extra = extra.min(max_additional);
-				ensure!(extra + ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
 				ledger.total += extra;
 				ledger.active += extra;
+				// last check: the new active amount of ledger must be more than ED.
+				ensure!(ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
 				Self::deposit_event(RawEvent::Bonded(stash, extra));
 				Self::update_ledger(&controller, &ledger);
 			}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1973,6 +1973,9 @@ decl_module! {
 			ensure!(!ledger.unlocking.is_empty(), Error::<T>::NoUnlockChunk);
 
 			let ledger = ledger.rebond(value);
+			// last check: the new active amount of ledger must be more than ED.
+			ensure!(ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
+
 			Self::update_ledger(&controller, &ledger);
 			Ok(Some(
 				35 * WEIGHT_PER_MICROS

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1474,9 +1474,9 @@ decl_module! {
 			let mut ledger = Self::ledger(&controller).ok_or(Error::<T>::NotController)?;
 
 			let stash_balance = T::Currency::free_balance(&stash);
-
 			if let Some(extra) = stash_balance.checked_sub(&ledger.total) {
 				let extra = extra.min(max_additional);
+				ensure!(extra + ledger.active > T::Currency::minimum_balance(), Error::<T>::InsufficientValue);
 				ledger.total += extra;
 				ledger.active += extra;
 				Self::deposit_event(RawEvent::Bonded(stash, extra));

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -581,6 +581,7 @@ fn assert_ledger_consistent(ctrl: AccountId) {
 	let ledger = Staking::ledger(ctrl).expect("Not a controller.");
 	let real_total: Balance = ledger.unlocking.iter().fold(ledger.active, |a, c| a + c.value);
 	assert_eq!(real_total, ledger.total);
+	assert!(ledger.active >= Balances::minimum_balance());
 }
 
 pub(crate) fn bond_validator(stash: AccountId, ctrl: AccountId, val: Balance) {

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -579,9 +579,18 @@ fn assert_is_stash(acc: AccountId) {
 fn assert_ledger_consistent(ctrl: AccountId) {
 	// ensures ledger.total == ledger.active + sum(ledger.unlocking).
 	let ledger = Staking::ledger(ctrl).expect("Not a controller.");
-	let real_total: Balance = ledger.unlocking.iter().fold(ledger.active, |a, c| a + c.value);
+	let real_total: Balance = ledger
+		.unlocking
+		.iter()
+		.fold(ledger.active, |a, c| a + c.value);
 	assert_eq!(real_total, ledger.total);
-	assert!(ledger.active >= Balances::minimum_balance());
+	assert!(
+		ledger.active >= Balances::minimum_balance() || ledger.active == 0,
+		"{}: active ledger amount ({}) must be greater than ED {}",
+		ctrl,
+		ledger.active,
+		Balances::minimum_balance()
+	);
 }
 
 pub(crate) fn bond_validator(stash: AccountId, ctrl: AccountId, val: Balance) {

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -4698,7 +4698,7 @@ fn payout_to_any_account_works() {
 }
 
 #[test]
-fn cannot_rebond_to_lower_than_ed() {
+fn cannot_bond_extra_to_lower_than_ed() {
 	ExtBuilder::default()
 		.existential_deposit(10)
 		.build_and_execute(|| {
@@ -4733,6 +4733,47 @@ fn cannot_rebond_to_lower_than_ed() {
 			// now bond a wee bit more
 			assert_noop!(
 				Staking::bond_extra(Origin::signed(21), 5),
+				Error::<Test>::InsufficientValue,
+			);
+		})
+}
+
+#[test]
+fn cannot_rebond_to_lower_than_ed() {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.build_and_execute(|| {
+			// stash must have more balance than bonded for this to work.
+			assert_eq!(Balances::free_balance(&21), 512_000);
+
+			// initial stuff.
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: 1000,
+					active: 1000,
+					unlocking: vec![],
+					claimed_rewards: vec![]
+				}
+			);
+
+			// unbond all of it.
+			assert_ok!(Staking::unbond(Origin::signed(20), 1000));
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: 1000,
+					active: 0,
+					unlocking: vec![UnlockChunk { value: 1000, era: 3 }],
+					claimed_rewards: vec![]
+				}
+			);
+
+			// now bond a wee bit more
+			assert_noop!(
+				Staking::rebond(Origin::signed(20), 5),
 				Error::<Test>::InsufficientValue,
 			);
 		})

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -4696,3 +4696,44 @@ fn payout_to_any_account_works() {
 		assert!(Balances::free_balance(42) > 0);
 	})
 }
+
+#[test]
+fn cannot_rebond_to_lower_than_ed() {
+	ExtBuilder::default()
+		.existential_deposit(10)
+		.build_and_execute(|| {
+			// stash must have more balance than bonded for this to work.
+			assert_eq!(Balances::free_balance(&21), 512_000);
+
+			// initial stuff.
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: 1000,
+					active: 1000,
+					unlocking: vec![],
+					claimed_rewards: vec![]
+				}
+			);
+
+			// unbond all of it.
+			assert_ok!(Staking::unbond(Origin::signed(20), 1000));
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: 1000,
+					active: 0,
+					unlocking: vec![UnlockChunk { value: 1000, era: 3 }],
+					claimed_rewards: vec![]
+				}
+			);
+
+			// now bond a wee bit more
+			assert_noop!(
+				Staking::bond_extra(Origin::signed(21), 5),
+				Error::<Test>::InsufficientValue,
+			);
+		})
+}


### PR DESCRIPTION
Current staking system allowed dust accounts to be created as such: 

1. Bond 1 DOTs
2. Unbond 1 DOTs
3. Bond-extra a tiny amount. 

Reported by @joepetrowski, example [here](https://polkadot.subscan.io/account/13SA1F2dEd7o45wQJZhPUwccFjWRtD2BaTVF3MSnRYNMtSd7), similarly, you could do the same with `rebond`.

I think the current logic is sane because we allow the `ledger.active` to either be `0`, in which case when you `withdraw` your funds your account gets deleted, or be greater than ED. As a safety measure I also change the condition here: if while `withdraw` your `ledger.active` is less than ED, then bye bye 👋🏻.  


An interesting migration-like task is to go and sweep the chain with remote-externalities and see if we have any dust accounts. In essence, I think no account should have `ledger.active` less than ED. cc @apopiak 