### PR TITLE
Pin pwasm-utils to 0.16.0

### DIFF
--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -23,7 +23,7 @@ frame-system = { version = "2.0.0", default-features = false, path = "../system"
 pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "common" }
 pallet-contracts-proc-macro = { version = "0.1.0", path = "proc-macro" }
 parity-wasm = { version = "0.41.0", default-features = false }
-pwasm-utils = { version = "0.16", default-features = false }
+pwasm-utils = { version = "=0.16.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }


### PR DESCRIPTION
pwasm-utils 0.16.1 upgrade parity-wasm to 0.42.1 which incompatible to 0.41.0 that the crate are using,
so it will broke compiling

before `contracts` upgrade to latest `parity-wasm`, I suggest pin `parity-wasm` for now

This problem can reproduce by `cargo update`

```
error[E0053]: method `instruction_cost` has an incompatible type for trait
   --> frame/contracts/src/schedule.rs:580:2
    |
580 |     fn instruction_cost(&self, instruction: &elements::Instruction) -> Option<u32> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `parity_wasm::elements::ops::Instruction`, found enum `Instruction`
    |
    = note: expected fn pointer `fn(&ScheduleRules<'a, T>, &parity_wasm::elements::ops::Instruction) -> std::option::Option<_>`
               found fn pointer `fn(&ScheduleRules<'a, T>, &Instruction) -> std::option::Option<_>`
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:193:4
    |
193 |             self.module,
    |             ^^^^^^^^^^^ expected struct `parity_wasm::elements::module::Module`, found struct `parity_wasm::elements::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:198:12
    |
198 |             module: contract_module,
    |                     ^^^^^^^^^^^^^^^ expected struct `parity_wasm::elements::Module`, found struct `parity_wasm::elements::module::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:206:22
    |
206 |                 ::inject_limiter(self.module, self.schedule.limits.stack_height)
    |                                  ^^^^^^^^^^^ expected struct `parity_wasm::elements::module::Module`, found struct `parity_wasm::elements::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:209:12
    |
209 |             module: contract_module,
    |                     ^^^^^^^^^^^^^^^ expected struct `parity_wasm::elements::Module`, found struct `parity_wasm::elements::module::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error: aborting due to 5 previous errors
[package]

Some errors have detailed explanations: E0053, E0308.
For more information about an error, try `rustc --explain E0053`.
error: could not compile `pallet-contracts`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error[E0053]: method `instruction_cost` has an incompatible type for trait
   --> frame/contracts/src/schedule.rs:580:2
    |
580 |     fn instruction_cost(&self, instruction: &elements::Instruction) -> Option<u32> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `parity_wasm::elements::ops::Instruction`, found enum `Instruction`
    |
    = note: expected fn pointer `fn(&ScheduleRules<'a, T>, &parity_wasm::elements::ops::Instruction) -> std::option::Option<_>`
               found fn pointer `fn(&ScheduleRules<'a, T>, &Instruction) -> std::option::Option<_>`
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:193:4
    |
193 |             self.module,
    |             ^^^^^^^^^^^ expected struct `parity_wasm::elements::module::Module`, found struct `parity_wasm::elements::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:198:12
    |
198 |             module: contract_module,
    |                     ^^^^^^^^^^^^^^^ expected struct `parity_wasm::elements::Module`, found struct `parity_wasm::elements::module::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:206:22
    |
206 |                 ::inject_limiter(self.module, self.schedule.limits.stack_height)
    |                                  ^^^^^^^^^^^ expected struct `parity_wasm::elements::module::Module`, found struct `parity_wasm::elements::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error[E0308]: mismatched types
   --> frame/contracts/src/wasm/prepare.rs:209:12
    |
209 |             module: contract_module,
    |                     ^^^^^^^^^^^^^^^ expected struct `parity_wasm::elements::Module`, found struct `parity_wasm::elements::module::Module`
    |
    = note: perhaps two different versions of crate `parity_wasm` are being used?

error: aborting due to 5 previous errors

Some errors have detailed explanations: E0053, E0308.
For more information about an error, try `rustc --explain E0053`.
```