### PR TITLE
Allow runtime_debug! where sp_io is not there

### DIFF
--- a/frame/support/src/debug.rs
+++ b/frame/support/src/debug.rs
@@ -134,7 +134,7 @@ macro_rules! runtime_print {
 			use core::fmt::Write;
 			let mut w = $crate::sp_std::Writer::default();
 			let _ = core::write!(&mut w, $($arg)+);
-			sp_io::misc::print_utf8(&w.inner())
+			$crate::sp_io::misc::print_utf8(&w.inner())
 		}
 	}
 }


### PR DESCRIPTION
Most pallets have `sp_io` anyhow, but still better to not depend on it being in scope directly. 