### PR TITLE
remove duplicate accounts in chain-spec.

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -234,9 +234,11 @@ pub fn testnet_genesis(
 			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 		]
 	});
-	endowed_accounts.extend(initial_authorities.iter().map(|x| x.0.clone()));
-	// if any of the initial_authorities are the above known accounts, dedup it out.
-	endowed_accounts.dedup();
+	initial_authorities.iter().for_each(|x|
+		if !endowed_accounts.contains(&x.0) {
+			endowed_accounts.push(x.0.clone())
+		}
+	);
 
 	let num_endowed_accounts = endowed_accounts.len();
 

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -218,7 +218,7 @@ pub fn testnet_genesis(
 	endowed_accounts: Option<Vec<AccountId>>,
 	enable_println: bool,
 ) -> GenesisConfig {
-	let endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
+	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
 			get_account_id_from_seed::<sr25519::Public>("Bob"),
@@ -234,10 +234,14 @@ pub fn testnet_genesis(
 			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 		]
 	});
+	endowed_accounts.extend(initial_authorities.iter());
+	// if any of the initial_authorities are the above known accounts, dedup it out.
+	endowed_accounts.dedup();
+
 	let num_endowed_accounts = endowed_accounts.len();
 
 	const ENDOWMENT: Balance = 10_000_000 * DOLLARS;
-	const STASH: Balance = 100 * DOLLARS;
+	const STASH: Balance = ENDOWMENT / 1000;
 
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -246,9 +250,8 @@ pub fn testnet_genesis(
 		}),
 		pallet_balances: Some(BalancesConfig {
 			balances: endowed_accounts.iter().cloned()
-				.map(|k| (k, ENDOWMENT))
-				.chain(initial_authorities.iter().map(|x| (x.0.clone(), STASH)))
-				.collect(),
+				.map(|x| (x, ENDOWMENT))
+				.collect()
 		}),
 		pallet_indices: Some(IndicesConfig {
 			indices: vec![],

--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -234,7 +234,7 @@ pub fn testnet_genesis(
 			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 		]
 	});
-	endowed_accounts.extend(initial_authorities.iter());
+	endowed_accounts.extend(initial_authorities.iter().map(|x| x.0.clone()));
 	// if any of the initial_authorities are the above known accounts, dedup it out.
 	endowed_accounts.dedup();
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -414,9 +414,7 @@ decl_storage! {
 			}
 
 			// ensure no duplicates exist.
-			let mut endowed_accounts = config.balances.iter().map(|(x, _)| x).cloned().collect::<Vec<_>>();
-			endowed_accounts.sort();
-			endowed_accounts.dedup();
+			let endowed_accounts = config.balances.iter().map(|(x, _)| x).cloned().collect::<std::collections::HashSet<_>>();
 
 			assert!(endowed_accounts.len() == config.balances.len(), "duplicate balances in genesis.");
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -412,6 +412,14 @@ decl_storage! {
 					"the balance of any account should always be at least the existential deposit.",
 				)
 			}
+
+			// ensure no duplicates exist.
+			let mut endowed_accounts = config.balances.iter().map(|(x, _)| x).cloned().collect::<Vec<_>>();
+			endowed_accounts.sort();
+			endowed_accounts.dedup();
+
+			assert!(endowed_accounts.len() == config.balances.len(), "duplicate balances in genesis.");
+
 			for &(ref who, free) in config.balances.iter() {
 				T::AccountStore::insert(who, AccountData { free, .. Default::default() });
 			}

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -414,7 +414,7 @@ decl_storage! {
 			}
 
 			// ensure no duplicates exist.
-			let endowed_accounts = config.balances.iter().map(|(x, _)| x).cloned().collect::<std::collections::HashSet<_>>();
+			let endowed_accounts = config.balances.iter().map(|(x, _)| x).cloned().collect::<std::collections::BTreeSet<_>>();
 
 			assert!(endowed_accounts.len() == config.balances.len(), "duplicate balances in genesis.");
 

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -640,6 +640,15 @@ macro_rules! decl_tests {
 		}
 
 		#[test]
+		#[should_panic = "duplicate balances in genesis."]
+		fn cannot_set_genesis_value_twice() {
+			let mut t = frame_system::GenesisConfig::default().build_storage::<$test>().unwrap();
+			let _ = GenesisConfig::<$test> {
+				balances: vec![(1, 10), (2, 20), (1, 15)],
+			}.assimilate_storage(&mut t).unwrap();
+		}
+
+		#[test]
 		fn dust_moves_between_free_and_reserved() {
 			<$ext_builder>::default()
 				.existential_deposit(100)


### PR DESCRIPTION
as reported by https://github.com/paritytech/substrate/issues/7713, almost insubstantial. 