### PR TITLE
Leave some header related info for inspection

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -753,7 +753,7 @@ mod tests {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
 					number: 1,
-					state_root: hex!("9f2b994ea98c4666668fcb8fe6e46ab412e34c6790f4b4f71e471eef4ba63ca7").into(),
+					state_root: hex!("ba1a82a264b8007e0c04c9ea35e541593daad08b6e2bf7c0a6780a67d1c55018").into(),
 					extrinsics_root: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into(),
 					digest: Digest { logs: vec![], },
 				},

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -753,7 +753,7 @@ mod tests {
 				header: Header {
 					parent_hash: [69u8; 32].into(),
 					number: 1,
-					state_root: hex!("6a3ad91caba5b8ac15c325a36d7568adf6a7e49321865de7527b851d870343d4").into(),
+					state_root: hex!("9f2b994ea98c4666668fcb8fe6e46ab412e34c6790f4b4f71e471eef4ba63ca7").into(),
 					extrinsics_root: hex!("03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314").into(),
 					digest: Digest { logs: vec![], },
 				},

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1013,16 +1013,17 @@ impl<T: Config> Module<T> {
 		}
 	}
 
-	/// Remove temporary "environment" entries in storage.
+	/// Remove temporary "environment" entries in storage, compute the storage root and return the
+	/// resulting header for this block.
 	pub fn finalize() -> T::Header {
 		ExecutionPhase::kill();
 		ExtrinsicCount::kill();
 		AllExtrinsicsLen::kill();
 
-		let number = <Number<T>>::take();
-		let parent_hash = <ParentHash<T>>::take();
-		let mut digest = <Digest<T>>::take();
-		let extrinsics_root = <ExtrinsicsRoot<T>>::take();
+		let number = <Number<T>>::get();
+		let parent_hash = <ParentHash<T>>::get();
+		let mut digest = <Digest<T>>::get();
+		let extrinsics_root = <ExtrinsicsRoot<T>>::get();
 
 		// move block hash pruning window by one block
 		let block_hash_count = <T::BlockHashCount>::get();

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1023,7 +1023,7 @@ impl<T: Config> Module<T> {
 		let number = <Number<T>>::get();
 		let parent_hash = <ParentHash<T>>::get();
 		let mut digest = <Digest<T>>::get();
-		let extrinsics_root = <ExtrinsicsRoot<T>>::get();
+		let extrinsics_root = <ExtrinsicsRoot<T>>::take();
 
 		// move block hash pruning window by one block
 		let block_hash_count = <T::BlockHashCount>::get();

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1020,9 +1020,20 @@ impl<T: Config> Module<T> {
 		ExtrinsicCount::kill();
 		AllExtrinsicsLen::kill();
 
+		// The following fields
+		//
+		// - <Events<T>>
+		// - <EventCount<T>>
+		// - <EventTopics<T>>
+		// - <Number<T>>
+		// - <ParentHash<T>>
+		// - <Digest<T>>
+		//
+		// stay to be inspected by the client and will be cleared by `Self::initialize`.
 		let number = <Number<T>>::get();
 		let parent_hash = <ParentHash<T>>::get();
 		let mut digest = <Digest<T>>::get();
+
 		let extrinsics_root = <ExtrinsicsRoot<T>>::take();
 
 		// move block hash pruning window by one block
@@ -1049,14 +1060,6 @@ impl<T: Config> Module<T> {
 			);
 			digest.push(item);
 		}
-
-		// The following fields
-		//
-		// - <Events<T>>
-		// - <EventCount<T>>
-		// - <EventTopics<T>>
-		//
-		// stay to be inspected by the client and will be cleared by `Self::initialize`.
 
 		<T::Header as traits::Header>::new(number, extrinsics_root, storage_root, parent_hash, digest)
 	}


### PR DESCRIPTION
This change leaves some header related data in chain after block finalization, notably the block number.

During working on Polkadot it's been discovered that removing this data eagerly leads to `System::block_number()` to return 0 if called in the context of a runtime API based on an in-chain block. 

This PR solves that by leaving in in-chain until the next call to `on_initialize` where it gets overwritten. While I was at it I also changed that for other header related data.
