### PR TITLE
Improve `InvalidTransaction::AncientBirthBlock` doc comment

### DIFF
--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -55,8 +55,12 @@ pub enum InvalidTransaction {
 	BadProof,
 	/// The transaction birth block is ancient.
 	///
-	/// For `FRAME`-based runtimes this means:
-	/// current block number - `Era::birth` block number > `BlockHashCount`.
+	/// # Possible causes
+	///
+	/// For `FRAME`-based runtimes this would be caused by `current block number
+	/// - Era::birth block number > BlockHashCount`. (e.g. in Polkadot `BlockHashCount` = 2400, so a
+	/// transaction with birth block number 1337 would be valid up until block number 1337 + 2400,
+	/// after which point the transaction would be considered to have an ancient birth block.)
 	AncientBirthBlock,
 	/// The transaction would exhaust the resources of current block.
 	///

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -53,7 +53,8 @@ pub enum InvalidTransaction {
 	/// itself. As the verifying side does not know which additional data was used while signing
 	/// it will only be able to assume a bad signature and cannot express a more meaningful error.
 	BadProof,
-	/// The transaction birth block is ancient.
+	/// The transaction birth block is ancient. For `FRAME`-based runtimes this means:
+	/// current block number - `Era::birth` block number > `BlockHashCount`.
 	AncientBirthBlock,
 	/// The transaction would exhaust the resources of current block.
 	///

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -53,7 +53,9 @@ pub enum InvalidTransaction {
 	/// itself. As the verifying side does not know which additional data was used while signing
 	/// it will only be able to assume a bad signature and cannot express a more meaningful error.
 	BadProof,
-	/// The transaction birth block is ancient. For `FRAME`-based runtimes this means:
+	/// The transaction birth block is ancient.
+	///
+	/// For `FRAME`-based runtimes this means:
 	/// current block number - `Era::birth` block number > `BlockHashCount`.
 	AncientBirthBlock,
 	/// The transaction would exhaust the resources of current block.


### PR DESCRIPTION
The `AncientBirthBlock` transaction validity error is a bit nuanced and the current doc comment relies on a rather cyclical explanation. 

I think giving the reader starting points for clarifying what constitutes a birth block and what makes one ancient is a cheap way to improve the debugging experience for transaction creators. I attempt to do that in this PR while keeping it concise.

I based these off of the [docs here](https://docs.rs/sp-runtime/2.0.0/sp_runtime/generic/enum.Era.html#variant.Mortal) and the [logic here](https://github.com/paritytech/substrate/blob/237874bb15bbac174b6cb8d594053b5512f32ca2/frame/system/src/extensions/check_mortality.rs#L59-L82)

cc @dvdplm, @joepetrowski 