### PR TITLE
Switch back to the crates.io release of trybuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9744,8 +9744,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trybuild"
-version = "1.0.35"
-source = "git+https://github.com/bkchr/trybuild.git?branch=bkchr-use-workspace-cargo-lock#0eaad05ba8a32a743751ff52b57a7d9f57da4869"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b06f8610494cbeb9a7665b398306f0109ab8708296d7f24b0bcd89178bb350"
 dependencies = [
  "dissimilar",
  "glob",

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -21,7 +21,7 @@ sp-inherents = { version = "2.0.0", default-features = false, path = "../../../p
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../../primitives/runtime" }
 sp-core = { version = "2.0.0", default-features = false, path = "../../../primitives/core" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../../primitives/std" }
-trybuild = { git = "https://github.com/bkchr/trybuild.git", branch = "bkchr-use-workspace-cargo-lock" }
+trybuild = "1.0.38"
 pretty_assertions = "0.6.1"
 rustversion = "1.0.0"
 frame-metadata = { version = "12.0.0", default-features = false, path = "../../metadata" }

--- a/primitives/api/test/Cargo.toml
+++ b/primitives/api/test/Cargo.toml
@@ -21,7 +21,7 @@ sp-consensus = { version = "0.8.0", path = "../../consensus/common" }
 sc-block-builder = { version = "0.8.0", path = "../../../client/block-builder" }
 codec = { package = "parity-scale-codec", version = "1.3.1" }
 sp-state-machine = { version = "0.8.0", path = "../../state-machine" }
-trybuild = { git = "https://github.com/bkchr/trybuild.git", branch = "bkchr-use-workspace-cargo-lock" }
+trybuild = "1.0.38"
 rustversion = "1.0.0"
 
 [dev-dependencies]

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -31,7 +31,7 @@ sp-state-machine = { version = "0.8.0", path = "../state-machine" }
 sp-core = { version = "2.0.0", path = "../core" }
 sp-io = { version = "2.0.0", path = "../io" }
 rustversion = "1.0.0"
-trybuild = { git = "https://github.com/bkchr/trybuild.git", branch = "bkchr-use-workspace-cargo-lock" }
+trybuild = "1.0.38"
 
 [features]
 default = [ "std" ]

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "0.2.13", features = ["macros"] }
 
 [dev-dependencies]
 sc-service = { version = "0.8.0", path = "../client/service" }
-trybuild = { git = "https://github.com/bkchr/trybuild.git", branch = "bkchr-use-workspace-cargo-lock", features = [ "diff" ] }
+trybuild = { version = "1.0.38", features = [ "diff" ] }


### PR DESCRIPTION
My fix was merged on upstream and this release contains it. So, no
more reason to keep the git dependency.

