### PR TITLE
Add account prefix for Valiu

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -502,6 +502,8 @@ ss58_address_format!(
 		(32, "robonomics", "Any Robonomics network standard account (*25519).")
 	DataHighwayAccount =>
 		(33, "datahighway", "DataHighway mainnet, standard account (*25519).")
+	ValiuAccount =>
+		(35, "vln", "Valiu Liquidity Network mainnet, standard account (*25519).")
 	CentrifugeAccount =>
 		(36, "centrifuge", "Centrifuge Chain mainnet, standard account (*25519).")
 	NodleAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -281,6 +281,15 @@
 			"website": null
 		},
 		{
+			"prefix": 35,
+			"network": "vln",
+			"displayName": "Valiu Liquidity Network",
+			"symbols": ["USDv"],
+			"decimals": [15],
+			"standardAccount": "*25519",
+			"website": "https://valiu.com/"
+		},
+		{
 			"prefix": 36,
 			"network": "centrifuge",
 			"displayName": "Centrifuge Chain",


### PR DESCRIPTION
Adding a key prefix(35) for the Valiu Liquidity Network mainnet.