### PR TITLE
Add ss58 version prefix for Patract/Jupiter (from PatractHubs)

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -494,6 +494,10 @@ ss58_address_format!(
 		(24, "zero", "ZERO mainnet, standard account (*25519).")
 	AlphavilleAccount =>
 		(25, "alphaville", "ZERO testnet, standard account (*25519).")
+	JupiterAccount =>
+		(26, "jupiter", "Jupiter testnet, standard account (*25519).")
+	PatractAccount =>
+		(27, "patract", "Patract mainnet, standard account (*25519).")
 	SubsocialAccount =>
 		(28, "subsocial", "Subsocial network, standard account (*25519).")
 	PhalaAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -245,6 +245,24 @@
 			"website": "https://zero.io"
 		},
 		{
+			"prefix": 26,
+			"network": "jupiter",
+			"displayName": "Jupiter",
+			"symbols": ["jDOT"],
+			"decimals": [10],
+			"standardAccount": "*25519",
+			"website": "https://jupiter.patract.io"
+		},
+		{
+			"prefix": 27,
+			"network": "patract",
+			"displayName": "Patract",
+			"symbols": ["pDOT", "pKSM"],
+			"decimals": [10, 12],
+			"standardAccount": "*25519",
+			"website": "https://patract.network"
+		},
+		{
 			"prefix": 28,
 			"network": "subsocial",
 			"displayName": "Subsocial",


### PR DESCRIPTION
Adding a key prefix(26/27) for the Jupiter testnet/Patract mainnet.
