### PR TITLE
add a `current_epoch` to BabeApi

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 260,
+	spec_version: 261,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1141,6 +1141,10 @@ impl_runtime_apis! {
 			Babe::current_epoch_start()
 		}
 
+		fn current_epoch() -> sp_consensus_babe::Epoch {
+			Babe::current_epoch()
+		}
+
 		fn generate_key_ownership_proof(
 			_slot_number: sp_consensus_babe::SlotNumber,
 			authority_id: sp_consensus_babe::AuthorityId,

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -43,7 +43,7 @@ use sp_timestamp::OnTimestampSet;
 use sp_consensus_babe::{
 	digests::{NextConfigDescriptor, NextEpochDescriptor, PreDigest},
 	inherents::{BabeInherentData, INHERENT_IDENTIFIER},
-	BabeAuthorityWeight, ConsensusLog, EquivocationProof, SlotNumber, BABE_ENGINE_ID,
+	BabeAuthorityWeight, ConsensusLog, Epoch, EquivocationProof, SlotNumber, BABE_ENGINE_ID,
 };
 use sp_consensus_vrf::schnorrkel;
 use sp_inherents::{InherentData, InherentIdentifier, MakeFatalError, ProvideInherent};
@@ -484,6 +484,17 @@ impl<T: Config> Module<T> {
 	// in the chain (as its result is based off of `GenesisSlot`).
 	pub fn current_epoch_start() -> SlotNumber {
 		(EpochIndex::get() * T::EpochDuration::get()) + GenesisSlot::get()
+	}
+
+	/// Produces information about the current epoch.
+	pub fn current_epoch() -> Epoch {
+		Epoch {
+			epoch_index: EpochIndex::get(),
+			start_slot: Self::current_epoch_start(),
+			duration: T::EpochDuration::get(),
+			authorities: Self::authorities(),
+			randomness: Self::randomness(),
+		}
 	}
 
 	fn deposit_consensus<U: Encode>(new: U) {

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -376,6 +376,9 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn configuration() -> BabeGenesisConfigurationV1;
 
+		/// Returns the slot number that started the current epoch.
+		fn current_epoch_start() -> SlotNumber;
+
 		/// Returns information regarding the current epoch.
 		fn current_epoch() -> Epoch;
 

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -350,6 +350,21 @@ impl OpaqueKeyOwnershipProof {
 	}
 }
 
+/// BABE epoch information
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
+pub struct Epoch {
+	/// The epoch index.
+	pub epoch_index: u64,
+	/// The starting slot of the epoch.
+	pub start_slot: SlotNumber,
+	/// The duration of this epoch.
+	pub duration: SlotNumber,
+	/// The authorities and their weights.
+	pub authorities: Vec<(AuthorityId, BabeAuthorityWeight)>,
+	/// Randomness for this epoch.
+	pub randomness: [u8; VRF_OUTPUT_LENGTH],
+}
+
 sp_api::decl_runtime_apis! {
 	/// API necessary for block authorship with BABE.
 	#[api_version(2)]
@@ -361,8 +376,8 @@ sp_api::decl_runtime_apis! {
 		#[changed_in(2)]
 		fn configuration() -> BabeGenesisConfigurationV1;
 
-		/// Returns the slot number that started the current epoch.
-		fn current_epoch_start() -> SlotNumber;
+		/// Returns information regarding the current epoch.
+		fn current_epoch() -> Epoch;
 
 		/// Generates a proof of key ownership for the given authority in the
 		/// current epoch. An example usage of this module is coupled with the

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -732,6 +732,10 @@ cfg_if! {
 					}
 				}
 
+				fn current_epoch_start() -> sp_consensus_babe::SlotNumber {
+					<pallet_babe::Module<Runtime>>::current_epoch_start()
+				}
+
 				fn current_epoch() -> sp_consensus_babe::Epoch {
 					<pallet_babe::Module<Runtime>>::current_epoch()
 				}
@@ -981,6 +985,10 @@ cfg_if! {
 						randomness: <pallet_babe::Module<Runtime>>::randomness(),
 						allowed_slots: AllowedSlots::PrimaryAndSecondaryPlainSlots,
 					}
+				}
+
+				fn current_epoch_start() -> sp_consensus_babe::SlotNumber {
+					<pallet_babe::Module<Runtime>>::current_epoch_start()
 				}
 
 				fn current_epoch() -> sp_consensus_babe::Epoch {

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -732,8 +732,8 @@ cfg_if! {
 					}
 				}
 
-				fn current_epoch_start() -> SlotNumber {
-					<pallet_babe::Module<Runtime>>::current_epoch_start()
+				fn current_epoch() -> sp_consensus_babe::Epoch {
+					<pallet_babe::Module<Runtime>>::current_epoch()
 				}
 
 				fn submit_report_equivocation_unsigned_extrinsic(
@@ -983,8 +983,8 @@ cfg_if! {
 					}
 				}
 
-				fn current_epoch_start() -> SlotNumber {
-					<pallet_babe::Module<Runtime>>::current_epoch_start()
+				fn current_epoch() -> sp_consensus_babe::Epoch {
+					<pallet_babe::Module<Runtime>>::current_epoch()
 				}
 
 				fn submit_report_equivocation_unsigned_extrinsic(


### PR DESCRIPTION
I wasn't sure exactly which release level or 'B' label to tag this with. I set the 'C' label to medium but I could see it being low as well. We just need to add this runtime API in a runtime upgrade before we enable the approvals protocol.

We either need this or something that lets us inspect the internal state of BABE much better for Polkadot's approval voting protocol which does self-assignment based on randomness derived from the VRF outputs in the header-chain. For that, we need to reconstruct the transcript that the VRF is produced with, which includes the epoch index, authority public key, and epoch randomness.  This API seemed generally useful anyway, and much easier to do than the alternative.

polkadot companion: https://github.com/paritytech/polkadot/pull/2170