### PR TITLE
add a slot-duration getter to babe config

### DIFF
--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -342,6 +342,11 @@ impl Config {
 			}
 		}
 	}
+
+	/// Get the inner slot duration, in milliseconds.
+	pub fn slot_duration(&self) -> u64 {
+		self.0.slot_duration()
+	}
 }
 
 impl std::ops::Deref for Config {


### PR DESCRIPTION
Will be used in approval-voting in Polkadot