### PR TITLE
Lazily evaluate error string

### DIFF
--- a/bin/node-template/node/src/chain_spec.rs
+++ b/bin/node-template/node/src/chain_spec.rs
@@ -39,7 +39,7 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 }
 
 pub fn development_config() -> Result<ChainSpec, String> {
-	let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
+	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
 	Ok(ChainSpec::from_genesis(
 		// Name
@@ -78,7 +78,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 }
 
 pub fn local_testnet_config() -> Result<ChainSpec, String> {
-	let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
+	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
 	Ok(ChainSpec::from_genesis(
 		// Name


### PR DESCRIPTION
This PR updates the node template's `chain_spec.rs` file to comply with Clippy's `or_fun_call` lint. Althoug hSubstrate itself does not enforce Clippy, many projects that start from the node template may, and this is a reasonable change in any case.

According to https://rust-lang.github.io/rust-clippy/master/index.html,

![image](https://user-images.githubusercontent.com/2915325/103233611-8765dd80-490b-11eb-90af-36fd69127535.png)
