### PR TITLE
Don't allow Self Proxies

### DIFF
--- a/frame/proxy/src/lib.rs
+++ b/frame/proxy/src/lib.rs
@@ -168,6 +168,8 @@ decl_error! {
 		NoPermission,
 		/// Announcement, if made at all, was made too recently.
 		Unannounced,
+		/// Cannot add self as proxy.
+		NoSelfProxy,
 	}
 }
 
@@ -567,6 +569,7 @@ impl<T: Config> Module<T> {
 		proxy_type: T::ProxyType,
 		delay: T::BlockNumber,
 	) -> DispatchResult {
+		ensure!(delegator != &delegatee, Error::<T>::NoSelfProxy);
 		Proxies::<T>::try_mutate(delegator, |(ref mut proxies, ref mut deposit)| {
 			ensure!(proxies.len() < T::MaxProxies::get() as usize, Error::<T>::TooMany);
 			let proxy_def = ProxyDefinition { delegate: delegatee, proxy_type, delay };

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -396,6 +396,7 @@ fn add_remove_proxies_works() {
 		assert_eq!(Balances::reserved_balance(1), 2);
 		assert_ok!(Proxy::remove_proxy(Origin::signed(1), 2, ProxyType::JustTransfer, 0));
 		assert_eq!(Balances::reserved_balance(1), 0);
+		assert_noop!(Proxy::add_proxy(Origin::signed(1), 1, ProxyType::Any, 0), Error::<Test>::NoSelfProxy);
 	});
 }
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/7799

AFAIK there is no scenario where it makes sense to make yourself a proxy of your own account... so let's throw an error to avoid people and UIs getting confused.