### PR TITLE
Use Path instead of Ident for Benchmarking `add_benchmark!`

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1072,7 +1072,7 @@ macro_rules! impl_benchmark_test {
 
 #[macro_export]
 macro_rules! add_benchmark {
-	( $params:ident, $batches:ident, $name:ident, $( $location:tt )* ) => (
+	( $params:ident, $batches:ident, $name:path, $( $location:tt )* ) => (
 		let name_string = stringify!($name).as_bytes();
 		let instance_string = stringify!( $( $location )* ).as_bytes();
 		let (config, whitelist) = $params;


### PR DESCRIPTION
This is a insignificant change to the `add_benchmark!` macro where we expect a `path` instead of an `ident` for the name of the crate.

This allows us to use a name like: `runtime_common::claims` where the pallet we are interested in benchmarking is actually a submodule of a crate like `runtime_common`. This allows most automation pipeline to continue to work without needing to fork extra logic, particularly on Polkadot where specific pallets aren't their own crate.

This has a small unfortunate effect that to run a benchmark, you must reference the crate as `runtime_common::claims`, but not much can be done about that I think.