### PR TITLE
Define ss58 prefix inside the runtime

### DIFF
--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -16,6 +16,7 @@ impl_outer_origin! {
 pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
+	pub const SS58Prefix: u8 = 42;
 }
 
 impl system::Config for Test {
@@ -40,6 +41,7 @@ impl system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = SS58Prefix;
 }
 
 impl Config for Test {

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -136,6 +136,7 @@ parameter_types! {
 		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+	pub const SS58Prefix: u8 = 42;
 }
 
 // Configure FRAME pallets to include in runtime.
@@ -185,6 +186,8 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = ();
+	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+	type SS58Prefix = SS58Prefix;
 }
 
 impl pallet_aura::Config for Runtime {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -176,6 +176,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
+	pub const SS58Prefix: u8 = 42;
 }
 
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());
@@ -202,6 +203,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = frame_system::weights::SubstrateWeight<Runtime>;
+	type SS58Prefix = SS58Prefix;
 }
 
 impl pallet_utility::Config for Runtime {

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -952,6 +952,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	parameter_types! {

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -42,6 +42,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -66,6 +66,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl pallet_timestamp::Config for Test {

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -164,6 +164,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	impl_outer_origin! {

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -438,6 +438,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	parameter_types! {

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -86,6 +86,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -77,6 +77,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;

--- a/frame/balances/src/tests_local.rs
+++ b/frame/balances/src/tests_local.rs
@@ -78,6 +78,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = Module<Test>;
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const TransactionByteFee: u64 = 1;

--- a/frame/benchmarking/src/tests.rs
+++ b/frame/benchmarking/src/tests.rs
@@ -94,6 +94,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl Config for Test {

--- a/frame/bounties/src/tests.rs
+++ b/frame/bounties/src/tests.rs
@@ -82,6 +82,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -996,6 +996,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	impl Config<Instance1> for Test {
 		type Origin = Origin;

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -130,6 +130,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();

--- a/frame/democracy/src/tests.rs
+++ b/frame/democracy/src/tests.rs
@@ -113,6 +113,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) * BlockWeights::get().max_block;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1099,6 +1099,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+	type SS58Prefix = ();
 	}
 
 	parameter_types! {

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -57,6 +57,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -76,6 +76,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 type Extrinsic = TestXt<Call<Test>, ()>;

--- a/frame/example-parallel/src/tests.rs
+++ b/frame/example-parallel/src/tests.rs
@@ -59,6 +59,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/example/src/lib.rs
+++ b/frame/example/src/lib.rs
@@ -764,6 +764,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 1;

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -618,6 +618,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	type Balance = u64;

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -100,6 +100,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Test

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -63,6 +63,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -130,6 +130,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/indices/src/mock.rs
+++ b/frame/indices/src/mock.rs
@@ -69,6 +69,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -321,6 +321,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	ord_parameter_types! {
 		pub const One: u64 = 1;

--- a/frame/merkle-mountain-range/src/mock.rs
+++ b/frame/merkle-mountain-range/src/mock.rs
@@ -63,6 +63,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl Config for Test {

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -80,6 +80,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -283,6 +283,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	parameter_types! {
 		pub const ExistentialDeposit: u64 = 1;

--- a/frame/node-authorization/src/lib.rs
+++ b/frame/node-authorization/src/lib.rs
@@ -472,6 +472,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	ord_parameter_types! {

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -63,6 +63,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = (Balances,);
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;

--- a/frame/offences/src/mock.rs
+++ b/frame/offences/src/mock.rs
@@ -116,6 +116,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -82,6 +82,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -180,6 +180,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	type System = frame_system::Module<Test>;

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -78,6 +78,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 parameter_types! {

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -837,6 +837,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+	type SS58Prefix = ();
 	}
 	impl logger::Config for Test {
 		type Event = ();

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -68,6 +68,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl pallet_balances::Config for Test {

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -67,6 +67,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = Balances;
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -218,6 +218,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl pallet_timestamp::Config for Test {

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -78,6 +78,7 @@ impl frame_system::Config for Test {
 	type OnKilledAccount = ();
 	type AccountData = pallet_balances::AccountData<u64>;
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl pallet_balances::Config for Test {

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -65,6 +65,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = (Balances,);
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -166,6 +166,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet_balances::Config for Test {
 	type MaxLocks = MaxLocks;

--- a/frame/sudo/src/mock.rs
+++ b/frame/sudo/src/mock.rs
@@ -139,6 +139,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 // Implement the logger module's `Config` on the Test runtime.

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -364,6 +364,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet::Config for Runtime {
 	type Event = Event;

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -226,6 +226,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet::Config for Runtime {
 	type Event = Event;

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -218,6 +218,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet::Config for Runtime {
 	type Event = Event;

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -259,6 +259,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 impl pallet::Config for Runtime {
 	type Event = Event;

--- a/frame/support/test/tests/pallet_version.rs
+++ b/frame/support/test/tests/pallet_version.rs
@@ -165,6 +165,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 frame_support::construct_runtime!(

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -141,6 +141,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	impl pallet_test::Trait for Runtime {

--- a/frame/system/benches/bench.rs
+++ b/frame/system/benches/bench.rs
@@ -87,6 +87,7 @@ impl system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl module::Config for Runtime {

--- a/frame/system/benchmarking/src/mock.rs
+++ b/frame/system/benchmarking/src/mock.rs
@@ -72,6 +72,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl crate::Config for Test {}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -257,6 +257,13 @@ pub trait Config: 'static + Eq + Clone {
 	type OnKilledAccount: OnKilledAccount<Self::AccountId>;
 
 	type SystemWeightInfo: WeightInfo;
+
+	/// The designated SS85 prefix of this chain.
+	///
+	/// This replaces the "ss58Format" property declared in the chain spec. Reason is
+	/// that the runtime should know about the prefix in order to make use of it as
+	/// an identifier of the chain.
+	type SS58Prefix: Get<u8>;
 }
 
 pub type DigestOf<T> = generic::Digest<<T as Config>::Hash>;
@@ -515,6 +522,13 @@ decl_module! {
 
 		/// The weight configuration (limits & base values) for each class of extrinsics and block.
 		const BlockWeights: limits::BlockWeights = T::BlockWeights::get();
+
+		/// The designated SS85 prefix of this chain.
+		///
+		/// This replaces the "ss58Format" property declared in the chain spec. Reason is
+		/// that the runtime should know about the prefix in order to make use of it as
+		/// an identifier of the chain.
+		const SS58Prefix: u8 = T::SS58Prefix::get();
 
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
 			if !UpgradedToU32RefCount::get() {

--- a/frame/system/src/mock.rs
+++ b/frame/system/src/mock.rs
@@ -117,6 +117,7 @@ impl Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = RecordKilled;
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 pub type System = Module<Test>;

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -335,6 +335,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	parameter_types! {
 		pub const MinimumPeriod: u64 = 5;

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -81,6 +81,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
@@ -292,28 +293,28 @@ fn slash_tip_works() {
 		System::set_block_number(1);
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
-		
+
 		assert_eq!(Balances::reserved_balance(0), 0);
 		assert_eq!(Balances::free_balance(0), 100);
-		
+
 		assert_ok!(TipsModTestInst::report_awesome(Origin::signed(0), b"awesome.dot".to_vec(), 3));
-		
+
 		assert_eq!(Balances::reserved_balance(0), 12);
 		assert_eq!(Balances::free_balance(0), 88);
-		
+
 		let h = tip_hash();
 		assert_eq!(last_event(), RawEvent::NewTip(h));
-		
+
 		// can't remove from any origin
 		assert_noop!(
 			TipsModTestInst::slash_tip(Origin::signed(0), h.clone()),
 			BadOrigin,
 		);
-		
+
 		// can remove from root.
 		assert_ok!(TipsModTestInst::slash_tip(Origin::root(), h.clone()));
 		assert_eq!(last_event(), RawEvent::TipSlashed(h, 0, 12));
-		
+
 		// tipper slashed
 		assert_eq!(Balances::reserved_balance(0), 0);
 		assert_eq!(Balances::free_balance(0), 88);

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -662,6 +662,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 
 	parameter_types! {

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -80,6 +80,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -118,6 +118,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -433,6 +433,7 @@ mod tests {
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
+		type SS58Prefix = ();
 	}
 	parameter_types! {
 		pub const MaxLocks: u32 = 10;

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -170,9 +170,6 @@ pub trait Externalities: ExtensionStore {
 		value: Option<Vec<u8>>,
 	);
 
-	/// Get the identity of the chain.
-	fn chain_id(&self) -> u64;
-
 	/// Get the trie root of the current storage map.
 	///
 	/// This will also update all child storage keys in the top-level storage map.

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -388,11 +388,6 @@ pub trait Trie {
 /// Interface that provides miscellaneous functions for communicating between the runtime and the node.
 #[runtime_interface]
 pub trait Misc {
-	/// The current relay chain identifier.
-	fn chain_id(&self) -> u64 {
-		sp_externalities::Externalities::chain_id(*self)
-	}
-
 	/// Print a number.
 	fn print_num(val: u64) {
 		log::debug!(target: "runtime", "{}", val);

--- a/primitives/state-machine/src/basic.rs
+++ b/primitives/state-machine/src/basic.rs
@@ -263,8 +263,6 @@ impl Externalities for BasicExternalities {
 		crate::ext::StorageAppend::new(current).append(value);
 	}
 
-	fn chain_id(&self) -> u64 { 42 }
-
 	fn storage_root(&mut self) -> Vec<u8> {
 		let mut top = self.inner.top.clone();
 		let prefixed_keys: Vec<_> = self.inner.children_default.iter().map(|(_k, v)| {

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -507,10 +507,6 @@ where
 		StorageAppend::new(current_value).append(value);
 	}
 
-	fn chain_id(&self) -> u64 {
-		42
-	}
-
 	fn storage_root(&mut self) -> Vec<u8> {
 		let _guard = guard();
 		if let Some(ref root) = self.storage_transaction_cache.transaction_storage_root {

--- a/primitives/state-machine/src/read_only.rs
+++ b/primitives/state-machine/src/read_only.rs
@@ -156,8 +156,6 @@ impl<'a, H: Hasher, B: 'a + Backend<H>> Externalities for ReadOnlyExternalities<
 		unimplemented!("storage_append is not supported in ReadOnlyExternalities")
 	}
 
-	fn chain_id(&self) -> u64 { 42 }
-
 	fn storage_root(&mut self) -> Vec<u8> {
 		unimplemented!("storage_root is not supported in ReadOnlyExternalities")
 	}

--- a/primitives/tasks/src/async_externalities.rs
+++ b/primitives/tasks/src/async_externalities.rs
@@ -143,8 +143,6 @@ impl Externalities for AsyncExternalities {
 		panic!("`storage_append`: should not be used in async externalities!")
 	}
 
-	fn chain_id(&self) -> u64 { 42 }
-
 	fn storage_root(&mut self) -> Vec<u8> {
 		panic!("`storage_root`: should not be used in async externalities!")
 	}

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -462,6 +462,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = ();
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
Historically, the ss58 prefix is declared as a [property of a chain spec](https://github.com/paritytech/substrate/blob/b44221489f0c491e2b1d797a9c7f65ef6f045ed6/client/chain-spec/src/lib.rs#L145). These properties are inaccessible for the runtime but [can be queried verbatim by any RPC client](https://github.com/paritytech/substrate/blob/b44221489f0c491e2b1d797a9c7f65ef6f045ed6/client/rpc-api/src/system/mod.rs#L52-L54) in order to learn about the prefix of a chain along with other properties like the currency symbol or denomination.

While ss58 parsing is firmly **not**  one of the runtime's responsibilities there are other reasons why the runtime might want to know about this prefix. One of them is using it as an identifier of the chain. At least in order to expose it to contracts. 

To that end we promote the ss58 prefix from a chain spec property to a member of the frame_system configuration trait so that the runtime is aware of this value. The frame_system module exposes it in its metadata so that rpc clients can access it. The chain spec property based approach to learn about the ss58 prefix is therefore considered deprecated. @jacogr 

There is a `fn chain_id` [runtime interface](https://github.com/paritytech/substrate/blob/b44221489f0c491e2b1d797a9c7f65ef6f045ed6/primitives/io/src/lib.rs#L391-L394) that is supposed to expose an identifier to the runtime but it was never properly implemented (it returned hardcoded 42). This PR removes removes this unused interface because the ss58 prefix should be used as identifier (or any other identifier determined by the runtime).

polkadot companion: https://github.com/paritytech/polkadot/pull/2182