### PR TITLE
Fix ss58check test when executed with other tests

### DIFF
--- a/primitives/core/src/ecdsa.rs
+++ b/primitives/core/src/ecdsa.rs
@@ -678,18 +678,34 @@ mod test {
 
 	#[test]
 	fn ss58check_custom_format_works() {
-		use crate::crypto::Ss58AddressFormat;
-		// temp save default format version
-		let default_format = Ss58AddressFormat::default();
-		// set current ss58 version is custom "200" `Ss58AddressFormat::Custom(200)`
-		set_default_ss58_version(Ss58AddressFormat::Custom(200));
-		// custom addr encoded by version 200
-		let addr = "2X64kMNEWAW5KLZMSKcGKEc96MyuaRsRUku7vomuYxKgqjVCRj";
-		Public::from_ss58check(&addr).unwrap();
-		set_default_ss58_version(default_format);
-		// set  current ss58 version to default version
-		let addr = "KWAfgC2aRG5UVD6CpbPQXCx4YZZUhvWqqAJE6qcYc9Rtr6g5C";
-		Public::from_ss58check(&addr).unwrap();
+		// We need to run this test in its own process to not interfere with other tests running in
+		// parallel and also relying on the ss58 version.
+		if std::env::var("RUN_CUSTOM_FORMAT_TEST") == Ok("1".into()) {
+			use crate::crypto::Ss58AddressFormat;
+			// temp save default format version
+			let default_format = Ss58AddressFormat::default();
+			// set current ss58 version is custom "200" `Ss58AddressFormat::Custom(200)`
+			set_default_ss58_version(Ss58AddressFormat::Custom(200));
+			// custom addr encoded by version 200
+			let addr = "2X64kMNEWAW5KLZMSKcGKEc96MyuaRsRUku7vomuYxKgqjVCRj";
+			Public::from_ss58check(&addr).unwrap();
+			set_default_ss58_version(default_format);
+			// set current ss58 version to default version
+			let addr = "KWAfgC2aRG5UVD6CpbPQXCx4YZZUhvWqqAJE6qcYc9Rtr6g5C";
+			Public::from_ss58check(&addr).unwrap();
+
+			println!("CUSTOM_FORMAT_SUCCESSFUL");
+		} else {
+			let executable = std::env::current_exe().unwrap();
+			let output = std::process::Command::new(executable)
+				.env("RUN_CUSTOM_FORMAT_TEST", "1")
+				.args(&["--nocapture", "ss58check_custom_format_works"])
+				.output()
+				.unwrap();
+
+			let output = String::from_utf8(output.stdout).unwrap();
+			assert!(output.contains("CUSTOM_FORMAT_SUCCESSFUL"));
+		}
 	}
 
 	#[test]


### PR DESCRIPTION
There was a bug that could make other ss58 tests fail when being
executed with this one in parallel. This test changes the default ss58
version and if other tests are run at the time the default version is
changed, they would fail. To fix this problem, we now run the actual
test as a new process.

