### PR TITLE
contracts: Prevent contracts from allocating a too large buffer

### DIFF
--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -110,6 +110,13 @@ pub struct Limits {
 	pub code_size: u32,
 }
 
+impl Limits {
+	/// The maximum memory size in bytes that a contract can occupy.
+	pub fn max_memory_size(&self) -> u32 {
+		self.memory_pages * 64 * 1024
+	}
+}
+
 /// Describes the weight for all categories of supported wasm instructions.
 ///
 /// There there is one field for each wasm instruction that describes the weight to

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -23,10 +23,8 @@ use crate::{
 	gas::{Gas, GasMeter, Token, GasMeterResult, ChargedAmount},
 	wasm::env_def::ConvertibleToWasm,
 };
-use sp_sandbox;
 use parity_wasm::elements::ValueType;
-use frame_system;
-use frame_support::dispatch::DispatchError;
+use frame_support::{dispatch::DispatchError, ensure};
 use sp_std::prelude::*;
 use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::traits::SaturatedConversion;
@@ -420,6 +418,7 @@ where
 	pub fn read_sandbox_memory(&self, ptr: u32, len: u32)
 	-> Result<Vec<u8>, DispatchError>
 	{
+		ensure!(len <= self.schedule.limits.max_memory_size(), Error::<E::T>::OutOfBounds);
 		let mut buf = vec![0u8; len as usize];
 		self.memory.get(ptr, buf.as_mut_slice())
 			.map_err(|_| Error::<E::T>::OutOfBounds)?;
@@ -1179,17 +1178,22 @@ define_env!(Env, <E: Ext>,
 		let rent_allowance: BalanceOf<<E as Ext>::T> =
 			ctx.read_sandbox_memory_as(rent_allowance_ptr, rent_allowance_len)?;
 		let delta = {
+			const KEY_SIZE: usize = 32;
+
 			// We can eagerly allocate because we charged for the complete delta count already
-			let mut delta = Vec::with_capacity(delta_count as usize);
+			// We still need to make sure that the allocation isn't larger than the memory
+			// allocator can handle.
+			ensure!(
+				delta_count * KEY_SIZE as u32 <= ctx.schedule.limits.max_memory_size(),
+				Error::<E::T>::OutOfBounds,
+			);
+			let mut delta = vec![[0; KEY_SIZE]; delta_count as usize];
 			let mut key_ptr = delta_ptr;
 
-			for _ in 0..delta_count {
-				const KEY_SIZE: usize = 32;
-
-				// Read the delta into the provided buffer and collect it into the buffer.
-				let mut delta_key: StorageKey = [0; KEY_SIZE];
-				ctx.read_sandbox_memory_into_buf(key_ptr, &mut delta_key)?;
-				delta.push(delta_key);
+			for i in 0..delta_count {
+				// Read the delta into the provided buffer
+				// This cannot panic because of the loop condition
+				ctx.read_sandbox_memory_into_buf(key_ptr, &mut delta[i as usize])?;
 
 				// Offset key_ptr to the next element.
 				key_ptr = key_ptr.checked_add(KEY_SIZE as u32).ok_or(Error::<E::T>::OutOfBounds)?;

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -1184,7 +1184,8 @@ define_env!(Env, <E: Ext>,
 			// We still need to make sure that the allocation isn't larger than the memory
 			// allocator can handle.
 			ensure!(
-				delta_count * KEY_SIZE as u32 <= ctx.schedule.limits.max_memory_size(),
+				delta_count
+					.saturating_mul(KEY_SIZE as u32) <= ctx.schedule.limits.max_memory_size(),
 				Error::<E::T>::OutOfBounds,
 			);
 			let mut delta = vec![[0; KEY_SIZE]; delta_count as usize];


### PR DESCRIPTION
Fixes #5379

This fixes a possibly exploitable issues with regard to the memory allocator:

When reading from contract memory a buffer to hold this memory inside the runtime was pre-allocated with a size supplied by the untrusted contract. While the gas for allocating such a buffer is charged before allocatting it is still possible that the sender is able to pay for a buffer that is larger than the maximum allowed allocation size (16MiB) which will in turn panic the runtime opening up a DoS vector.