### PR TITLE
Fix the upgrade helper provided by decl_storage

### DIFF
--- a/frame/support/procedural/src/storage/print_pallet_upgrade.rs
+++ b/frame/support/procedural/src/storage/print_pallet_upgrade.rs
@@ -323,10 +323,6 @@ pub mod pallet {{
 	#[pallet::generate_store({store_vis} trait Store)]
 	pub struct Pallet{decl_gen}(PhantomData{use_gen_tuple});
 
-	/// Old name for pallet.
-	#[deprecated(note=\"use `Pallet` instead\")]
-	pub type Module{decl_gen} = Pallet{use_gen};
-
 	#[pallet::interface]
 	impl{impl_gen} Hooks<BlockNumberFor<T>> for Pallet{use_gen}
 		// TODO_MAYBE_WHERE_CLAUSE


### PR DESCRIPTION
In the last iteration of pallet macro we made the macro declare `Module` type alias to be used by construct_runtime (instead of changing construct_runtime).
Thus the helper provided by decl_storage is wrong.