### PR TITLE
babe: expose next epoch data

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1160,6 +1160,10 @@ impl_runtime_apis! {
 			Babe::current_epoch()
 		}
 
+		fn next_epoch() -> sp_consensus_babe::Epoch {
+			Babe::next_epoch()
+		}
+
 		fn generate_key_ownership_proof(
 			_slot_number: sp_consensus_babe::SlotNumber,
 			authority_id: sp_consensus_babe::AuthorityId,

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -64,6 +64,8 @@ pub use equivocation::{BabeEquivocationOffence, EquivocationHandler, HandleEquiv
 
 pub trait Config: pallet_timestamp::Config {
 	/// The amount of time, in slots, that each epoch should last.
+	/// NOTE: Currently it is not possible to change the epoch duration after
+	/// the chain has started. Attempting to do so will brick block production.
 	type EpochDuration: Get<SlotNumber>;
 
 	/// The expected average block time at which BABE should be creating
@@ -236,6 +238,9 @@ decl_module! {
 	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		/// The number of **slots** that an epoch takes. We couple sessions to
 		/// epochs, i.e. we start a new session once the new epoch begins.
+		/// NOTE: Currently it is not possible to change the epoch duration
+		/// after the chain has started. Attempting to do so will brick block
+		/// production.
 		const EpochDuration: u64 = T::EpochDuration::get();
 
 		/// The expected average block time at which BABE should be creating

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -504,7 +504,8 @@ impl<T: Config> Module<T> {
 		}
 	}
 
-	/// Produces information about the next epoch.
+	/// Produces information about the next epoch (which was already previously
+	/// announced).
 	pub fn next_epoch() -> Epoch {
 		let next_epoch_index = EpochIndex::get() + 1;
 

--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -468,12 +468,11 @@ impl<T: Config> Module<T> {
 		Randomness::put(randomness);
 
 		// Update the next epoch authorities.
-		NextAuthorities::put(next_authorities);
+		NextAuthorities::put(&next_authorities);
 
 		// After we update the current epoch, we signal the *next* epoch change
 		// so that nodes can track changes.
 		let next_randomness = NextRandomness::get();
-		let next_authorities = NextAuthorities::get();
 
 		let next_epoch = NextEpochDescriptor {
 			authorities: next_authorities,

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -295,7 +295,7 @@ pub fn start_era(era_index: EraIndex) {
 	assert_eq!(Staking::current_era(), Some(era_index));
 }
 
-pub fn make_pre_digest(
+pub fn make_primary_pre_digest(
 	authority_index: sp_consensus_babe::AuthorityIndex,
 	slot_number: sp_consensus_babe::SlotNumber,
 	vrf_output: VRFOutput,

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -66,7 +66,7 @@ fn first_block_epoch_zero_start() {
 		let (vrf_output, vrf_proof, vrf_randomness) = make_vrf_output(genesis_slot, &pairs[0]);
 
 		let first_vrf = vrf_output;
-		let pre_digest = make_pre_digest(
+		let pre_digest = make_primary_pre_digest(
 			0,
 			genesis_slot,
 			first_vrf.clone(),
@@ -122,7 +122,7 @@ fn author_vrf_output_for_primary() {
 	ext.execute_with(|| {
 		let genesis_slot = 10;
 		let (vrf_output, vrf_proof, vrf_randomness) = make_vrf_output(genesis_slot, &pairs[0]);
-		let primary_pre_digest = make_pre_digest(0, genesis_slot, vrf_output, vrf_proof);
+		let primary_pre_digest = make_primary_pre_digest(0, genesis_slot, vrf_output, vrf_proof);
 
 		System::initialize(
 			&1,
@@ -249,6 +249,33 @@ fn can_enact_next_config() {
 		let consensus_digest = DigestItem::Consensus(BABE_ENGINE_ID, consensus_log.encode());
 
 		assert_eq!(header.digest.logs[2], consensus_digest.clone())
+	});
+}
+
+#[test]
+fn can_fetch_current_and_next_epoch_data() {
+	new_test_ext(5).execute_with(|| {
+		// 1 era = 3 epochs
+		// 1 epoch = 3 slots
+		// Eras start from 0.
+		// Therefore at era 1 we should be starting epoch 3 with slot 10.
+		start_era(1);
+
+		let current_epoch = Babe::current_epoch();
+		assert_eq!(current_epoch.epoch_index, 3);
+		assert_eq!(current_epoch.start_slot, 10);
+		assert_eq!(current_epoch.authorities.len(), 5);
+
+		let next_epoch = Babe::next_epoch();
+		assert_eq!(next_epoch.epoch_index, 4);
+		assert_eq!(next_epoch.start_slot, 13);
+		assert_eq!(next_epoch.authorities.len(), 5);
+
+		// the on-chain randomness should always change across epochs
+		assert!(current_epoch.randomness != next_epoch.randomness);
+
+		// but in this case the authorities stay the same
+		assert!(current_epoch.authorities == next_epoch.authorities);
 	});
 }
 

--- a/primitives/consensus/babe/src/lib.rs
+++ b/primitives/consensus/babe/src/lib.rs
@@ -382,6 +382,10 @@ sp_api::decl_runtime_apis! {
 		/// Returns information regarding the current epoch.
 		fn current_epoch() -> Epoch;
 
+		/// Returns information regarding the next epoch (which was already
+		/// previously announced).
+		fn next_epoch() -> Epoch;
+
 		/// Generates a proof of key ownership for the given authority in the
 		/// current epoch. An example usage of this module is coupled with the
 		/// session historical module to prove that a given authority key is

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -741,6 +741,10 @@ cfg_if! {
 					<pallet_babe::Module<Runtime>>::current_epoch()
 				}
 
+				fn next_epoch() -> sp_consensus_babe::Epoch {
+					<pallet_babe::Module<Runtime>>::next_epoch()
+				}
+
 				fn submit_report_equivocation_unsigned_extrinsic(
 					_equivocation_proof: sp_consensus_babe::EquivocationProof<
 						<Block as BlockT>::Header,
@@ -994,6 +998,10 @@ cfg_if! {
 
 				fn current_epoch() -> sp_consensus_babe::Epoch {
 					<pallet_babe::Module<Runtime>>::current_epoch()
+				}
+
+				fn next_epoch() -> sp_consensus_babe::Epoch {
+					<pallet_babe::Module<Runtime>>::next_epoch()
 				}
 
 				fn submit_report_equivocation_unsigned_extrinsic(


### PR DESCRIPTION
In BABE next epoch data is announced one epoch in advance, i.e. when we start epoch N we announce the details for epoch N+1. Currently the information about the upcoming epoch is not exposed from the runtime, this PR adds a runtime API to be able to query this data. This will be useful for warp sync clients that will rely on finality to warp to the latest block (i.e. GRANDPA) and will thus be able to fetch all epoch data necessary to validate subsequent BABE blocks from the runtime (rather than having to fetch this data from past block headers).

polkadot companion: https://github.com/paritytech/polkadot/pull/2200