### PR TITLE
Improve spans of pallet macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
 name = "frame-support-procedural"
 version = "2.0.0"
 dependencies = [
+ "Inflector",
  "frame-support-procedural-tools",
  "proc-macro2",
  "quote",

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 frame-support-procedural-tools = { version = "2.0.0", path = "./tools" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
+Inflector = "0.11.4"
 syn = { version = "1.0.7", features = ["full"] }
 
 [features]

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -24,9 +24,9 @@ use syn::spanned::Spanned;
 pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let frame_system = &def.frame_system;
-	let type_impl_gen = &def.type_impl_generics();
-	let type_decl_bounded_gen = &def.type_decl_bounded_generics();
-	let type_use_gen = &def.type_use_generics();
+	let type_impl_gen = &def.type_impl_generics(def.call.attr_span);
+	let type_decl_bounded_gen = &def.type_decl_bounded_generics(def.call.attr_span);
+	let type_use_gen = &def.type_use_generics(def.call.attr_span);
 	let call_ident = syn::Ident::new("Call", def.call.attr_span.clone());
 	let pallet_ident = &def.pallet_struct.pallet;
 	let where_clause = &def.call.where_clause;
@@ -61,7 +61,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 		method.args.iter()
 			.map(|(is_compact, _, type_)| {
 				let final_type = if *is_compact {
-					quote::quote!(Compact<#type_>)
+					quote::quote_spanned!(type_.span() => Compact<#type_>)
 				} else {
 					quote::quote!(#type_)
 				};

--- a/frame/support/procedural/src/pallet/expand/constants.rs
+++ b/frame/support/procedural/src/pallet/expand/constants.rs
@@ -33,9 +33,9 @@ struct ConstDef {
 /// * Impl fn module_constant_metadata for pallet.
 pub fn expand_constants(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
-	let type_impl_gen = &def.type_impl_generics();
-	let type_decl_gen = &def.type_decl_generics();
-	let type_use_gen = &def.type_use_generics();
+	let type_impl_gen = &def.type_impl_generics(proc_macro2::Span::call_site());
+	let type_decl_gen = &def.type_decl_generics(proc_macro2::Span::call_site());
+	let type_use_gen = &def.type_use_generics(proc_macro2::Span::call_site());
 	let pallet_ident = &def.pallet_struct.pallet;
 
 	let mut where_clauses = vec![&def.config.where_clause];

--- a/frame/support/procedural/src/pallet/expand/hooks.rs
+++ b/frame/support/procedural/src/pallet/expand/hooks.rs
@@ -16,21 +16,17 @@
 // limitations under the License.
 
 use crate::pallet::Def;
-use syn::spanned::Spanned;
 
 /// * implement the individual traits using the Hooks trait
 pub fn expand_hooks(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
-	let type_impl_gen = &def.type_impl_generics();
-	let type_use_gen = &def.type_use_generics();
+	let type_impl_gen = &def.type_impl_generics(def.hooks.attr_span);
+	let type_use_gen = &def.type_use_generics(def.hooks.attr_span);
 	let pallet_ident = &def.pallet_struct.pallet;
 	let where_clause = &def.hooks.where_clause;
 	let frame_system = &def.frame_system;
 
-	let hooks_item_span = def.item.content.as_mut()
-		.expect("Checked by def parser").1[def.hooks.index].span();
-
-	quote::quote_spanned!(hooks_item_span =>
+	quote::quote_spanned!(def.hooks.attr_span =>
 		impl<#type_impl_gen>
 			#frame_support::traits::OnFinalize<<T as #frame_system::Config>::BlockNumber>
 			for #pallet_ident<#type_use_gen> #where_clause

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -25,9 +25,9 @@ use crate::pallet::Def;
 pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let frame_system = &def.frame_system;
-	let type_impl_gen = &def.type_impl_generics();
-	let type_use_gen = &def.type_use_generics();
-	let type_decl_gen = &def.type_decl_generics();
+	let type_impl_gen = &def.type_impl_generics(def.pallet_struct.attr_span);
+	let type_use_gen = &def.type_use_generics(def.pallet_struct.attr_span);
+	let type_decl_gen = &def.type_decl_generics(def.pallet_struct.attr_span);
 	let pallet_ident = &def.pallet_struct.pallet;
 	let config_where_clause = &def.config.where_clause;
 
@@ -52,7 +52,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 
 	let module_error_metadata = if let Some(error_def) = &def.error {
 		let error_ident = &error_def.error;
-		quote::quote!(
+		quote::quote_spanned!(def.pallet_struct.attr_span =>
 			impl<#type_impl_gen> #frame_support::error::ModuleErrorMetadata
 				for #pallet_ident<#type_use_gen>
 				#config_where_clause
@@ -65,7 +65,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			}
 		)
 	} else {
-		quote::quote!(
+		quote::quote_spanned!(def.pallet_struct.attr_span =>
 			impl<#type_impl_gen> #frame_support::error::ModuleErrorMetadata
 				for #pallet_ident<#type_use_gen>
 				#config_where_clause
@@ -77,7 +77,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		)
 	};
 
-	quote::quote!(
+	quote::quote_spanned!(def.pallet_struct.attr_span =>
 		#module_error_metadata
 
 		/// Type alias to `Pallet`, to be used by `construct_runtime`.

--- a/frame/support/procedural/src/pallet/expand/store_trait.rs
+++ b/frame/support/procedural/src/pallet/expand/store_trait.rs
@@ -28,8 +28,8 @@ pub fn expand_store_trait(def: &mut Def) -> proc_macro2::TokenStream {
 		return Default::default()
 	};
 
-	let type_impl_gen = &def.type_impl_generics();
-	let type_use_gen = &def.type_use_generics();
+	let type_impl_gen = &def.type_impl_generics(trait_store.span());
+	let type_use_gen = &def.type_use_generics(trait_store.span());
 	let pallet_ident = &def.pallet_struct.pallet;
 
 	let mut where_clauses = vec![&def.config.where_clause];

--- a/frame/support/procedural/src/pallet/expand/type_value.rs
+++ b/frame/support/procedural/src/pallet/expand/type_value.rs
@@ -16,38 +16,55 @@
 // limitations under the License.
 
 use crate::pallet::Def;
-use syn::spanned::Spanned;
 
 /// * Generate the struct
 /// * implement the `Get<..>` on it
+/// * Rename the name of the function to internal name
 pub fn expand_type_values(def: &mut Def) -> proc_macro2::TokenStream {
 	let mut expand = quote::quote!();
 	let frame_support = &def.frame_support;
 
 	for type_value in &def.type_values {
-		// Remove item from module content
-		let item = &mut def.item.content.as_mut().expect("Checked by def").1[type_value.index];
-		let span = item.span();
-		*item = syn::Item::Verbatim(Default::default());
+		let fn_ident_renamed = syn::Ident::new(
+			&format!("__type_value_for_{}", type_value.ident),
+			type_value.ident.span(),
+		);
+
+		let type_value_item = {
+			let item = &mut def.item.content.as_mut().expect("Checked by def").1[type_value.index];
+			if let syn::Item::Fn(item) = item {
+				item
+			} else {
+				unreachable!("Checked by error parser")
+			}
+		};
+
+		// Rename the type_value function name
+		type_value_item.sig.ident = fn_ident_renamed.clone();
+		type_value_item.attrs.push(syn::parse_quote!(#[allow(non_snake_case)]));
 
 		let vis = &type_value.vis;
 		let ident = &type_value.ident;
-		let block = &type_value.block;
 		let type_ = &type_value.type_;
 		let where_clause = &type_value.where_clause;
 
 		let (struct_impl_gen, struct_use_gen) = if type_value.is_generic {
-			(def.type_impl_generics(), def.type_use_generics())
+			(
+				def.type_impl_generics(type_value.attr_span),
+				def.type_use_generics(type_value.attr_span),
+			)
 		} else {
 			(Default::default(), Default::default())
 		};
 
-		expand.extend(quote::quote_spanned!(span =>
+		expand.extend(quote::quote_spanned!(type_value.attr_span =>
 			#vis struct #ident<#struct_use_gen>(core::marker::PhantomData<((), #struct_use_gen)>);
 			impl<#struct_impl_gen> #frame_support::traits::Get<#type_> for #ident<#struct_use_gen>
 			#where_clause
 			{
-				fn get() -> #type_ #block
+				fn get() -> #type_ {
+					#fn_ident_renamed::<#struct_use_gen>()
+				}
 			}
 		));
 	}

--- a/frame/support/procedural/src/pallet/expand/type_value.rs
+++ b/frame/support/procedural/src/pallet/expand/type_value.rs
@@ -25,8 +25,10 @@ pub fn expand_type_values(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 
 	for type_value in &def.type_values {
+		let fn_name_str = &type_value.ident.to_string();
+		let fn_name_snakecase = inflector::cases::snakecase::to_snake_case(fn_name_str);
 		let fn_ident_renamed = syn::Ident::new(
-			&format!("__type_value_for_{}", type_value.ident),
+			&format!("__type_value_for_{}", fn_name_snakecase),
 			type_value.ident.span(),
 		);
 
@@ -41,7 +43,6 @@ pub fn expand_type_values(def: &mut Def) -> proc_macro2::TokenStream {
 
 		// Rename the type_value function name
 		type_value_item.sig.ident = fn_ident_renamed.clone();
-		type_value_item.attrs.push(syn::parse_quote!(#[allow(non_snake_case)]));
 
 		let vis = &type_value.vis;
 		let ident = &type_value.ident;

--- a/frame/support/procedural/src/pallet/parse/call.rs
+++ b/frame/support/procedural/src/pallet/parse/call.rs
@@ -40,7 +40,7 @@ pub struct CallDef {
 	pub index: usize,
 	/// Information on methods (used for expansion).
 	pub methods: Vec<CallVariantDef>,
-	/// The span of the attribute.
+	/// The span of the pallet::call attribute.
 	pub attr_span: proc_macro2::Span,
 }
 
@@ -124,7 +124,6 @@ pub fn check_dispatchable_first_arg_type(ty: &syn::Type) -> syn::Result<()> {
 
 impl CallDef {
 	pub fn try_from(
-		// Span needed for expansion
 		attr_span: proc_macro2::Span,
 		index: usize,
 		item: &mut syn::Item

--- a/frame/support/procedural/src/pallet/parse/config.rs
+++ b/frame/support/procedural/src/pallet/parse/config.rs
@@ -48,7 +48,8 @@ pub struct ConfigDef {
 	pub has_event_type: bool,
 	/// The where clause on trait definition but modified so `Self` is `T`.
 	pub where_clause: Option<syn::WhereClause>,
-
+	/// The span of the pallet::config attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 /// Input definition for a constant in pallet config.
@@ -262,8 +263,9 @@ pub fn replace_self_by_t(input: proc_macro2::TokenStream) -> proc_macro2::TokenS
 impl ConfigDef {
 	pub fn try_from(
 		frame_system: &syn::Ident,
+		attr_span: proc_macro2::Span,
 		index: usize,
-		item: &mut syn::Item
+		item: &mut syn::Item,
 	) -> syn::Result<Self> {
 		let item = if let syn::Item::Trait(item) = item {
 			item
@@ -379,6 +381,7 @@ impl ConfigDef {
 			consts_metadata,
 			has_event_type,
 			where_clause,
+			attr_span,
 		})
 	}
 }

--- a/frame/support/procedural/src/pallet/parse/error.rs
+++ b/frame/support/procedural/src/pallet/parse/error.rs
@@ -34,11 +34,17 @@ pub struct ErrorDef {
 	/// A set of usage of instance, must be check for consistency with trait.
 	pub instances: Vec<helper::InstanceUsage>,
 	/// The keyword error used (contains span).
-	pub error: keyword::Error
+	pub error: keyword::Error,
+	/// The span of the pallet::error attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 impl ErrorDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Enum(item) = item {
 			item
 		} else {
@@ -77,6 +83,7 @@ impl ErrorDef {
 			.collect::<Result<_, _>>()?;
 
 		Ok(ErrorDef {
+			attr_span,
 			index,
 			variants,
 			instances,

--- a/frame/support/procedural/src/pallet/parse/event.rs
+++ b/frame/support/procedural/src/pallet/parse/event.rs
@@ -45,6 +45,8 @@ pub struct EventDef {
 	pub deposit_event: Option<(syn::Visibility, proc_macro2::Span)>,
 	/// Where clause used in event definition.
 	pub where_clause: Option<syn::WhereClause>,
+	/// The span of the pallet::event attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 /// Attribute for Event: defines metadata name to use.
@@ -150,7 +152,11 @@ impl PalletEventAttrInfo {
 }
 
 impl EventDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Enum(item) = item {
 			item
 		} else {
@@ -208,6 +214,7 @@ impl EventDef {
 			.collect();
 
 		Ok(EventDef {
+			attr_span,
 			index,
 			metadata,
 			instances,

--- a/frame/support/procedural/src/pallet/parse/genesis_build.rs
+++ b/frame/support/procedural/src/pallet/parse/genesis_build.rs
@@ -26,10 +26,16 @@ pub struct GenesisBuildDef {
 	pub instances: Vec<helper::InstanceUsage>,
 	/// The where_clause used.
 	pub where_clause: Option<syn::WhereClause>,
+	/// The span of the pallet::genesis_build attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 impl GenesisBuildDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Impl(item) = item {
 			item
 		} else {
@@ -48,6 +54,7 @@ impl GenesisBuildDef {
 		instances.push(helper::check_genesis_builder_usage(&item_trait)?);
 
 		Ok(Self {
+			attr_span,
 			index,
 			instances,
 			where_clause: item.generics.where_clause.clone(),

--- a/frame/support/procedural/src/pallet/parse/hooks.rs
+++ b/frame/support/procedural/src/pallet/parse/hooks.rs
@@ -26,10 +26,16 @@ pub struct HooksDef {
 	pub instances: Vec<helper::InstanceUsage>,
 	/// The where_clause used.
 	pub where_clause: Option<syn::WhereClause>,
+	/// The span of the pallet::hooks attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 impl HooksDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Impl(item) = item {
 			item
 		} else {
@@ -61,6 +67,7 @@ impl HooksDef {
 		}
 
 		Ok(Self {
+			attr_span,
 			index,
 			instances,
 			where_clause: item.generics.where_clause.clone(),

--- a/frame/support/procedural/src/pallet/parse/mod.rs
+++ b/frame/support/procedural/src/pallet/parse/mod.rs
@@ -92,38 +92,42 @@ impl Def {
 			let pallet_attr: Option<PalletAttr> = helper::take_first_item_attr(item)?;
 
 			match pallet_attr {
-				Some(PalletAttr::Config(_)) if config.is_none() =>
-					config = Some(config::ConfigDef::try_from(&frame_system, index, item)?),
-				Some(PalletAttr::Pallet(_)) if pallet_struct.is_none() =>
-					pallet_struct = Some(pallet_struct::PalletStructDef::try_from(index, item)?),
-				Some(PalletAttr::Hooks(_)) if hooks.is_none() => {
-					let m = hooks::HooksDef::try_from(index, item)?;
+				Some(PalletAttr::Config(span)) if config.is_none() =>
+					config = Some(config::ConfigDef::try_from(&frame_system, span, index, item)?),
+				Some(PalletAttr::Pallet(span)) if pallet_struct.is_none() => {
+					let p = pallet_struct::PalletStructDef::try_from(span, index, item)?;
+					pallet_struct = Some(p);
+				},
+				Some(PalletAttr::Hooks(span)) if hooks.is_none() => {
+					let m = hooks::HooksDef::try_from(span, index, item)?;
 					hooks = Some(m);
 				},
 				Some(PalletAttr::Call(span)) if call.is_none() =>
 					call = Some(call::CallDef::try_from(span, index, item)?),
-				Some(PalletAttr::Error(_)) if error.is_none() =>
-					error = Some(error::ErrorDef::try_from(index, item)?),
-				Some(PalletAttr::Event(_)) if event.is_none() =>
-					event = Some(event::EventDef::try_from(index, item)?),
+				Some(PalletAttr::Error(span)) if error.is_none() =>
+					error = Some(error::ErrorDef::try_from(span, index, item)?),
+				Some(PalletAttr::Event(span)) if event.is_none() =>
+					event = Some(event::EventDef::try_from(span, index, item)?),
 				Some(PalletAttr::GenesisConfig(_)) if genesis_config.is_none() => {
-					genesis_config =
-						Some(genesis_config::GenesisConfigDef::try_from(index, item)?);
+					let g = genesis_config::GenesisConfigDef::try_from(index, item)?;
+					genesis_config = Some(g);
 				},
-				Some(PalletAttr::GenesisBuild(_)) if genesis_build.is_none() =>
-					genesis_build = Some(genesis_build::GenesisBuildDef::try_from(index, item)?),
+				Some(PalletAttr::GenesisBuild(span)) if genesis_build.is_none() => {
+					let g = genesis_build::GenesisBuildDef::try_from(span, index, item)?;
+					genesis_build = Some(g);
+				},
 				Some(PalletAttr::Origin(_)) if origin.is_none() =>
 					origin = Some(origin::OriginDef::try_from(index, item)?),
 				Some(PalletAttr::Inherent(_)) if inherent.is_none() =>
 					inherent = Some(inherent::InherentDef::try_from(index, item)?),
-				Some(PalletAttr::Storage(_)) =>
-					storages.push(storage::StorageDef::try_from(index, item)?),
+				Some(PalletAttr::Storage(span)) =>
+					storages.push(storage::StorageDef::try_from(span, index, item)?),
 				Some(PalletAttr::ValidateUnsigned(_)) if validate_unsigned.is_none() => {
 					let v = validate_unsigned::ValidateUnsignedDef::try_from(index, item)?;
 					validate_unsigned = Some(v);
 				},
-				Some(PalletAttr::TypeValue(_)) =>
-					type_values.push(type_value::TypeValueDef::try_from(index, item)?),
+				Some(PalletAttr::TypeValue(span)) =>
+					type_values.push(type_value::TypeValueDef::try_from(span, index, item)?),
 				Some(PalletAttr::ExtraConstants(_)) => {
 					extra_constants =
 						Some(extra_constants::ExtraConstantsDef::try_from(index, item)?)
@@ -255,33 +259,33 @@ impl Def {
 	/// Depending on if pallet is instantiable:
 	/// * either `T: Config`
 	/// * or `T: Config<I>, I: 'static`
-	pub fn type_impl_generics(&self) -> proc_macro2::TokenStream {
+	pub fn type_impl_generics(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		if self.config.has_instance {
-			quote::quote!(T: Config<I>, I: 'static)
+			quote::quote_spanned!(span => T: Config<I>, I: 'static)
 		} else {
-			quote::quote!(T: Config)
+			quote::quote_spanned!(span => T: Config)
 		}
 	}
 
 	/// Depending on if pallet is instantiable:
 	/// * either `T: Config`
 	/// * or `T: Config<I>, I: 'static = ()`
-	pub fn type_decl_bounded_generics(&self) -> proc_macro2::TokenStream {
+	pub fn type_decl_bounded_generics(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		if self.config.has_instance {
-			quote::quote!(T: Config<I>, I: 'static = ())
+			quote::quote_spanned!(span => T: Config<I>, I: 'static = ())
 		} else {
-			quote::quote!(T: Config)
+			quote::quote_spanned!(span => T: Config)
 		}
 	}
 
 	/// Depending on if pallet is instantiable:
 	/// * either `T`
 	/// * or `T, I = ()`
-	pub fn type_decl_generics(&self) -> proc_macro2::TokenStream {
+	pub fn type_decl_generics(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		if self.config.has_instance {
-			quote::quote!(T, I = ())
+			quote::quote_spanned!(span => T, I = ())
 		} else {
-			quote::quote!(T)
+			quote::quote_spanned!(span => T)
 		}
 	}
 
@@ -289,22 +293,22 @@ impl Def {
 	/// * either ``
 	/// * or `<I>`
 	/// to be used when using pallet trait `Config`
-	pub fn trait_use_generics(&self) -> proc_macro2::TokenStream {
+	pub fn trait_use_generics(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		if self.config.has_instance {
-			quote::quote!(<I>)
+			quote::quote_spanned!(span => <I>)
 		} else {
-			quote::quote!()
+			quote::quote_spanned!(span => )
 		}
 	}
 
 	/// Depending on if pallet is instantiable:
 	/// * either `T`
 	/// * or `T, I`
-	pub fn type_use_generics(&self) -> proc_macro2::TokenStream {
+	pub fn type_use_generics(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		if self.config.has_instance {
-			quote::quote!(T, I)
+			quote::quote_spanned!(span => T, I)
 		} else {
-			quote::quote!(T)
+			quote::quote_spanned!(span => T)
 		}
 	}
 }
@@ -331,20 +335,20 @@ impl GenericKind {
 	/// Return the generic to be used when using the type.
 	///
 	/// Depending on its definition it can be: ``, `T` or `T, I`
-	pub fn type_use_gen(&self) -> proc_macro2::TokenStream {
+	pub fn type_use_gen(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		match self {
 			GenericKind::None => quote::quote!(),
-			GenericKind::Config => quote::quote!(T),
-			GenericKind::ConfigAndInstance => quote::quote!(T, I),
+			GenericKind::Config => quote::quote_spanned!(span => T),
+			GenericKind::ConfigAndInstance => quote::quote_spanned!(span => T, I),
 		}
 	}
 
 	/// Return the generic to be used in `impl<..>` when implementing on the type.
-	pub fn type_impl_gen(&self) -> proc_macro2::TokenStream {
+	pub fn type_impl_gen(&self, span: proc_macro2::Span) -> proc_macro2::TokenStream {
 		match self {
 			GenericKind::None => quote::quote!(),
-			GenericKind::Config => quote::quote!(T: Config),
-			GenericKind::ConfigAndInstance => quote::quote!(T: Config<I>, I: 'static),
+			GenericKind::Config => quote::quote_spanned!(span => T: Config),
+			GenericKind::ConfigAndInstance => quote::quote_spanned!(span => T: Config<I>, I: 'static),
 		}
 	}
 

--- a/frame/support/procedural/src/pallet/parse/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/parse/pallet_struct.rs
@@ -36,7 +36,9 @@ pub struct PalletStructDef {
 	/// The keyword Pallet used (contains span).
 	pub pallet: keyword::Pallet,
 	/// Whether the trait `Store` must be generated.
-	pub store: Option<(syn::Visibility, keyword::Store)>
+	pub store: Option<(syn::Visibility, keyword::Store)>,
+	/// The span of the pallet::pallet attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 /// Parse for `#[pallet::generate_store($vis trait Store)]`
@@ -64,7 +66,11 @@ impl syn::parse::Parse for PalletStructAttr {
 }
 
 impl PalletStructDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Struct(item) = item {
 			item
 		} else {
@@ -94,6 +100,6 @@ impl PalletStructDef {
 		let mut instances = vec![];
 		instances.push(helper::check_type_def_gen_no_bounds(&item.generics, item.ident.span())?);
 
-		Ok(Self { index, instances, pallet, store })
+		Ok(Self { index, instances, pallet, store, attr_span })
 	}
 }

--- a/frame/support/procedural/src/pallet/parse/storage.rs
+++ b/frame/support/procedural/src/pallet/parse/storage.rs
@@ -89,6 +89,8 @@ pub struct StorageDef {
 	pub query_kind: Option<QueryKind>,
 	/// Where clause of type definition.
 	pub where_clause: Option<syn::WhereClause>,
+	/// The span of the pallet::storage attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 /// In `Foo<A, B, C>` retrieve the argument at given position, i.e. A is argument at position 0.
@@ -112,7 +114,11 @@ fn retrieve_arg(
 }
 
 impl StorageDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Type(item) = item {
 			item
 		} else {
@@ -207,6 +213,7 @@ impl StorageDef {
 			})?;
 
 		Ok(StorageDef {
+			attr_span,
 			index,
 			vis: item.vis.clone(),
 			ident: item.ident.clone(),

--- a/frame/support/procedural/src/pallet/parse/type_value.rs
+++ b/frame/support/procedural/src/pallet/parse/type_value.rs
@@ -36,10 +36,16 @@ pub struct TypeValueDef {
 	pub instances: Vec<helper::InstanceUsage>,
 	/// The where clause of the function.
 	pub where_clause: Option<syn::WhereClause>,
+	/// The span of the pallet::type_value attribute.
+	pub attr_span: proc_macro2::Span,
 }
 
 impl TypeValueDef {
-	pub fn try_from(index: usize, item: &mut syn::Item) -> syn::Result<Self> {
+	pub fn try_from(
+		attr_span: proc_macro2::Span,
+		index: usize,
+		item: &mut syn::Item,
+	) -> syn::Result<Self> {
 		let item = if let syn::Item::Fn(item) = item {
 			item
 		} else {
@@ -88,6 +94,7 @@ impl TypeValueDef {
 		let where_clause = item.sig.generics.where_clause.clone();
 
 		Ok(TypeValueDef {
+			attr_span,
 			index,
 			is_generic,
 			vis,

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1399,8 +1399,9 @@ pub mod pallet_prelude {
 ///
 /// ### Macro expansion
 ///
-/// Macro generate struct with the name of the function and its generic, and implement
-/// `Get<$ReturnType>` on it using the provided function block.
+/// Macro renames the function to some internal name, generate a struct with the original name of
+/// the function and its generic, and implement `Get<$ReturnType>` by calling the user defined
+/// function.
 ///
 /// # Genesis config: `#[pallet::genesis_config]` optional
 ///

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.stderr
@@ -6,8 +6,8 @@ error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Co
    |
 help: consider further restricting this bound
    |
-1  | #[frame_support::pallet] + std::cmp::PartialEq
-   |                          ^^^^^^^^^^^^^^^^^^^^^
+17 |     #[pallet::call + std::cmp::PartialEq]
+   |                    ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `<T as pallet::Config>::Bar: Clone` is not satisfied
   --> $DIR/call_argument_invalid_bound.rs:20:37

--- a/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
+++ b/frame/support/test/tests/pallet_ui/store_trait_leak_private.stderr
@@ -4,5 +4,5 @@ error[E0446]: private type `_GeneratedPrefixForStorageFoo<T>` in public interfac
 11 |     #[pallet::generate_store(pub trait Store)]
    |                                        ^^^^^ can't leak private type
 ...
-21 |     type Foo<T> = StorageValue<_, u8>;
-   |          - `_GeneratedPrefixForStorageFoo<T>` declared as private
+20 |     #[pallet::storage]
+   |               - `_GeneratedPrefixForStorageFoo<T>` declared as private

--- a/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
@@ -1,0 +1,28 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, PhantomData};
+	use frame_system::pallet_prelude::BlockNumberFor;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config
+	where <Self as frame_system::Config>::AccountId: From<u32>
+	{}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
+	where <T as frame_system::Config>::AccountId: From<u32>
+	{}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where <T as frame_system::Config>::AccountId: From<u32>
+	{}
+
+	#[pallet::type_value] fn Foo<T: Config>() -> u32 { 3u32 }
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.stderr
+++ b/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.stderr
@@ -1,0 +1,47 @@
+error[E0277]: the trait bound `<T as frame_system::Config>::AccountId: From<u32>` is not satisfied
+  --> $DIR/type_value_forgotten_where_clause.rs:24:34
+   |
+7  |     pub trait Config: frame_system::Config
+   |               ------ required by a bound in this
+8  |     where <Self as frame_system::Config>::AccountId: From<u32>
+   |                                                      --------- required by this bound in `pallet::Config`
+...
+24 |     #[pallet::type_value] fn Foo<T: Config>() -> u32 { 3u32 }
+   |                                     ^^^^^^ the trait `From<u32>` is not implemented for `<T as frame_system::Config>::AccountId`
+   |
+help: consider further restricting the associated type
+   |
+24 |     #[pallet::type_value] fn Foo<T: Config>() -> u32 where <T as frame_system::Config>::AccountId: From<u32> { 3u32 }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `<T as frame_system::Config>::AccountId: From<u32>` is not satisfied
+  --> $DIR/type_value_forgotten_where_clause.rs:24:12
+   |
+7  |     pub trait Config: frame_system::Config
+   |               ------ required by a bound in this
+8  |     where <Self as frame_system::Config>::AccountId: From<u32>
+   |                                                      --------- required by this bound in `pallet::Config`
+...
+24 |     #[pallet::type_value] fn Foo<T: Config>() -> u32 { 3u32 }
+   |               ^^^^^^^^^^ the trait `From<u32>` is not implemented for `<T as frame_system::Config>::AccountId`
+   |
+help: consider further restricting the associated type
+   |
+24 |     #[pallet::type_value where <T as frame_system::Config>::AccountId: From<u32>] fn Foo<T: Config>() -> u32 { 3u32 }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `<T as frame_system::Config>::AccountId: From<u32>` is not satisfied
+  --> $DIR/type_value_forgotten_where_clause.rs:24:12
+   |
+7  |     pub trait Config: frame_system::Config
+   |               ------ required by a bound in this
+8  |     where <Self as frame_system::Config>::AccountId: From<u32>
+   |                                                      --------- required by this bound in `pallet::Config`
+...
+24 |     #[pallet::type_value] fn Foo<T: Config>() -> u32 { 3u32 }
+   |               ^^^^^^^^^^ the trait `From<u32>` is not implemented for `<T as frame_system::Config>::AccountId`
+   |
+help: consider further restricting the associated type
+   |
+24 |     #[pallet::type_value] fn Foo<T: Config>() -> u32 where <T as frame_system::Config>::AccountId: From<u32> { 3u32 }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR does 2 things:

1 - Improve spans of most code generations: all code generated are span from the attribute which generates them. (note: the generated code should be correct when the user rust code is correct. Thus if it is failing the first error should generally be in the user code, not in the expansion, an exception to that is the trait store, if the trait store is public and some storages are private then the rust error will point to generated code, but this is in ui tests and error is good I think).

2 - Improve error message of type_value: before we were removing the user code and generating the struct and implement get on the struct. Now we keep the user code, change the function name to an internal name and generate the struct and impl get by calling the function written by user. This way, when the function is incorrect, then the error message will be better. (see added ui test).

Thanks @kianenigma for reporting these unhelpful spans.

## Sidenote on type_value syntax

This makes me think of type_value syntax: would something like this make more sense ?
```rust
#[pallet::type_value(pub struct Foo)]
pub fn foo() -> u32 { 0u32 }
```
it would not even touch the user input and just generate the struct Foo.
Anyway I think it is fine as it is now