### PR TITLE
bump fs-swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "fs-swap"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921d332c89b3b61a826de38c61ee5b6e02c56806cade1b0e5d81bd71f57a71bb"
+checksum = "5839fda247e24ca4919c87c71dd5ca658f1f39e4f06829f80e3f15c3bafcfc2c"
 dependencies = [
  "lazy_static",
  "libc",


### PR DESCRIPTION
To include this change https://github.com/debris/fs-swap/pull/10

One less issue when building on M1. The only other one is rust-rocksdb.