### PR TITLE
Fix incorrect use of syn::exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6898,6 +6898,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "parking_lot 0.10.2",
+ "paste 0.1.18",
  "sc-executor-common",
  "sc-executor-wasmi",
  "sc-executor-wasmtime",
@@ -6918,7 +6919,6 @@ dependencies = [
  "sp-version",
  "sp-wasm-interface",
  "substrate-test-runtime",
- "test-case",
  "tracing",
  "tracing-subscriber",
  "wasmi",
@@ -9206,19 +9206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf11676eb135389f21fcda654382c4859bbfc1d2f36e4425a2f829bb41b1e20e"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "test-case"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a605baa797821796a751f4a959e1206079b24a4b7e1ed302b7d785d81a9276c9"
-dependencies = [
- "lazy_static",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9152,9 +9152,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9789,7 +9789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.6.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/client/chain-spec/derive/Cargo.toml
+++ b/client/chain-spec/derive/Cargo.toml
@@ -18,6 +18,6 @@ proc-macro = true
 proc-macro-crate = "0.1.4"
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
-syn = "1.0.7"
+syn = "1.0.58"
 
 [dev-dependencies]

--- a/client/cli/proc-macro/Cargo.toml
+++ b/client/cli/proc-macro/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro = true
 proc-macro-crate = "0.1.4"
 proc-macro2 = "1.0.6"
 quote = { version = "1.0.3", features = ["proc-macro"] }
-syn = { version = "1.0.7", features = ["proc-macro", "full", "extra-traits", "parsing"] }
+syn = { version = "1.0.58", features = ["proc-macro", "full", "extra-traits", "parsing"] }

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -44,12 +44,12 @@ hex-literal = "0.3.1"
 sc-runtime-test = { version = "2.0.0", path = "runtime-test" }
 substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime" }
 sp-state-machine = { version = "0.8.0", path = "../../primitives/state-machine" }
-test-case = "0.3.3"
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-tracing = { version = "2.0.0", path = "../../primitives/tracing" }
 sc-tracing = { version = "2.0.0", path = "../tracing" }
 tracing = "0.1.22"
 tracing-subscriber = "0.2.15"
+paste = "0.1.6"
 
 [features]
 default = [ "std" ]

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -26,7 +26,6 @@ use sp_core::{
 };
 use sc_runtime_test::wasm_binary_unwrap;
 use sp_state_machine::TestExternalities as CoreTestExternalities;
-use test_case::test_case;
 use sp_trie::{TrieConfiguration, trie_types::Layout};
 use sp_wasm_interface::HostFunctions as _;
 use sp_runtime::traits::BlakeTwo256;
@@ -36,6 +35,25 @@ use crate::WasmExecutionMethod;
 
 pub type TestExternalities = CoreTestExternalities<BlakeTwo256, u64>;
 type HostFunctions = sp_io::SubstrateHostFunctions;
+
+/// Simple macro that runs a given method as test with the available wasm execution methods.
+#[macro_export]
+macro_rules! test_wasm_execution {
+	($method_name:ident) => {
+		paste::item! {
+			#[test]
+			fn [<$method_name _interpreted>]() {
+				$method_name(WasmExecutionMethod::Interpreted);
+			}
+
+			#[test]
+			#[cfg(feature = "wasmtime")]
+			fn [<$method_name _compiled>]() {
+				$method_name(WasmExecutionMethod::Compiled);
+			}
+		}
+	};
+}
 
 fn call_in_wasm<E: Externalities>(
 	function: &str,
@@ -59,8 +77,7 @@ fn call_in_wasm<E: Externalities>(
 	)
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(returning_should_work);
 fn returning_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -74,8 +91,7 @@ fn returning_should_work(wasm_method: WasmExecutionMethod) {
 	assert_eq!(output, vec![0u8; 0]);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(call_not_existing_function);
 fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -102,8 +118,7 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 	}
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(call_yet_another_not_existing_function);
 fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -130,8 +145,7 @@ fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 	}
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(panicking_should_work);
 fn panicking_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -161,8 +175,7 @@ fn panicking_should_work(wasm_method: WasmExecutionMethod) {
 	assert!(output.is_err());
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(storage_should_work);
 fn storage_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 
@@ -191,8 +204,7 @@ fn storage_should_work(wasm_method: WasmExecutionMethod) {
 	assert_eq!(ext, expected);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(clear_prefix_should_work);
 fn clear_prefix_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	{
@@ -225,8 +237,7 @@ fn clear_prefix_should_work(wasm_method: WasmExecutionMethod) {
 	assert_eq!(expected, ext);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(blake2_256_should_work);
 fn blake2_256_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -250,8 +261,7 @@ fn blake2_256_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(blake2_128_should_work);
 fn blake2_128_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -275,8 +285,7 @@ fn blake2_128_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(sha2_256_should_work);
 fn sha2_256_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -306,8 +315,7 @@ fn sha2_256_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(twox_256_should_work);
 fn twox_256_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -335,8 +343,7 @@ fn twox_256_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(twox_128_should_work);
 fn twox_128_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -360,8 +367,7 @@ fn twox_128_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(ed25519_verify_should_work);
 fn ed25519_verify_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -397,8 +403,7 @@ fn ed25519_verify_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(sr25519_verify_should_work);
 fn sr25519_verify_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -434,8 +439,7 @@ fn sr25519_verify_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(ordered_trie_root_should_work);
 fn ordered_trie_root_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let trie_input = vec![b"zero".to_vec(), b"one".to_vec(), b"two".to_vec()];
@@ -450,8 +454,7 @@ fn ordered_trie_root_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(offchain_index);
 fn offchain_index(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let (offchain, _state) = testing::TestOffchainExt::new();
@@ -472,8 +475,7 @@ fn offchain_index(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(offchain_local_storage_should_work);
 fn offchain_local_storage_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let (offchain, state) = testing::TestOffchainExt::new();
@@ -490,8 +492,7 @@ fn offchain_local_storage_should_work(wasm_method: WasmExecutionMethod) {
 	assert_eq!(state.read().persistent_storage.get(b"test"), Some(vec![]));
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(offchain_http_should_work);
 fn offchain_http_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let (offchain, state) = testing::TestOffchainExt::new();
@@ -519,9 +520,7 @@ fn offchain_http_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
-#[should_panic(expected = "Allocator ran out of space")]
+test_wasm_execution!(should_trap_when_heap_exhausted);
 fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 
@@ -531,18 +530,20 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		HostFunctions::host_functions(),
 		8,
 	);
-	executor.call_in_wasm(
+
+	let err = executor.call_in_wasm(
 		&wasm_binary_unwrap()[..],
 		None,
 		"test_exhaust_heap",
 		&[0],
 		&mut ext.ext(),
 		sp_core::traits::MissingHostFunctions::Allow,
-	).unwrap();
+	).unwrap_err();
+
+	assert!(err.contains("Allocator ran out of space"));
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(returns_mutable_static);
 fn returns_mutable_static(wasm_method: WasmExecutionMethod) {
 	let runtime = crate::wasm_runtime::create_wasm_runtime_with_code(
 		wasm_method,
@@ -567,8 +568,7 @@ fn returns_mutable_static(wasm_method: WasmExecutionMethod) {
 // returned to its initial value and thus the stack space is going to be leaked.
 //
 // See https://github.com/paritytech/substrate/issues/2967 for details
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(restoration_of_globals);
 fn restoration_of_globals(wasm_method: WasmExecutionMethod) {
 	// Allocate 32 pages (of 65536 bytes) which gives the runtime 2048KB of heap to operate on
 	// (plus some additional space unused from the initial pages requested by the wasm runtime
@@ -596,7 +596,7 @@ fn restoration_of_globals(wasm_method: WasmExecutionMethod) {
 	assert!(res.is_ok());
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
+test_wasm_execution!(heap_is_reset_between_calls);
 fn heap_is_reset_between_calls(wasm_method: WasmExecutionMethod) {
 	let runtime = crate::wasm_runtime::create_wasm_runtime_with_code(
 		wasm_method,
@@ -620,8 +620,7 @@ fn heap_is_reset_between_calls(wasm_method: WasmExecutionMethod) {
 	instance.call_export("check_and_set_in_heap", &params).unwrap();
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(parallel_execution);
 fn parallel_execution(wasm_method: WasmExecutionMethod) {
 	let executor = std::sync::Arc::new(crate::WasmExecutor::new(
 		wasm_method,
@@ -656,7 +655,7 @@ fn parallel_execution(wasm_method: WasmExecutionMethod) {
 	}
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
+test_wasm_execution!(wasm_tracing_should_work);
 fn wasm_tracing_should_work(wasm_method: WasmExecutionMethod) {
 
 	use std::sync::{Arc, Mutex};
@@ -728,10 +727,8 @@ fn wasm_tracing_should_work(wasm_method: WasmExecutionMethod) {
 	assert_eq!(len, 2);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(spawning_runtime_instance_should_work);
 fn spawning_runtime_instance_should_work(wasm_method: WasmExecutionMethod) {
-
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
@@ -743,10 +740,8 @@ fn spawning_runtime_instance_should_work(wasm_method: WasmExecutionMethod) {
 	).unwrap();
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(spawning_runtime_instance_nested_should_work);
 fn spawning_runtime_instance_nested_should_work(wasm_method: WasmExecutionMethod) {
-
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 
@@ -758,10 +753,8 @@ fn spawning_runtime_instance_nested_should_work(wasm_method: WasmExecutionMethod
 	).unwrap();
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(panic_in_spawned_instance_panics_on_joining_its_result);
 fn panic_in_spawned_instance_panics_on_joining_its_result(wasm_method: WasmExecutionMethod) {
-
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
 

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -53,6 +53,15 @@ macro_rules! test_wasm_execution {
 			}
 		}
 	};
+
+	(interpreted_only $method_name:ident) => {
+		paste::item! {
+			#[test]
+			fn [<$method_name _interpreted>]() {
+				$method_name(WasmExecutionMethod::Interpreted);
+			}
+		}
+	};
 }
 
 fn call_in_wasm<E: Externalities>(
@@ -596,7 +605,7 @@ fn restoration_of_globals(wasm_method: WasmExecutionMethod) {
 	assert!(res.is_ok());
 }
 
-test_wasm_execution!(heap_is_reset_between_calls);
+test_wasm_execution!(interpreted_only heap_is_reset_between_calls);
 fn heap_is_reset_between_calls(wasm_method: WasmExecutionMethod) {
 	let runtime = crate::wasm_runtime::create_wasm_runtime_with_code(
 		wasm_method,

--- a/client/executor/src/integration_tests/sandbox.rs
+++ b/client/executor/src/integration_tests/sandbox.rs
@@ -18,12 +18,11 @@
 
 use super::{TestExternalities, call_in_wasm};
 use crate::WasmExecutionMethod;
+use crate::test_wasm_execution;
 
 use codec::Encode;
-use test_case::test_case;
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(sandbox_should_work);
 fn sandbox_should_work(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -60,8 +59,7 @@ fn sandbox_should_work(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(sandbox_trap);
 fn sandbox_trap(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -87,8 +85,7 @@ fn sandbox_trap(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(start_called);
 fn start_called(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -131,8 +128,7 @@ fn start_called(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(invoke_args);
 fn invoke_args(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -171,8 +167,7 @@ fn invoke_args(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(return_val);
 fn return_val(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -199,8 +194,7 @@ fn return_val(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(unlinkable_module);
 fn unlinkable_module(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -225,8 +219,7 @@ fn unlinkable_module(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(corrupted_module);
 fn corrupted_module(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -245,8 +238,7 @@ fn corrupted_module(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(start_fn_ok);
 fn start_fn_ok(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -274,8 +266,7 @@ fn start_fn_ok(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(start_fn_traps);
 fn start_fn_traps(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();
@@ -304,8 +295,7 @@ fn start_fn_traps(wasm_method: WasmExecutionMethod) {
 	);
 }
 
-#[test_case(WasmExecutionMethod::Interpreted)]
-#[cfg_attr(feature = "wasmtime", test_case(WasmExecutionMethod::Compiled))]
+test_wasm_execution!(get_global_val_works);
 fn get_global_val_works(wasm_method: WasmExecutionMethod) {
 	let mut ext = TestExternalities::default();
 	let mut ext = ext.ext();

--- a/frame/staking/reward-curve/Cargo.toml
+++ b/frame/staking/reward-curve/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.7", features = ["full", "visit"] }
+syn = { version = "1.0.58", features = ["full", "visit"] }
 quote = "1.0.3"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"

--- a/frame/support/procedural/Cargo.toml
+++ b/frame/support/procedural/Cargo.toml
@@ -19,7 +19,7 @@ frame-support-procedural-tools = { version = "2.0.0", path = "./tools" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
 Inflector = "0.11.4"
-syn = { version = "1.0.7", features = ["full"] }
+syn = { version = "1.0.58", features = ["full"] }
 
 [features]
 default = ["std"]

--- a/frame/support/procedural/src/storage/parse.rs
+++ b/frame/support/procedural/src/storage/parse.rs
@@ -47,7 +47,7 @@ mod keyword {
 pub struct Opt<P> {
 	pub inner: Option<P>,
 }
-impl<P: syn::export::ToTokens> syn::export::ToTokens for Opt<P> {
+impl<P: quote::ToTokens> quote::ToTokens for Opt<P> {
 	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
 		if let Some(ref p) = self.inner {
 			p.to_tokens(tokens);

--- a/frame/support/procedural/tools/Cargo.toml
+++ b/frame/support/procedural/tools/Cargo.toml
@@ -15,5 +15,5 @@ targets = ["x86_64-unknown-linux-gnu"]
 frame-support-procedural-tools-derive = { version = "2.0.0", path = "./derive" }
 proc-macro2 = "1.0.6"
 quote = "1.0.3"
-syn = { version = "1.0.7", features = ["full", "visit"] }
+syn = { version = "1.0.58", features = ["full", "visit"] }
 proc-macro-crate = "0.1.5"

--- a/frame/support/procedural/tools/derive/Cargo.toml
+++ b/frame/support/procedural/tools/derive/Cargo.toml
@@ -17,4 +17,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.6"
 quote = { version = "1.0.3", features = ["proc-macro"] }
-syn = { version = "1.0.7", features = ["proc-macro" ,"full", "extra-traits", "parsing"] }
+syn = { version = "1.0.58", features = ["proc-macro" ,"full", "extra-traits", "parsing"] }

--- a/primitives/api/proc-macro/Cargo.toml
+++ b/primitives/api/proc-macro/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.3"
-syn = { version = "1.0.8", features = ["full", "fold", "extra-traits", "visit"] }
+syn = { version = "1.0.58", features = ["full", "fold", "extra-traits", "visit"] }
 proc-macro2 = "1.0.6"
 blake2-rfc = { version = "0.2.18", default-features = false }
 proc-macro-crate = "0.1.4"

--- a/primitives/debug-derive/Cargo.toml
+++ b/primitives/debug-derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.3"
-syn = "1.0.7"
+syn = "1.0.58"
 proc-macro2 = "1.0"
 
 [features]

--- a/primitives/npos-elections/compact/Cargo.toml
+++ b/primitives/npos-elections/compact/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.7", features = ["full", "visit"] }
+syn = { version = "1.0.58", features = ["full", "visit"] }
 quote = "1.0"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"

--- a/primitives/runtime-interface/proc-macro/Cargo.toml
+++ b/primitives/runtime-interface/proc-macro/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.5", features = ["full", "visit", "fold", "extra-traits"] }
+syn = { version = "1.0.58", features = ["full", "visit", "fold", "extra-traits"] }
 quote = "1.0.3"
 proc-macro2 = "1.0.3"
 Inflector = "0.11.4"

--- a/test-utils/derive/Cargo.toml
+++ b/test-utils/derive/Cargo.toml
@@ -10,7 +10,7 @@ description = "Substrate test utilities macros"
 
 [dependencies]
 quote = "1.0.6"
-syn = { version = "1.0.33", features = ["full"] }
+syn = { version = "1.0.58", features = ["full"] }
 proc-macro-crate = "0.1.4"
 
 [lib]


### PR DESCRIPTION
Instead of using `syn::exports` we should import the trait from the
quote crate directly.

Fixes: https://github.com/paritytech/substrate/issues/7836