### PR TITLE
CI: remove squash and fix buildah push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -507,20 +507,17 @@ build-rust-doc:
     - echo "${PRODUCT} version = ${VERSION}"
     - test -z "${VERSION}" && exit 1
     - buildah bud
-      --squash
-      --format=docker
-      --build-arg VCS_REF="${CI_COMMIT_SHA}"
-      --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      --tag "$IMAGE_NAME:$VERSION"
-      --tag "$IMAGE_NAME:latest"
-      --file "$DOCKERFILE" .
+        --format=docker
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        --tag "$IMAGE_NAME:$VERSION"
+        --tag "$IMAGE_NAME:latest"
+        --file "$DOCKERFILE" .
     - echo "$Docker_Hub_Pass_Parity" |
       buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
-    - buildah push
-      --format=v2s2
-      "$IMAGE_NAME:$VERSION"
-      "$IMAGE_NAME:latest"
+    - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
+    - buildah push --format=v2s2 "$IMAGE_NAME:latest"
 
 publish-docker-substrate:
   stage:                           publish


### PR DESCRIPTION
- fixes buildah bush, apparently it couldn't push several tags within one command
- removes --squash, is wins in the final image size, but makes it one layer, hence unable to reuse the base image, looses in download time.

Polkadot companion: https://github.com/paritytech/polkadot/pull/2212