### PR TITLE
Subkey should not import the entire world.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8913,13 +8913,8 @@ dependencies = [
 name = "subkey"
 version = "2.0.0"
 dependencies = [
- "frame-system",
- "node-primitives",
- "node-runtime",
  "sc-cli",
- "sp-core",
  "structopt",
- "substrate-frame-cli",
 ]
 
 [[package]]

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -16,13 +16,5 @@ name = "subkey"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-node-runtime = { version = "2.0.0", path = "../../node/runtime" }
-node-primitives = { version = "2.0.0", path = "../../node/primitives" }
 sc-cli = { version = "0.8.0", path = "../../../client/cli" }
-substrate-frame-cli = { version = "2.0.0", path = "../../../utils/frame/frame-utilities-cli" }
 structopt = "0.3.14"
-frame-system = { version = "2.0.0", path = "../../../frame/system" }
-sp-core = { version = "2.0.0", path = "../../../primitives/core" }
-
-[features]
-bench = []

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -21,8 +21,6 @@ use sc_cli::{
 	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectKeyCmd,
 	InspectNodeKeyCmd
 };
-use substrate_frame_cli::ModuleIdCmd;
-use sp_core::crypto::Ss58Codec;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -44,9 +42,6 @@ pub enum Subkey {
 	/// Print the peer ID corresponding to the node key in the given file
 	InspectNodeKey(InspectNodeKeyCmd),
 
-	/// Inspect a module ID address
-	ModuleId(ModuleIdCmd),
-
 	/// Sign a message, with a given (secret) key.
 	Sign(SignCmd),
 
@@ -58,21 +53,14 @@ pub enum Subkey {
 }
 
 /// Run the subkey command, given the apropriate runtime.
-pub fn run<R>() -> Result<(), Error>
-	where
-		R: frame_system::Config,
-		R::AccountId: Ss58Codec
-{
+pub fn run() -> Result<(), Error> {
 	match Subkey::from_args() {
-		Subkey::GenerateNodeKey(cmd) => cmd.run()?,
-		Subkey::Generate(cmd) => cmd.run()?,
-		Subkey::Inspect(cmd) => cmd.run()?,
-		Subkey::InspectNodeKey(cmd) => cmd.run()?,
-		Subkey::ModuleId(cmd) => cmd.run::<R>()?,
-		Subkey::Vanity(cmd) => cmd.run()?,
-		Subkey::Verify(cmd) => cmd.run()?,
-		Subkey::Sign(cmd) => cmd.run()?,
-	};
-
-	Ok(())
+		Subkey::GenerateNodeKey(cmd) => cmd.run(),
+		Subkey::Generate(cmd) => cmd.run(),
+		Subkey::Inspect(cmd) => cmd.run(),
+		Subkey::InspectNodeKey(cmd) => cmd.run(),
+		Subkey::Vanity(cmd) => cmd.run(),
+		Subkey::Verify(cmd) => cmd.run(),
+		Subkey::Sign(cmd) => cmd.run(),
+	}
 }

--- a/bin/utils/subkey/src/main.rs
+++ b/bin/utils/subkey/src/main.rs
@@ -18,8 +18,6 @@
 
 //! Subkey utility, based on node_runtime.
 
-use node_runtime::Runtime;
-
 fn main() -> Result<(), sc_cli::Error> {
-	subkey::run::<Runtime>()
+	subkey::run()
 }


### PR DESCRIPTION
There is no reason for subkey to import the default Substrate node to
support a feature that would only be usable for the Substrate node.
Subkey itself should be more the default key management binary for
Substrate related chains. If certain chains require some special
functionality, they can easily stick together their own "my-chain-key".

