### PR TITLE
Store dispatch info of calls locally in weight calculation

### DIFF
--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -225,12 +225,14 @@ decl_module! {
 		/// # </weight>
 		#[weight = {
 			let dispatch_info = call.get_dispatch_info();
-			(T::WeightInfo::as_multi_threshold_1(call.using_encoded(|c| c.len() as u32))
-				.saturating_add(dispatch_info.weight)
-				 // AccountData for inner call origin accountdata.
-				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			dispatch_info.class,
-		)}]
+			(
+				T::WeightInfo::as_multi_threshold_1(call.using_encoded(|c| c.len() as u32))
+					.saturating_add(dispatch_info.weight)
+					// AccountData for inner call origin accountdata.
+					.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
+				dispatch_info.class,
+			)
+		}]
 		fn as_multi_threshold_1(origin,
 			other_signatories: Vec<T::AccountId>,
 			call: Box<<T as Config>::Call>,

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -223,13 +223,14 @@ decl_module! {
 		/// - DB Weight: None
 		/// - Plus Call Weight
 		/// # </weight>
-		#[weight = (
-			T::WeightInfo::as_multi_threshold_1(call.using_encoded(|c| c.len() as u32))
-				.saturating_add(call.get_dispatch_info().weight)
+		#[weight = {
+			let dispatch_info = call.get_dispatch_info();
+			(T::WeightInfo::as_multi_threshold_1(call.using_encoded(|c| c.len() as u32))
+				.saturating_add(dispatch_info.weight)
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			call.get_dispatch_info().class,
-		)]
+			dispatch_info.class,
+		)}]
 		fn as_multi_threshold_1(origin,
 			other_signatories: Vec<T::AccountId>,
 			call: Box<<T as Config>::Call>,

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -352,13 +352,14 @@ decl_module! {
 		/// - The weight of the `call` + 10,000.
 		/// - One storage lookup to check account is recovered by `who`. O(1)
 		/// # </weight>
-		#[weight = (
-			call.get_dispatch_info().weight
+		#[weight = {
+			let dispatch_info = call.get_dispatch_info();
+			(dispatch_info.weight
 				.saturating_add(10_000)
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			call.get_dispatch_info().class
-		)]
+			dispatch_info.class
+		)}]
 		fn as_recovered(origin,
 			account: T::AccountId,
 			call: Box<<T as Config>::Call>

--- a/frame/recovery/src/lib.rs
+++ b/frame/recovery/src/lib.rs
@@ -354,12 +354,14 @@ decl_module! {
 		/// # </weight>
 		#[weight = {
 			let dispatch_info = call.get_dispatch_info();
-			(dispatch_info.weight
-				.saturating_add(10_000)
-				 // AccountData for inner call origin accountdata.
-				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			dispatch_info.class
-		)}]
+			(
+				dispatch_info.weight
+					.saturating_add(10_000)
+					// AccountData for inner call origin accountdata.
+					.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
+				dispatch_info.class,
+			)
+		}]
 		fn as_recovered(origin,
 			account: T::AccountId,
 			call: Box<<T as Config>::Call>

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -202,12 +202,14 @@ decl_module! {
 		/// # </weight>
 		#[weight = {
 			let dispatch_info = call.get_dispatch_info();
-			(dispatch_info.weight
-				.saturating_add(10_000)
-				 // AccountData for inner call origin accountdata.
-				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			dispatch_info.class
-		)}]
+			(
+				dispatch_info.weight
+					.saturating_add(10_000)
+					// AccountData for inner call origin accountdata.
+					.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
+				dispatch_info.class,
+			)
+		}]
 		fn sudo_as(origin,
 			who: <T::Lookup as StaticLookup>::Source,
 			call: Box<<T as Config>::Call>

--- a/frame/sudo/src/lib.rs
+++ b/frame/sudo/src/lib.rs
@@ -130,7 +130,10 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (call.get_dispatch_info().weight + 10_000, call.get_dispatch_info().class)]
+		#[weight = {
+			let dispatch_info = call.get_dispatch_info();
+			(dispatch_info.weight.saturating_add(10_000), dispatch_info.class)
+		}]
 		fn sudo(origin, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
 			let sender = ensure_signed(origin)?;
@@ -197,13 +200,14 @@ decl_module! {
 		/// - One DB write (event).
 		/// - Weight of derivative `call` execution + 10,000.
 		/// # </weight>
-		#[weight = (
-			call.get_dispatch_info().weight
+		#[weight = {
+			let dispatch_info = call.get_dispatch_info();
+			(dispatch_info.weight
 				.saturating_add(10_000)
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			call.get_dispatch_info().class
-		)]
+			dispatch_info.class
+		)}]
 		fn sudo_as(origin,
 			who: <T::Lookup as StaticLookup>::Source,
 			call: Box<<T as Config>::Call>

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -133,14 +133,15 @@ decl_module! {
 		/// `BatchInterrupted` event is deposited, along with the number of successful calls made
 		/// and the error of the failed call. If all were successful, then the `BatchCompleted`
 		/// event is deposited.
-		#[weight = (
-			calls.iter()
-				.map(|call| call.get_dispatch_info().weight)
+		#[weight = {
+			let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info()).collect::<Vec<_>>();
+			(dispatch_infos.iter()
+				.map(|di| di.weight)
 				.fold(0, |total: Weight, weight: Weight| total.saturating_add(weight))
 				.saturating_add(T::WeightInfo::batch(calls.len() as u32)),
 			{
-				let all_operational = calls.iter()
-					.map(|call| call.get_dispatch_info().class)
+				let all_operational = dispatch_infos.iter()
+					.map(|di| di.class)
 					.all(|class| class == DispatchClass::Operational);
 				if all_operational {
 					DispatchClass::Operational
@@ -148,7 +149,7 @@ decl_module! {
 					DispatchClass::Normal
 				}
 			},
-		)]
+		)}]
 		fn batch(origin, calls: Vec<<T as Config>::Call>) -> DispatchResultWithPostInfo {
 			let is_root = ensure_root(origin.clone()).is_ok();
 			let calls_len = calls.len();
@@ -227,14 +228,15 @@ decl_module! {
 		/// # <weight>
 		/// - Complexity: O(C) where C is the number of calls to be batched.
 		/// # </weight>
-		#[weight = (
-			calls.iter()
-				.map(|call| call.get_dispatch_info().weight)
+		#[weight = {
+			let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info()).collect::<Vec<_>>();
+			(dispatch_infos.iter()
+				.map(|di| di.weight)
 				.fold(0, |total: Weight, weight: Weight| total.saturating_add(weight))
 				.saturating_add(T::WeightInfo::batch_all(calls.len() as u32)),
 			{
-				let all_operational = calls.iter()
-					.map(|call| call.get_dispatch_info().class)
+				let all_operational = dispatch_infos.iter()
+					.map(|di| di.class)
 					.all(|class| class == DispatchClass::Operational);
 				if all_operational {
 					DispatchClass::Operational
@@ -242,7 +244,7 @@ decl_module! {
 					DispatchClass::Normal
 				}
 			},
-		)]
+		)}]
 		#[transactional]
 		fn batch_all(origin, calls: Vec<<T as Config>::Call>) -> DispatchResultWithPostInfo {
 			let is_root = ensure_root(origin.clone()).is_ok();

--- a/frame/utility/src/lib.rs
+++ b/frame/utility/src/lib.rs
@@ -191,13 +191,14 @@ decl_module! {
 		/// NOTE: Prior to version *12, this was called `as_limited_sub`.
 		///
 		/// The dispatch origin for this call must be _Signed_.
-		#[weight = (
-			T::WeightInfo::as_derivative()
-				.saturating_add(call.get_dispatch_info().weight)
+		#[weight = {
+			let dispatch_info = call.get_dispatch_info();
+			(T::WeightInfo::as_derivative()
+				.saturating_add(dispatch_info.weight)
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1)),
-			call.get_dispatch_info().class,
-		)]
+			dispatch_info.class,
+		)}]
 		fn as_derivative(origin, index: u16, call: Box<<T as Config>::Call>) -> DispatchResultWithPostInfo {
 			let mut origin = origin;
 			let who = ensure_signed(origin.clone())?;


### PR DESCRIPTION
The weight functions for some extrinsics were not very efficient in that they called the `dispatch_info()` function for the same call multiple times.

This PR optimizes that behavior so that this function is only ever called once, then stored in a local variable which can be reused.

- [x] fn batch and fn batch_all( in frame/utility/src/lib.rs
- [x] fn sudo and fn sudo_as in frame/sudo/src/lib.rs
- [x] fn as_derivative (used to be as_sub) in frame/utility/src/lib.rs.
- [x] fn as_multi_threshold_1 in frame/multisig/src/lib.rs
- [x] fn as_recovered in frame/recovery/src/lib.rs

closes https://github.com/paritytech/srlabs_findings/issues/34