### PR TITLE
Fix clippy error

### DIFF
--- a/frame/contracts/proc-macro/src/lib.rs
+++ b/frame/contracts/proc-macro/src/lib.rs
@@ -64,7 +64,6 @@ fn derive_debug(
 	#[cfg(not(feature = "full"))]
 	let fields = {
 		drop(fmt);
-		drop(data);
 		TokenStream::new()
 	};
 

--- a/frame/support/procedural/src/storage/print_pallet_upgrade.rs
+++ b/frame/support/procedural/src/storage/print_pallet_upgrade.rs
@@ -81,13 +81,13 @@ pub fn maybe_print_pallet_upgrade(def: &super::DeclStorageDefExt) {
 		};
 
 		let genesis_config_impl_gen = if genesis_config_def.is_generic {
-			impl_gen.clone()
+			<&str>::clone(&impl_gen)
 		} else {
 			Default::default()
 		};
 
 		let genesis_config_use_gen = if genesis_config_def.is_generic {
-			use_gen.clone()
+			<&str>::clone(&use_gen)
 		} else {
 			Default::default()
 		};


### PR DESCRIPTION
error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
  --> frame/support/procedural/src/storage/print_pallet_upgrade.rs:84:4
   |
84 |             impl_gen.clone()
   |             ^^^^^^^^^^^^^^^^
   |
   = note: `#[deny(clippy::clone_double_ref)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_double_ref
help: try dereferencing it
   |
84 |             &(*impl_gen).clone()
   |
help: or try being explicit if you are sure, that you want to clone a reference
   |
84 |             <&str>::clone(impl_gen)
   |

error: using `clone` on a double-reference; this will copy the reference instead of cloning the inner type
  --> frame/support/procedural/src/storage/print_pallet_upgrade.rs:90:4
   |
90 |             use_gen.clone()
   |             ^^^^^^^^^^^^^^^

error: calls to `std::mem::drop` with a reference instead of an owned value. Dropping a reference does nothing.