### PR TITLE
Fix missing network for uniarts

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -372,6 +372,7 @@
 		},
 		{
 			"prefix": 45,
+			"network": "uniarts",
 			"displayName": "UniArts Network",
 			"symbols": ["UART", "UINK"],
 			"decimals": [12, 12],


### PR DESCRIPTION
Uniarts network missed a `network` key in `ss58-registry.json`, this PR fixes that.

Fixes #7651 
