### PR TITLE
Allow users to opt-in to owning and using Assets

### DIFF
--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -55,6 +55,8 @@
 //!   or to set the Issuer, Freezer or Admin of that asset class.
 //! * **Zombie**: An account which has a balance of some assets in this pallet, but no other
 //!   footprint on-chain, in particular no account managed in the `frame_system` pallet.
+//! * **Active**: An account who has some state stored in this pallet and a reference counter placed
+//!   by this pallet. An active account can only become deactive by emptying their asset balance.
 //!
 //! ### Goals
 //!
@@ -79,6 +81,7 @@
 //!
 //! * `force_create`: Creates a new asset class without taking any deposit.
 //! * `force_destroy`: Destroys an asset class.
+//! * `trust_asset`: Allow the Root origin to trust some asset holds practical value.
 //!
 //! ### Privileged Functions
 //! * `destroy`: Destroys an entire asset class; called by the asset class's Owner.
@@ -90,6 +93,7 @@
 //! * `transfer_ownership`: Changes an asset class's Owner; called by the asset class's Owner.
 //! * `set_team`: Changes an asset class's Admin, Freezer and Issuer; called by the asset class's
 //!   Owner.
+//! * `activate`: Allow a user to activate their account to use some asset.
 //!
 //! Please refer to the [`Call`](./enum.Call.html) enum and its associated variants for documentation on each function.
 //!
@@ -100,6 +104,17 @@
 //! * `total_supply` - Get the total supply of an asset `id`.
 //!
 //! Please refer to the [`Module`](./struct.Module.html) struct for details on publicly available functions.
+//!
+//! ### Additional Considerations
+//!
+//! When interacting with this pallet, it is important that you always use mortal extrinsics to avoid the possibility
+//! of replay attacks of transfers and other balance manipulating functions. This can occur if a user's account is
+//! destroyed, causing their nonce to reset, then an immortal transaction for this pallet could be submitted again
+//! successfully and transfer funds where it shouldn't.
+//!
+//! Additionally note that every active user will be forced to keep their account alive, i.e. they cannot make normal
+//! balance transfers below the existential deposit. A user who wants to be able to kill their account must first purge
+//! themselves of any tokens they hold in this pallet, and ultimately reduce their reference count to zero.
 //!
 //! ## Related Modules
 //!

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -710,7 +710,7 @@ decl_module! {
 					let new_balance = a.balance.saturating_add(amount);
 					ensure!(new_balance >= details.min_balance, Error::<T>::BalanceLow);
 					// We don't allow permissionless transfers to new accounts to prevent zombie griefing.
-					ensure!(Self::is_new_account(&a), Error::<T>::InactiveAccount);
+					ensure!(!Self::is_new_account(&a), Error::<T>::InactiveAccount);
 					a.balance = new_balance;
 					Ok(())
 				})?;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -540,7 +540,6 @@ decl_module! {
 					let new_balance = t.balance.saturating_add(amount);
 					ensure!(new_balance >= details.min_balance, Error::<T>::BalanceLow);
 					if Self::is_new_account(&t) {
-						println!("hi shawn");
 						Self::new_zombie(details)?;
 						t.is_zombie = true;
 					}
@@ -651,7 +650,6 @@ decl_module! {
 						details.accounts = accounts;
 					}
 					Self::activate(&target, details, &mut a.is_zombie, &mut a.is_active);
-					println!("Final Active {:?}", a);
 					Ok(())
 				})?;
 


### PR DESCRIPTION
This PR prevents a potential grief attack where a malicious asset can mint to arbitrary users, forcing those accounts to hold a reference counter, and thus preventing them from being destroyed or going below the existential deposit.

This PR modifies the logic of the pallet in the following ways:
* A new user is defined as an account whose state for an asset is equivalent to the `Default` state:
    * balance: 0
    * is_zombie: false
    * is_frozen: false
    * is_active: false
* All new users who obtain a balance for the first time become a zombie, no matter if that account already exists in FRAME system.
* Users can then activate their account, transitioning them from a zombie into an active account. This can be done explicitly through `activate_account` extrinsic, or implicitly by having this user make a transfer of the asset, where their final balance would still have them own some of the asset.
* Assets can now have a "trusted" status which is delegated by the Root origin, which allows the token issue of that asset to activate users too. This can specifically help with very well known assets with real value, where the asset owner may want to keep the number of zombie accounts below the `max_zombie` limit.

Assumptions that should be held by this PR:

* An account with `Default` state should be completely unmanaged by this pallet. Actually, it might be better to even have this check be more extreme and say that the `contains_key` check should be false... @gavofyork ? This state is represented by `is_new_account` returning true.
* An account with `is_zombie` will have incremented the `zombie_count` of the asset by 1.
* An account with `is_active` will have a reference counter on it.
* `is_zombie` and `is_active` should be mutually exclusive.