### PR TITLE
Add Prometheus alerts if unbounded channels are too large

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -147,3 +147,32 @@ groups:
       message: 'Authority discovery on node {{ $labels.instance }} fails to
       process more than 50 % of the values found on the DHT for more than 2
       hours.'
+
+  - alert: UnboundedChannelPersistentlyLarge
+    expr: '
+    (
+        (polkadot_unbounded_channel_len{action = "send"} -
+            ignoring(action) polkadot_unbounded_channel_len{action = "received"})
+        # Fallback if the `received` is null
+        or on(instance) polkadot_unbounded_channel_len{action = "send"}
+    ) >= 200'
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      message: 'Channel {{ $labels.entity }} on node {{ $labels.instance }} contains
+      more than 200 items for more than 5 minutes. Nore might be frozen.'
+
+  - alert: UnboundedChannelVeryLarge
+    expr: '
+    (
+        (polkadot_unbounded_channel_len{action = "send"} -
+            ignoring(action) polkadot_unbounded_channel_len{action = "received"})
+        # Fallback if the `received` is null
+        or on(instance) polkadot_unbounded_channel_len{action = "send"}
+    ) > 5000'
+    labels:
+      severity: warning
+    annotations:
+      message: 'Channel {{ $labels.entity }} on node {{ $labels.instance }} contains more than
+      5000 items.'

--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -149,11 +149,9 @@ groups:
       hours.'
 
   - alert: UnboundedChannelPersistentlyLarge
-    expr: '
-    (
+    expr: '(
         (polkadot_unbounded_channel_len{action = "send"} -
             ignoring(action) polkadot_unbounded_channel_len{action = "received"})
-        # Fallback if the `received` is null
         or on(instance) polkadot_unbounded_channel_len{action = "send"}
     ) >= 200'
     for: 5m
@@ -161,14 +159,12 @@ groups:
       severity: warning
     annotations:
       message: 'Channel {{ $labels.entity }} on node {{ $labels.instance }} contains
-      more than 200 items for more than 5 minutes. Nore might be frozen.'
+      more than 200 items for more than 5 minutes. Node might be frozen.'
 
   - alert: UnboundedChannelVeryLarge
-    expr: '
-    (
+    expr: '(
         (polkadot_unbounded_channel_len{action = "send"} -
             ignoring(action) polkadot_unbounded_channel_len{action = "received"})
-        # Fallback if the `received` is null
         or on(instance) polkadot_unbounded_channel_len{action = "send"}
     ) > 5000'
     labels:


### PR DESCRIPTION
Fix #7856 

I have successfully tested the alerting rule (with a smaller constant).

For what it's worth, the second rule (more than 5000 items) would have been triggered once in the past week, as a channel contained 18000 items for a brief moment.

As usual with Prometheus rules, we should make sure, after merging this PR, that the deployment through CI properly works.
