### PR TITLE
Bump cargo-unleash to latest alpha release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ variables:                         &default-vars
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
   # FIXME set to release
-  CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.10"
+  CARGO_UNLEASH_INSTALL_PARAMS:    "--version 1.0.0-alpha.11"
   CARGO_UNLEASH_PKG_DEF:           "--skip node node-* pallet-template pallet-example pallet-example-* subkey chain-spec-builder"
 
 default:


### PR DESCRIPTION
[The release has major improvements](https://github.com/paritytech/cargo-unleash/releases/tag/v1.0.0-alpha.11), not the last of them being a terms-of-service-compliant index-fetching.

Note: Because alpha.10 is doing the index fetching in a pretty bad way and apparently, unleash is used more and more, the sysadmins of crates.io consider banning it.