### PR TITLE
network-gossip: add metric for number of local messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7218,6 +7218,7 @@ dependencies = [
  "rand 0.7.3",
  "sc-network",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "substrate-test-runtime-client",
  "wasm-timer",
 ]

--- a/client/finality-grandpa/src/communication/mod.rs
+++ b/client/finality-grandpa/src/communication/mod.rs
@@ -217,7 +217,8 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 		let gossip_engine = Arc::new(Mutex::new(GossipEngine::new(
 			service.clone(),
 			GRANDPA_PROTOCOL_NAME,
-			validator.clone()
+			validator.clone(),
+			prometheus_registry.clone(),
 		)));
 
 		{

--- a/client/finality-grandpa/src/communication/mod.rs
+++ b/client/finality-grandpa/src/communication/mod.rs
@@ -218,7 +218,7 @@ impl<B: BlockT, N: Network<B>> NetworkBridge<B, N> {
 			service.clone(),
 			GRANDPA_PROTOCOL_NAME,
 			validator.clone(),
-			prometheus_registry.clone(),
+			prometheus_registry,
 		)));
 
 		{

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -20,6 +20,7 @@ futures-timer = "3.0.1"
 libp2p = { version = "0.33.0", default-features = false }
 log = "0.4.8"
 lru = "0.6.1"
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.8.0", path = "../../utils/prometheus" }
 sc-network = { version = "0.8.0", path = "../network" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 wasm-timer = "0.2"

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -25,6 +25,7 @@ use futures::prelude::*;
 use futures::channel::mpsc::{channel, Sender, Receiver};
 use libp2p::PeerId;
 use log::trace;
+use prometheus_endpoint::Registry;
 use sp_runtime::traits::Block as BlockT;
 use std::{
 	borrow::Cow,
@@ -72,12 +73,13 @@ impl<B: BlockT> GossipEngine<B> {
 		network: N,
 		protocol: impl Into<Cow<'static, str>>,
 		validator: Arc<dyn Validator<B>>,
+		metrics_registry: Option<&Registry>,
 	) -> Self where B: 'static {
 		let protocol = protocol.into();
 		let network_event_stream = network.event_stream();
 
 		GossipEngine {
-			state_machine: ConsensusGossip::new(validator, protocol.clone()),
+			state_machine: ConsensusGossip::new(validator, protocol.clone(), metrics_registry),
 			network: Box::new(network),
 			periodic_maintenance_interval: futures_timer::Delay::new(PERIODIC_MAINTENANCE_INTERVAL),
 			protocol,

--- a/client/network-gossip/src/bridge.rs
+++ b/client/network-gossip/src/bridge.rs
@@ -374,7 +374,8 @@ mod tests {
 		let mut gossip_engine = GossipEngine::<Block>::new(
 			network.clone(),
 			"/my_protocol",
-			Arc::new(AllowAll{}),
+			Arc::new(AllowAll {}),
+			None,
 		);
 
 		// Drop network event stream sender side.
@@ -401,7 +402,8 @@ mod tests {
 		let mut gossip_engine = GossipEngine::<Block>::new(
 			network.clone(),
 			protocol.clone(),
-			Arc::new(AllowAll{}),
+			Arc::new(AllowAll {}),
+			None,
 		);
 
 		let mut event_sender = network.inner.lock()
@@ -535,7 +537,8 @@ mod tests {
 			let mut gossip_engine = GossipEngine::<Block>::new(
 				network.clone(),
 				protocol.clone(),
-				Arc::new(TestValidator{}),
+				Arc::new(TestValidator {}),
+				None,
 			);
 
 			// Create channels.
@@ -551,8 +554,10 @@ mod tests {
 			// Insert sender sides into `gossip_engine`.
 			for (topic, tx) in txs {
 				match gossip_engine.message_sinks.get_mut(&topic) {
-					Some(entry) =>  entry.push(tx),
-					None => {gossip_engine.message_sinks.insert(topic, vec![tx]);},
+					Some(entry) => entry.push(tx),
+					None => {
+						gossip_engine.message_sinks.insert(topic, vec![tx]);
+					}
 				}
 			}
 

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -32,6 +32,11 @@ use sc_network::ObservedRole;
 use wasm_timer::Instant;
 
 // FIXME: Add additional spam/DoS attack protection: https://github.com/paritytech/substrate/issues/1115
+// NOTE: The current value is adjusted based on largest production network deployment (Kusama) and
+// the current main gossip user (GRANDPA). Currently there are ~800 validators on Kusama, as such,
+// each GRANDPA round should generate ~1600 messages, and we currently keep track of the last 2
+// completed rounds and the current live one. That makes it so that at any point we will be holding
+// ~4800 live messages.
 const KNOWN_MESSAGES_CACHE_SIZE: usize = 8192;
 
 const REBROADCAST_INTERVAL: time::Duration = time::Duration::from_secs(30);

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -581,7 +581,7 @@ mod tests {
 
 		let prev_hash = H256::random();
 		let best_hash = H256::random();
-		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into());
+		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into(), None);
 		let m1_hash = H256::random();
 		let m2_hash = H256::random();
 		let m1 = vec![1, 2, 3];
@@ -608,11 +608,11 @@ mod tests {
 
 	#[test]
 	fn message_stream_include_those_sent_before_asking() {
-		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into());
+		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into(), None);
 
 		// Register message.
 		let message = vec![4, 5, 6];
-		let topic = HashFor::<Block>::hash(&[1,2,3]);
+		let topic = HashFor::<Block>::hash(&[1, 2, 3]);
 		consensus.register_message(topic, message.clone());
 
 		assert_eq!(
@@ -623,7 +623,7 @@ mod tests {
 
 	#[test]
 	fn can_keep_multiple_messages_per_topic() {
-		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into());
+		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into(), None);
 
 		let topic = [1; 32].into();
 		let msg_a = vec![1, 2, 3];
@@ -637,7 +637,7 @@ mod tests {
 
 	#[test]
 	fn peer_is_removed_on_disconnect() {
-		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into());
+		let mut consensus = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into(), None);
 
 		let mut network = NoOpNetwork::default();
 
@@ -651,14 +651,12 @@ mod tests {
 
 	#[test]
 	fn on_incoming_ignores_discarded_messages() {
-		let to_forward = ConsensusGossip::<Block>::new(
-			Arc::new(DiscardAll),
-			"/foo".into(),
-		).on_incoming(
-			&mut NoOpNetwork::default(),
-			PeerId::random(),
-			vec![vec![1, 2, 3]],
-		);
+		let to_forward = ConsensusGossip::<Block>::new(Arc::new(DiscardAll), "/foo".into(), None)
+			.on_incoming(
+				&mut NoOpNetwork::default(),
+				PeerId::random(),
+				vec![vec![1, 2, 3]],
+			);
 
 		assert!(
 			to_forward.is_empty(),
@@ -671,15 +669,13 @@ mod tests {
 		let mut network = NoOpNetwork::default();
 		let remote = PeerId::random();
 
-		let to_forward = ConsensusGossip::<Block>::new(
-			Arc::new(AllowAll),
-			"/foo".into(),
-		).on_incoming(
-			&mut network,
-			// Unregistered peer.
-			remote.clone(),
-			vec![vec![1, 2, 3]],
-		);
+		let to_forward = ConsensusGossip::<Block>::new(Arc::new(AllowAll), "/foo".into(), None)
+			.on_incoming(
+				&mut network,
+				// Unregistered peer.
+				remote.clone(),
+				vec![vec![1, 2, 3]],
+			);
 
 		assert!(
 			to_forward.is_empty(),

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -37,6 +37,9 @@ use wasm_timer::Instant;
 // each GRANDPA round should generate ~1600 messages, and we currently keep track of the last 2
 // completed rounds and the current live one. That makes it so that at any point we will be holding
 // ~4800 live messages.
+//
+// Assuming that each known message is tracked with a 32 byte hash (common for `Block::Hash`), then
+// this cache should take about 256 KB of memory.
 const KNOWN_MESSAGES_CACHE_SIZE: usize = 8192;
 
 const REBROADCAST_INTERVAL: time::Duration = time::Duration::from_secs(30);

--- a/client/network-gossip/src/state_machine.rs
+++ b/client/network-gossip/src/state_machine.rs
@@ -32,7 +32,7 @@ use sc_network::ObservedRole;
 use wasm_timer::Instant;
 
 // FIXME: Add additional spam/DoS attack protection: https://github.com/paritytech/substrate/issues/1115
-const KNOWN_MESSAGES_CACHE_SIZE: usize = 4096;
+const KNOWN_MESSAGES_CACHE_SIZE: usize = 8192;
 
 const REBROADCAST_INTERVAL: time::Duration = time::Duration::from_secs(30);
 


### PR DESCRIPTION
This is useful to debug if any gossip validator might be leaking messages (i.e. by not expiring them).

Additionally this PR also increases the known messages cache size of network-gossip. This is to accommodate the increasing number of kusama validators. ~800 validators -> ~1600 GRANDPA messages per round -> we keep track of the last 2 completed rounds plus the current one -> ~4800 messages.

Setting this cache to 8192 should use about 256KB of memory (8192 * 32 bytes per block hash).