### PR TITLE
babe: initialize next authorities on genesis

### DIFF
--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -674,6 +674,7 @@ impl<T: Config> Module<T> {
 		if !authorities.is_empty() {
 			assert!(Authorities::get().is_empty(), "Authorities are already initialized!");
 			Authorities::put(authorities);
+			NextAuthorities::put(authorities);
 		}
 	}
 

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -255,6 +255,12 @@ fn can_enact_next_config() {
 #[test]
 fn can_fetch_current_and_next_epoch_data() {
 	new_test_ext(5).execute_with(|| {
+		// genesis authorities should be used for the first and second epoch
+		assert_eq!(
+			Babe::current_epoch().authorities,
+			Babe::next_epoch().authorities,
+		);
+
 		// 1 era = 3 epochs
 		// 1 epoch = 3 slots
 		// Eras start from 0.


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/7829 introduced a method to fetch the next epoch data. When starting the chain the first and second epoch use the same data, i.e. same authorities and randomness. This PR fixes genesis initialization of `NextAuthorities` storage entry.