### PR TITLE
Remove dependency of deploy-kubernetes-alerting-rules towards the rest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -613,6 +613,7 @@ publish-to-crates-io:
 
 deploy-kubernetes-alerting-rules:
   stage:                           deploy
+  needs:                           []
   interruptible:                   true
   retry:                           1
   tags:


### PR DESCRIPTION
This job doesn't require the build to succeed or anything of the sort. As such, we should always run it even if the other stages fail.

Documentation: https://docs.gitlab.com/ee/ci/yaml/#needs