### PR TITLE
contracts: Fix possible overflow in storage size calculation

### DIFF
--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -421,6 +421,11 @@ decl_error! {
 		/// This can be returned from [`Module::claim_surcharge`] because the target
 		/// contract has enough balance to pay for its rent.
 		ContractNotEvictable,
+		/// A storage modification exhausted the 32bit type that holds the storage size.
+		///
+		/// This can either happen when the accumulated storage in bytes is too large or
+		/// when number of storage items is too large.
+		StorageExhausted,
 	}
 }
 

--- a/frame/contracts/src/storage.rs
+++ b/frame/contracts/src/storage.rs
@@ -49,8 +49,6 @@ pub struct DeletedContract {
 	trie_id: TrieId,
 }
 
-
-
 pub struct Storage<T>(PhantomData<T>);
 
 impl<T> Storage<T>
@@ -75,15 +73,19 @@ where
 	/// `read`, this function also requires the `account` ID.
 	///
 	/// If the contract specified by the id `account` doesn't exist `Err` is returned.`
+	///
+	/// # Panics
+	///
+	/// Panics iff the `account` specified is not alive and in storage.
 	pub fn write(
 		account: &AccountIdOf<T>,
 		trie_id: &TrieId,
 		key: &StorageKey,
 		opt_new_value: Option<Vec<u8>>,
-	) -> Result<(), ContractAbsentError> {
+	) -> DispatchResult {
 		let mut new_info = match <ContractInfoOf<T>>::get(account) {
 			Some(ContractInfo::Alive(alive)) => alive,
-			None | Some(ContractInfo::Tombstone(_)) => return Err(ContractAbsentError),
+			None | Some(ContractInfo::Tombstone(_)) => panic!("Contract not found"),
 		};
 
 		let hashed_key = blake2_256(key);
@@ -103,10 +105,12 @@ where
 		// Update the total number of KV pairs and the number of empty pairs.
 		match (&opt_prev_value, &opt_new_value) {
 			(Some(_), None) => {
-				new_info.pair_count -= 1;
+				new_info.pair_count = new_info.pair_count.checked_sub(1)
+					.ok_or_else(|| Error::<T>::StorageExhausted)?;
 			},
 			(None, Some(_)) => {
-				new_info.pair_count += 1;
+				new_info.pair_count = new_info.pair_count.checked_add(1)
+					.ok_or_else(|| Error::<T>::StorageExhausted)?;
 			},
 			(Some(_), Some(_)) => {},
 			(None, None) => {},
@@ -123,8 +127,9 @@ where
 			.unwrap_or(0);
 		new_info.storage_size = new_info
 			.storage_size
-			.saturating_add(new_value_len)
-			.saturating_sub(prev_value_len);
+			.checked_sub(prev_value_len)
+			.and_then(|val| val.checked_add(new_value_len))
+			.ok_or_else(|| Error::<T>::StorageExhausted)?;
 
 		new_info.last_write = Some(<frame_system::Module<T>>::block_number());
 		<ContractInfoOf<T>>::insert(&account, ContractInfo::Alive(new_info));

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -18,15 +18,15 @@
 //! This module provides a means for executing contracts
 //! represented in wasm.
 
-use crate::{CodeHash, Schedule, Config};
-use crate::wasm::env_def::FunctionImplProvider;
-use crate::exec::Ext;
-use crate::gas::GasMeter;
-
+use crate::{
+	CodeHash, Schedule, Config,
+	wasm::env_def::FunctionImplProvider,
+	exec::Ext,
+	gas::GasMeter,
+};
 use sp_std::prelude::*;
 use sp_core::crypto::UncheckedFrom;
 use codec::{Encode, Decode};
-use sp_sandbox;
 
 #[macro_use]
 mod env_def;
@@ -172,7 +172,7 @@ mod tests {
 	use sp_core::H256;
 	use hex_literal::hex;
 	use sp_runtime::DispatchError;
-	use frame_support::weights::Weight;
+	use frame_support::{dispatch::DispatchResult, weights::Weight};
 	use assert_matches::assert_matches;
 	use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags, ExecError, ErrorOrigin};
 
@@ -228,8 +228,9 @@ mod tests {
 		fn get_storage(&self, key: &StorageKey) -> Option<Vec<u8>> {
 			self.storage.get(key).cloned()
 		}
-		fn set_storage(&mut self, key: StorageKey, value: Option<Vec<u8>>) {
+		fn set_storage(&mut self, key: StorageKey, value: Option<Vec<u8>>) -> DispatchResult {
 			*self.storage.entry(key).or_insert(Vec::new()) = value.unwrap_or(Vec::new());
+			Ok(())
 		}
 		fn instantiate(
 			&mut self,
@@ -362,7 +363,7 @@ mod tests {
 		fn get_storage(&self, key: &[u8; 32]) -> Option<Vec<u8>> {
 			(**self).get_storage(key)
 		}
-		fn set_storage(&mut self, key: [u8; 32], value: Option<Vec<u8>>) {
+		fn set_storage(&mut self, key: [u8; 32], value: Option<Vec<u8>>) -> DispatchResult {
 			(**self).set_storage(key, value)
 		}
 		fn instantiate(

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -643,8 +643,7 @@ define_env!(Env, <E: Ext>,
 		let mut key: StorageKey = [0; 32];
 		ctx.read_sandbox_memory_into_buf(key_ptr, &mut key)?;
 		let value = Some(ctx.read_sandbox_memory(value_ptr, value_len)?);
-		ctx.ext.set_storage(key, value);
-		Ok(())
+		ctx.ext.set_storage(key, value).map_err(Into::into)
 	},
 
 	// Clear the value at the given key in the contract storage.
@@ -656,8 +655,7 @@ define_env!(Env, <E: Ext>,
 		ctx.charge_gas(RuntimeToken::ClearStorage)?;
 		let mut key: StorageKey = [0; 32];
 		ctx.read_sandbox_memory_into_buf(key_ptr, &mut key)?;
-		ctx.ext.set_storage(key, None);
-		Ok(())
+		ctx.ext.set_storage(key, None).map_err(Into::into)
 	},
 
 	// Retrieve the value under the given key from storage.


### PR DESCRIPTION
Fixes #2672

For the reasons explained in the linked issue we replace unchecked and saturating math by checked math. Every contract call that tries to accumulate more storage than can be hold by the `u32` type will be trapped.

It is extremely unlikely that such a large contract will be economically feasible.