### PR TITLE
CI: test and deploy prometheus alerts streamlined

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,8 +52,6 @@ default:
 .kubernetes-build:                 &kubernetes-build
   tags:
     - kubernetes-parity-build
-  environment:
-    name: parity-build
   interruptible:                   true
 
 .docker-env:                       &docker-env
@@ -129,7 +127,7 @@ check-signed-tag:
   <<:                              *kubernetes-build
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - ./.maintain/gitlab/check_signed.sh
 
@@ -149,6 +147,19 @@ test-dependency-rules:
   <<:                              *kubernetes-build
   script:
     - .maintain/ensure-deps.sh
+
+test-prometheus-alerting-rules:
+  stage:                           check
+  image:                           paritytech/tools:latest
+  <<:                              *kubernetes-build
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      changes:
+        - .gitlab-ci.yml
+        - .maintain/monitoring/**/*
+  script:
+    - echo "promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml"
+    - cat .maintain/monitoring/alerting-rules/alerting-rules.yaml | promtool test rules .maintain/monitoring/alerting-rules/alerting-rule-tests.yaml
 
 #### stage:                        test
 
@@ -340,14 +351,6 @@ cargo-check-macos:
   tags:
     - osx
 
-test-prometheus-alerting-rules:
-  stage:                           test
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-build
-  script:
-    - promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
-    - cat .maintain/monitoring/alerting-rules/alerting-rules.yaml | promtool test rules .maintain/monitoring/alerting-rules/alerting-rule-tests.yaml
-
 #### stage:                        build
 
 check-polkadot-companion-status:
@@ -509,7 +512,7 @@ build-rust-doc:
         --tag "$IMAGE_NAME:latest"
         --file "$DOCKERFILE" .
     - echo "$Docker_Hub_Pass_Parity" |
-      buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:latest"
@@ -595,7 +598,7 @@ publish-draft-release:
   image:                           paritytech/tools:latest
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - ./.maintain/gitlab/publish_draft_release.sh
   allow_failure:                   true
@@ -605,14 +608,17 @@ publish-to-crates-io:
   <<:                              *docker-env
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*$/
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
     - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
   allow_failure:                   true
 
-deploy-kubernetes-alerting-rules:
+deploy-prometheus-alerting-rules:
   stage:                           deploy
+  needs:
+    - job:                         test-prometheus-alerting-rules
+      artifacts:                   false
   interruptible:                   true
   retry:                           1
   tags:


### PR DESCRIPTION
- `test-prometheus-alerting-rules:` is now on check phase and starts if only mentioned files are edited, on any branch
- `deploy-prometheus-alerting-rules:` now starts right away after the test is green, but only on `master` AND if those files are changed.
- `*kubernetes-build` jobs actually do not require a special environment since they are not the deployments, this was an unnecessary complication
- some chore