### PR TITLE
Clean-up pass in network/src/protocol.rs

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -244,8 +244,6 @@ struct Peer<B: BlockT, H: ExHashT> {
 	known_transactions: LruHashSet<H>,
 	/// Holds a set of blocks known to this peer.
 	known_blocks: LruHashSet<B::Hash>,
-	/// Request counter,
-	next_request_id: message::RequestId,
 }
 
 /// Info about a peer's known state.
@@ -897,7 +895,6 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 				.expect("Constant is nonzero")),
 			known_blocks: LruHashSet::new(NonZeroUsize::new(MAX_KNOWN_BLOCKS)
 				.expect("Constant is nonzero")),
-			next_request_id: 0,
 		};
 
 		let req = if peer.info.roles.is_full() {
@@ -1407,13 +1404,11 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 fn prepare_block_request<B: BlockT, H: ExHashT>(
 	peers: &mut HashMap<PeerId, Peer<B, H>>,
 	who: PeerId,
-	mut request: message::BlockRequest<B>,
+	request: message::BlockRequest<B>,
 ) -> CustomMessageOutcome<B> {
 	let (tx, rx) = oneshot::channel();
 
 	if let Some(ref mut peer) = peers.get_mut(&who) {
-		request.id = peer.next_request_id;
-		peer.next_request_id += 1;
 		peer.block_request = Some((request.clone(), rx));
 	}
 

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -54,6 +54,7 @@ use sp_runtime::traits::{
 use sp_arithmetic::traits::SaturatedConversion;
 use sync::{ChainSync, SyncState};
 use std::borrow::Cow;
+use std::convert::TryFrom as _;
 use std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry};
 use std::sync::Arc;
 use std::{io, iter, num::NonZeroUsize, pin::Pin, task::Poll, time};
@@ -1378,10 +1379,8 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 	}
 
 	fn report_metrics(&self) {
-		use std::convert::TryInto;
-
 		if let Some(metrics) = &self.metrics {
-			let n = self.peers.len().try_into().unwrap_or(std::u64::MAX);
+			let n = u64::try_from(self.peers.len()).unwrap_or(std::u64::MAX);
 			metrics.peers.set(n);
 
 			let m = self.sync.metrics();

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1777,8 +1777,8 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 				}
 			},
 			GenericProtoOut::Notification { peer_id, set_id, message } =>
-				match usize::from(set_id) {
-					0 if self.peers.contains_key(&peer_id) => {
+				match set_id {
+					HARDCODED_PEERSETS_SYNC if self.peers.contains_key(&peer_id) => {
 						if let Ok(announce) = message::BlockAnnounce::decode(&mut message.as_ref()) {
 							self.push_block_announce_validation(peer_id, announce);
 
@@ -1794,7 +1794,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 							CustomMessageOutcome::None
 						}
 					}
-					1 if self.peers.contains_key(&peer_id) => {
+					HARDCODED_PEERSETS_TX if self.peers.contains_key(&peer_id) => {
 						if let Ok(m) = <message::Transactions<B::Extrinsic> as Decode>::decode(
 							&mut message.as_ref(),
 						) {
@@ -1804,7 +1804,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 						}
 						CustomMessageOutcome::None
 					}
-					0 | 1 => {
+					HARDCODED_PEERSETS_SYNC | HARDCODED_PEERSETS_TX => {
 						debug!(
 							target: "sync",
 							"Received sync or transaction for peer earlier refused by sync layer: {}",

--- a/client/network/src/protocol/message.rs
+++ b/client/network/src/protocol/message.rs
@@ -286,30 +286,6 @@ pub mod generic {
 		ConsensusBatch(Vec<ConsensusMessage>),
 	}
 
-	impl<Header, Hash, Number, Extrinsic> Message<Header, Hash, Number, Extrinsic> {
-		/// Message id useful for logging.
-		pub fn id(&self) -> &'static str {
-			match self {
-				Message::Status(_) => "Status",
-				Message::BlockRequest(_) => "BlockRequest",
-				Message::BlockResponse(_) => "BlockResponse",
-				Message::BlockAnnounce(_) => "BlockAnnounce",
-				Message::Transactions(_) => "Transactions",
-				Message::Consensus(_) => "Consensus",
-				Message::RemoteCallRequest(_) => "RemoteCallRequest",
-				Message::RemoteCallResponse(_) => "RemoteCallResponse",
-				Message::RemoteReadRequest(_) => "RemoteReadRequest",
-				Message::RemoteReadResponse(_) => "RemoteReadResponse",
-				Message::RemoteHeaderRequest(_) => "RemoteHeaderRequest",
-				Message::RemoteHeaderResponse(_) => "RemoteHeaderResponse",
-				Message::RemoteChangesRequest(_) => "RemoteChangesRequest",
-				Message::RemoteChangesResponse(_) => "RemoteChangesResponse",
-				Message::RemoteReadChildRequest(_) => "RemoteReadChildRequest",
-				Message::ConsensusBatch(_) => "ConsensusBatch",
-			}
-		}
-	}
-
 	/// Status sent on connection.
 	// TODO https://github.com/paritytech/substrate/issues/4674: replace the `Status`
 	// struct with this one, after waiting a few releases beyond `NetworkSpecialization`'s


### PR DESCRIPTION
This PR does some straight-forward clean ups of `protocol.rs`.

Can be reviewed commit by commit if necessary.

The statistics system removed in the first commit is something that existed before Prometheus was introduced and is now completely obsolete.
