### PR TITLE
Log target before prefix for more consistent logging

### DIFF
--- a/client/tracing/src/logging.rs
+++ b/client/tracing/src/logging.rs
@@ -125,6 +125,10 @@ where
 			}
 		}
 
+		if self.display_target {
+			write!(writer, "{}:", meta.target())?;
+		}
+
 		// Custom code to display node name
 		if let Some(span) = ctx.lookup_current() {
 			let parents = span.parents();
@@ -137,9 +141,6 @@ where
 			}
 		}
 
-		if self.display_target {
-			write!(writer, "{}:", meta.target())?;
-		}
 		ctx.format_fields(writer, event)?;
 		writeln!(writer)?;
 

--- a/client/tracing/src/logging.rs
+++ b/client/tracing/src/logging.rs
@@ -126,7 +126,7 @@ where
 		}
 
 		if self.display_target {
-			write!(writer, "{}:", meta.target())?;
+			write!(writer, "{}: ", meta.target())?;
 		}
 
 		// Custom code to display node name


### PR DESCRIPTION
As requested, this moves the target before the prefix to have consistent
logging between logs with and without a prefix.

