### PR TITLE
contracts: Fix failing benchmark test

### DIFF
--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -413,7 +413,7 @@ benchmarks! {
 			caller_funding::<T>() - instance.endowment
 		);
 		assert!(
-			T::Currency::free_balance(&instance.caller) <
+			T::Currency::free_balance(&instance.caller) <=
 			caller_funding::<T>() - instance.endowment + <T as Config>::SurchargeReward::get(),
 		);
 	}


### PR DESCRIPTION
The logic of this `assert!` was flawed. It slipped though the cracks because it was the result of two PRs that were merged at roughly the same time.