### PR TITLE
Fix decl_storage provided template to migrate to `pallet!`

### DIFF
--- a/frame/support/procedural/src/storage/print_pallet_upgrade.rs
+++ b/frame/support/procedural/src/storage/print_pallet_upgrade.rs
@@ -323,7 +323,7 @@ pub mod pallet {{
 	#[pallet::generate_store({store_vis} trait Store)]
 	pub struct Pallet{decl_gen}(PhantomData{use_gen_tuple});
 
-	#[pallet::interface]
+	#[pallet::hooks]
 	impl{impl_gen} Hooks<BlockNumberFor<T>> for Pallet{use_gen}
 		// TODO_MAYBE_WHERE_CLAUSE
 	{{


### PR DESCRIPTION
just the template wasn't renamed when we decided to change interface to hooks.

thanks @ascjones 