### PR TITLE
Fix not restoring non-poisoned state

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -1674,8 +1674,9 @@ impl NetworkBehaviour for GenericProto {
 									notifications_sink: replacement_sink,
 								};
 								self.events.push_back(NetworkBehaviourAction::GenerateEvent(event));
-								*entry.into_mut() = PeerState::Enabled { connections };
 							}
+
+							*entry.into_mut() = PeerState::Enabled { connections };
 
 						} else {
 							// List of open connections wasn't empty before but now it is.


### PR DESCRIPTION
Context: we replace the current state of a peer with `Poisoned` with the intention of later putting back the proper state.
In that specific situation where a substream on a secondary connection gets closed, we didn't put back the proper state.
I've tried to figure out why it is this way (is it some missing code instead?), and I can't find any explanation other than a mistake.

I've also reviewed again the rest of the state machine, and can't find any place where we leave a `Poisoned` state.

