### PR TITLE
Allow configuring Yamux window size

### DIFF
--- a/client/cli/src/params/network_params.rs
+++ b/client/cli/src/params/network_params.rs
@@ -175,6 +175,7 @@ impl NetworkParams {
 			max_parallel_downloads: self.max_parallel_downloads,
 			allow_non_globals_in_dht,
 			kademlia_disjoint_query_paths: self.kademlia_disjoint_query_paths,
+			yamux_window_size: None,
 		}
 	}
 }

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -401,6 +401,27 @@ pub struct NetworkConfiguration {
 	/// Require iterative Kademlia DHT queries to use disjoint paths for increased resiliency in the
 	/// presence of potentially adversarial nodes.
 	pub kademlia_disjoint_query_paths: bool,
+
+	/// Size of Yamux window receive window of all substreams. `None` for the default (256kiB).
+	/// Any value inferior to 256kiB is invalid.
+	///
+	/// # Context
+	///
+	/// By design, notifications substreams on top of Yamux connections only allow up to `N` bytes
+	/// to be transferred at a time, where `N` is the Yamux receive window size configurable here.
+	/// This means, in practice, that every `N` bytes must be acknowledged by the receiver before
+	/// the sender can send more data. The maximum bandwidth of each notifications substream is
+	/// therefore `N / round_trip_time`.
+	///
+	/// It is recommended to leave this to `None`, and use a request-response protocol instead if
+	/// a large amount of data must be transferred. The reason why the value is configurable is
+	/// that some Substrate users mis-use notification protocols to send large amounts of data.
+	/// As such, this option isn't designed to stay and will likely get removed in the future.
+	///
+	/// Note that configuring a value here isn't a modification of the Yamux protocol, but rather
+	/// a modification of the way the implementation works. Different nodes with different
+	/// configured values remain compatible with each other.
+	pub yamux_window_size: Option<u32>,
 }
 
 impl NetworkConfiguration {
@@ -430,6 +451,7 @@ impl NetworkConfiguration {
 			max_parallel_downloads: 5,
 			allow_non_globals_in_dht: false,
 			kademlia_disjoint_query_paths: false,
+			yamux_window_size: None,
 		}
 	}
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -311,7 +311,13 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 					TransportConfig::Normal { wasm_external_transport, .. } =>
 						(false, wasm_external_transport)
 				};
-				transport::build_transport(local_identity, config_mem, config_wasm)
+
+				transport::build_transport(
+					local_identity,
+					config_mem,
+					config_wasm,
+					params.network_config.yamux_window_size
+				)
 			};
 			let mut builder = SwarmBuilder::new(transport, behaviour, local_peer_id.clone())
 				.connection_limits(ConnectionLimits::default()


### PR DESCRIPTION
See the code comment for details.

Context: Polkadot at the moment tries to send large (3.5MiB) collations through a notifications protocol, with a one second timeout. This can't work right now. See https://github.com/libp2p/rust-libp2p/issues/1849.

In the long term we would like Polkadot to use a request-response protocol for collations, which alongside with https://github.com/libp2p/rust-libp2p/issues/1849, would allow acceptable transfer rates.

The intention with this PR is to set this value to something large in Polkadot, in order to permit large collations to be sent for as long as everything isn't properly implemented.


