### PR TITLE
Add ss58 version prefix for Litentry Network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -504,6 +504,8 @@ ss58_address_format!(
 		(29, "cord", "Dhiway CORD network, standard account (*25519).")	
 	PhalaAccount =>
 		(30, "phala", "Phala Network, standard account (*25519).")
+	LitentryAccount =>
+		(31, "litentry", "Litentry Network, standard account (*25519).")
 	RobonomicsAccount =>
 		(32, "robonomics", "Any Robonomics network standard account (*25519).")
 	DataHighwayAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -290,6 +290,15 @@
 			"website": "https://phala.network"
 		},
 		{
+			"prefix": 31,
+			"network": "litentry",
+			"displayName": "Litentry Network",
+			"symbols": ["LIT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://litentry.com/"
+		},
+		{
 			"prefix": 32,
 			"network": "robonomics",
 			"displayName": "Robonomics Network",


### PR DESCRIPTION
Adding a key prefix(31) for the Litentry Network.
