### PR TITLE
Add explicit limits to notifications sizes and adjust yamux buffer size

### DIFF
--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -672,6 +672,8 @@ pub struct GrandpaParams<Block: BlockT, C, N, SC, VR> {
 pub fn grandpa_peers_set_config() -> sc_network::config::NonDefaultSetConfig {
 	sc_network::config::NonDefaultSetConfig {
 		notifications_protocol: communication::GRANDPA_PROTOCOL_NAME.into(),
+		// Notifications reach ~256kiB in size at the time of writing on Kusama and Polkadot.
+		max_notification_size: 1024 * 1024,
 		set_config: sc_network::config::SetConfig {
 			in_peers: 25,
 			out_peers: 25,

--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -528,6 +528,8 @@ pub struct NonDefaultSetConfig {
 	/// > **Note**: This field isn't present for the default set, as this is handled internally
 	/// >           by the networking code.
 	pub notifications_protocol: Cow<'static, str>,
+	/// Maximum allowed size of single notifications.
+	pub max_notification_size: u64,
 	/// Base configuration.
 	pub set_config: SetConfig,
 }

--- a/client/network/src/gossip/tests.rs
+++ b/client/network/src/gossip/tests.rs
@@ -144,6 +144,7 @@ fn build_nodes_one_proto()
 		extra_sets: vec![
 			config::NonDefaultSetConfig {
 				notifications_protocol: PROTOCOL_NAME,
+				max_notification_size: 1024 * 1024,
 				set_config: Default::default()
 			}
 		],
@@ -157,6 +158,7 @@ fn build_nodes_one_proto()
 		extra_sets: vec![
 			config::NonDefaultSetConfig {
 				notifications_protocol: PROTOCOL_NAME,
+				max_notification_size: 1024 * 1024,
 				set_config: config::SetConfig {
 					reserved_nodes: vec![config::MultiaddrWithPeerId {
 						multiaddr: listen_addr,

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -475,16 +475,19 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 				best_hash,
 				genesis_hash,
 			).encode();
+
 			GenericProto::new(
 				protocol_id.clone(),
 				versions,
 				build_status_message::<B>(&config, best_number, best_hash, genesis_hash),
 				peerset,
-				iter::once((block_announces_protocol, block_announces_handshake))
-					.chain(iter::once((transactions_protocol, vec![])))
-					.chain(network_config.extra_sets.iter()
-						.map(|s| (s.notifications_protocol.clone(), handshake_message.clone()))
-					),
+				iter::once((block_announces_protocol, block_announces_handshake, 1024 * 1024))
+					.chain(iter::once((transactions_protocol, vec![], 1024 * 1024)))
+					.chain(network_config.extra_sets.iter().map(|s| (
+						s.notifications_protocol.clone(),
+						handshake_message.clone(),
+						s.max_notification_size
+					))),
 			)
 		};
 

--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -103,7 +103,7 @@ pub struct GenericProto {
 	/// Notification protocols. Entries are only ever added and not removed.
 	/// Contains, for each protocol, the protocol name and the message to send as part of the
 	/// initial handshake.
-	notif_protocols: Vec<(Cow<'static, str>, Arc<RwLock<Vec<u8>>>)>,
+	notif_protocols: Vec<(Cow<'static, str>, Arc<RwLock<Vec<u8>>>, u64)>,
 
 	/// Receiver for instructions about who to connect to or disconnect from.
 	peerset: sc_peerset::Peerset,
@@ -374,10 +374,10 @@ impl GenericProto {
 		versions: &[u8],
 		handshake_message: Vec<u8>,
 		peerset: sc_peerset::Peerset,
-		notif_protocols: impl Iterator<Item = (Cow<'static, str>, Vec<u8>)>,
+		notif_protocols: impl Iterator<Item = (Cow<'static, str>, Vec<u8>, u64)>,
 	) -> Self {
 		let notif_protocols = notif_protocols
-			.map(|(n, hs)| (n, Arc::new(RwLock::new(hs))))
+			.map(|(n, hs, sz)| (n, Arc::new(RwLock::new(hs)), sz))
 			.collect::<Vec<_>>();
 
 		assert!(!notif_protocols.is_empty());

--- a/client/network/src/protocol/generic_proto/tests.rs
+++ b/client/network/src/protocol/generic_proto/tests.rs
@@ -82,7 +82,7 @@ fn build_nodes() -> (Swarm<CustomProtoWithAddr>, Swarm<CustomProtoWithAddr>) {
 		let behaviour = CustomProtoWithAddr {
 			inner: GenericProto::new(
 				"test", &[1], vec![], peerset,
-				iter::once(("/foo".into(), Vec::new()))
+				iter::once(("/foo".into(), Vec::new(), 1024 * 1024))
 			),
 			addrs: addrs
 				.iter()

--- a/client/network/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/notifications.rs
@@ -452,7 +452,7 @@ mod tests {
 			let socket = TcpStream::connect(listener_addr_rx.await.unwrap()).await.unwrap();
 			let (handshake, mut substream) = upgrade::apply_outbound(
 				socket,
-				NotificationsOut::new(PROTO_NAME, &b"initial message"[..]),
+				NotificationsOut::new(PROTO_NAME, &b"initial message"[..], 1024 * 1024),
 				upgrade::Version::V1
 			).await.unwrap();
 
@@ -467,7 +467,7 @@ mod tests {
 			let (socket, _) = listener.accept().await.unwrap();
 			let (initial_message, mut substream) = upgrade::apply_inbound(
 				socket,
-				NotificationsIn::new(PROTO_NAME)
+				NotificationsIn::new(PROTO_NAME, 1024 * 1024)
 			).await.unwrap();
 
 			assert_eq!(initial_message, b"initial message");
@@ -491,7 +491,7 @@ mod tests {
 			let socket = TcpStream::connect(listener_addr_rx.await.unwrap()).await.unwrap();
 			let (handshake, mut substream) = upgrade::apply_outbound(
 				socket,
-				NotificationsOut::new(PROTO_NAME, vec![]),
+				NotificationsOut::new(PROTO_NAME, vec![], 1024 * 1024),
 				upgrade::Version::V1
 			).await.unwrap();
 
@@ -506,7 +506,7 @@ mod tests {
 			let (socket, _) = listener.accept().await.unwrap();
 			let (initial_message, mut substream) = upgrade::apply_inbound(
 				socket,
-				NotificationsIn::new(PROTO_NAME)
+				NotificationsIn::new(PROTO_NAME, 1024 * 1024)
 			).await.unwrap();
 
 			assert!(initial_message.is_empty());
@@ -528,7 +528,7 @@ mod tests {
 			let socket = TcpStream::connect(listener_addr_rx.await.unwrap()).await.unwrap();
 			let outcome = upgrade::apply_outbound(
 				socket,
-				NotificationsOut::new(PROTO_NAME, &b"hello"[..]),
+				NotificationsOut::new(PROTO_NAME, &b"hello"[..], 1024 * 1024),
 				upgrade::Version::V1
 			).await;
 
@@ -545,7 +545,7 @@ mod tests {
 			let (socket, _) = listener.accept().await.unwrap();
 			let (initial_msg, substream) = upgrade::apply_inbound(
 				socket,
-				NotificationsIn::new(PROTO_NAME)
+				NotificationsIn::new(PROTO_NAME, 1024 * 1024)
 			).await.unwrap();
 
 			assert_eq!(initial_msg, b"hello");
@@ -567,7 +567,7 @@ mod tests {
 			let ret = upgrade::apply_outbound(
 				socket,
 				// We check that an initial message that is too large gets refused.
-				NotificationsOut::new(PROTO_NAME, (0..32768).map(|_| 0).collect::<Vec<_>>()),
+				NotificationsOut::new(PROTO_NAME, (0..32768).map(|_| 0).collect::<Vec<_>>(), 1024 * 1024),
 				upgrade::Version::V1
 			).await;
 			assert!(ret.is_err());
@@ -580,7 +580,7 @@ mod tests {
 			let (socket, _) = listener.accept().await.unwrap();
 			let ret = upgrade::apply_inbound(
 				socket,
-				NotificationsIn::new(PROTO_NAME)
+				NotificationsIn::new(PROTO_NAME, 1024 * 1024)
 			).await;
 			assert!(ret.is_err());
 		});
@@ -597,7 +597,7 @@ mod tests {
 			let socket = TcpStream::connect(listener_addr_rx.await.unwrap()).await.unwrap();
 			let ret = upgrade::apply_outbound(
 				socket,
-				NotificationsOut::new(PROTO_NAME, &b"initial message"[..]),
+				NotificationsOut::new(PROTO_NAME, &b"initial message"[..], 1024 * 1024),
 				upgrade::Version::V1
 			).await;
 			assert!(ret.is_err());
@@ -610,7 +610,7 @@ mod tests {
 			let (socket, _) = listener.accept().await.unwrap();
 			let (initial_message, mut substream) = upgrade::apply_inbound(
 				socket,
-				NotificationsIn::new(PROTO_NAME)
+				NotificationsIn::new(PROTO_NAME, 1024 * 1024)
 			).await.unwrap();
 			assert_eq!(initial_message, b"initial message");
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -295,7 +295,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				// The yamux buffer size limit is configured to be equal to the maximum frame size
 				// of all protocols. 10 bytes are added to each limit for the length prefix that
 				// is not included in the upper layer protocols limit but is still present in the
-				// yamux buffer.
+				// yamux buffer. These 10 bytes correspond to the maximum size required to encode
+				// a variable-length-encoding 64bits number. In other words, we make the
+				// assumption that no notification larger than 2^64 will ever be sent.
 				let yamux_maximum_buffer_size = {
 					let requests_max = params.network_config
 						.request_response_protocols.iter()

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -83,7 +83,9 @@ use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedReceiver, TracingUnbound
 use std::{
 	borrow::Cow,
 	collections::{HashMap, HashSet},
+	convert::TryFrom as _,
 	fs,
+	iter,
 	marker::PhantomData,
 	num:: NonZeroUsize,
 	pin::Pin,
@@ -283,6 +285,46 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				config
 			};
 
+			let (transport, bandwidth) = {
+				let (config_mem, config_wasm) = match params.network_config.transport {
+					TransportConfig::MemoryOnly => (true, None),
+					TransportConfig::Normal { wasm_external_transport, .. } =>
+						(false, wasm_external_transport)
+				};
+
+				// The yamux buffer size limit is configured to be equal to the maximum frame size
+				// of all protocols. 10 bytes are added to each limit for the length prefix that
+				// is not included in the upper layer protocols limit but is still present in the
+				// yamux buffer.
+				let yamux_maximum_buffer_size = {
+					let requests_max = params.network_config
+						.request_response_protocols.iter()
+						.map(|cfg| usize::try_from(cfg.max_request_size).unwrap_or(usize::max_value()));
+					let responses_max = params.network_config
+						.request_response_protocols.iter()
+						.map(|cfg| usize::try_from(cfg.max_response_size).unwrap_or(usize::max_value()));
+					let notifs_max = params.network_config
+						.extra_sets.iter()
+						.map(|cfg| usize::try_from(cfg.max_notification_size).unwrap_or(usize::max_value()));
+
+					// A "default" max is added to cover all the other protocols: ping, identify,
+					// kademlia.
+					let default_max = 1024 * 1024;
+					iter::once(default_max)
+						.chain(requests_max).chain(responses_max).chain(notifs_max)
+						.max().expect("iterator known to always yield at least one element; qed")
+						.saturating_add(10)
+				};
+
+				transport::build_transport(
+					local_identity,
+					config_mem,
+					config_wasm,
+					params.network_config.yamux_window_size,
+					yamux_maximum_buffer_size
+				)
+			};
+
 			let behaviour = {
 				let result = Behaviour::new(
 					protocol,
@@ -305,20 +347,6 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 				}
 			};
 
-			let (transport, bandwidth) = {
-				let (config_mem, config_wasm) = match params.network_config.transport {
-					TransportConfig::MemoryOnly => (true, None),
-					TransportConfig::Normal { wasm_external_transport, .. } =>
-						(false, wasm_external_transport)
-				};
-
-				transport::build_transport(
-					local_identity,
-					config_mem,
-					config_wasm,
-					params.network_config.yamux_window_size
-				)
-			};
 			let mut builder = SwarmBuilder::new(transport, behaviour, local_peer_id.clone())
 				.connection_limits(ConnectionLimits::default()
 					.with_max_established_per_peer(Some(crate::MAX_CONNECTIONS_PER_PEER as u32))

--- a/client/network/src/service/tests.rs
+++ b/client/network/src/service/tests.rs
@@ -144,6 +144,7 @@ fn build_nodes_one_proto()
 		extra_sets: vec![
 			config::NonDefaultSetConfig {
 				notifications_protocol: PROTOCOL_NAME,
+				max_notification_size: 1024 * 1024,
 				set_config: Default::default()
 			}
 		],
@@ -156,6 +157,7 @@ fn build_nodes_one_proto()
 		extra_sets: vec![
 			config::NonDefaultSetConfig {
 				notifications_protocol: PROTOCOL_NAME,
+				max_notification_size: 1024 * 1024,
 				set_config: config::SetConfig {
 					reserved_nodes: vec![config::MultiaddrWithPeerId {
 						multiaddr: listen_addr,
@@ -311,6 +313,7 @@ fn lots_of_incoming_peers_works() {
 		extra_sets: vec![
 			config::NonDefaultSetConfig {
 				notifications_protocol: PROTOCOL_NAME,
+				max_notification_size: 1024 * 1024,
 				set_config: config::SetConfig {
 					in_peers: u32::max_value(),
 					.. Default::default()
@@ -335,6 +338,7 @@ fn lots_of_incoming_peers_works() {
 			extra_sets: vec![
 				config::NonDefaultSetConfig {
 					notifications_protocol: PROTOCOL_NAME,
+					max_notification_size: 1024 * 1024,
 					set_config: config::SetConfig {
 						reserved_nodes: vec![config::MultiaddrWithPeerId {
 							multiaddr: listen_addr.clone(),

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -39,9 +39,9 @@ pub use self::bandwidth::BandwidthSinks;
 /// default (256kiB).
 ///
 /// `yamux_maximum_buffer_size` is the maximum allowed size of the Yamux buffer. This should be
-/// set either the maximum of all the maximum allowed sizes of messages frames of all high-level
-/// protocols combined, or to some generously high value if you are sure that a maximum size is
-/// enforced on all high-level protocols.
+/// set either to the maximum of all the maximum allowed sizes of messages frames of all
+/// high-level protocols combined, or to some generously high value if you are sure that a maximum
+/// size is enforced on all high-level protocols.
 ///
 /// Returns a `BandwidthSinks` object that allows querying the average bandwidth produced by all
 /// the connections spawned with this transport.

--- a/client/network/src/transport.rs
+++ b/client/network/src/transport.rs
@@ -35,8 +35,13 @@ pub use self::bandwidth::BandwidthSinks;
 /// If `memory_only` is true, then only communication within the same process are allowed. Only
 /// addresses with the format `/memory/...` are allowed.
 ///
-///`yamux_window_size` is the maximum size of the Yamux receive windows. `None` to leave the
+/// `yamux_window_size` is the maximum size of the Yamux receive windows. `None` to leave the
 /// default (256kiB).
+///
+/// `yamux_maximum_buffer_size` is the maximum allowed size of the Yamux buffer. This should be
+/// set either the maximum of all the maximum allowed sizes of messages frames of all high-level
+/// protocols combined, or to some generously high value if you are sure that a maximum size is
+/// enforced on all high-level protocols.
 ///
 /// Returns a `BandwidthSinks` object that allows querying the average bandwidth produced by all
 /// the connections spawned with this transport.
@@ -45,6 +50,7 @@ pub fn build_transport(
 	memory_only: bool,
 	wasm_external_transport: Option<wasm_ext::ExtTransport>,
 	yamux_window_size: Option<u32>,
+	yamux_maximum_buffer_size: usize,
 ) -> (Boxed<(PeerId, StreamMuxerBox)>, Arc<BandwidthSinks>) {
 	// Build the base layer of the transport.
 	let transport = if let Some(t) = wasm_external_transport {
@@ -101,6 +107,7 @@ pub fn build_transport(
 		// Enable proper flow-control: window updates are only sent when
 		// buffered data has been consumed.
 		yamux_config.set_window_update_mode(libp2p::yamux::WindowUpdateMode::on_read());
+		yamux_config.set_max_buffer_size(yamux_maximum_buffer_size);
 
 		if let Some(yamux_window_size) = yamux_window_size {
 			yamux_config.set_receive_window_size(yamux_window_size);

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -685,6 +685,7 @@ pub trait TestNetFactory: Sized {
 		network_config.extra_sets = config.notifications_protocols.into_iter().map(|p| {
 			NonDefaultSetConfig {
 				notifications_protocol: p,
+				max_notification_size: 1024 * 1024,
 				set_config: Default::default()
 			}
 		}).collect();


### PR DESCRIPTION
polkadot companion: https://github.com/paritytech/polkadot/pull/2287

From an API point of view, this PR adds a new field to `NonDefaultSetConfig`, `max_notification_size`, which sets the maximum allowed limit of notifications using that notifications protocol.

Before this PR, the maximum size of notifications is in theory 128MiB, coming from `UviBytes::default()`. In practice, however, it was actually 1MiB because Yamux will refuse to buffer more than 1MiB.

This PR also thus configures the Yamux buffer size limit to automatically match the maximum frame size of all network protocols that we use.
