### PR TITLE
Make pallets use construct_runtime

### DIFF
--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -28,7 +28,7 @@ frame-benchmarking = { version = "2.0.0", default-features = false, path = "../b
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-std = { version = "2.0.0", path = "../../primitives/std" }
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
-pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }
+pallet-balances = { version = "2.0.0", path = "../balances" }
 
 [features]
 default = ["std"]
@@ -37,7 +37,6 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
-	"pallet-balances/std",
 	"frame-support/std",
 	"frame-system/std",
 	"frame-benchmarking/std",

--- a/frame/assets/Cargo.toml
+++ b/frame/assets/Cargo.toml
@@ -37,6 +37,7 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
+	"pallet-balances/std",
 	"frame-support/std",
 	"frame-system/std",
 	"frame-benchmarking/std",

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1091,8 +1091,8 @@ mod tests {
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 	use pallet_balances::Error as BalancesError;
 
-	type UncheckedExtrinsic = frame_system::MockUncheckedExtrinsic<Test>;
-	type Block = frame_system::MockBlock<Test>;
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
 	frame_support::construct_runtime!(
 		pub enum Test where

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -1084,30 +1084,28 @@ impl<T: Config> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate as pallet_assets;
 
-	use frame_support::{impl_outer_origin, assert_ok, assert_noop, parameter_types, impl_outer_event};
+	use frame_support::{assert_ok, assert_noop, parameter_types};
 	use sp_core::H256;
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 	use pallet_balances::Error as BalancesError;
 
-	mod pallet_assets {
-		pub use crate::Event;
-	}
+	type UncheckedExtrinsic = frame_system::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::MockBlock<Test>;
 
-	impl_outer_event! {
-		pub enum Event for Test {
-			frame_system<T>,
-			pallet_balances<T>,
-			pallet_assets<T>,
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Assets: pallet_assets::{Module, Call, Storage, Event<T>},
 		}
-	}
+	);
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
-
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 	}
@@ -1118,7 +1116,7 @@ mod tests {
 		type DbWeight = ();
 		type Origin = Origin;
 		type Index = u64;
-		type Call = ();
+		type Call = Call;
 		type BlockNumber = u64;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
@@ -1128,7 +1126,7 @@ mod tests {
 		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -1171,9 +1169,6 @@ mod tests {
 		type MetadataDepositPerByte = MetadataDepositPerByte;
 		type WeightInfo = ();
 	}
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Assets = Module<Test>;
 
 	pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 		frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -965,7 +965,7 @@ mod tests {
 	use hex_literal::hex;
 	use sp_core::H256;
 	use sp_runtime::{
-		traits::{BlakeTwo256, IdentityLookup, Block as BlockT}, testing::Header,
+		traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 		BuildStorage,
 	};
 	use crate as collective;

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -1047,7 +1047,7 @@ mod tests {
 	use sp_core::H256;
 	use sp_runtime::{
 		testing::Header, BuildStorage, DispatchResult,
-		traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
+		traits::{BlakeTwo256, IdentityLookup},
 	};
 	use crate as elections_phragmen;
 

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -25,7 +25,7 @@ use frame_support::{
 };
 use sp_core::H256;
 use sp_runtime::{
-	BuildStorage, testing::Header, traits::{BlakeTwo256, IdentityLookup, Block as BlockT},
+	BuildStorage, testing::Header, traits::{BlakeTwo256, IdentityLookup},
 };
 use crate as elections;
 

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use frame_system as system;
 use sp_runtime::{
-	traits::{IdentityLookup, Block as BlockT},
+	traits::IdentityLookup,
 	testing::{Header, UintAuthorityId},
 };
 

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -302,6 +302,11 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 /// The population of the genesis storage depends on the order of modules. So, if one of your
 /// modules depends on another module, the module that is depended upon needs to come before
 /// the module depending on it.
+///
+/// # Macro generation
+///
+/// * The macro generates for each pallet a type alias to their `Module` (or `Pallet`).
+///   E.g. `type System = frame_system::Module<Runtime>`
 #[proc_macro]
 pub fn construct_runtime(input: TokenStream) -> TokenStream {
 	construct_runtime::construct_runtime(input)

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -305,7 +305,7 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 ///
 /// # Type definitions
 ///
-/// * The macro generates for each pallet a type alias to their `Module` (or `Pallet`).
+/// * The macro generates a type alias for each pallet to their `Module` (or `Pallet`).
 ///   E.g. `type System = frame_system::Module<Runtime>`
 #[proc_macro]
 pub fn construct_runtime(input: TokenStream) -> TokenStream {

--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -303,7 +303,7 @@ pub fn decl_storage(input: TokenStream) -> TokenStream {
 /// modules depends on another module, the module that is depended upon needs to come before
 /// the module depending on it.
 ///
-/// # Macro generation
+/// # Type definitions
 ///
 /// * The macro generates for each pallet a type alias to their `Module` (or `Pallet`).
 ///   E.g. `type System = frame_system::Module<Runtime>`

--- a/frame/support/src/inherent.rs
+++ b/frame/support/src/inherent.rs
@@ -75,6 +75,7 @@ macro_rules! impl_outer_inherent {
 			fn check_extrinsics(&self, block: &$block) -> $crate::inherent::CheckInherentsResult {
 				use $crate::inherent::{ProvideInherent, IsFatalError};
 				use $crate::traits::IsSubType;
+				use $crate::sp_runtime::traits::Block as _;
 
 				let mut result = $crate::inherent::CheckInherentsResult::new();
 				for xt in block.extrinsics() {

--- a/frame/support/test/tests/construct_runtime.rs
+++ b/frame/support/test/tests/construct_runtime.rs
@@ -21,7 +21,7 @@
 
 #![recursion_limit="128"]
 
-use sp_runtime::{generic, traits::{BlakeTwo256, Block as _, Verify}, DispatchError};
+use sp_runtime::{generic, traits::{BlakeTwo256, Verify}, DispatchError};
 use sp_core::{H256, sr25519};
 use sp_std::cell::RefCell;
 use frame_support::traits::PalletInfo as _;

--- a/frame/support/test/tests/instance.rs
+++ b/frame/support/test/tests/instance.rs
@@ -18,7 +18,7 @@
 #![recursion_limit="128"]
 
 use codec::{Codec, EncodeLike, Encode, Decode};
-use sp_runtime::{generic, BuildStorage, traits::{BlakeTwo256, Block as _, Verify}};
+use sp_runtime::{generic, BuildStorage, traits::{BlakeTwo256, Verify}};
 use frame_support::{
 	Parameter, traits::Get, parameter_types,
 	metadata::{

--- a/frame/support/test/tests/issue2219.rs
+++ b/frame/support/test/tests/issue2219.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use frame_support::sp_runtime::generic;
-use frame_support::sp_runtime::traits::{BlakeTwo256, Block as _, Verify};
+use frame_support::sp_runtime::traits::{BlakeTwo256, Verify};
 use frame_support::codec::{Encode, Decode};
 use sp_core::{H256, sr25519};
 use serde::{Serialize, Deserialize};

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -23,7 +23,7 @@ use frame_support::{
 	dispatch::{UnfilteredDispatchable, Parameter},
 	storage::unhashed,
 };
-use sp_runtime::{traits::Block as _, DispatchError};
+use sp_runtime::DispatchError;
 use sp_io::{TestExternalities, hashing::{twox_64, twox_128, blake2_128}};
 
 pub struct SomeType1;

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -15,8 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sp_runtime::traits::Block as _;
-
 pub trait SomeAssociation {
 	type A: frame_support::dispatch::Parameter + Default;
 }

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -15,8 +15,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sp_runtime::traits::Block as _;
-
 mod pallet_old {
 	use frame_support::{
 		decl_storage, decl_error, decl_event, decl_module, weights::Weight, traits::Get, Parameter

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -23,7 +23,7 @@ use frame_support::{
 	dispatch::UnfilteredDispatchable,
 	storage::unhashed,
 };
-use sp_runtime::{traits::Block as _, DispatchError};
+use sp_runtime::DispatchError;
 use sp_io::{TestExternalities, hashing::{twox_64, twox_128, blake2_128}};
 
 #[frame_support::pallet]

--- a/frame/support/test/tests/pallet_version.rs
+++ b/frame/support/test/tests/pallet_version.rs
@@ -20,7 +20,7 @@
 #![recursion_limit="128"]
 
 use codec::{Decode, Encode};
-use sp_runtime::{generic, traits::{BlakeTwo256, Block as _, Verify}, BuildStorage};
+use sp_runtime::{generic, traits::{BlakeTwo256, Verify}, BuildStorage};
 use frame_support::{
 	traits::{PALLET_VERSION_STORAGE_KEY_POSTFIX, PalletVersion, OnRuntimeUpgrade, GetPalletVersion},
 	crate_to_pallet_version, weights::Weight,

--- a/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
+++ b/frame/support/test/tests/pallet_with_name_trait_is_valid.rs
@@ -88,7 +88,6 @@ mod tests {
 	use crate as pallet_test;
 
 	use frame_support::parameter_types;
-	use sp_runtime::traits::Block;
 
 	type SignedExtra = (
 		frame_system::CheckEra<Runtime>,

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1537,7 +1537,7 @@ pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::Unchec
 	<T as Config>::AccountId, <T as Config>::Call, Signature, Extra,
 >;
 
-/// An implementation of `sp_runtime::traits::Block` to be used in test.
+/// An implementation of `sp_runtime::traits::Block` to be used in tests.
 pub type MockBlock<T> = generic::Block<
 	generic::Header<<T as Config>::BlockNumber, sp_runtime::traits::BlakeTwo256>,
 	MockUncheckedExtrinsic<T>,

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -112,6 +112,8 @@ mod extensions;
 pub mod weights;
 #[cfg(test)]
 mod tests;
+#[cfg(feature = "std")]
+pub mod mocking;
 
 
 pub use extensions::{
@@ -1530,15 +1532,3 @@ pub mod pallet_prelude {
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
-
-
-/// An unchecked extrinsic type to be used in tests.
-pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::UncheckedExtrinsic<
-	<T as Config>::AccountId, <T as Config>::Call, Signature, Extra,
->;
-
-/// An implementation of `sp_runtime::traits::Block` to be used in tests.
-pub type MockBlock<T> = generic::Block<
-	generic::Header<<T as Config>::BlockNumber, sp_runtime::traits::BlakeTwo256>,
-	MockUncheckedExtrinsic<T>,
->;

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1532,7 +1532,7 @@ pub mod pallet_prelude {
 }
 
 
-/// An unchecked extrinsic type to be used in test.
+/// An unchecked extrinsic type to be used in tests.
 pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::UncheckedExtrinsic<
 	<T as Config>::AccountId, <T as Config>::Call, Signature, Extra,
 >;

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1530,3 +1530,15 @@ pub mod pallet_prelude {
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
+
+
+/// An unchecked extrinsic type to be used in test.
+pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::UncheckedExtrinsic<
+	<T as Config>::AccountId, <T as Config>::Call, Signature, Extra,
+>;
+
+/// An implementation of `sp_runtime::traits::Block` to be used in test.
+pub type MockBlock<T> = generic::Block<
+	generic::Header<<T as Config>::BlockNumber, sp_runtime::traits::BlakeTwo256>,
+	MockUncheckedExtrinsic<T>,
+>;

--- a/frame/system/src/mocking.rs
+++ b/frame/system/src/mocking.rs
@@ -1,0 +1,31 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provide types to help defining a mock environment when testing pallets.
+
+use sp_runtime::generic;
+
+/// An unchecked extrinsic type to be used in tests.
+pub type MockUncheckedExtrinsic<T, Signature = (), Extra = ()> = generic::UncheckedExtrinsic<
+	<T as crate::Config>::AccountId, <T as crate::Config>::Call, Signature, Extra,
+>;
+
+/// An implementation of `sp_runtime::traits::Block` to be used in tests.
+pub type MockBlock<T> = generic::Block<
+	generic::Header<<T as crate::Config>::BlockNumber, sp_runtime::traits::BlakeTwo256>,
+	MockUncheckedExtrinsic<T>,
+>;


### PR DESCRIPTION
Related to https://github.com/paritytech/substrate/issues/7949

This PR introduce a few types, and make pallet-assets use construct_runtime.