### PR TITLE
Adds host function for handle panicking

### DIFF
--- a/client/executor/wasmtime/src/instance_wrapper.rs
+++ b/client/executor/wasmtime/src/instance_wrapper.rs
@@ -98,7 +98,7 @@ impl EntryPoint {
 		let data_ptr = u32::from(data_ptr) as i32;
 		let data_len = u32::from(data_len) as i32;
 
-		(match self.call_type {
+		match self.call_type {
 			EntryPointType::Direct => {
 				self.func.call(&[
 					wasmtime::Val::I32(data_ptr),
@@ -112,15 +112,14 @@ impl EntryPoint {
 					wasmtime::Val::I32(data_len),
 				])
 			},
-		})
-			.map(|results| 
-				// the signature is checked to have i64 return type
-				results[0].unwrap_i64() as u64
-			)
-			.map_err(|err| Error::from(format!(
-				"Wasm execution trapped: {}",
-				err
-			)))
+		}.map(|results|
+			// the signature is checked to have i64 return type
+			results[0].unwrap_i64() as u64
+		)
+		.map_err(|err| Error::from(format!(
+			"Wasm execution trapped: {}",
+			err,
+		)))
 	}
 
 	pub fn direct(func: wasmtime::Func) -> std::result::Result<Self, &'static str> {

--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1007,6 +1007,17 @@ trait Allocator {
 	}
 }
 
+/// Wasm only panic handler.
+#[runtime_interface(wasm_only)]
+trait PanicHandler {
+	/// Should be called when the wasm instance is panicking.
+	///
+	/// The given `message` should correspond to the reason the instance panicked.
+	fn panicking(&mut self, message: &str) {
+		self.instance_panicked(message);
+	}
+}
+
 /// Interface that provides functions for logging from within the runtime.
 #[runtime_interface]
 pub trait Logging {

--- a/primitives/wasm-interface/src/lib.rs
+++ b/primitives/wasm-interface/src/lib.rs
@@ -272,7 +272,9 @@ impl PartialEq for dyn Function {
 	}
 }
 
-/// Context used by `Function` to interact with the allocator and the memory of the wasm instance.
+/// Context used by [`Function`] to interact with the executing context.
+///
+/// This includes access to the memory and the sandbox.
 pub trait FunctionContext {
 	/// Read memory from `address` into a vector.
 	fn read_memory(&self, address: Pointer<u8>, size: WordSize) -> Result<Vec<u8>> {
@@ -290,6 +292,8 @@ pub trait FunctionContext {
 	fn deallocate_memory(&mut self, ptr: Pointer<u8>) -> Result<()>;
 	/// Provides access to the sandbox.
 	fn sandbox(&mut self) -> &mut dyn Sandbox;
+	/// The wasm instance panicked with the given `message`.
+	fn instance_panicked(&mut self, message: &str);
 }
 
 /// Sandbox memory identifier.


### PR DESCRIPTION
This pr adds an extra host function that should be called by the wasm
instance when its panicking. Currently we only log such a panic with an
error severity. In the future we would call this host function and
have the advantage that the panic message would be returned as error,
instead of just some generic "panicked" message.

This pr only adds the host function and the client side implementation.
Some future pr would switch over the runtime to use this functionality.

