### PR TITLE
Enable sync mode for parity-db

### DIFF
--- a/client/db/src/parity_db.rs
+++ b/client/db/src/parity_db.rs
@@ -37,6 +37,7 @@ pub fn open<H: Clone>(path: &std::path::Path, db_type: DatabaseType)
 	-> parity_db::Result<std::sync::Arc<dyn Database<H>>>
 {
 	let mut config = parity_db::Options::with_columns(path, NUM_COLUMNS as u8);
+	config.sync = true; // Flush each commit
 	if db_type == DatabaseType::Full {
 		let mut state_col = &mut config.columns[columns::STATE as usize];
 		state_col.ref_counted = true;


### PR DESCRIPTION
This enable filesystem flush on each commit, which should prevent DB corruption on system power loss or VM crash.
Has minor effect on performance.