### PR TITLE
Remove hidden item `__NonExhaustive` in syn crate

### DIFF
--- a/frame/support/procedural/src/pallet/parse/helper.rs
+++ b/frame/support/procedural/src/pallet/parse/helper.rs
@@ -98,8 +98,7 @@ impl MutItemAttrs for syn::Item {
 			Self::Type(item) => Some(item.attrs.as_mut()),
 			Self::Union(item) => Some(item.attrs.as_mut()),
 			Self::Use(item) => Some(item.attrs.as_mut()),
-			Self::Verbatim(_) => None,
-			Self::__Nonexhaustive => None,
+			_ => None,
 		}
 	}
 }
@@ -112,8 +111,7 @@ impl MutItemAttrs for syn::TraitItem {
 			Self::Method(item) => Some(item.attrs.as_mut()),
 			Self::Type(item) => Some(item.attrs.as_mut()),
 			Self::Macro(item) => Some(item.attrs.as_mut()),
-			Self::Verbatim(_) => None,
-			Self::__Nonexhaustive => None,
+			_ => None,
 		}
 	}
 }


### PR DESCRIPTION
`Item::__Nonexhaustive` from `syn` crate is not supposed to be public, and using it may lead to unintentional API break when `syn` updates. This PR changes it to use non-exhaustive matching with `_`.

Alternatively, `syn` supports using the `__TestExhaustive` idiom for exhaustive matching (https://docs.rs/syn/1.0.60/src/syn/item.rs.html#74):

```
match expr {
  #[cfg(test)]
  Item::__TestExhaustive(_) => unimplemented!(),
  #[cfg(not(test))]
  _ => { /* some sane fallback */ }
}
```

I slightly prefer we continue to use non-exhaustive matching because it's already sufficient.