### PR TITLE
Use construct_runtime for some more pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,6 +4351,7 @@ dependencies = [
  "frame-system",
  "impl-trait-for-tuples 0.2.0",
  "parity-scale-codec",
+ "serde",
  "sp-authorship",
  "sp-core",
  "sp-inherents",

--- a/frame/atomic-swap/src/tests.rs
+++ b/frame/atomic-swap/src/tests.rs
@@ -1,20 +1,30 @@
 #![cfg(test)]
 
 use super::*;
+use crate as pallet_atomic_swap;
 
-use frame_support::{impl_outer_origin, parameter_types};
+use frame_support::parameter_types;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-#[derive(Clone, Eq, Debug, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		AtomicSwap: pallet_atomic_swap::{Module, Call, Event<T>},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -29,15 +39,15 @@ impl frame_system::Config for Test {
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
-	type Call = ();
+	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -51,7 +61,7 @@ impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
 	type DustRemoval = ();
-	type Event = ();
+	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
@@ -61,13 +71,10 @@ parameter_types! {
 	pub const ExpireDuration: u64 = 100;
 }
 impl Config for Test {
-	type Event = ();
+	type Event = Event;
 	type SwapAction = BalanceSwapAction<u64, Balances>;
 	type ProofLimit = ProofLimit;
 }
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
-type AtomicSwap = Module<Test>;
 
 const A: u64 = 1;
 const B: u64 = 2;

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -19,23 +19,30 @@
 
 #![cfg(test)]
 
-use crate::{Config, Module, GenesisConfig};
+use crate as pallet_aura;
 use sp_consensus_aura::ed25519::AuthorityId;
 use sp_runtime::{
 	traits::IdentityLookup,
 	testing::{Header, UintAuthorityId},
 };
-use frame_support::{impl_outer_origin, parameter_types};
+use frame_support::parameter_types;
 use sp_io;
 use sp_core::H256;
 
-impl_outer_origin!{
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+		Aura: pallet_aura::{Module, Call, Storage, Config<T>, Inherent},
+	}
+);
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -52,16 +59,16 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
-	type Call = ();
+	type Call = Call;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -76,16 +83,14 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
-impl Config for Test {
+impl pallet_aura::Config for Test {
 	type AuthorityId = AuthorityId;
 }
 
 pub fn new_test_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	GenesisConfig::<Test>{
+	pallet_aura::GenesisConfig::<Test>{
 		authorities: authorities.into_iter().map(|a| UintAuthorityId(a).to_public_key()).collect(),
 	}.assimilate_storage(&mut t).unwrap();
 	t.into()
 }
-
-pub type Aura = Module<Test>;

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -115,6 +115,7 @@ impl<T: Config> pallet_session::OneSessionHandler<T::AccountId> for Module<T> {
 
 #[cfg(test)]
 mod tests {
+	use crate as pallet_authority_discovery;
 	use super::*;
 	use sp_authority_discovery::AuthorityPair;
 	use sp_application_crypto::Pair;
@@ -124,12 +125,23 @@ mod tests {
 		testing::{Header, UintAuthorityId}, traits::{ConvertInto, IdentityLookup, OpaqueKeys},
 		Perbill, KeyTypeId,
 	};
-	use frame_support::{impl_outer_origin, parameter_types};
+	use frame_support::parameter_types;
 
-	type AuthorityDiscovery = Module<Test>;
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
+			AuthorityDiscovery: pallet_authority_discovery::{Module, Call, Config},
+		}
+	);
+
 	impl Config for Test {}
 
 	parameter_types! {
@@ -141,7 +153,7 @@ mod tests {
 		type Keys = UintAuthorityId;
 		type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
 		type SessionHandler = TestSessionHandler;
-		type Event = ();
+		type Event = Event;
 		type ValidatorId = AuthorityId;
 		type ValidatorIdOf = ConvertInto;
 		type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
@@ -173,25 +185,21 @@ mod tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = BlockNumber;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = ::sp_runtime::traits::BlakeTwo256;
 		type AccountId = AuthorityId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
-	}
-
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
 	}
 
 	pub struct TestSessionHandler;
@@ -247,7 +255,7 @@ mod tests {
 			.build_storage::<Test>()
 			.unwrap();
 
-		GenesisConfig {
+		pallet_authority_discovery::GenesisConfig {
 			keys: vec![],
 		}
 		.assimilate_storage::<Test>(&mut t)

--- a/frame/authorship/Cargo.toml
+++ b/frame/authorship/Cargo.toml
@@ -25,6 +25,7 @@ impl-trait-for-tuples = "0.2.0"
 [dev-dependencies]
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-io ={ version = "2.0.0", path = "../../primitives/io" }
+serde = { version = "1.0.101" }
 
 [features]
 default = ["std"]

--- a/frame/authorship/src/lib.rs
+++ b/frame/authorship/src/lib.rs
@@ -396,19 +396,27 @@ impl<T: Config> ProvideInherent for Module<T> {
 
 #[cfg(test)]
 mod tests {
+	use crate as pallet_authorship;
 	use super::*;
 	use sp_core::H256;
 	use sp_runtime::{
 		traits::{BlakeTwo256, IdentityLookup}, testing::Header, generic::DigestItem,
 	};
-	use frame_support::{parameter_types, impl_outer_origin, ConsensusEngineId};
+	use frame_support::{parameter_types, ConsensusEngineId};
 
-	impl_outer_origin!{
-		pub enum Origin for Test where system = frame_system {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Authorship: pallet_authorship::{Module, Call, Storage, Inherent},
+		}
+	);
 
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
@@ -424,16 +432,16 @@ mod tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -451,9 +459,6 @@ mod tests {
 		type FilterUncle = SealVerify<VerifyBlock>;
 		type EventHandler = ();
 	}
-
-	type System = frame_system::Module<Test>;
-	type Authorship = Module<Test>;
 
 	const TEST_ID: ConsensusEngineId = [1, 2, 3, 4];
 


### PR DESCRIPTION
related https://github.com/paritytech/substrate/issues/7949

this make tests for aura, atomic-swap, authority-discovery and authorship making use of construct_runtime runtime