### PR TITLE
Ensure transactional with ? works in frame v2

### DIFF
--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -155,11 +155,11 @@ pub mod pallet {
 			#[pallet::compact] foo: u32,
 		) -> DispatchResultWithPostInfo {
 			Self::deposit_event(Event::Something(0));
-			if foo != 0 {
-				Ok(().into())
-			} else {
-				Err(Error::<T>::InsufficientProposersBalance.into())
+			if foo == 0 {
+				Err(Error::<T>::InsufficientProposersBalance)?;
 			}
+
+			Ok(().into())
 		}
 	}
 

--- a/frame/support/test/tests/storage_transaction.rs
+++ b/frame/support/test/tests/storage_transaction.rs
@@ -195,7 +195,8 @@ fn transactional_annotation() {
 	#[transactional]
 	fn value_rollbacks(v: u32) -> result::Result<u32, &'static str> {
 		set_value(v)?;
-		Err("nah")
+		Err("nah")?;
+		Ok(v)
 	}
 
 	TestExternalities::default().execute_with(|| {


### PR DESCRIPTION
actually I'm not sure it is needed to test for it as transactional macro is independant from frame v2, but anyway having it in the test might be better to show usage

cc @apopiak 

EDIT: this comes from my missunderstood of Apopiak message, sorry