### PR TITLE
Fix Network trait implementation not doing what it's supposed to do

### DIFF
--- a/client/network-gossip/src/lib.rs
+++ b/client/network-gossip/src/lib.rs
@@ -113,7 +113,7 @@ impl<B: BlockT, H: ExHashT> Network<B> for Arc<NetworkService<B, H>> {
 	fn add_set_reserved(&self, who: PeerId, protocol: Cow<'static, str>) {
 		let addr = iter::once(multiaddr::Protocol::P2p(who.into()))
 			.collect::<multiaddr::Multiaddr>();
-		let result = NetworkService::add_to_peers_set(self, protocol, iter::once(addr).collect());
+		let result = NetworkService::add_peers_to_reserved_set(self, protocol, iter::once(addr).collect());
 		if let Err(err) = result {
 			log::error!(target: "gossip", "add_set_reserved failed: {}", err);
 		}
@@ -122,7 +122,7 @@ impl<B: BlockT, H: ExHashT> Network<B> for Arc<NetworkService<B, H>> {
 	fn remove_set_reserved(&self, who: PeerId, protocol: Cow<'static, str>) {
 		let addr = iter::once(multiaddr::Protocol::P2p(who.into()))
 			.collect::<multiaddr::Multiaddr>();
-		let result = NetworkService::remove_from_peers_set(self, protocol, iter::once(addr).collect());
+		let result = NetworkService::remove_peers_from_reserved_set(self, protocol, iter::once(addr).collect());
 		if let Err(err) = result {
 			log::error!(target: "gossip", "remove_set_reserved failed: {}", err);
 		}


### PR DESCRIPTION
The `add_set_reserved` and `remove_set_reserved` trait methods are supposed to add/remove nodes from the reserved nodes, to guarantee that a substream will be opened and closed.
They were mistakenly only adding/removing the peer from the list of nodes of the set. This means that `add_set_reserved` didn't guarantee that a substream was opened. 

Fix #7983
