### PR TITLE
Make pallet use construct_runtime in tests instead of impl_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4860,6 +4860,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
+ "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/frame/randomness-collective-flip/Cargo.toml
+++ b/frame/randomness-collective-flip/Cargo.toml
@@ -23,6 +23,7 @@ sp-std = { version = "2.0.0", default-features = false, path = "../../primitives
 [dev-dependencies]
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
+serde = { version = "1.0.101" }
 
 [features]
 default = ["std"]

--- a/frame/randomness-collective-flip/src/lib.rs
+++ b/frame/randomness-collective-flip/src/lib.rs
@@ -132,6 +132,7 @@ impl<T: Config> Randomness<T::Hash> for Module<T> {
 
 #[cfg(test)]
 mod tests {
+	use crate as pallet_randomness_collective_flip;
 	use super::*;
 	use sp_core::H256;
 	use sp_runtime::{
@@ -139,16 +140,21 @@ mod tests {
 		traits::{BlakeTwo256, Header as _, IdentityLookup},
 	};
 	use frame_system::limits;
-	use frame_support::{
-		impl_outer_origin, parameter_types, traits::{Randomness, OnInitialize},
-	};
+	use frame_support::{parameter_types, traits::{Randomness, OnInitialize}};
 
-	#[derive(Clone, PartialEq, Eq)]
-	pub struct Test;
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			CollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+		}
+	);
 
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
@@ -166,25 +172,22 @@ mod tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 	}
-
-	type System = frame_system::Module<Test>;
-	type CollectiveFlip = Module<Test>;
 
 	fn new_test_ext() -> sp_io::TestExternalities {
 		let t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/frame/recovery/src/mock.rs
+++ b/frame/recovery/src/mock.rs
@@ -19,36 +19,27 @@
 
 use super::*;
 
-use frame_support::{
-	impl_outer_origin, impl_outer_dispatch, impl_outer_event, parameter_types,
-	traits::{OnInitialize, OnFinalize},
-};
+use frame_support::{parameter_types, traits::{OnInitialize, OnFinalize}};
 use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };
 use crate as recovery;
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-impl_outer_event! {
-	pub enum TestEvent for Test {
-		system<T>,
-		pallet_balances<T>,
-		recovery<T>,
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Recovery: recovery::{Module, Call, Storage, Event<T>},
 	}
-}
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		pallet_balances::Balances,
-		recovery::Recovery,
-	}
-}
-
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+);
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -70,10 +61,10 @@ impl frame_system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u128>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -89,7 +80,7 @@ impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u128;
 	type DustRemoval = ();
-	type Event = TestEvent;
+	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
@@ -103,7 +94,7 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Event = TestEvent;
+	type Event = Event;
 	type Call = Call;
 	type Currency = Balances;
 	type ConfigDepositBase = ConfigDepositBase;
@@ -111,10 +102,6 @@ impl Config for Test {
 	type MaxFriends = MaxFriends;
 	type RecoveryDeposit = RecoveryDeposit;
 }
-
-pub type Recovery = Module<Test>;
-pub type System = frame_system::Module<Test>;
-pub type Balances = pallet_balances::Module<Test>;
 
 pub type BalancesCall = pallet_balances::Call<Test>;
 pub type RecoveryCall = super::Call<Test>;

--- a/frame/scored-pool/src/mock.rs
+++ b/frame/scored-pool/src/mock.rs
@@ -18,21 +18,31 @@
 //! Test utilities
 
 use super::*;
+use crate as pallet_scored_pool;
 
 use std::cell::RefCell;
-use frame_support::{impl_outer_origin, parameter_types, ord_parameter_types};
+use frame_support::{parameter_types, ord_parameter_types};
 use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };
 use frame_system::EnsureSignedBy;
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		ScoredPool: pallet_scored_pool::{Module, Call, Storage, Config<T>, Event<T>},
+	}
+);
+
 parameter_types! {
 	pub const CandidateDeposit: u64 = 25;
 	pub const Period: u64 = 4;
@@ -55,15 +65,15 @@ impl frame_system::Config for Test {
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
-	type Call = ();
+	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -74,7 +84,7 @@ impl frame_system::Config for Test {
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
-	type Event = ();
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -109,7 +119,7 @@ impl InitializeMembers<u64> for TestChangeMembers {
 }
 
 impl Config for Test {
-	type Event = ();
+	type Event = Event;
 	type KickOrigin = EnsureSignedBy<KickOrigin, u64>;
 	type MembershipInitialized = TestChangeMembers;
 	type MembershipChanged = TestChangeMembers;
@@ -119,9 +129,6 @@ impl Config for Test {
 	type Score = u64;
 	type ScoreOrigin = EnsureSignedBy<ScoreOrigin, u64>;
 }
-
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
@@ -136,7 +143,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 			(99, 1),
 		],
 	}.assimilate_storage(&mut t).unwrap();
-	GenesisConfig::<Test>{
+	pallet_scored_pool::GenesisConfig::<Test>{
 		pool: vec![
 			(5, None),
 			(10, Some(1)),

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use std::cell::RefCell;
-use frame_support::{impl_outer_origin, parameter_types, BasicExternalities};
+use frame_support::{parameter_types, BasicExternalities};
 use sp_core::{crypto::key_types::DUMMY, H256};
 use sp_runtime::{
 	Perbill, impl_opaque_keys,
@@ -27,6 +27,9 @@ use sp_runtime::{
 	testing::{Header, UintAuthorityId},
 };
 use sp_staking::SessionIndex;
+use crate as pallet_session;
+#[cfg(feature = "historical")]
+use crate::historical as pallet_session_historical;
 
 impl_opaque_keys! {
 	pub struct MockSessionKeys {
@@ -65,9 +68,34 @@ impl OpaqueKeys for PreUpgradeMockSessionKeys {
 	}
 }
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[cfg(feature = "historical")]
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
+		Historical: pallet_session_historical::{Module},
+	}
+);
+
+#[cfg(not(feature = "historical"))]
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
+	}
+);
+
 
 thread_local! {
 	pub static VALIDATORS: RefCell<Vec<u64>> = RefCell::new(vec![1, 2, 3]);
@@ -189,12 +217,9 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		// An additional identity that we use.
 		frame_system::Module::<Test>::inc_providers(&69);
 	});
-	GenesisConfig::<Test> { keys }.assimilate_storage(&mut t).unwrap();
+	pallet_session::GenesisConfig::<Test> { keys }.assimilate_storage(&mut t).unwrap();
 	sp_io::TestExternalities::new(t)
 }
-
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
 
 parameter_types! {
 	pub const MinimumPeriod: u64 = 5;
@@ -211,16 +236,16 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
-	type Call = ();
+	type Call = Call;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -249,7 +274,7 @@ impl Config for Test {
 	type ValidatorId = u64;
 	type ValidatorIdOf = ConvertInto;
 	type Keys = MockSessionKeys;
-	type Event = ();
+	type Event = Event;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = ();
 	type WeightInfo = ();
@@ -260,6 +285,3 @@ impl crate::historical::Config for Test {
 	type FullIdentification = u64;
 	type FullIdentificationOf = sp_runtime::traits::ConvertInto;
 }
-
-pub type System = frame_system::Module<Test>;
-pub type Session = Module<Test>;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -96,7 +96,6 @@ frame_support::construct_runtime!(
 	}
 );
 
-
 thread_local! {
 	pub static VALIDATORS: RefCell<Vec<u64>> = RefCell::new(vec![1, 2, 3]);
 	pub static NEXT_VALIDATORS: RefCell<Vec<u64>> = RefCell::new(vec![1, 2, 3]);

--- a/frame/society/src/mock.rs
+++ b/frame/society/src/mock.rs
@@ -18,9 +18,10 @@
 //! Test utilities
 
 use super::*;
+use crate as pallet_society;
 
 use frame_support::{
-	impl_outer_origin, parameter_types, ord_parameter_types,
+	parameter_types, ord_parameter_types,
 	traits::{OnInitialize, OnFinalize, TestRandomness},
 };
 use sp_core::H256;
@@ -30,12 +31,21 @@ use sp_runtime::{
 };
 use frame_system::EnsureSignedBy;
 
-impl_outer_origin! {
-	pub enum Origin for Test {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Society: pallet_society::{Module, Call, Storage, Event<T>, Config<T>},
+	}
+);
+
 parameter_types! {
 	pub const CandidateDeposit: u64 = 25;
 	pub const WrongSideDeduction: u64 = 2;
@@ -65,12 +75,12 @@ impl frame_system::Config for Test {
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
-	type Call = ();
+	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = u128;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = ();
@@ -84,7 +94,7 @@ impl frame_system::Config for Test {
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
-	type Event = ();
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -92,7 +102,7 @@ impl pallet_balances::Config for Test {
 }
 
 impl Config for Test {
-	type Event = ();
+	type Event = Event;
 	type Currency = pallet_balances::Module<Self>;
 	type Randomness = TestRandomness;
 	type CandidateDeposit = CandidateDeposit;
@@ -107,10 +117,6 @@ impl Config for Test {
 	type ChallengePeriod = ChallengePeriod;
 	type ModuleId = SocietyModuleId;
 }
-
-pub type Society = Module<Test>;
-pub type System = frame_system::Module<Test>;
-pub type Balances = pallet_balances::Module<Test>;
 
 pub struct EnvBuilder {
 	members: Vec<u128>,
@@ -147,7 +153,7 @@ impl EnvBuilder {
 		pallet_balances::GenesisConfig::<Test> {
 			balances: self.balances,
 		}.assimilate_storage(&mut t).unwrap();
-		GenesisConfig::<Test>{
+		pallet_society::GenesisConfig::<Test>{
 			members: self.members,
 			pot: self.pot,
 			max_members: self.max_members,

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -18,8 +18,9 @@
 //! Test utilities
 
 use crate::*;
+use crate as staking;
 use frame_support::{
-	assert_ok, impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types,
+	assert_ok, parameter_types,
 	traits::{Currency, FindAuthor, Get, OnFinalize, OnInitialize},
 	weights::{constants::RocksDbWeight, Weight},
 	IterableStorageMap, StorageDoubleMap, StorageMap, StorageValue,
@@ -87,32 +88,22 @@ pub fn is_disabled(controller: AccountId) -> bool {
 	SESSION.with(|d| d.borrow().1.contains(&stash))
 }
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		staking::Staking,
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Staking: staking::{Module, Call, Config<T>, Storage, Event<T>, ValidateUnsigned},
+		Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
 	}
-}
-
-mod staking {
-	// Re-export needed for `impl_outer_event!`.
-	pub use super::super::*;
-}
-use frame_system as system;
-use pallet_balances as balances;
-use pallet_session as session;
-
-impl_outer_event! {
-	pub enum MetaEvent for Test {
-		system<T>,
-		balances<T>,
-		session,
-		staking<T>,
-	}
-}
+);
 
 /// Author of block is always 11
 pub struct Author11;
@@ -123,10 +114,6 @@ impl FindAuthor<AccountId> for Author11 {
 		Some(11)
 	}
 }
-
-// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct Test;
 
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
@@ -158,10 +145,10 @@ impl frame_system::Config for Test {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = MetaEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -171,7 +158,7 @@ impl frame_system::Config for Test {
 impl pallet_balances::Config for Test {
 	type MaxLocks = MaxLocks;
 	type Balance = Balance;
-	type Event = MetaEvent;
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -191,7 +178,7 @@ impl pallet_session::Config for Test {
 	type Keys = SessionKeys;
 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
 	type SessionHandler = (OtherSessionHandler,);
-	type Event = MetaEvent;
+	type Event = Event;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = crate::StashOf<Test>;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
@@ -257,7 +244,7 @@ impl Config for Test {
 	type UnixTime = Timestamp;
 	type CurrencyToVote = frame_support::traits::SaturatingCurrencyToVote;
 	type RewardRemainder = RewardRemainderMock;
-	type Event = MetaEvent;
+	type Event = Event;
 	type Slash = ();
 	type Reward = ();
 	type SessionsPerEra = SessionsPerEra;
@@ -450,7 +437,7 @@ impl ExtBuilder {
 				(101, 100, balance_factor * 500, StakerStatus::<AccountId>::Nominator(nominated))
 			];
 		}
-		let _ = GenesisConfig::<Test>{
+		let _ = staking::GenesisConfig::<Test>{
 			stakers: stakers,
 			validator_count: self.validator_count,
 			minimum_validator_count: self.minimum_validator_count,
@@ -494,12 +481,6 @@ impl ExtBuilder {
 		ext.execute_with(post_conditions);
 	}
 }
-
-pub type System = frame_system::Module<Test>;
-pub type Balances = pallet_balances::Module<Test>;
-pub type Session = pallet_session::Module<Test>;
-pub type Timestamp = pallet_timestamp::Module<Test>;
-pub type Staking = Module<Test>;
 
 fn post_conditions() {
 	check_nominators();
@@ -1016,9 +997,9 @@ macro_rules! assert_session_era {
 	};
 }
 
-pub(crate) fn staking_events() -> Vec<Event<Test>> {
+pub(crate) fn staking_events() -> Vec<staking::Event<Test>> {
 	System::events().into_iter().map(|r| r.event).filter_map(|e| {
-		if let MetaEvent::staking(inner) = e {
+		if let Event::staking(inner) = e {
 			Some(inner)
 		} else {
 			None

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -3181,7 +3181,7 @@ mod offchain_election {
 					.into_iter()
 					.map(|r| r.event)
 					.filter_map(|e| {
-						if let MetaEvent::staking(inner) = e {
+						if let mock::Event::staking(inner) = e {
 							Some(inner)
 						} else {
 							None
@@ -3266,7 +3266,7 @@ mod offchain_election {
 						.into_iter()
 						.map(|r| r.event)
 						.filter_map(|e| {
-							if let MetaEvent::staking(inner) = e {
+							if let mock::Event::staking(inner) = e {
 								Some(inner)
 							} else {
 								None
@@ -3285,7 +3285,7 @@ mod offchain_election {
 						.into_iter()
 						.map(|r| r.event)
 						.filter_map(|e| {
-							if let MetaEvent::staking(inner) = e {
+							if let mock::Event::staking(inner) = e {
 								Some(inner)
 							} else {
 								None
@@ -3322,7 +3322,7 @@ mod offchain_election {
 						.into_iter()
 						.map(|r| r.event)
 						.filter_map(|e| {
-							if let MetaEvent::staking(inner) = e {
+							if let mock::Event::staking(inner) = e {
 								Some(inner)
 							} else {
 								None
@@ -3458,6 +3458,7 @@ mod offchain_election {
 			let call = extrinsic.call;
 			let inner = match call {
 				mock::Call::Staking(inner) => inner,
+				_ => unreachable!(),
 			};
 
 			assert_eq!(
@@ -3501,6 +3502,7 @@ mod offchain_election {
 			let call = extrinsic.call;
 			let inner = match call {
 				mock::Call::Staking(inner) => inner,
+				_ => unreachable!(),
 			};
 
 			assert_eq!(
@@ -3548,6 +3550,7 @@ mod offchain_election {
 			let call = extrinsic.call;
 			let inner = match call {
 				mock::Call::Staking(inner) => inner,
+				_ => unreachable!(),
 			};
 
 			// pass this call to ValidateUnsigned

--- a/frame/sudo/src/tests.rs
+++ b/frame/sudo/src/tests.rs
@@ -19,7 +19,8 @@
 
 use super::*;
 use mock::{
-	Sudo, SudoCall, Origin, Call, Test, new_test_ext, LoggerCall, Logger, System, TestEvent,
+	Sudo, SudoCall, Origin, Call, Test, new_test_ext, LoggerCall, Logger, System,
+	Event as TestEvent,
 };
 use frame_support::{assert_ok, assert_noop};
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -290,9 +290,10 @@ impl<T: Config> UnixTime for Module<T> {
 
 #[cfg(test)]
 mod tests {
+	use crate as pallet_timestamp;
 	use super::*;
 
-	use frame_support::{impl_outer_origin, assert_ok, parameter_types};
+	use frame_support::{assert_ok, parameter_types};
 	use sp_io::TestExternalities;
 	use sp_core::H256;
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
@@ -302,12 +303,20 @@ mod tests {
 		TestExternalities::new(t)
 	}
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
+		}
+	);
+
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub BlockWeights: frame_system::limits::BlockWeights =
@@ -321,16 +330,16 @@ mod tests {
 		type Origin = Origin;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Call = ();
+		type Call = Call;
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -346,7 +355,6 @@ mod tests {
 		type MinimumPeriod = MinimumPeriod;
 		type WeightInfo = ();
 	}
-	type Timestamp = Module<Test>;
 
 	#[test]
 	fn timestamp_works() {

--- a/frame/tips/src/tests.rs
+++ b/frame/tips/src/tests.rs
@@ -19,13 +19,11 @@
 
 #![cfg(test)]
 
+use crate as tips;
 use super::*;
 use std::cell::RefCell;
-use frame_support::{
-	assert_noop, assert_ok, impl_outer_origin, parameter_types, weights::Weight,
-	impl_outer_event, traits::{Contains}
-};
-use sp_runtime::{Permill};
+use frame_support::{assert_noop, assert_ok, parameter_types, weights::Weight, traits::Contains};
+use sp_runtime::Permill;
 use sp_core::H256;
 use sp_runtime::{
 	Perbill, ModuleId,
@@ -33,26 +31,22 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup, BadOrigin},
 };
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-mod tips {
-	// Re-export needed for `impl_outer_event!`.
-	pub use crate::*;
-}
-
-impl_outer_event! {
-	pub enum Event for Test {
-		system<T>,
-		pallet_balances<T>,
-		pallet_treasury<T>,
-		tips<T>,
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Treasury: pallet_treasury::{Module, Call, Storage, Config, Event<T>},
+		TipsModTestInst: tips::{Module, Call, Storage, Event<T>},
 	}
-}
+);
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
@@ -67,7 +61,7 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Index = u64;
 	type BlockNumber = u64;
-	type Call = ();
+	type Call = Call;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u128; // u64 is not enough to hold bytes used to generate bounty account
@@ -76,7 +70,7 @@ impl frame_system::Config for Test {
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -159,10 +153,6 @@ impl Config for Test {
 	type Event = Event;
 	type WeightInfo = ();
 }
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
-type Treasury = pallet_treasury::Module<Test>;
-type TipsModTestInst = Module<Test>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -22,8 +22,7 @@
 use super::*;
 
 use frame_support::{
-	assert_ok, assert_noop, impl_outer_origin, parameter_types, impl_outer_dispatch, impl_outer_event,
-	assert_err_ignore_postinfo,
+	assert_ok, assert_noop, parameter_types, assert_err_ignore_postinfo,
 	weights::{Weight, Pays},
 	dispatch::{DispatchError, DispatchErrorWithPostInfo, Dispatchable},
 	traits::Filter,
@@ -67,30 +66,22 @@ pub mod example {
 	}
 }
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
-impl_outer_event! {
-	pub enum TestEvent for Test {
-		frame_system<T>,
-		pallet_balances<T>,
-		utility,
-	}
-}
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		frame_system::System,
-		pallet_balances::Balances,
-		utility::Utility,
-		example::Example,
-	}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-// For testing the pallet, we construct most of a mock runtime. This means
-// first constructing a configuration type (`Test`) which `impl`s each of the
-// configuration traits of pallets we want to use.
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Utility: utility::{Module, Call, Event},
+		Example: example::{Module, Call},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -110,7 +101,7 @@ impl frame_system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
 	type PalletInfo = ();
@@ -127,7 +118,7 @@ impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
 	type DustRemoval = ();
-	type Event = TestEvent;
+	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
@@ -156,14 +147,10 @@ impl Filter<Call> for TestBaseCallFilter {
 	}
 }
 impl Config for Test {
-	type Event = TestEvent;
+	type Event = Event;
 	type Call = Call;
 	type WeightInfo = ();
 }
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
-type Example = example::Module<Test>;
-type Utility = Module<Test>;
 
 type ExampleCall = example::Call<Test>;
 type UtilityCall = crate::Call<Test>;
@@ -182,11 +169,11 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn last_event() -> TestEvent {
+fn last_event() -> Event {
 	frame_system::Module::<Test>::events().pop().map(|e| e.event).expect("Event expected")
 }
 
-fn expect_event<E: Into<TestEvent>>(e: E) {
+fn expect_event<E: Into<Event>>(e: E) {
 	assert_eq!(last_event(), e.into());
 }
 
@@ -324,7 +311,7 @@ fn batch_with_signed_filters() {
 				Call::Balances(pallet_balances::Call::transfer_keep_alive(2, 1))
 			]),
 		);
-		expect_event(Event::BatchInterrupted(0, DispatchError::BadOrigin));
+		expect_event(utility::Event::BatchInterrupted(0, DispatchError::BadOrigin));
 	});
 }
 
@@ -398,7 +385,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(Event::BatchInterrupted(1, DispatchError::Other("")));
+		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
 		// No weight is refunded
 		assert_eq!(extract_actual_weight(&result, &info), info.weight);
 
@@ -411,7 +398,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(Event::BatchInterrupted(1, DispatchError::Other("")));
+		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
 		assert_eq!(extract_actual_weight(&result, &info), info.weight - diff * batch_len);
 
 		// Partial batch completion
@@ -422,7 +409,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(Event::BatchInterrupted(1, DispatchError::Other("")));
+		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
 		assert_eq!(
 			extract_actual_weight(&result, &info),
 			// Real weight is 2 calls at end_weight

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -389,10 +389,9 @@ impl<T: Config> VestingSchedule<T::AccountId> for Module<T> where
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate as pallet_vesting;
 
-	use frame_support::{
-		assert_ok, assert_noop, impl_outer_origin, parameter_types,
-	};
+	use frame_support::{assert_ok, assert_noop, parameter_types};
 	use sp_core::H256;
 	use sp_runtime::{
 		testing::Header,
@@ -400,12 +399,21 @@ mod tests {
 	};
 	use frame_system::RawOrigin;
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Vesting: pallet_vesting::{Module, Call, Storage, Event<T>, Config<T>},
+		}
+	);
+
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub BlockWeights: frame_system::limits::BlockWeights =
@@ -420,15 +428,15 @@ mod tests {
 		type Index = u64;
 		type BlockNumber = u64;
 		type Hash = H256;
-		type Call = ();
+		type Call = Call;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -441,7 +449,7 @@ mod tests {
 	impl pallet_balances::Config for Test {
 		type Balance = u64;
 		type DustRemoval = ();
-		type Event = ();
+		type Event = Event;
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
 		type MaxLocks = MaxLocks;
@@ -452,16 +460,12 @@ mod tests {
 		pub static ExistentialDeposit: u64 = 0;
 	}
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type BlockNumberToBalance = Identity;
 		type MinVestedTransfer = MinVestedTransfer;
 		type WeightInfo = ();
 	}
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Vesting = Module<Test>;
-
 
 	pub struct ExtBuilder {
 		existential_deposit: u64,
@@ -490,7 +494,7 @@ mod tests {
 					(12, 10 * self.existential_deposit)
 				],
 			}.assimilate_storage(&mut t).unwrap();
-			GenesisConfig::<Test> {
+			pallet_vesting::GenesisConfig::<Test> {
 				vesting: vec![
 					(1, 0, 10, 5 * self.existential_deposit),
 					(2, 10, 20, 0),


### PR DESCRIPTION
I make changes for pallets randomness-collective-flip, recovery, scheduler, scored-pool, session, society, staking, sudo, timestamp, tips, transaction-payment, treasury, utility, vesting.

the reason some pallet needs to import serde is because when macro_rules macro are using `$crate::serde` I think it can result is errors somehow.

There is an attribute that can be given to serde to resolve this https://serde.rs/container-attrs.html#crate but it is difficult to do this in this macro_rules macro. IMO it should be solved later when those are rewritten in procedural macro.