### PR TITLE
Let mock in pallet-template use construct_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5056,6 +5056,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
+ "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -15,6 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.6", default-features = false, features = ["derive"] }
 
+[dev-dependencies]
+serde = { version = "1.0.101" }
+
 [dependencies.frame-support]
 default-features = false
 version = "2.0.0"

--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -1,19 +1,26 @@
-use crate::{Module, Config};
+use crate as pallet_template;
 use sp_core::H256;
-use frame_support::{impl_outer_origin, parameter_types};
+use frame_support::{parameter_types};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };
 use frame_system as system;
 
-impl_outer_origin! {
-	pub enum Origin for Test {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>; 
 
 // Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		TemplateModule: pallet_template::{Module, Call, Storage, Event<T>},
+	}
+);
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const SS58Prefix: u8 = 42;
@@ -25,7 +32,7 @@ impl system::Config for Test {
 	type BlockLength = ();
 	type DbWeight = ();
 	type Origin = Origin;
-	type Call = ();
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -33,10 +40,10 @@ impl system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -44,11 +51,9 @@ impl system::Config for Test {
 	type SS58Prefix = SS58Prefix;
 }
 
-impl Config for Test {
-	type Event = ();
+impl pallet_template::Config for Test {
+	type Event = Event;
 }
-
-pub type TemplateModule = Module<Test>;
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/bin/node-template/pallets/template/src/mock.rs
+++ b/bin/node-template/pallets/template/src/mock.rs
@@ -1,6 +1,6 @@
 use crate as pallet_template;
 use sp_core::H256;
-use frame_support::{parameter_types};
+use frame_support::parameter_types;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup}, testing::Header,
 };


### PR DESCRIPTION
Use construct_runtime for the mock in pallet-template as suggest by @thiolliere in #7981 