### PR TITLE
Increase maximum size of transaction notifications

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -72,14 +72,23 @@ const TICK_TIMEOUT: time::Duration = time::Duration::from_millis(1100);
 /// Interval at which we propagate transactions;
 const PROPAGATE_TIMEOUT: time::Duration = time::Duration::from_millis(2900);
 
-/// Maximim number of known block hashes to keep for a peer.
+/// Maximum number of known block hashes to keep for a peer.
 const MAX_KNOWN_BLOCKS: usize = 1024; // ~32kb per peer + LruHashSet overhead
-/// Maximim number of known transaction hashes to keep for a peer.
+/// Maximum number of known transaction hashes to keep for a peer.
 ///
 /// This should be approx. 2 blocks full of transactions for the network to function properly.
 const MAX_KNOWN_TRANSACTIONS: usize = 10240; // ~300kb per peer + overhead.
 
-/// Maximim number of transaction validation request we keep at any moment.
+/// Maximum allowed size for a block announce.
+const MAX_BLOCK_ANNOUNCE_SIZE: u64 = 1024 * 1024;
+/// Maximum allowed size for a transactions notification.
+const MAX_TRANSACTIONS_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Maximum size used for notifications in the block announce and transaction protocols.
+// Must be equal to `max(MAX_BLOCK_ANNOUNCE_SIZE, MAX_TRANSACTIONS_SIZE)`.
+pub(crate) const BLOCK_ANNOUNCES_TRANSACTIONS_SUBSTREAM_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Maximum number of transaction validation request we keep at any moment.
 const MAX_PENDING_TRANSACTIONS: usize = 8192;
 
 /// Current protocol version.
@@ -483,8 +492,8 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 				versions,
 				build_status_message::<B>(&config, best_number, best_hash, genesis_hash),
 				peerset,
-				iter::once((block_announces_protocol, block_announces_handshake, 1024 * 1024))
-					.chain(iter::once((transactions_protocol, vec![], 1024 * 1024)))
+				iter::once((block_announces_protocol, block_announces_handshake, MAX_BLOCK_ANNOUNCE_SIZE))
+					.chain(iter::once((transactions_protocol, vec![], MAX_TRANSACTIONS_SIZE)))
 					.chain(network_config.extra_sets.iter().map(|s| (
 						s.notifications_protocol.clone(),
 						handshake_message.clone(),


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/7925 reduced the maximum notification sizes for transactions to 1MiB.

I didn't realize that, since we're sending runtime upgrades through transactions, 1MiB isn't enough.
This PR bumps this to 16MiB.
