### PR TITLE
Rename system_networkState to system_unstable_networkState

### DIFF
--- a/bin/node/cli/browser-demo/index.html
+++ b/bin/node/cli/browser-demo/index.html
@@ -27,8 +27,8 @@ async function start() {
 
 	setInterval(() => {
 		client
-			.rpcSend('{"method":"system_networkState","params":[],"id":1,"jsonrpc":"2.0"}')
-			.then((r) => log("Network state: " + r));
+			.rpcSend('{"method":"system_localPeerId","params":[],"id":1,"jsonrpc":"2.0"}')
+			.then((r) => log("Local PeerId: " + r));
 	}, 20000);
 }
 

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -79,9 +79,11 @@ pub trait SystemApi<Hash, Number> {
 
 	/// Returns current state of the network.
 	///
-	/// **Warning**: This API is not stable.
-	// TODO: make this stable and move structs https://github.com/paritytech/substrate/issues/1890
-	#[rpc(name = "system_networkState", returns = "jsonrpc_core::Value")]
+	/// **Warning**: This API is not stable. Please do not programmatically interpret its output,
+	/// as its format might change at any time.
+	// TODO: the future of this call is uncertain: https://github.com/paritytech/substrate/issues/1890
+	// https://github.com/paritytech/substrate/issues/5541
+	#[rpc(name = "system_unstable_networkState", returns = "jsonrpc_core::Value")]
 	fn system_network_state(&self)
 		-> Compat<BoxFuture<'static, jsonrpc_core::Result<jsonrpc_core::Value>>>;
 


### PR DESCRIPTION
Renames this JSON-RPC function in order to make it clean that has never been intended to be stable nor long-term.

This is a breaking change. If you had an automatic script that is using `system_networkState`, which you weren't supposed to do in the first place, then it will break.

If you were using this function to get the local PeerId and listened addresses, then I invite you to use `system_localPeerId` and `system_localListenAddresses` instead.

cc https://github.com/paritytech/substrate/issues/5541
