### PR TITLE
contracts: Make ChainExtension trait generic over the runtime

### DIFF
--- a/frame/contracts/src/chain_extension.rs
+++ b/frame/contracts/src/chain_extension.rs
@@ -63,7 +63,7 @@ use sp_std::{
 pub use frame_system::Config as SysConfig;
 pub use pallet_contracts_primitives::ReturnFlags;
 pub use sp_core::crypto::UncheckedFrom;
-pub use crate::exec::Ext;
+pub use crate::{Config, exec::Ext};
 pub use state::Init as InitState;
 
 /// Result that returns a [`DispatchError`] on error.
@@ -74,7 +74,7 @@ pub type Result<T> = sp_std::result::Result<T, DispatchError>;
 /// In order to create a custom chain extension this trait must be implemented and supplied
 /// to the pallet contracts configuration trait as the associated type of the same name.
 /// Consult the [module documentation](self) for a general explanation of chain extensions.
-pub trait ChainExtension {
+pub trait ChainExtension<C: Config> {
 	/// Call the chain extension logic.
 	///
 	/// This is the only function that needs to be implemented in order to write a
@@ -91,8 +91,9 @@ pub trait ChainExtension {
 	/// In case of `Err` the contract execution is immediatly suspended and the passed error
 	/// is returned to the caller. Otherwise the value of [`RetVal`] determines the exit
 	/// behaviour.
-	fn call<E: Ext>(func_id: u32, env: Environment<E, InitState>) -> Result<RetVal>
+	fn call<E>(func_id: u32, env: Environment<E, InitState>) -> Result<RetVal>
 	where
+		E: Ext<T = C>,
 		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>;
 
 	/// Determines whether chain extensions are enabled for this chain.
@@ -108,9 +109,10 @@ pub trait ChainExtension {
 }
 
 /// Implementation that indicates that no chain extension is available.
-impl ChainExtension for () {
-	fn call<E: Ext>(_func_id: u32, mut _env: Environment<E, InitState>) -> Result<RetVal>
+impl<C: Config> ChainExtension<C> for () {
+	fn call<E>(_func_id: u32, mut _env: Environment<E, InitState>) -> Result<RetVal>
 	where
+		E: Ext<T = C>,
 		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		// Never called since [`Self::enabled()`] is set to `false`. Because we want to

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -337,7 +337,7 @@ pub trait Config: frame_system::Config {
 	type WeightInfo: WeightInfo;
 
 	/// Type that allows the runtime authors to add new host functions for a contract to call.
-	type ChainExtension: chain_extension::ChainExtension;
+	type ChainExtension: chain_extension::ChainExtension<Self>;
 
 	/// The maximum number of tries that can be queued for deletion.
 	type DeletionQueueDepth: Get<u32>;

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -143,9 +143,10 @@ impl Default for TestExtension {
 	}
 }
 
-impl ChainExtension for TestExtension {
-	fn call<E: Ext>(func_id: u32, env: Environment<E, InitState>) -> ExtensionResult<RetVal>
+impl ChainExtension<Test> for TestExtension {
+	fn call<E>(func_id: u32, env: Environment<E, InitState>) -> ExtensionResult<RetVal>
 	where
+		E: Ext<T = Test>,
 		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
 	{
 		match func_id {


### PR DESCRIPTION
This PR changes the `ChainExtensions` trait to be defined as `ChainExtension<C: pallet_contracts::Config>`. This is necessary because the `ChainExtension::call` method has a parameter that is generic over the pallet's configuration. This trait however, only is bound by `: frame_system::Config` with no way for the `ChainExtension` implementer to add additional bounds. Therefore calling into any pallet that is not system or contracts would not work because of the missing bounds on that trait. 

This PR changes this by giving the implementer the tools to call all runtime functions. A implementation would look like this:

```rust
// We assume we are a direct child of the runtime module here
use super::Runtime;

struct TestExtension;

impl ChainExtension<Runtime> for TestExtension {
	fn call<E>(func_id: u32, env: Environment<E, InitState>) -> ExtensionResult<RetVal>
	where
		E: Ext<T = Runtime>,
		<E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
{
        // The `env` is now connected to the runtime and we can call all pallets of the runtime and pass
        //  around types like `E::T::AccountId` that were read from `env.ext()`.
}
```

@gregzaitsev : This should fix your problem where you weren't able to pass `T::AccountId` to your pallet.


