### PR TITLE
CI: return flaming fir deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -653,6 +653,48 @@ trigger-simnet:
     branch:                        master
     strategy:                      depend
 
+.validator-deploy:                 &validator-deploy
+  stage:                           deploy
+  rules:
+    # .build-refs, but manual
+    - if: $CI_COMMIT_REF_NAME == "master"
+      when: manual
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+      when: manual
+    # this job runs only on nightly pipeline with the mentioned variable, against `master` branch
+    - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "nightly"
+  needs:
+    # script will fail if there is no artifacts/substrate/VERSION
+    - job:                         publish-docker-substrate
+      artifacts:                   true
+  image:                           parity/azure-ansible:v1
+  allow_failure:                   true
+  interruptible:                   true
+  tags:
+    - linux-docker
+
+validator 1 4:
+  <<:                              *validator-deploy
+  script:
+    - ./.maintain/flamingfir-deploy.sh flamingfir-validator1
+
+validator 2 4:
+  <<:                              *validator-deploy
+  script:
+    - ./.maintain/flamingfir-deploy.sh flamingfir-validator2
+
+validator 3 4:
+  <<:                              *validator-deploy
+  script:
+    - ./.maintain/flamingfir-deploy.sh flamingfir-validator3
+
+validator 4 4:
+  <<:                              *validator-deploy
+  script:
+    - ./.maintain/flamingfir-deploy.sh flamingfir-validator4
+
 #### stage:                        .post
 
 check-labels:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -656,20 +656,13 @@ trigger-simnet:
 .validator-deploy:                 &validator-deploy
   stage:                           deploy
   rules:
-    # .build-refs, but manual
-    - if: $CI_COMMIT_REF_NAME == "master"
-      when: manual
-    - if: $CI_PIPELINE_SOURCE == "web"
-      when: manual
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-      when: manual
     # this job runs only on nightly pipeline with the mentioned variable, against `master` branch
     - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "nightly"
   needs:
     # script will fail if there is no artifacts/substrate/VERSION
     - job:                         publish-docker-substrate
       artifacts:                   true
-  image:                           parity/azure-ansible:v1
+  image:                           parity/azure-ansible:v2
   allow_failure:                   true
   interruptible:                   true
   tags:

--- a/.maintain/flamingfir-deploy.sh
+++ b/.maintain/flamingfir-deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+RETRY_COUNT=10
+RETRY_ATTEMPT=0
+SLEEP_TIME=15
+TARGET_HOST="$1"
+COMMIT=$(cat artifacts/substrate/VERSION)
+DOWNLOAD_URL="https://releases.parity.io/substrate/x86_64-debian:stretch/${COMMIT}/substrate/substrate"
+POST_DATA='{"extra_vars":{"artifact_path":"'${DOWNLOAD_URL}'","target_host":"'${TARGET_HOST}'"}}'
+
+JOB_ID=$(wget -O - --header "Authorization: Bearer ${AWX_TOKEN}" --header "Content-type: application/json" --post-data "${POST_DATA}" https://ansible-awx.parity.io/api/v2/job_templates/32/launch/ | jq .job)
+
+echo "Launched job: $JOB_ID"
+
+
+while [ ${RETRY_ATTEMPT} -le ${RETRY_COUNT} ] ; do
+	export RETRY_RESULT=$(wget -O - --header "Authorization: Bearer ${AWX_TOKEN}"  https://ansible-awx.parity.io/api/v2/jobs/${JOB_ID}/ | jq .status)
+	RETRY_ATTEMPT=$(( $RETRY_ATTEMPT +1 ))
+	sleep $SLEEP_TIME
+	if [ $(echo $RETRY_RESULT | egrep  -e successful -e failed) ] ; then
+            break
+        fi
+done
+
+AWX_OUTPUT=$(wget -O - --header "Authorization: Bearer ${AWX_TOKEN}"  https://ansible-awx.parity.io/api/v2/jobs/${JOB_ID}/stdout?format=txt_download)
+
+echo "AWX job log:"
+echo "${AWX_OUTPUT}"
+
+
+JOB_STATUS=$(wget -O - --header "Authorization: Bearer ${AWX_TOKEN}"  https://ansible-awx.parity.io/api/v2/jobs/${JOB_ID}/ | jq .status )
+
+echo "==================================="
+echo -e "Ansible AWX Remote Job: ${JOB_ID} \x1B[31mStatus: ${JOB_STATUS}\x1B[0m"
+echo "==================================="


### PR DESCRIPTION
Returns the `flaming-fir` deployment as it was except without manual jobs, it's no need in them.