### PR TITLE
Add a send_request function to NetworkService

### DIFF
--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -248,8 +248,9 @@ impl<B: BlockT, H: ExHashT> Behaviour<B, H> {
 		protocol: &str,
 		request: Vec<u8>,
 		pending_response: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
+		connect: bool,
 	) {
-		self.request_responses.send_request(target, protocol, request, pending_response)
+		self.request_responses.send_request(target, protocol, request, pending_response, connect)
 	}
 
 	/// Returns a shared reference to the user protocol.
@@ -317,7 +318,7 @@ Behaviour<B, H> {
 				}
 
 				self.request_responses.send_request(
-					&target, &self.block_request_protocol_name, buf, pending_response,
+					&target, &self.block_request_protocol_name, buf, pending_response, false,
 				);
 			},
 			CustomMessageOutcome::NotificationStreamOpened { remote, protocol, roles, notifications_sink } => {

--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -45,6 +45,7 @@ use std::{
 
 pub use crate::request_responses::{
 	ResponseFailure, InboundFailure, RequestFailure, OutboundFailure, RequestId,
+	IfDisconnected
 };
 
 /// General behaviour of the network. Combines all protocols together.
@@ -248,7 +249,7 @@ impl<B: BlockT, H: ExHashT> Behaviour<B, H> {
 		protocol: &str,
 		request: Vec<u8>,
 		pending_response: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
-		connect: bool,
+		connect: IfDisconnected,
 	) {
 		self.request_responses.send_request(target, protocol, request, pending_response, connect)
 	}
@@ -318,7 +319,7 @@ Behaviour<B, H> {
 				}
 
 				self.request_responses.send_request(
-					&target, &self.block_request_protocol_name, buf, pending_response, false,
+					&target, &self.block_request_protocol_name, buf, pending_response, IfDisconnected::ImmediateError,
 				);
 			},
 			CustomMessageOutcome::NotificationStreamOpened { remote, protocol, roles, notifications_sink } => {

--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -459,7 +459,7 @@ impl<B: BlockT, H: ExHashT> Behaviour<B, H> {
 		while let Poll::Ready(Some(event)) = self.light_client_request_sender.poll_next_unpin(cx) {
 			match event {
 				OutEvent::SendRequest { target, request, pending_response, protocol_name } => {
-					self.request_responses.send_request(&target, &protocol_name, request, pending_response)
+					self.request_responses.send_request(&target, &protocol_name, request, pending_response, IfDisconnected::ImmediateError)
 				}
 			}
 		}

--- a/client/network/src/behaviour.rs
+++ b/client/network/src/behaviour.rs
@@ -456,11 +456,22 @@ impl<B: BlockT, H: ExHashT> Behaviour<B, H> {
 		_: &mut impl PollParameters,
 	) -> Poll<NetworkBehaviourAction<TEv, BehaviourOut<B>>> {
 		use light_client_requests::sender::OutEvent;
-		while let Poll::Ready(Some(event)) = self.light_client_request_sender.poll_next_unpin(cx) {
+		while let Poll::Ready(Some(event)) =
+			self.light_client_request_sender.poll_next_unpin(cx)
+		{
 			match event {
-				OutEvent::SendRequest { target, request, pending_response, protocol_name } => {
-					self.request_responses.send_request(&target, &protocol_name, request, pending_response, IfDisconnected::ImmediateError)
-				}
+				OutEvent::SendRequest {
+					target,
+					request,
+					pending_response,
+					protocol_name,
+				} => self.request_responses.send_request(
+					&target,
+					&protocol_name,
+					request,
+					pending_response,
+					IfDisconnected::ImmediateError,
+				),
 			}
 		}
 

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -204,7 +204,7 @@ pub enum IfDisconnected {
     ImmediateError,
 }
 
-/// Convenience functions for `IfDisconnectedBehaviour`.
+/// Convenience functions for `IfDisconnected`.
 impl IfDisconnected {
 	/// Shall we connect to a disconnected peer?
 	pub fn should_connect(self) -> bool {

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -199,9 +199,9 @@ impl From<(Cow<'static, str>, RequestId)> for ProtocolRequestId {
 /// When sending a request, what to do on a disconnected recipient.
 pub enum IfDisconnected {
 	/// Try to connect to the peer.
-    TryConnect,
+	TryConnect,
 	/// Just fail if the destination is not yet connected.
-    ImmediateError,
+	ImmediateError,
 }
 
 /// Convenience functions for `IfDisconnected`.

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -950,6 +950,7 @@ mod tests {
 							protocol_name,
 							b"this is a request".to_vec(),
 							sender,
+							false,
 						);
 						assert!(response_receiver.is_none());
 						response_receiver = Some(receiver);
@@ -1038,6 +1039,7 @@ mod tests {
 							protocol_name,
 							b"this is a request".to_vec(),
 							sender,
+							false,
 						);
 						assert!(response_receiver.is_none());
 						response_receiver = Some(receiver);
@@ -1180,12 +1182,14 @@ mod tests {
 								protocol_name_1,
 								b"this is a request".to_vec(),
 								sender_1,
+								false,
 							);
 							swarm_1.send_request(
 								&peer_id,
 								protocol_name_2,
 								b"this is a request".to_vec(),
 								sender_2,
+								false,
 							);
 							assert!(response_receivers.is_none());
 							response_receivers = Some((receiver_1, receiver_2));

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -269,17 +269,18 @@ impl RequestResponsesBehaviour {
 
 	/// Initiates sending a request.
 	///
-	/// An error is returned if we are not connected to the target peer or if the protocol doesn't
-	/// match one that has been registered.
+	/// An error is returned if we are not connected to the target peer and `connect` is false. An
+	/// error is also returned if the protocol doesn't match one that has been registered.
 	pub fn send_request(
 		&mut self,
 		target: &PeerId,
 		protocol_name: &str,
 		request: Vec<u8>,
 		pending_response: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
+		connect: bool,
 	) {
 		if let Some((protocol, _)) = self.protocols.get_mut(protocol_name) {
-			if protocol.is_connected(target) {
+			if protocol.is_connected(target) || connect {
 				let request_id = protocol.send_request(target, request);
 				let prev_req_id = self.pending_requests.insert(
 					(protocol_name.to_string().into(), request_id).into(),

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -288,8 +288,9 @@ impl RequestResponsesBehaviour {
 
 	/// Initiates sending a request.
 	///
-	/// An error is returned if we are not connected to the target peer and `connect` is false. An
-	/// error is also returned if the protocol doesn't match one that has been registered.
+	/// If there is no established connection to the target peer, the behavior is determined by the choice of `connect`.
+	///
+	/// An error is returned if the protocol doesn't match one that has been registered.
 	pub fn send_request(
 		&mut self,
 		target: &PeerId,

--- a/client/network/src/request_responses.rs
+++ b/client/network/src/request_responses.rs
@@ -510,7 +510,6 @@ impl NetworkBehaviour for RequestResponsesBehaviour {
 							return Poll::Ready(NetworkBehaviourAction::DialAddress { address })
 						}
 						NetworkBehaviourAction::DialPeer { peer_id, condition } => {
-							log::error!("The request-response isn't supposed to start dialing peers");
 							return Poll::Ready(NetworkBehaviourAction::DialPeer {
 								peer_id,
 								condition,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -843,7 +843,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		}
 	}
 
-	/// Variation of `request` which takes a sender for sending responses back.
+	/// Variation of `request` which starts a request whose response is delivered on a provided channel.
 	///
 	/// Instead of blocking and waiting for a reply, this function returns immediately, sending
 	/// responses via the passed in sender. This alternative API exists to make it easier to

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -832,7 +832,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	) -> Result<Vec<u8>, RequestFailure> {
 		let (tx, rx) = oneshot::channel();
 
-		self.send_request(target, protocol, request, tx, connect);
+		self.detached_request(target, protocol, request, tx, connect);
 
 		match rx.await {
 			Ok(v) => v,
@@ -852,7 +852,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// Keep in mind that the connected receiver might receive a `Canceled` event in case of a
 	/// closing connection, this is expected behaviour. In `request` you would get a
 	/// `RequestFailure::Network(OutboundFailure::ConnectionClosed` in that case.
-	pub fn send_request(
+	pub fn detached_request(
 		&self,
 		target: PeerId,
 		protocol: impl Into<Cow<'static, str>>,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -813,7 +813,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// peer can announce something through a notification, after which the recipient can obtain
 	/// more information by performing a request.
 	/// As such, call this function with `IfDisconnected::ImmediateError` for `connect`. This way you
-	/// will get an error immediately for disconnected peers, instead of waiting a potentially very
+	/// will get an error immediately for disconnected peers, instead of waiting for a potentially very
 	/// long connection attempt, which would suggest that something is wrong anway, as you are
 	/// supposed to be connected because of the notification protocol.
 	///

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -850,7 +850,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// integrate with message passing APIs.
 	///
 	/// Keep in mind that the connected receiver might receive a `Canceled` event in case of a
-	/// closing connection, this is expected behaviour. In `request` you would get a
+	/// closing connection. This is expected behaviour. With `request` you would get a
 	/// `RequestFailure::Network(OutboundFailure::ConnectionClosed` in that case.
 	pub fn detached_request(
 		&self,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -844,8 +844,10 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// Variation of `request` which can connect to peers when necessary.
 	///
 	/// In some cases we do request data, without prior notification. For those cases this function
-	/// exists, it has no guarantees on connection staying alive, so you might still want to pass
+	/// exists. It has no guarantees on connection staying alive, so you might still want to pass
 	/// false to the `connect` parameter and ensure liveness of connections via peer sets.
+	/// Connecting to a peer can take up to several seconds, if a peer exposes multiple
+	/// addresses, but is only reachable by some of them, for example.
 	///
 	/// Apart from exposing whether or not we want to connect, in case of a disconnected peer, this
 	/// function also takes a sender for sending the response back, instead of returning the

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -851,7 +851,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	///
 	/// Keep in mind that the connected receiver might receive a `Canceled` event in case of a
 	/// closing connection. This is expected behaviour. With `request` you would get a
-	/// `RequestFailure::Network(OutboundFailure::ConnectionClosed` in that case.
+	/// `RequestFailure::Network(OutboundFailure::ConnectionClosed)` in that case.
 	pub fn detached_request(
 		&self,
 		target: PeerId,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -832,7 +832,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	) -> Result<Vec<u8>, RequestFailure> {
 		let (tx, rx) = oneshot::channel();
 
-		self.detached_request(target, protocol, request, tx, connect);
+		self.start_request(target, protocol, request, tx, connect);
 
 		match rx.await {
 			Ok(v) => v,
@@ -852,7 +852,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// Keep in mind that the connected receiver might receive a `Canceled` event in case of a
 	/// closing connection. This is expected behaviour. With `request` you would get a
 	/// `RequestFailure::Network(OutboundFailure::ConnectionClosed)` in that case.
-	pub fn detached_request(
+	pub fn start_request(
 		&self,
 		target: PeerId,
 		protocol: impl Into<Cow<'static, str>>,

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -814,7 +814,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 	/// more information by performing a request.
 	/// As such, call this function with `IfDisconnected::ImmediateError` for `connect`. This way you
 	/// will get an error immediately for disconnected peers, instead of waiting for a potentially very
-	/// long connection attempt, which would suggest that something is wrong anway, as you are
+	/// long connection attempt, which would suggest that something is wrong anyway, as you are
 	/// supposed to be connected because of the notification protocol.
 	///
 	/// No limit or throttling of concurrent outbound requests per peer and protocol are enforced.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -859,7 +859,7 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {
 		request: Vec<u8>,
 		tx: oneshot::Sender<Result<Vec<u8>, RequestFailure>>,
 		connect: IfDisconnected,
-		) {
+	) {
 		let _ = self.to_worker.unbounded_send(ServiceToWorkerMsg::Request {
 			target,
 			protocol: protocol.into(),


### PR DESCRIPTION
This function differs from the already provided `request` method in two ways.

1. It allows sending of messages to currently disconnected peers, which is required for my first go at request based availability distribution.
2. Instead of creating a sender/receiver pair and awaiting the receiver, it takes a sender as argument. This suits our use in Polkadot better, where the subsystem will hold the corresponding receiver.


This PR changes the signature of some apparently only internally used `send_request` functions to accept an additional boolean parameter.
