### PR TITLE
contracts: Emit event on contract termination

### DIFF
--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -582,6 +582,7 @@ where
 		)?;
 		if let Some(ContractInfo::Alive(info)) = ContractInfoOf::<T>::take(&self_id) {
 			Storage::<T>::queue_trie_for_deletion(&info)?;
+			Contracts::<T>::deposit_event(RawEvent::Terminated(self_id, beneficiary.clone()));
 			Ok(())
 		} else {
 			panic!(

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -671,7 +671,7 @@ where
 	fn deposit_event(&mut self, topics: Vec<T::Hash>, data: Vec<u8>) {
 		deposit_event::<Self::T>(
 			topics,
-			RawEvent::ContractExecution(self.ctx.self_account.clone(), data)
+			RawEvent::ContractEmitted(self.ctx.self_account.clone(), data)
 		);
 	}
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -756,38 +756,43 @@ decl_event! {
 		<T as frame_system::Config>::AccountId,
 		<T as frame_system::Config>::Hash
 	{
-		/// Contract deployed by address at the specified address. \[owner, contract\]
+		/// Contract deployed by address at the specified address. \[deployer, contract\]
 		Instantiated(AccountId, AccountId),
 
-		/// Contract has been evicted and is now in tombstone state.
-		/// \[contract\]
-		///
-		/// # Params
-		///
-		/// - `contract`: `AccountId`: The account ID of the evicted contract.
+		/// Contract has been evicted and is now in tombstone state. \[contract\]
 		Evicted(AccountId),
 
-		/// Restoration for a contract has been successful.
-		/// \[donor, dest, code_hash, rent_allowance\]
+		/// Restoration of a contract has been successful.
+		/// \[restorer, dest, code_hash, rent_allowance\]
 		///
 		/// # Params
 		///
-		/// - `donor`: `AccountId`: Account ID of the restoring contract
-		/// - `dest`: `AccountId`: Account ID of the restored contract
-		/// - `code_hash`: `Hash`: Code hash of the restored contract
-		/// - `rent_allowance: `Balance`: Rent allowance of the restored contract
+		/// - `restorer`: Account ID of the restoring contract.
+		/// - `dest`: Account ID of the restored contract.
+		/// - `code_hash`: Code hash of the restored contract.
+		/// - `rent_allowance`: Rent allowance of the restored contract.
 		Restored(AccountId, AccountId, Hash, Balance),
 
-		/// Code with the specified hash has been stored.
-		/// \[code_hash\]
+		/// Code with the specified hash has been stored. \[code_hash\]
 		CodeStored(Hash),
 
-		/// Triggered when the current \[schedule\] is updated.
+		/// Triggered when the current schedule is updated.
+		/// \[version\]
+		///
+		/// # Params
+		///
+		/// - `version`: The version of the newly set schedule.
 		ScheduleUpdated(u32),
 
-		/// An event deposited upon execution of a contract from the account.
-		/// \[account, data\]
-		ContractExecution(AccountId, Vec<u8>),
+		/// A custom event emitted by the contract.
+		/// \[contract, data\]
+		///
+		/// # Params
+		///
+		/// - `contract`: The contract that emitted the event.
+		/// - `data`: Data supplied by the contract. Metadata generated during contract
+		///           compilation is needed to decode it.
+		ContractEmitted(AccountId, Vec<u8>),
 	}
 }
 

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -762,6 +762,20 @@ decl_event! {
 		/// Contract has been evicted and is now in tombstone state. \[contract\]
 		Evicted(AccountId),
 
+		/// Contract has been terminated without leaving a tombstone.
+		/// \[contract, beneficiary\]
+		///
+		/// # Params
+		///
+		/// - `contract`: The contract that was terminated.
+		/// - `beneficiary`: The account that received the contracts remaining balance.
+		///
+		/// # Note
+		///
+		/// The only way for a contract to be removed without a tombstone and emitting
+		/// this event is by calling `seal_terminate`.
+		Terminated(AccountId, AccountId),
+
 		/// Restoration of a contract has been successful.
 		/// \[restorer, dest, code_hash, rent_allowance\]
 		///

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -760,13 +760,12 @@ decl_event! {
 		Instantiated(AccountId, AccountId),
 
 		/// Contract has been evicted and is now in tombstone state.
-		/// \[contract, tombstone\]
+		/// \[contract\]
 		///
 		/// # Params
 		///
 		/// - `contract`: `AccountId`: The account ID of the evicted contract.
-		/// - `tombstone`: `bool`: True if the evicted contract left behind a tombstone.
-		Evicted(AccountId, bool),
+		Evicted(AccountId),
 
 		/// Restoration for a contract has been successful.
 		/// \[donor, dest, code_hash, rent_allowance\]

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -261,7 +261,7 @@ where
 				);
 				let tombstone_info = ContractInfo::Tombstone(tombstone);
 				<ContractInfoOf<T>>::insert(account, &tombstone_info);
-				<Module<T>>::deposit_event(RawEvent::Evicted(account.clone(), true));
+				<Module<T>>::deposit_event(RawEvent::Evicted(account.clone()));
 				Ok(Some(tombstone_info))
 			}
 			Verdict::Charge { amount } => {

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -512,7 +512,7 @@ fn instantiate_and_call_and_deposit_event() {
 				EventRecord {
 					phase: Phase::Initialization,
 					event: MetaEvent::contracts(
-						RawEvent::ContractExecution(addr.clone(), vec![1, 2, 3, 4])
+						RawEvent::ContractEmitted(addr.clone(), vec![1, 2, 3, 4])
 					),
 					topics: vec![],
 				},

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -1300,7 +1300,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 				EventRecord {
 					phase: Phase::Initialization,
 					event: MetaEvent::contracts(
-						RawEvent::Evicted(addr_bob.clone(), true)
+						RawEvent::Evicted(addr_bob.clone())
 					),
 					topics: vec![],
 				},
@@ -1385,7 +1385,7 @@ fn restoration(test_different_storage: bool, test_restore_to_with_dirty_storage:
 						pretty_assertions::assert_eq!(System::events(), vec![
 							EventRecord {
 								phase: Phase::Initialization,
-								event: MetaEvent::contracts(RawEvent::Evicted(addr_bob, true)),
+								event: MetaEvent::contracts(RawEvent::Evicted(addr_bob)),
 								topics: vec![],
 							},
 							EventRecord {


### PR DESCRIPTION
When the `seal_terminate` API was introduced no event was added. This adds the appropriate event and also removes the now redundant `tombstone` argument from the `ContractEvicted` event as it was always true.

Some renames and doc improvements where done as a drive-by.