### PR TITLE
make AllModules public

### DIFF
--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -470,7 +470,10 @@ fn decl_all_modules<'a>(
 
 	quote!(
 		#types
+		/// All pallets included in the runtime as a nested tuple of types.
+		/// Excludes the System pallet.
 		pub type AllModules = ( #all_modules );
+		/// All pallets included in the runtime as a nested tuple of types.
 		pub type AllModulesWithSystem = ( #all_modules_with_system );
 	)
 }

--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -470,8 +470,8 @@ fn decl_all_modules<'a>(
 
 	quote!(
 		#types
-		type AllModules = ( #all_modules );
-		type AllModulesWithSystem = ( #all_modules_with_system );
+		pub type AllModules = ( #all_modules );
+		pub type AllModulesWithSystem = ( #all_modules_with_system );
 	)
 }
 


### PR DESCRIPTION
Make the generated `AllModules` and `AllModuleWithSystem` types public so crates depending on FRAME runtimes can access them. (Useful for e.g. testing.)