### PR TITLE
relax translate closure to FnMut

### DIFF
--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -383,7 +383,7 @@ impl<
 		iterator
 	}
 
-	fn translate<O: Decode, F: Fn(K1, K2, O) -> Option<V>>(f: F) {
+	fn translate<O: Decode, F: FnMut(K1, K2, O) -> Option<V>>(mut f: F) {
 		let prefix = G::prefix_hash();
 		let mut previous_key = prefix.clone();
 		while let Some(next) = sp_io::storage::next_key(&previous_key)

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -162,7 +162,7 @@ impl<
 		iterator
 	}
 
-	fn translate<O: Decode, F: Fn(K, O) -> Option<V>>(f: F) {
+	fn translate<O: Decode, F: FnMut(K, O) -> Option<V>>(mut f: F) {
 		let prefix = G::prefix_hash();
 		let mut previous_key = prefix.clone();
 		while let Some(next) = sp_io::storage::next_key(&previous_key)

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -315,7 +315,7 @@ pub trait IterableStorageMap<K: FullEncode, V: FullCodec>: StorageMap<K, V> {
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
 	///
 	/// NOTE: If a value fail to decode because storage is corrupted then it is skipped.
-	fn translate<O: Decode, F: Fn(K, O) -> Option<V>>(f: F);
+	fn translate<O: Decode, F: FnMut(K, O) -> Option<V>>(f: F);
 }
 
 /// A strongly-typed double map in storage whose secondary keys and values can be iterated over.
@@ -352,7 +352,7 @@ pub trait IterableStorageDoubleMap<
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
 	///
 	/// NOTE: If a value fail to decode because storage is corrupted then it is skipped.
-	fn translate<O: Decode, F: Fn(K1, K2, O) -> Option<V>>(f: F);
+	fn translate<O: Decode, F: FnMut(K1, K2, O) -> Option<V>>(f: F);
 }
 
 /// An implementation of a map with a two keys.
@@ -614,7 +614,7 @@ pub trait StoragePrefixedMap<Value: FullCodec> {
 	/// # Usage
 	///
 	/// This would typically be called inside the module implementation of on_runtime_upgrade.
-	fn translate_values<OldValue: Decode, F: Fn(OldValue) -> Option<Value>>(f: F) {
+	fn translate_values<OldValue: Decode, F: FnMut(OldValue) -> Option<Value>>(mut f: F) {
 		let prefix = Self::final_prefix();
 		let mut previous_key = prefix.clone().to_vec();
 		while let Some(next) = sp_io::storage::next_key(&previous_key)

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -326,7 +326,7 @@ where
 	/// # Usage
 	///
 	/// This would typically be called inside the module implementation of on_runtime_upgrade.
-	pub fn translate_values<OldValue: Decode, F: Fn(OldValue) -> Option<Value>>(f: F) {
+	pub fn translate_values<OldValue: Decode, F: FnMut(OldValue) -> Option<Value>>(f: F) {
 		<Self as crate::storage::StoragePrefixedMap<Value>>::translate_values(f)
 	}
 }
@@ -379,7 +379,7 @@ where
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
 	///
 	/// NOTE: If a value fail to decode because storage is corrupted then it is skipped.
-	pub fn translate<O: Decode, F: Fn(Key1, Key2, O) -> Option<Value>>(f: F) {
+	pub fn translate<O: Decode, F: FnMut(Key1, Key2, O) -> Option<Value>>(f: F) {
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::translate(f)
 	}
 }

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -249,7 +249,7 @@ where
 	/// # Usage
 	///
 	/// This would typically be called inside the module implementation of on_runtime_upgrade.
-	pub fn translate_values<OldValue: Decode, F: Fn(OldValue) -> Option<Value>>(f: F) {
+	pub fn translate_values<OldValue: Decode, F: FnMut(OldValue) -> Option<Value>>(f: F) {
 		<Self as crate::storage::StoragePrefixedMap<Value>>::translate_values(f)
 	}
 }
@@ -283,7 +283,7 @@ where
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
 	///
 	/// NOTE: If a value fail to decode because storage is corrupted then it is skipped.
-	pub fn translate<O: Decode, F: Fn(Key, O) -> Option<Value>>(f: F) {
+	pub fn translate<O: Decode, F: FnMut(Key, O) -> Option<Value>>(f: F) {
 		<Self as crate::storage::IterableStorageMap<Key, Value>>::translate(f)
 	}
 }


### PR DESCRIPTION
Relax the type constraints for `translate` to `FnMut` to allow passing closures to `translate` that mutate captured variables.
Useful for migrations where you want to e.g. count the amount of values that were migrated.