### PR TITLE
AURA: Switch to `CurrentSlot` instead of `LastTimestamp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,7 +4320,6 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-core",
- "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -273,7 +273,7 @@ construct_runtime!(
 		System: frame_system::{Module, Call, Config, Storage, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-		Aura: pallet_aura::{Module, Config<T>, Inherent},
+		Aura: pallet_aura::{Module, Config<T>},
 		Grandpa: pallet_grandpa::{Module, Call, Storage, Config, Event},
 		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 		TransactionPayment: pallet_transaction_payment::{Module, Storage},

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -15,7 +15,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-application-crypto = { version = "2.0.0", default-features = false, path = "../../primitives/application-crypto" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-inherents = { version = "2.0.0", default-features = false, path = "../../primitives/inherents" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
 serde = { version = "1.0.101", optional = true }
 pallet-session = { version = "2.0.0", default-features = false, path = "../session" }
@@ -37,7 +36,6 @@ default = ["std"]
 std = [
 	"sp-application-crypto/std",
 	"codec/std",
-	"sp-inherents/std",
 	"sp-std/std",
 	"serde",
 	"sp-runtime/std",

--- a/frame/aura/Cargo.toml
+++ b/frame/aura/Cargo.toml
@@ -26,7 +26,6 @@ frame-system = { version = "2.0.0", default-features = false, path = "../system"
 sp-timestamp = { version = "2.0.0", default-features = false, path = "../../primitives/timestamp" }
 pallet-timestamp = { version = "2.0.0", default-features = false, path = "../timestamp" }
 
-
 [dev-dependencies]
 sp-core = { version = "2.0.0", default-features = false, path = "../../primitives/core" }
 sp-io ={ version = "2.0.0", path = "../../primitives/io" }

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -264,31 +264,3 @@ impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
 		assert!(CurrentSlot::<T>::get() == timestamp_slot, "Timestamp slot must match `CurrentSlot`");
 	}
 }
-
-impl<T: Config> ProvideInherent for Pallet<T> {
-	type Call = pallet_timestamp::Call<T>;
-	type Error = MakeFatalError<sp_inherents::Error>;
-	const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
-
-	fn create_inherent(_: &InherentData) -> Option<Self::Call> {
-		None
-	}
-
-	/// Verify the validity of the inherent using the timestamp.
-	fn check_inherent(call: &Self::Call, data: &InherentData) -> result::Result<(), Self::Error> {
-		let timestamp = match call {
-			pallet_timestamp::Call::set(ref timestamp) => timestamp.clone(),
-			_ => return Ok(()),
-		};
-
-		let timestamp_based_slot = timestamp / Self::slot_duration();
-
-		let seal_slot = u64::from(data.aura_inherent_data()?).saturated_into();
-
-		if timestamp_based_slot == seal_slot {
-			Ok(())
-		} else {
-			Err(sp_inherents::Error::from("timestamp set in block doesn't match slot in seal").into())
-		}
-	}
-}

--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -34,17 +34,10 @@
 //!
 //! - [Timestamp](../pallet_timestamp/index.html): The Timestamp module is used in Aura to track
 //! consensus rounds (via `slots`).
-//!
-//! ## References
-//!
-//! If you're interested in hacking on this module, it is useful to understand the interaction with
-//! `substrate/primitives/inherents/src/lib.rs` and, specifically, the required implementation of
-//! [`ProvideInherent`](../sp_inherents/trait.ProvideInherent.html) and
-//! [`ProvideInherentData`](../sp_inherents/trait.ProvideInherentData.html) to create and check inherents.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use sp_std::{result, prelude::*};
+use sp_std::prelude::*;
 use codec::{Encode, Decode};
 use frame_support::{Parameter, traits::{Get, FindAuthor}, ConsensusEngineId};
 use sp_runtime::{
@@ -52,11 +45,7 @@ use sp_runtime::{
 	traits::{SaturatedConversion, Saturating, Zero, Member, IsMember}, generic::DigestItem,
 };
 use sp_timestamp::OnTimestampSet;
-use sp_inherents::{InherentIdentifier, InherentData, ProvideInherent, MakeFatalError};
-use sp_consensus_aura::{
-	AURA_ENGINE_ID, ConsensusLog, AuthorityIndex, Slot,
-	inherents::{INHERENT_IDENTIFIER, AuraInherentData},
-};
+use sp_consensus_aura::{AURA_ENGINE_ID, ConsensusLog, AuthorityIndex, Slot};
 
 mod mock;
 mod tests;

--- a/frame/aura/src/migrations.rs
+++ b/frame/aura/src/migrations.rs
@@ -39,5 +39,5 @@ pub trait RemoveLastTimestamp: super::Config {
 /// This migration requires a type `T` that implements [`RemoveLastTimestamp`].
 pub fn remove_last_timestamp<T: RemoveLastTimestamp>() -> Weight {
 	LastTimestamp::<T>::kill();
-	T::DbWeight::get().reads(1)
+	T::DbWeight::get().writes(1)
 }

--- a/frame/aura/src/migrations.rs
+++ b/frame/aura/src/migrations.rs
@@ -36,7 +36,7 @@ pub trait RemoveLastTimestamp: super::Config {
 /// This storage value was removed and replaced by `CurrentSlot`. As we only remove this storage
 /// value, it is safe to call this method multiple times.
 ///
-/// This migration requires a type `T` that implements [`MigrationFromLastTimestamp`].
+/// This migration requires a type `T` that implements [`RemoveLastTimestamp`].
 pub fn remove_last_timestamp<T: RemoveLastTimestamp>() -> Weight {
 	LastTimestamp::<T>::kill();
 	T::DbWeight::get().reads(1)

--- a/frame/aura/src/migrations.rs
+++ b/frame/aura/src/migrations.rs
@@ -1,0 +1,43 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Migrations for the AURA pallet.
+
+use frame_support::{traits::Get, weights::Weight, pallet_prelude::*};
+
+struct __LastTimestamp<T>(sp_std::marker::PhantomData<T>);
+impl<T: RemoveLastTimestamp> frame_support::traits::StorageInstance for __LastTimestamp<T> {
+	fn pallet_prefix() -> &'static str { T::PalletPrefix::get() }
+	const STORAGE_PREFIX: &'static str = "LastTimestamp";
+}
+
+type LastTimestamp<T> = StorageValue<__LastTimestamp<T>, (), ValueQuery>;
+
+pub trait RemoveLastTimestamp: super::Config {
+	type PalletPrefix: Get<&'static str>;
+}
+
+/// Remove the `LastTimestamp` storage value.
+///
+/// This storage value was removed and replaced by `CurrentSlot`. As we only remove this storage
+/// value, it is safe to call this method multiple times.
+///
+/// This migration requires a type `T` that implements [`MigrationFromLastTimestamp`].
+pub fn remove_last_timestamp<T: RemoveLastTimestamp>() -> Weight {
+	LastTimestamp::<T>::kill();
+	T::DbWeight::get().reads(1)
+}

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -25,7 +25,7 @@ use sp_runtime::{
 	traits::IdentityLookup,
 	testing::{Header, UintAuthorityId},
 };
-use frame_support::parameter_types;
+use frame_support::{parameter_types, traits::GenesisBuild};
 use sp_io;
 use sp_core::H256;
 

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -40,7 +40,7 @@ frame_support::construct_runtime!(
 	{
 		System: frame_system::{Module, Call, Config, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
-		Aura: pallet_aura::{Module, Call, Storage, Config<T>, Inherent},
+		Aura: pallet_aura::{Module, Call, Storage, Config<T>},
 	}
 );
 

--- a/frame/aura/src/mock.rs
+++ b/frame/aura/src/mock.rs
@@ -21,12 +21,8 @@
 
 use crate as pallet_aura;
 use sp_consensus_aura::ed25519::AuthorityId;
-use sp_runtime::{
-	traits::IdentityLookup,
-	testing::{Header, UintAuthorityId},
-};
+use sp_runtime::{traits::IdentityLookup, testing::{Header, UintAuthorityId}};
 use frame_support::{parameter_types, traits::GenesisBuild};
-use sp_io;
 use sp_core::H256;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -24,7 +24,7 @@ use crate::mock::{Aura, new_test_ext};
 #[test]
 fn initial_values() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
-		assert_eq!(Aura::last_timestamp(), 0u64);
+		assert_eq!(Aura::current_slot(), 0u64);
 		assert_eq!(Aura::authorities().len(), 4);
 	});
 }

--- a/frame/aura/src/tests.rs
+++ b/frame/aura/src/tests.rs
@@ -24,7 +24,7 @@ use crate::mock::{Aura, new_test_ext};
 #[test]
 fn initial_values() {
 	new_test_ext(vec![0, 1, 2, 3]).execute_with(|| {
-		assert_eq!(Aura::last(), 0u64);
+		assert_eq!(Aura::last_timestamp(), 0u64);
 		assert_eq!(Aura::authorities().len(), 4);
 	});
 }

--- a/primitives/consensus/aura/src/inherents.rs
+++ b/primitives/consensus/aura/src/inherents.rs
@@ -48,6 +48,7 @@ impl AuraInherentData for InherentData {
 }
 
 /// Provides the slot duration inherent data for `Aura`.
+// TODO: Remove in the future. https://github.com/paritytech/substrate/issues/8029
 #[cfg(feature = "std")]
 pub struct InherentDataProvider {
 	slot_duration: u64,

--- a/primitives/consensus/aura/src/lib.rs
+++ b/primitives/consensus/aura/src/lib.rs
@@ -61,6 +61,8 @@ pub mod ed25519 {
 	pub type AuthorityId = app_ed25519::Public;
 }
 
+pub use sp_consensus_slots::Slot;
+
 /// The `ConsensusEngineId` of AuRa.
 pub const AURA_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
 


### PR DESCRIPTION
This switches AURA to use `CurrentSlot` instead of `LastTimestamp`.

Based on: https://github.com/paritytech/substrate/pull/8020 (so only the last commit is important at the moment)