### PR TITLE
Better formatting for doc comments

### DIFF
--- a/primitives/debug-derive/src/lib.rs
+++ b/primitives/debug-derive/src/lib.rs
@@ -27,9 +27,9 @@
 //!
 //! ```rust
 //! #[derive(sp_debug_derive::RuntimeDebug)]
-//!	struct MyStruct;
+//! struct MyStruct;
 //!
-//!	assert_eq!(format!("{:?}", MyStruct), "MyStruct");
+//! assert_eq!(format!("{:?}", MyStruct), "MyStruct");
 //! ```
 
 mod impls;


### PR DESCRIPTION
This PR changes the whitespace in a doc comment. Clippy was complaining about this as follows:

```
  error: using tabs in doc comments is not recommended
    --> /home/joshy/.cargo/git/checkouts/substrate-7e08433d4c370a21/f977fb8/primitives/debug-derive/src/lib.rs:30:4
     |
  30 | //!    struct MyStruct;
     |    ^^^^ help: consider using four spaces per tab
     |
     = note: `-D clippy::tabs-in-doc-comments` implied by `-D warnings`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments

  error: using tabs in doc comments is not recommended
    --> /home/joshy/.cargo/git/checkouts/substrate-7e08433d4c370a21/f977fb8/primitives/debug-derive/src/lib.rs:32:4
     |
  32 | //!    assert_eq!(format!("{:?}", MyStruct), "MyStruct");
     |    ^^^^ help: consider using four spaces per tab
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#tabs_in_doc_comments

  error: aborting due to 2 previous errors

  error: could not compile `sp-debug-derive`
```