### PR TITLE
frame-system: Index type 'MaybeSerializeDeserialize' bound.

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -174,7 +174,7 @@ pub mod pallet {
 		/// Account index (aka nonce) type. This stores the number of previous transactions associated
 		/// with a sender account.
 		type Index:
-			Parameter + Member + MaybeSerialize + Debug + Default + MaybeDisplay + AtLeast32Bit
+			Parameter + Member + MaybeSerializeDeserialize + Debug + Default + MaybeDisplay + AtLeast32Bit
 			+ Copy;
 
 		/// The block number type used by the runtime.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -77,7 +77,7 @@ use sp_runtime::{
 	traits::{
 		self, CheckEqual, AtLeast32Bit, Zero, Lookup, LookupError,
 		SimpleBitOps, Hash, Member, MaybeDisplay, BadOrigin,
-		MaybeSerialize, MaybeSerializeDeserialize, MaybeMallocSizeOf, StaticLookup, One, Bounded,
+		MaybeSerializeDeserialize, MaybeMallocSizeOf, StaticLookup, One, Bounded,
 		Dispatchable, AtLeast32BitUnsigned, Saturating, StoredMapError,
 	},
 	offchain::storage_lock::BlockNumberProvider,


### PR DESCRIPTION
Update `Index` type bound: `MaybeSerialize` => `MaybeSerializeDeserialize`. So that it could be used in genesis config with new pallet macro.