### PR TITLE
Move aura inherent to pallet module

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -113,7 +113,6 @@ pub mod pallet {
 		}
 	}
 
-
 	#[pallet::inherent]
 	impl<T: Config> ProvideInherent for Pallet<T> {
 		type Call = pallet_timestamp::Call<T>;


### PR DESCRIPTION
inherent is part of pallet module, this is because it is an element in `construct_runtime`. And in the future it will be needed for automatic construct_runtime parts.

This doesn't change anything for now, but it is better for future usage in the pallet macro and construct_runtime macro.