### PR TITLE
client: honor transaction propagation config

### DIFF
--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -668,8 +668,11 @@ async fn transaction_notifications<TBl, TExPool>(
 	// transaction notifications
 	transaction_pool
 		.import_notification_stream()
-		.for_each(move |hash| {
-			network.propagate_transaction(hash);
+		.for_each(move |notification| {
+			if notification.propagate {
+				network.propagate_transaction(notification.hash);
+			}
+
 			let status = transaction_pool.status();
 			telemetry!(SUBSTRATE_INFO; "txpool.import";
 				"ready" => status.ready,

--- a/client/transaction-pool/graph/src/pool.rs
+++ b/client/transaction-pool/graph/src/pool.rs
@@ -656,9 +656,9 @@ mod tests {
 
 		// then
 		let mut it = futures::executor::block_on_stream(stream);
-		assert_eq!(it.next(), Some(hash0));
-		assert_eq!(it.next(), Some(hash1));
-		assert_eq!(it.next(), None);
+		assert_eq!(it.next().map(|n| n.hash), Some(hash0));
+		assert_eq!(it.next().map(|n| n.hash), Some(hash1));
+		assert!(it.next().is_none());
 	}
 
 	#[test]

--- a/primitives/transaction-pool/src/pool.rs
+++ b/primitives/transaction-pool/src/pool.rs
@@ -127,10 +127,24 @@ pub enum TransactionStatus<Hash, BlockHash> {
 }
 
 /// The stream of transaction events.
-pub type TransactionStatusStream<Hash, BlockHash> = dyn Stream<Item=TransactionStatus<Hash, BlockHash>> + Send + Unpin;
+pub type TransactionStatusStream<Hash, BlockHash> =
+	dyn Stream<Item = TransactionStatus<Hash, BlockHash>> + Send + Unpin;
 
 /// The import notification event stream.
-pub type ImportNotificationStream<H> = futures::channel::mpsc::Receiver<H>;
+pub type ImportNotificationStream<Hash> =
+	futures::channel::mpsc::Receiver<ImportNotification<Hash>>;
+
+/// The import notification that is sent when a transaction is imported into the pool.
+pub struct ImportNotification<Hash> {
+	/// Transaction hash (unique)
+	pub hash: Hash,
+	/// Transaction priority (higher = better)
+	pub priority: TransactionPriority,
+	/// Should that transaction be propagated.
+	pub propagate: bool,
+	/// Source of that transaction.
+	pub source: TransactionSource,
+}
 
 /// Transaction hash type for a pool.
 pub type TxHash<P> = <P as TransactionPool>::Hash;


### PR DESCRIPTION
Whenever we imported a tx into the pool we were eagerly propagating it to other peers without checking whether we should do it or not.