### PR TITLE
move some pallet test to use construct_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4791,6 +4791,7 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "parity-scale-codec",
+ "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -16,10 +16,11 @@
 // limitations under the License.
 
 use crate::*;
-use crate as example_offchain_worker;
 use std::sync::Arc;
-use codec::Decode;
-use frame_support::{assert_ok, parameter_types};
+use codec::{Encode, Decode};
+use frame_support::{
+	assert_ok, impl_outer_origin, parameter_types,
+};
 use sp_core::{
 	H256,
 	offchain::{OffchainExt, TransactionPoolExt, testing},
@@ -39,20 +40,15 @@ use sp_runtime::{
 	},
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
-type Block = frame_system::mocking::MockBlock<Test>;
+impl_outer_origin! {
+	pub enum Origin for Test where system = frame_system {}
+}
 
-frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
-	{
-		System: frame_system::{Module, Call, Config, Storage, Event<T>},
-		Example: example_offchain_worker::{Module, Call, Storage, Event<T>, ValidateUnsigned},
-	}
-);
-
+// For testing the module, we construct most of a mock runtime. This means
+// first constructing a configuration type (`Test`) which `impl`s each of the
+// configuration traits of modules we want to use.
+#[derive(Clone, Eq, PartialEq, Encode, Decode)]
+pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -64,7 +60,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type DbWeight = ();
 	type Origin = Origin;
-	type Call = Call;
+	type Call = ();
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -72,10 +68,10 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::sr25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = Event;
+	type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = PalletInfo;
+	type PalletInfo = ();
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -118,13 +114,15 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Event = Event;
+	type Event = ();
 	type AuthorityId = crypto::TestAuthId;
 	type Call = Call<Test>;
 	type GracePeriod = GracePeriod;
 	type UnsignedInterval = UnsignedInterval;
 	type UnsignedPriority = UnsignedPriority;
 }
+
+type Example = Module<Test>;
 
 #[test]
 fn it_aggregates_the_price() {

--- a/frame/example-offchain-worker/src/tests.rs
+++ b/frame/example-offchain-worker/src/tests.rs
@@ -16,11 +16,10 @@
 // limitations under the License.
 
 use crate::*;
+use crate as example_offchain_worker;
 use std::sync::Arc;
-use codec::{Encode, Decode};
-use frame_support::{
-	assert_ok, impl_outer_origin, parameter_types,
-};
+use codec::Decode;
+use frame_support::{assert_ok, parameter_types};
 use sp_core::{
 	H256,
 	offchain::{OffchainExt, TransactionPoolExt, testing},
@@ -40,15 +39,20 @@ use sp_runtime::{
 	},
 };
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-// For testing the module, we construct most of a mock runtime. This means
-// first constructing a configuration type (`Test`) which `impl`s each of the
-// configuration traits of modules we want to use.
-#[derive(Clone, Eq, PartialEq, Encode, Decode)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Example: example_offchain_worker::{Module, Call, Storage, Event<T>, ValidateUnsigned},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -60,7 +64,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type DbWeight = ();
 	type Origin = Origin;
-	type Call = ();
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -68,10 +72,10 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::sr25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -114,15 +118,13 @@ parameter_types! {
 }
 
 impl Config for Test {
-	type Event = ();
+	type Event = Event;
 	type AuthorityId = crypto::TestAuthId;
 	type Call = Call<Test>;
 	type GracePeriod = GracePeriod;
 	type UnsignedInterval = UnsignedInterval;
 	type UnsignedPriority = UnsignedPriority;
 }
-
-type Example = Module<Test>;
 
 #[test]
 fn it_aggregates_the_price() {

--- a/frame/identity/src/tests.rs
+++ b/frame/identity/src/tests.rs
@@ -18,24 +18,31 @@
 // Tests for Identity Pallet
 
 use super::*;
+use crate as pallet_identity;
 
 use sp_runtime::traits::BadOrigin;
-use frame_support::{
-	assert_ok, assert_noop, impl_outer_origin, parameter_types,
-	ord_parameter_types,
-};
+use frame_support::{assert_ok, assert_noop, parameter_types, ord_parameter_types};
 use sp_core::H256;
 use frame_system::{EnsureSignedBy, EnsureOneOf, EnsureRoot};
 use sp_runtime::{
 	testing::Header, traits::{BlakeTwo256, IdentityLookup},
 };
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Identity: pallet_identity::{Module, Call, Storage, Event<T>},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -49,16 +56,16 @@ impl frame_system::Config for Test {
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
-	type Call = ();
+	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -70,7 +77,7 @@ parameter_types! {
 }
 impl pallet_balances::Config for Test {
 	type Balance = u64;
-	type Event = ();
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -100,7 +107,7 @@ type EnsureTwoOrRoot = EnsureOneOf<
 	EnsureSignedBy<Two, u64>
 >;
 impl Config for Test {
-	type Event = ();
+	type Event = Event;
 	type Currency = Balances;
 	type Slashed = ();
 	type BasicDeposit = BasicDeposit;
@@ -113,9 +120,6 @@ impl Config for Test {
 	type ForceOrigin = EnsureTwoOrRoot;
 	type WeightInfo = ();
 }
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
-type Identity = Module<Test>;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/frame/im-online/src/mock.rs
+++ b/frame/im-online/src/mock.rs
@@ -21,23 +21,31 @@
 
 use std::cell::RefCell;
 
-use crate::{Module, Config};
+use crate::Config;
 use sp_runtime::Perbill;
 use sp_staking::{SessionIndex, offence::{ReportOffence, OffenceError}};
 use sp_runtime::testing::{Header, UintAuthorityId, TestXt};
 use sp_runtime::traits::{IdentityLookup, BlakeTwo256, ConvertInto};
 use sp_core::H256;
-use frame_support::{impl_outer_origin, impl_outer_dispatch, parameter_types};
+use frame_support::parameter_types;
+use crate as imonline;
+use pallet_session::historical as pallet_session_historical;
 
-impl_outer_origin!{
-	pub enum Origin for Runtime {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
 
-impl_outer_dispatch! {
-	pub enum Call for Runtime where origin: Origin {
-		imonline::ImOnline,
+frame_support::construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Session: pallet_session::{Module, Call, Storage, Event, Config<T>},
+		ImOnline: imonline::{Module, Call, Storage, Config<T>, Event<T>},
+		Historical: pallet_session_historical::{Module},
 	}
-}
+);
 
 thread_local! {
 	pub static VALIDATORS: RefCell<Option<Vec<u64>>> = RefCell::new(Some(vec![
@@ -99,9 +107,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	t.into()
 }
 
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Runtime;
-
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -122,10 +127,10 @@ impl frame_system::Config for Runtime {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -149,7 +154,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = u64;
 	type ValidatorIdOf = ConvertInto;
 	type Keys = UintAuthorityId;
-	type Event = ();
+	type Event = Event;
 	type DisabledValidatorsThreshold = DisabledValidatorsThreshold;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
 	type WeightInfo = ();
@@ -177,7 +182,7 @@ parameter_types! {
 
 impl Config for Runtime {
 	type AuthorityId = UintAuthorityId;
-	type Event = ();
+	type Event = Event;
 	type ReportUnresponsiveness = OffenceHandler;
 	type ValidatorSet = Historical;
 	type SessionDuration = Period;
@@ -191,12 +196,6 @@ impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Runt
 	type OverarchingCall = Call;
 	type Extrinsic = Extrinsic;
 }
-
-/// Im Online module.
-pub type ImOnline = Module<Runtime>;
-pub type System = frame_system::Module<Runtime>;
-pub type Session = pallet_session::Module<Runtime>;
-pub type Historical = pallet_session::historical::Module<Runtime>;
 
 pub fn advance_session() {
 	let now = System::block_number().max(1);

--- a/frame/lottery/Cargo.toml
+++ b/frame/lottery/Cargo.toml
@@ -25,6 +25,7 @@ frame-benchmarking = { version = "2.0.0", default-features = false, path = "../b
 pallet-balances = { version = "2.0.0", path = "../balances" }
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
+serde = { version = "1.0.101" }
 
 [features]
 default = ["std"]

--- a/frame/lottery/src/mock.rs
+++ b/frame/lottery/src/mock.rs
@@ -18,9 +18,10 @@
 //! Test utilities
 
 use super::*;
+use crate as pallet_lottery;
 
 use frame_support::{
-	impl_outer_origin, impl_outer_dispatch, parameter_types,
+	parameter_types,
 	traits::{OnInitialize, OnFinalize, TestRandomness},
 };
 use sp_core::H256;
@@ -31,19 +32,21 @@ use sp_runtime::{
 };
 use frame_system::EnsureRoot;
 
-impl_outer_origin! {
-	pub enum Origin for Test {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		frame_system::System,
-		pallet_balances::Balances,
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Lottery: pallet_lottery::{Module, Call, Storage, Event<T>},
 	}
-}
+);
 
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: u32 = 1024;
@@ -65,10 +68,10 @@ impl frame_system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -83,7 +86,7 @@ parameter_types! {
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
-	type Event = ();
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
@@ -101,17 +104,13 @@ impl Config for Test {
 	type Call = Call;
 	type Currency = Balances;
 	type Randomness = TestRandomness;
-	type Event = ();
+	type Event = Event;
 	type ManagerOrigin = EnsureRoot<u64>;
 	type MaxCalls = MaxCalls;
 	type ValidateCall = Lottery;
 	type MaxGenerateRandom = MaxGenerateRandom;
 	type WeightInfo = ();
 }
-
-pub type Lottery = Module<Test>;
-pub type System = frame_system::Module<Test>;
-pub type Balances = pallet_balances::Module<Test>;
 
 pub type SystemCall = frame_system::Call<Test>;
 pub type BalancesCall = pallet_balances::Call<Test>;

--- a/frame/merkle-mountain-range/src/mock.rs
+++ b/frame/merkle-mountain-range/src/mock.rs
@@ -19,9 +19,7 @@ use crate::*;
 use crate as pallet_mmr;
 
 use codec::{Encode, Decode};
-use frame_support::{
-	impl_outer_origin, parameter_types,
-};
+use frame_support::parameter_types;
 use pallet_mmr_primitives::{LeafDataProvider, Compact};
 use sp_core::H256;
 use sp_runtime::{
@@ -43,7 +41,7 @@ frame_support::construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system::{Module, Call, Config, Storage, Event<T>},
-		MMR: pallet_mmr::{Module, Call, Storage, Event<T>},
+		MMR: pallet_mmr::{Module, Call, Storage},
 	}
 );
 

--- a/frame/merkle-mountain-range/src/mock.rs
+++ b/frame/merkle-mountain-range/src/mock.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::*;
+use crate as pallet_mmr;
 
 use codec::{Encode, Decode};
 use frame_support::{
@@ -32,19 +33,27 @@ use sp_runtime::{
 use sp_std::cell::RefCell;
 use sp_std::prelude::*;
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-#[derive(Clone, Eq, PartialEq, Encode, Decode)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		MMR: pallet_mmr::{Module, Call, Storage, Event<T>},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = ();
 	type Origin = Origin;
-	type Call = ();
+	type Call = Call;
 	type Index = u64;
 	type BlockNumber = u64;
 	type Hash = H256;
@@ -52,13 +61,13 @@ impl frame_system::Config for Test {
 	type AccountId = sp_core::sr25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();
 	type BlockWeights = ();
 	type BlockLength = ();
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = ();
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -102,5 +111,3 @@ impl LeafDataProvider for LeafData {
 		LEAF_DATA.with(|r| r.borrow().clone())
 	}
 }
-
-pub(crate) type MMR = Module<Test>;

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -239,23 +239,30 @@ decl_module! {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate as pallet_nicks;
 
-	use frame_support::{
-		assert_ok, assert_noop, impl_outer_origin, parameter_types,
-		ord_parameter_types
-	};
+	use frame_support::{assert_ok, assert_noop, parameter_types, ord_parameter_types};
 	use sp_core::H256;
 	use frame_system::EnsureSignedBy;
 	use sp_runtime::{
 		testing::Header, traits::{BlakeTwo256, IdentityLookup, BadOrigin},
 	};
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+			Nicks: pallet_nicks::{Module, Call, Storage, Event<T>},
+		}
+	);
+
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
 		pub BlockWeights: frame_system::limits::BlockWeights =
@@ -270,15 +277,15 @@ mod tests {
 		type Index = u64;
 		type BlockNumber = u64;
 		type Hash = H256;
-		type Call = ();
+		type Call = Call;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = pallet_balances::AccountData<u64>;
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -291,7 +298,7 @@ mod tests {
 	impl pallet_balances::Config for Test {
 		type MaxLocks = ();
 		type Balance = u64;
-		type Event = ();
+		type Event = Event;
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
@@ -306,7 +313,7 @@ mod tests {
 		pub const One: u64 = 1;
 	}
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type Currency = Balances;
 		type ReservationFee = ReservationFee;
 		type Slashed = ();
@@ -314,9 +321,6 @@ mod tests {
 		type MinLength = MinLength;
 		type MaxLength = MaxLength;
 	}
-	type System = frame_system::Module<Test>;
-	type Balances = pallet_balances::Module<Test>;
-	type Nicks = Module<Test>;
 
 	fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();

--- a/frame/node-authorization/src/lib.rs
+++ b/frame/node-authorization/src/lib.rs
@@ -431,21 +431,28 @@ impl<T: Config> Module<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate as pallet_node_authorization;
 
-	use frame_support::{
-		assert_ok, assert_noop, impl_outer_origin,
-		parameter_types, ord_parameter_types,
-	};
+	use frame_support::{assert_ok, assert_noop, parameter_types, ord_parameter_types};
 	use frame_system::EnsureSignedBy;
 	use sp_core::H256;
 	use sp_runtime::{traits::{BlakeTwo256, IdentityLookup, BadOrigin}, testing::Header};
 
-	impl_outer_origin! {
-		pub enum Origin for Test where system = frame_system {}
-	}
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
 
-	#[derive(Clone, Eq, PartialEq)]
-	pub struct Test;
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Module, Call, Config, Storage, Event<T>},
+			NodeAuthorization: pallet_node_authorization::{
+				Module, Call, Storage, Config<T>, Event<T>,
+			},
+		}
+	);
 
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
@@ -459,15 +466,15 @@ mod tests {
 		type Index = u64;
 		type BlockNumber = u64;
 		type Hash = H256;
-		type Call = ();
+		type Call = Call;
 		type Hashing = BlakeTwo256;
 		type AccountId = u64;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
-		type Event = ();
+		type Event = Event;
 		type BlockHashCount = BlockHashCount;
 		type Version = ();
-		type PalletInfo = ();
+		type PalletInfo = PalletInfo;
 		type AccountData = ();
 		type OnNewAccount = ();
 		type OnKilledAccount = ();
@@ -486,7 +493,7 @@ mod tests {
 		pub const MaxPeerIdLength: u32 = 2;
 	}
 	impl Config for Test {
-		type Event = ();
+		type Event = Event;
 		type MaxWellKnownNodes = MaxWellKnownNodes;
 		type MaxPeerIdLength = MaxPeerIdLength;
 		type AddOrigin = EnsureSignedBy<One, u64>;
@@ -496,15 +503,13 @@ mod tests {
 		type WeightInfo = ();
 	}
 
-	type NodeAuthorization = Module<Test>;
-
 	fn test_node(id: u8) -> PeerId {
 		PeerId(vec![id])
 	}
 
 	fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-		GenesisConfig::<Test> {
+		pallet_node_authorization::GenesisConfig::<Test> {
 			nodes: vec![(test_node(10), 10), (test_node(20), 20), (test_node(30), 30)],
 		}.assimilate_storage(&mut t).unwrap();
 		t.into()

--- a/frame/offences/src/tests.rs
+++ b/frame/offences/src/tests.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 use crate::mock::{
-	Offences, System, Offence, TestEvent, KIND, new_test_ext, with_on_offence_fractions,
+	Offences, System, Offence, Event, KIND, new_test_ext, with_on_offence_fractions,
 	offence_reports, set_can_report, set_offence_weight,
 };
 use sp_runtime::Perbill;
@@ -132,7 +132,7 @@ fn should_deposit_event() {
 			System::events(),
 			vec![EventRecord {
 				phase: Phase::Initialization,
-				event: TestEvent::offences(crate::Event::Offence(KIND, time_slot.encode(), true)),
+				event: Event::offences(crate::Event::Offence(KIND, time_slot.encode(), true)),
 				topics: vec![],
 			}]
 		);
@@ -167,7 +167,7 @@ fn doesnt_deposit_event_for_dups() {
 			System::events(),
 			vec![EventRecord {
 				phase: Phase::Initialization,
-				event: TestEvent::offences(crate::Event::Offence(KIND, time_slot.encode(), true)),
+				event: Event::offences(crate::Event::Offence(KIND, time_slot.encode(), true)),
 				topics: vec![],
 			}]
 		);
@@ -304,7 +304,7 @@ fn should_queue_and_resubmit_rejected_offence() {
 			System::events(),
 			vec![EventRecord {
 				phase: Phase::Initialization,
-				event: TestEvent::offences(crate::Event::Offence(KIND, 42u128.encode(), false)),
+				event: Event::offences(crate::Event::Offence(KIND, 42u128.encode(), false)),
 				topics: vec![],
 			}]
 		);

--- a/frame/proxy/src/tests.rs
+++ b/frame/proxy/src/tests.rs
@@ -22,39 +22,29 @@
 use super::*;
 
 use frame_support::{
-	assert_ok, assert_noop, impl_outer_origin, parameter_types, impl_outer_dispatch,
-	impl_outer_event, RuntimeDebug, dispatch::DispatchError, traits::Filter,
+	assert_ok, assert_noop, parameter_types, RuntimeDebug, dispatch::DispatchError, traits::Filter,
 };
 use codec::{Encode, Decode};
 use sp_core::H256;
 use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
 use crate as proxy;
 
-impl_outer_origin! {
-	pub enum Origin for Test where system = frame_system {}
-}
-impl_outer_event! {
-	pub enum TestEvent for Test {
-		system<T>,
-		pallet_balances<T>,
-		proxy<T>,
-		pallet_utility,
-	}
-}
-impl_outer_dispatch! {
-	pub enum Call for Test where origin: Origin {
-		frame_system::System,
-		pallet_balances::Balances,
-		proxy::Proxy,
-		pallet_utility::Utility,
-	}
-}
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
-// For testing the pallet, we construct most of a mock runtime. This means
-// first constructing a configuration type (`Test`) which `impl`s each of the
-// configuration traits of pallets we want to use.
-#[derive(Clone, Eq, PartialEq)]
-pub struct Test;
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Module, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
+		Proxy: proxy::{Module, Call, Storage, Event<T>},
+		Utility: pallet_utility::{Module, Call, Event},
+	}
+);
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
@@ -74,10 +64,10 @@ impl frame_system::Config for Test {
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = TestEvent;
+	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
-	type PalletInfo = ();
+	type PalletInfo = PalletInfo;
 	type AccountData = pallet_balances::AccountData<u64>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
@@ -90,14 +80,14 @@ parameter_types! {
 impl pallet_balances::Config for Test {
 	type MaxLocks = ();
 	type Balance = u64;
-	type Event = TestEvent;
+	type Event = Event;
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
 }
 impl pallet_utility::Config for Test {
-	type Event = TestEvent;
+	type Event = Event;
 	type Call = Call;
 	type WeightInfo = ();
 }
@@ -140,7 +130,7 @@ impl Filter<Call> for BaseFilter {
 	}
 }
 impl Config for Test {
-	type Event = TestEvent;
+	type Event = Event;
 	type Call = Call;
 	type Currency = Balances;
 	type ProxyType = ProxyType;
@@ -153,11 +143,6 @@ impl Config for Test {
 	type AnnouncementDepositBase = AnnouncementDepositBase;
 	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
-
-type System = frame_system::Module<Test>;
-type Balances = pallet_balances::Module<Test>;
-type Utility = pallet_utility::Module<Test>;
-type Proxy = Module<Test>;
 
 use frame_system::Call as SystemCall;
 use pallet_balances::Call as BalancesCall;
@@ -177,19 +162,19 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn last_event() -> TestEvent {
+fn last_event() -> Event {
 	system::Module::<Test>::events().pop().expect("Event expected").event
 }
 
-fn expect_event<E: Into<TestEvent>>(e: E) {
+fn expect_event<E: Into<Event>>(e: E) {
 	assert_eq!(last_event(), e.into());
 }
 
-fn last_events(n: usize) -> Vec<TestEvent> {
+fn last_events(n: usize) -> Vec<Event> {
 	system::Module::<Test>::events().into_iter().rev().take(n).rev().map(|e| e.event).collect()
 }
 
-fn expect_events(e: Vec<TestEvent>) {
+fn expect_events(e: Vec<Event>) {
 	assert_eq!(last_events(e.len()), e);
 }
 


### PR DESCRIPTION
related https://github.com/paritytech/substrate/issues/7949

simply use construct_runtime in tests, nothing substantial here.