### PR TITLE
WasmExecutor takes a cache directory

### DIFF
--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -75,6 +75,7 @@ fn call_in_wasm<E: Externalities>(
 		Some(1024),
 		HostFunctions::host_functions(),
 		8,
+		None,
 	);
 	executor.call_in_wasm(
 		&wasm_binary_unwrap()[..],
@@ -536,6 +537,7 @@ fn should_trap_when_heap_exhausted(wasm_method: WasmExecutionMethod) {
 		Some(17),  // `17` is the initial number of pages compiled into the binary.
 		HostFunctions::host_functions(),
 		8,
+		None,
 	);
 
 	let err = executor.call_in_wasm(
@@ -558,6 +560,7 @@ fn returns_mutable_static(wasm_method: WasmExecutionMethod) {
 		&wasm_binary_unwrap()[..],
 		HostFunctions::host_functions(),
 		true,
+		None,
 	).expect("Creates runtime");
 
 	let instance = runtime.new_instance().unwrap();
@@ -591,6 +594,7 @@ fn restoration_of_globals(wasm_method: WasmExecutionMethod) {
 		&wasm_binary_unwrap()[..],
 		HostFunctions::host_functions(),
 		true,
+		None,
 	).expect("Creates runtime");
 	let instance = runtime.new_instance().unwrap();
 
@@ -611,6 +615,7 @@ fn heap_is_reset_between_calls(wasm_method: WasmExecutionMethod) {
 		&wasm_binary_unwrap()[..],
 		HostFunctions::host_functions(),
 		true,
+		None,
 	).expect("Creates runtime");
 	let instance = runtime.new_instance().unwrap();
 
@@ -634,6 +639,7 @@ fn parallel_execution(wasm_method: WasmExecutionMethod) {
 		Some(1024),
 		HostFunctions::host_functions(),
 		8,
+		None,
 	));
 	let code_hash = blake2_256(wasm_binary_unwrap()).to_vec();
 	let threads: Vec<_> = (0..8).map(|_|

--- a/client/executor/src/lib.rs
+++ b/client/executor/src/lib.rs
@@ -80,6 +80,7 @@ mod tests {
 			Some(8),
 			sp_io::SubstrateHostFunctions::host_functions(),
 			8,
+			None,
 		);
 		let res = executor.call_in_wasm(
 			&wasm_binary_unwrap()[..],

--- a/primitives/runtime-interface/test/src/lib.rs
+++ b/primitives/runtime-interface/test/src/lib.rs
@@ -44,6 +44,7 @@ fn call_wasm_method_with_result<HF: HostFunctionsT>(
 		Some(8),
 		host_functions,
 		8,
+		None,
 	);
 	executor.call_in_wasm(
 		binary,


### PR DESCRIPTION
This PR allows to specify a cache directory when creating a `WasmExecutor`. If specified and wasmtime executor is used, we configure wasmtime to use it to put its compiled artifacts cache there.

This change is motivated by the polkadot validation function which has to execute many different wasm blobs as quickly as possible. Right now, the lack of caching leads to severe stalls.

polkadot companion: https://github.com/paritytech/polkadot/pull/2387
