### PR TITLE
Remove backwards-compatibility networking hack

### DIFF
--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -676,10 +676,10 @@ pub fn grandpa_peers_set_config() -> sc_network::config::NonDefaultSetConfig {
 		// Notifications reach ~256kiB in size at the time of writing on Kusama and Polkadot.
 		max_notification_size: 1024 * 1024,
 		set_config: sc_network::config::SetConfig {
-			in_peers: 25,
-			out_peers: 25,
+			in_peers: 0,
+			out_peers: 0,
 			reserved_nodes: Vec::new(),
-			non_reserved_mode: sc_network::config::NonReservedPeerMode::Accept,
+			non_reserved_mode: sc_network::config::NonReservedPeerMode::Deny,
 		},
 	}
 }

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -424,12 +424,11 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 			// The `reserved_nodes` of this set are later kept in sync with the peers we connect
 			// to through set 0.
 			sets.push(sc_peerset::SetConfig {
-				in_peers: network_config.default_peers_set.in_peers,
-				out_peers: network_config.default_peers_set.out_peers,
+				in_peers: 0,
+				out_peers: 0,
 				bootnodes: Vec::new(),
-				reserved_nodes: default_sets_reserved,
-				reserved_only: network_config.default_peers_set.non_reserved_mode
-					== config::NonReservedPeerMode::Deny,
+				reserved_nodes: Vec::new(),
+				reserved_only: true,
 			});
 
 			for set_cfg in &network_config.extra_sets {

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -427,7 +427,7 @@ impl<B: BlockT, H: ExHashT> Protocol<B, H> {
 				in_peers: 0,
 				out_peers: 0,
 				bootnodes: Vec::new(),
-				reserved_nodes: Vec::new(),
+				reserved_nodes: HashSet::new(),
 				reserved_only: true,
 			});
 

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1697,7 +1697,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 
 							if self.on_sync_peer_connected(peer_id.clone(), handshake).is_ok() {
 								// Set 1 is kept in sync with the connected peers of set 0.
-								self.peerset_handle.add_to_peers_set(
+								self.peerset_handle.add_reserved_peer(
 									HARDCODED_PEERSETS_TX,
 									peer_id.clone()
 								);
@@ -1721,7 +1721,7 @@ impl<B: BlockT, H: ExHashT> NetworkBehaviour for Protocol<B, H> {
 								Ok(handshake) => {
 									if self.on_sync_peer_connected(peer_id.clone(), handshake).is_ok() {
 										// Set 1 is kept in sync with the connected peers of set 0.
-										self.peerset_handle.add_to_peers_set(
+										self.peerset_handle.add_reserved_peer(
 											HARDCODED_PEERSETS_TX,
 											peer_id.clone()
 										);


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/7852

After this PR, Polkadot 0.8.26 and below will be unable to open the transactions and GrandPa substreams with clients that have this PR in.

It is a noticable breakage, because so far even old versions of Polkadot (even maybe 0.8.0) were capable of connecting to recent versions. Only the other way around (recent connecting to older) was known to be broken.

## Detailed explanations

In Polkadot 0.8.26 and below, we consider that either all substreams (block announces, transactions, and GrandPa) are open with a given peer, or none. As long as the block announces substream (i.e. the "main" one) is open, we silently ignore situations where the transactions and/or GrandPa has failed to open. If the rest of the client tries to send a transaction or a GrandPa message with a peer where it failed to open, the message is silently discarded.

In Polkadot 0.8.27 and later (since #7700), however, we properly separate substreams individually from each other. As part of #7700, nodes now open the block announces substream first, then, only if it is open, opens the transactions substreams and GrandPa.
Similarly, if a 0.8.27 node receives an open request for transactions without the block announces being already open, it will be refused. Later, this receiving node will then send back an open request on their own for a transactions substream.

Unfortunately, this causes some compatibility issue between 0.8.26- and 0.8.27+. Nodes on 0.8.26- try to open everything at once, and only the block announces will successfully open. Nodes on 0.8.26- then silently ignore the situation. Even though nodes on 0.8.27+, after refusing a transactions/grandpa substream, will later try to open an outgoing transactions/grandpa substream, this re-opening will be ignored by nodes on 0.8.26-.

In order to solve this problem, a backwards-compatibility hack was added by allowing a certain number of nodes to open transactions and GrandPa substreams despite having no block announces substream open.
This PR removes this hack.
