### PR TITLE
Migrate pallet-timestamp to pallet attribute macro.

### DIFF
--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -33,7 +33,7 @@ benchmarks! {
 	set {
 		let t = MAX_TIME;
 		// Ignore write to `DidUpdate` since it transient.
-		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
+		let did_update_key = crate::DidUpdate::<T>::hashed_key().to_vec();
 		frame_benchmarking::benchmarking::add_to_whitelist(TrackedStorageKey {
 			key: did_update_key,
 			has_been_read: false,
@@ -47,13 +47,13 @@ benchmarks! {
 	on_finalize {
 		let t = MAX_TIME;
 		Timestamp::<T>::set(RawOrigin::None.into(), t.into())?;
-		ensure!(DidUpdate::exists(), "Time was not set.");
+		ensure!(DidUpdate::<T>::exists(), "Time was not set.");
 		// Ignore read/write to `DidUpdate` since it is transient.
-		let did_update_key = crate::DidUpdate::hashed_key().to_vec();
+		let did_update_key = crate::DidUpdate::<T>::hashed_key().to_vec();
 		frame_benchmarking::benchmarking::add_to_whitelist(did_update_key.into());
 	}: { Timestamp::<T>::on_finalize(t.into()); }
 	verify {
-		ensure!(!DidUpdate::exists(), "Time was not removed.");
+		ensure!(!DidUpdate::<T>::exists(), "Time was not removed.");
 	}
 }
 

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -152,7 +152,7 @@ pub mod pallet {
 
 	/// Did the timestamp get updated in this block?
 	#[pallet::storage]
-	pub(crate) type DidUpdate<T: Config> = StorageValue<_, bool, ValueQuery>;
+	pub(super) type DidUpdate<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -192,7 +192,7 @@ pub mod pallet {
 			T::WeightInfo::set(),
 			DispatchClass::Mandatory
 		))]
-		pub(crate) fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
+		pub(super) fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 			assert!(!<Self as Store>::DidUpdate::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -15,23 +15,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Timestamp Module
+//! # Timestamp Pallet
 //!
-//! The Timestamp module provides functionality to get and set the on-chain time.
+//! The Timestamp pallet provides functionality to get and set the on-chain time.
 //!
 //! - [`timestamp::Config`](./trait.Config.html)
 //! - [`Call`](./enum.Call.html)
-//! - [`Module`](./struct.Module.html)
+//! - [`Pallet`](./struct.Pallet.html)
 //!
 //! ## Overview
 //!
-//! The Timestamp module allows the validators to set and validate a timestamp with each block.
+//! The Timestamp pallet allows the validators to set and validate a timestamp with each block.
 //!
 //! It uses inherents for timestamp data, which is provided by the block author and validated/verified
 //! by other validators. The timestamp can be set only once per block and must be set each block.
 //! There could be a constraint on how much time must pass before setting the new timestamp.
 //!
-//! **NOTE:** The Timestamp module is the recommended way to query the on-chain time instead of using
+//! **NOTE:** The Timestamp pallet is the recommended way to query the on-chain time instead of using
 //! an approach based on block numbers. The block number based time measurement can cause issues
 //! because of cumulative calculation errors and hence should be avoided.
 //!
@@ -52,11 +52,11 @@
 //!
 //! ## Usage
 //!
-//! The following example shows how to use the Timestamp module in your custom module to query the current timestamp.
+//! The following example shows how to use the Timestamp pallet in your custom pallet to query the current timestamp.
 //!
 //! ### Prerequisites
 //!
-//! Import the Timestamp module into your custom module and derive the module configuration
+//! Import the Timestamp pallet into your custom pallet and derive the pallet configuration
 //! trait from the timestamp trait.
 //!
 //! ### Get current timestamp
@@ -83,10 +83,10 @@
 //!
 //! ### Example from the FRAME
 //!
-//! The [Session module](https://github.com/paritytech/substrate/blob/master/frame/session/src/lib.rs) uses
-//! the Timestamp module for session management.
+//! The [Session pallet](https://github.com/paritytech/substrate/blob/master/frame/session/src/lib.rs) uses
+//! the Timestamp pallet for session management.
 //!
-//! ## Related Modules
+//! ## Related Pallets
 //!
 //! * [Session](../pallet_session/index.html)
 
@@ -99,51 +99,80 @@ use sp_std::{result, cmp};
 use sp_inherents::{ProvideInherent, InherentData, InherentIdentifier};
 #[cfg(feature = "std")]
 use frame_support::debug;
-use frame_support::{
-	Parameter, decl_storage, decl_module,
-	traits::{Time, UnixTime, Get},
-	weights::{DispatchClass, Weight},
-};
+use frame_support::traits::{Time, UnixTime, Get};
 use sp_runtime::{
 	RuntimeString,
 	traits::{
 		AtLeast32Bit, Zero, SaturatedConversion, Scale,
 	}
 };
-use frame_system::ensure_none;
 use sp_timestamp::{
 	InherentError, INHERENT_IDENTIFIER, InherentType,
 	OnTimestampSet,
 };
 pub use weights::WeightInfo;
 
-/// The module configuration trait
-pub trait Config: frame_system::Config {
-	/// Type used for expressing timestamp.
-	type Moment: Parameter + Default + AtLeast32Bit
-		+ Scale<Self::BlockNumber, Output = Self::Moment> + Copy;
+pub use pallet::*;
 
-	/// Something which can be notified when the timestamp is set. Set this to `()` if not needed.
-	type OnTimestampSet: OnTimestampSet<Self::Moment>;
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use super::*;
 
-	/// The minimum period between blocks. Beware that this is different to the *expected* period
-	/// that the block production apparatus provides. Your chosen consensus system will generally
-	/// work with this to determine a sensible block time. e.g. For Aura, it will be double this
-	/// period on default settings.
-	type MinimumPeriod: Get<Self::Moment>;
+	/// The pallet configuration trait
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Type used for expressing timestamp.
+		type Moment: Parameter + Default + AtLeast32Bit
+			+ Scale<Self::BlockNumber, Output = Self::Moment> + Copy;
 
-	/// Weight information for extrinsics in this pallet.
-	type WeightInfo: WeightInfo;
-}
+		/// Something which can be notified when the timestamp is set. Set this to `()` if not needed.
+		type OnTimestampSet: OnTimestampSet<Self::Moment>;
 
-decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: T::Origin {
 		/// The minimum period between blocks. Beware that this is different to the *expected* period
 		/// that the block production apparatus provides. Your chosen consensus system will generally
 		/// work with this to determine a sensible block time. e.g. For Aura, it will be double this
 		/// period on default settings.
-		const MinimumPeriod: T::Moment = T::MinimumPeriod::get();
+		#[pallet::constant]
+		type MinimumPeriod: Get<Self::Moment>;
 
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	/// Current time for the current block.
+	#[pallet::storage]
+	#[pallet::getter(fn now)]
+	pub type Now<T: Config> = StorageValue<_, T::Moment, ValueQuery>;
+
+	/// Did the timestamp get updated in this block?
+	#[pallet::storage]
+	pub(crate) type DidUpdate<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		/// dummy `on_initialize` to return the weight used in `on_finalize`.
+		fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
+			// weight of `on_finalize`
+			T::WeightInfo::on_finalize()
+		}
+
+		/// # <weight>
+		/// - `O(1)`
+		/// - 1 storage deletion (codec `O(1)`).
+		/// # </weight>
+		fn on_finalize(_n: BlockNumberFor<T>) {
+			assert!(<Self as Store>::DidUpdate::take(), "Timestamp must be updated once in the block");
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Set the current time.
 		///
 		/// This call should be invoked exactly once per block. It will panic at the finalization
@@ -159,11 +188,11 @@ decl_module! {
 		/// - 1 storage read and 1 storage mutation (codec `O(1)`). (because of `DidUpdate::take` in `on_finalize`)
 		/// - 1 event handler `on_timestamp_set`. Must be `O(1)`.
 		/// # </weight>
-		#[weight = (
+		#[pallet::weight((
 			T::WeightInfo::set(),
 			DispatchClass::Mandatory
-		)]
-		fn set(origin, #[compact] now: T::Moment) {
+		))]
+		pub(crate) fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
 			assert!(!<Self as Store>::DidUpdate::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
@@ -175,35 +204,13 @@ decl_module! {
 			<Self as Store>::DidUpdate::put(true);
 
 			<T::OnTimestampSet as OnTimestampSet<_>>::on_timestamp_set(now);
-		}
 
-		/// dummy `on_initialize` to return the weight used in `on_finalize`.
-		fn on_initialize() -> Weight {
-			// weight of `on_finalize`
-			T::WeightInfo::on_finalize()
-		}
-
-		/// # <weight>
-		/// - `O(1)`
-		/// - 1 storage deletion (codec `O(1)`).
-		/// # </weight>
-		fn on_finalize() {
-			assert!(<Self as Store>::DidUpdate::take(), "Timestamp must be updated once in the block");
+			Ok(().into())
 		}
 	}
 }
 
-decl_storage! {
-	trait Store for Module<T: Config> as Timestamp {
-		/// Current time for the current block.
-		pub Now get(fn now): T::Moment;
-
-		/// Did the timestamp get updated in this block?
-		DidUpdate: bool;
-	}
-}
-
-impl<T: Config> Module<T> {
+impl<T: Config> Pallet<T> {
 	/// Get the current time for the current block.
 	///
 	/// NOTE: if this function is called prior to setting the timestamp,
@@ -225,7 +232,7 @@ fn extract_inherent_data(data: &InherentData) -> Result<InherentType, RuntimeStr
 		.ok_or_else(|| "Timestamp inherent data is not provided.".into())
 }
 
-impl<T: Config> ProvideInherent for Module<T> {
+impl<T: Config> ProvideInherent for Pallet<T> {
 	type Call = Call<T>;
 	type Error = InherentError;
 	const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
@@ -260,7 +267,7 @@ impl<T: Config> ProvideInherent for Module<T> {
 	}
 }
 
-impl<T: Config> Time for Module<T> {
+impl<T: Config> Time for Pallet<T> {
 	type Moment = T::Moment;
 
 	/// Before the first set of now with inherent the value returned is zero.
@@ -272,7 +279,7 @@ impl<T: Config> Time for Module<T> {
 /// Before the timestamp inherent is applied, it returns the time of previous block.
 ///
 /// On genesis the time returned is not valid.
-impl<T: Config> UnixTime for Module<T> {
+impl<T: Config> UnixTime for Pallet<T> {
 	fn now() -> core::time::Duration {
 		// now is duration since unix epoch in millisecond as documented in
 		// `sp_timestamp::InherentDataProvider`.

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -167,7 +167,7 @@ pub mod pallet {
 		/// - 1 storage deletion (codec `O(1)`).
 		/// # </weight>
 		fn on_finalize(_n: BlockNumberFor<T>) {
-			assert!(<Self as Store>::DidUpdate::take(), "Timestamp must be updated once in the block");
+			assert!(DidUpdate::<T>::take(), "Timestamp must be updated once in the block");
 		}
 	}
 
@@ -194,14 +194,14 @@ pub mod pallet {
 		))]
 		pub(super) fn set(origin: OriginFor<T>, #[pallet::compact] now: T::Moment) -> DispatchResultWithPostInfo {
 			ensure_none(origin)?;
-			assert!(!<Self as Store>::DidUpdate::exists(), "Timestamp must be updated only once in the block");
+			assert!(!DidUpdate::<T>::exists(), "Timestamp must be updated only once in the block");
 			let prev = Self::now();
 			assert!(
 				prev.is_zero() || now >= prev + T::MinimumPeriod::get(),
 				"Timestamp must increment by at least <MinimumPeriod> between sequential blocks"
 			);
-			<Self as Store>::Now::put(now);
-			<Self as Store>::DidUpdate::put(true);
+			Now::<T>::put(now);
+			DidUpdate::<T>::put(true);
 
 			<T::OnTimestampSet as OnTimestampSet<_>>::on_timestamp_set(now);
 
@@ -258,7 +258,7 @@ impl<T: Config> Pallet<T> {
 	/// Set the timestamp to something in particular. Only used for tests.
 	#[cfg(feature = "std")]
 	pub fn set_timestamp(now: T::Moment) {
-		<Self as Store>::Now::put(now);
+		Now::<T>::put(now);
 	}
 }
 


### PR DESCRIPTION
Part of #7882.

Converts the `Timestamp` pallet to the new pallet attribute macro introduced in #6877.

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

## ⚠️ Breaking Change ⚠️ 

From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

> storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.

So users of the `Timestamp` pallet must be careful about the name they used in `construct_runtime!`. Hence the `runtime-migration` label, which might not be needed depending on the configuration of the `Timestamp` pallet.