### PR TITLE
sc-network: switch on default features for libp2p on non-wasm-builds

### DIFF
--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -64,8 +64,12 @@ zeroize = "1.2.0"
 
 [dependencies.libp2p]
 version = "0.34.0"
+
+[target.'cfg(target_os = "unknown")'.dependencies.libp2p]
+version = "0.34.0"
 default-features = false
 features = ["identify", "kad", "mdns", "mplex", "noise", "ping", "request-response", "tcp-async-io", "websocket", "yamux"]
+
 
 [dev-dependencies]
 assert_matches = "1.3"


### PR DESCRIPTION
currently `sc-network` doesn't build if separated from the rest of workspace (see https://github.com/libp2p/rust-libp2p/issues/1952). This fix flips the dependency switch around: activates the libp2p default features and excludes some for wasm-builds.