### PR TITLE
pallet macro: easier syntax for `#[pallet::pallet]` with `struct Pallet<T>(_)`

### DIFF
--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -26,7 +26,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	// The pallet's runtime storage items.
 	// https://substrate.dev/docs/en/knowledgebase/runtime/storage

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -143,7 +143,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::config]
 	/// The module configuration trait.

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -22,7 +22,7 @@ use crate::pallet::Def;
 /// * Implement OnGenesis on Pallet
 /// * Implement ModuleErrorMetadata on Pallet
 /// * declare Module type alias for construct_runtime
-/// * replace first field type of `struct Pallet` with `PhantomData` if it is `_`
+/// * replace the first field type of `struct Pallet` with `PhantomData` if it is `_`
 pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let frame_system = &def.frame_system;
@@ -42,7 +42,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 		}
 	};
 
-	// If first field type is `_` then we replace with `PhantomData`
+	// If the first field type is `_` then we replace with `PhantomData`
 	if let Some(field) = pallet_item.fields.iter_mut().next() {
 		if field.ty == syn::parse_quote!(_) {
 			field.ty = syn::parse_quote!(

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -22,6 +22,7 @@ use crate::pallet::Def;
 /// * Implement OnGenesis on Pallet
 /// * Implement ModuleErrorMetadata on Pallet
 /// * declare Module type alias for construct_runtime
+/// * replace first field type of `struct Pallet` with `PhantomData` if it is `_`
 pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let frame_system = &def.frame_system;
@@ -40,6 +41,15 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 			unreachable!("Checked by pallet struct parser")
 		}
 	};
+
+	// If first field type is `_` then we replace with `PhantomData`
+	if let Some(field) = pallet_item.fields.iter_mut().next() {
+		if field.ty == syn::parse_quote!(_) {
+			field.ty = syn::parse_quote!(
+				#frame_support::pallet_prelude::PhantomData<(#type_use_gen)>
+			);
+		}
+	}
 
 	pallet_item.attrs.push(syn::parse_quote!(
 		#[derive(

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -46,7 +46,7 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 	if let Some(field) = pallet_item.fields.iter_mut().next() {
 		if field.ty == syn::parse_quote!(_) {
 			field.ty = syn::parse_quote!(
-				#frame_support::pallet_prelude::PhantomData<(#type_use_gen)>
+				#frame_support::sp_std::marker::PhantomData<(#type_use_gen)>
 			);
 		}
 	}

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1129,7 +1129,7 @@ pub mod pallet_prelude {
 /// Item must be defined as followed:
 /// ```ignore
 /// #[pallet::pallet]
-/// pub struct Pallet<T>(PhantomData<T>);
+/// pub struct Pallet<T>(_);
 /// ```
 /// I.e. a regular struct definition named `Pallet`, with generic T and no where clause.
 ///
@@ -1138,7 +1138,7 @@ pub mod pallet_prelude {
 /// ```ignore
 /// #[pallet::pallet]
 /// #[pallet::generate_store(pub(super) trait Store)]
-/// pub struct Pallet<T>(PhantomData<T>);
+/// pub struct Pallet<T>(_);
 /// ```
 /// More precisely the store trait contains an associated type for each storage. It is implemented
 /// for `Pallet` allowing to access the storage from pallet struct.
@@ -1157,6 +1157,7 @@ pub mod pallet_prelude {
 /// 	frame_support::RuntimeDebugNoBound,
 /// )]
 /// ```
+/// and replace the type `_` by `PhantomData<T>`.
 ///
 /// It implements on pallet:
 /// * [`traits::GetPalletVersion`]
@@ -1590,7 +1591,7 @@ pub mod pallet_prelude {
 /// 	// Define the pallet struct placeholder, various pallet function are implemented on it.
 /// 	#[pallet::pallet]
 /// 	#[pallet::generate_store(pub(super) trait Store)]
-/// 	pub struct Pallet<T>(PhantomData<T>);
+/// 	pub struct Pallet<T>(_);
 ///
 /// 	// Implement the pallet hooks.
 /// 	#[pallet::hooks]
@@ -1908,7 +1909,7 @@ pub mod pallet_prelude {
 /// 		#[pallet::generate_store($visibility_of_trait_store trait Store)]
 /// 		// NOTE: if the visibility of trait store is private but you want to make it available
 /// 		// in super, then use `pub(super)` or `pub(crate)` to make it available in crate.
-/// 		pub struct Pallet<T>(PhantomData<T>);
+/// 		pub struct Pallet<T>(_);
 /// 		// pub struct Pallet<T, I = ()>(PhantomData<T>); // for instantiable pallet
 /// 	}
 /// 	```

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -100,7 +100,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(crate) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
@@ -290,7 +290,7 @@ pub mod pallet2 {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(crate) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>

--- a/frame/support/test/tests/pallet_compatibility.rs
+++ b/frame/support/test/tests/pallet_compatibility.rs
@@ -106,7 +106,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {

--- a/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/hooks_invalid_item.rs
@@ -1,12 +1,12 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, PhantomData};
+	use frame_support::pallet_prelude::Hooks;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_error_in_block.rs
@@ -1,13 +1,13 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, PhantomData};
+	use frame_support::pallet_prelude::Hooks;
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_forgotten_where_clause.rs
@@ -1,6 +1,6 @@
 #[frame_support::pallet]
 mod pallet {
-	use frame_support::pallet_prelude::{Hooks, PhantomData};
+	use frame_support::pallet_prelude::Hooks;
 	use frame_system::pallet_prelude::BlockNumberFor;
 
 	#[pallet::config]
@@ -9,7 +9,7 @@ mod pallet {
 	{}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>

--- a/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_invalid_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/type_value_no_return.rs
+++ b/frame/support/test/tests/pallet_ui/type_value_no_return.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_version.rs
+++ b/frame/support/test/tests/pallet_version.rs
@@ -86,7 +86,7 @@ mod pallet3 {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -257,7 +257,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub (super) trait Store)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {


### PR DESCRIPTION
This PR makes the declaration of pallet placeholder less boilerplatey.

now user can just write:
```rust
#[pallet::pallet]
pub struct Pallet<T>(_);
```
And the macro will replace `_` with the expected PhantomData.

Note that this macro doesn't forbid to write it explicitly like:
```rust
#[pallet::pallet]
pub struct Pallet<T>(sp_std::maker::PhantomData<T>);
```
If this PR gets into before substrate 3.0 I guess we can forbid any other syntax than `_`. otherwise I guess better to let user choose.