### PR TITLE
Implement syntax enforcment for `Pallet<T>(_);`

### DIFF
--- a/frame/aura/src/lib.rs
+++ b/frame/aura/src/lib.rs
@@ -66,7 +66,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(sp_std::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {

--- a/frame/support/procedural/src/pallet/parse/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/parse/pallet_struct.rs
@@ -97,6 +97,11 @@ impl PalletStructDef {
 			return Err(syn::Error::new(item.generics.where_clause.span(), msg));
 		}
 
+		if item.fields != syn::FieldsUnnamed::into(syn::parse_quote!((_))) {
+			let msg = "Invalid pallet::pallet, expected 1 unnamed field: `(_)`";
+			return Err(syn::Error::new(item.fields.span(), msg));
+		}
+
 		let mut instances = vec![];
 		instances.push(helper::check_type_def_gen_no_bounds(&item.generics, item.ident.span())?);
 

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1786,7 +1786,7 @@ pub mod pallet_prelude {
 ///
 /// 	#[pallet::pallet]
 /// 	#[pallet::generate_store(pub(super) trait Store)]
-/// 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+/// 	pub struct Pallet<T, I = ()>(_);
 ///
 /// 	#[pallet::hooks]
 /// 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
@@ -1922,7 +1922,7 @@ pub mod pallet_prelude {
 /// 		// NOTE: if the visibility of trait store is private but you want to make it available
 /// 		// in super, then use `pub(super)` or `pub(crate)` to make it available in crate.
 /// 		pub struct Pallet<T>(_);
-/// 		// pub struct Pallet<T, I = ()>(PhantomData<T>); // for instantiable pallet
+/// 		// pub struct Pallet<T, I = ()>(_); // for instantiable pallet
 /// 	}
 /// 	```
 /// 5. **migrate Config**: move trait into the module with

--- a/frame/support/test/tests/pallet_compatibility_instance.rs
+++ b/frame/support/test/tests/pallet_compatibility_instance.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {

--- a/frame/support/test/tests/pallet_instance.rs
+++ b/frame/support/test/tests/pallet_instance.rs
@@ -44,7 +44,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(crate) trait Store)]
-	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {
@@ -199,7 +199,7 @@ pub mod pallet2 {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(crate) trait Store)]
-	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound.rs
@@ -9,7 +9,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.rs
@@ -9,7 +9,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_3.rs
@@ -8,7 +8,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_invalid_const.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_const.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_origin_type.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_missing_weight.rs
+++ b/frame/support/test/tests/pallet_ui/call_missing_weight.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_no_origin.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_origin.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/call_no_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_no_return.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_call_attr.rs
@@ -9,7 +9,7 @@ mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(trait Store)]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
+++ b/frame/support/test/tests/pallet_ui/duplicate_store_attr.rs
@@ -10,7 +10,7 @@ mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(trait Store)]
 	#[pallet::generate_store(trait Store)]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
+++ b/frame/support/test/tests/pallet_ui/error_no_fieldless.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_where_clause.rs
+++ b/frame/support/test/tests/pallet_ui/error_where_clause.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/error_wrong_item_name.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_field_not_member.rs
+++ b/frame/support/test/tests/pallet_ui/event_field_not_member.rs
@@ -10,7 +10,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
+++ b/frame/support/test/tests/pallet_ui/event_not_in_trait.rs
@@ -9,7 +9,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/event_type_invalid_bound.rs
@@ -10,7 +10,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_type_invalid_bound_2.rs
+++ b/frame/support/test/tests/pallet_ui/event_type_invalid_bound_2.rs
@@ -10,7 +10,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
+++ b/frame/support/test/tests/pallet_ui/event_wrong_item_name.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_default_not_satisfied.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_inconsistent_build_config.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_invalid_generic.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
+++ b/frame/support/test/tests/pallet_ui/genesis_wrong_name.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config<I: 'static = ()>: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_1.stderr
@@ -13,7 +13,7 @@ error: Invalid generic declaration, trait is defined with instance but generic u
 error: Invalid generic declaration, trait is defined with instance but generic use none
   --> $DIR/inconsistent_instance_1.rs:10:20
    |
-10 |     pub struct Pallet<T>(core::marker::PhantomData<T>);
+10 |     pub struct Pallet<T>(_);
    |                       ^
 
 error: Invalid generic declaration, trait is defined with instance but generic use none

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T, I = ()>(core::marker::PhantomData<(T, I)>);
+	pub struct Pallet<T, I = ()>(_);
 
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}

--- a/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
+++ b/frame/support/test/tests/pallet_ui/inconsistent_instance_2.stderr
@@ -13,7 +13,7 @@ error: Invalid generic declaration, trait is defined without instance but generi
 error: Invalid generic declaration, trait is defined without instance but generic use some
   --> $DIR/inconsistent_instance_2.rs:10:20
    |
-10 |     pub struct Pallet<T, I = ()>(core::marker::PhantomData<(T, I)>);
+10 |     pub struct Pallet<T, I = ()>(_);
    |                       ^
 
 error: Invalid generic declaration, trait is defined without instance but generic use some

--- a/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_check_inner_span.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/inherent_invalid_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field.rs
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field.rs
@@ -7,16 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(_);
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
-
-	#[pallet::storage]
-	type Foo<T> = u8;
+	pub struct Pallet<T>();
 }
 
 fn main() {

--- a/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field.stderr
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field.stderr
@@ -1,0 +1,5 @@
+error: Invalid pallet::pallet, expected 1 unnamed field: `(_)`
+  --> $DIR/pallet_struct_wrong_field.rs:10:22
+   |
+10 |     pub struct Pallet<T>();
+   |                         ^^

--- a/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field2.rs
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field2.rs
@@ -7,16 +7,9 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(_);
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
-
-	#[pallet::storage]
-	type Foo<T> = u8;
+	pub struct Pallet<T> {
+		some: T,
+	}
 }
 
 fn main() {

--- a/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field2.stderr
+++ b/frame/support/test/tests/pallet_ui/pallet_struct_wrong_field2.stderr
@@ -1,0 +1,8 @@
+error: Invalid pallet::pallet, expected 1 unnamed field: `(_)`
+  --> $DIR/pallet_struct_wrong_field2.rs:10:23
+   |
+10 |       pub struct Pallet<T> {
+   |  __________________________^
+11 | |         some: T,
+12 | |     }
+   | |_____^

--- a/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_incomplete_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_invalid_first_generic.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
+++ b/frame/support/test/tests/pallet_ui/storage_value_no_generic.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
+++ b/frame/support/test/tests/pallet_ui/storage_wrong_item.rs
@@ -7,7 +7,7 @@ mod pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
+++ b/frame/support/test/tests/pallet_ui/store_trait_leak_private.rs
@@ -9,7 +9,7 @@ mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub trait Store)]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
+++ b/frame/support/test/tests/pallet_ui/trait_constant_invalid_bound.rs
@@ -10,7 +10,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
+++ b/frame/support/test/tests/pallet_ui/trait_invalid_item.rs
@@ -10,7 +10,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
+++ b/frame/support/test/tests/pallet_ui/trait_no_supertrait.rs
@@ -8,7 +8,7 @@ mod pallet {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}

--- a/frame/support/test/tests/pallet_version.rs
+++ b/frame/support/test/tests/pallet_version.rs
@@ -110,7 +110,7 @@ mod pallet4 {
 	}
 
 	#[pallet::pallet]
-	pub struct Pallet<T, I=()>(PhantomData<(T, I)>);
+	pub struct Pallet<T, I=()>(_);
 
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {


### PR DESCRIPTION
As a follow up on https://github.com/paritytech/substrate/pull/8091

This PR enforce the new syntax.
For now nothing is enforced on the fields of pallet.

If this PR doesn't get through before 3.0 I think we can close it.