### PR TITLE
Use log level error to report telemetry

### DIFF
--- a/client/telemetry/src/lib.rs
+++ b/client/telemetry/src/lib.rs
@@ -86,7 +86,7 @@ impl TelemetrySpan {
 
 	/// Constructs a new [`TelemetrySpan`].
 	pub fn new() -> Self {
-		Self(tracing::info_span!(TELEMETRY_LOG_SPAN))
+		Self(tracing::error_span!(TELEMETRY_LOG_SPAN))
 	}
 
 	/// Return a clone of the underlying `tracing::Span` instance.
@@ -230,6 +230,11 @@ impl TelemetryWorker {
 				};
 
 				for (addr, verbosity) in endpoints {
+					log::trace!(
+						target: "telemetry",
+						"Initializing telemetry for: {:?}",
+						addr,
+					);
 					node_map
 						.entry(id.clone())
 						.or_default()


### PR DESCRIPTION
Please beware that if you do `-loff,telemetry=trace` it still fails!

```
./target/debug/substrate --dev --tmp --telemetry-url "ws://127.0.0.1:1337 10" -loff,telemetry=trace
2021-02-10 12:55:03.801  ERROR main telemetry: Could not initialize telemetry: the span could not be entered    
2021-02-10 12:55:03.807  ERROR tokio-runtime-worker telemetry: Received connection notifier for unknown node (/ip4/127.0.0.1/tcp/1337/ws). This is a bug.    
```

It just doesn't fail anymore for -lerror and -lwarn

Fixes: https://github.com/paritytech/substrate/issues/8093