### PR TITLE
[CI] Move check_labels to github actions

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,16 @@
+name: Check labels
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, unlabeled]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check labels
+        run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
+        env:
+          GITHUB_PR: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -687,14 +687,3 @@ validator 4 4:
   <<:                              *validator-deploy
   script:
     - ./.maintain/flamingfir-deploy.sh flamingfir-validator4
-
-#### stage:                        .post
-
-check-labels:
-  stage:                           .post
-  image:                           paritytech/tools:latest
-  <<:                              *kubernetes-build
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-  script:
-    - ./.maintain/gitlab/check_labels.sh

--- a/.maintain/common/lib.sh
+++ b/.maintain/common/lib.sh
@@ -66,11 +66,17 @@ has_label(){
   repo="$1"
   pr_id="$2"
   label="$3"
+
+  # These will exist if the function is called in Gitlab.
+  # If the function's called in Github, we should have GITHUB_ACCESS_TOKEN set
+  # already.
   if [ -n "$GITHUB_RELEASE_TOKEN" ]; then
-    out=$(curl -H "Authorization: token $GITHUB_RELEASE_TOKEN" -s "$api_base/$repo/pulls/$pr_id")
-  else
-    out=$(curl -H "Authorization: token $GITHUB_PR_TOKEN" -s "$api_base/$repo/pulls/$pr_id")
+    GITHUB_TOKEN="$GITHUB_RELEASE_TOKEN"
+  elif [ -n "$GITHUB_PR_TOKEN" ]; then
+    GITHUB_TOKEN="$GITHUB_PR_TOKEN"
   fi
+
+  out=$(curl -H "Authorization: token $GITHUB_TOKEN" -s "$api_base/$repo/pulls/$pr_id")
   [ -n "$(echo "$out" | tr -d '\r\n' | jq ".labels | .[] | select(.name==\"$label\")")" ]
 }
 

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -3,9 +3,12 @@
 #shellcheck source=../common/lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
+repo="$GITHUB_REPOSITORY"
+pr="$GITHUB_PR"
+
 ensure_labels() {
   for label in "$@"; do
-    if has_label 'paritytech/substrate' "$CI_COMMIT_BRANCH" "$label"; then
+    if has_label "$repo" "$pr" "$label"; then
       return 0
     fi
   done
@@ -27,7 +30,7 @@ criticality_labels=(
   'C9-critical'
 )
 
-echo "[+] Checking release notes (B) labels for $CI_COMMIT_BRANCH"
+echo "[+] Checking release notes (B) labels"
 if ensure_labels "${releasenotes_labels[@]}";  then
   echo "[+] Release notes label detected. All is well."
 else
@@ -35,7 +38,7 @@ else
   exit 1
 fi
 
-echo "[+] Checking release criticality (C) labels for $CI_COMMIT_BRANCH"
+echo "[+] Checking release criticality (C) labels"
 if ensure_labels "${criticality_labels[@]}";  then
   echo "[+] Release criticality label detected. All is well."
 else

--- a/.maintain/gitlab/check_labels.sh
+++ b/.maintain/gitlab/check_labels.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-#shellcheck source=lib.sh
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+#shellcheck source=../common/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
 ensure_labels() {
   for label in "$@"; do

--- a/.maintain/gitlab/check_signed.sh
+++ b/.maintain/gitlab/check_signed.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# shellcheck source=lib.sh
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+# shellcheck source=../common/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
 version="$CI_COMMIT_TAG"
 

--- a/.maintain/gitlab/generate_changelog.sh
+++ b/.maintain/gitlab/generate_changelog.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# shellcheck source=lib.sh
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+# shellcheck source=../common/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
 version="$2"
 last_version="$1"

--- a/.maintain/gitlab/publish_draft_release.sh
+++ b/.maintain/gitlab/publish_draft_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# shellcheck source=lib.sh
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/lib.sh"
+# shellcheck source=../common/lib.sh
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
 
 version="$CI_COMMIT_TAG"
 


### PR DESCRIPTION
Basically same change as https://github.com/paritytech/polkadot/pull/2415/ - allows the job to re-run when labels are changed, saving the dev the effort of having to manually retrigger the job.

@TriplEight if you have access to admin functions on this repo, can you do the same as the polkadot repo please? :)