### PR TITLE
[multisig, insubstantial] WeightTooLow -> MaxWeightTooLow 

### DIFF
--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -160,7 +160,7 @@ decl_error! {
 		/// A timepoint was given, yet no multisig operation is underway.
 		UnexpectedTimepoint,
 		/// The maximum weight information provided was too low.
-		WeightTooLow,
+		MaxWeightTooLow,
 		/// The data to be stored is already stored.
 		AlreadyStored,
 	}
@@ -503,7 +503,7 @@ impl<T: Config> Module<T> {
 
 			if let Some((call, call_len)) = maybe_approved_call {
 				// verify weight
-				ensure!(call.get_dispatch_info().weight <= max_weight, Error::<T>::WeightTooLow);
+				ensure!(call.get_dispatch_info().weight <= max_weight, Error::<T>::MaxWeightTooLow);
 
 				// Clean up storage before executing call to avoid an possibility of reentrancy
 				// attack.

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -531,7 +531,7 @@ fn weight_check_works() {
 
 		assert_noop!(
 			Multisig::as_multi(Origin::signed(2), 2, vec![1, 3], Some(now()), data, false, 0),
-			Error::<Test>::WeightTooLow,
+			Error::<Test>::MaxWeightTooLow,
 		);
 	});
 }


### PR DESCRIPTION
I am uncertain if anyone watches for this error by name, a perfunctory search through https://github.com/LocalCoinSwap/substrate-multisig-reference shows no reference to the error and if they don't have it hardcoded anywhere, I don't imagine many others do, so this is probably insubstantial. 