### PR TITLE
CI: temporarily allow cargo deny to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,6 +199,8 @@ cargo-deny:
     when:                          always
     paths:
       - deny.log
+  # FIXME: Temorarily allow to fail.
+  allow_failure:                   true
 
 cargo-check-benches:
   stage:                           test


### PR DESCRIPTION
- temporarily allow `cargo-deny` to fail.
  We are aware of the current problems and have them checked in the release checklist.