### PR TITLE
additional doc on repatriate_reserved

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1304,6 +1304,8 @@ impl<T: Config<I>, I: 'static> ReservableCurrency<T::AccountId> for Pallet<T, I>
 
 	/// Move the reserved balance of one account into the balance of another, according to `status`.
 	///
+	/// `beneficiary` must be an existing account.
+	///
 	/// Is a no-op if:
 	/// - the value to be moved is zero; or
 	/// - the `slashed` id equal to `beneficiary` and the `status` is `Reserved`.


### PR DESCRIPTION
Related https://github.com/paritytech/substrate/issues/7992

repatriate_reserved is failing if beneficiary is not an existing account, thus better to make it explicit in the doc.

Otherwise we can also make repatriate_reserved allowing to repatriate to unexisting account but this is changing the current logic.