### PR TITLE
Remove invalid timestamp check

### DIFF
--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -234,11 +234,8 @@ pub mod pallet {
 
 			let data = extract_inherent_data(data).map_err(|e| InherentError::Other(e))?;
 
-			let minimum = (Self::now() + T::MinimumPeriod::get()).saturated_into::<u64>();
 			if t > data + MAX_TIMESTAMP_DRIFT_MILLIS {
 				Err(InherentError::Other("Timestamp too far in future to accept".into()))
-			} else if t < minimum {
-				Err(InherentError::ValidAtTimestamp(minimum))
 			} else {
 				Ok(())
 			}


### PR DESCRIPTION
I can't understand this check:

AFAIK check_inherents is run after the block is build. Thus `Self::now()` contains the block timestamp.
So:
```
t < minimum
== timestamp_block < Self::now() + MinimumPeriod
== timestamp_block < timestamp_block + MinimumPeriod
== false
```
I guess it is not a fatal error, and that's probably why it was working fine.

Or maybe I missunderstand what value contains `Self::now()` in this context, but anyway it seems to me this check is redundant with the `assert` in the set call:
https://github.com/paritytech/substrate/blob/743accbe3256de2fc615adcaa3ab03ebdbbb4dbd/frame/timestamp/src/lib.rs#L199-L202

If I'm correct we can then refactor timestamp InherentError.