### PR TITLE
Make it clear in CLI that paritydb is experimental

### DIFF
--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -165,18 +165,35 @@ impl Into<sc_service::config::RpcMethods> for RpcMethods {
 	}
 }
 
-arg_enum! {
-	/// Database backend
-	#[allow(missing_docs)]
-	#[derive(Debug, Clone, Copy)]
-	pub enum Database {
-		// Facebooks RocksDB
-		RocksDb,
-		// ParityDb. https://github.com/paritytech/parity-db/
-		ParityDb,
+/// Database backend
+#[derive(Debug, Clone, Copy)]
+pub enum Database {
+	/// Facebooks RocksDB
+	RocksDb,
+	/// ParityDb. https://github.com/paritytech/parity-db/
+	ParityDb,
+}
+
+impl std::str::FromStr for Database {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, String> {
+		if s.eq_ignore_ascii_case("rocksdb") {
+			Ok(Self::RocksDb)
+		} else if s.eq_ignore_ascii_case("paritydb-experimental") {
+			Ok(Self::ParityDb)
+		} else {
+			Err(format!("Unknwon variant `{}`, known variants: {:?}", s, Self::variants()))
+		}
 	}
 }
 
+impl Database {
+	/// Returns all the variants of this enum to be shown in the cli.
+	pub fn variants() -> &'static [&'static str] {
+		&["rocksdb", "paritydb-experimental"]
+	}
+}
 
 arg_enum! {
 	/// Whether off-chain workers are enabled.

--- a/client/cli/src/params/database_params.rs
+++ b/client/cli/src/params/database_params.rs
@@ -29,6 +29,7 @@ pub struct DatabaseParams {
 		alias = "db",
 		value_name = "DB",
 		case_insensitive = true,
+		possible_values = &Database::variants(),
 	)]
 	pub database: Option<Database>,
 
@@ -38,7 +39,7 @@ pub struct DatabaseParams {
 
 	/// Enable storage chain mode
 	///
-	/// This changes the storage format for blocks bodys. 
+	/// This changes the storage format for blocks bodys.
 	/// If this is enabled, each transaction is stored separately in the
 	/// transaction database column and is only referenced by hash
 	/// in the block body column.

--- a/client/cli/src/params/database_params.rs
+++ b/client/cli/src/params/database_params.rs
@@ -39,7 +39,7 @@ pub struct DatabaseParams {
 
 	/// Enable storage chain mode
 	///
-	/// This changes the storage format for blocks bodys.
+	/// This changes the storage format for blocks bodies.
 	/// If this is enabled, each transaction is stored separately in the
 	/// transaction database column and is only referenced by hash
 	/// in the block body column.


### PR DESCRIPTION
Sadly this is a breaking change for the CLI.

Fixes: https://github.com/paritytech/substrate/issues/8145

Migration: Everyone that uses `--database paritydb` needs to change to `--database parity-experimental`.