### PR TITLE
Remove `OnSlot` associated type

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -71,14 +71,15 @@ pub struct SlotResult<Block: BlockT> {
 /// The implementation should not make any assumptions of the slot being bound to the time or
 /// similar. The only valid assumption is that the slot number is always increasing.
 pub trait SlotWorker<B: BlockT> {
-	/// The type of the future that will be returned when a new slot is triggered.
-	type OnSlot: Future<Output = Option<SlotResult<B>>>;
-
 	/// Called when a new slot is triggered.
 	///
 	/// Returns a future that resolves to a [`SlotResult`] iff a block was successfully built in
 	/// the slot. Otherwise `None` is returned.
-	fn on_slot(&mut self, chain_head: B::Header, slot_info: SlotInfo) -> Self::OnSlot;
+	fn on_slot(
+		&mut self,
+		chain_head: B::Header,
+		slot_info: SlotInfo,
+	) -> Pin<Box<dyn Future<Output = Option<SlotResult<B>>> + Send>>;
 }
 
 /// A skeleton implementation for `SlotWorker` which tries to claim a slot at
@@ -383,9 +384,11 @@ pub trait SimpleSlotWorker<B: BlockT> {
 }
 
 impl<B: BlockT, T: SimpleSlotWorker<B>> SlotWorker<B> for T {
-	type OnSlot = Pin<Box<dyn Future<Output = Option<SlotResult<B>>> + Send>>;
-
-	fn on_slot(&mut self, chain_head: B::Header, slot_info: SlotInfo) -> Self::OnSlot {
+	fn on_slot(
+		&mut self,
+		chain_head: B::Header,
+		slot_info: SlotInfo,
+	) -> Pin<Box<dyn Future<Output = Option<SlotResult<B>>> + Send>> {
 		SimpleSlotWorker::on_slot(self, chain_head, slot_info)
 	}
 }
@@ -416,7 +419,6 @@ where
 	B: BlockT,
 	C: SelectChain<B>,
 	W: SlotWorker<B>,
-	W::OnSlot: Unpin,
 	SO: SyncOracle + Send,
 	SC: SlotCompatible + Unpin,
 	T: SlotData + Clone,


### PR DESCRIPTION
Currently we always use a boxed future everywhere anyway. This also
enables us to use a boxed `SlotWorker` (which is required for Cumulus).

