### PR TITLE
contracts: Convert to framev2 macros

### DIFF
--- a/bin/node/executor/tests/basic.rs
+++ b/bin/node/executor/tests/basic.rs
@@ -17,7 +17,6 @@
 
 use codec::{Encode, Decode, Joiner};
 use frame_support::{
-	StorageMap,
 	traits::Currency,
 	weights::{GetDispatchInfo, DispatchInfo, DispatchClass},
 };

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment, Currency
 use pallet_session::{historical as pallet_session_historical};
 use sp_inherents::{InherentData, CheckInherentsResult};
 use static_assertions::const_assert;
-use pallet_contracts::WeightInfo;
+use pallet_contracts::weights::WeightInfo;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -42,6 +42,7 @@ use parity_wasm::elements::{Instruction, ValueType, BlockType};
 use sp_runtime::traits::{Hash, Bounded, Zero};
 use sp_std::{default::Default, convert::{TryInto}, vec::Vec, vec};
 use pallet_contracts_primitives::RentProjection;
+use frame_support::weights::Weight;
 
 /// How many batches we do per API benchmark.
 const API_BENCHMARK_BATCHES: u32 = 20;

--- a/frame/contracts/src/chain_extension.rs
+++ b/frame/contracts/src/chain_extension.rs
@@ -18,7 +18,7 @@
 //! A mechanism for runtime authors to augment the functionality of contracts.
 //!
 //! The runtime is able to call into any contract and retrieve the result using
-//! [`bare_call`](crate::Module::bare_call). This already allows customization of runtime
+//! [`bare_call`](crate::Pallet::bare_call). This already allows customization of runtime
 //! behaviour by user generated code (contracts). However, often it is more straightforward
 //! to allow the reverse behaviour: The contract calls into the runtime. We call the latter
 //! one a "chain extension" because it allows the chain to extend the set of functions that are
@@ -37,7 +37,7 @@
 //! [`charge_weight`](Environment::charge_weight) function must be called **before**
 //! carrying out any action that causes the consumption of the chargeable weight.
 //! It cannot be overstated how delicate of a process the creation of a chain extension
-//! is. Check whether using [`bare_call`](crate::Module::bare_call) suffices for the
+//! is. Check whether using [`bare_call`](crate::Pallet::bare_call) suffices for the
 //! use case at hand.
 //!
 //! # Benchmarking
@@ -328,7 +328,7 @@ where
 	///
 	/// If the contract supplied buffer is smaller than the passed `buffer` an `Err` is returned.
 	/// If `allow_skip` is set to true the contract is allowed to skip the copying of the buffer
-	/// by supplying the guard value of [`u32::max_value()`] as `out_ptr`. The
+	/// by supplying the guard value of `u32::max_value()` as `out_ptr`. The
 	/// `weight_per_byte` is only charged when the write actually happens and is not skipped or
 	/// failed due to a too small output buffer.
 	pub fn write(

--- a/frame/contracts/src/exec.rs
+++ b/frame/contracts/src/exec.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 use crate::{
-	CodeHash, Event, RawEvent, Config, Module as Contracts,
+	CodeHash, Event, Config, Module as Contracts,
 	TrieId, BalanceOf, ContractInfo, gas::GasMeter, rent::Rent, storage::{self, Storage},
 	Error, ContractInfoOf, Schedule,
 };
@@ -30,7 +30,7 @@ use frame_support::{
 	dispatch::{DispatchResult, DispatchError},
 	traits::{ExistenceRequirement, Currency, Time, Randomness, Get},
 	weights::Weight,
-	ensure, StorageMap,
+	ensure,
 };
 use pallet_contracts_primitives::{ErrorOrigin, ExecError, ExecReturnValue, ExecResult, ReturnFlags};
 
@@ -446,7 +446,7 @@ where
 					.ok_or(Error::<T>::NewContractNotFunded)?;
 
 				// Deposit an instantiation event.
-				deposit_event::<T>(vec![], RawEvent::Instantiated(caller.clone(), dest.clone()));
+				deposit_event::<T>(vec![], Event::Instantiated(caller.clone(), dest.clone()));
 
 				Ok(output)
 			});
@@ -664,7 +664,7 @@ where
 		if let Some(ContractInfo::Alive(info)) = ContractInfoOf::<T>::take(&self_id) {
 			Storage::<T>::queue_trie_for_deletion(&info).map_err(|e| (e, 0))?;
 			let code_len = E::remove_user(info.code_hash);
-			Contracts::<T>::deposit_event(RawEvent::Terminated(self_id, beneficiary.clone()));
+			Contracts::<T>::deposit_event(Event::Terminated(self_id, beneficiary.clone()));
 			Ok(code_len)
 		} else {
 			panic!(
@@ -708,7 +708,7 @@ where
 		if let Ok(_) = result {
 			deposit_event::<Self::T>(
 				vec![],
-				RawEvent::Restored(
+				Event::Restored(
 					self.ctx.self_account.clone(),
 					dest,
 					code_hash,
@@ -754,7 +754,7 @@ where
 	fn deposit_event(&mut self, topics: Vec<T::Hash>, data: Vec<u8>) {
 		deposit_event::<Self::T>(
 			topics,
-			RawEvent::ContractEmitted(self.ctx.self_account.clone(), data)
+			Event::ContractEmitted(self.ctx.self_account.clone(), data)
 		);
 	}
 
@@ -1334,7 +1334,7 @@ mod tests {
 			// there are instantiation event.
 			assert_eq!(Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
 			assert_eq!(&events(), &[
-				RawEvent::Instantiated(ALICE, instantiated_contract_address)
+				Event::Instantiated(ALICE, instantiated_contract_address)
 			]);
 		});
 	}
@@ -1410,7 +1410,7 @@ mod tests {
 			// there are instantiation event.
 			assert_eq!(Storage::<Test>::code_hash(&instantiated_contract_address).unwrap(), dummy_ch);
 			assert_eq!(&events(), &[
-				RawEvent::Instantiated(BOB, instantiated_contract_address)
+				Event::Instantiated(BOB, instantiated_contract_address)
 			]);
 		});
 	}

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -102,262 +102,424 @@ pub use crate::{
 	wasm::{ReturnCode as RuntimeReturnCode, PrefabWasmModule},
 	weights::WeightInfo,
 	schedule::{Schedule, HostFnWeights, InstructionWeights, Limits},
+	pallet::*,
 };
 use crate::{
 	exec::{ExecutionContext, Executable},
 	rent::Rent,
-	storage::Storage,
+	storage::{Storage, DeletedContract},
 };
 use sp_core::crypto::UncheckedFrom;
 use sp_std::{prelude::*, marker::PhantomData, fmt::Debug};
 use codec::{Codec, Encode, Decode};
 use sp_runtime::{
 	traits::{
-		Hash, StaticLookup, Zero, MaybeSerializeDeserialize, Member, Convert, Saturating,
+		Hash, StaticLookup, MaybeSerializeDeserialize, Member, Convert, Saturating, Zero,
 	},
 	RuntimeDebug, Perbill,
 };
 use frame_support::{
-	decl_module, decl_event, decl_storage, decl_error, ensure,
 	storage::child::ChildInfo,
-	dispatch::{DispatchResult, DispatchResultWithPostInfo},
 	traits::{OnUnbalanced, Currency, Get, Time, Randomness},
-	weights::Pays,
 };
-use frame_system::{ensure_signed, ensure_root, Module as System};
+use frame_system::Module as System;
 use pallet_contracts_primitives::{
 	RentProjectionResult, GetStorageResult, ContractAccessError, ContractExecResult,
 };
-use frame_support::weights::{Weight, PostDispatchInfo, WithPostDispatchInfo};
+use frame_support::weights::{PostDispatchInfo, WithPostDispatchInfo};
 
 pub type CodeHash<T> = <T as frame_system::Config>::Hash;
 pub type TrieId = Vec<u8>;
-
-/// Information for managing an account and its sub trie abstraction.
-/// This is the required info to cache for an account
-#[derive(Encode, Decode, RuntimeDebug)]
-pub enum ContractInfo<T: Config> {
-	Alive(AliveContractInfo<T>),
-	Tombstone(TombstoneContractInfo<T>),
-}
-
-impl<T: Config> ContractInfo<T> {
-	/// If contract is alive then return some alive info
-	pub fn get_alive(self) -> Option<AliveContractInfo<T>> {
-		if let ContractInfo::Alive(alive) = self {
-			Some(alive)
-		} else {
-			None
-		}
-	}
-	/// If contract is alive then return some reference to alive info
-	pub fn as_alive(&self) -> Option<&AliveContractInfo<T>> {
-		if let ContractInfo::Alive(ref alive) = self {
-			Some(alive)
-		} else {
-			None
-		}
-	}
-	/// If contract is alive then return some mutable reference to alive info
-	pub fn as_alive_mut(&mut self) -> Option<&mut AliveContractInfo<T>> {
-		if let ContractInfo::Alive(ref mut alive) = self {
-			Some(alive)
-		} else {
-			None
-		}
-	}
-
-	/// If contract is tombstone then return some tombstone info
-	pub fn get_tombstone(self) -> Option<TombstoneContractInfo<T>> {
-		if let ContractInfo::Tombstone(tombstone) = self {
-			Some(tombstone)
-		} else {
-			None
-		}
-	}
-	/// If contract is tombstone then return some reference to tombstone info
-	pub fn as_tombstone(&self) -> Option<&TombstoneContractInfo<T>> {
-		if let ContractInfo::Tombstone(ref tombstone) = self {
-			Some(tombstone)
-		} else {
-			None
-		}
-	}
-	/// If contract is tombstone then return some mutable reference to tombstone info
-	pub fn as_tombstone_mut(&mut self) -> Option<&mut TombstoneContractInfo<T>> {
-		if let ContractInfo::Tombstone(ref mut tombstone) = self {
-			Some(tombstone)
-		} else {
-			None
-		}
-	}
-}
-
-pub type AliveContractInfo<T> =
-	RawAliveContractInfo<CodeHash<T>, BalanceOf<T>, <T as frame_system::Config>::BlockNumber>;
-
-/// Information for managing an account and its sub trie abstraction.
-/// This is the required info to cache for an account.
-#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
-pub struct RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
-	/// Unique ID for the subtree encoded as a bytes vector.
-	pub trie_id: TrieId,
-	/// The total number of bytes used by this contract.
-	///
-	/// It is a sum of each key-value pair stored by this contract.
-	pub storage_size: u32,
-	/// The total number of key-value pairs in storage of this contract.
-	pub pair_count: u32,
-	/// The code associated with a given account.
-	pub code_hash: CodeHash,
-	/// Pay rent at most up to this value.
-	pub rent_allowance: Balance,
-	/// The amount of rent that was payed by the contract over its whole lifetime.
-	///
-	/// A restored contract starts with a value of zero just like a new contract.
-	pub rent_payed: Balance,
-	/// Last block rent has been payed.
-	pub deduct_block: BlockNumber,
-	/// Last block child storage has been written.
-	pub last_write: Option<BlockNumber>,
-}
-
-impl<CodeHash, Balance, BlockNumber> RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
-	/// Associated child trie unique id is built from the hash part of the trie id.
-	pub fn child_trie_info(&self) -> ChildInfo {
-		child_trie_info(&self.trie_id[..])
-	}
-}
-
-/// Associated child trie unique id is built from the hash part of the trie id.
-pub(crate) fn child_trie_info(trie_id: &[u8]) -> ChildInfo {
-	ChildInfo::new_default(trie_id)
-}
-
-pub type TombstoneContractInfo<T> =
-	RawTombstoneContractInfo<<T as frame_system::Config>::Hash, <T as frame_system::Config>::Hashing>;
-
-#[derive(Encode, Decode, PartialEq, Eq, RuntimeDebug)]
-pub struct RawTombstoneContractInfo<H, Hasher>(H, PhantomData<Hasher>);
-
-impl<H, Hasher> RawTombstoneContractInfo<H, Hasher>
-where
-	H: Member + MaybeSerializeDeserialize+ Debug
-		+ AsRef<[u8]> + AsMut<[u8]> + Copy + Default
-		+ sp_std::hash::Hash + Codec,
-	Hasher: Hash<Output=H>,
-{
-	fn new(storage_root: &[u8], code_hash: H) -> Self {
-		let mut buf = Vec::new();
-		storage_root.using_encoded(|encoded| buf.extend_from_slice(encoded));
-		buf.extend_from_slice(code_hash.as_ref());
-		RawTombstoneContractInfo(<Hasher as Hash>::hash(&buf[..]), PhantomData)
-	}
-}
-
-impl<T: Config> From<AliveContractInfo<T>> for ContractInfo<T> {
-	fn from(alive_info: AliveContractInfo<T>) -> Self {
-		Self::Alive(alive_info)
-	}
-}
-
 pub type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 pub type NegativeImbalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::NegativeImbalance;
+pub type AliveContractInfo<T> =
+	RawAliveContractInfo<CodeHash<T>, BalanceOf<T>, <T as frame_system::Config>::BlockNumber>;
+pub type TombstoneContractInfo<T> =
+	RawTombstoneContractInfo<<T as frame_system::Config>::Hash, <T as frame_system::Config>::Hashing>;
 
-pub trait Config: frame_system::Config {
-	type Time: Time;
-	type Randomness: Randomness<Self::Hash>;
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use super::*;
 
-	/// The currency in which fees are paid and contract balances are held.
-	type Currency: Currency<Self::AccountId>;
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The time implementation used to supply timestamps to conntracts through `seal_now`.
+		type Time: Time;
 
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
+		/// The generator used to supply randomness to contracts through `seal_random`.
+		type Randomness: Randomness<Self::Hash>;
 
-	/// Handler for rent payments.
-	type RentPayment: OnUnbalanced<NegativeImbalanceOf<Self>>;
+		/// The currency in which fees are paid and contract balances are held.
+		type Currency: Currency<Self::AccountId>;
 
-	/// Number of block delay an extrinsic claim surcharge has.
-	///
-	/// When claim surcharge is called by an extrinsic the rent is checked
-	/// for current_block - delay
-	type SignedClaimHandicap: Get<Self::BlockNumber>;
+		/// The overarching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
-	/// The minimum amount required to generate a tombstone.
-	type TombstoneDeposit: Get<BalanceOf<Self>>;
+		/// Handler for rent payments.
+		type RentPayment: OnUnbalanced<NegativeImbalanceOf<Self>>;
 
-	/// The balance every contract needs to deposit to stay alive indefinitely.
-	///
-	/// This is different from the [`Self::TombstoneDeposit`] because this only needs to be
-	/// deposited while the contract is alive. Costs for additional storage are added to
-	/// this base cost.
-	///
-	/// This is a simple way to ensure that contracts with empty storage eventually get deleted by
-	/// making them pay rent. This creates an incentive to remove them early in order to save rent.
-	type DepositPerContract: Get<BalanceOf<Self>>;
+		/// Number of block delay an extrinsic claim surcharge has.
+		///
+		/// When claim surcharge is called by an extrinsic the rent is checked
+		/// for current_block - delay
+		#[pallet::constant]
+		type SignedClaimHandicap: Get<Self::BlockNumber>;
 
-	/// The balance a contract needs to deposit per storage byte to stay alive indefinitely.
-	///
-	/// Let's suppose the deposit is 1,000 BU (balance units)/byte and the rent is 1 BU/byte/day,
-	/// then a contract with 1,000,000 BU that uses 1,000 bytes of storage would pay no rent.
-	/// But if the balance reduced to 500,000 BU and the storage stayed the same at 1,000,
-	/// then it would pay 500 BU/day.
-	type DepositPerStorageByte: Get<BalanceOf<Self>>;
+		/// The minimum amount required to generate a tombstone.
+		#[pallet::constant]
+		type TombstoneDeposit: Get<BalanceOf<Self>>;
 
-	/// The balance a contract needs to deposit per storage item to stay alive indefinitely.
-	///
-	/// It works the same as [`Self::DepositPerStorageByte`] but for storage items.
-	type DepositPerStorageItem: Get<BalanceOf<Self>>;
+		/// The balance every contract needs to deposit to stay alive indefinitely.
+		///
+		/// This is different from the [`Self::TombstoneDeposit`] because this only needs to be
+		/// deposited while the contract is alive. Costs for additional storage are added to
+		/// this base cost.
+		///
+		/// This is a simple way to ensure that contracts with empty storage eventually get deleted by
+		/// making them pay rent. This creates an incentive to remove them early in order to save rent.
+		#[pallet::constant]
+		type DepositPerContract: Get<BalanceOf<Self>>;
 
-	/// The fraction of the deposit that should be used as rent per block.
-	///
-	/// When a contract hasn't enough balance deposited to stay alive indefinitely it needs
-	/// to pay per block for the storage it consumes that is not covered by the deposit.
-	/// This determines how high this rent payment is per block as a fraction of the deposit.
-	type RentFraction: Get<Perbill>;
+		/// The balance a contract needs to deposit per storage byte to stay alive indefinitely.
+		///
+		/// Let's suppose the deposit is 1,000 BU (balance units)/byte and the rent is 1 BU/byte/day,
+		/// then a contract with 1,000,000 BU that uses 1,000 bytes of storage would pay no rent.
+		/// But if the balance reduced to 500,000 BU and the storage stayed the same at 1,000,
+		/// then it would pay 500 BU/day.
+		#[pallet::constant]
+		type DepositPerStorageByte: Get<BalanceOf<Self>>;
 
-	/// Reward that is received by the party whose touch has led
-	/// to removal of a contract.
-	type SurchargeReward: Get<BalanceOf<Self>>;
+		/// The balance a contract needs to deposit per storage item to stay alive indefinitely.
+		///
+		/// It works the same as [`Self::DepositPerStorageByte`] but for storage items.
+		#[pallet::constant]
+		type DepositPerStorageItem: Get<BalanceOf<Self>>;
 
-	/// The maximum nesting level of a call/instantiate stack.
-	type MaxDepth: Get<u32>;
+		/// The fraction of the deposit that should be used as rent per block.
+		///
+		/// When a contract hasn't enough balance deposited to stay alive indefinitely it needs
+		/// to pay per block for the storage it consumes that is not covered by the deposit.
+		/// This determines how high this rent payment is per block as a fraction of the deposit.
+		#[pallet::constant]
+		type RentFraction: Get<Perbill>;
 
-	/// The maximum size of a storage value and event payload in bytes.
-	type MaxValueSize: Get<u32>;
+		/// Reward that is received by the party whose touch has led
+		/// to removal of a contract.
+		#[pallet::constant]
+		type SurchargeReward: Get<BalanceOf<Self>>;
 
-	/// Used to answer contracts's queries regarding the current weight price. This is **not**
-	/// used to calculate the actual fee and is only for informational purposes.
-	type WeightPrice: Convert<Weight, BalanceOf<Self>>;
+		/// The maximum nesting level of a call/instantiate stack.
+		#[pallet::constant]
+		type MaxDepth: Get<u32>;
 
-	/// Describes the weights of the dispatchables of this module and is also used to
-	/// construct a default cost schedule.
-	type WeightInfo: WeightInfo;
+		/// The maximum size of a storage value and event payload in bytes.
+		#[pallet::constant]
+		type MaxValueSize: Get<u32>;
 
-	/// Type that allows the runtime authors to add new host functions for a contract to call.
-	type ChainExtension: chain_extension::ChainExtension<Self>;
+		/// Used to answer contracts's queries regarding the current weight price. This is **not**
+		/// used to calculate the actual fee and is only for informational purposes.
+		type WeightPrice: Convert<Weight, BalanceOf<Self>>;
 
-	/// The maximum number of tries that can be queued for deletion.
-	type DeletionQueueDepth: Get<u32>;
+		/// Describes the weights of the dispatchables of this module and is also used to
+		/// construct a default cost schedule.
+		type WeightInfo: WeightInfo;
 
-	/// The maximum amount of weight that can be consumed per block for lazy trie removal.
-	type DeletionWeightLimit: Get<Weight>;
+		/// Type that allows the runtime authors to add new host functions for a contract to call.
+		type ChainExtension: chain_extension::ChainExtension<Self>;
 
-	/// The maximum length of a contract code in bytes. This limit applies to the instrumented
-	/// version of the code. Therefore `instantiate_with_code` can fail even when supplying
-	/// a wasm binary below this maximum size.
-	type MaxCodeSize: Get<u32>;
-}
+		/// The maximum number of tries that can be queued for deletion.
+		#[pallet::constant]
+		type DeletionQueueDepth: Get<u32>;
 
-decl_error! {
-	/// Error for the contracts module.
-	pub enum Error for Module<T: Config>
+		/// The maximum amount of weight that can be consumed per block for lazy trie removal.
+		#[pallet::constant]
+		type DeletionWeightLimit: Get<Weight>;
+
+		/// The maximum length of a contract code in bytes. This limit applies to the instrumented
+		/// version of the code. Therefore `instantiate_with_code` can fail even when supplying
+		/// a wasm binary below this maximum size.
+		#[pallet::constant]
+		type MaxCodeSize: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T>
 	where
 		T::AccountId: UncheckedFrom<T::Hash>,
 		T::AccountId: AsRef<[u8]>,
 	{
+		fn on_initialize(_block: T::BlockNumber) -> Weight {
+			// We do not want to go above the block limit and rather avoid lazy deletion
+			// in that case. This should only happen on runtime upgrades.
+			let weight_limit = T::BlockWeights::get().max_block
+				.saturating_sub(System::<T>::block_weight().total())
+				.min(T::DeletionWeightLimit::get());
+			Storage::<T>::process_deletion_queue_batch(weight_limit)
+				.saturating_add(T::WeightInfo::on_initialize())
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T::AccountId: UncheckedFrom<T::Hash>,
+		T::AccountId: AsRef<[u8]>,
+	{
+		/// Updates the schedule for metering contracts.
+		///
+		/// The schedule must have a greater version than the stored schedule.
+		#[pallet::weight(T::WeightInfo::update_schedule())]
+		pub fn update_schedule(
+			origin: OriginFor<T>,
+			schedule: Schedule<T>
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			if <Module<T>>::current_schedule().version >= schedule.version {
+				Err(Error::<T>::InvalidScheduleVersion)?
+			}
+			Self::deposit_event(Event::ScheduleUpdated(schedule.version));
+			CurrentSchedule::put(schedule);
+			Ok(().into())
+		}
+
+		/// Makes a call to an account, optionally transferring some balance.
+		///
+		/// * If the account is a smart-contract account, the associated code will be
+		/// executed and any value will be transferred.
+		/// * If the account is a regular account, any value will be transferred.
+		/// * If no account exists and the call value is not less than `existential_deposit`,
+		/// a regular account will be created and any value will be transferred.
+		#[pallet::weight(T::WeightInfo::call(T::MaxCodeSize::get() / 1024).saturating_add(*gas_limit))]
+		pub fn call(
+			origin: OriginFor<T>,
+			dest: <T::Lookup as StaticLookup>::Source,
+			#[pallet::compact] value: BalanceOf<T>,
+			#[pallet::compact] gas_limit: Gas,
+			data: Vec<u8>
+		) -> DispatchResultWithPostInfo {
+			let origin = ensure_signed(origin)?;
+			let dest = T::Lookup::lookup(dest)?;
+			let mut gas_meter = GasMeter::new(gas_limit);
+			let schedule = <Module<T>>::current_schedule();
+			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
+			let (result, code_len) = match ctx.call(dest, value, &mut gas_meter, data) {
+				Ok((output, len)) => (Ok(output), len),
+				Err((err, len)) => (Err(err), len),
+			};
+			gas_meter.into_dispatch_result(result, T::WeightInfo::call(code_len / 1024))
+		}
+
+		/// Instantiates a new contract from the supplied `code` optionally transferring
+		/// some balance.
+		///
+		/// This is the only function that can deploy new code to the chain.
+		///
+		/// # Parameters
+		///
+		/// * `endowment`: The balance to transfer from the `origin` to the newly created contract.
+		/// * `gas_limit`: The gas limit enforced when executing the constructor.
+		/// * `code`: The contract code to deploy in raw bytes.
+		/// * `data`: The input data to pass to the contract constructor.
+		/// * `salt`: Used for the address derivation. See [`Self::contract_address`].
+		///
+		/// Instantiation is executed as follows:
+		///
+		/// - The supplied `code` is instrumented, deployed, and a `code_hash` is created for that code.
+		/// - If the `code_hash` already exists on the chain the underlying `code` will be shared.
+		/// - The destination address is computed based on the sender, code_hash and the salt.
+		/// - The smart-contract account is created at the computed address.
+		/// - The `endowment` is transferred to the new account.
+		/// - The `deploy` function is executed in the context of the newly-created account.
+		#[pallet::weight(
+			T::WeightInfo::instantiate_with_code(
+				code.len() as u32 / 1024,
+				salt.len() as u32 / 1024,
+			)
+			.saturating_add(*gas_limit)
+		)]
+		pub fn instantiate_with_code(
+			origin: OriginFor<T>,
+			#[pallet::compact] endowment: BalanceOf<T>,
+			#[pallet::compact] gas_limit: Gas,
+			code: Vec<u8>,
+			data: Vec<u8>,
+			salt: Vec<u8>,
+		) -> DispatchResultWithPostInfo {
+			let origin = ensure_signed(origin)?;
+			let code_len = code.len() as u32;
+			ensure!(code_len <= T::MaxCodeSize::get(), Error::<T>::CodeTooLarge);
+			let mut gas_meter = GasMeter::new(gas_limit);
+			let schedule = <Module<T>>::current_schedule();
+			let executable = PrefabWasmModule::from_code(code, &schedule)?;
+			let code_len = executable.code_len();
+			ensure!(code_len <= T::MaxCodeSize::get(), Error::<T>::CodeTooLarge);
+			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
+			let result = ctx.instantiate(endowment, &mut gas_meter, executable, data, &salt)
+				.map(|(_address, output)| output);
+			gas_meter.into_dispatch_result(
+				result,
+				T::WeightInfo::instantiate_with_code(code_len / 1024, salt.len() as u32 / 1024)
+			)
+		}
+
+		/// Instantiates a contract from a previously deployed wasm binary.
+		///
+		/// This function is identical to [`Self::instantiate_with_code`] but without the
+		/// code deployment step. Instead, the `code_hash` of an on-chain deployed wasm binary
+		/// must be supplied.
+		#[pallet::weight(
+			T::WeightInfo::instantiate(T::MaxCodeSize::get() / 1024, salt.len() as u32 / 1024)
+				.saturating_add(*gas_limit)
+		)]
+		pub fn instantiate(
+			origin: OriginFor<T>,
+			#[pallet::compact] endowment: BalanceOf<T>,
+			#[pallet::compact] gas_limit: Gas,
+			code_hash: CodeHash<T>,
+			data: Vec<u8>,
+			salt: Vec<u8>,
+		) -> DispatchResultWithPostInfo {
+			let origin = ensure_signed(origin)?;
+			let mut gas_meter = GasMeter::new(gas_limit);
+			let schedule = <Module<T>>::current_schedule();
+			let executable = PrefabWasmModule::from_storage(code_hash, &schedule, &mut gas_meter)?;
+			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
+			let code_len = executable.code_len();
+			let result = ctx.instantiate(endowment, &mut gas_meter, executable, data, &salt)
+				.map(|(_address, output)| output);
+			gas_meter.into_dispatch_result(
+				result,
+				T::WeightInfo::instantiate(code_len / 1024, salt.len() as u32 / 1024),
+			)
+		}
+
+		/// Allows block producers to claim a small reward for evicting a contract. If a block
+		/// producer fails to do so, a regular users will be allowed to claim the reward.
+		///
+		/// In case of a successful eviction no fees are charged from the sender. However, the
+		/// reward is capped by the total amount of rent that was payed by the contract while
+		/// it was alive.
+		///
+		/// If contract is not evicted as a result of this call, [`Error::ContractNotEvictable`]
+		/// is returned and the sender is not eligible for the reward.
+		#[pallet::weight(T::WeightInfo::claim_surcharge(T::MaxCodeSize::get() / 1024))]
+		pub fn claim_surcharge(
+			origin: OriginFor<T>,
+			dest: T::AccountId,
+			aux_sender: Option<T::AccountId>
+		) -> DispatchResultWithPostInfo {
+			let origin = origin.into();
+			let (signed, rewarded) = match (origin, aux_sender) {
+				(Ok(frame_system::RawOrigin::Signed(account)), None) => {
+					(true, account)
+				},
+				(Ok(frame_system::RawOrigin::None), Some(aux_sender)) => {
+					(false, aux_sender)
+				},
+				_ => Err(Error::<T>::InvalidSurchargeClaim)?,
+			};
+
+			// Add some advantage for block producers (who send unsigned extrinsics) by
+			// adding a handicap: for signed extrinsics we use a slightly older block number
+			// for the eviction check. This can be viewed as if we pushed regular users back in past.
+			let handicap = if signed {
+				T::SignedClaimHandicap::get()
+			} else {
+				Zero::zero()
+			};
+
+			// If poking the contract has lead to eviction of the contract, give out the rewards.
+			match Rent::<T, PrefabWasmModule<T>>::try_eviction(&dest, handicap)? {
+				(Some(rent_payed), code_len) => {
+					T::Currency::deposit_into_existing(
+						&rewarded,
+						T::SurchargeReward::get().min(rent_payed),
+					)
+					.map(|_| PostDispatchInfo {
+						actual_weight: Some(T::WeightInfo::claim_surcharge(code_len / 1024)),
+						pays_fee: Pays::No,
+					})
+					.map_err(Into::into)
+				}
+				(None, code_len) => Err(Error::<T>::ContractNotEvictable.with_weight(
+					T::WeightInfo::claim_surcharge(code_len / 1024)
+				)),
+			}
+		}
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Contract deployed by address at the specified address. \[deployer, contract\]
+		Instantiated(T::AccountId, T::AccountId),
+
+		/// Contract has been evicted and is now in tombstone state. \[contract\]
+		Evicted(T::AccountId),
+
+		/// Contract has been terminated without leaving a tombstone.
+		/// \[contract, beneficiary\]
+		///
+		/// # Params
+		///
+		/// - `contract`: The contract that was terminated.
+		/// - `beneficiary`: The account that received the contracts remaining balance.
+		///
+		/// # Note
+		///
+		/// The only way for a contract to be removed without a tombstone and emitting
+		/// this event is by calling `seal_terminate`.
+		Terminated(T::AccountId, T::AccountId),
+
+		/// Restoration of a contract has been successful.
+		/// \[restorer, dest, code_hash, rent_allowance\]
+		///
+		/// # Params
+		///
+		/// - `restorer`: Account ID of the restoring contract.
+		/// - `dest`: Account ID of the restored contract.
+		/// - `code_hash`: Code hash of the restored contract.
+		/// - `rent_allowance`: Rent allowance of the restored contract.
+		Restored(T::AccountId, T::AccountId, T::Hash, BalanceOf<T>),
+
+		/// Code with the specified hash has been stored. \[code_hash\]
+		CodeStored(T::Hash),
+
+		/// Triggered when the current schedule is updated.
+		/// \[version\]
+		///
+		/// # Params
+		///
+		/// - `version`: The version of the newly set schedule.
+		ScheduleUpdated(u32),
+
+		/// A custom event emitted by the contract.
+		/// \[contract, data\]
+		///
+		/// # Params
+		///
+		/// - `contract`: The contract that emitted the event.
+		/// - `data`: Data supplied by the contract. Metadata generated during contract
+		///           compilation is needed to decode it.
+		ContractEmitted(T::AccountId, Vec<u8>),
+
+		/// A code with the specified hash was removed.
+		/// \[code_hash\]
+		///
+		/// This happens when the last contract that uses this code hash was removed or evicted.
+		CodeRemoved(T::Hash),
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
 		/// A new schedule must have a greater version than the current one.
 		InvalidScheduleVersion,
 		/// An origin must be signed or inherent and auxiliary sender only provided on inherent.
@@ -423,13 +585,13 @@ decl_error! {
 		NoChainExtension,
 		/// Removal of a contract failed because the deletion queue is full.
 		///
-		/// This can happen when either calling [`Module::claim_surcharge`] or `seal_terminate`.
+		/// This can happen when either calling [`Pallet::claim_surcharge`] or `seal_terminate`.
 		/// The queue is filled by deleting contracts and emptied by a fixed amount each block.
 		/// Trying again during another block is the only way to resolve this issue.
 		DeletionQueueFull,
 		/// A contract could not be evicted because it has enough balance to pay rent.
 		///
-		/// This can be returned from [`Module::claim_surcharge`] because the target
+		/// This can be returned from [`Pallet::claim_surcharge`] because the target
 		/// contract has enough balance to pay for its rent.
 		ContractNotEvictable,
 		/// A storage modification exhausted the 32bit type that holds the storage size.
@@ -440,265 +602,61 @@ decl_error! {
 		/// A contract with the same AccountId already exists.
 		DuplicateContract,
 	}
-}
 
-decl_module! {
-	/// Contracts module.
-	pub struct Module<T: Config> for enum Call
-	where
-		origin: T::Origin,
-		T::AccountId: UncheckedFrom<T::Hash>,
-		T::AccountId: AsRef<[u8]>,
-	{
-		type Error = Error<T>;
+	#[pallet::type_value]
+	pub fn Null() -> u64 {
+		0
+	}
 
-		/// Number of block delay an extrinsic claim surcharge has.
-		///
-		/// When claim surcharge is called by an extrinsic the rent is checked
-		/// for current_block - delay
-		const SignedClaimHandicap: T::BlockNumber = T::SignedClaimHandicap::get();
+	/// Current cost schedule for contracts.
+	#[pallet::storage]
+	#[pallet::getter(fn current_schedule)]
+	pub(super) type CurrentSchedule<T: Config> = StorageValue<_, Schedule<T>, ValueQuery>;
 
-		/// The minimum amount required to generate a tombstone.
-		const TombstoneDeposit: BalanceOf<T> = T::TombstoneDeposit::get();
+	/// A mapping from an original code hash to the original code, untouched by instrumentation.
+	#[pallet::storage]
+	pub type PristineCode<T: Config> = StorageMap<_, Identity, CodeHash<T>, Vec<u8>>;
 
-		/// The balance every contract needs to deposit to stay alive indefinitely.
-		///
-		/// This is different from the [`Self::TombstoneDeposit`] because this only needs to be
-		/// deposited while the contract is alive. Costs for additional storage are added to
-		/// this base cost.
-		///
-		/// This is a simple way to ensure that contracts with empty storage eventually get deleted by
-		/// making them pay rent. This creates an incentive to remove them early in order to save rent.
-		const DepositPerContract: BalanceOf<T> = T::DepositPerContract::get();
+	/// A mapping between an original code hash and instrumented wasm code, ready for execution.
+	#[pallet::storage]
+	pub type CodeStorage<T: Config> = StorageMap<_, Identity, CodeHash<T>, PrefabWasmModule<T>>;
 
-		/// The balance a contract needs to deposit per storage byte to stay alive indefinitely.
-		///
-		/// Let's suppose the deposit is 1,000 BU (balance units)/byte and the rent is 1 BU/byte/day,
-		/// then a contract with 1,000,000 BU that uses 1,000 bytes of storage would pay no rent.
-		/// But if the balance reduced to 500,000 BU and the storage stayed the same at 1,000,
-		/// then it would pay 500 BU/day.
-		const DepositPerStorageByte: BalanceOf<T> = T::DepositPerStorageByte::get();
+	/// The subtrie counter.
+	#[pallet::storage]
+	pub type AccountCounter<T: Config> = StorageValue<_, u64, ValueQuery, Null>;
 
-		/// The balance a contract needs to deposit per storage item to stay alive indefinitely.
-		///
-		/// It works the same as [`Self::DepositPerStorageByte`] but for storage items.
-		const DepositPerStorageItem: BalanceOf<T> = T::DepositPerStorageItem::get();
+	/// The code associated with a given account.
+	///
+	/// TWOX-NOTE: SAFE since `AccountId` is a secure hash.
+	#[pallet::storage]
+	pub type ContractInfoOf<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, ContractInfo<T>>;
 
-		/// The fraction of the deposit that should be used as rent per block.
-		///
-		/// When a contract hasn't enough balance deposited to stay alive indefinitely it needs
-		/// to pay per block for the storage it consumes that is not covered by the deposit.
-		/// This determines how high this rent payment is per block as a fraction of the deposit.
-		const RentFraction: Perbill = T::RentFraction::get();
+	/// Evicted contracts that await child trie deletion.
+	///
+	/// Child trie deletion is a heavy operation depending on the amount of storage items
+	/// stored in said trie. Therefore this operation is performed lazily in `on_initialize`.
+	#[pallet::storage]
+	pub type DeletionQueue<T: Config> = StorageValue<_, Vec<DeletedContract>, ValueQuery>;
 
-		/// Reward that is received by the party whose touch has led
-		/// to removal of a contract.
-		const SurchargeReward: BalanceOf<T> = T::SurchargeReward::get();
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		#[doc = "Current cost schedule for contracts."]
+		pub current_schedule: Schedule<T>,
+	}
 
-		/// The maximum nesting level of a call/instantiate stack. A reasonable default
-		/// value is 100.
-		const MaxDepth: u32 = T::MaxDepth::get();
-
-		/// The maximum size of a storage value in bytes. A reasonable default is 16 KiB.
-		const MaxValueSize: u32 = T::MaxValueSize::get();
-
-		/// The maximum number of tries that can be queued for deletion.
-		const DeletionQueueDepth: u32 = T::DeletionQueueDepth::get();
-
-		/// The maximum amount of weight that can be consumed per block for lazy trie removal.
-		const DeletionWeightLimit: Weight = T::DeletionWeightLimit::get();
-
-		fn deposit_event() = default;
-
-		fn on_initialize() -> Weight {
-			// We do not want to go above the block limit and rather avoid lazy deletion
-			// in that case. This should only happen on runtime upgrades.
-			let weight_limit = T::BlockWeights::get().max_block
-				.saturating_sub(System::<T>::block_weight().total())
-				.min(T::DeletionWeightLimit::get());
-			Storage::<T>::process_deletion_queue_batch(weight_limit)
-				.saturating_add(T::WeightInfo::on_initialize())
-		}
-
-		/// Updates the schedule for metering contracts.
-		///
-		/// The schedule must have a greater version than the stored schedule.
-		#[weight = T::WeightInfo::update_schedule()]
-		pub fn update_schedule(origin, schedule: Schedule<T>) -> DispatchResult {
-			ensure_root(origin)?;
-			if <Module<T>>::current_schedule().version >= schedule.version {
-				Err(Error::<T>::InvalidScheduleVersion)?
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				current_schedule: Default::default(),
 			}
-
-			Self::deposit_event(RawEvent::ScheduleUpdated(schedule.version));
-			CurrentSchedule::put(schedule);
-
-			Ok(())
 		}
+	}
 
-		/// Makes a call to an account, optionally transferring some balance.
-		///
-		/// * If the account is a smart-contract account, the associated code will be
-		/// executed and any value will be transferred.
-		/// * If the account is a regular account, any value will be transferred.
-		/// * If no account exists and the call value is not less than `existential_deposit`,
-		/// a regular account will be created and any value will be transferred.
-		#[weight = T::WeightInfo::call(T::MaxCodeSize::get() / 1024).saturating_add(*gas_limit)]
-		pub fn call(
-			origin,
-			dest: <T::Lookup as StaticLookup>::Source,
-			#[compact] value: BalanceOf<T>,
-			#[compact] gas_limit: Gas,
-			data: Vec<u8>
-		) -> DispatchResultWithPostInfo {
-			let origin = ensure_signed(origin)?;
-			let dest = T::Lookup::lookup(dest)?;
-			let mut gas_meter = GasMeter::new(gas_limit);
-			let schedule = <Module<T>>::current_schedule();
-			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
-			let (result, code_len) = match ctx.call(dest, value, &mut gas_meter, data) {
-				Ok((output, len)) => (Ok(output), len),
-				Err((err, len)) => (Err(err), len),
-			};
-			gas_meter.into_dispatch_result(result, T::WeightInfo::call(code_len / 1024))
-		}
-
-		/// Instantiates a new contract from the supplied `code` optionally transferring
-		/// some balance.
-		///
-		/// This is the only function that can deploy new code to the chain.
-		///
-		/// # Parameters
-		///
-		/// * `endowment`: The balance to transfer from the `origin` to the newly created contract.
-		/// * `gas_limit`: The gas limit enforced when executing the constructor.
-		/// * `code`: The contract code to deploy in raw bytes.
-		/// * `data`: The input data to pass to the contract constructor.
-		/// * `salt`: Used for the address derivation. See [`Self::contract_address`].
-		///
-		/// Instantiation is executed as follows:
-		///
-		/// - The supplied `code` is instrumented, deployed, and a `code_hash` is created for that code.
-		/// - If the `code_hash` already exists on the chain the underlying `code` will be shared.
-		/// - The destination address is computed based on the sender, code_hash and the salt.
-		/// - The smart-contract account is created at the computed address.
-		/// - The `endowment` is transferred to the new account.
-		/// - The `deploy` function is executed in the context of the newly-created account.
-		#[weight =
-			T::WeightInfo::instantiate_with_code(
-				code.len() as u32 / 1024,
-				salt.len() as u32 / 1024,
-			)
-			.saturating_add(*gas_limit)
-		]
-		pub fn instantiate_with_code(
-			origin,
-			#[compact] endowment: BalanceOf<T>,
-			#[compact] gas_limit: Gas,
-			code: Vec<u8>,
-			data: Vec<u8>,
-			salt: Vec<u8>,
-		) -> DispatchResultWithPostInfo {
-			let origin = ensure_signed(origin)?;
-			let code_len = code.len() as u32;
-			ensure!(code_len <= T::MaxCodeSize::get(), Error::<T>::CodeTooLarge);
-			let mut gas_meter = GasMeter::new(gas_limit);
-			let schedule = <Module<T>>::current_schedule();
-			let executable = PrefabWasmModule::from_code(code, &schedule)?;
-			let code_len = executable.code_len();
-			ensure!(code_len <= T::MaxCodeSize::get(), Error::<T>::CodeTooLarge);
-			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
-			let result = ctx.instantiate(endowment, &mut gas_meter, executable, data, &salt)
-				.map(|(_address, output)| output);
-			gas_meter.into_dispatch_result(
-				result,
-				T::WeightInfo::instantiate_with_code(code_len / 1024, salt.len() as u32 / 1024)
-			)
-		}
-
-		/// Instantiates a contract from a previously deployed wasm binary.
-		///
-		/// This function is identical to [`Self::instantiate_with_code`] but without the
-		/// code deployment step. Instead, the `code_hash` of an on-chain deployed wasm binary
-		/// must be supplied.
-		#[weight =
-			T::WeightInfo::instantiate(T::MaxCodeSize::get() / 1024, salt.len() as u32 / 1024)
-				.saturating_add(*gas_limit)
-		]
-		pub fn instantiate(
-			origin,
-			#[compact] endowment: BalanceOf<T>,
-			#[compact] gas_limit: Gas,
-			code_hash: CodeHash<T>,
-			data: Vec<u8>,
-			salt: Vec<u8>,
-		) -> DispatchResultWithPostInfo {
-			let origin = ensure_signed(origin)?;
-			let mut gas_meter = GasMeter::new(gas_limit);
-			let schedule = <Module<T>>::current_schedule();
-			let executable = PrefabWasmModule::from_storage(code_hash, &schedule, &mut gas_meter)?;
-			let mut ctx = ExecutionContext::<T, PrefabWasmModule<T>>::top_level(origin, &schedule);
-			let code_len = executable.code_len();
-			let result = ctx.instantiate(endowment, &mut gas_meter, executable, data, &salt)
-				.map(|(_address, output)| output);
-			gas_meter.into_dispatch_result(
-				result,
-				T::WeightInfo::instantiate(code_len / 1024, salt.len() as u32 / 1024),
-			)
-		}
-
-		/// Allows block producers to claim a small reward for evicting a contract. If a block
-		/// producer fails to do so, a regular users will be allowed to claim the reward.
-		///
-		/// In case of a successful eviction no fees are charged from the sender. However, the
-		/// reward is capped by the total amount of rent that was payed by the contract while
-		/// it was alive.
-		///
-		/// If contract is not evicted as a result of this call, [`Error::ContractNotEvictable`]
-		/// is returned and the sender is not eligible for the reward.
-		#[weight = T::WeightInfo::claim_surcharge(T::MaxCodeSize::get() / 1024)]
-		pub fn claim_surcharge(
-			origin,
-			dest: T::AccountId,
-			aux_sender: Option<T::AccountId>
-		) -> DispatchResultWithPostInfo {
-			let origin = origin.into();
-			let (signed, rewarded) = match (origin, aux_sender) {
-				(Ok(frame_system::RawOrigin::Signed(account)), None) => {
-					(true, account)
-				},
-				(Ok(frame_system::RawOrigin::None), Some(aux_sender)) => {
-					(false, aux_sender)
-				},
-				_ => Err(Error::<T>::InvalidSurchargeClaim)?,
-			};
-
-			// Add some advantage for block producers (who send unsigned extrinsics) by
-			// adding a handicap: for signed extrinsics we use a slightly older block number
-			// for the eviction check. This can be viewed as if we pushed regular users back in past.
-			let handicap = if signed {
-				T::SignedClaimHandicap::get()
-			} else {
-				Zero::zero()
-			};
-
-			// If poking the contract has lead to eviction of the contract, give out the rewards.
-			match Rent::<T, PrefabWasmModule<T>>::try_eviction(&dest, handicap)? {
-				(Some(rent_payed), code_len) => {
-					T::Currency::deposit_into_existing(
-						&rewarded,
-						T::SurchargeReward::get().min(rent_payed),
-					)
-					.map(|_| PostDispatchInfo {
-						actual_weight: Some(T::WeightInfo::claim_surcharge(code_len / 1024)),
-						pays_fee: Pays::No,
-					})
-					.map_err(Into::into)
-				}
-				(None, code_len) => Err(Error::<T>::ContractNotEvictable.with_weight(
-					T::WeightInfo::claim_surcharge(code_len / 1024)
-				)),
-			}
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+			<CurrentSchedule<T>>::put(&self.current_schedule);
 		}
 	}
 }
@@ -783,7 +741,7 @@ where
 
 	/// Store code for benchmarks which does not check nor instrument the code.
 	#[cfg(feature = "runtime-benchmarks")]
-	fn store_code_raw(code: Vec<u8>) -> DispatchResult {
+	fn store_code_raw(code: Vec<u8>) -> frame_support::dispatch::DispatchResult {
 		let schedule = <Module<T>>::current_schedule();
 		PrefabWasmModule::store_code_unchecked(code, &schedule)?;
 		Ok(())
@@ -794,99 +752,129 @@ where
 	fn reinstrument_module(
 		module: &mut PrefabWasmModule<T>,
 		schedule: &Schedule<T>
-	) -> DispatchResult {
+	) -> frame_support::dispatch::DispatchResult {
 		self::wasm::reinstrument(module, schedule)
 	}
 }
 
-decl_event! {
-	pub enum Event<T>
-	where
-		Balance = BalanceOf<T>,
-		<T as frame_system::Config>::AccountId,
-		<T as frame_system::Config>::Hash
-	{
-		/// Contract deployed by address at the specified address. \[deployer, contract\]
-		Instantiated(AccountId, AccountId),
+/// Information for managing an account and its sub trie abstraction.
+/// This is the required info to cache for an account
+#[derive(Encode, Decode, RuntimeDebug)]
+pub enum ContractInfo<T: Config> {
+	Alive(AliveContractInfo<T>),
+	Tombstone(TombstoneContractInfo<T>),
+}
 
-		/// Contract has been evicted and is now in tombstone state. \[contract\]
-		Evicted(AccountId),
+impl<T: Config> ContractInfo<T> {
+	/// If contract is alive then return some alive info
+	pub fn get_alive(self) -> Option<AliveContractInfo<T>> {
+		if let ContractInfo::Alive(alive) = self {
+			Some(alive)
+		} else {
+			None
+		}
+	}
+	/// If contract is alive then return some reference to alive info
+	pub fn as_alive(&self) -> Option<&AliveContractInfo<T>> {
+		if let ContractInfo::Alive(ref alive) = self {
+			Some(alive)
+		} else {
+			None
+		}
+	}
+	/// If contract is alive then return some mutable reference to alive info
+	pub fn as_alive_mut(&mut self) -> Option<&mut AliveContractInfo<T>> {
+		if let ContractInfo::Alive(ref mut alive) = self {
+			Some(alive)
+		} else {
+			None
+		}
+	}
 
-		/// Contract has been terminated without leaving a tombstone.
-		/// \[contract, beneficiary\]
-		///
-		/// # Params
-		///
-		/// - `contract`: The contract that was terminated.
-		/// - `beneficiary`: The account that received the contracts remaining balance.
-		///
-		/// # Note
-		///
-		/// The only way for a contract to be removed without a tombstone and emitting
-		/// this event is by calling `seal_terminate`.
-		Terminated(AccountId, AccountId),
-
-		/// Restoration of a contract has been successful.
-		/// \[restorer, dest, code_hash, rent_allowance\]
-		///
-		/// # Params
-		///
-		/// - `restorer`: Account ID of the restoring contract.
-		/// - `dest`: Account ID of the restored contract.
-		/// - `code_hash`: Code hash of the restored contract.
-		/// - `rent_allowance`: Rent allowance of the restored contract.
-		Restored(AccountId, AccountId, Hash, Balance),
-
-		/// Code with the specified hash has been stored. \[code_hash\]
-		CodeStored(Hash),
-
-		/// Triggered when the current schedule is updated.
-		/// \[version\]
-		///
-		/// # Params
-		///
-		/// - `version`: The version of the newly set schedule.
-		ScheduleUpdated(u32),
-
-		/// A custom event emitted by the contract.
-		/// \[contract, data\]
-		///
-		/// # Params
-		///
-		/// - `contract`: The contract that emitted the event.
-		/// - `data`: Data supplied by the contract. Metadata generated during contract
-		///           compilation is needed to decode it.
-		ContractEmitted(AccountId, Vec<u8>),
-
-		/// A code with the specified hash was removed.
-		/// \[code_hash\]
-		///
-		/// This happens when the last contract that uses this code hash was removed or evicted.
-		CodeRemoved(Hash),
+	/// If contract is tombstone then return some tombstone info
+	pub fn get_tombstone(self) -> Option<TombstoneContractInfo<T>> {
+		if let ContractInfo::Tombstone(tombstone) = self {
+			Some(tombstone)
+		} else {
+			None
+		}
+	}
+	/// If contract is tombstone then return some reference to tombstone info
+	pub fn as_tombstone(&self) -> Option<&TombstoneContractInfo<T>> {
+		if let ContractInfo::Tombstone(ref tombstone) = self {
+			Some(tombstone)
+		} else {
+			None
+		}
+	}
+	/// If contract is tombstone then return some mutable reference to tombstone info
+	pub fn as_tombstone_mut(&mut self) -> Option<&mut TombstoneContractInfo<T>> {
+		if let ContractInfo::Tombstone(ref mut tombstone) = self {
+			Some(tombstone)
+		} else {
+			None
+		}
 	}
 }
 
-decl_storage! {
-	trait Store for Module<T: Config> as Contracts
-	where
-		T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>
-	{
-		/// Current cost schedule for contracts.
-		CurrentSchedule get(fn current_schedule) config(): Schedule<T> = Default::default();
-		/// A mapping from an original code hash to the original code, untouched by instrumentation.
-		pub PristineCode: map hasher(identity) CodeHash<T> => Option<Vec<u8>>;
-		/// A mapping between an original code hash and instrumented wasm code, ready for execution.
-		pub CodeStorage: map hasher(identity) CodeHash<T> => Option<PrefabWasmModule<T>>;
-		/// The subtrie counter.
-		pub AccountCounter: u64 = 0;
-		/// The code associated with a given account.
-		///
-		/// TWOX-NOTE: SAFE since `AccountId` is a secure hash.
-		pub ContractInfoOf: map hasher(twox_64_concat) T::AccountId => Option<ContractInfo<T>>;
-		/// Evicted contracts that await child trie deletion.
-		///
-		/// Child trie deletion is a heavy operation depending on the amount of storage items
-		/// stored in said trie. Therefore this operation is performed lazily in `on_initialize`.
-		pub DeletionQueue: Vec<storage::DeletedContract>;
+/// Information for managing an account and its sub trie abstraction.
+/// This is the required info to cache for an account.
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub struct RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
+	/// Unique ID for the subtree encoded as a bytes vector.
+	pub trie_id: TrieId,
+	/// The total number of bytes used by this contract.
+	///
+	/// It is a sum of each key-value pair stored by this contract.
+	pub storage_size: u32,
+	/// The total number of key-value pairs in storage of this contract.
+	pub pair_count: u32,
+	/// The code associated with a given account.
+	pub code_hash: CodeHash,
+	/// Pay rent at most up to this value.
+	pub rent_allowance: Balance,
+	/// The amount of rent that was payed by the contract over its whole lifetime.
+	///
+	/// A restored contract starts with a value of zero just like a new contract.
+	pub rent_payed: Balance,
+	/// Last block rent has been payed.
+	pub deduct_block: BlockNumber,
+	/// Last block child storage has been written.
+	pub last_write: Option<BlockNumber>,
+}
+
+impl<CodeHash, Balance, BlockNumber> RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
+	/// Associated child trie unique id is built from the hash part of the trie id.
+	pub fn child_trie_info(&self) -> ChildInfo {
+		child_trie_info(&self.trie_id[..])
+	}
+}
+
+/// Associated child trie unique id is built from the hash part of the trie id.
+pub(crate) fn child_trie_info(trie_id: &[u8]) -> ChildInfo {
+	ChildInfo::new_default(trie_id)
+}
+
+#[derive(Encode, Decode, PartialEq, Eq, RuntimeDebug)]
+pub struct RawTombstoneContractInfo<H, Hasher>(H, PhantomData<Hasher>);
+
+impl<H, Hasher> RawTombstoneContractInfo<H, Hasher>
+where
+	H: Member + MaybeSerializeDeserialize+ Debug
+		+ AsRef<[u8]> + AsMut<[u8]> + Copy + Default
+		+ sp_std::hash::Hash + Codec,
+	Hasher: Hash<Output=H>,
+{
+	fn new(storage_root: &[u8], code_hash: H) -> Self {
+		let mut buf = Vec::new();
+		storage_root.using_encoded(|encoded| buf.extend_from_slice(encoded));
+		buf.extend_from_slice(code_hash.as_ref());
+		RawTombstoneContractInfo(<Hasher as Hash>::hash(&buf[..]), PhantomData)
+	}
+}
+
+impl<T: Config> From<AliveContractInfo<T>> for ContractInfo<T> {
+	fn from(alive_info: AliveContractInfo<T>) -> Self {
+		Self::Alive(alive_info)
 	}
 }

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -98,16 +98,16 @@ pub mod weights;
 mod tests;
 
 pub use crate::{
-	gas::{Gas, GasMeter},
-	wasm::{ReturnCode as RuntimeReturnCode, PrefabWasmModule},
-	weights::WeightInfo,
+	wasm::PrefabWasmModule,
 	schedule::{Schedule, HostFnWeights, InstructionWeights, Limits},
 	pallet::*,
 };
 use crate::{
+	gas::GasMeter,
 	exec::{ExecutionContext, Executable},
 	rent::Rent,
 	storage::{Storage, DeletedContract},
+	weights::WeightInfo,
 };
 use sp_core::crypto::UncheckedFrom;
 use sp_std::{prelude::*, marker::PhantomData, fmt::Debug};
@@ -121,6 +121,7 @@ use sp_runtime::{
 use frame_support::{
 	storage::child::ChildInfo,
 	traits::{OnUnbalanced, Currency, Get, Time, Randomness},
+	weights::Weight,
 };
 use frame_system::Module as System;
 use pallet_contracts_primitives::{
@@ -302,7 +303,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			dest: <T::Lookup as StaticLookup>::Source,
 			#[pallet::compact] value: BalanceOf<T>,
-			#[pallet::compact] gas_limit: Gas,
+			#[pallet::compact] gas_limit: Weight,
 			data: Vec<u8>
 		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
@@ -348,7 +349,7 @@ pub mod pallet {
 		pub fn instantiate_with_code(
 			origin: OriginFor<T>,
 			#[pallet::compact] endowment: BalanceOf<T>,
-			#[pallet::compact] gas_limit: Gas,
+			#[pallet::compact] gas_limit: Weight,
 			code: Vec<u8>,
 			data: Vec<u8>,
 			salt: Vec<u8>,
@@ -382,7 +383,7 @@ pub mod pallet {
 		pub fn instantiate(
 			origin: OriginFor<T>,
 			#[pallet::compact] endowment: BalanceOf<T>,
-			#[pallet::compact] gas_limit: Gas,
+			#[pallet::compact] gas_limit: Weight,
 			code_hash: CodeHash<T>,
 			data: Vec<u8>,
 			salt: Vec<u8>,
@@ -675,7 +676,7 @@ where
 		origin: T::AccountId,
 		dest: T::AccountId,
 		value: BalanceOf<T>,
-		gas_limit: Gas,
+		gas_limit: Weight,
 		input_data: Vec<u8>,
 	) -> ContractExecResult {
 		let mut gas_meter = GasMeter::new(gas_limit);

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -458,6 +458,7 @@ pub mod pallet {
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	#[pallet::metadata(T::AccountId = "AccountId", T::Hash = "Hash", BalanceOf<T> = "Balance")]
 	pub enum Event<T: Config> {
 		/// Contract deployed by address at the specified address. \[deployer, contract\]
 		Instantiated(T::AccountId, T::AccountId),

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -121,13 +121,12 @@ use sp_runtime::{
 use frame_support::{
 	storage::child::ChildInfo,
 	traits::{OnUnbalanced, Currency, Get, Time, Randomness},
-	weights::Weight,
+	weights::{Weight, PostDispatchInfo, WithPostDispatchInfo},
 };
 use frame_system::Module as System;
 use pallet_contracts_primitives::{
 	RentProjectionResult, GetStorageResult, ContractAccessError, ContractExecResult,
 };
-use frame_support::weights::{PostDispatchInfo, WithPostDispatchInfo};
 
 pub type CodeHash<T> = <T as frame_system::Config>::Hash;
 pub type TrieId = Vec<u8>;

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -604,11 +604,6 @@ pub mod pallet {
 		DuplicateContract,
 	}
 
-	#[pallet::type_value]
-	pub fn Null() -> u64 {
-		0
-	}
-
 	/// Current cost schedule for contracts.
 	#[pallet::storage]
 	#[pallet::getter(fn current_schedule)]
@@ -624,7 +619,7 @@ pub mod pallet {
 
 	/// The subtrie counter.
 	#[pallet::storage]
-	pub type AccountCounter<T: Config> = StorageValue<_, u64, ValueQuery, Null>;
+	pub type AccountCounter<T: Config> = StorageValue<_, u64, ValueQuery>;
 
 	/// The code associated with a given account.
 	///

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -18,7 +18,7 @@
 //! A module responsible for computing the right amount of weight and charging it.
 
 use crate::{
-	AliveContractInfo, BalanceOf, ContractInfo, ContractInfoOf, Module, RawEvent,
+	AliveContractInfo, BalanceOf, ContractInfo, ContractInfoOf, Module, Event,
 	TombstoneContractInfo, Config, CodeHash, Error,
 	storage::Storage, wasm::PrefabWasmModule, exec::Executable,
 };
@@ -26,7 +26,7 @@ use sp_std::prelude::*;
 use sp_io::hashing::blake2_256;
 use sp_core::crypto::UncheckedFrom;
 use frame_support::{
-	debug, StorageMap,
+	debug,
 	storage::child,
 	traits::{Currency, ExistenceRequirement, Get, OnUnbalanced, WithdrawReasons},
 };
@@ -268,7 +268,7 @@ where
 				let tombstone_info = ContractInfo::Tombstone(tombstone);
 				<ContractInfoOf<T>>::insert(account, &tombstone_info);
 				code.drop_from_storage();
-				<Module<T>>::deposit_event(RawEvent::Evicted(account.clone()));
+				<Module<T>>::deposit_event(Event::Evicted(account.clone()));
 				Ok(None)
 			}
 			(Verdict::Evict { amount: _ }, None) => {

--- a/frame/contracts/src/storage.rs
+++ b/frame/contracts/src/storage.rs
@@ -31,9 +31,8 @@ use sp_runtime::traits::{Bounded, Saturating, Zero};
 use sp_core::crypto::UncheckedFrom;
 use frame_support::{
 	dispatch::DispatchResult,
-	StorageMap,
 	debug,
-	storage::{child::{self, KillOutcome}, StorageValue},
+	storage::child::{self, KillOutcome},
 	traits::Get,
 	weights::Weight,
 };
@@ -196,10 +195,10 @@ where
 	/// You must make sure that the contract is also removed or converted into a tombstone
 	/// when queuing the trie for deletion.
 	pub fn queue_trie_for_deletion(contract: &AliveContractInfo<T>) -> DispatchResult {
-		if DeletionQueue::decode_len().unwrap_or(0) >= T::DeletionQueueDepth::get() as usize {
+		if <DeletionQueue<T>>::decode_len().unwrap_or(0) >= T::DeletionQueueDepth::get() as usize {
 			Err(Error::<T>::DeletionQueueFull.into())
 		} else {
-			DeletionQueue::append(DeletedContract {
+			<DeletionQueue<T>>::append(DeletedContract {
 				pair_count: contract.pair_count,
 				trie_id: contract.trie_id.clone(),
 			});
@@ -234,7 +233,7 @@ where
 	/// It returns the amount of weight used for that task or `None` when no weight was used
 	/// apart from the base weight.
 	pub fn process_deletion_queue_batch(weight_limit: Weight) -> Weight {
-		let queue_len = DeletionQueue::decode_len().unwrap_or(0);
+		let queue_len = <DeletionQueue<T>>::decode_len().unwrap_or(0);
 		if queue_len == 0 {
 			return weight_limit;
 		}
@@ -251,7 +250,7 @@ where
 			return weight_limit;
 		}
 
-		let mut queue = DeletionQueue::get();
+		let mut queue = <DeletionQueue<T>>::get();
 
 		while !queue.is_empty() && remaining_key_budget > 0 {
 			// Cannot panic due to loop condition
@@ -283,7 +282,7 @@ where
 				.saturating_sub(remaining_key_budget.min(pair_count));
 		}
 
-		DeletionQueue::put(queue);
+		<DeletionQueue<T>>::put(queue);
 		weight_limit.saturating_sub(weight_per_key.saturating_mul(remaining_key_budget as Weight))
 	}
 
@@ -293,7 +292,7 @@ where
 		use sp_runtime::traits::Hash;
 		// Note that skipping a value due to error is not an issue here.
 		// We only need uniqueness, not sequence.
-		let new_seed = AccountCounter::mutate(|v| {
+		let new_seed = <AccountCounter<T>>::mutate(|v| {
 			*v = v.wrapping_add(1);
 			*v
 		});
@@ -322,6 +321,6 @@ where
 			trie_id: vec![],
 		})
 		.collect();
-		DeletionQueue::put(queue);
+		<DeletionQueue<T>>::put(queue);
 	}
 }

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	BalanceOf, ContractInfo, ContractInfoOf, Module,
-	RawAliveContractInfo, RawEvent, Config, Schedule, gas::Gas,
+	RawAliveContractInfo, Config, Schedule, gas::Gas,
 	Error, RuntimeReturnCode, storage::Storage,
 	chain_extension::{
 		Result as ExtensionResult, Environment, ChainExtension, Ext, SysConfig, RetVal,
@@ -36,8 +36,8 @@ use sp_runtime::{
 use sp_io::hashing::blake2_256;
 use frame_support::{
 	assert_ok, assert_err, assert_err_ignore_postinfo,
-	parameter_types, StorageMap, StorageValue, assert_storage_noop,
-	traits::{Currency, ReservableCurrency, OnInitialize},
+	parameter_types, assert_storage_noop,
+	traits::{Currency, ReservableCurrency, OnInitialize, GenesisBuild},
 	weights::{Weight, PostDispatchInfo, DispatchClass, constants::WEIGHT_PER_SECOND},
 	dispatch::DispatchErrorWithPostInfo,
 	storage::child,
@@ -73,7 +73,7 @@ pub mod test_utils {
 		exec::{StorageKey, AccountIdOf},
 		Module as Contracts,
 	};
-	use frame_support::{StorageMap, traits::Currency};
+	use frame_support::traits::Currency;
 
 	pub fn set_storage(addr: &AccountIdOf<Test>, key: &StorageKey, value: Option<Vec<u8>>) {
 		let contract_info = <ContractInfoOf::<Test>>::get(&addr).unwrap().get_alive().unwrap();
@@ -501,19 +501,19 @@ fn instantiate_and_call_and_deposit_event() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::pallet_contracts(RawEvent::CodeStored(code_hash.into())),
+					event: Event::pallet_contracts(crate::Event::CodeStored(code_hash.into())),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
 					event: Event::pallet_contracts(
-						RawEvent::ContractEmitted(addr.clone(), vec![1, 2, 3, 4])
+						crate::Event::ContractEmitted(addr.clone(), vec![1, 2, 3, 4])
 					),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::pallet_contracts(RawEvent::Instantiated(ALICE, addr.clone())),
+					event: Event::pallet_contracts(crate::Event::Instantiated(ALICE, addr.clone())),
 					topics: vec![],
 				},
 			]);
@@ -1230,12 +1230,16 @@ fn restoration(
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::pallet_contracts(RawEvent::CodeStored(set_rent_code_hash.into())),
+					event: Event::pallet_contracts(
+						crate::Event::CodeStored(set_rent_code_hash.into())
+					),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::pallet_contracts(RawEvent::Instantiated(ALICE, addr_bob.clone())),
+					event: Event::pallet_contracts(
+						crate::Event::Instantiated(ALICE, addr_bob.clone())
+					),
 					topics: vec![],
 				},
 			];
@@ -1275,7 +1279,9 @@ fn restoration(
 					},
 					EventRecord {
 						phase: Phase::Initialization,
-						event: Event::pallet_contracts(RawEvent::Instantiated(ALICE, addr_dummy.clone())),
+						event: Event::pallet_contracts(
+							crate::Event::Instantiated(ALICE, addr_dummy.clone())
+						),
 						topics: vec![],
 					},
 				].iter().cloned());
@@ -1401,7 +1407,7 @@ fn restoration(
 						assert_eq!(System::events(), vec![
 							EventRecord {
 								phase: Phase::Initialization,
-								event: Event::pallet_contracts(RawEvent::Evicted(addr_bob)),
+								event: Event::pallet_contracts(crate::Event::Evicted(addr_bob)),
 								topics: vec![],
 							},
 							EventRecord {
@@ -1433,12 +1439,16 @@ fn restoration(
 							},
 							EventRecord {
 								phase: Phase::Initialization,
-								event: Event::pallet_contracts(RawEvent::CodeStored(restoration_code_hash)),
+								event: Event::pallet_contracts(
+									crate::Event::CodeStored(restoration_code_hash)
+								),
 								topics: vec![],
 							},
 							EventRecord {
 								phase: Phase::Initialization,
-								event: Event::pallet_contracts(RawEvent::Instantiated(CHARLIE, addr_django.clone())),
+								event: Event::pallet_contracts(
+									crate::Event::Instantiated(CHARLIE, addr_django.clone())
+								),
 								topics: vec![],
 							},
 
@@ -1470,7 +1480,7 @@ fn restoration(
 				assert_eq!(System::events(), vec![
 					EventRecord {
 						phase: Phase::Initialization,
-						event: Event::pallet_contracts(RawEvent::CodeRemoved(restoration_code_hash)),
+						event: Event::pallet_contracts(crate::Event::CodeRemoved(restoration_code_hash)),
 						topics: vec![],
 					},
 					EventRecord {
@@ -1481,7 +1491,9 @@ fn restoration(
 					EventRecord {
 						phase: Phase::Initialization,
 						event: Event::pallet_contracts(
-							RawEvent::Restored(addr_django, addr_bob, bob_contract.code_hash, 50)
+							crate::Event::Restored(
+								addr_django, addr_bob, bob_contract.code_hash, 50
+							)
 						),
 						topics: vec![],
 					},
@@ -1720,13 +1732,13 @@ fn self_destruct_works() {
 				},
 				EventRecord {
 					phase: Phase::Initialization,
-					event: Event::pallet_contracts(RawEvent::CodeRemoved(code_hash)),
+					event: Event::pallet_contracts(crate::Event::CodeRemoved(code_hash)),
 					topics: vec![],
 				},
 				EventRecord {
 					phase: Phase::Initialization,
 					event: Event::pallet_contracts(
-						RawEvent::Terminated(addr.clone(), DJANGO)
+						crate::Event::Terminated(addr.clone(), DJANGO)
 					),
 					topics: vec![],
 				},

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -17,14 +17,15 @@
 
 use crate::{
 	BalanceOf, ContractInfo, ContractInfoOf, Module,
-	RawAliveContractInfo, Config, Schedule, gas::Gas,
-	Error, RuntimeReturnCode, storage::Storage,
+	RawAliveContractInfo, Config, Schedule,
+	Error, storage::Storage,
 	chain_extension::{
 		Result as ExtensionResult, Environment, ChainExtension, Ext, SysConfig, RetVal,
 		UncheckedFrom, InitState, ReturnFlags,
 	},
 	exec::{AccountIdOf, Executable}, wasm::PrefabWasmModule,
 	weights::WeightInfo,
+	wasm::ReturnCode as RuntimeReturnCode,
 };
 use assert_matches::assert_matches;
 use codec::Encode;
@@ -292,7 +293,7 @@ pub const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 pub const CHARLIE: AccountId32 = AccountId32::new([3u8; 32]);
 pub const DJANGO: AccountId32 = AccountId32::new([4u8; 32]);
 
-const GAS_LIMIT: Gas = 10_000_000_000;
+const GAS_LIMIT: Weight = 10_000_000_000;
 
 pub struct ExtBuilder {
 	existential_deposit: u64,

--- a/frame/contracts/src/wasm/code_cache.rs
+++ b/frame/contracts/src/wasm/code_cache.rs
@@ -29,12 +29,12 @@
 
 use crate::{
 	CodeHash, CodeStorage, PristineCode, Schedule, Config, Error,
-	wasm::{prepare, PrefabWasmModule}, Module as Contracts, RawEvent,
+	wasm::{prepare, PrefabWasmModule}, Module as Contracts, Event,
 	gas::{Gas, GasMeter, Token},
 	weights::WeightInfo,
 };
 use sp_core::crypto::UncheckedFrom;
-use frame_support::{StorageMap, dispatch::DispatchError};
+use frame_support::dispatch::DispatchError;
 #[cfg(feature = "runtime-benchmarks")]
 pub use self::private::reinstrument as reinstrument;
 
@@ -58,7 +58,7 @@ where
 			Some(module) => increment_64(&mut module.refcount),
 			None => {
 				*existing = Some(prefab_module);
-				Contracts::<T>::deposit_event(RawEvent::CodeStored(code_hash))
+				Contracts::<T>::deposit_event(Event::CodeStored(code_hash))
 			}
 		}
 	});
@@ -170,7 +170,7 @@ where
 	T::AccountId: UncheckedFrom<T::Hash> + AsRef<[u8]>
 {
 	<PristineCode<T>>::remove(code_hash);
-	Contracts::<T>::deposit_event(RawEvent::CodeRemoved(code_hash))
+	Contracts::<T>::deposit_event(Event::CodeRemoved(code_hash))
 }
 
 /// Increment the refcount panicking if it should ever overflow (which will not happen).

--- a/frame/contracts/src/wasm/code_cache.rs
+++ b/frame/contracts/src/wasm/code_cache.rs
@@ -28,9 +28,9 @@
 //! Thus, before executing a contract it should be reinstrument with new schedule.
 
 use crate::{
-	CodeHash, CodeStorage, PristineCode, Schedule, Config, Error,
+	CodeHash, CodeStorage, PristineCode, Schedule, Config, Error, Weight,
 	wasm::{prepare, PrefabWasmModule}, Module as Contracts, Event,
-	gas::{Gas, GasMeter, Token},
+	gas::{GasMeter, Token},
 	weights::WeightInfo,
 };
 use sp_core::crypto::UncheckedFrom;
@@ -196,7 +196,7 @@ struct InstrumentToken(u32);
 impl<T: Config> Token<T> for InstrumentToken {
 	type Metadata = ();
 
-	fn calculate_amount(&self, _metadata: &Self::Metadata) -> Gas {
+	fn calculate_amount(&self, _metadata: &Self::Metadata) -> Weight {
 		T::WeightInfo::instrument(self.0 / 1024)
 	}
 }

--- a/frame/contracts/src/wasm/env_def/macros.rs
+++ b/frame/contracts/src/wasm/env_def/macros.rs
@@ -20,13 +20,11 @@
 //!
 //! Most likely you should use `define_env` macro.
 
-#[macro_export]
 macro_rules! convert_args {
 	() => (vec![]);
 	( $( $t:ty ),* ) => ( vec![ $( { use $crate::wasm::env_def::ConvertibleToWasm; <$t>::VALUE_TYPE }, )* ] );
 }
 
-#[macro_export]
 macro_rules! gen_signature {
 	( ( $( $params: ty ),* ) ) => (
 		{
@@ -43,7 +41,6 @@ macro_rules! gen_signature {
 	);
 }
 
-#[macro_export]
 macro_rules! gen_signature_dispatch {
 	(
 		$needle_name:ident,
@@ -102,7 +99,6 @@ where
 	f
 }
 
-#[macro_export]
 macro_rules! unmarshall_then_body_then_marshall {
 	( $args_iter:ident, $ctx:ident, ( $( $names:ident : $params:ty ),* ) -> $returns:ty => $body:tt ) => ({
 		let body = $crate::wasm::env_def::macros::constrain_closure::<
@@ -128,7 +124,6 @@ macro_rules! unmarshall_then_body_then_marshall {
 	})
 }
 
-#[macro_export]
 macro_rules! define_func {
 	( < E: $seal_ty:tt > $name:ident ( $ctx: ident $(, $names:ident : $params:ty)*) $(-> $returns:ty)* => $body:tt ) => {
 		fn $name< E: $seal_ty >(
@@ -152,7 +147,6 @@ macro_rules! define_func {
 	};
 }
 
-#[macro_export]
 macro_rules! register_func {
 	( $reg_cb:ident, < E: $seal_ty:tt > ; ) => {};
 
@@ -215,9 +209,9 @@ mod tests {
 	use sp_runtime::traits::Zero;
 	use sp_sandbox::{ReturnValue, Value};
 	use crate::{
+		Weight,
 		wasm::{Runtime, runtime::TrapReason, tests::MockExt},
 		exec::Ext,
-		gas::Gas,
 	};
 
 	struct TestRuntime {
@@ -282,7 +276,7 @@ mod tests {
 	#[test]
 	fn macro_define_func() {
 		define_func!( <E: Ext> seal_gas (_ctx, amount: u32) => {
-			let amount = Gas::from(amount);
+			let amount = Weight::from(amount);
 			if !amount.is_zero() {
 				Ok(())
 			} else {
@@ -334,7 +328,7 @@ mod tests {
 
 		define_env!(Env, <E: Ext>,
 			seal_gas( _ctx, amount: u32 ) => {
-				let amount = Gas::from(amount);
+				let amount = Weight::from(amount);
 				if !amount.is_zero() {
 					Ok(())
 				} else {

--- a/frame/contracts/src/wasm/env_def/mod.rs
+++ b/frame/contracts/src/wasm/env_def/mod.rs
@@ -22,7 +22,7 @@ use sp_sandbox::Value;
 use parity_wasm::elements::{FunctionType, ValueType};
 
 #[macro_use]
-pub(crate) mod macros;
+pub mod macros;
 
 pub trait ConvertibleToWasm: Sized {
 	const VALUE_TYPE: ValueType;
@@ -67,13 +67,13 @@ impl ConvertibleToWasm for u64 {
 	}
 }
 
-pub(crate) type HostFunc<E> =
+pub type HostFunc<E> =
 	fn(
 		&mut Runtime<E>,
 		&[sp_sandbox::Value]
 	) -> Result<sp_sandbox::ReturnValue, sp_sandbox::HostError>;
 
-pub(crate) trait FunctionImplProvider<E: Ext> {
+pub trait FunctionImplProvider<E: Ext> {
 	fn impls<F: FnMut(&[u8], HostFunc<E>)>(f: &mut F);
 }
 

--- a/frame/contracts/src/wasm/mod.rs
+++ b/frame/contracts/src/wasm/mod.rs
@@ -38,6 +38,8 @@ use pallet_contracts_primitives::ExecResult;
 pub use self::runtime::{ReturnCode, Runtime, RuntimeToken};
 #[cfg(feature = "runtime-benchmarks")]
 pub use self::code_cache::reinstrument;
+#[cfg(test)]
+pub use tests::MockExt;
 
 /// A prepared wasm module ready for execution.
 ///
@@ -237,7 +239,7 @@ mod tests {
 	use crate::{
 		CodeHash, BalanceOf, Error, Module as Contracts,
 		exec::{Ext, StorageKey, AccountIdOf, Executable},
-		gas::{Gas, GasMeter},
+		gas::GasMeter,
 		tests::{Test, Call, ALICE, BOB},
 	};
 	use std::collections::HashMap;
@@ -248,7 +250,7 @@ mod tests {
 	use assert_matches::assert_matches;
 	use pallet_contracts_primitives::{ExecReturnValue, ReturnFlags, ExecError, ErrorOrigin};
 
-	const GAS_LIMIT: Gas = 10_000_000_000;
+	const GAS_LIMIT: Weight = 10_000_000_000;
 
 	#[derive(Debug, PartialEq, Eq)]
 	struct DispatchEntry(Call);
@@ -1202,7 +1204,7 @@ mod tests {
 			&mut gas_meter,
 		).unwrap();
 
-		let gas_left = Gas::decode(&mut output.data.as_slice()).unwrap();
+		let gas_left = Weight::decode(&mut output.data.as_slice()).unwrap();
 		assert!(gas_left < GAS_LIMIT, "gas_left must be less than initial");
 		assert!(gas_left > gas_meter.gas_left(), "gas_left must be greater than final");
 	}

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -20,11 +20,11 @@
 use crate::{
 	HostFnWeights, Config, CodeHash, BalanceOf, Error,
 	exec::{Ext, StorageKey, TopicOf},
-	gas::{Gas, GasMeter, Token, ChargedAmount},
+	gas::{GasMeter, Token, ChargedAmount},
 	wasm::env_def::ConvertibleToWasm,
 };
 use parity_wasm::elements::ValueType;
-use frame_support::{dispatch::DispatchError, ensure, traits::Get};
+use frame_support::{dispatch::DispatchError, ensure, traits::Get, weights::Weight};
 use sp_std::prelude::*;
 use codec::{Decode, DecodeAll, Encode};
 use sp_runtime::traits::SaturatedConversion;
@@ -223,7 +223,7 @@ where
 {
 	type Metadata = HostFnWeights<T>;
 
-	fn calculate_amount(&self, s: &Self::Metadata) -> Gas {
+	fn calculate_amount(&self, s: &Self::Metadata) -> Weight {
 		use self::RuntimeToken::*;
 		match *self {
 			MeteringBlock(amount) => s.gas.saturating_add(amount.into()),


### PR DESCRIPTION
## Convert to the new frame macros.

Metadata diff:

```diff
diff --git a/old.json b/new.json
index 2201706..0467169 100644
--- a/old.json
+++ b/new.json
@@ -744,7 +744,7 @@
         "name": "DeletionQueue",
         "modifier": "Default",
         "ty": {
-          "Plain": "Vec<storage::DeletedContract>"
+          "Plain": "Vec<DeletedContract>"
         },
         "default": [
           0
@@ -786,7 +786,7 @@
         },
         {
           "name": "gas_limit",
-          "ty": "Compact<Gas>"
+          "ty": "Compact<Weight>"
         },
         {
           "name": "data",
@@ -812,7 +812,7 @@
         },
         {
           "name": "gas_limit",
-          "ty": "Compact<Gas>"
+          "ty": "Compact<Weight>"
         },
         {
           "name": "code",
@@ -860,7 +860,7 @@
         },
         {
           "name": "gas_limit",
-          "ty": "Compact<Gas>"
+          "ty": "Compact<Weight>"
         },
         {
           "name": "code_hash",
@@ -1206,8 +1206,7 @@
         0
       ],
       "documentation": [
-        " The maximum nesting level of a call/instantiate stack. A reasonable default",
-        " value is 100."
+        " The maximum nesting level of a call/instantiate stack."
       ]
     },
     {
@@ -1220,7 +1219,7 @@
         0
       ],
       "documentation": [
-        " The maximum size of a storage value in bytes. A reasonable default is 16 KiB."
+        " The maximum size of a storage value and event payload in bytes."
       ]
     },
     {
@@ -1252,6 +1251,21 @@
       "documentation": [
         " The maximum amount of weight that can be consumed per block for lazy trie removal."
       ]
+    },
+    {
+      "name": "MaxCodeSize",
+      "ty": "u32",
+      "value": [
+        0,
+        0,
+        2,
+        0
+      ],
+      "documentation": [
+        " The maximum length of a contract code in bytes. This limit applies to the instrumented",
+        " version of the code. Therefore `instantiate_with_code` can fail even when supplying",
+        " a wasm binary below this maximum size."
+      ]
     }
   ],
   "errors": [
@@ -1423,7 +1437,7 @@
       "documentation": [
         " Removal of a contract failed because the deletion queue is full.",
         "",
-        " This can happen when either calling [`Module::claim_surcharge`] or `seal_terminate`.",
+        " This can happen when either calling [`Pallet::claim_surcharge`] or `seal_terminate`.",
         " The queue is filled by deleting contracts and emptied by a fixed amount each block.",
         " Trying again during another block is the only way to resolve this issue."
       ]
@@ -1433,7 +1447,7 @@
       "documentation": [
         " A contract could not be evicted because it has enough balance to pay rent.",
         "",
-        " This can be returned from [`Module::claim_surcharge`] because the target",
+        " This can be returned from [`Pallet::claim_surcharge`] because the target",
         " contract has enough balance to pay for its rent."
       ]
     },
```

## Reduce API surface

Remove some types from the public API that does not need to be exposed. This gives us more leeway to make changes without bumping the major version once v3 is out.

This also seals the `Ext` trait which is not meant to be implemented by downstream crates. Implementations of it are merely passed to the chain extension for consumption.