### PR TITLE
Reserve ss58 prefix 48 for Neatcoin

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -582,7 +582,15 @@ ss58_address_format!(
 		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
 	CrustAccount =>
 		(66, "crust", "Crust Network, standard account (*25519).")
-	// Note: 48 and above are reserved.
+	NeatcoinReserved1 =>
+		(8862, "neatcoinreserved1", "Neatcoin, reserved #1 (*25519).")
+	NeatcoinReserved2 =>
+		(9886, "neatcoinreserved2", "Neatcoin, reserved #2 (*25519).")
+	NeatcoinAccount =>
+		(12698, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
+	NeatcoinReserved3 =>
+		(13722, "neatcoinreserved3", "Neatcoin, reserved #3 (*25519).")
+	// Note: 16384 and above are reserved.
 );
 
 /// Set the default "version" (actually, this is a bit of a misnomer and the version byte is

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -579,7 +579,7 @@ ss58_address_format!(
 	Reserved47 =>
 		(47, "reserved47", "Reserved for future use (47).")
 	NeatcoinAccount =>
-		(63, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
+		(48, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
 	AventusAccount =>
 		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
 	CrustAccount =>

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -578,18 +578,12 @@ ss58_address_format!(
 		(46, "reserved46", "Reserved for future use (46).")
 	Reserved47 =>
 		(47, "reserved47", "Reserved for future use (47).")
+	NeatcoinAccount =>
+		(63, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
 	AventusAccount =>
 		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
 	CrustAccount =>
 		(66, "crust", "Crust Network, standard account (*25519).")
-	NeatcoinReserved1 =>
-		(8862, "neatcoinreserved1", "Neatcoin, reserved #1 (*25519).")
-	NeatcoinReserved2 =>
-		(9886, "neatcoinreserved2", "Neatcoin, reserved #2 (*25519).")
-	NeatcoinAccount =>
-		(12698, "neatcoin", "Neatcoin mainnet, standard account (*25519).")
-	NeatcoinReserved3 =>
-		(13722, "neatcoinreserved3", "Neatcoin, reserved #3 (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -459,6 +459,42 @@
 			"decimals": [12],
 			"standardAccount": "*25519",
 			"website": "https://crust.network"
+		},
+		{
+			"prefix": 8862,
+			"network": "neatcoin",
+			"displayName": "Neatcoin Reserved#1",
+			"symbols": ["NEAT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://neatcoin.org"
+		},
+		{
+			"prefix": 9886,
+			"network": "neatcoin",
+			"displayName": "Neatcoin Reserved#2",
+			"symbols": ["NEAT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://neatcoin.org"
+		},
+		{
+			"prefix": 12698,
+			"network": "neatcoin",
+			"displayName": "Neatcoin Mainnet",
+			"symbols": ["NEAT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://neatcoin.org"
+		},
+		{
+			"prefix": 13722,
+			"network": "neatcoin",
+			"displayName": "Neatcoin Reserved#3",
+			"symbols": ["NEAT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://neatcoin.org"
 		}
 	]
 }

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -443,6 +443,15 @@
 			"website": null
 		},
 		{
+			"prefix": 63,
+			"network": "neatcoin",
+			"displayName": "Neatcoin Mainnet",
+			"symbols": ["NEAT"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://neatcoin.org"
+		},
+		{
 			"prefix": 65,
 			"network": "aventus",
 			"displayName": "AvN Mainnet",
@@ -459,42 +468,6 @@
 			"decimals": [12],
 			"standardAccount": "*25519",
 			"website": "https://crust.network"
-		},
-		{
-			"prefix": 8862,
-			"network": "neatcoin",
-			"displayName": "Neatcoin Reserved#1",
-			"symbols": ["NEAT"],
-			"decimals": [12],
-			"standardAccount": "*25519",
-			"website": "https://neatcoin.org"
-		},
-		{
-			"prefix": 9886,
-			"network": "neatcoin",
-			"displayName": "Neatcoin Reserved#2",
-			"symbols": ["NEAT"],
-			"decimals": [12],
-			"standardAccount": "*25519",
-			"website": "https://neatcoin.org"
-		},
-		{
-			"prefix": 12698,
-			"network": "neatcoin",
-			"displayName": "Neatcoin Mainnet",
-			"symbols": ["NEAT"],
-			"decimals": [12],
-			"standardAccount": "*25519",
-			"website": "https://neatcoin.org"
-		},
-		{
-			"prefix": 13722,
-			"network": "neatcoin",
-			"displayName": "Neatcoin Reserved#3",
-			"symbols": ["NEAT"],
-			"decimals": [12],
-			"standardAccount": "*25519",
-			"website": "https://neatcoin.org"
 		}
 	]
 }

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -443,7 +443,7 @@
 			"website": null
 		},
 		{
-			"prefix": 63,
+			"prefix": 48,
 			"network": "neatcoin",
 			"displayName": "Neatcoin Mainnet",
 			"symbols": ["NEAT"],


### PR DESCRIPTION
This reserves ss58 prefix 48 for Neatcoin (a network where I plan on experimenting something related to the Move smart contract platform).