### PR TITLE
pallet-staking: add RewardDestination::None for explictly not receiving rewards

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -439,6 +439,8 @@ pub enum RewardDestination<AccountId> {
 	Controller,
 	/// Pay into a specified account.
 	Account(AccountId),
+	/// Receive no reward.
+	None,
 }
 
 impl<AccountId> Default for RewardDestination<AccountId> {
@@ -2469,7 +2471,8 @@ impl<T: Config> Module<T> {
 				}),
 			RewardDestination::Account(dest_account) => {
 				Some(T::Currency::deposit_creating(&dest_account, amount))
-			}
+			},
+			RewardDestination::None => None,
 		}
 	}
 


### PR DESCRIPTION
It can happen in some contexts that a validator/nominator might want to carry out the functionality of validating/nominating, but does not want to receive any rewards (either permanently or temporarily). This PR adds a simple `None` reward destination for this use case.