### PR TITLE
authority-discovery: store past session keys

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -244,6 +244,7 @@ pub fn testnet_genesis(
 
 	const ENDOWMENT: Balance = 10_000_000 * DOLLARS;
 	const STASH: Balance = ENDOWMENT / 1000;
+	const PAST_SESSIONS_TO_TRACK: u32 = 4;
 
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
@@ -311,6 +312,7 @@ pub fn testnet_genesis(
 		}),
 		pallet_authority_discovery: Some(AuthorityDiscoveryConfig {
 			keys: vec![],
+			past_sessions_to_track: PAST_SESSIONS_TO_TRACK,
 		}),
 		pallet_grandpa: Some(GrandpaConfig {
 			authorities: vec![],

--- a/client/authority-discovery/src/worker.rs
+++ b/client/authority-discovery/src/worker.rs
@@ -87,7 +87,7 @@ pub enum Role {
 ///
 /// When constructed with either [`Role::PublishAndDiscover`] or [`Role::Publish`] a [`Worker`] will
 ///
-///    1. Retrieve the current and next set of authorities.
+///    1. Retrieve last few, current and next set of authorities.
 ///
 ///    2. Start DHT queries for the ids of the authorities.
 ///
@@ -527,12 +527,12 @@ where
 		Ok(())
 	}
 
-	/// Retrieve our public keys within the current and next authority set.
+	/// Retrieve our public keys within the last few, current and next authority set.
 	//
 	// A node might have multiple authority discovery keys within its keystore, e.g. an old one and
 	// one for the upcoming session. In addition it could be participating in the current and (/ or)
 	// next authority set with two keys. The function does not return all of the local authority
-	// discovery public keys, but only the ones intersecting with the current or next authority set.
+	// discovery public keys, but only the ones intersecting with the last few, current and next authority set.
 	async fn get_own_public_keys_within_authority_set(
 		key_store: Arc<dyn CryptoStore>,
 		client: &Client,


### PR DESCRIPTION
Modifying authority-discovery pallet to keep track of configurable N number of past session's `authority_ids`.

Fixes #6910


