### PR TITLE
Fix: stash account reaped when ledger.active == ED

### DIFF
--- a/frame/staking/reward-curve/src/lib.rs
+++ b/frame/staking/reward-curve/src/lib.rs
@@ -420,14 +420,14 @@ fn generate_test_module(input: &INposInput) -> TokenStream2 {
 							/ float_res as u64
 						) as u32;
 						if err > #precision {
-							panic!(format!("\n\
+							panic!("\n\
 								Generated reward curve approximation differ from real one:\n\t\
 								for i = {} and base = {}, f(i/base) * base = {},\n\t\
 								but approximation = {},\n\t\
 								err = {:07} millionth,\n\t\
 								try increase the number of segment: {} or the test_error: {}.\n",
 								i, base, float_res, int_res, err, #max_piece_count, #precision
-							));
+							);
 						}
 					}
 				}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1638,7 +1638,7 @@ decl_module! {
 				ledger = ledger.consolidate_unlocked(current_era)
 			}
 
-			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active <= T::Currency::minimum_balance() {
+			let post_info_weight = if ledger.unlocking.is_empty() && ledger.active < T::Currency::minimum_balance() {
 				// This account must have called `unbond()` with some value that caused the active
 				// portion to fall below existential deposit + will have no more unlocking chunks
 				// left. We can now safely remove all staking-related information.
@@ -3080,7 +3080,7 @@ impl<T: Config> Module<T> {
 	/// Assumes storage is upgraded before calling.
 	///
 	/// This is called:
-	/// - after a `withdraw_unbond()` call that frees all of a stash's bonded balance.
+	/// - after a `withdraw_unbonded()` call that frees all of a stash's bonded balance.
 	/// - through `reap_stash()` if the balance has fallen to zero (through slashing).
 	fn kill_stash(stash: &T::AccountId, num_slashing_spans: u32) -> DispatchResult {
 		let controller = <Bonded<T>>::get(stash).ok_or(Error::<T>::NotStash)?;

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -4978,3 +4978,40 @@ fn cannot_bond_extra_to_lower_than_ed() {
 			);
 		})
 }
+
+#[test]
+fn do_not_die_when_active_is_ed() {
+	let ed = 10;
+	ExtBuilder::default()
+		.existential_deposit(ed)
+		.build_and_execute(|| {
+			// initial stuff.
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: 1000,
+					active: 1000,
+					unlocking: vec![],
+					claimed_rewards: vec![]
+				}
+			);
+
+			// unbond all of it except ed.
+			assert_ok!(Staking::unbond(Origin::signed(20), 1000 - ed));
+			start_active_era(3);
+			assert_ok!(Staking::withdraw_unbonded(Origin::signed(20), 100));
+
+			// initial stuff.
+			assert_eq!(
+				Staking::ledger(&20).unwrap(),
+				StakingLedger {
+					stash: 21,
+					total: ed,
+					active: ed,
+					unlocking: vec![],
+					claimed_rewards: vec![]
+				}
+			);
+		})
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! assert_eq_uvec {
 macro_rules! __assert_eq_uvec {
 	( $x:expr, $y:expr ) => {
 		$x.iter().for_each(|e| {
-			if !$y.contains(e) { panic!(format!("vectors not equal: {:?} != {:?}", $x, $y)); }
+			if !$y.contains(e) { panic!("vectors not equal: {:?} != {:?}", $x, $y); }
 		});
 	}
 }


### PR DESCRIPTION
Currently when a stash ledger has active == ED.
And call `withdraw_unbonded` then the stash got reaped and the ed is lost.

looking at `unbond` which unbond all active balance if goes below ED. I think this is a misstake.