### PR TITLE
Bump thread_local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9414,9 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]


### PR DESCRIPTION
Fixes memory leaks when TLS objects are dropped