### PR TITLE
contracts: Release as v3.0.0 and add reserved field to `ContractInfoOf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-primitives"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "0.1.0"
+version = "3.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc"
-version = "0.8.1"
+version = "3.0.0"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.1"
+version = "3.0.0"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -79,7 +79,7 @@ sc-finality-grandpa-warp-sync = { version = "0.9.0", path = "../../../client/fin
 # frame dependencies
 pallet-indices = { version = "3.0.0", path = "../../../frame/indices" }
 pallet-timestamp = { version = "3.0.0", default-features = false, path = "../../../frame/timestamp" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0", path = "../../../frame/contracts" }
 frame-system = { version = "3.0.0", path = "../../../frame/system" }
 pallet-balances = { version = "3.0.0", path = "../../../frame/balances" }
 pallet-transaction-payment = { version = "3.0.0", path = "../../../frame/transaction-payment" }

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -30,7 +30,7 @@ frame-support = { version = "3.0.0", path = "../../../frame/support" }
 frame-system = { version = "3.0.0", path = "../../../frame/system" }
 node-testing = { version = "2.0.0", path = "../testing" }
 pallet-balances = { version = "3.0.0", path = "../../../frame/balances" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "3.0.0", path = "../../../frame/grandpa" }
 pallet-im-online = { version = "3.0.0", path = "../../../frame/im-online" }
 pallet-indices = { version = "3.0.0", path = "../../../frame/indices" }

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 jsonrpc-core = "15.1.0"
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-runtime = { version = "2.0.0", path = "../runtime" }
-pallet-contracts-rpc = { version = "0.8.0", path = "../../../frame/contracts/rpc/" }
+pallet-contracts-rpc = { version = "3.0.0", path = "../../../frame/contracts/rpc/" }
 pallet-transaction-payment-rpc = { version = "3.0.0", path = "../../../frame/transaction-payment/rpc/" }
 sc-client-api = { version = "3.0.0", path = "../../../client/api" }
 sc-consensus-babe = { version = "0.9.0", path = "../../../client/consensus/babe" }

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -51,9 +51,9 @@ pallet-babe = { version = "3.0.0", default-features = false, path = "../../../fr
 pallet-balances = { version = "3.0.0", default-features = false, path = "../../../frame/balances" }
 pallet-bounties = { version = "3.0.0", default-features = false, path = "../../../frame/bounties" }
 pallet-collective = { version = "3.0.0", default-features = false, path = "../../../frame/collective" }
-pallet-contracts = { version = "2.0.0", default-features = false, path = "../../../frame/contracts" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "../../../frame/contracts/common/" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
+pallet-contracts = { version = "3.0.0", default-features = false, path = "../../../frame/contracts" }
+pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "../../../frame/contracts/common/" }
+pallet-contracts-rpc-runtime-api = { version = "3.0.0", default-features = false, path = "../../../frame/contracts/rpc/runtime-api/" }
 pallet-democracy = { version = "3.0.0", default-features = false, path = "../../../frame/democracy" }
 pallet-elections-phragmen = { version = "3.0.0", default-features = false, path = "../../../frame/elections-phragmen" }
 pallet-grandpa = { version = "3.0.0", default-features = false, path = "../../../frame/grandpa" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -18,7 +18,7 @@ sc-service = { version = "0.9.0", features = ["test-helpers", "db"],  path = "..
 sc-client-db = { version = "0.9.0", path = "../../../client/db/", features = ["kvdb-rocksdb", "parity-db"] }
 sc-client-api = { version = "3.0.0", path = "../../../client/api/" }
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-pallet-contracts = { version = "2.0.0", path = "../../../frame/contracts" }
+pallet-contracts = { version = "3.0.0", path = "../../../frame/contracts" }
 pallet-grandpa = { version = "3.0.0", path = "../../../frame/grandpa" }
 pallet-indices = { version = "3.0.0", path = "../../../frame/indices" }
 sp-keyring = { version = "3.0.0", path = "../../../primitives/keyring" }

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-benchmarking"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/frame/contracts/CHANGELOG.md
+++ b/frame/contracts/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The semantic versioning garantuees do cover the interface to the substrate runtime which
+includes this pallet as a dependency. This module will also add storage migrations whenever
+changes require this. Stability with regard to offchain tooling is explicitly excluded from
+this garantuee: For example adding a new field to an in-storage data structure will require
+changes to frontends to properly display it. However, those changes will still be regarded
+as a minor version bump.
+
+The interface provided to smart contracts will adhere to semver to with one exception: Even
+major version bumps will be backwards compatible with regard to already deployed contracts.
+In other words: Upgrading this pallet will not break pre-existing contracts.
+
+## [v3.0.0]
+
+This version constitutes the first release that brings any stability garantuess (see above).
+
+### Added
+
+- Emit an event when a contract terminates (self-destructs).
+[1](https://github.com/paritytech/substrate/pull/8014)
+
+- Charge rent for code stored on the chain in addition to the already existing
+rent that is payed for data storage.
+[1](https://github.com/paritytech/substrate/pull/7935)
+
+- Allow the runtime to configure per storage item costs in addition
+to the already existing per byte costs.
+[1](https://github.com/paritytech/substrate/pull/7819)
+
+- Contracts are now deleted lazily so that the user who removes a contract
+does not need to pay for the deletion of the contract storage.
+[1](https://github.com/paritytech/substrate/pull/7740)
+
+- Allow runtime authors to define chain extensions in order to provide custom
+functionality to contracts.
+[1](https://github.com/paritytech/substrate/pull/7548)
+[2](https://github.com/paritytech/substrate/pull/8003)
+
+- Proper weights which are fully automated by benchmarking.
+[1](https://github.com/paritytech/substrate/pull/6715)
+[2](https://github.com/paritytech/substrate/pull/7017)
+[3](https://github.com/paritytech/substrate/pull/7361)
+
+### Changes
+
+- Collect the rent for one block during instantiation.
+[1](https://github.com/paritytech/substrate/pull/7847)
+
+- Instantiation takes a `salt` argument to allow for easier instantion of the
+same code by the same sender.
+[1](https://github.com/paritytech/substrate/pull/7482)
+
+- Improve the information returned by the `contracts_call` RPC.
+[1](https://github.com/paritytech/substrate/pull/7468)
+
+- Simplify the node configuration necessary to add this module.
+[1](https://github.com/paritytech/substrate/pull/7409)
+
+### Fixed
+
+- Consider the code size of a contract in the weight that is charged for
+loading a contract from storage.
+[1](https://github.com/paritytech/substrate/pull/8086)
+
+- Fix possible overflow in storage size calculation
+[1](https://github.com/paritytech/substrate/pull/7885)
+
+- Cap the surcharge reward that can be claimed.
+[1](https://github.com/paritytech/substrate/pull/7870)
+
+- Fix a possible DoS vector where contracts could allocate too large buffers.
+[1](https://github.com/paritytech/substrate/pull/7818)

--- a/frame/contracts/CHANGELOG.md
+++ b/frame/contracts/CHANGELOG.md
@@ -5,20 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The semantic versioning garantuees do cover the interface to the substrate runtime which
+The semantic versioning guarantees do cover the interface to the substrate runtime which
 includes this pallet as a dependency. This module will also add storage migrations whenever
 changes require this. Stability with regard to offchain tooling is explicitly excluded from
-this garantuee: For example adding a new field to an in-storage data structure will require
+this guarantee: For example adding a new field to an in-storage data structure will require
 changes to frontends to properly display it. However, those changes will still be regarded
 as a minor version bump.
 
-The interface provided to smart contracts will adhere to semver to with one exception: Even
+The interface provided to smart contracts will adhere to semver with one exception: Even
 major version bumps will be backwards compatible with regard to already deployed contracts.
 In other words: Upgrading this pallet will not break pre-existing contracts.
 
 ## [v3.0.0]
 
-This version constitutes the first release that brings any stability garantuess (see above).
+This version constitutes the first release that brings any stability guarantees (see above).
 
 ### Added
 

--- a/frame/contracts/CHANGELOG.md
+++ b/frame/contracts/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The semantic versioning guarantees do cover the interface to the substrate runtime which
+The semantic versioning guarantees cover the interface to the substrate runtime which
 includes this pallet as a dependency. This module will also add storage migrations whenever
-changes require this. Stability with regard to offchain tooling is explicitly excluded from
+changes require it. Stability with regard to offchain tooling is explicitly excluded from
 this guarantee: For example adding a new field to an in-storage data structure will require
 changes to frontends to properly display it. However, those changes will still be regarded
 as a minor version bump.

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,9 +8,6 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "FRAME pallet for WASM contracts"
 readme = "README.md"
-
-# Prevent publish until we are ready to release 3.0.0
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -20,8 +17,8 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 frame-benchmarking = { version = "3.0.0", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "3.0.0", default-features = false, path = "../support" }
 frame-system = { version = "3.0.0", default-features = false, path = "../system" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "common" }
-pallet-contracts-proc-macro = { version = "0.1.0", path = "proc-macro" }
+pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "common" }
+pallet-contracts-proc-macro = { version = "3.0.0", path = "proc-macro" }
 parity-wasm = { version = "0.41.0", default-features = false }
 pwasm-utils = { version = "0.16", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-frame-benchmarking = { version = "3.0.0", default-features = false, path = "../benchmarking", optional = true }
+frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "3.0.0", default-features = false, path = "../support" }
 frame-system = { version = "3.0.0", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "common" }

--- a/frame/contracts/README.md
+++ b/frame/contracts/README.md
@@ -2,8 +2,10 @@
 
 The Contract module provides functionality for the runtime to deploy and execute WebAssembly smart-contracts.
 
-- [`contract::Trait`](https://docs.rs/pallet-contracts/latest/pallet_contracts/trait.Trait.html)
 - [`Call`](https://docs.rs/pallet-contracts/latest/pallet_contracts/enum.Call.html)
+- [`Config`](https://docs.rs/pallet-contracts/latest/pallet_contracts/trait.Config.html)
+- [`Error`](https://docs.rs/pallet-contracts/latest/pallet_contracts/enum.Error.html)
+- [`Event`](https://docs.rs/pallet-contracts/latest/pallet_contracts/enum.Event.html)
 
 ## Overview
 
@@ -32,6 +34,9 @@ reverted at the current call's contract level. For example, if contract A calls 
 then all of B's calls are reverted. Assuming correct error handling by contract A, A's other calls and state
 changes still persist.
 
+One gas is equivalent to one [weight](https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight)
+which is defined as one picosecond of execution time on the runtime's reference machine.
+
 ### Notable Scenarios
 
 Contract call failures are not always cascading. When failures occur in a sub-call, they do not "bubble up",
@@ -42,19 +47,14 @@ fails, A can decide how to handle that failure, either proceeding or reverting A
 
 ### Dispatchable functions
 
-Those are documented in the reference documentation of the `Module`.
+Those are documented in the [reference documentation](https://docs.rs/pallet-contracts/latest/pallet_contracts/#dispatchable-functions).
 
 ## Usage
 
-The Contract module is a work in progress. The following examples show how this Contract module
-can be used to instantiate and call contracts.
-
-- [`ink`](https://github.com/paritytech/ink) is
-an [`eDSL`](https://wiki.haskell.org/Embedded_domain_specific_language) that enables writing
-WebAssembly based smart contracts in the Rust programming language. This is a work in progress.
-
-## Related Modules
-
-- [Balances](https://docs.rs/pallet-balances/latest/pallet_balances/)
+This module executes WebAssembly smart contracts. These can potentially be written in any language
+that compiles to web assembly. However, using a language that specifically targets this module
+will make things a lot easier. One such language is [`ink`](https://github.com/paritytech/ink)
+which is an [`eDSL`](https://wiki.haskell.org/Embedded_domain_specific_language) that enables
+writing WebAssembly based smart contracts in the Rust programming language.
 
 License: Apache-2.0

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-primitives"
-version = "2.0.1"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,6 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "A crate that hosts a common definitions that are relevant for the pallet-contracts."
 readme = "README.md"
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/proc-macro/Cargo.toml
+++ b/frame/contracts/proc-macro/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "pallet-contracts-proc-macro"
-version = "0.1.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
 homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Procedural macros used in pallet_contracts"
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc"
-version = "0.8.1"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,6 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Node-specific RPC methods for interaction with contracts."
 readme = "README.md"
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -24,8 +23,8 @@ sp-rpc = { version = "3.0.0", path = "../../../primitives/rpc" }
 serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }
 sp-api = { version = "3.0.0", path = "../../../primitives/api" }
-pallet-contracts-primitives = { version = "2.0.0", path = "../common" }
-pallet-contracts-rpc-runtime-api = { version = "0.8.0", path = "./runtime-api" }
+pallet-contracts-primitives = { version = "3.0.0", path = "../common" }
+pallet-contracts-rpc-runtime-api = { version = "3.0.0", path = "./runtime-api" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.1"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,6 @@ homepage = "https://substrate.dev"
 repository = "https://github.com/paritytech/substrate/"
 description = "Runtime API definition required by Contracts RPC extensions."
 readme = "README.md"
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,7 +17,7 @@ sp-api = { version = "3.0.0", default-features = false, path = "../../../../prim
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-std = { version = "3.0.0", default-features = false, path = "../../../../primitives/std" }
 sp-runtime = { version = "3.0.0", default-features = false, path = "../../../../primitives/runtime" }
-pallet-contracts-primitives = { version = "2.0.0", default-features = false, path = "../../common" }
+pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "../../common" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/src/lib.rs
+++ b/frame/contracts/src/lib.rs
@@ -837,6 +837,8 @@ pub struct RawAliveContractInfo<CodeHash, Balance, BlockNumber> {
 	pub deduct_block: BlockNumber,
 	/// Last block child storage has been written.
 	pub last_write: Option<BlockNumber>,
+	/// This field is reserved for future evolution of format.
+	pub _reserved: Option<()>,
 }
 
 impl<CodeHash, Balance, BlockNumber> RawAliveContractInfo<CodeHash, Balance, BlockNumber> {

--- a/frame/contracts/src/rent.rs
+++ b/frame/contracts/src/rent.rs
@@ -514,14 +514,12 @@ where
 		<ContractInfoOf<T>>::remove(&origin);
 		let tombstone_code_len = E::remove_user(origin_contract.code_hash);
 		<ContractInfoOf<T>>::insert(&dest, ContractInfo::Alive(AliveContractInfo::<T> {
-			trie_id: origin_contract.trie_id,
-			storage_size: origin_contract.storage_size,
-			pair_count: origin_contract.pair_count,
 			code_hash,
 			rent_allowance,
 			rent_payed: <BalanceOf<T>>::zero(),
 			deduct_block: current_block,
 			last_write,
+			.. origin_contract
 		}));
 
 		let origin_free_balance = T::Currency::free_balance(&origin);

--- a/frame/contracts/src/storage.rs
+++ b/frame/contracts/src/storage.rs
@@ -182,6 +182,7 @@ where
 				rent_payed: <BalanceOf<T>>::zero(),
 				pair_count: 0,
 				last_write: None,
+				_reserved: None,
 			};
 
 			*existing = Some(contract.into());

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -392,6 +392,7 @@ fn account_removal_does_not_remove_storage() {
 				rent_allowance: 40,
 				rent_payed: 0,
 				last_write: None,
+				_reserved: None,
 			});
 			let _ = Balances::deposit_creating(&ALICE, 110);
 			ContractInfoOf::<Test>::insert(ALICE, &alice_contract_info);
@@ -407,6 +408,7 @@ fn account_removal_does_not_remove_storage() {
 				rent_allowance: 40,
 				rent_payed: 0,
 				last_write: None,
+				_reserved: None,
 			});
 			let _ = Balances::deposit_creating(&BOB, 110);
 			ContractInfoOf::<Test>::insert(BOB, &bob_contract_info);


### PR DESCRIPTION
Preparing pallet_contracts for release. It seems that [this PR](https://github.com/paritytech/substrate/pull/8104) requires the release of a `frame-benchmarks v3.1.0` before releasing contracts.

- Update README.md
- Add a CHANGELOG.md
- Bump version numbers and allow publishing.
- Add a `_reserved` field to `ContractInfoOf` for future proofing.