### PR TITLE
Make `on_slot` return the block with the post header

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -334,7 +334,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 
 		proposal_work.and_then(move |(proposal, claim)| async move {
 			let (block, storage_proof) = (proposal.block, proposal.proof);
-			let (header, body) = block.clone().deconstruct();
+			let (header, body) = block.deconstruct();
 			let header_num = *header.number();
 			let header_hash = header.hash();
 			let parent_hash = *header.parent_hash();
@@ -342,7 +342,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 			let block_import_params = block_import_params_maker(
 				header,
 				&header_hash,
-				body,
+				body.clone(),
 				proposal.storage_changes,
 				claim,
 				epoch_data,
@@ -361,6 +361,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 				"hash_previously" => ?header_hash,
 			);
 
+			let header = block_import_params.post_header();
 			if let Err(err) = block_import.lock().import_block(block_import_params, Default::default()) {
 				warn!(
 					target: logging_target,
@@ -376,7 +377,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 				);
 			}
 
-			Ok(SlotResult { block, storage_proof })
+			Ok(SlotResult { block: B::new(header, body), storage_proof })
 		}).then(|r| async move {
 			r.map_err(|e| warn!(target: "slots", "Encountered consensus error: {:?}", e)).ok()
 		}).boxed()

--- a/primitives/consensus/common/src/block_import.rs
+++ b/primitives/consensus/common/src/block_import.rs
@@ -193,16 +193,21 @@ impl<Block: BlockT, Transaction> BlockImportParams<Block, Transaction> {
 		if let Some(hash) = self.post_hash {
 			hash
 		} else {
-			if self.post_digests.is_empty() {
-				self.header.hash()
-			} else {
-				let mut hdr = self.header.clone();
-				for digest_item in &self.post_digests {
-					hdr.digest_mut().push(digest_item.clone());
-				}
+			self.post_header().hash()
+		}
+	}
 
-				hdr.hash()
+	/// Get the post header.
+	pub fn post_header(&self) -> Block::Header {
+		if self.post_digests.is_empty() {
+				self.header.clone()
+		} else {
+			let mut hdr = self.header.clone();
+			for digest_item in &self.post_digests {
+				hdr.digest_mut().push(digest_item.clone());
 			}
+
+			hdr
 		}
 	}
 

--- a/primitives/consensus/common/src/block_import.rs
+++ b/primitives/consensus/common/src/block_import.rs
@@ -200,7 +200,7 @@ impl<Block: BlockT, Transaction> BlockImportParams<Block, Transaction> {
 	/// Get the post header.
 	pub fn post_header(&self) -> Block::Header {
 		if self.post_digests.is_empty() {
-				self.header.clone()
+			self.header.clone()
 		} else {
 			let mut hdr = self.header.clone();
 			for digest_item in &self.post_digests {


### PR DESCRIPTION
Before this pr `on_slot` returned the pre block. However this is wrong,
because adding some post digest changes the hash of the header. Thus,
we need to make sure to return the correct block that uses the post
header.

