### PR TITLE
Reserve ss58 prefix 206 for Cerulean

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -585,7 +585,7 @@ ss58_address_format!(
 	CrustAccount =>
 		(66, "crust", "Crust Network, standard account (*25519).")
 	CeruleanAccount =>
-		(206, "crust", "Cerulean mainnet, standard account (*25519).")
+		(206, "cerulean", "Cerulean mainnet, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -584,6 +584,8 @@ ss58_address_format!(
 		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
 	CrustAccount =>
 		(66, "crust", "Crust Network, standard account (*25519).")
+	CeruleanAccount =>
+		(206, "crust", "Cerulean mainnet, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -468,6 +468,15 @@
 			"decimals": [12],
 			"standardAccount": "*25519",
 			"website": "https://crust.network"
+		},
+		{
+			"prefix": 206,
+			"network": "cerulean",
+			"displayName": "Cerulean Mainnet",
+			"symbols": ["CER"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://cerulean.cash"
 		}
 	]
 }


### PR DESCRIPTION
A0-pleasereview B0-silent c1-low
This reserves ss58 prefix 206 for Cerulean MainNet. Cerulean is a network I am currently working on that aims for user friendly integration with live-streaming platforms, custom-token generation and trading, as well as potential integration on some games.

EDIT: It's not letting me add labels for some reason
edit2: Thanks for fixing the labels.
