### PR TITLE
Re-export weights for eleciton.

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -241,7 +241,8 @@ const LOG_TARGET: &'static str = "runtime::election-provider";
 pub mod unsigned;
 pub mod weights;
 
-use weights::WeightInfo;
+/// The weight declaration of the pallet.
+pub use weights::WeightInfo;
 
 /// The compact solution type used by this crate.
 pub type CompactOf<T> = <T as Config>::CompactSolution;


### PR DESCRIPTION
Turns out the polkadot bot assumes that this guys is exported from the root of the pallet.
