### PR TITLE
Add some migration helper to help migrating pallet changing pallet prefix

### DIFF
--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -282,7 +282,7 @@ pub fn move_prefix(from_prefix: &[u8], to_prefix: &[u8]) {
 	};
 
 	for (key, value) in iter {
-		let full_key = [to_prefix.clone(), &key].concat();
+		let full_key = [to_prefix, &key].concat();
 		unhashed::put_raw(&full_key, &value);
 	}
 }

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -220,6 +220,9 @@ pub fn move_storage_from_pallet(item: &[u8], old_pallet: &[u8], new_pallet: &[u8
 }
 
 /// Move all storage key after the pallet prefix `old_pallet` to `new_pallet`
+///
+/// NOTE: It actually moves every key after the pallet prefix to the new pallet prefix,
+/// key on pallet prefix is not moved.
 pub fn move_pallet(old_pallet: &[u8], new_pallet: &[u8]) {
 	move_prefix(&Twox128::hash(old_pallet), &Twox128::hash(new_pallet))
 }

--- a/frame/support/src/storage/migration.rs
+++ b/frame/support/src/storage/migration.rs
@@ -217,7 +217,6 @@ pub fn move_storage_from_pallet(item: &[u8], old_pallet: &[u8], new_pallet: &[u8
 		unhashed::put_raw(&new_prefix, &value);
 		unhashed::kill(&old_prefix);
 	}
-
 }
 
 /// Move all storage key after the pallet prefix `old_pallet` to `new_pallet`


### PR DESCRIPTION
when migrating from decl_storage to frame v2, some pallet needs to migrate their storage too.

This is some helper to move some specific storage in case the pallet prefix is shared by multiple pallets (e.g. treasury and bounty) or to move all pallet.

This can be useful for
https://github.com/paritytech/substrate/pull/8193
https://github.com/paritytech/substrate/pull/8196
https://github.com/paritytech/substrate/pull/8044