### PR TITLE
Fix ignored error in benchmark tests

### DIFF
--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1169,9 +1169,16 @@ macro_rules! impl_benchmark_test_suite {
 					let mut anything_failed = false;
 					println!("failing benchmark tests:");
 					for benchmark_name in $bench_module::<$test>::benchmarks($extra) {
-						if let Err(err) = std::panic::catch_unwind(|| test_bench_by_name::<$test>(benchmark_name)) {
-							println!("{}: {:?}", String::from_utf8_lossy(benchmark_name), err);
-							anything_failed = true;
+						match std::panic::catch_unwind(|| test_bench_by_name::<$test>(benchmark_name)) {
+							Err(err) => {
+								println!("{}: {:?}", String::from_utf8_lossy(benchmark_name), err);
+								anything_failed = true;
+							},
+							Ok(Err(err)) => {
+								println!("{}: {:?}", String::from_utf8_lossy(benchmark_name), err);
+								anything_failed = true;
+							},
+							_ => (),
 						}
 					}
 					assert!(!anything_failed);

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1178,7 +1178,7 @@ macro_rules! impl_benchmark_test_suite {
 								println!("{}: {}", String::from_utf8_lossy(benchmark_name), err);
 								anything_failed = true;
 							},
-							_ => (),
+							Ok(Ok(_)) => (),
 						}
 					}
 					assert!(!anything_failed);

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -1175,7 +1175,7 @@ macro_rules! impl_benchmark_test_suite {
 								anything_failed = true;
 							},
 							Ok(Err(err)) => {
-								println!("{}: {:?}", String::from_utf8_lossy(benchmark_name), err);
+								println!("{}: {}", String::from_utf8_lossy(benchmark_name), err);
 								anything_failed = true;
 							},
 							_ => (),


### PR DESCRIPTION
Currently if a benchmark fails and return error (instead of panicking) then the test ignores it.

That might worth a frame-benchmarking 3.1.1 release.