### PR TITLE
Add benchmark to node-template pallet-template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5293,6 +5293,7 @@ dependencies = [
 name = "pallet-template"
 version = "2.0.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -5300,6 +5301,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5301,7 +5301,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -25,6 +25,18 @@ default-features = false
 version = "3.0.0"
 path = "../../../../frame/system"
 
+[dependencies.frame-benchmarking]
+default-features = false
+version = "3.1.0"
+path = "../../../../frame/benchmarking"
+optional = true
+
+[dependencies.sp-std]
+default-features = false
+version = "3.0.0"
+path = "../../../../primitives/std"
+optional = true
+
 [dev-dependencies]
 serde = { version = "1.0.101" }
 
@@ -43,12 +55,13 @@ default-features = false
 version = "3.0.0"
 path = "../../../../primitives/runtime"
 
-
 [features]
 default = ['std']
 std = [
 	'codec/std',
 	'frame-support/std',
-	'frame-system/std'
+	'frame-system/std',
+	'sp-std/std',
 ]
+runtime-benchmarks = ["frame-benchmarking"]
 try-runtime = ["frame-support/try-runtime"]

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -31,12 +31,6 @@ version = "3.1.0"
 path = "../../../../frame/benchmarking"
 optional = true
 
-[dependencies.sp-std]
-default-features = false
-version = "3.0.0"
-path = "../../../../primitives/std"
-optional = true
-
 [dev-dependencies]
 serde = { version = "1.0.101" }
 
@@ -61,7 +55,6 @@ std = [
 	'codec/std',
 	'frame-support/std',
 	'frame-system/std',
-	'sp-std/std',
 ]
 runtime-benchmarks = ["frame-benchmarking"]
 try-runtime = ["frame-support/try-runtime"]

--- a/bin/node-template/pallets/template/Cargo.toml
+++ b/bin/node-template/pallets/template/Cargo.toml
@@ -55,6 +55,7 @@ std = [
 	'codec/std',
 	'frame-support/std',
 	'frame-system/std',
+	'frame-benchmarking/std',
 ]
 runtime-benchmarks = ["frame-benchmarking"]
 try-runtime = ["frame-support/try-runtime"]

--- a/bin/node-template/pallets/template/src/benchmarking.rs
+++ b/bin/node-template/pallets/template/src/benchmarking.rs
@@ -1,21 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! Balances pallet benchmarking.
+//! Benchmarking setup for pallet-template
 
 use super::*;
 

--- a/bin/node-template/pallets/template/src/benchmarking.rs
+++ b/bin/node-template/pallets/template/src/benchmarking.rs
@@ -7,7 +7,6 @@ use frame_benchmarking::{benchmarks, whitelisted_caller, impl_benchmark_test_sui
 #[allow(unused)]
 use crate::Module as Template;
 
-
 benchmarks! {
 	do_something {
 		let s in 0 .. 100;

--- a/bin/node-template/pallets/template/src/benchmarking.rs
+++ b/bin/node-template/pallets/template/src/benchmarking.rs
@@ -1,0 +1,42 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Balances pallet benchmarking.
+
+use super::*;
+
+use frame_system::RawOrigin;
+use frame_benchmarking::{benchmarks, whitelisted_caller, impl_benchmark_test_suite};
+#[allow(unused)]
+use crate::Module as Template;
+
+
+benchmarks! {
+	do_something {
+		let s in 0 .. 100;
+		let caller: T::AccountId = whitelisted_caller();
+	}: _(RawOrigin::Signed(caller), s)
+	verify {
+		assert_eq!(Something::<T>::get(), Some(s));
+	}
+}
+
+impl_benchmark_test_suite!(
+	Template,
+	crate::mock::new_test_ext(),
+	crate::mock::Test,
+);

--- a/bin/node-template/pallets/template/src/lib.rs
+++ b/bin/node-template/pallets/template/src/lib.rs
@@ -12,6 +12,9 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::{dispatch::DispatchResultWithPostInfo, pallet_prelude::*};
@@ -46,7 +49,7 @@ pub mod pallet {
 		/// parameters. [something, who]
 		SomethingStored(u32, T::AccountId),
 	}
-	
+
 	// Errors inform users that something went wrong.
 	#[pallet::error]
 	pub enum Error<T> {

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -89,4 +89,5 @@ runtime-benchmarks = [
 	"frame-system/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
+	"template/runtime-benchmarks",
 ]

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -475,7 +475,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 			add_benchmark!(params, batches, pallet_balances, Balances);
 			add_benchmark!(params, batches, pallet_timestamp, Timestamp);
-			add_benchmark!(params, batches, template, Template);
+			add_benchmark!(params, batches, template, TemplateModule);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -475,6 +475,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 			add_benchmark!(params, batches, pallet_balances, Balances);
 			add_benchmark!(params, batches, pallet_timestamp, Timestamp);
+			add_benchmark!(params, batches, template, Template);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -34,7 +34,7 @@ pub use sp_runtime::traits::Zero;
 #[doc(hidden)]
 pub use frame_support;
 #[doc(hidden)]
-pub use sp_std;
+pub use sp_std::{self, vec, prelude::Vec, boxed::Box};
 #[doc(hidden)]
 pub use paste;
 #[doc(hidden)]
@@ -568,8 +568,8 @@ macro_rules! benchmark_backend {
 			$crate::BenchmarkingSetup<T $(, $instance)? > for $name
 			where $( $where_clause )*
 		{
-			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
-				vec! [
+			fn components(&self) -> $crate::Vec<($crate::BenchmarkParameter, u32, u32)> {
+				$crate::vec! [
 					$(
 						($crate::BenchmarkParameter::$param, $param_from, $param_to)
 					),*
@@ -580,7 +580,7 @@ macro_rules! benchmark_backend {
 				&self,
 				components: &[($crate::BenchmarkParameter, u32)],
 				verify: bool
-			) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
+			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
 				$(
 					// Prepare instance
 					let $param = components.iter()
@@ -594,7 +594,7 @@ macro_rules! benchmark_backend {
 				$( $param_instancer ; )*
 				$( $post )*
 
-				Ok(Box::new(move || -> Result<(), &'static str> {
+				Ok($crate::Box::new(move || -> Result<(), &'static str> {
 					$eval;
 					if verify {
 						$postcode;
@@ -639,7 +639,7 @@ macro_rules! selected_benchmark {
 			$crate::BenchmarkingSetup<T $(, $instance )? > for SelectedBenchmark
 			where $( $where_clause )*
 		{
-			fn components(&self) -> Vec<($crate::BenchmarkParameter, u32, u32)> {
+			fn components(&self) -> $crate::Vec<($crate::BenchmarkParameter, u32, u32)> {
 				match self {
 					$(
 						Self::$bench => <
@@ -653,7 +653,7 @@ macro_rules! selected_benchmark {
 				&self,
 				components: &[($crate::BenchmarkParameter, u32)],
 				verify: bool
-			) -> Result<Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
+			) -> Result<$crate::Box<dyn FnOnce() -> Result<(), &'static str>>, &'static str> {
 				match self {
 					$(
 						Self::$bench => <
@@ -679,8 +679,8 @@ macro_rules! impl_benchmark {
 			$crate::Benchmarking<$crate::BenchmarkResults> for Module<T $(, $instance)? >
 			where T: frame_system::Config, $( $where_clause )*
 		{
-			fn benchmarks(extra: bool) -> Vec<&'static [u8]> {
-				let mut all = vec![ $( stringify!($name).as_ref() ),* ];
+			fn benchmarks(extra: bool) -> $crate::Vec<&'static [u8]> {
+				let mut all = $crate::vec![ $( stringify!($name).as_ref() ),* ];
 				if !extra {
 					let extra = [ $( stringify!($name_extra).as_ref() ),* ];
 					all.retain(|x| !extra.contains(x));
@@ -696,7 +696,7 @@ macro_rules! impl_benchmark {
 				repeat: u32,
 				whitelist: &[$crate::TrackedStorageKey],
 				verify: bool,
-			) -> Result<Vec<$crate::BenchmarkResults>, &'static str> {
+			) -> Result<$crate::Vec<$crate::BenchmarkResults>, &'static str> {
 				// Map the input to the selected benchmark.
 				let extrinsic = $crate::sp_std::str::from_utf8(extrinsic)
 					.map_err(|_| "`extrinsic` is not a valid utf8 string!")?;
@@ -704,7 +704,7 @@ macro_rules! impl_benchmark {
 					$( stringify!($name) => SelectedBenchmark::$name, )*
 					_ => return Err("Could not find extrinsic."),
 				};
-				let mut results: Vec<$crate::BenchmarkResults> = Vec::new();
+				let mut results: $crate::Vec<$crate::BenchmarkResults> = $crate::Vec::new();
 				if repeat == 0 {
 					return Ok(results);
 				}
@@ -732,7 +732,7 @@ macro_rules! impl_benchmark {
 				let repeat_benchmark = |
 					repeat: u32,
 					c: &[($crate::BenchmarkParameter, u32)],
-					results: &mut Vec<$crate::BenchmarkResults>,
+					results: &mut $crate::Vec<$crate::BenchmarkResults>,
 					verify: bool,
 				| -> Result<(), &'static str> {
 					// Run the benchmark `repeat` times.
@@ -809,7 +809,7 @@ macro_rules! impl_benchmark {
 				if components.is_empty() {
 					if verify {
 						// If `--verify` is used, run the benchmark once to verify it would complete.
-						repeat_benchmark(1, Default::default(), &mut Vec::new(), true)?;
+						repeat_benchmark(1, Default::default(), &mut $crate::Vec::new(), true)?;
 					}
 					repeat_benchmark(repeat, Default::default(), &mut results, false)?;
 				} else {
@@ -836,7 +836,7 @@ macro_rules! impl_benchmark {
 							let component_value = lowest + step_size * s;
 
 							// Select the max value for all the other components.
-							let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
+							let c: $crate::Vec<($crate::BenchmarkParameter, u32)> = components.iter()
 								.enumerate()
 								.map(|(idx, (n, _, h))|
 									if n == name {
@@ -849,7 +849,7 @@ macro_rules! impl_benchmark {
 
 							if verify {
 								// If `--verify` is used, run the benchmark once to verify it would complete.
-								repeat_benchmark(1, &c, &mut Vec::new(), true)?;
+								repeat_benchmark(1, &c, &mut $crate::Vec::new(), true)?;
 							}
 							repeat_benchmark(repeat, &c, &mut results, false)?;
 						}
@@ -907,7 +907,7 @@ macro_rules! impl_benchmark_test {
 				>::components(&selected_benchmark);
 
 				let execute_benchmark = |
-					c: Vec<($crate::BenchmarkParameter, u32)>
+					c: $crate::Vec<($crate::BenchmarkParameter, u32)>
 				| -> Result<(), &'static str> {
 					// Set up the benchmark, return execution + verification function.
 					let closure_to_verify = <
@@ -933,9 +933,9 @@ macro_rules! impl_benchmark_test {
 				} else {
 					for (_, (name, low, high)) in components.iter().enumerate() {
 						// Test only the low and high value, assuming values in the middle won't break
-						for component_value in vec![low, high] {
+						for component_value in $crate::vec![low, high] {
 							// Select the max value for all the other components.
-							let c: Vec<($crate::BenchmarkParameter, u32)> = components.iter()
+							let c: $crate::Vec<($crate::BenchmarkParameter, u32)> = components.iter()
 								.enumerate()
 								.map(|(_, (n, _, h))|
 									if n == name {

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -34,6 +34,8 @@ pub use sp_runtime::traits::Zero;
 #[doc(hidden)]
 pub use frame_support;
 #[doc(hidden)]
+pub use sp_std;
+#[doc(hidden)]
 pub use paste;
 #[doc(hidden)]
 pub use sp_storage::TrackedStorageKey;
@@ -696,7 +698,7 @@ macro_rules! impl_benchmark {
 				verify: bool,
 			) -> Result<Vec<$crate::BenchmarkResults>, &'static str> {
 				// Map the input to the selected benchmark.
-				let extrinsic = sp_std::str::from_utf8(extrinsic)
+				let extrinsic = $crate::sp_std::str::from_utf8(extrinsic)
 					.map_err(|_| "`extrinsic` is not a valid utf8 string!")?;
 				let selected_benchmark = match extrinsic {
 					$( stringify!($name) => SelectedBenchmark::$name, )*
@@ -710,7 +712,7 @@ macro_rules! impl_benchmark {
 				// Add whitelist to DB including whitelisted caller
 				let mut whitelist = whitelist.to_vec();
 				let whitelisted_caller_key =
-					<frame_system::Account::<T> as frame_support::storage::StorageMap<_,_>>::hashed_key_for(
+					<frame_system::Account::<T> as $crate::frame_support::storage::StorageMap<_,_>>::hashed_key_for(
 						$crate::whitelisted_caller::<T::AccountId>()
 					);
 				whitelist.push(whitelisted_caller_key.into());
@@ -872,7 +874,7 @@ macro_rules! impl_benchmark {
 		where
 			T: Config + frame_system::Config, $( $where_clause )*
 		{
-			let name = sp_std::str::from_utf8(name)
+			let name = $crate::sp_std::str::from_utf8(name)
 				.map_err(|_| "`name` is not a valid utf8 string!")?;
 			match name {
 				$( stringify!($name) => {

--- a/frame/merkle-mountain-range/src/benchmarking.rs
+++ b/frame/merkle-mountain-range/src/benchmarking.rs
@@ -22,7 +22,6 @@
 use crate::*;
 use frame_support::traits::OnInitialize;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
-use sp_std::prelude::*;
 
 benchmarks! {
 	on_initialize {

--- a/frame/timestamp/src/benchmarking.rs
+++ b/frame/timestamp/src/benchmarking.rs
@@ -20,7 +20,6 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use sp_std::prelude::*;
 use frame_system::RawOrigin;
 use frame_support::{ensure, traits::OnFinalize};
 use frame_benchmarking::{benchmarks, TrackedStorageKey, impl_benchmark_test_suite};


### PR DESCRIPTION
This adds a basic benchmarks to the `pallet-template` found in the `node-template`.

Fixes an issue where `sp_std` was being depended on in multiple ways without being exported by the `benchmarking` crate.