### PR TITLE
Allow pallet::call to return `DispatchResult`

### DIFF
--- a/frame/support/procedural/src/pallet/parse/call.rs
+++ b/frame/support/procedural/src/pallet/parse/call.rs
@@ -21,7 +21,6 @@ use syn::spanned::Spanned;
 
 /// List of additional token to be used for parsing.
 mod keyword {
-	syn::custom_keyword!(DispatchResultWithPostInfo);
 	syn::custom_keyword!(Call);
 	syn::custom_keyword!(OriginFor);
 	syn::custom_keyword!(weight);
@@ -163,7 +162,7 @@ impl CallDef {
 				}
 
 				if let syn::ReturnType::Type(_, type_) = &method.sig.output {
-					syn::parse2::<keyword::DispatchResultWithPostInfo>(type_.to_token_stream())?;
+					helper::check_pallet_call_return_type(type_)?;
 				} else {
 					let msg = "Invalid pallet::call, require return type \
 						DispatchResultWithPostInfo";

--- a/frame/support/procedural/src/pallet/parse/helper.rs
+++ b/frame/support/procedural/src/pallet/parse/helper.rs
@@ -603,7 +603,6 @@ pub fn check_type_value_gen(
 pub fn check_pallet_call_return_type(
 	type_: &syn::Type,
 ) -> syn::Result<()> {
-	let expected = "expected `DispatchResultWithPostInfo` or `DispatchResult`";
 	pub struct Checker;
 	impl syn::parse::Parse for Checker {
 		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
@@ -621,11 +620,5 @@ pub fn check_pallet_call_return_type(
 	}
 
 	syn::parse2::<Checker>(type_.to_token_stream())
-		.map_err(|e| {
-			let msg = format!("Invalid pallet::call return type: {}", expected);
-			let mut err = syn::Error::new(type_.span(), msg);
-			err.combine(e);
-			err
-		})
 		.map(|_| ())
 }

--- a/frame/support/procedural/src/pallet/parse/helper.rs
+++ b/frame/support/procedural/src/pallet/parse/helper.rs
@@ -27,6 +27,8 @@ mod keyword {
 	syn::custom_keyword!(T);
 	syn::custom_keyword!(Pallet);
 	syn::custom_keyword!(origin);
+	syn::custom_keyword!(DispatchResult);
+	syn::custom_keyword!(DispatchResultWithPostInfo);
 }
 
 /// A usage of instance, either the trait `Config` has been used with instance or without instance.
@@ -595,4 +597,35 @@ pub fn check_type_value_gen(
 		.map(|mut i| { i.span = span; i });
 
 	Ok(i)
+}
+
+/// Check the keyword `DispatchResultWithPostInfo` or `DispatchResult`.
+pub fn check_pallet_call_return_type(
+	type_: &syn::Type,
+) -> syn::Result<()> {
+	let expected = "expected `DispatchResultWithPostInfo` or `DispatchResult`";
+	pub struct Checker;
+	impl syn::parse::Parse for Checker {
+		fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+			let lookahead = input.lookahead1();
+			if lookahead.peek(keyword::DispatchResultWithPostInfo) {
+				input.parse::<keyword::DispatchResultWithPostInfo>()?;
+				Ok(Self)
+			} else if lookahead.peek(keyword::DispatchResult) {
+				input.parse::<keyword::DispatchResult>()?;
+				Ok(Self)
+			} else {
+				Err(lookahead.error())
+			}
+		}
+	}
+
+	syn::parse2::<Checker>(type_.to_token_stream())
+		.map_err(|e| {
+			let msg = format!("Invalid pallet::call return type: {}", expected);
+			let mut err = syn::Error::new(type_.span(), msg);
+			err.combine(e);
+			err
+		})
+		.map(|_| ())
 }

--- a/frame/support/procedural/src/pallet/parse/helper.rs
+++ b/frame/support/procedural/src/pallet/parse/helper.rs
@@ -619,6 +619,5 @@ pub fn check_pallet_call_return_type(
 		}
 	}
 
-	syn::parse2::<Checker>(type_.to_token_stream())
-		.map(|_| ())
+	syn::parse2::<Checker>(type_.to_token_stream()).map(|_| ())
 }

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1054,7 +1054,7 @@ pub mod pallet_prelude {
 		Twox128, Blake2_256, Blake2_128, Identity, Twox64Concat, Blake2_128Concat, debug, ensure,
 		RuntimeDebug, storage,
 		traits::{Get, Hooks, IsType, GetPalletVersion, EnsureOrigin},
-		dispatch::{DispatchResultWithPostInfo, Parameter, DispatchError},
+		dispatch::{DispatchResultWithPostInfo, Parameter, DispatchError, DispatchResult},
 		weights::{DispatchClass, Pays, Weight},
 		storage::types::{StorageValue, StorageMap, StorageDoubleMap, ValueQuery, OptionQuery},
 	};
@@ -1220,7 +1220,7 @@ pub mod pallet_prelude {
 /// 		$some_arg: $some_type,
 /// 		// or with compact attribute: #[pallet::compact] $some_arg: $some_type,
 /// 		...
-/// 	) -> DispatchResultWithPostInfo {
+/// 	) -> DispatchResultWithPostInfo { // or `-> DispatchResult`
 /// 		...
 /// 	}
 /// 	...
@@ -1231,7 +1231,8 @@ pub mod pallet_prelude {
 ///
 /// Each dispatchable needs to define a weight with `#[pallet::weight($expr)]` attribute,
 /// the first argument must be `origin: OriginFor<T>`, compact encoding for argument can be used
-/// using `#[pallet::compact]`, function must return DispatchResultWithPostInfo.
+/// using `#[pallet::compact]`, function must return `DispatchResultWithPostInfo` or
+/// `DispatchResult`.
 ///
 /// All arguments must implement `Debug`, `PartialEq`, `Eq`, `Decode`, `Encode`, `Clone`. For ease
 /// of use, bound the trait `Member` available in frame_support::pallet_prelude.

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -161,6 +161,14 @@ pub mod pallet {
 
 			Ok(().into())
 		}
+
+		// Test for DispatchResult return type
+		#[pallet::weight(1)]
+		fn foo_no_post_info(
+			_origin: OriginFor<T>,
+		) -> DispatchResult {
+			Ok(())
+		}
 	}
 
 	#[pallet::error]

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -677,6 +677,11 @@ fn metadata() {
 					" Doc comment put in metadata".to_string(),
 				]),
 			},
+			FunctionMetadata {
+				name: DecodeDifferent::Decoded("foo_no_post_info".to_string()),
+				arguments: DecodeDifferent::Decoded(vec![]),
+				documentation: DecodeDifferent::Decoded(vec![]),
+			},
 		])),
 		event: Some(DecodeDifferent::Decoded(vec![
 			EventMetadata {

--- a/frame/support/test/tests/pallet.rs
+++ b/frame/support/test/tests/pallet.rs
@@ -433,7 +433,7 @@ fn call_expand() {
 	assert_eq!(call_foo.get_call_name(), "foo");
 	assert_eq!(
 		pallet::Call::<Runtime>::get_call_names(),
-		&["foo", "foo_transactional"],
+		&["foo", "foo_transactional", "foo_no_post_info"],
 	);
 }
 

--- a/frame/support/test/tests/pallet_ui/call_invalid_return.rs
+++ b/frame/support/test/tests/pallet_ui/call_invalid_return.rs
@@ -1,0 +1,22 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::Hooks;
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		fn foo(origin: OriginFor<T>) -> ::DispatchResult { todo!() }
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_invalid_return.stderr
+++ b/frame/support/test/tests/pallet_ui/call_invalid_return.stderr
@@ -1,0 +1,5 @@
+error: expected `DispatchResultWithPostInfo` or `DispatchResult`
+  --> $DIR/call_invalid_return.rs:17:35
+   |
+17 |         fn foo(origin: OriginFor<T>) -> ::DispatchResult { todo!() }
+   |                                         ^^


### PR DESCRIPTION
This PR allows calls in `#[pallet::call]` to return a `DispatchResult`.