### PR TITLE
Make `ExecuteBlock::execute_block` return the final block header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9282,7 +9282,6 @@ name = "substrate-test-runtime"
 version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
- "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",

--- a/bin/node-template/runtime/src/lib.rs
+++ b/bin/node-template/runtime/src/lib.rs
@@ -323,7 +323,7 @@ impl_runtime_apis! {
 		}
 
 		fn execute_block(block: Block) {
-			Executive::execute_block(block)
+			Executive::execute_block(block);
 		}
 
 		fn initialize_block(header: &<Block as BlockT>::Header) {

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1179,7 +1179,7 @@ impl_runtime_apis! {
 		}
 
 		fn execute_block(block: Block) {
-			Executive::execute_block(block)
+			Executive::execute_block(block);
 		}
 
 		fn initialize_block(header: &<Block as BlockT>::Header) {

--- a/frame/executive/README.md
+++ b/frame/executive/README.md
@@ -22,7 +22,6 @@ The Executive module provides functions to:
 
 The Executive module provides the following implementations:
 
-- `ExecuteBlock`: Trait that can be used to execute a block.
 - `Executive`: Type that can be used to make the FRAME available from the runtime.
 
 ## Usage

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -119,25 +119,19 @@
 use sp_std::{prelude::*, marker::PhantomData};
 use frame_support::{
 	weights::{GetDispatchInfo, DispatchInfo, DispatchClass},
-	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade, OffchainWorker},
+	traits::{OnInitialize, OnFinalize, OnRuntimeUpgrade, OffchainWorker, ExecuteBlock},
 	dispatch::PostDispatchInfo,
 };
 use sp_runtime::{
 	generic::Digest, ApplyExtrinsicResult,
 	traits::{
 		self, Header, Zero, One, Checkable, Applyable, CheckEqual, ValidateUnsigned, NumberFor,
-		Block as BlockT, Dispatchable, Saturating,
+		Dispatchable, Saturating,
 	},
 	transaction_validity::{TransactionValidity, TransactionSource},
 };
 use codec::{Codec, Encode};
 use frame_system::DigestOf;
-
-/// Trait that can be used to execute a block.
-pub trait ExecuteBlock<Block: BlockT> {
-	/// Actually execute all transitions for `block`.
-	fn execute_block(block: Block);
-}
 
 pub type CheckedOf<E, C> = <E as Checkable<C>>::Checked;
 pub type CallOf<E, C> = <CheckedOf<E, C> as Applyable>::Call;
@@ -180,8 +174,8 @@ where
 	OriginOf<Block::Extrinsic, Context>: From<Option<System::AccountId>>,
 	UnsignedValidator: ValidateUnsigned<Call=CallOf<Block::Extrinsic, Context>>,
 {
-	fn execute_block(block: Block) {
-		Executive::<System, Block, Context, UnsignedValidator, AllModules>::execute_block(block);
+	fn execute_block(block: Block) -> Block::Header {
+		Executive::<System, Block, Context, UnsignedValidator, AllModules>::execute_block(block)
 	}
 }
 
@@ -318,11 +312,11 @@ where
 	}
 
 	/// Actually execute all transitions for `block`.
-	pub fn execute_block(block: Block) {
+	pub fn execute_block(block: Block) -> Block::Header {
 		sp_io::init_tracing();
 		sp_tracing::within_span! {
-			sp_tracing::info_span!( "execute_block", ?block);
-		{
+			sp_tracing::info_span!("execute_block", ?block);
+
 			Self::initialize_block(block.header());
 
 			// any initial checks
@@ -339,8 +333,8 @@ where
 			}
 
 			// any final checks
-			Self::final_checks(&header);
-		} };
+			Self::final_checks(&header)
+		}
 	}
 
 	/// Execute given extrinsics and take care of post-extrinsics book-keeping.
@@ -412,7 +406,7 @@ where
 		Ok(r.map(|_| ()).map_err(|e| e.error))
 	}
 
-	fn final_checks(header: &System::Header) {
+	fn final_checks(header: &System::Header) -> System::Header {
 		sp_tracing::enter_span!(sp_tracing::Level::TRACE, "final_checks");
 		// remove temporaries
 		let new_header = <frame_system::Module<System>>::finalize();
@@ -438,6 +432,8 @@ where
 			header.extrinsics_root() == new_header.extrinsics_root(),
 			"Transaction trie root must be valid.",
 		);
+
+		new_header
 	}
 
 	/// Check a given signed transaction for validity. This doesn't execute any
@@ -502,7 +498,7 @@ mod tests {
 	use sp_core::H256;
 	use sp_runtime::{
 		generic::{Era, DigestItem}, DispatchError, testing::{Digest, Header, Block},
-		traits::{Header as HeaderT, BlakeTwo256, IdentityLookup},
+		traits::{Header as HeaderT, BlakeTwo256, IdentityLookup, Block as BlockT},
 		transaction_validity::{
 			InvalidTransaction, ValidTransaction, TransactionValidityError, UnknownTransaction
 		},

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -26,9 +26,9 @@ use sp_runtime::{
 	RuntimeAppPublic, RuntimeDebug, BoundToRuntimeAppPublic,
 	ConsensusEngineId, DispatchResult, DispatchError,
 	traits::{
-	MaybeSerializeDeserialize, AtLeast32Bit, Saturating, TrailingZeroInput, Bounded, Zero,
-	BadOrigin, AtLeast32BitUnsigned, Convert, UniqueSaturatedFrom, UniqueSaturatedInto,
-	SaturatedConversion, StoredMapError,
+		MaybeSerializeDeserialize, AtLeast32Bit, Saturating, TrailingZeroInput, Bounded, Zero,
+		BadOrigin, AtLeast32BitUnsigned, Convert, UniqueSaturatedFrom, UniqueSaturatedInto,
+		SaturatedConversion, StoredMapError, Block as BlockT,
 	},
 };
 use sp_staking::SessionIndex;
@@ -2226,6 +2226,23 @@ pub trait GetPalletVersion {
 	/// If there was no previous version of the pallet stored in the state,
 	/// this function returns `None`.
 	fn storage_version() -> Option<PalletVersion>;
+}
+
+/// Something that can execute a given block.
+///
+/// Executing a block means that all extrinsics in a given block will be executed and the resulting
+/// header will be checked against the header of the given block.
+pub trait ExecuteBlock<Block: BlockT> {
+	/// Execute the given `block`.
+	///
+	/// This will execute all extrinsics in the block and check that the resulting header is correct.
+	///
+	/// Returns the result header.
+	///
+	/// # Panic
+	///
+	/// Panics when an extrinsics panics or the resulting header doesn't match the expected header.
+	fn execute_block(block: Block) -> Block::Header;
 }
 
 #[cfg(test)]

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -18,7 +18,6 @@ sp-consensus-aura = { version = "0.9.0", default-features = false, path = "../..
 sp-consensus-babe = { version = "0.9.0", default-features = false, path = "../../primitives/consensus/babe" }
 sp-block-builder = { version = "3.0.0", default-features = false, path = "../../primitives/block-builder" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-frame-executive = { version = "3.0.0", default-features = false, path = "../../frame/executive" }
 sp-inherents = { version = "3.0.0", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "3.0.0", optional = true, path = "../../primitives/keyring" }
 memory-db = { version = "0.26.0", default-features = false }
@@ -68,7 +67,6 @@ std = [
 	"sp-consensus-babe/std",
 	"sp-block-builder/std",
 	"codec/std",
-	"frame-executive/std",
 	"sp-inherents/std",
 	"sp-keyring",
 	"log/std",

--- a/test-utils/runtime/src/lib.rs
+++ b/test-utils/runtime/src/lib.rs
@@ -615,7 +615,7 @@ cfg_if! {
 				}
 
 				fn execute_block(block: Block) {
-					system::execute_block(block)
+					system::execute_block(block);
 				}
 
 				fn initialize_block(header: &<Block as BlockT>::Header) {
@@ -869,7 +869,7 @@ cfg_if! {
 				}
 
 				fn execute_block(block: Block) {
-					system::execute_block(block)
+					system::execute_block(block);
 				}
 
 				fn initialize_block(header: &<Block as BlockT>::Header) {

--- a/test-utils/runtime/src/system.rs
+++ b/test-utils/runtime/src/system.rs
@@ -107,11 +107,11 @@ pub fn polish_block(block: &mut Block) {
 	execute_block_with_state_root_handler(block, Mode::Overwrite);
 }
 
-pub fn execute_block(mut block: Block) {
-	execute_block_with_state_root_handler(&mut block, Mode::Verify);
+pub fn execute_block(mut block: Block) -> Header {
+	execute_block_with_state_root_handler(&mut block, Mode::Verify)
 }
 
-fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) {
+fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) -> Header {
 	let header = &mut block.header;
 
 	initialize_block(header);
@@ -142,14 +142,16 @@ fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) {
 			"Transaction trie root must be valid.",
 		);
 	}
+
+	new_header
 }
 
 /// The block executor.
 pub struct BlockExecutor;
 
-impl frame_executive::ExecuteBlock<Block> for BlockExecutor {
-	fn execute_block(block: Block) {
-		execute_block(block);
+impl frame_support::traits::ExecuteBlock<Block> for BlockExecutor {
+	fn execute_block(block: Block) -> Header {
+		execute_block(block)
 	}
 }
 
@@ -407,7 +409,7 @@ mod tests {
 
 	#[test]
 	fn block_import_works_native() {
-		block_import_works(|b, ext| ext.execute_with(|| execute_block(b)));
+		block_import_works(|b, ext| ext.execute_with(|| { execute_block(b); }));
 	}
 
 	#[test]
@@ -507,7 +509,7 @@ mod tests {
 
 	#[test]
 	fn block_import_with_transaction_works_native() {
-		block_import_with_transaction_works(|b, ext| ext.execute_with(|| execute_block(b)));
+		block_import_with_transaction_works(|b, ext| ext.execute_with(|| { execute_block(b); }));
 	}
 
 	#[test]


### PR DESCRIPTION
This pr changes the `ExecuteBlock` trait to return the final header that
results from executing the given block.

polkadot companion: https://github.com/paritytech/polkadot/pull/2548
