### PR TITLE
Move AuRa digest from client to primitives

### DIFF
--- a/primitives/consensus/aura/src/digests.rs
+++ b/primitives/consensus/aura/src/digests.rs
@@ -22,7 +22,7 @@
 //! `CompatibleDigestItem` trait to appear in public interfaces.
 
 use crate::AURA_ENGINE_ID;
-use sp_runtime::generic::{DigestItem, OpaqueDigestItemId};
+use sp_runtime::generic::DigestItem;
 use sp_consensus_slots::Slot;
 use codec::{Encode, Codec};
 use sp_std::fmt::Debug;
@@ -51,7 +51,7 @@ impl<Signature, Hash> CompatibleDigestItem<Signature> for DigestItem<Hash> where
 	}
 
 	fn as_aura_seal(&self) -> Option<Signature> {
-		self.seal_try_to(OpaqueDigestItemId::Seal(&AURA_ENGINE_ID))
+		self.seal_try_to(&AURA_ENGINE_ID)
 	}
 
 	fn aura_pre_digest(slot: Slot) -> Self {
@@ -59,6 +59,6 @@ impl<Signature, Hash> CompatibleDigestItem<Signature> for DigestItem<Hash> where
 	}
 
 	fn as_aura_pre_digest(&self) -> Option<Slot> {
-		self.pre_runtime_try_to(OpaqueDigestItemId::PreRuntime(&AURA_ENGINE_ID))
+		self.pre_runtime_try_to(&AURA_ENGINE_ID)
 	}
 }

--- a/primitives/consensus/aura/src/digests.rs
+++ b/primitives/consensus/aura/src/digests.rs
@@ -21,22 +21,19 @@
 //! This implements the digests for AuRa, to allow the private
 //! `CompatibleDigestItem` trait to appear in public interfaces.
 
-use sp_core::Pair;
-use sp_consensus_aura::AURA_ENGINE_ID;
+use crate::AURA_ENGINE_ID;
 use sp_runtime::generic::{DigestItem, OpaqueDigestItemId};
 use sp_consensus_slots::Slot;
 use codec::{Encode, Codec};
-use std::fmt::Debug;
-
-type Signature<P> = <P as Pair>::Signature;
+use sp_std::fmt::Debug;
 
 /// A digest item which is usable with aura consensus.
-pub trait CompatibleDigestItem<P: Pair>: Sized {
+pub trait CompatibleDigestItem<Signature>: Sized {
 	/// Construct a digest item which contains a signature on the hash.
-	fn aura_seal(signature: Signature<P>) -> Self;
+	fn aura_seal(signature: Signature) -> Self;
 
 	/// If this item is an Aura seal, return the signature.
-	fn as_aura_seal(&self) -> Option<Signature<P>>;
+	fn as_aura_seal(&self) -> Option<Signature>;
 
 	/// Construct a digest item which contains the slot number
 	fn aura_pre_digest(slot: Slot) -> Self;
@@ -45,17 +42,16 @@ pub trait CompatibleDigestItem<P: Pair>: Sized {
 	fn as_aura_pre_digest(&self) -> Option<Slot>;
 }
 
-impl<P, Hash> CompatibleDigestItem<P> for DigestItem<Hash> where
-	P: Pair,
-	Signature<P>: Codec,
+impl<Signature, Hash> CompatibleDigestItem<Signature> for DigestItem<Hash> where
+	Signature: Codec,
 	Hash: Debug + Send + Sync + Eq + Clone + Codec + 'static
 {
-	fn aura_seal(signature: Signature<P>) -> Self {
+	fn aura_seal(signature: Signature) -> Self {
 		DigestItem::Seal(AURA_ENGINE_ID, signature.encode())
 	}
 
-	fn as_aura_seal(&self) -> Option<Signature<P>> {
-		self.try_to(OpaqueDigestItemId::Seal(&AURA_ENGINE_ID))
+	fn as_aura_seal(&self) -> Option<Signature> {
+		self.seal_try_to(OpaqueDigestItemId::Seal(&AURA_ENGINE_ID))
 	}
 
 	fn aura_pre_digest(slot: Slot) -> Self {
@@ -63,6 +59,6 @@ impl<P, Hash> CompatibleDigestItem<P> for DigestItem<Hash> where
 	}
 
 	fn as_aura_pre_digest(&self) -> Option<Slot> {
-		self.try_to(OpaqueDigestItemId::PreRuntime(&AURA_ENGINE_ID))
+		self.pre_runtime_try_to(OpaqueDigestItemId::PreRuntime(&AURA_ENGINE_ID))
 	}
 }

--- a/primitives/consensus/aura/src/lib.rs
+++ b/primitives/consensus/aura/src/lib.rs
@@ -23,6 +23,7 @@ use codec::{Encode, Decode, Codec};
 use sp_std::vec::Vec;
 use sp_runtime::ConsensusEngineId;
 
+pub mod digests;
 pub mod inherents;
 
 pub mod sr25519 {

--- a/primitives/consensus/babe/src/digests.rs
+++ b/primitives/consensus/babe/src/digests.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use codec::{Codec, Decode, Encode};
 use sp_std::vec::Vec;
-use sp_runtime::{generic::OpaqueDigestItemId, DigestItem, RuntimeDebug};
+use sp_runtime::{DigestItem, RuntimeDebug};
 
 use sp_consensus_vrf::schnorrkel::{Randomness, VRFOutput, VRFProof};
 
@@ -184,7 +184,7 @@ impl<Hash> CompatibleDigestItem for DigestItem<Hash> where
 	}
 
 	fn as_babe_pre_digest(&self) -> Option<PreDigest> {
-		self.try_to(OpaqueDigestItemId::PreRuntime(&BABE_ENGINE_ID))
+		self.pre_runtime_try_to(&BABE_ENGINE_ID)
 	}
 
 	fn babe_seal(signature: AuthoritySignature) -> Self {
@@ -192,11 +192,11 @@ impl<Hash> CompatibleDigestItem for DigestItem<Hash> where
 	}
 
 	fn as_babe_seal(&self) -> Option<AuthoritySignature> {
-		self.try_to(OpaqueDigestItemId::Seal(&BABE_ENGINE_ID))
+		self.seal_try_to(&BABE_ENGINE_ID)
 	}
 
 	fn as_next_epoch_descriptor(&self) -> Option<NextEpochDescriptor> {
-		self.try_to(OpaqueDigestItemId::Consensus(&BABE_ENGINE_ID))
+		self.consensus_try_to(&BABE_ENGINE_ID)
 			.and_then(|x: super::ConsensusLog| match x {
 				super::ConsensusLog::NextEpochData(n) => Some(n),
 				_ => None,
@@ -204,7 +204,7 @@ impl<Hash> CompatibleDigestItem for DigestItem<Hash> where
 	}
 
 	fn as_next_config_descriptor(&self) -> Option<NextConfigDescriptor> {
-		self.try_to(OpaqueDigestItemId::Consensus(&BABE_ENGINE_ID))
+		self.consensus_try_to(&BABE_ENGINE_ID)
 			.and_then(|x: super::ConsensusLog| match x {
 				super::ConsensusLog::NextConfigData(n) => Some(n),
 				_ => None,

--- a/primitives/runtime/src/generic/digest.rs
+++ b/primitives/runtime/src/generic/digest.rs
@@ -263,25 +263,24 @@ impl<Hash> DigestItem<Hash> {
 
 	/// Try to match this to a `Self::Seal`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a seal item, the `id` isn't of variant seal,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn seal_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
+	/// Returns `None` if this isn't a seal item, the `id` doesn't match or when the decoding fails.
+	pub fn seal_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
 		self.dref().seal_try_to(id)
 	}
 
 	/// Try to match this to a `Self::Consensus`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a consensus item, the `id` isn't of variant consensus,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn consensus_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
+	/// Returns `None` if this isn't a consensus item, the `id` doesn't match or
+	/// when the decoding fails.
+	pub fn consensus_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
 		self.dref().consensus_try_to(id)
 	}
 
 	/// Try to match this to a `Self::PreRuntime`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a pre-runtime item, the `id` isn't of variant pre runtime,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn pre_runtime_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
+	/// Returns `None` if this isn't a pre-runtime item, the `id` doesn't match or
+	/// when the decoding fails.
+	pub fn pre_runtime_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
 		self.dref().pre_runtime_try_to(id)
 	}
 }
@@ -394,11 +393,10 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 
 	/// Try to match this to a `Self::Seal`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a seal item, the `id` isn't of variant seal,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn seal_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
-		match (id, self) {
-			(OpaqueDigestItemId::Seal(w), &Self::Seal(v, s)) if v == w =>
+	/// Returns `None` if this isn't a seal item, the `id` doesn't match or when the decoding fails.
+	pub fn seal_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
+		match self {
+			Self::Seal(v, s) if *v == id =>
 				Decode::decode(&mut &s[..]).ok(),
 			_ => None,
 		}
@@ -406,11 +404,11 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 
 	/// Try to match this to a `Self::Consensus`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a consensus item, the `id` isn't of variant consensus,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn consensus_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
-		match (id, self) {
-			(OpaqueDigestItemId::Consensus(w), &Self::Consensus(v, s)) if v == w =>
+	/// Returns `None` if this isn't a consensus item, the `id` doesn't match or
+	/// when the decoding fails.
+	pub fn consensus_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
+		match self {
+			Self::Consensus(v, s) if *v == id =>
 				Decode::decode(&mut &s[..]).ok(),
 			_ => None,
 		}
@@ -418,11 +416,11 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 
 	/// Try to match this to a `Self::PreRuntime`, check `id` matches and decode it.
 	///
-	/// Returns `None` if this isn't a pre-runtime item, the `id` isn't of variant pre runtime,
-	/// the `id` identifier doesn't match or when the decoding fails.
-	pub fn pre_runtime_try_to<T: Decode>(&self, id: OpaqueDigestItemId) -> Option<T> {
-		match (id, self) {
-			(OpaqueDigestItemId::PreRuntime(w), &Self::PreRuntime(v, s)) if v == w =>
+	/// Returns `None` if this isn't a pre-runtime item, the `id` doesn't match or
+	/// when the decoding fails.
+	pub fn pre_runtime_try_to<T: Decode>(&self, id: &ConsensusEngineId) -> Option<T> {
+		match self {
+			Self::PreRuntime(v, s) if *v == id =>
 				Decode::decode(&mut &s[..]).ok(),
 			_ => None,
 		}

--- a/primitives/runtime/src/generic/digest.rs
+++ b/primitives/runtime/src/generic/digest.rs
@@ -261,7 +261,6 @@ impl<Hash> DigestItem<Hash> {
 		self.dref().try_to::<T>(id)
 	}
 
-
 	/// Try to match this to a `Self::Seal`, check `id` matches and decode it.
 	///
 	/// Returns `None` if this isn't a seal item, the `id` isn't of variant seal,


### PR DESCRIPTION
This makes the digest stuff usable from inside the runtime ;)

