### PR TITLE
Do not return the `Header` from `execute_block`

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -174,8 +174,8 @@ where
 	OriginOf<Block::Extrinsic, Context>: From<Option<System::AccountId>>,
 	UnsignedValidator: ValidateUnsigned<Call=CallOf<Block::Extrinsic, Context>>,
 {
-	fn execute_block(block: Block) -> Block::Header {
-		Executive::<System, Block, Context, UnsignedValidator, AllModules>::execute_block(block)
+	fn execute_block(block: Block) {
+		Executive::<System, Block, Context, UnsignedValidator, AllModules>::execute_block(block);
 	}
 }
 
@@ -312,7 +312,7 @@ where
 	}
 
 	/// Actually execute all transitions for `block`.
-	pub fn execute_block(block: Block) -> Block::Header {
+	pub fn execute_block(block: Block) {
 		sp_io::init_tracing();
 		sp_tracing::within_span! {
 			sp_tracing::info_span!("execute_block", ?block);
@@ -333,7 +333,7 @@ where
 			}
 
 			// any final checks
-			Self::final_checks(&header)
+			Self::final_checks(&header);
 		}
 	}
 
@@ -406,7 +406,7 @@ where
 		Ok(r.map(|_| ()).map_err(|e| e.error))
 	}
 
-	fn final_checks(header: &System::Header) -> System::Header {
+	fn final_checks(header: &System::Header) {
 		sp_tracing::enter_span!(sp_tracing::Level::TRACE, "final_checks");
 		// remove temporaries
 		let new_header = <frame_system::Module<System>>::finalize();
@@ -432,8 +432,6 @@ where
 			header.extrinsics_root() == new_header.extrinsics_root(),
 			"Transaction trie root must be valid.",
 		);
-
-		new_header
 	}
 
 	/// Check a given signed transaction for validity. This doesn't execute any

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -2237,12 +2237,10 @@ pub trait ExecuteBlock<Block: BlockT> {
 	///
 	/// This will execute all extrinsics in the block and check that the resulting header is correct.
 	///
-	/// Returns the result header.
-	///
 	/// # Panic
 	///
 	/// Panics when an extrinsics panics or the resulting header doesn't match the expected header.
-	fn execute_block(block: Block) -> Block::Header;
+	fn execute_block(block: Block);
 }
 
 #[cfg(test)]

--- a/test-utils/runtime/src/system.rs
+++ b/test-utils/runtime/src/system.rs
@@ -107,11 +107,11 @@ pub fn polish_block(block: &mut Block) {
 	execute_block_with_state_root_handler(block, Mode::Overwrite);
 }
 
-pub fn execute_block(mut block: Block) -> Header {
-	execute_block_with_state_root_handler(&mut block, Mode::Verify)
+pub fn execute_block(mut block: Block) {
+	execute_block_with_state_root_handler(&mut block, Mode::Verify);
 }
 
-fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) -> Header {
+fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) {
 	let header = &mut block.header;
 
 	initialize_block(header);
@@ -142,16 +142,14 @@ fn execute_block_with_state_root_handler(block: &mut Block, mode: Mode) -> Heade
 			"Transaction trie root must be valid.",
 		);
 	}
-
-	new_header
 }
 
 /// The block executor.
 pub struct BlockExecutor;
 
 impl frame_support::traits::ExecuteBlock<Block> for BlockExecutor {
-	fn execute_block(block: Block) -> Header {
-		execute_block(block)
+	fn execute_block(block: Block) {
+		execute_block(block);
 	}
 }
 


### PR DESCRIPTION
That was actually a bad idea by me, because it should essentially be the
same as block.header.

Ty @kianenigma