### PR TITLE
Ease weight with `#[pallet::autoweight(arg1, arg2, ...)]` expanding to`#[pallet::weight(T::WeightInfo::call_name(arg1, arg2, ...))]`

### DIFF
--- a/frame/support/test/tests/pallet_ui/call_missing_weight.stderr
+++ b/frame/support/test/tests/pallet_ui/call_missing_weight.stderr
@@ -1,4 +1,5 @@
-error: Invalid pallet::call, requires weight attribute i.e. `#[pallet::weight($expr)]`
+error: Invalid pallet::call, weight must be specified with `#[pallet::weight($expr)]` or otherwise weight info type must be specified on the
+                impl item with `#[pallet::weight_info($type)]`.
   --> $DIR/call_missing_weight.rs:17:3
    |
 17 |         fn foo(origin: OriginFor<T>) -> DispatchResultWithPostInfo {}

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight.rs
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight.rs
@@ -1,0 +1,31 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, Weight, DispatchResultWithPostInfo};
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	struct WeightInfo;
+	impl WeightInfo {
+		fn foo(a: u32, b: u32) -> Weight {
+			unimplemented!();
+		}
+	}
+	#[pallet::call]
+	#[pallet::weight_info(WeightInfo)]
+	impl<T: Config> Pallet<T> {
+		fn foo(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			unimplemented!();
+		}
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight.stderr
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight.stderr
@@ -1,0 +1,23 @@
+error[E0061]: this function takes 2 arguments but 0 arguments were supplied
+  --> $DIR/call_wrong_autoweight.rs:22:24
+   |
+1  |    #[frame_support::pallet]
+   |   _________________________-
+2  |  | mod pallet {
+3  |  |     use frame_support::pallet_prelude::{Hooks, Weight, DispatchResultWithPostInfo};
+4  |  |     use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+...   |
+22 |  |     #[pallet::weight_info(WeightInfo)]
+   |  |___________________________^
+23 | ||     impl<T: Config> Pallet<T> {
+24 | ||         fn foo(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+   | ||              ^
+   | ||______________|
+   | |_______________supplied 0 arguments
+   |                 expected 2 arguments
+   |
+note: associated function defined here
+  --> $DIR/call_wrong_autoweight.rs:17:6
+   |
+17 |         fn foo(a: u32, b: u32) -> Weight {
+   |            ^^^---------

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight2.rs
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight2.rs
@@ -1,0 +1,32 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, Weight, DispatchResultWithPostInfo};
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	struct WeightInfo;
+	impl WeightInfo {
+		fn foo(a: u32) -> Weight {
+			unimplemented!();
+		}
+	}
+	#[pallet::call]
+	#[pallet::weight_info(WeightInfo)]
+	impl<T: Config> Pallet<T> {
+		#[pallet::autoweight(a)]
+		fn foo(origin: OriginFor<T>, a: u64) -> DispatchResultWithPostInfo {
+			unimplemented!();
+		}
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight2.stderr
@@ -1,0 +1,5 @@
+error[E0308]: mismatched types
+  --> $DIR/call_wrong_autoweight2.rs:24:24
+   |
+24 |         #[pallet::autoweight(a)]
+   |                              ^ expected `u32`, found `&u64`

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight3.rs
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight3.rs
@@ -1,0 +1,32 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, Weight, DispatchResultWithPostInfo};
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	struct WeightInfo;
+	impl WeightInfo {
+		fn foo(a: u32, b: u32) -> Weight {
+			unimplemented!();
+		}
+	}
+	#[pallet::call]
+	#[pallet::weight_info(WeightInfo)]
+	impl<T: Config> Pallet<T> {
+		#[pallet::autoweight(*a, *a, *a)]
+		fn foo(origin: OriginFor<T>, a: u32) -> DispatchResultWithPostInfo {
+			unimplemented!();
+		}
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_wrong_autoweight3.stderr
+++ b/frame/support/test/tests/pallet_ui/call_wrong_autoweight3.stderr
@@ -1,0 +1,16 @@
+error[E0061]: this function takes 2 arguments but 3 arguments were supplied
+  --> $DIR/call_wrong_autoweight3.rs:22:24
+   |
+22 |       #[pallet::weight_info(WeightInfo)]
+   |  ___________________________^
+23 | |     impl<T: Config> Pallet<T> {
+24 | |         #[pallet::autoweight(*a, *a, *a)]
+   | |                              --  --  -- supplied 3 arguments
+25 | |         fn foo(origin: OriginFor<T>, a: u32) -> DispatchResultWithPostInfo {
+   | |______________^ expected 2 arguments
+   |
+note: associated function defined here
+  --> $DIR/call_wrong_autoweight3.rs:17:6
+   |
+17 |         fn foo(a: u32, b: u32) -> Weight {
+   |            ^^^---------

--- a/frame/support/test/tests/pallet_ui/call_wrong_weight_info.rs
+++ b/frame/support/test/tests/pallet_ui/call_wrong_weight_info.rs
@@ -1,0 +1,22 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::Hooks;
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	#[pallet::call]
+	#[pallet::weight_info(not a type)]
+	impl<T: Config> Pallet<T> {
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_wrong_weight_info.stderr
+++ b/frame/support/test/tests/pallet_ui/call_wrong_weight_info.stderr
@@ -1,0 +1,5 @@
+error: unexpected token
+  --> $DIR/call_wrong_weight_info.rs:16:28
+   |
+16 |     #[pallet::weight_info(not a type)]
+   |                               ^

--- a/frame/support/test/tests/pallet_ui/call_wrong_weight_info2.rs
+++ b/frame/support/test/tests/pallet_ui/call_wrong_weight_info2.rs
@@ -1,0 +1,32 @@
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, DispatchResultWithPostInfo};
+	use frame_system::pallet_prelude::{BlockNumberFor, OriginFor};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	struct NotWeight;
+	struct WeightInfo;
+	impl WeightInfo {
+		fn foo() -> NotWeight {
+			unimplemented!();
+		}
+	}
+	#[pallet::call]
+	#[pallet::weight_info(WeightInfo)]
+	impl<T: Config> Pallet<T> {
+		fn foo(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			unimplemented!();
+		}
+	}
+}
+
+fn main() {
+}

--- a/frame/support/test/tests/pallet_ui/call_wrong_weight_info2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_wrong_weight_info2.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `NotWeight: WeighData<()>` is not satisfied
+  --> $DIR/call_wrong_weight_info2.rs:22:12
+   |
+22 |     #[pallet::call]
+   |               ^^^^ the trait `WeighData<()>` is not implemented for `NotWeight`
+   |
+   = note: required for the cast to the object type `dyn WeighData<()>`
+
+error[E0277]: the trait bound `NotWeight: ClassifyDispatch<()>` is not satisfied
+  --> $DIR/call_wrong_weight_info2.rs:22:12
+   |
+22 |     #[pallet::call]
+   |               ^^^^ the trait `ClassifyDispatch<()>` is not implemented for `NotWeight`
+   |
+   = note: required for the cast to the object type `dyn ClassifyDispatch<()>`
+
+error[E0277]: the trait bound `NotWeight: PaysFee<()>` is not satisfied
+  --> $DIR/call_wrong_weight_info2.rs:22:12
+   |
+22 |     #[pallet::call]
+   |               ^^^^ the trait `PaysFee<()>` is not implemented for `NotWeight`
+   |
+   = note: required for the cast to the object type `dyn PaysFee<()>`


### PR DESCRIPTION
### Description

From Gav:

something like this could be nice:

```rust
#[pallet::call]
impl<T:Config> Pallet<T> {
	#[pallet::weight(T::WeightInfo::set_target())]
	pub fn set_target(origin: OriginFor<T>, arg: u32) { ... }

	#[pallet::weight(T::WeightInfo::set_admin())]
	pub fn set_admin(origin: OriginFor<T>, arg: T::AccountId) { ... }

	#[pallet::weight(T::WeightInfo::set_vec(arg.len() as u32))]
	pub fn set_vec(origin: OriginFor<T>, arg: Vec<u32>) { ... }
}
```

would become:

```rust
#[pallet::call]
#[pallet::weight_info(T::WeightInfo)]
impl<T:Config> Pallet<T> {
	#[pallet::autoweight]
	pub fn set_target(origin: OriginFor<T>, arg: u32) { ... }

	#[pallet::autoweight]
	pub fn set_admin(origin: OriginFor<T>, arg: T::AccountId) { ... }

	#[pallet::autoweight(x: arg.len() as u32)]
	pub fn set_vec(origin: OriginFor<T>, arg: Vec<u32>) { ... }
}
```

and perhaps the #[pallet::autoweight]s could even be dropped in this case.

### Debatable

* I implemented: if no attribute is given on the call, then it is same as `#[pallet::autoweight]`
* should autoweight also have a syntax to specify dispatch class `Normal`, `Operational` or `Mandatory` and a syntax to specify `Pays::No` or `Pays::Yes`.

### TODO

* [ ] doc
* [ ] tests