### PR TITLE
pallet macros: Improve emitted rustdoc

### DIFF
--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -70,7 +70,17 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			.collect::<Vec<_>>()
 	});
 
+	let default_docs = [syn::parse_quote!(
+		r"Contains one variant per dispatchable that can be called by an extrinsic."
+	)];
+	let docs = if def.call.docs.is_empty() {
+		&default_docs[..]
+	} else {
+		&def.call.docs[..]
+	};
+
 	quote::quote_spanned!(def.call.attr_span =>
+		#( #[doc = #docs] )*
 		#[derive(
 			#frame_support::RuntimeDebugNoBound,
 			#frame_support::CloneNoBound,
@@ -87,7 +97,7 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 				#frame_support::sp_std::marker::PhantomData<(#type_use_gen,)>,
 				#frame_support::Never,
 			),
-			#( #fn_name( #( #args_compact_attr #args_type ),* ), )*
+			#( #( #[doc = #fn_doc] )* #fn_name( #( #args_compact_attr #args_type ),* ), )*
 		}
 
 		impl<#type_impl_gen> #frame_support::dispatch::GetDispatchInfo

--- a/frame/support/procedural/src/pallet/expand/config.rs
+++ b/frame/support/procedural/src/pallet/expand/config.rs
@@ -1,0 +1,43 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::pallet::{Def, parse::helper::get_doc_literals};
+
+/// * Generate default rust doc
+pub fn expand_config(def: &mut Def) -> proc_macro2::TokenStream {
+	let config = &def.config;
+	let config_item = {
+		let item = &mut def.item.content.as_mut().expect("Checked by def parser").1[config.index];
+		if let syn::Item::Trait(item) = item {
+			item
+		} else {
+			unreachable!("Checked by config parser")
+		}
+	};
+
+	if get_doc_literals(&config_item.attrs).is_empty() {
+		config_item.attrs.push(syn::parse_quote!(
+			#[doc = r"
+			Configuration trait of this pallet.
+
+			Implement this type for a runtime in order to customize this pallet.
+			"]
+		));
+	}
+
+	Default::default()
+}

--- a/frame/support/procedural/src/pallet/expand/error.rs
+++ b/frame/support/procedural/src/pallet/expand/error.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pallet::Def;
+use crate::pallet::{Def, parse::helper::get_doc_literals};
 
 /// * impl various trait on Error
 /// * impl ModuleErrorMetadata for Error
@@ -73,6 +73,15 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 	};
 
 	error_item.variants.insert(0, phantom_variant);
+
+	if get_doc_literals(&error_item.attrs).is_empty() {
+		error_item.attrs.push(syn::parse_quote!(
+			#[doc = r"
+			Custom [dispatch errors](https://substrate.dev/docs/en/knowledgebase/runtime/errors)
+			of this pallet.
+			"]
+		));
+	}
 
 	quote::quote_spanned!(error.attr_span =>
 		impl<#type_impl_gen> #frame_support::sp_std::fmt::Debug for #error_ident<#type_use_gen>

--- a/frame/support/procedural/src/pallet/expand/genesis_config.rs
+++ b/frame/support/procedural/src/pallet/expand/genesis_config.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pallet::Def;
+use crate::pallet::{Def, parse::helper::get_doc_literals};
 
 /// * add various derive trait on GenesisConfig struct.
 pub fn expand_genesis_config(def: &mut Def) -> proc_macro2::TokenStream {
@@ -33,6 +33,15 @@ pub fn expand_genesis_config(def: &mut Def) -> proc_macro2::TokenStream {
 		syn::Item::Enum(syn::ItemEnum { attrs, ..}) |
 		syn::Item::Struct(syn::ItemStruct { attrs, .. }) |
 		syn::Item::Type(syn::ItemType { attrs, .. }) => {
+			if get_doc_literals(&attrs).is_empty() {
+				attrs.push(syn::parse_quote!(
+					#[doc = r"
+					Can be used to configure the
+					[genesis state](https://substrate.dev/docs/en/knowledgebase/integrate/chain-spec#the-genesis-state)
+					of the contracts pallet.
+					"]
+				));
+			}
 			attrs.push(syn::parse_quote!( #[cfg(feature = "std")] ));
 			attrs.push(syn::parse_quote!(
 				#[derive(#frame_support::Serialize, #frame_support::Deserialize)]

--- a/frame/support/procedural/src/pallet/expand/pallet_struct.rs
+++ b/frame/support/procedural/src/pallet/expand/pallet_struct.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::pallet::Def;
+use crate::pallet::{Def, parse::helper::get_doc_literals};
 
 /// * Add derive trait on Pallet
 /// * Implement GetPalletVersion on Pallet
@@ -49,6 +49,15 @@ pub fn expand_pallet_struct(def: &mut Def) -> proc_macro2::TokenStream {
 				#frame_support::sp_std::marker::PhantomData<(#type_use_gen)>
 			);
 		}
+	}
+
+	if get_doc_literals(&pallet_item.attrs).is_empty() {
+		pallet_item.attrs.push(syn::parse_quote!(
+			#[doc = r"
+			The [pallet](https://substrate.dev/docs/en/knowledgebase/runtime/pallets) implementing
+			the on-chain logic.
+			"]
+		));
 	}
 
 	pallet_item.attrs.push(syn::parse_quote!(

--- a/frame/support/procedural/src/pallet/parse/call.rs
+++ b/frame/support/procedural/src/pallet/parse/call.rs
@@ -41,6 +41,8 @@ pub struct CallDef {
 	pub methods: Vec<CallVariantDef>,
 	/// The span of the pallet::call attribute.
 	pub attr_span: proc_macro2::Span,
+	/// Docs, specified on the impl Block.
+	pub docs: Vec<syn::Lit>,
 }
 
 /// Definition of dispatchable typically: `#[weight...] fn foo(origin .., param1: ...) -> ..`
@@ -228,6 +230,7 @@ impl CallDef {
 			instances,
 			methods,
 			where_clause: item.generics.where_clause.clone(),
+			docs: helper::get_doc_literals(&item.attrs),
 		})
 	}
 }


### PR DESCRIPTION
Having types in the reference documentation without a rust doc creates a low quality impression. That said, many types emitted or augmented by the pallet macro don't need custom docs because those are well known types like `Call` and `Config` which pretty much can get a stock documentation pointing users to the relevant knowledge base article.

This PR emits such a stock documentation for the well known types in case no own documentation is specified.

* Emit default docs for: `mod pallet`, `Config`, `GenesisConfig`, `Pallet`, `Call`, `Error`, `Event`
* Emit documentation for the `Call` variants (copied from the pallet impl)

Please also review and improve the actual docs emitted.