### PR TITLE
Introduce new concept of "slot portion for proposing"

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -9,7 +9,7 @@ use sp_inherents::InherentDataProviders;
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use sc_consensus_aura::{ImportQueueParams, StartAuraParams};
+use sc_consensus_aura::{ImportQueueParams, StartAuraParams, SlotPortion};
 use sc_finality_grandpa::SharedVoterState;
 use sc_keystore::LocalKeystore;
 use sc_telemetry::TelemetrySpan;
@@ -212,6 +212,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 				keystore: keystore_container.sync_keystore(),
 				can_author_with,
 				sync_oracle: network.clone(),
+				slot_portion_proposing: SlotPortion::new(2f32 / 3f32),
 			},
 		)?;
 

--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -9,7 +9,7 @@ use sp_inherents::InherentDataProviders;
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
-use sc_consensus_aura::{ImportQueueParams, StartAuraParams, SlotPortion};
+use sc_consensus_aura::{ImportQueueParams, StartAuraParams, SlotProportion};
 use sc_finality_grandpa::SharedVoterState;
 use sc_keystore::LocalKeystore;
 use sc_telemetry::TelemetrySpan;
@@ -212,7 +212,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 				keystore: keystore_container.sync_keystore(),
 				can_author_with,
 				sync_oracle: network.clone(),
-				slot_portion_proposing: SlotPortion::new(2f32 / 3f32),
+				block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
 			},
 		)?;
 

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -25,8 +25,7 @@ use sc_consensus_babe;
 use node_primitives::Block;
 use node_runtime::RuntimeApi;
 use sc_service::{
-	config::{Configuration}, error::{Error as ServiceError},
-	RpcHandlers, TaskManager,
+	config::Configuration, error::Error as ServiceError, RpcHandlers, TaskManager,
 };
 use sp_inherents::InherentDataProviders;
 use sc_network::{Event, NetworkService};
@@ -35,6 +34,7 @@ use futures::prelude::*;
 use sc_client_api::{ExecutorProvider, RemoteBackend};
 use node_executor::Executor;
 use sc_telemetry::{TelemetryConnectionNotifier, TelemetrySpan};
+use sc_consensus_babe::SlotPortion;
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
 type FullBackend = sc_service::TFullBackend<Block>;
@@ -279,6 +279,7 @@ pub fn new_full_base(
 			backoff_authoring_blocks,
 			babe_link,
 			can_author_with,
+			slot_portion_proposing: SlotPortion::new(0.5),
 		};
 
 		let babe = sc_consensus_babe::start_babe(babe_config)?;

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -34,7 +34,7 @@ use futures::prelude::*;
 use sc_client_api::{ExecutorProvider, RemoteBackend};
 use node_executor::Executor;
 use sc_telemetry::{TelemetryConnectionNotifier, TelemetrySpan};
-use sc_consensus_babe::SlotPortion;
+use sc_consensus_babe::SlotProportion;
 
 type FullClient = sc_service::TFullClient<Block, RuntimeApi, Executor>;
 type FullBackend = sc_service::TFullBackend<Block>;
@@ -279,7 +279,7 @@ pub fn new_full_base(
 			backoff_authoring_blocks,
 			babe_link,
 			can_author_with,
-			slot_portion_proposing: SlotPortion::new(0.5),
+			block_proposal_slot_portion: SlotProportion::new(0.5),
 		};
 
 		let babe = sc_consensus_babe::start_babe(babe_config)?;

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -69,6 +69,7 @@ pub use sp_consensus_aura::{
 };
 pub use sp_consensus::SyncOracle;
 pub use import_queue::{ImportQueueParams, import_queue, AuraBlockImport, CheckForEquivocation};
+pub use sc_consensus_slots::SlotPortion;
 
 type AuthorityId<P> = <P as Pair>::Public;
 
@@ -142,6 +143,12 @@ pub struct StartAuraParams<C, SC, I, PF, SO, BS, CAW> {
 	pub keystore: SyncCryptoStorePtr,
 	/// Can we author a block with this node?
 	pub can_author_with: CAW,
+	/// The portion of the slot dedicated to proposing.
+	///
+	/// The block proposing will be limited to this portion of the slot from the starting of the slot.
+	/// However, the proposing can still take longer when there is some lenience factor applied,
+	/// because there were no blocks produced for some slots.
+	pub slot_portion_proposing: SlotPortion,
 }
 
 /// Start the aura worker. The returned future should be run in a futures executor.
@@ -158,6 +165,7 @@ pub fn start_aura<P, B, C, SC, PF, I, SO, CAW, BS, Error>(
 		backoff_authoring_blocks,
 		keystore,
 		can_author_with,
+		slot_portion_proposing,
 	}: StartAuraParams<C, SC, I, PF, SO, BS, CAW>,
 ) -> Result<impl Future<Output = ()>, sp_consensus::Error> where
 	B: BlockT,
@@ -184,6 +192,7 @@ pub fn start_aura<P, B, C, SC, PF, I, SO, CAW, BS, Error>(
 		force_authoring,
 		backoff_authoring_blocks,
 		_key_type: PhantomData::<P>,
+		slot_portion_proposing,
 	};
 	register_aura_inherent_data_provider(
 		&inherent_data_providers,
@@ -208,6 +217,7 @@ struct AuraWorker<C, E, I, P, SO, BS> {
 	sync_oracle: SO,
 	force_authoring: bool,
 	backoff_authoring_blocks: Option<BS>,
+	slot_portion_proposing: SlotPortion,
 	_key_type: PhantomData<P>,
 }
 
@@ -365,11 +375,22 @@ where
 		&self,
 		head: &B::Header,
 		slot_info: &SlotInfo,
-	) -> Option<std::time::Duration> {
-		let slot_remaining = self.slot_remaining_duration(slot_info);
+	) -> std::time::Duration {
+		let max_proposing = slot_info.duration.mul_f32(self.slot_portion_proposing.get());
+
+		let slot_remaining = slot_info.ends_at
+			.checked_duration_since(std::time::Instant::now())
+			.unwrap_or_default();
+
+		let slot_remaining = std::cmp::min(slot_remaining, max_proposing);
+
+		// If parent is genesis block, we don't require any lenience factor.
+		if head.number().is_zero() {
+			return slot_remaining
+		}
 
 		let parent_slot = match find_pre_digest::<B, P::Signature>(head) {
-			Err(_) => return Some(slot_remaining),
+			Err(_) => return slot_remaining,
 			Ok(d) => d,
 		};
 
@@ -383,9 +404,9 @@ where
 				slot_lenience.as_secs(),
 			);
 
-			Some(slot_remaining + slot_lenience)
+			slot_remaining + slot_lenience
 		} else {
-			Some(slot_remaining)
+			slot_remaining
 		}
 	}
 }
@@ -648,6 +669,7 @@ mod tests {
 				backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
 				keystore,
 				can_author_with: sp_consensus::AlwaysCanAuthor,
+				slot_portion_proposing: SlotPortion::new(0.5),
 			}).expect("Starts aura"));
 		}
 
@@ -708,6 +730,7 @@ mod tests {
 			force_authoring: false,
 			backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
 			_key_type: PhantomData::<AuthorityPair>,
+			slot_portion_proposing: SlotPortion::new(0.5),
 		};
 
 		let head = Header::new(
@@ -755,6 +778,7 @@ mod tests {
 			force_authoring: false,
 			backoff_authoring_blocks: Option::<()>::None,
 			_key_type: PhantomData::<AuthorityPair>,
+			slot_portion_proposing: SlotPortion::new(0.5),
 		};
 
 		let head = client.header(&BlockId::Number(0)).unwrap().unwrap();
@@ -766,7 +790,7 @@ mod tests {
 				timestamp: 0,
 				ends_at: Instant::now() + Duration::from_secs(100),
 				inherent_data: InherentData::new(),
-				duration: 1000,
+				duration: Duration::from_millis(1000),
 			},
 		)).unwrap();
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -74,6 +74,7 @@ pub use sp_consensus_babe::{
 	},
 };
 pub use sp_consensus::SyncOracle;
+pub use sc_consensus_slots::SlotPortion;
 use std::{
 	collections::HashMap, sync::Arc, u64, pin::Pin, time::{Instant, Duration},
 	any::Any, borrow::Cow, convert::TryInto,
@@ -394,6 +395,13 @@ pub struct BabeParams<B: BlockT, C, E, I, SO, SC, CAW, BS> {
 
 	/// Checks if the current native implementation can author with a runtime at a given block.
 	pub can_author_with: CAW,
+
+	/// The portion of the slot dedicated to proposing.
+	///
+	/// The block proposing will be limited to this portion of the slot from the starting of the slot.
+	/// However, the proposing can still take longer when there is some lenience factor applied,
+	/// because there were no blocks produced for some slots.
+	pub slot_portion_proposing: SlotPortion,
 }
 
 /// Start the babe worker.
@@ -409,6 +417,7 @@ pub fn start_babe<B, C, SC, E, I, SO, CAW, BS, Error>(BabeParams {
 	backoff_authoring_blocks,
 	babe_link,
 	can_author_with,
+	slot_portion_proposing,
 }: BabeParams<B, C, E, I, SO, SC, CAW, BS>) -> Result<
 	BabeWorker<B>,
 	sp_consensus::Error,
@@ -443,6 +452,7 @@ pub fn start_babe<B, C, SC, E, I, SO, CAW, BS, Error>(BabeParams {
 		epoch_changes: babe_link.epoch_changes.clone(),
 		slot_notification_sinks: slot_notification_sinks.clone(),
 		config: config.clone(),
+		slot_portion_proposing,
 	};
 
 	register_babe_inherent_data_provider(&inherent_data_providers, config.slot_duration())?;
@@ -597,6 +607,7 @@ struct BabeSlotWorker<B: BlockT, C, E, I, SO, BS> {
 	epoch_changes: SharedEpochChanges<B, Epoch>,
 	slot_notification_sinks: SlotNotificationSinks<B>,
 	config: Config,
+	slot_portion_proposing: SlotPortion,
 }
 
 impl<B, C, E, I, Error, SO, BS> sc_consensus_slots::SimpleSlotWorker<B>
@@ -791,16 +802,22 @@ where
 		&self,
 		parent_head: &B::Header,
 		slot_info: &SlotInfo,
-	) -> Option<std::time::Duration> {
-		let slot_remaining = self.slot_remaining_duration(slot_info);
+	) -> std::time::Duration {
+		let max_proposing = slot_info.duration.mul_f32(self.slot_portion_proposing.get());
+
+		let slot_remaining = slot_info.ends_at
+			.checked_duration_since(Instant::now())
+			.unwrap_or_default();
+
+		let slot_remaining = std::cmp::min(slot_remaining, max_proposing);
 
 		// If parent is genesis block, we don't require any lenience factor.
 		if parent_head.number().is_zero() {
-			return Some(slot_remaining)
+			return slot_remaining
 		}
 
 		let parent_slot = match find_pre_digest::<B>(parent_head) {
-			Err(_) => return Some(slot_remaining),
+			Err(_) => return slot_remaining,
 			Ok(d) => d.slot(),
 		};
 
@@ -814,9 +831,9 @@ where
 				slot_lenience.as_secs(),
 			);
 
-			Some(slot_remaining + slot_lenience)
+			slot_remaining + slot_lenience
 		} else {
-			Some(slot_remaining)
+			slot_remaining
 		}
 	}
 }

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -431,7 +431,7 @@ fn run_one_test(
 			babe_link: data.link.clone(),
 			keystore,
 			can_author_with: sp_consensus::AlwaysCanAuthor,
-			slot_portion_proposing: SlotPortion::new(0.5),
+			block_proposal_slot_portion: SlotProportion::new(0.5),
 		}).expect("Starts babe"));
 	}
 	futures::executor::block_on(future::select(

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -431,6 +431,7 @@ fn run_one_test(
 			babe_link: data.link.clone(),
 			keystore,
 			can_author_with: sp_consensus::AlwaysCanAuthor,
+			slot_portion_proposing: SlotPortion::new(0.5),
 		}).expect("Starts babe"));
 	}
 	futures::executor::block_on(future::select(

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -621,7 +621,8 @@ pub fn slot_lenience_linear(parent_slot: Slot, slot_info: &SlotInfo) -> Option<D
 		None
 	} else {
 		let slot_lenience = std::cmp::min(skipped_slots, BACKOFF_CAP);
-		Some(slot_info.duration.mul_f64(slot_lenience as f64))
+		// We cap `slot_lenience` to `20`, so it should always fit into an `u32`.
+		Some(slot_info.duration * (slot_lenience as u32))
 	}
 }
 

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -554,11 +554,11 @@ impl<T: Clone + Send + Sync + 'static> SlotDuration<T> {
 	}
 }
 
-/// A unit type wrapper to express the portion of a slot.
-pub struct SlotPortion(f32);
+/// A unit type wrapper to express the proportion of a slot.
+pub struct SlotProportion(f32);
 
-impl SlotPortion {
-	/// Create a new portion.
+impl SlotProportion {
+	/// Create a new proportion.
 	///
 	/// The given value `inner` should be in the range `[0,1]`. If the value is not in the required
 	/// range, it is clamped into the range.

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -32,7 +32,7 @@ pub use slots::SlotInfo;
 use slots::Slots;
 pub use aux_schema::{check_equivocation, MAX_SLOT_CAPACITY, PRUNING_BOUND};
 
-use std::{fmt::Debug, ops::Deref, pin::Pin, sync::Arc, time::{Instant, Duration}};
+use std::{fmt::Debug, ops::Deref, pin::Pin, sync::Arc, time::Duration};
 use codec::{Decode, Encode};
 use futures::{prelude::*, future::{self, Either}};
 use futures_timer::Delay;
@@ -180,24 +180,12 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	/// Returns a `Proposer` to author on top of the given block.
 	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer;
 
-	/// Remaining duration of the slot.
-	fn slot_remaining_duration(&self, slot_info: &SlotInfo) -> Duration {
-		let now = Instant::now();
-		if now < slot_info.ends_at {
-			slot_info.ends_at.duration_since(now)
-		} else {
-			Duration::from_millis(0)
-		}
-	}
-
-	/// Remaining duration for proposing. None means unlimited.
+	/// Remaining duration for proposing.
 	fn proposing_remaining_duration(
 		&self,
-		_head: &B::Header,
+		head: &B::Header,
 		slot_info: &SlotInfo,
-	) -> Option<Duration> {
-		Some(self.slot_remaining_duration(slot_info))
-	}
+	) -> Duration;
 
 	/// Implements [`SlotWorker::on_slot`].
 	fn on_slot(
@@ -210,21 +198,19 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	{
 		let (timestamp, slot) = (slot_info.timestamp, slot_info.slot);
 
-		let slot_remaining_duration = self.slot_remaining_duration(&slot_info);
 		let proposing_remaining_duration = self.proposing_remaining_duration(&chain_head, &slot_info);
 
-		let proposing_remaining = match proposing_remaining_duration {
-			Some(r) if r.as_secs() == 0 && r.as_nanos() == 0 => {
-				debug!(
-					target: self.logging_target(),
-					"Skipping proposal slot {} since there's no time left to propose",
-					slot,
-				);
+		let proposing_remaining = if proposing_remaining_duration == Duration::default() {
+			debug!(
+				target: self.logging_target(),
+				"Skipping proposal slot {} since there's no time left to propose",
+				slot,
+			);
 
-				return Box::pin(future::ready(None));
-			},
-			Some(r) => Box::new(Delay::new(r)) as Box<dyn Future<Output = ()> + Unpin + Send>,
-			None => Box::new(future::pending()) as Box<_>,
+			return Box::pin(future::ready(None));
+		} else {
+			Box::new(Delay::new(proposing_remaining_duration))
+				as Box<dyn Future<Output = ()> + Unpin + Send>
 		};
 
 		let epoch_data = match self.epoch_data(&chain_head, slot) {
@@ -298,20 +284,25 @@ pub trait SimpleSlotWorker<B: BlockT> {
 
 		let logs = self.pre_digest_data(slot, &claim);
 
-		// deadline our production to approx. the end of the slot
+		// deadline our production to 98% of the total time left for proposing. As we deadline
+		// the proposing below to the same total time left, the 2% margin should be enough for
+		// the result to be returned.
 		let proposing = awaiting_proposer.and_then(move |proposer| proposer.propose(
 			slot_info.inherent_data,
 			sp_runtime::generic::Digest {
 				logs,
 			},
-			slot_remaining_duration,
+			proposing_remaining_duration.mul_f32(0.98),
 		).map_err(|e| sp_consensus::Error::ClientImport(format!("{:?}", e))));
 
 		let proposal_work =
 			futures::future::select(proposing, proposing_remaining).map(move |v| match v {
 				Either::Left((b, _)) => b.map(|b| (b, claim)),
 				Either::Right(_) => {
-					info!("⌛️ Discarding proposal for slot {}; block production took too long", slot);
+					info!(
+						"⌛️ Discarding proposal for slot {}; block production took too long",
+						slot,
+					);
 					// If the node was compiled with debug, tell the user to use release optimizations.
 					#[cfg(build_type="debug")]
 					info!("👉 Recompile your node in `--release` mode to mitigate this problem.");
@@ -381,8 +372,7 @@ pub trait SimpleSlotWorker<B: BlockT> {
 	}
 }
 
-impl<B: BlockT, T: SimpleSlotWorker<B>> SlotWorker<B, <T::Proposer as Proposer<B>>::Proof> for T
-{
+impl<B: BlockT, T: SimpleSlotWorker<B>> SlotWorker<B, <T::Proposer as Proposer<B>>::Proof> for T {
 	fn on_slot(
 		&mut self,
 		chain_head: B::Header,
@@ -564,6 +554,24 @@ impl<T: Clone + Send + Sync + 'static> SlotDuration<T> {
 	}
 }
 
+/// A unit type wrapper to express the portion of a slot.
+pub struct SlotPortion(f32);
+
+impl SlotPortion {
+	/// Create a new portion.
+	///
+	/// The given value `inner` should be in the range `[0,1]`. If the value is not in the required
+	/// range, it is clamped into the range.
+	pub fn new(inner: f32) -> Self {
+		Self(inner.clamp(0.0, 1.0))
+	}
+
+	/// Returns the inner that is guaranted to be in the range `[0,1]`.
+	pub fn get(&self) -> f32 {
+		self.0
+	}
+}
+
 /// Calculate a slot duration lenience based on the number of missed slots from current
 /// to parent. If the number of skipped slots is greated than 0 this method will apply
 /// an exponential backoff of at most `2^7 * slot_duration`, if no slots were skipped
@@ -589,7 +597,7 @@ pub fn slot_lenience_exponential(parent_slot: Slot, slot_info: &SlotInfo) -> Opt
 		let slot_lenience = skipped_slots / BACKOFF_STEP;
 		let slot_lenience = std::cmp::min(slot_lenience, BACKOFF_CAP);
 		let slot_lenience = 1 << slot_lenience;
-		Some(Duration::from_millis(slot_lenience * slot_info.duration))
+		Some(slot_lenience * slot_info.duration)
 	}
 }
 
@@ -613,7 +621,7 @@ pub fn slot_lenience_linear(parent_slot: Slot, slot_info: &SlotInfo) -> Option<D
 		None
 	} else {
 		let slot_lenience = std::cmp::min(skipped_slots, BACKOFF_CAP);
-		Some(Duration::from_millis(slot_lenience * slot_info.duration))
+		Some(slot_info.duration.mul_f64(slot_lenience as f64))
 	}
 }
 
@@ -727,7 +735,7 @@ mod test {
 	fn slot(slot: u64) -> super::slots::SlotInfo {
 		super::slots::SlotInfo {
 			slot: slot.into(),
-			duration: SLOT_DURATION.as_millis() as u64,
+			duration: SLOT_DURATION,
 			timestamp: Default::default(),
 			inherent_data: Default::default(),
 			ends_at: Instant::now(),

--- a/client/consensus/slots/src/slots.rs
+++ b/client/consensus/slots/src/slots.rs
@@ -40,9 +40,11 @@ pub fn duration_now() -> Duration {
 }
 
 /// Returns the duration until the next slot, based on current duration since
-pub fn time_until_next(now: Duration, slot_duration: u64) -> Duration {
-	let remaining_full_millis = slot_duration - (now.as_millis() as u64 % slot_duration) - 1;
-	Duration::from_millis(remaining_full_millis)
+pub fn time_until_next(now: Duration, slot_duration: Duration) -> Duration {
+	let remaining_full_millis = slot_duration.as_millis()
+		- (now.as_millis() % slot_duration.as_millis())
+		- 1;
+	Duration::from_millis(remaining_full_millis as u64)
 }
 
 /// Information about a slot.
@@ -56,13 +58,13 @@ pub struct SlotInfo {
 	/// The inherent data.
 	pub inherent_data: InherentData,
 	/// Slot duration.
-	pub duration: u64,
+	pub duration: Duration,
 }
 
 /// A stream that returns every time there is a new slot.
 pub(crate) struct Slots<SC> {
 	last_slot: Slot,
-	slot_duration: u64,
+	slot_duration: Duration,
 	inner_delay: Option<Delay>,
 	inherent_data_providers: InherentDataProviders,
 	timestamp_extractor: SC,
@@ -77,7 +79,7 @@ impl<SC> Slots<SC> {
 	) -> Self {
 		Slots {
 			last_slot: 0.into(),
-			slot_duration,
+			slot_duration: Duration::from_millis(slot_duration),
 			inner_delay: None,
 			inherent_data_providers,
 			timestamp_extractor,


### PR DESCRIPTION
Currently when building a block we actually give the proposer all of the
time in the slot, while this is wrong. The slot is actually split in at
least two phases proposing and propagation or in the polkadot case into
three phases validating pov's, proposing and propagation. As we don't
want to bring that much polkadot concepts into Substrate, we only
support splitting the slot into proposing and propagation. The portion
can now be passed as parameter to AuRa and BABE to configure this value.
However, this slot portion for propagation doesn't mean that the
proposer can not go over this limit. When we miss slots we still apply
the lenience factor to increase the proposing time, so that we have
enough time to build a heavy block.

Besides all what was said above, this is especially required for
parachains. Parachains have a much more constraint proposing window.
Currently the slot duration is at minimum 12 seconds, but we only have
around 500ms for proposing. So, this slot portion for proposing is
really required to make it working without hacks.

polkadot companion: https://github.com/paritytech/polkadot/pull/2578

