### PR TITLE
Log incoming block requests with sync

### DIFF
--- a/client/network/src/block_request_handler.rs
+++ b/client/network/src/block_request_handler.rs
@@ -34,7 +34,7 @@ use std::cmp::min;
 use std::sync::{Arc};
 use std::time::Duration;
 
-const LOG_TARGET: &str = "block-request-handler";
+const LOG_TARGET: &str = "sync";
 const MAX_BLOCKS_IN_RESPONSE: usize = 128;
 const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 


### PR DESCRIPTION
`sync` is the target relevant to everything related to syncing, and thus it should be used to log incoming block requests as well.
This is technically a CLI breaking change, but I don't think it matters much.