### PR TITLE
Introduce IgnoredIssuance into Gilts

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1046,6 +1046,7 @@ impl pallet_assets::Config for Runtime {
 }
 
 parameter_types! {
+	pub IgnoredIssuance: Balance = Treasury::pot();
 	pub const QueueCount: u32 = 300;
 	pub const MaxQueueLen: u32 = 1000;
 	pub const FifoQueueLen: u32 = 500;
@@ -1061,6 +1062,7 @@ impl pallet_gilt::Config for Runtime {
 	type AdminOrigin = frame_system::EnsureRoot<AccountId>;
 	type Deficit = ();
 	type Surplus = ();
+	type IgnoredIssuance = IgnoredIssuance;
 	type QueueCount = QueueCount;
 	type MaxQueueLen = MaxQueueLen;
 	type FifoQueueLen = FifoQueueLen;

--- a/frame/gilt/src/mock.rs
+++ b/frame/gilt/src/mock.rs
@@ -20,7 +20,8 @@
 use crate as pallet_gilt;
 
 use frame_support::{
-	parameter_types, ord_parameter_types, traits::{OnInitialize, OnFinalize, GenesisBuild},
+	parameter_types, ord_parameter_types,
+	traits::{OnInitialize, OnFinalize, GenesisBuild, Get, Currency},
 };
 use sp_core::H256;
 use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
@@ -98,12 +99,21 @@ ord_parameter_types! {
 	pub const One: u64 = 1;
 }
 
+pub struct IgnoredIssuance;
+impl Get<u64> for IgnoredIssuance {
+	fn get() -> u64 {
+		// Account zero is ignored.
+		Balances::total_balance(&0)
+	}
+}
+
 impl pallet_gilt::Config for Test {
 	type Event = Event;
 	type Currency = Balances;
 	type AdminOrigin = frame_system::EnsureSignedBy<One, Self::AccountId>;
 	type Deficit = ();
 	type Surplus = ();
+	type IgnoredIssuance = IgnoredIssuance;
 	type QueueCount = QueueCount;
 	type MaxQueueLen = MaxQueueLen;
 	type FifoQueueLen = FifoQueueLen;

--- a/frame/gilt/src/mock.rs
+++ b/frame/gilt/src/mock.rs
@@ -21,7 +21,7 @@ use crate as pallet_gilt;
 
 use frame_support::{
 	parameter_types, ord_parameter_types,
-	traits::{OnInitialize, OnFinalize, GenesisBuild, Get, Currency},
+	traits::{OnInitialize, OnFinalize, GenesisBuild, Currency},
 };
 use sp_core::H256;
 use sp_runtime::{traits::{BlakeTwo256, IdentityLookup}, testing::Header};
@@ -87,6 +87,7 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
+	pub IgnoredIssuance: u64 = Balances::total_balance(&0); // Account zero is ignored.
 	pub const QueueCount: u32 = 3;
 	pub const MaxQueueLen: u32 = 3;
 	pub const FifoQueueLen: u32 = 1;
@@ -97,14 +98,6 @@ parameter_types! {
 }
 ord_parameter_types! {
 	pub const One: u64 = 1;
-}
-
-pub struct IgnoredIssuance;
-impl Get<u64> for IgnoredIssuance {
-	fn get() -> u64 {
-		// Account zero is ignored.
-		Balances::total_balance(&0)
-	}
 }
 
 impl pallet_gilt::Config for Test {

--- a/frame/gilt/src/tests.rs
+++ b/frame/gilt/src/tests.rs
@@ -323,6 +323,30 @@ fn thaw_when_issuance_higher_works() {
 }
 
 #[test]
+fn thaw_with_ignored_issuance_works() {
+	new_test_ext().execute_with(|| {
+		run_to_block(1);
+		// Give account zero some balance.
+		Balances::make_free_balance_be(&0, 200);
+
+		assert_ok!(Gilt::place_bid(Origin::signed(1), 100, 1));
+		Gilt::enlarge(100, 1);
+
+		// Account zero transfers 50 into everyone else's accounts.
+		assert_ok!(Balances::transfer(Origin::signed(0), 2, 50));
+		assert_ok!(Balances::transfer(Origin::signed(0), 3, 50));
+		assert_ok!(Balances::transfer(Origin::signed(0), 4, 50));
+
+		run_to_block(4);
+		assert_ok!(Gilt::thaw(Origin::signed(1), 0));
+
+		// Account zero changes have been ignored.
+		assert_eq!(Balances::free_balance(1), 150);
+		assert_eq!(Balances::reserved_balance(1), 0);
+	});
+}
+
+#[test]
 fn thaw_when_issuance_lower_works() {
 	new_test_ext().execute_with(|| {
 		run_to_block(1);


### PR DESCRIPTION
IgnoredIssuance allows for excuding some balance from total_issuance for determining the degree to which the taken base has been inflated/deflated. This is expected to be used to exclude the treasury account.