### PR TITLE
Fix typo in generated docs

### DIFF
--- a/frame/support/procedural/src/pallet/expand/genesis_config.rs
+++ b/frame/support/procedural/src/pallet/expand/genesis_config.rs
@@ -38,7 +38,7 @@ pub fn expand_genesis_config(def: &mut Def) -> proc_macro2::TokenStream {
 					#[doc = r"
 					Can be used to configure the
 					[genesis state](https://substrate.dev/docs/en/knowledgebase/integrate/chain-spec#the-genesis-state)
-					of the contracts pallet.
+					of this pallet.
 					"]
 				));
 			}


### PR DESCRIPTION
This is a fixup for #8276. I copy and pasted the doc comment from the contracts module.