### PR TITLE
CI: return docs jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -478,7 +478,6 @@ build-rust-doc:
   variables:
     <<:                            *default-vars
     SKIP_WASM_BUILD:               1
-    RUSTDOCFLAGS:                  "--html-in-header $(pwd)/.maintain/rustdoc-header.html"
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success
@@ -486,8 +485,8 @@ build-rust-doc:
     paths:
     - ./crate-docs/
   script:
-    - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
-    - time cargo +nightly doc --no-deps --workspace --all-features --verbose
+    - RUSTDOCFLAGS="--html-in-header $(pwd)/.maintain/rustdoc-header.html"
+        time cargo +nightly doc --no-deps --workspace --all-features --verbose
     - mv ./target/doc ./crate-docs
     - echo "<meta http-equiv=refresh content=0;url=sc_service/index.html>" > ./crate-docs/index.html
     - sccache -s

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -478,7 +478,7 @@ build-rust-doc:
   variables:
     <<:                            *default-vars
     SKIP_WASM_BUILD:               1
-    RUSTDOCFLAGS:                  "--html-in-header $(pwd)/.maintain/rustdoc-header.html -Dwarnings"
+    RUSTDOCFLAGS:                  "--html-in-header $(pwd)/.maintain/rustdoc-header.html"
   artifacts:
     name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
     when:                          on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -468,6 +468,31 @@ build-macos-subkey:
   tags:
     - osx
 
+build-rust-doc:
+  stage:                           build
+  <<:                              *docker-env
+  <<:                              *test-refs
+  needs:
+    - job:                         test-linux-stable
+      artifacts:                   false
+  variables:
+    <<:                            *default-vars
+    SKIP_WASM_BUILD:               1
+    RUSTDOCFLAGS:                  "--html-in-header $(pwd)/.maintain/rustdoc-header.html -Dwarnings"
+  artifacts:
+    name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}-doc"
+    when:                          on_success
+    expire_in:                     7 days
+    paths:
+    - ./crate-docs/
+  script:
+    - rm -f ./crate-docs/index.html # use it as an indicator if the job succeeds
+    - time cargo +nightly doc --no-deps --workspace --all-features --verbose
+    - mv ./target/doc ./crate-docs
+    - echo "<meta http-equiv=refresh content=0;url=sc_service/index.html>" > ./crate-docs/index.html
+    - sccache -s
+  allow_failure:                   true
+
 #### stage:                        publish
 
 .build-push-docker-image:          &build-push-docker-image
@@ -549,6 +574,32 @@ publish-s3-release:
   after_script:
     - aws s3 ls s3://${BUCKET}/${PREFIX}/latest/
         --recursive --human-readable --summarize
+
+publish-s3-doc:
+  stage:                           publish
+  image:                           paritytech/awscli:latest
+  allow_failure:                   true
+  needs:
+    - job:                         build-rust-doc
+      artifacts:                   true
+    - job:                         build-linux-substrate
+      artifacts:                   false
+  <<:                              *publish-refs
+  <<:                              *kubernetes-build
+  variables:
+    GIT_STRATEGY:                  none
+    BUCKET:                        "releases.parity.io"
+    PREFIX:                        "substrate-rustdoc"
+  script:
+    - test -r ./crate-docs/index.html || (
+        echo "./crate-docs/index.html not present, build:rust:doc:release job not complete";
+        exit 1
+      )
+    - aws s3 sync --delete --size-only --only-show-errors
+        ./crate-docs/ s3://${BUCKET}/${PREFIX}/
+  after_script:
+    - aws s3 ls s3://${BUCKET}/${PREFIX}/
+        --human-readable --summarize
 
 publish-draft-release:
   stage:                           publish


### PR DESCRIPTION
- run docs generation on PRs temporarily (until https://github.com/paritytech/substrate/pull/7670 is resolved) allowing them to fail 
- publish successful docs on master updates