### PR TITLE
Fix #8306

### DIFF
--- a/client/network/src/protocol/generic_proto/behaviour.rs
+++ b/client/network/src/protocol/generic_proto/behaviour.rs
@@ -1790,6 +1790,7 @@ impl NetworkBehaviour for GenericProto {
 						}
 					},
 
+					Some(PeerState::Incoming { connections, .. }) |
 					Some(PeerState::DisabledPendingEnable { connections, .. }) |
 					Some(PeerState::Disabled { connections, .. }) => {
 						if let Some((_, connec_state)) = connections.iter_mut().find(|(c, s)|
@@ -1861,36 +1862,29 @@ impl NetworkBehaviour for GenericProto {
 							*entry.into_mut() = PeerState::Enabled { connections };
 						}
 					},
-					PeerState::Disabled { mut connections, backoff_until } => {
-						if let Some((_, connec_state)) = connections.iter_mut().find(|(c, s)|
-							*c == connection && matches!(s, ConnectionState::OpeningThenClosing))
-						{
-							*connec_state = ConnectionState::Closing;
-						} else {
-							error!(target: "sub-libp2p",
-								"OpenResultErr: State mismatch in the custom protos handler");
-							debug_assert!(false);
-						}
-
-						*entry.into_mut() = PeerState::Disabled { connections, backoff_until };
-					},
-					PeerState::DisabledPendingEnable { mut connections, timer, timer_deadline } => {
-						if let Some((_, connec_state)) = connections.iter_mut().find(|(c, s)|
-							*c == connection && matches!(s, ConnectionState::OpeningThenClosing))
-						{
-							*connec_state = ConnectionState::Closing;
-						} else {
-							error!(target: "sub-libp2p",
-								"OpenResultErr: State mismatch in the custom protos handler");
-							debug_assert!(false);
-						}
-
-						*entry.into_mut() = PeerState::DisabledPendingEnable {
-							connections,
-							timer,
-							timer_deadline,
+					mut state @ PeerState::Incoming { .. } |
+					mut state @ PeerState::DisabledPendingEnable { .. } |
+					mut state @ PeerState::Disabled { .. } => {
+						match &mut state {
+							PeerState::Incoming { connections, .. } |
+							PeerState::Disabled { connections, .. } |
+							PeerState::DisabledPendingEnable { connections, .. } => {
+								if let Some((_, connec_state)) = connections.iter_mut().find(|(c, s)|
+									*c == connection && matches!(s, ConnectionState::OpeningThenClosing))
+								{
+									*connec_state = ConnectionState::Closing;
+								} else {
+									error!(target: "sub-libp2p",
+										"OpenResultErr: State mismatch in the custom protos handler");
+									debug_assert!(false);
+								}
+							},
+							_ => unreachable!("Match branches are the same as the one on which we
+							enter this block; qed"),
 						};
-					},
+
+						*entry.into_mut() = state;
+					}
 					state => {
 						error!(target: "sub-libp2p",
 							"Unexpected state in the custom protos handler: {:?}",


### PR DESCRIPTION
Fix #8306 

If the behaviour sends `Open` then `Close`, the peer state is switched to `Disabled`. If it then receives an `OpenDesiredByRemote`, the behaviour switches the peer state to `Incoming` to reflect the fact that the peerset is processing an incoming connection.

If, then, the behaviour receives `OpenResultErr` and `CloseResult`, as is expected if you send `Open` then `Close`, then it is normal to find an `Incoming` there.
Before this PR, we would consider finding `Incoming` there as a bug in the code.
