### PR TITLE
Don't log so many stkaing events on genesis block

### DIFF
--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1024,7 +1024,9 @@ impl<T: Config> Pallet<T> {
 			})
 			.map_err(|err| {
 				Self::deposit_event(Event::ElectionFinalized(None));
-				log!(warn, "Failed to finalize election round. reason {:?}", err);
+				if !<frame_system::Pallet<T>>::block_number().is_zero() {
+					log!(warn, "Failed to finalize election round. reason {:?}", err);
+				}
 				err
 			})
 	}

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -1019,12 +1019,14 @@ impl<T: Config> Pallet<T> {
 			)
 			.map(|(supports, compute)| {
 				Self::deposit_event(Event::ElectionFinalized(Some(compute)));
-				log!(info, "Finalized election round with compute {:?}.", compute);
+				if Self::round() != 1 {
+					log!(info, "Finalized election round with compute {:?}.", compute);
+				}
 				supports
 			})
 			.map_err(|err| {
 				Self::deposit_event(Event::ElectionFinalized(None));
-				if !<frame_system::Pallet<T>>::block_number().is_zero() {
+				if Self::round() != 1 {
 					log!(warn, "Failed to finalize election round. reason {:?}", err);
 				}
 				err

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3182,7 +3182,7 @@ impl<T: Config> Module<T> {
 	/// Enact and process the election using the `ElectionProvider` type.
 	///
 	/// This will also process the election, as noted in [`process_election`].
-	fn enact_election(current_era: EraIndex) -> Option<Vec<T::AccountId>> {
+	fn enact_election(_current_era: EraIndex) -> Option<Vec<T::AccountId>> {
 		let _outcome = T::ElectionProvider::elect().map(|_| ());
 		log!(debug, "Experimental election provider outputted {:?}", _outcome);
 		// TWO_PHASE_NOTE: This code path shall not return anything for now. Later on, redirect the

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3131,7 +3131,7 @@ impl<T: Config> Module<T> {
 		let elected_stashes = exposures.iter().cloned().map(|(x, _)| x).collect::<Vec<_>>();
 
 		if (elected_stashes.len() as u32) <= Self::minimum_validator_count() {
-			if current_era != 0 {
+			if current_era > 0 {
 				log!(
 					warn,
 					"chain does not have enough staking candidates to operate for era {:?}",

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2935,13 +2935,15 @@ impl<T: Config> Module<T> {
 			// emit event
 			Self::deposit_event(RawEvent::StakingElection(compute));
 
-			log!(
-				info,
-				"new validator set of size {:?} has been elected via {:?} for staring era {:?}",
-				elected_stashes.len(),
-				compute,
-				current_era,
-			);
+			if current_era > 0 {
+				log!(
+					info,
+					"new validator set of size {:?} has been elected via {:?} for staring era {:?}",
+					elected_stashes.len(),
+					compute,
+					current_era,
+				);
+			}
 
 			Some(elected_stashes)
 		} else {
@@ -3178,9 +3180,11 @@ impl<T: Config> Module<T> {
 	/// Enact and process the election using the `ElectionProvider` type.
 	///
 	/// This will also process the election, as noted in [`process_election`].
-	fn enact_election(_current_era: EraIndex) -> Option<Vec<T::AccountId>> {
+	fn enact_election(current_era: EraIndex) -> Option<Vec<T::AccountId>> {
 		let _outcome = T::ElectionProvider::elect().map(|_| ());
-		log!(debug, "Experimental election provider outputted {:?}", _outcome);
+		if current_era > 0 {
+			log!(debug, "Experimental election provider outputted {:?}", _outcome);
+		}
 		// TWO_PHASE_NOTE: This code path shall not return anything for now. Later on, redirect the
 		// results to `process_election`.
 		None
@@ -3407,31 +3411,37 @@ impl<T: Config> sp_election_providers::ElectionDataProvider<T::AccountId, T::Blo
 /// some session can lag in between the newest session planned and the latest session started.
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Module<T> {
 	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
-		log!(
-			trace,
-			"[{:?}] planning new_session({})",
-			<frame_system::Module<T>>::block_number(),
-			new_index,
-		);
+		if new_index > 1 {
+			log!(
+				trace,
+				"[{:?}] planning new_session({})",
+				<frame_system::Module<T>>::block_number(),
+				new_index,
+			);
+		}
 		CurrentPlannedSession::put(new_index);
 		Self::new_session(new_index)
 	}
 	fn start_session(start_index: SessionIndex) {
-		log!(
-			trace,
-			"[{:?}] starting start_session({})",
-			<frame_system::Module<T>>::block_number(),
-			start_index,
-		);
+		if start_index > 0 {
+			log!(
+				trace,
+				"[{:?}] starting start_session({})",
+				<frame_system::Module<T>>::block_number(),
+				start_index,
+			);
+		}
 		Self::start_session(start_index)
 	}
 	fn end_session(end_index: SessionIndex) {
-		log!(
-			trace,
-			"[{:?}] ending end_session({})",
-			<frame_system::Module<T>>::block_number(),
-			end_index,
-		);
+		if end_index > 0 {
+			log!(
+				trace,
+				"[{:?}] ending end_session({})",
+				<frame_system::Module<T>>::block_number(),
+				end_index,
+			);
+		}
 		Self::end_session(end_index)
 	}
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3131,11 +3131,13 @@ impl<T: Config> Module<T> {
 		let elected_stashes = exposures.iter().cloned().map(|(x, _)| x).collect::<Vec<_>>();
 
 		if (elected_stashes.len() as u32) <= Self::minimum_validator_count() {
-			log!(
-				warn,
-				"chain does not have enough staking candidates to operate for era {:?}",
-				current_era,
-			);
+			if current_era != 0 {
+				log!(
+					warn,
+					"chain does not have enough staking candidates to operate for era {:?}",
+					current_era,
+				);
+			}
 			return Err(());
 		}
 
@@ -3182,9 +3184,7 @@ impl<T: Config> Module<T> {
 	/// This will also process the election, as noted in [`process_election`].
 	fn enact_election(current_era: EraIndex) -> Option<Vec<T::AccountId>> {
 		let _outcome = T::ElectionProvider::elect().map(|_| ());
-		if current_era > 0 {
-			log!(debug, "Experimental election provider outputted {:?}", _outcome);
-		}
+		log!(debug, "Experimental election provider outputted {:?}", _outcome);
 		// TWO_PHASE_NOTE: This code path shall not return anything for now. Later on, redirect the
 		// results to `process_election`.
 		None
@@ -3411,37 +3411,31 @@ impl<T: Config> sp_election_providers::ElectionDataProvider<T::AccountId, T::Blo
 /// some session can lag in between the newest session planned and the latest session started.
 impl<T: Config> pallet_session::SessionManager<T::AccountId> for Module<T> {
 	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
-		if new_index > 1 {
-			log!(
-				trace,
-				"[{:?}] planning new_session({})",
-				<frame_system::Module<T>>::block_number(),
-				new_index,
-			);
-		}
+		log!(
+			trace,
+			"[{:?}] planning new_session({})",
+			<frame_system::Module<T>>::block_number(),
+			new_index,
+		);
 		CurrentPlannedSession::put(new_index);
 		Self::new_session(new_index)
 	}
 	fn start_session(start_index: SessionIndex) {
-		if start_index > 0 {
-			log!(
-				trace,
-				"[{:?}] starting start_session({})",
-				<frame_system::Module<T>>::block_number(),
-				start_index,
-			);
-		}
+		log!(
+			trace,
+			"[{:?}] starting start_session({})",
+			<frame_system::Module<T>>::block_number(),
+			start_index,
+		);
 		Self::start_session(start_index)
 	}
 	fn end_session(end_index: SessionIndex) {
-		if end_index > 0 {
-			log!(
-				trace,
-				"[{:?}] ending end_session({})",
-				<frame_system::Module<T>>::block_number(),
-				end_index,
-			);
-		}
+		log!(
+			trace,
+			"[{:?}] ending end_session({})",
+			<frame_system::Module<T>>::block_number(),
+			end_index,
+		);
 		Self::end_session(end_index)
 	}
 }


### PR DESCRIPTION
Not so pretty on the code, but these logs are polluting other commands as well that build the genesis spec. For example, running benchmarking before would give you:

```
     Running `target/release/substrate benchmark --chain=dev --steps=5 --repeat=5 --pallet=pallet_election_provider_multi_phase --extrinsic=elect_queued --execution=native --wasm-execution=compiled --heap-pages=4096 --output=.`
2021-03-12 12:50:16.591  TRACE main runtime::staking: 💸 [0] planning new_session(0)
2021-03-12 12:50:16.591   INFO main runtime::staking: 💸 new validator set of size 1 has been elected via ElectionCompute::OnChain for staring era 0
2021-03-12 12:50:16.591   WARN main runtime::election-provider: 🗳 Failed to finalize election round. reason NoFallbackConfigured
2021-03-12 12:50:16.591  DEBUG main runtime::staking: 💸 Experimental election provider outputted Err(NoFallbackConfigured)
2021-03-12 12:50:16.591  TRACE main runtime::staking: 💸 [0] planning new_session(1)
2021-03-12 12:50:16.591  TRACE main runtime::staking: 💸 [0] starting start_session(0)
```

all of which are gone now. 