### PR TITLE
[CI] Require D*-audit labels for any runtime changes

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
       - name: Check labels
         run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
         env:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Check labels
-        run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
         with:
           fetch-depth: 0
+      - name: Check labels
+        run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
         env:
           GITHUB_PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,9 +11,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Check labels
         run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
         env:
           GITHUB_PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check labels
         run: bash ${{ github.workspace }}/.maintain/github/check_labels.sh
+        with:
+          fetch-depth: 0
         env:
           GITHUB_PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.maintain/common/lib.sh
+++ b/.maintain/common/lib.sh
@@ -108,8 +108,7 @@ has_runtime_changes() {
   from=$1
   to=$2
   if git diff --name-only "${from}...${to}" \
-    | grep -v -e '^primitives/sr-arithmetic/fuzzer' \
-    | grep -q -e '^bin/node/src/runtime' -e '^frame/' -e '^primitives/sr-'
+    | grep -q -e '^frame/' -e '^primitives/'
   then
     return 0
   else

--- a/.maintain/common/lib.sh
+++ b/.maintain/common/lib.sh
@@ -82,7 +82,7 @@ has_label(){
 
 # Formats a message into a JSON string for posting to Matrix
 # message: 'any plaintext message'
-# formatted_message: '<strong>optional message formatted in <em>html</em></strong>' 
+# formatted_message: '<strong>optional message formatted in <em>html</em></strong>'
 # Usage: structure_message $content $formatted_content (optional)
 structure_message() {
   if [ -z "$2" ]; then
@@ -100,4 +100,19 @@ structure_message() {
 # Usage: send_message $body (json formatted) $room_id $access_token
 send_message() {
 curl -XPOST -d "$1" "https://matrix.parity.io/_matrix/client/r0/rooms/$2/send/m.room.message?access_token=$3"
+}
+
+# Check for runtime changes between two commits. This is defined as any changes
+# to bin/node/src/runtime, frame/ and primitives/sr_* trees.
+has_runtime_changes() {
+  from=$1
+  to=$2
+  if git diff --name-only "${from}...${to}" \
+    | grep -v -e '^primitives/sr-arithmetic/fuzzer' \
+    | grep -q -e '^bin/node/src/runtime' -e '^frame/' -e '^primitives/sr-'
+  then
+    return 0
+  else
+    return 1
+  fi
 }

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -53,7 +53,7 @@ else
   exit 1
 fi
 
-if has_runtime_changes master "${HEAD_SHA}"; then
+if has_runtime_changes origin/master "${HEAD_SHA}"; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
   if ensure_labels "${audit_labels[@]}";  then
     echo "[+] Release audit label detected. All is well."

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -52,7 +52,7 @@ else
   exit 1
 fi
 
-if has_runtime_changes origin/master "${CI_COMMIT_SHA}"; then
+if has_runtime_changes origin/master "${GITHUB_SHA}"; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
   if ensure_labels "${audit_labels[@]}";  then
     echo "[+] Release audit label detected. All is well."

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -52,7 +52,7 @@ else
   exit 1
 fi
 
-if has_runtime_changes ; then
+if has_runtime_changes origin/master "${CI_COMMIT_SHA}"; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
   if ensure_labels "${audit_labels[@]}";  then
     echo "[+] Release audit label detected. All is well."

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -54,10 +54,10 @@ fi
 
 if has_runtime_changes ; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
-  if ensure_labels "${criticality_labels[@]}";  then
-    echo "[+] Release criticality label detected. All is well."
+  if ensure_labels "${audit_labels[@]}";  then
+    echo "[+] Release audit label detected. All is well."
   else
-    echo "[!] Release criticality label not detected. Please add one of: ${criticality_labels[*]}"
+    echo "[!] Release audit label not detected. Please add one of: ${audit_labels[*]}"
     exit 1
   fi
 fi

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -7,9 +7,6 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../com
 repo="$GITHUB_REPOSITORY"
 pr="$GITHUB_PR"
 
-# TODO: remove before merging
-env
-
 ensure_labels() {
   for label in "$@"; do
     if has_label "$repo" "$pr" "$label"; then

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -53,7 +53,7 @@ else
   exit 1
 fi
 
-if has_runtime_changes master "${GITHUB_SHA}"; then
+if has_runtime_changes master "${HEAD_SHA}"; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
   if ensure_labels "${audit_labels[@]}";  then
     echo "[+] Release audit label detected. All is well."

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -30,6 +30,12 @@ criticality_labels=(
   'C9-critical'
 )
 
+audit_labels=(
+  'D1-audited👍'
+  'D5-nicetohaveaudit⚠️ '
+  'D9-needsaudit👮'
+)
+
 echo "[+] Checking release notes (B) labels"
 if ensure_labels "${releasenotes_labels[@]}";  then
   echo "[+] Release notes label detected. All is well."
@@ -44,6 +50,16 @@ if ensure_labels "${criticality_labels[@]}";  then
 else
   echo "[!] Release criticality label not detected. Please add one of: ${criticality_labels[*]}"
   exit 1
+fi
+
+if has_runtime_changes ; then
+  echo "[+] Runtime changes detected. Checking audit (D) labels"
+  if ensure_labels "${criticality_labels[@]}";  then
+    echo "[+] Release criticality label detected. All is well."
+  else
+    echo "[!] Release criticality label not detected. Please add one of: ${criticality_labels[*]}"
+    exit 1
+  fi
 fi
 
 exit 0

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -7,6 +7,9 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../com
 repo="$GITHUB_REPOSITORY"
 pr="$GITHUB_PR"
 
+# TODO: remove before merging
+env
+
 ensure_labels() {
   for label in "$@"; do
     if has_label "$repo" "$pr" "$label"; then

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 #shellcheck source=../common/lib.sh
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../common/lib.sh"
@@ -52,7 +53,7 @@ else
   exit 1
 fi
 
-if has_runtime_changes origin/master "${GITHUB_SHA}"; then
+if has_runtime_changes master "${GITHUB_SHA}"; then
   echo "[+] Runtime changes detected. Checking audit (D) labels"
   if ensure_labels "${audit_labels[@]}";  then
     echo "[+] Release audit label detected. All is well."

--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -33,7 +33,7 @@ criticality_labels=(
 
 audit_labels=(
   'D1-audited👍'
-  'D5-nicetohaveaudit⚠️ '
+  'D5-nicetohaveaudit⚠️'
   'D9-needsaudit👮'
 )
 

--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -8,7 +8,8 @@
 
 set -e # fail on any error
 
-
+#shellcheck source=../common/lib.sh
+. "$(dirname "${0}")/../common/lib.sh"
 
 VERSIONS_FILE="bin/node/runtime/src/lib.rs"
 

--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -12,8 +12,8 @@ set -e # fail on any error
 
 VERSIONS_FILE="bin/node/runtime/src/lib.rs"
 
-boldprint () { printf "|\n| \033[1m${@}\033[0m\n|\n" ; }
-boldcat () { printf "|\n"; while read l; do printf "| \033[1m${l}\033[0m\n"; done; printf "|\n" ; }
+boldprint () { printf "|\n| \033[1m%s\033[0m\n|\n" "${@}"; }
+boldcat () { printf "|\n"; while read -r l; do printf "| \033[1m%s\033[0m\n" "${l}"; done; printf "|\n" ; }
 
 github_label () {
 	echo
@@ -23,7 +23,7 @@ github_label () {
 		-F "ref=master" \
 		-F "variables[LABEL]=${1}" \
 		-F "variables[PRNO]=${CI_COMMIT_REF_NAME}" \
-		${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline
+		"${GITLAB_API}/projects/${GITHUB_API_PROJECT}/trigger/pipeline"
 }
 
 
@@ -31,8 +31,8 @@ boldprint "latest 10 commits of ${CI_COMMIT_REF_NAME}"
 git log --graph --oneline --decorate=short -n 10
 
 boldprint "make sure the master branch and release tag are available in shallow clones"
-git fetch --depth=${GIT_DEPTH:-100} origin master
-git fetch --depth=${GIT_DEPTH:-100} origin release
+git fetch --depth="${GIT_DEPTH:-100}" origin master
+git fetch --depth="${GIT_DEPTH:-100}" origin release
 git tag -f release FETCH_HEAD
 git log -n1 release
 
@@ -55,9 +55,9 @@ fi
 # consensus-critical logic that has changed. the runtime wasm blobs must be
 # rebuilt.
 
-add_spec_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+add_spec_version="$(git diff "tags/release...${CI_COMMIT_SHA}" "${VERSIONS_FILE}" \
 	| sed -n -r "s/^\+[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
-sub_spec_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+sub_spec_version="$(git diff "tags/release...${CI_COMMIT_SHA}" "${VERSIONS_FILE}" \
 	| sed -n -r "s/^\-[[:space:]]+spec_version: +([0-9]+),$/\1/p")"
 
 
@@ -80,9 +80,9 @@ else
 	# check for impl_version updates: if only the impl versions changed, we assume
 	# there is no consensus-critical logic that has changed.
 
-	add_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+	add_impl_version="$(git diff "tags/release...${CI_COMMIT_SHA}" "${VERSIONS_FILE}" \
 		| sed -n -r 's/^\+[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
-	sub_impl_version="$(git diff tags/release...${CI_COMMIT_SHA} ${VERSIONS_FILE} \
+	sub_impl_version="$(git diff "tags/release...${CI_COMMIT_SHA}" "${VERSIONS_FILE}" \
 		| sed -n -r 's/^\-[[:space:]]+impl_version: +([0-9]+),$/\1/p')"
 
 

--- a/.maintain/gitlab/check_runtime.sh
+++ b/.maintain/gitlab/check_runtime.sh
@@ -38,9 +38,7 @@ git log -n1 release
 
 
 boldprint "check if the wasm sources changed"
-if ! git diff --name-only origin/master...${CI_COMMIT_SHA} \
-	| grep -v -e '^primitives/sr-arithmetic/fuzzer' \
-	| grep -q -e '^bin/node/src/runtime' -e '^frame/' -e '^primitives/sr-'
+if ! has_runtime_changes origin/master "${CI_COMMIT_SHA}"
 then
 	boldcat <<-EOT
 


### PR DESCRIPTION
As of this PR, any changes to the runtime must be labelled with one of the following labels in order to pass CI:

* 'D1-audited👍'
* 'D5-nicetohaveaudit⚠️ '
* 'D9-needsaudit👮'
