### PR TITLE
Add a prefix to every log that occurs inside a future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7879,6 +7879,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "erased-serde",
+ "futures 0.3.12",
  "lazy_static",
  "log",
  "once_cell",

--- a/client/tracing/Cargo.toml
+++ b/client/tracing/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 ansi_term = "0.12.1"
 atty = "0.2.13"
 erased-serde = "0.3.9"
+futures = "0.3.12"
 lazy_static = "1.4.0"
 log = { version = "0.4.8" }
 once_cell = "1.4.1"

--- a/client/tracing/src/lib.rs
+++ b/client/tracing/src/lib.rs
@@ -51,6 +51,8 @@ use sp_tracing::{WASM_NAME_KEY, WASM_TARGET_KEY, WASM_TRACE_IDENTIFIER};
 #[doc(hidden)]
 pub use tracing;
 
+pub use tracing::Instrument;
+
 const ZERO_DURATION: Duration = Duration::from_nanos(0);
 
 /// Responsible for assigning ids to new spans, which are not re-used.

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -29,8 +29,9 @@ mod layers;
 pub use directives::*;
 pub use sc_tracing_proc_macro::*;
 
+use futures::prelude::*;
 use std::io;
-use tracing::Subscriber;
+use tracing::{Instrument, Subscriber};
 use tracing_subscriber::{
 	filter::LevelFilter,
 	fmt::time::ChronoLocal,
@@ -287,6 +288,20 @@ impl LoggerBuilder {
 			}
 		}
 	}
+}
+
+/// Add a prefix to every log that occurs inside the future provided.
+///
+/// See [`prefix_logs_with`] for more details.
+pub fn prefix_future_logs_with<T>(
+	prefix: &str,
+	f: impl Future<Output = T>,
+) -> impl Future<Output = T> {
+	let span = tracing::info_span!(
+		PREFIX_LOG_SPAN,
+		name = prefix,
+	);
+	f.instrument(span)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a very small life improvement for sc-tracing that does 2 things:

1.  It adds a function `prefix_future_logs_with(prefix_string, future) -> prefixed_future` (I'm very bad at naming things so feel free to suggest me a better name :grin:) that allows the user to change the log prefixing of a future.

    This is handy in cumulus because some tasks (collation) are spawn in the background from polkadot but they really belong to the parachain. You can already do it without this helper but it requires a bit of knowledge on the internals.

    Normally you should use the macro `sc_tracing::logging::prefix_logs_with` but that macro works only as function decorator.

2.  I added a re-export of `tracing::Instrument` in `sc-tracing::Instrument`.

    The reasoning is that no matter what you do with sc-tracing, you might want to use this to preserve the spans you're in. 