### PR TITLE
Add more relaxed pallet-name parsing

### DIFF
--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -21,11 +21,17 @@ mod writer;
 use sc_cli::{ExecutionStrategy, WasmExecutionMethod};
 use std::fmt::Debug;
 
+// Add a more relaxed parsing for pallet names by allowing pallet directory names with `-` to be used
+// like crate names with `_`
+fn parse_pallet_name(pallet: &str) -> String {
+	pallet.replace("-", "_")
+}
+
 /// The `benchmark` command used to benchmark FRAME Pallets.
 #[derive(Debug, structopt::StructOpt)]
 pub struct BenchmarkCmd {
 	/// Select a FRAME Pallet to benchmark, or `*` for all (in which case `extrinsic` must be `*`).
-	#[structopt(short, long)]
+	#[structopt(short, long, parse(from_str = parse_pallet_name))]
 	pub pallet: String,
 
 	/// Select an extrinsic inside the pallet to benchmark, or `*` for all.


### PR DESCRIPTION
Make it possbible to use the pallet's path name, with `-` separator or crate name with `_` separator.
fixes #8226

Thank you for your Pull Request!

Before you submitting, please check that:

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [x] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [x] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
