### PR TITLE
Don't log to debug for every failed extrinsic. 

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1451,7 +1451,7 @@ impl<T: Config> Module<T> {
 				Err(err) => {
 					log::trace!(
 						target: "runtime::system", 
-						"Extrinsic failed at block({}): {:?}", 
+						"Extrinsic failed at block({:?}): {:?}", 
 						Self::block_number(), 
 						err,
 					);

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1451,7 +1451,7 @@ impl<T: Config> Module<T> {
 				Err(err) => {
 					log::trace!(
 						target: "runtime::system", 
-						"failed extrinsic at {:?} => {:?}", 
+						"Extrinsic failed at block({}): {:?}", 
 						Self::block_number(), 
 						err,
 					);

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1449,7 +1449,12 @@ impl<T: Config> Module<T> {
 			match r {
 				Ok(_) => Event::ExtrinsicSuccess(info),
 				Err(err) => {
-					sp_runtime::print(err);
+					log::trace!(
+						target: "runtime::system", 
+						"failed extrinsic at {:?} => {:?}", 
+						Self::block_number(), 
+						err,
+					);
 					Event::ExtrinsicFailed(err.error, info)
 				},
 			}


### PR DESCRIPTION
Another step toward cleaning the runtime logs. 