### PR TITLE
alerting-rules: ContinuousTaskEnded alert shouldn't drop unspecified labels

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -135,7 +135,7 @@ groups:
 
   - alert: ContinuousTaskEnded
     expr: '(polkadot_tasks_spawned_total{task_name != "basic-authorship-proposer"} == 1)
-        - on(instance, task_name) (polkadot_tasks_ended_total == 1)'
+        - on(instance, task_name) group_left() (polkadot_tasks_ended_total == 1)'
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION

When using the `-` operators and specifying matching labels with the `on` keyword all other labels are being dropped. This breaks some custom alert routing where additional labels are made use of.

This can be prevented with adding the generic `group_left()` parameter which basically defines which label set to take from as a base.

ref: https://prometheus.io/docs/prometheus/latest/querying/operators/