### PR TITLE
Fast CompactAssignment search

### DIFF
--- a/frame/election-provider-multi-phase/src/benchmarking.rs
+++ b/frame/election-provider-multi-phase/src/benchmarking.rs
@@ -115,7 +115,7 @@ fn solution_with_size<T: Config>(
 	let cache = helpers::generate_voter_cache::<T>(&all_voters);
 	let stake_of = helpers::stake_of_fn::<T>(&all_voters, &cache);
 	let voter_index = helpers::voter_index_fn::<T>(&cache);
-	let target_index = helpers::target_index_fn_linear::<T>(&targets);
+	let target_index = helpers::target_index_fn::<T>(&targets);
 	let voter_at = helpers::voter_at_fn::<T>(&all_voters);
 	let target_at = helpers::target_at_fn::<T>(&targets);
 

--- a/frame/election-provider-multi-phase/src/helpers.rs
+++ b/frame/election-provider-multi-phase/src/helpers.rs
@@ -18,7 +18,7 @@
 //! Some helper functions/macros for this crate.
 
 use super::{Config, VoteWeight, CompactVoterIndexOf, CompactTargetIndexOf};
-use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, boxed::Box, prelude::*};
+use sp_std::{collections::btree_map::BTreeMap, convert::TryInto, prelude::*};
 
 #[macro_export]
 macro_rules! log {

--- a/frame/election-provider-multi-phase/src/helpers.rs
+++ b/frame/election-provider-multi-phase/src/helpers.rs
@@ -100,7 +100,7 @@ pub fn voter_index_fn_linear<T: Config>(
 /// in `O(log n)`.
 pub fn target_index_fn<T: Config>(
 	snapshot: &Vec<T::AccountId>,
-) -> impl '_ + Fn(&T::AccountId) -> Option<CompactTargetIndexOf<T>> {
+) -> impl Fn(&T::AccountId) -> Option<CompactTargetIndexOf<T>> + '_ {
 	let cache: BTreeMap<_, _> =
 		snapshot.iter().enumerate().map(|(idx, account_id)| (account_id, idx)).collect();
 	move |who| {

--- a/frame/election-provider-multi-phase/src/helpers.rs
+++ b/frame/election-provider-multi-phase/src/helpers.rs
@@ -91,7 +91,7 @@ pub fn voter_index_fn_linear<T: Config>(
 	})
 }
 
-/// Create a function the returns the index a targets in the snapshot.
+/// Create a function the returns the index to a target in the snapshot.
 ///
 /// The returned index type is the same as the one defined in `T::CompactSolution::Target`.
 ///
@@ -110,7 +110,7 @@ pub fn target_index_fn<T: Config>(
 	})
 }
 
-/// Create a function the returns the index a targets in the snapshot.
+/// Create a function the returns the index to a target in the snapshot.
 ///
 /// The returned index type is the same as the one defined in `T::CompactSolution::Target`.
 ///

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -145,7 +145,7 @@ impl<T: Config> Pallet<T> {
 		// closures.
 		let cache = helpers::generate_voter_cache::<T>(&voters);
 		let voter_index = helpers::voter_index_fn::<T>(&cache);
-		let target_index = helpers::target_index_fn_linear::<T>(&targets);
+		let target_index = helpers::target_index_fn::<T>(&targets);
 		let voter_at = helpers::voter_at_fn::<T>(&voters);
 		let target_at = helpers::target_at_fn::<T>(&targets);
 		let stake_of = helpers::stake_of_fn::<T>(&voters, &cache);

--- a/frame/staking/src/offchain_election.rs
+++ b/frame/staking/src/offchain_election.rs
@@ -31,7 +31,7 @@ use sp_npos_elections::{
 use sp_runtime::{
 	offchain::storage::StorageValueRef, traits::TrailingZeroInput, RuntimeDebug,
 };
-use sp_std::{convert::TryInto, prelude::*};
+use sp_std::{convert::TryInto, prelude::*, collections::btree_map::BTreeMap};
 
 /// Error types related to the offchain election machinery.
 #[derive(RuntimeDebug)]
@@ -331,18 +331,22 @@ pub fn prepare_submission<T: Config>(
 	let snapshot_nominators =
 		<Module<T>>::snapshot_nominators().ok_or(OffchainElectionError::SnapshotUnavailable)?;
 
+	// indexing caches
+	let nominator_indices: BTreeMap<_, _> =
+		snapshot_nominators.iter().enumerate().map(|(idx, account_id)| (account_id, idx)).collect();
+	let validator_indices: BTreeMap<_, _> =
+		snapshot_validators.iter().enumerate().map(|(idx, account_id)| (account_id, idx)).collect();
+
 	// all helper closures that we'd ever need.
 	let nominator_index = |a: &T::AccountId| -> Option<NominatorIndex> {
-		snapshot_nominators
-			.iter()
-			.position(|x| x == a)
-			.and_then(|i| <usize as TryInto<NominatorIndex>>::try_into(i).ok())
+		nominator_indices
+			.get(a)
+			.and_then(|i| <usize as TryInto<NominatorIndex>>::try_into(*i).ok())
 	};
 	let validator_index = |a: &T::AccountId| -> Option<ValidatorIndex> {
-		snapshot_validators
-			.iter()
-			.position(|x| x == a)
-			.and_then(|i| <usize as TryInto<ValidatorIndex>>::try_into(i).ok())
+		validator_indices
+			.get(a)
+			.and_then(|i| <usize as TryInto<ValidatorIndex>>::try_into(*i).ok())
 	};
 	let nominator_at = |i: NominatorIndex| -> Option<T::AccountId> {
 		snapshot_nominators.get(i as usize).cloned()


### PR DESCRIPTION
Addresses https://github.com/paritytech/srlabs_findings/issues/63.

- [x] improve performance of `frame/staking/src/offchain_election.rs::validator_index`
- [x] improve performance of `frame/staking/src/offchain_election.rs::nominator_index`
- [x] mark all `frame/election-provider-multi-phase/src/helpers.rs::*_linear` as test-only
- [x] add an efficient `frame/election-provider-multi-phase/src/helpers.rs::target_index_fn`

Marked as "nice to have audit" instead of "audit needed" because it directly and trivially implements the mitigation suggestions from a previous audit report.