### PR TITLE
Add D1-trivial label

### DIFF
--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -32,6 +32,7 @@ criticality_labels=(
 )
 
 audit_labels=(
+  'D1-trivial'
   'D1-audited👍'
   'D5-nicetohaveaudit⚠️'
   'D9-needsaudit👮'


### PR DESCRIPTION
For labeling changes to the runtime directories that do not require an audit (e.g., updating docs, what have you)