### PR TITLE
Check `unreserve` and `transfer` returnvalues in debug code

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -763,7 +763,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 			);
 		}
 		// No way this can fail since we do not alter the existential balances.
-		let _ = Self::mutate_account(who, |b| {
+		let res = Self::mutate_account(who, |b| {
 			b.misc_frozen = Zero::zero();
 			b.fee_frozen = Zero::zero();
 			for l in locks.iter() {
@@ -775,6 +775,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				}
 			}
 		});
+		debug_assert!(res.is_ok());
 
 		let existed = Locks::<T, I>::contains_key(who);
 		if locks.is_empty() {

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -684,7 +684,7 @@ macro_rules! decl_tests {
 					let _ = Balances::deposit_creating(&1, 100);
 
 					System::set_block_number(2);
-					let _ = Balances::reserve(&1, 10);
+					assert_ok!(Balances::reserve(&1, 10));
 
 					assert_eq!(
 						last_event(),

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -692,7 +692,7 @@ macro_rules! decl_tests {
 					);
 
 					System::set_block_number(3);
-					let _ = Balances::unreserve(&1, 5);
+					assert!(Balances::unreserve(&1, 5).is_zero());
 
 					assert_eq!(
 						last_event(),
@@ -700,7 +700,7 @@ macro_rules! decl_tests {
 					);
 
 					System::set_block_number(4);
-					let _ = Balances::unreserve(&1, 6);
+					assert_eq!(Balances::unreserve(&1, 6), 1);
 
 					// should only unreserve 5
 					assert_eq!(

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1541,7 +1541,8 @@ impl<T: Config> Module<T> {
 		let preimage = <Preimages<T>>::take(&proposal_hash);
 		if let Some(PreimageStatus::Available { data, provider, deposit, .. }) = preimage {
 			if let Ok(proposal) = T::Proposal::decode(&mut &data[..]) {
-				let _ = T::Currency::unreserve(&provider, deposit);
+				let err_amount = T::Currency::unreserve(&provider, deposit);
+				debug_assert!(err_amount.is_zero());
 				Self::deposit_event(RawEvent::PreimageUsed(proposal_hash, provider, deposit));
 
 				let ok = proposal.dispatch(frame_system::RawOrigin::Root.into()).is_ok();

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -1010,7 +1010,8 @@ decl_module! {
 			ensure!(now >= since + voting + additional, Error::<T>::TooEarly);
 			ensure!(expiry.map_or(true, |e| now > e), Error::<T>::Imminent);
 
-			let _ = T::Currency::repatriate_reserved(&provider, &who, deposit, BalanceStatus::Free);
+			let res = T::Currency::repatriate_reserved(&provider, &who, deposit, BalanceStatus::Free);
+			debug_assert!(res.is_ok());
 			<Preimages<T>>::remove(&proposal_hash);
 			Self::deposit_event(RawEvent::PreimageReaped(proposal_hash, provider, deposit, who));
 		}

--- a/frame/identity/src/lib.rs
+++ b/frame/identity/src/lib.rs
@@ -598,7 +598,8 @@ decl_module! {
 				T::Currency::reserve(&sender, id.deposit - old_deposit)?;
 			}
 			if old_deposit > id.deposit {
-				let _ = T::Currency::unreserve(&sender, old_deposit - id.deposit);
+				let err_amount = T::Currency::unreserve(&sender, old_deposit - id.deposit);
+				debug_assert!(err_amount.is_zero());
 			}
 
 			let judgements = id.judgements.len();
@@ -655,7 +656,8 @@ decl_module! {
 			if old_deposit < new_deposit {
 				T::Currency::reserve(&sender, new_deposit - old_deposit)?;
 			} else if old_deposit > new_deposit {
-				let _ = T::Currency::unreserve(&sender, old_deposit - new_deposit);
+				let err_amount = T::Currency::unreserve(&sender, old_deposit - new_deposit);
+				debug_assert!(err_amount.is_zero());
 			}
 			// do nothing if they're equal.
 
@@ -713,7 +715,8 @@ decl_module! {
 				<SuperOf<T>>::remove(sub);
 			}
 
-			let _ = T::Currency::unreserve(&sender, deposit.clone());
+			let err_amount = T::Currency::unreserve(&sender, deposit.clone());
+			debug_assert!(err_amount.is_zero());
 
 			Self::deposit_event(RawEvent::IdentityCleared(sender, deposit));
 
@@ -819,7 +822,8 @@ decl_module! {
 				Err(Error::<T>::JudgementGiven)?
 			};
 
-			let _ = T::Currency::unreserve(&sender, fee);
+			let err_amount = T::Currency::unreserve(&sender, fee);
+			debug_assert!(err_amount.is_zero());
 			let judgements = id.judgements.len();
 			let extra_fields = id.info.additional.len();
 			<IdentityOf<T>>::insert(&sender, id);
@@ -1095,7 +1099,8 @@ decl_module! {
 				sub_ids.retain(|x| x != &sub);
 				let deposit = T::SubAccountDeposit::get().min(*subs_deposit);
 				*subs_deposit -= deposit;
-				let _ = T::Currency::unreserve(&sender, deposit);
+				let err_amount = T::Currency::unreserve(&sender, deposit);
+				debug_assert!(err_amount.is_zero());
 				Self::deposit_event(RawEvent::SubIdentityRemoved(sub, sender, deposit));
 			});
 		}

--- a/frame/lottery/src/lib.rs
+++ b/frame/lottery/src/lib.rs
@@ -324,7 +324,8 @@ decl_module! {
 						let winning_number = Self::choose_winner(ticket_count);
 						let winner = Tickets::<T>::get(winning_number).unwrap_or(lottery_account);
 						// Not much we can do if this fails...
-						let _ = T::Currency::transfer(&Self::account_id(), &winner, lottery_balance, KeepAlive);
+						let res = T::Currency::transfer(&Self::account_id(), &winner, lottery_balance, KeepAlive);
+						debug_assert!(res.is_ok());
 
 						Self::deposit_event(RawEvent::Winner(winner, lottery_balance));
 

--- a/frame/multisig/src/lib.rs
+++ b/frame/multisig/src/lib.rs
@@ -436,7 +436,8 @@ decl_module! {
 			ensure!(m.when == timepoint, Error::<T>::WrongTimepoint);
 			ensure!(m.depositor == who, Error::<T>::NotOwner);
 
-			let _ = T::Currency::unreserve(&m.depositor, m.deposit);
+			let err_amount = T::Currency::unreserve(&m.depositor, m.deposit);
+			debug_assert!(err_amount.is_zero());
 			<Multisigs<T>>::remove(&id, &call_hash);
 			Self::clear_call(&call_hash);
 

--- a/frame/nicks/src/lib.rs
+++ b/frame/nicks/src/lib.rs
@@ -179,7 +179,8 @@ decl_module! {
 
 			let deposit = <NameOf<T>>::take(&sender).ok_or(Error::<T>::Unnamed)?.1;
 
-			let _ = T::Currency::unreserve(&sender, deposit.clone());
+			let err_amount = T::Currency::unreserve(&sender, deposit.clone());
+			debug_assert!(err_amount.is_zero());
 
 			Self::deposit_event(RawEvent::NameCleared(sender, deposit));
 		}

--- a/frame/society/src/lib.rs
+++ b/frame/society/src/lib.rs
@@ -584,7 +584,8 @@ decl_module! {
 					// no reason that either should fail.
 					match b.remove(pos).kind {
 						BidKind::Deposit(deposit) => {
-							let _ = T::Currency::unreserve(&who, deposit);
+							let err_amount = T::Currency::unreserve(&who, deposit);
+							debug_assert!(err_amount.is_zero());
 						}
 						BidKind::Vouch(voucher, _) => {
 							<Vouching<T, I>>::remove(&voucher);
@@ -1235,7 +1236,8 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 			let Bid { who: popped, kind, .. } = bids.pop().expect("b.len() > 1000; qed");
 			match kind {
 				BidKind::Deposit(deposit) => {
-					let _ = T::Currency::unreserve(&popped, deposit);
+					let err_amount = T::Currency::unreserve(&popped, deposit);
+					debug_assert!(err_amount.is_zero());
 				}
 				BidKind::Vouch(voucher, _) => {
 					<Vouching<T, I>>::remove(&voucher);
@@ -1402,7 +1404,8 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 					Self::bump_payout(winner, maturity, total_slash);
 				} else {
 					// Move the slashed amount back from payouts account to local treasury.
-					let _ = T::Currency::transfer(&Self::payouts(), &Self::account_id(), total_slash, AllowDeath);
+					let res = T::Currency::transfer(&Self::payouts(), &Self::account_id(), total_slash, AllowDeath);
+					debug_assert!(res.is_ok());
 				}
 			}
 
@@ -1413,7 +1416,8 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 
 				// this should never fail since we ensure we can afford the payouts in a previous
 				// block, but there's not much we can do to recover if it fails anyway.
-				let _ = T::Currency::transfer(&Self::account_id(), &Self::payouts(), total_payouts, AllowDeath);
+				let res = T::Currency::transfer(&Self::account_id(), &Self::payouts(), total_payouts, AllowDeath);
+				debug_assert!(res.is_ok());
 			}
 
 			// if at least one candidate was accepted...
@@ -1514,7 +1518,8 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 			BidKind::Deposit(deposit) => {
 				// In the case that a normal deposit bid is accepted we unreserve
 				// the deposit.
-				let _ = T::Currency::unreserve(candidate, deposit);
+				let err_amount = T::Currency::unreserve(candidate, deposit);
+				debug_assert!(err_amount.is_zero());
 				value
 			}
 			BidKind::Vouch(voucher, tip) => {

--- a/frame/support/src/storage/generator/mod.rs
+++ b/frame/support/src/storage/generator/mod.rs
@@ -80,7 +80,8 @@ mod tests {
 			let translate_fn = |old: Option<u32>| -> Option<(u64, u64)> {
 				old.map(|o| (o.into(), (o*2).into()))
 			};
-			let _ = Value::translate(translate_fn);
+			let res = Value::translate(translate_fn);
+			debug_assert!(res.is_ok());
 
 			// new storage should be `(1111, 1111 * 2)`
 			assert_eq!(Value::get(), (1111, 2222));

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -377,7 +377,8 @@ impl<T: Config<I>, I: Instance> Module<T, I> {
 						<Proposals<T, I>>::remove(index);
 
 						// return their deposit.
-						let _ = T::Currency::unreserve(&p.proposer, p.bond);
+						let err_amount = T::Currency::unreserve(&p.proposer, p.bond);
+						debug_assert!(err_amount.is_zero());
 
 						// provide the allocation.
 						imbalance.subsume(T::Currency::deposit_creating(&p.beneficiary, p.value));

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -374,7 +374,8 @@ impl<T: Config> VestingSchedule<T::AccountId> for Module<T> where
 		};
 		Vesting::<T>::insert(who, vesting_schedule);
 		// it can't fail, but even if somehow it did, we don't really care.
-		let _ = Self::update_lock(who.clone());
+		let res = Self::update_lock(who.clone());
+		debug_assert!(res.is_ok());
 		Ok(())
 	}
 
@@ -382,7 +383,8 @@ impl<T: Config> VestingSchedule<T::AccountId> for Module<T> where
 	fn remove_vesting_schedule(who: &T::AccountId) {
 		Vesting::<T>::remove(who);
 		// it can't fail, but even if somehow it did, we don't really care.
-		let _ = Self::update_lock(who.clone());
+		let res = Self::update_lock(who.clone());
+		debug_assert!(res.is_ok());
 	}
 }
 


### PR DESCRIPTION
fixes some of #8106

Thank you for your Pull Request!

Before you submitting, please check that:

- [ ] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
