### PR TITLE
Better description for assert in frame-session genesis

### DIFF
--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -445,7 +445,7 @@ decl_storage! {
 				assert!(
 					frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
 					"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
-					val,
+					account,
 				);
 			}
 

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -442,7 +442,11 @@ decl_storage! {
 			for (account, val, keys) in config.keys.iter().cloned() {
 				<Module<T>>::inner_set_keys(&val, keys)
 					.expect("genesis config must not contain duplicates; qed");
-				assert!(frame_system::Pallet::<T>::inc_consumers(&account).is_ok());
+				assert!(
+					frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
+					"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
+					val,
+				);
 			}
 
 			let initial_validators_0 = T::SessionManager::new_session(0)


### PR DESCRIPTION
There is an assert that checks that an account exists, after setting a
key. However, this assert isn't very self-descriptive.

