### PR TITLE
Add `D1-notlive` audit label

### DIFF
--- a/.maintain/github/check_labels.sh
+++ b/.maintain/github/check_labels.sh
@@ -33,6 +33,7 @@ criticality_labels=(
 
 audit_labels=(
   'D1-trivial'
+  'D1-notlive'
   'D1-audited👍'
   'D5-nicetohaveaudit⚠️'
   'D9-needsaudit👮'


### PR DESCRIPTION
This label is for changes which are not trivial but still do not need an audit because they are not deployed to any live chain that requires one.