### PR TITLE
grandpa: speed up tests

### DIFF
--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -610,6 +610,8 @@ pub struct FullPeerConfig {
 	///
 	/// If `None`, it will be connected to all other peers.
 	pub connect_to_peers: Option<Vec<usize>>,
+	/// Whether the full peer should have the authority role.
+	pub is_authority: bool,
 }
 
 pub trait TestNetFactory: Sized {
@@ -743,7 +745,7 @@ pub trait TestNetFactory: Sized {
 		};
 
 		let network = NetworkWorker::new(sc_network::config::Params {
-			role: Role::Full,
+			role: if config.is_authority { Role::Authority } else { Role::Full },
 			executor: None,
 			transactions_handler_executor: Box::new(|task| { async_std::task::spawn(task); }),
 			network_config,


### PR DESCRIPTION
The nodes in the GRANDPA test net were added without the authority role, which makes it so that the GRANDPA gossip layer will take longer to propagate the messages. This PR changes the testnet code to add nodes as authorities in order to make gossiping messages faster and speed up the tests.

Before: `test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 184.97s`
After: `test result: ok. 75 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 20.02s`