### PR TITLE
Migrate pallet-vesting to pallet attribute macro.

### DIFF
--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -25,7 +25,7 @@ use frame_system::{RawOrigin, Pallet as System};
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 use sp_runtime::traits::Bounded;
 
-use crate::Module as Vesting;
+use crate::Pallet as Vesting;
 
 const SEED: u32 = 0;
 

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -15,15 +15,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Vesting Module
+//! # Vesting Pallet
 //!
 //! - [`Config`]
 //! - [`Call`]
 //!
 //! ## Overview
 //!
-//! A simple module providing a means of placing a linear curve on an account's locked balance. This
-//! module ensures that there is a lock in place preventing the balance to drop below the *unvested*
+//! A simple pallet providing a means of placing a linear curve on an account's locked balance. This
+//! pallet ensures that there is a lock in place preventing the balance to drop below the *unvested*
 //! amount for any reason other than transaction fee payment.
 //!
 //! As the amount vested increases over time, the amount unvested reduces. However, locks remain in
@@ -34,7 +34,7 @@
 //!
 //! ## Interface
 //!
-//! This module implements the `VestingSchedule` trait.
+//! This pallet implements the `VestingSchedule` trait.
 //!
 //! ### Dispatchable Functions
 //!
@@ -50,36 +50,20 @@ pub mod weights;
 use sp_std::prelude::*;
 use sp_std::fmt::Debug;
 use codec::{Encode, Decode};
-use sp_runtime::{DispatchResult, RuntimeDebug, traits::{
+use sp_runtime::{RuntimeDebug, traits::{
 	StaticLookup, Zero, AtLeast32BitUnsigned, MaybeSerializeDeserialize, Convert
 }};
-use frame_support::{decl_module, decl_event, decl_storage, decl_error, ensure};
+use frame_support::{ensure, pallet_prelude::*};
 use frame_support::traits::{
 	Currency, LockableCurrency, VestingSchedule, WithdrawReasons, LockIdentifier,
 	ExistenceRequirement, Get,
 };
-use frame_system::{ensure_signed, ensure_root};
+use frame_system::{ensure_signed, ensure_root, pallet_prelude::*};
 pub use weights::WeightInfo;
+pub use pallet::*;
 
 type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 type MaxLocksOf<T> = <<T as Config>::Currency as LockableCurrency<<T as frame_system::Config>::AccountId>>::MaxLocks;
-
-pub trait Config: frame_system::Config {
-	/// The overarching event type.
-	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
-
-	/// The currency trait.
-	type Currency: LockableCurrency<Self::AccountId>;
-
-	/// Convert the block number into a balance.
-	type BlockNumberToBalance: Convert<Self::BlockNumber, BalanceOf<Self>>;
-
-	/// The minimum amount transferred to call `vested_transfer`.
-	type MinVestedTransfer: Get<BalanceOf<Self>>;
-
-	/// Weight information for extrinsics in this pallet.
-	type WeightInfo: WeightInfo;
-}
 
 const VESTING_ID: LockIdentifier = *b"vesting ";
 
@@ -116,23 +100,68 @@ impl<
 	}
 }
 
-decl_storage! {
-	trait Store for Module<T: Config> as Vesting {
-		/// Information regarding the vesting of a given account.
-		pub Vesting get(fn vesting):
-			map hasher(blake2_128_concat) T::AccountId
-			=> Option<VestingInfo<BalanceOf<T>, T::BlockNumber>>;
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+		/// The currency trait.
+		type Currency: LockableCurrency<Self::AccountId>;
+
+		/// Convert the block number into a balance.
+		type BlockNumberToBalance: Convert<Self::BlockNumber, BalanceOf<Self>>;
+
+		/// The minimum amount transferred to call `vested_transfer`.
+		#[pallet::constant]
+		type MinVestedTransfer: Get<BalanceOf<Self>>;
+
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
 	}
-	add_extra_genesis {
-		config(vesting): Vec<(T::AccountId, T::BlockNumber, T::BlockNumber, BalanceOf<T>)>;
-		build(|config: &GenesisConfig<T>| {
+
+	/// Information regarding the vesting of a given account.
+	#[pallet::storage]
+	#[pallet::getter(fn vesting)]
+	pub type Vesting<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		VestingInfo<BalanceOf<T>, T::BlockNumber>,
+	>;
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub vesting: Vec<(T::AccountId, T::BlockNumber, T::BlockNumber, BalanceOf<T>)>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			GenesisConfig {
+				vesting: Default::default(),
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
 			use sp_runtime::traits::Saturating;
+
 			// Generate initial vesting configuration
 			// * who - Account which we are generating vesting configuration for
 			// * begin - Block when the account will start to vest
 			// * length - Number of blocks from `begin` until fully vested
 			// * liquid - Number of units which can be spent before vesting begins
-			for &(ref who, begin, length, liquid) in config.vesting.iter() {
+			for &(ref who, begin, length, liquid) in self.vesting.iter() {
 				let balance = T::Currency::free_balance(who);
 				assert!(!balance.is_zero(), "Currencies must be init'd before vesting");
 				// Total genesis `balance` minus `liquid` equals funds locked for vesting
@@ -148,24 +177,24 @@ decl_storage! {
 				let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
 				T::Currency::set_lock(VESTING_ID, who, locked, reasons);
 			}
-		})
+		}
 	}
-}
 
-decl_event!(
-	pub enum Event<T> where AccountId = <T as frame_system::Config>::AccountId, Balance = BalanceOf<T> {
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	#[pallet::metadata(T::AccountId = "AccountId", T::Balance = "Balance")]
+	pub enum Event<T: Config> {
 		/// The amount vested has been updated. This could indicate more funds are available. The
 		/// balance given is the amount which is left unvested (and thus locked).
 		/// \[account, unvested\]
-		VestingUpdated(AccountId, Balance),
+		VestingUpdated(T::AccountId, BalanceOf<T>),
 		/// An \[account\] has become fully vested. No further vesting can happen.
-		VestingCompleted(AccountId),
+		VestingCompleted(T::AccountId),
 	}
-);
 
-decl_error! {
-	/// Error for the vesting module.
-	pub enum Error for Module<T: Config> {
+	/// Error for the vesting pallet.
+	#[pallet::error]
+	pub enum Error<T> {
 		/// The account given is not vesting.
 		NotVesting,
 		/// An existing vesting schedule already exists for this account that cannot be clobbered.
@@ -173,22 +202,16 @@ decl_error! {
 		/// Amount being transferred is too low to create a vesting schedule.
 		AmountLow,
 	}
-}
 
-decl_module! {
-	/// Vesting module declaration.
-	pub struct Module<T: Config> for enum Call where origin: T::Origin {
-		type Error = Error<T>;
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
-		/// The minimum amount to be transferred to create a new vesting schedule.
-		const MinVestedTransfer: BalanceOf<T> = T::MinVestedTransfer::get();
-
-		fn deposit_event() = default;
-
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
 		/// Unlock any vested funds of the sender account.
 		///
 		/// The dispatch origin for this call must be _Signed_ and the sender must have funds still
-		/// locked under this module.
+		/// locked under this pallet.
 		///
 		/// Emits either `VestingCompleted` or `VestingUpdated`.
 		///
@@ -198,10 +221,10 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, [Sender Account]
 		/// # </weight>
-		#[weight = T::WeightInfo::vest_locked(MaxLocksOf::<T>::get())
+		#[pallet::weight(T::WeightInfo::vest_locked(MaxLocksOf::<T>::get())
 			.max(T::WeightInfo::vest_unlocked(MaxLocksOf::<T>::get()))
-		]
-		fn vest(origin) -> DispatchResult {
+		)]
+		pub fn vest(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			Self::update_lock(who)
 		}
@@ -211,7 +234,7 @@ decl_module! {
 		/// The dispatch origin for this call must be _Signed_.
 		///
 		/// - `target`: The account whose vested funds should be unlocked. Must have funds still
-		/// locked under this module.
+		/// locked under this pallet.
 		///
 		/// Emits either `VestingCompleted` or `VestingUpdated`.
 		///
@@ -221,10 +244,10 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account
 		///     - Writes: Vesting Storage, Balances Locks, Target Account
 		/// # </weight>
-		#[weight = T::WeightInfo::vest_other_locked(MaxLocksOf::<T>::get())
+		#[pallet::weight(T::WeightInfo::vest_other_locked(MaxLocksOf::<T>::get())
 			.max(T::WeightInfo::vest_other_unlocked(MaxLocksOf::<T>::get()))
-		]
-		fn vest_other(origin, target: <T::Lookup as StaticLookup>::Source) -> DispatchResult {
+		)]
+		pub fn vest_other(origin: OriginFor<T>, target: <T::Lookup as StaticLookup>::Source) -> DispatchResult {
 			ensure_signed(origin)?;
 			Self::update_lock(T::Lookup::lookup(target)?)
 		}
@@ -245,9 +268,9 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account, [Sender Account]
 		///     - Writes: Vesting Storage, Balances Locks, Target Account, [Sender Account]
 		/// # </weight>
-		#[weight = T::WeightInfo::vested_transfer(MaxLocksOf::<T>::get())]
+		#[pallet::weight(T::WeightInfo::vested_transfer(MaxLocksOf::<T>::get()))]
 		pub fn vested_transfer(
-			origin,
+			origin: OriginFor<T>,
 			target: <T::Lookup as StaticLookup>::Source,
 			schedule: VestingInfo<BalanceOf<T>, T::BlockNumber>,
 		) -> DispatchResult {
@@ -282,9 +305,9 @@ decl_module! {
 		///     - Reads: Vesting Storage, Balances Locks, Target Account, Source Account
 		///     - Writes: Vesting Storage, Balances Locks, Target Account, Source Account
 		/// # </weight>
-		#[weight = T::WeightInfo::force_vested_transfer(MaxLocksOf::<T>::get())]
+		#[pallet::weight(T::WeightInfo::force_vested_transfer(MaxLocksOf::<T>::get()))]
 		pub fn force_vested_transfer(
-			origin,
+			origin: OriginFor<T>,
 			source: <T::Lookup as StaticLookup>::Source,
 			target: <T::Lookup as StaticLookup>::Source,
 			schedule: VestingInfo<BalanceOf<T>, T::BlockNumber>,
@@ -306,8 +329,8 @@ decl_module! {
 	}
 }
 
-impl<T: Config> Module<T> {
-	/// (Re)set or remove the module's currency lock on `who`'s account in accordance with their
+impl<T: Config> Pallet<T> {
+	/// (Re)set or remove the pallet's currency lock on `who`'s account in accordance with their
 	/// current unvested amount.
 	fn update_lock(who: T::AccountId) -> DispatchResult {
 		let vesting = Self::vesting(&who).ok_or(Error::<T>::NotVesting)?;
@@ -317,17 +340,17 @@ impl<T: Config> Module<T> {
 		if locked_now.is_zero() {
 			T::Currency::remove_lock(VESTING_ID, &who);
 			Vesting::<T>::remove(&who);
-			Self::deposit_event(RawEvent::VestingCompleted(who));
+			Self::deposit_event(Event::<T>::VestingCompleted(who));
 		} else {
 			let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
 			T::Currency::set_lock(VESTING_ID, &who, locked_now, reasons);
-			Self::deposit_event(RawEvent::VestingUpdated(who, locked_now));
+			Self::deposit_event(Event::<T>::VestingUpdated(who, locked_now));
 		}
 		Ok(())
 	}
 }
 
-impl<T: Config> VestingSchedule<T::AccountId> for Module<T> where
+impl<T: Config> VestingSchedule<T::AccountId> for Pallet<T> where
 	BalanceOf<T>: MaybeSerializeDeserialize + Debug
 {
 	type Moment = T::BlockNumber;

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -182,7 +182,7 @@ pub mod pallet {
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
-	#[pallet::metadata(T::AccountId = "AccountId", T::Balance = "Balance")]
+	#[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
 	pub enum Event<T: Config> {
 		/// The amount vested has been updated. This could indicate more funds are available. The
 		/// balance given is the amount which is left unvested (and thus locked).


### PR DESCRIPTION
Part of #7882.

Converts the `Vesting` pallet to the new pallet attribute macro introduced in #6877.

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

## ⚠️ Breaking Change ⚠️ 

From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

> storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.

So users of the `Vesting` pallet must be careful about the name they used in `construct_runtime!`. Hence the `runtime-migration` label, which might not be needed depending on the configuration of the `Vesting` pallet.