### PR TITLE
Fix local variable names conflict in pallet call expansion

### DIFF
--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -108,26 +108,26 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 				match *self {
 					#(
 						Self::#fn_name ( #( ref #args_name, )* ) => {
-							let base_weight = #fn_weight;
+							let __pallet_base_weight = #fn_weight;
 
-							let weight = <
+							let __pallet_weight = <
 								dyn #frame_support::dispatch::WeighData<( #( & #args_type, )* )>
-							>::weigh_data(&base_weight, ( #( #args_name, )* ));
+							>::weigh_data(&__pallet_base_weight, ( #( #args_name, )* ));
 
-							let class = <
+							let __pallet_class = <
 								dyn #frame_support::dispatch::ClassifyDispatch<
 									( #( & #args_type, )* )
 								>
-							>::classify_dispatch(&base_weight, ( #( #args_name, )* ));
+							>::classify_dispatch(&__pallet_base_weight, ( #( #args_name, )* ));
 
-							let pays_fee = <
+							let __pallet_pays_fee = <
 								dyn #frame_support::dispatch::PaysFee<( #( & #args_type, )* )>
-							>::pays_fee(&base_weight, ( #( #args_name, )* ));
+							>::pays_fee(&__pallet_base_weight, ( #( #args_name, )* ));
 
 							#frame_support::dispatch::DispatchInfo {
-								weight,
-								class,
-								pays_fee,
+								weight: __pallet_weight,
+								class: __pallet_class,
+								pays_fee: __pallet_pays_fee,
 							}
 						},
 					)*

--- a/frame/support/src/dispatch.rs
+++ b/frame/support/src/dispatch.rs
@@ -1967,23 +1967,23 @@ macro_rules! decl_module {
 				match *self {
 					$(
 						$call_type::$fn_name( $( ref $param_name ),* ) => {
-							let base_weight = $weight;
-							let weight = <dyn $crate::dispatch::WeighData<( $( & $param, )* )>>::weigh_data(
-								&base_weight,
+							let __pallet_base_weight = $weight;
+							let __pallet_weight = <dyn $crate::dispatch::WeighData<( $( & $param, )* )>>::weigh_data(
+								&__pallet_base_weight,
 								($( $param_name, )*)
 							);
-							let class = <dyn $crate::dispatch::ClassifyDispatch<( $( & $param, )* )>>::classify_dispatch(
-								&base_weight,
+							let __pallet_class = <dyn $crate::dispatch::ClassifyDispatch<( $( & $param, )* )>>::classify_dispatch(
+								&__pallet_base_weight,
 								($( $param_name, )*)
 							);
-							let pays_fee = <dyn $crate::dispatch::PaysFee<( $( & $param, )* )>>::pays_fee(
-								&base_weight,
+							let __pallet_pays_fee = <dyn $crate::dispatch::PaysFee<( $( & $param, )* )>>::pays_fee(
+								&__pallet_base_weight,
 								($( $param_name, )*)
 							);
 							$crate::dispatch::DispatchInfo {
-								weight,
-								class,
-								pays_fee,
+								weight: __pallet_weight,
+								class: __pallet_class,
+								pays_fee: __pallet_pays_fee,
 							}
 						},
 					)*


### PR DESCRIPTION
The code generated to compute weight use local variables which names can conflict with dispatchable arguments.

In the past if a call has an argument `weight: bool` the name `weight` would conflict with the local variable.