### PR TITLE
Remove redundant libp2p dependency from test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9712,7 +9712,6 @@ dependencies = [
  "futures 0.1.31",
  "futures 0.3.13",
  "jsonrpc-core",
- "libp2p",
  "log",
  "node-cli",
  "parity-scale-codec 1.3.7",

--- a/test-utils/test-runner/Cargo.toml
+++ b/test-utils/test-runner/Cargo.toml
@@ -50,7 +50,6 @@ futures01 = { package = "futures", version = "0.1.29" }
 futures = { package = "futures", version = "0.3", features = ["compat"] }
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"] }
-libp2p = "0.36.0"
 
 # Calling RPC
 jsonrpc-core = "15.1"

--- a/test-utils/test-runner/Cargo.toml
+++ b/test-utils/test-runner/Cargo.toml
@@ -50,7 +50,7 @@ futures01 = { package = "futures", version = "0.1.29" }
 futures = { package = "futures", version = "0.3", features = ["compat"] }
 rand = "0.7"
 tokio = { version = "0.2", features = ["full"] }
-libp2p = "0.35.1"
+libp2p = "0.36.0"
 
 # Calling RPC
 jsonrpc-core = "15.1"


### PR DESCRIPTION
Should fix CI check `test-linux-stable` failing  with `the lock file /builds/parity/substrate/Cargo.lock needs to be updated but --locked was passed to prevent this`. https://gitlab.parity.io/parity/substrate/-/jobs/866870#L63