### PR TITLE
helper macro to create storage types on the fly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,22 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b8538953a3f0d0d3868f0a706eb4273535e10d72acb5c82c1c23ae48835c85"
+dependencies = [
+ "async-io",
+ "futures 0.3.13",
+ "futures-lite",
+ "if-addrs",
+ "ipnet",
+ "libc",
+ "log",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-watch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6d52908d4ea4ab2bc22474ba149bf1011c8e2c3ebc1ff593ae28ac44f494b6"
@@ -3111,6 +3127,44 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc225a49973cf9ab10d0cdd6a4b8f0cda299df9b760824bbb623f15f8f0c95a"
+dependencies = [
+ "atomic",
+ "bytes 1.0.1",
+ "futures 0.3.13",
+ "lazy_static",
+ "libp2p-core 0.27.1",
+ "libp2p-deflate 0.27.1",
+ "libp2p-dns 0.27.0",
+ "libp2p-floodsub 0.27.0",
+ "libp2p-gossipsub 0.28.0",
+ "libp2p-identify 0.27.0",
+ "libp2p-kad 0.28.1",
+ "libp2p-mdns 0.28.1",
+ "libp2p-mplex 0.27.1",
+ "libp2p-noise 0.29.0",
+ "libp2p-ping 0.27.0",
+ "libp2p-plaintext 0.27.1",
+ "libp2p-pnet",
+ "libp2p-request-response 0.9.1",
+ "libp2p-swarm 0.27.2",
+ "libp2p-swarm-derive",
+ "libp2p-tcp 0.27.1",
+ "libp2p-uds 0.27.0",
+ "libp2p-wasm-ext 0.27.0",
+ "libp2p-websocket 0.28.0",
+ "libp2p-yamux 0.30.1",
+ "parity-multiaddr",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.5",
+ "smallvec 1.6.1",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5759b526f75102829c15e4d8566603b4bf502ed19b5f35920d98113873470d"
@@ -3119,33 +3173,67 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.13",
  "lazy_static",
- "libp2p-core",
- "libp2p-deflate",
- "libp2p-dns",
- "libp2p-floodsub",
- "libp2p-gossipsub",
- "libp2p-identify",
- "libp2p-kad",
- "libp2p-mdns",
- "libp2p-mplex",
- "libp2p-noise",
- "libp2p-ping",
- "libp2p-plaintext",
+ "libp2p-core 0.28.1",
+ "libp2p-deflate 0.28.0",
+ "libp2p-dns 0.28.0",
+ "libp2p-floodsub 0.28.0",
+ "libp2p-gossipsub 0.29.0",
+ "libp2p-identify 0.28.0",
+ "libp2p-kad 0.29.0",
+ "libp2p-mdns 0.29.0",
+ "libp2p-mplex 0.28.0",
+ "libp2p-noise 0.30.0",
+ "libp2p-ping 0.28.0",
+ "libp2p-plaintext 0.28.0",
  "libp2p-pnet",
  "libp2p-relay",
- "libp2p-request-response",
- "libp2p-swarm",
+ "libp2p-request-response 0.10.0",
+ "libp2p-swarm 0.28.0",
  "libp2p-swarm-derive",
- "libp2p-tcp",
- "libp2p-uds",
- "libp2p-wasm-ext",
- "libp2p-websocket",
- "libp2p-yamux",
+ "libp2p-tcp 0.28.0",
+ "libp2p-uds 0.28.0",
+ "libp2p-wasm-ext 0.28.0",
+ "libp2p-websocket 0.29.0",
+ "libp2p-yamux 0.31.0",
  "parity-multiaddr",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
  "smallvec 1.6.1",
  "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2d56aadc2c2bf22cd7797f86e56a65b5b3994a0136b65be3106938acae7a26"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.13",
+ "futures-timer 3.0.2",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "multihash",
+ "multistream-select",
+ "parity-multiaddr",
+ "parking_lot 0.11.1",
+ "pin-project 1.0.5",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.9.3",
+ "smallvec 1.6.1",
+ "thiserror",
+ "unsigned-varint 0.7.0",
+ "void",
+ "zeroize",
 ]
 
 [[package]]
@@ -3184,13 +3272,35 @@ dependencies = [
 
 [[package]]
 name = "libp2p-deflate"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d42eed63305f0420736fa487f9acef720c4528bd7852a6a760f5ccde4813345"
+dependencies = [
+ "flate2",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+]
+
+[[package]]
+name = "libp2p-deflate"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2181a641cd15f9b6ba71b1335800f309012a0a97a29ffaabbbf40e9d3d58f08"
 dependencies = [
  "flate2",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
+dependencies = [
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "log",
 ]
 
 [[package]]
@@ -3201,10 +3311,28 @@ checksum = "9712eb3e9f7dcc77cc5ca7d943b6a85ce4b1faaf91a67e003442412a26d6d6f8"
 dependencies = [
  "async-std-resolver",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "smallvec 1.6.1",
  "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-floodsub"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c63dfa06581b24b1d12bf9815b43689a784424be217d6545c800c7c75a207f"
+dependencies = [
+ "cuckoofilter",
+ "fnv",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -3216,13 +3344,39 @@ dependencies = [
  "cuckoofilter",
  "fnv",
  "futures 0.3.13",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "prost",
  "prost-build",
  "rand 0.7.3",
  "smallvec 1.6.1",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502dc5fcbfec4aa1c63ef3f7307ffe20e90c1a1387bf23ed0bec087f2dde58a1"
+dependencies = [
+ "asynchronous-codec 0.6.0",
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.0.1",
+ "fnv",
+ "futures 0.3.13",
+ "hex_fmt",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "regex",
+ "sha2 0.9.3",
+ "smallvec 1.6.1",
+ "unsigned-varint 0.7.0",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -3238,8 +3392,8 @@ dependencies = [
  "fnv",
  "futures 0.3.13",
  "hex_fmt",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "prost",
  "prost-build",
@@ -3253,17 +3407,59 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
+dependencies = [
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "prost",
+ "prost-build",
+ "smallvec 1.6.1",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88ebc841d744979176ab4b8b294a3e655a7ba4ef26a905d073a52b49ed4dff5"
 dependencies = [
  "futures 0.3.13",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "prost",
  "prost-build",
  "smallvec 1.6.1",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3da6c9acbcc05f93235d201d7d45ef4e8b88a45d8836f98becd8b4d443f066"
+dependencies = [
+ "arrayvec 0.5.2",
+ "asynchronous-codec 0.6.0",
+ "bytes 1.0.1",
+ "either",
+ "fnv",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.3",
+ "smallvec 1.6.1",
+ "uint",
+ "unsigned-varint 0.7.0",
+ "void",
  "wasm-timer",
 ]
 
@@ -3279,8 +3475,8 @@ dependencies = [
  "either",
  "fnv",
  "futures 0.3.13",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "prost",
  "prost-build",
@@ -3295,6 +3491,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9e6374814d1b118d97ccabdfc975c8910bd16dc38a8bc058eeb08bf2080fe1"
+dependencies = [
+ "async-io",
+ "data-encoding",
+ "dns-parser",
+ "futures 0.3.13",
+ "if-watch 0.1.8",
+ "lazy_static",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "socket2 0.3.19",
+ "void",
+]
+
+[[package]]
+name = "libp2p-mdns"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be28ca13bb648d249a9baebd750ebc64ce7040ddd5f0ce1035ff1f4549fb596d"
@@ -3303,15 +3520,33 @@ dependencies = [
  "data-encoding",
  "dns-parser",
  "futures 0.3.13",
- "if-watch",
+ "if-watch 0.2.0",
  "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "rand 0.8.3",
  "smallvec 1.6.1",
  "socket2 0.4.0",
  "void",
+]
+
+[[package]]
+name = "libp2p-mplex"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350ce8b3923594aedabd5d6e3f875d058435052a29c3f32df378bc70d10be464"
+dependencies = [
+ "asynchronous-codec 0.6.0",
+ "bytes 1.0.1",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.11.1",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "unsigned-varint 0.7.0",
 ]
 
 [[package]]
@@ -3323,13 +3558,35 @@ dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
+dependencies = [
+ "bytes 1.0.1",
+ "curve25519-dalek 3.0.2",
+ "futures 0.3.13",
+ "lazy_static",
+ "libp2p-core 0.27.1",
+ "log",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "sha2 0.9.3",
+ "snow",
+ "static_assertions",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -3342,7 +3599,7 @@ dependencies = [
  "curve25519-dalek 3.0.2",
  "futures 0.3.13",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "prost",
  "prost-build",
@@ -3356,17 +3613,49 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
+dependencies = [
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "rand 0.7.3",
+ "void",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-ping"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea10fc5209260915ea65b78f612d7ff78a29ab288e7aa3250796866af861c45"
 dependencies = [
  "futures 0.3.13",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "rand 0.7.3",
  "void",
  "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-plaintext"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d58defcadb646ae4b033e130b48d87410bf76394dc3335496cae99dac803e61"
+dependencies = [
+ "asynchronous-codec 0.6.0",
+ "bytes 1.0.1",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "log",
+ "prost",
+ "prost-build",
+ "unsigned-varint 0.7.0",
+ "void",
 ]
 
 [[package]]
@@ -3378,7 +3667,7 @@ dependencies = [
  "asynchronous-codec 0.6.0",
  "bytes 1.0.1",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "prost",
  "prost-build",
@@ -3410,8 +3699,8 @@ dependencies = [
  "bytes 1.0.1",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "pin-project 1.0.5",
  "prost",
@@ -3425,6 +3714,26 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e5552827c33d8326502682da73a0ba4bfa40c1b55b216af3c303f32169dd89"
+dependencies = [
+ "async-trait",
+ "bytes 1.0.1",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "libp2p-swarm 0.27.2",
+ "log",
+ "lru",
+ "minicbor 0.7.2",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "unsigned-varint 0.7.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-request-response"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725367dd2318c54c5ab1a6418592e5b01c63b0dedfbbfb8389220b2bcf691899"
@@ -3432,14 +3741,30 @@ dependencies = [
  "async-trait",
  "bytes 1.0.1",
  "futures 0.3.13",
- "libp2p-core",
- "libp2p-swarm",
+ "libp2p-core 0.28.1",
+ "libp2p-swarm 0.28.0",
  "log",
  "lru",
- "minicbor",
+ "minicbor 0.8.0",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "unsigned-varint 0.7.0",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7955b973e1fd2bd61ffd43ce261c1223f61f4aacd5bae362a924993f9a25fd98"
+dependencies = [
+ "either",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "log",
+ "rand 0.7.3",
+ "smallvec 1.6.1",
+ "void",
  "wasm-timer",
 ]
 
@@ -3451,7 +3776,7 @@ checksum = "75c26980cadd7c25d89071cb23e1f7f5df4863128cc91d83c6ddc72338cecafa"
 dependencies = [
  "either",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "rand 0.7.3",
  "smallvec 1.6.1",
@@ -3471,6 +3796,23 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5aef80e519a6cb8e2663605142f97baaaea1a252eecbf8756184765f7471b"
+dependencies = [
+ "async-io",
+ "futures 0.3.13",
+ "futures-timer 3.0.2",
+ "if-watch 0.1.8",
+ "ipnet",
+ "libc",
+ "libp2p-core 0.27.1",
+ "log",
+ "socket2 0.3.19",
+]
+
+[[package]]
+name = "libp2p-tcp"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b1a27d21c477951799e99d5c105d78868258502ce092988040a808d5a19bbd9"
@@ -3478,12 +3820,24 @@ dependencies = [
  "async-io",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "if-watch",
+ "if-watch 0.2.0",
  "ipnet",
  "libc",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "socket2 0.4.0",
+]
+
+[[package]]
+name = "libp2p-uds"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ac51ce419f60be966e02103c17f67ff5dc4422ba83ba54d251d6c62a4ed487"
+dependencies = [
+ "async-std",
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "log",
 ]
 
 [[package]]
@@ -3494,8 +3848,22 @@ checksum = "ffd6564bb3b7ff203661ccbb69003c2b551e34cef974f2d6c6a28306a12170b5"
 dependencies = [
  "async-std",
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
+]
+
+[[package]]
+name = "libp2p-wasm-ext"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6149c46cb76935c80bc8be6ec6e3ebd5f5e1679765a255fb34331d54610f15dd"
+dependencies = [
+ "futures 0.3.13",
+ "js-sys",
+ "libp2p-core 0.27.1",
+ "parity-send-wrapper",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3506,10 +3874,28 @@ checksum = "6df65fc13f6188edf7e6927b086330448b3ca27af86b49748c6d299d7c8d9040"
 dependencies = [
  "futures 0.3.13",
  "js-sys",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "parity-send-wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b1c6a3431045da8b925ed83384e4c5163e14b990572307fca9c507435d4d22"
+dependencies = [
+ "either",
+ "futures 0.3.13",
+ "futures-rustls",
+ "libp2p-core 0.27.1",
+ "log",
+ "quicksink",
+ "rw-stream-sink",
+ "soketto",
+ "url 2.2.1",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3521,7 +3907,7 @@ dependencies = [
  "either",
  "futures 0.3.13",
  "futures-rustls",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "log",
  "quicksink",
  "rw-stream-sink",
@@ -3532,12 +3918,25 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4819358c542a86ff95f6ae691efb4b94ddaf477079b01a686f5705b79bfc232a"
+dependencies = [
+ "futures 0.3.13",
+ "libp2p-core 0.27.1",
+ "parking_lot 0.11.1",
+ "thiserror",
+ "yamux",
+]
+
+[[package]]
+name = "libp2p-yamux"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d6144cc94143fb0a8dd1e7c2fbcc32a2808168bcd1d69920635424d5993b7b"
 dependencies = [
  "futures 0.3.13",
- "libp2p-core",
+ "libp2p-core 0.28.1",
  "parking_lot 0.11.1",
  "thiserror",
  "yamux",
@@ -3792,6 +4191,15 @@ dependencies = [
  "keccak",
  "rand_core 0.5.1",
  "zeroize",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2b2c73f9640fccab53947e2b3474d5071fcbc8f82cac51ddf6c8041a30a9ea"
+dependencies = [
+ "minicbor-derive",
 ]
 
 [[package]]
@@ -4073,7 +4481,7 @@ dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
  "jsonrpc-core",
- "libp2p",
+ "libp2p 0.36.0",
  "node-cli",
  "sc-rpc-api",
  "serde",
@@ -4094,7 +4502,7 @@ dependencies = [
  "frame-system",
  "futures 0.3.13",
  "hex-literal",
- "libp2p-wasm-ext",
+ "libp2p-wasm-ext 0.28.0",
  "log",
  "nix",
  "node-executor",
@@ -6898,7 +7306,7 @@ dependencies = [
  "either",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "parity-scale-codec 2.0.1",
  "prost",
@@ -7000,7 +7408,7 @@ dependencies = [
  "fdlimit",
  "futures 0.3.13",
  "hex",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "names",
  "parity-scale-codec 2.0.1",
@@ -7615,7 +8023,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "hex",
  "ip_network",
- "libp2p",
+ "libp2p 0.36.0",
  "linked-hash-map",
  "linked_hash_set",
  "log",
@@ -7661,7 +8069,7 @@ dependencies = [
  "async-std",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "lru",
  "quickcheck",
@@ -7681,7 +8089,7 @@ dependencies = [
  "async-std",
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "parking_lot 0.11.1",
  "rand 0.7.3",
@@ -7742,7 +8150,7 @@ name = "sc-peerset"
 version = "3.0.0"
 dependencies = [
  "futures 0.3.13",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "rand 0.7.3",
  "serde_json",
@@ -7998,7 +8406,7 @@ version = "3.0.0"
 dependencies = [
  "chrono",
  "futures 0.3.13",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "parking_lot 0.11.1",
  "pin-project 1.0.5",
@@ -8666,7 +9074,7 @@ version = "0.9.0"
 dependencies = [
  "futures 0.3.13",
  "futures-timer 3.0.2",
- "libp2p",
+ "libp2p 0.36.0",
  "log",
  "parity-scale-codec 2.0.1",
  "parking_lot 0.11.1",
@@ -9394,7 +9802,7 @@ dependencies = [
  "getrandom 0.2.2",
  "js-sys",
  "kvdb-web",
- "libp2p-wasm-ext",
+ "libp2p-wasm-ext 0.28.0",
  "log",
  "rand 0.7.3",
  "sc-chain-spec",
@@ -9712,7 +10120,7 @@ dependencies = [
  "futures 0.1.31",
  "futures 0.3.13",
  "jsonrpc-core",
- "libp2p",
+ "libp2p 0.35.1",
  "log",
  "node-cli",
  "parity-scale-codec 1.3.7",

--- a/frame/elections-phragmen/src/migrations_3_0_0.rs
+++ b/frame/elections-phragmen/src/migrations_3_0_0.rs
@@ -21,7 +21,6 @@ use codec::{Encode, Decode, FullCodec};
 use sp_std::prelude::*;
 use frame_support::{
 	RuntimeDebug, weights::Weight, Twox64Concat,
-	storage::types::{StorageMap, StorageValue},
 	traits::{GetPalletVersion, PalletVersion},
 };
 
@@ -51,38 +50,21 @@ pub trait V2ToV3 {
 	type Balance: 'static + FullCodec + Copy;
 }
 
-struct __Candidates;
-impl frame_support::traits::StorageInstance for __Candidates {
-	fn pallet_prefix() -> &'static str { "PhragmenElection" }
-	const STORAGE_PREFIX: &'static str = "Candidates";
-}
-
-#[allow(type_alias_bounds)]
-type Candidates<T: V2ToV3> = StorageValue<__Candidates, Vec<(T::AccountId, T::Balance)>>;
-
-struct __Members;
-impl frame_support::traits::StorageInstance for __Members {
-	fn pallet_prefix() -> &'static str { "PhragmenElection" }
-	const STORAGE_PREFIX: &'static str = "Members";
-}
-#[allow(type_alias_bounds)]
-type Members<T: V2ToV3> = StorageValue<__Members, Vec<SeatHolder<T::AccountId, T::Balance>>>;
-
-struct __RunnersUp;
-impl frame_support::traits::StorageInstance for __RunnersUp {
-	fn pallet_prefix() -> &'static str { "PhragmenElection" }
-	const STORAGE_PREFIX: &'static str = "RunnersUp";
-}
-#[allow(type_alias_bounds)]
-type RunnersUp<T: V2ToV3> = StorageValue<__RunnersUp, Vec<SeatHolder<T::AccountId, T::Balance>>>;
-
-struct __Voting;
-impl frame_support::traits::StorageInstance for __Voting {
-	fn pallet_prefix() -> &'static str { "PhragmenElection" }
-	const STORAGE_PREFIX: &'static str = "Voting";
-}
-#[allow(type_alias_bounds)]
-type Voting<T: V2ToV3> = StorageMap<__Voting, Twox64Concat, T::AccountId, Voter<T::AccountId, T::Balance>>;
+frame_support::generate_storage_alias!(
+	PhragmenElection, Candidates<T: V2ToV3> => Value<Vec<(T::AccountId, T::Balance)>>
+);
+frame_support::generate_storage_alias!(
+	PhragmenElection, Members<T: V2ToV3> => Value<Vec<SeatHolder<T::AccountId, T::Balance>>>
+);
+frame_support::generate_storage_alias!(
+	PhragmenElection, RunnersUp<T: V2ToV3> => Value<Vec<SeatHolder<T::AccountId, T::Balance>>>
+);
+frame_support::generate_storage_alias!(
+	PhragmenElection, Voting<T: V2ToV3> => Map<
+		(Twox64Concat, T::AccountId),
+		Voter<T::AccountId, T::Balance>
+	>
+);
 
 /// Apply all of the migrations from 2_0_0 to 3_0_0.
 ///

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1036,30 +1036,15 @@ pub mod migrations {
 
 	pub mod v6 {
 		use super::*;
-		use frame_support::{traits::Get, weights::Weight, pallet_prelude::*};
-
-		macro_rules! generate_storage_types {
-			($name:ident => Value<$value:ty>) => {
-				paste::paste! {
-					struct [<$name Instance>];
-					impl frame_support::traits::StorageInstance for [<$name Instance>] {
-						fn pallet_prefix() -> &'static str {
-							"Staking"
-						}
-						const STORAGE_PREFIX: &'static str = stringify!($name);
-					}
-					type $name = StorageValue<[<$name Instance>], $value, ValueQuery>;
-				}
-			}
-		}
+		use frame_support::{traits::Get, weights::Weight, generate_storage_alias};
 
 		// NOTE: value type doesn't matter, we just set it to () here.
-		generate_storage_types!(SnapshotValidators => Value<()>);
-		generate_storage_types!(SnapshotNominators => Value<()>);
-		generate_storage_types!(QueuedElected => Value<()>);
-		generate_storage_types!(QueuedScore => Value<()>);
-		generate_storage_types!(EraElectionStatus => Value<()>);
-		generate_storage_types!(IsCurrentSessionFinal => Value<()>);
+		generate_storage_alias!(Staking, SnapshotValidators => Value<()>);
+		generate_storage_alias!(Staking, SnapshotNominators => Value<()>);
+		generate_storage_alias!(Staking, QueuedElected => Value<()>);
+		generate_storage_alias!(Staking, QueuedScore => Value<()>);
+		generate_storage_alias!(Staking, EraElectionStatus => Value<()>);
+		generate_storage_alias!(Staking, IsCurrentSessionFinal => Value<()>);
 
 		/// check to execute prior to migration.
 		pub fn pre_migrate<T: Config>() -> Result<(), &'static str> {

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -87,6 +87,120 @@ pub const LOG_TARGET: &'static str = "runtime::frame-support";
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Never {}
 
+/// Generate a new type aliases for [`storage::types::value::StorageValue`],
+/// [`storage::types::value::StorageMap`] and [`storage::types::value::StorageDoubleMap`].
+///
+/// Useful for creating a *storage-like* struct for test and migrations.
+///
+///```
+/// # use frame_support::generate_storage_alias;
+/// use frame_support::codec;
+/// use frame_support::Twox64Concat;
+/// // generate a storage value with type u32.
+/// generate_storage_alias!(Prefix, StorageName => Value<u32>);
+///
+/// // generate a double map from `(u32, u32)` (with hasher `Twox64Concat`) to `Vec<u8>`
+/// generate_storage_alias!(
+///		OtherPrefix, OtherStorageName => DoubleMap<
+/// 		(T::AccountId, u32),
+/// 		(T::AccountId, u32),
+/// 		Vec<u8>
+///		>
+/// );
+///
+/// // generate a map from `Config::AccountId` (with hasher `Twox64Concat`) to `Vec<u8>`
+/// trait Config { type AccountId: codec::FullCodec; }
+/// generate_storage_alias!(
+///		Prefix, GenericStorage<T: Config> => Map<(Twox64Concat, T::AccountId), Vec<u8>>
+/// );
+/// # fn main() {}
+///```
+#[macro_export]
+macro_rules! generate_storage_alias {
+	// without generic for $name.
+	($pallet:ident, $name:ident => Map<($key:ty, $hasher:ty), $value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			type $name = $crate::storage::types::StorageMap<
+				[<$name Instance>],
+				$hasher,
+				$key,
+				$value,
+			>;
+		}
+	};
+	($pallet:ident, $name:ident => DoubleMap<($key1:ty, $hasher1:ty), ($key2:ty, $hasher2:ty), $value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			type $name = $crate::storage::types::StorageMap<
+				[<$name Instance>],
+				$hasher1,
+				$key1,
+				$hasher2,
+				$key2,
+				$value,
+			>;
+		}
+	};
+	($pallet:ident, $name:ident => Value<$value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			type $name = $crate::storage::types::StorageValue<
+				[<$name Instance>],
+				$value,
+			>;
+		}
+	};
+	// with generic for $name.
+	($pallet:ident, $name:ident<$t:ident : $bounds:tt> => Map<($key:ty, $hasher:ty), $value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			#[allow(type_alias_bounds)]
+			type $name<$t : $bounds> = $crate::storage::types::StorageMap<
+				[<$name Instance>],
+				$key,
+				$hasher,
+				$value,
+			>;
+		}
+	};
+	($pallet:ident, $name:ident<$t:ident : $bounds:tt> => DoubleMap<($key1:ty, $hasher1:ty), ($key2:ty, $hasher2:ty), $value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			#[allow(type_alias_bounds)]
+			type $name<$t : $bounds> = $crate::storage::types::StorageMap<
+				[<$name Instance>],
+				$key1,
+				$hasher1,
+				$key2,
+				$hasher2,
+				$value,
+			>;
+		}
+	};
+	($pallet:ident, $name:ident<$t:ident : $bounds:tt> => Value<$value:ty>) => {
+		$crate::paste::paste! {
+			$crate::generate_storage_alias!(@GENERATE_INSTANCE_STRUCT $pallet, $name);
+			#[allow(type_alias_bounds)]
+			type $name<$t : $bounds> = $crate::storage::types::StorageValue<
+				[<$name Instance>],
+				$value,
+				$crate::storage::types::ValueQuery,
+			>;
+		}
+	};
+	// helper used in all arms.
+	(@GENERATE_INSTANCE_STRUCT $pallet:ident, $name:ident) => {
+		$crate::paste::paste! {
+			struct [<$name Instance>];
+			impl $crate::traits::StorageInstance for [<$name Instance>] {
+				fn pallet_prefix() -> &'static str { stringify!($pallet) }
+				const STORAGE_PREFIX: &'static str = stringify!($name);
+			}
+		}
+	}
+}
+
 /// Create new implementations of the [`Get`](crate::traits::Get) trait.
 ///
 /// The so-called parameter type can be created in four different ways:


### PR DESCRIPTION
Of course, the codes that I changed now with this macro are all dead-codes, but we can use this in the future. 

I also see a lot of potential use case for this in tests where we want to define a storage item on the fly, instead of doing a fake `decl_storage`, but didn't refactor them here. 

cc @Lohann