### PR TITLE
Fixed sync skipping some block announcements

### DIFF
--- a/client/network/src/protocol/message.rs
+++ b/client/network/src/protocol/message.rs
@@ -144,6 +144,26 @@ pub struct RemoteReadResponse {
 	pub proof: StorageProof,
 }
 
+/// Announcement summary used for debug logging.
+#[derive(Debug)]
+pub struct AnnouncementSummary<H: HeaderT> {
+	block_hash: H::Hash,
+	number: H::Number,
+	parent_hash: H::Hash,
+	state: Option<BlockState>,
+}
+
+impl<H: HeaderT> generic::BlockAnnounce<H> {
+	pub fn summary(&self) -> AnnouncementSummary<H> {
+		AnnouncementSummary {
+			block_hash: self.header.hash(),
+			number: *self.header.number(),
+			parent_hash: self.header.parent_hash().clone(),
+			state: self.state,
+		}
+	}
+}
+
 /// Generic types.
 pub mod generic {
 	use bitflags::bitflags;

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -505,9 +505,10 @@ impl<B: BlockT> ChainSync<B> {
 		}
 	}
 
-	/// Number of active sync requests.
+	/// Number of active forks requests. This inludes
+	/// request that are pending or can be issued right away.
 	pub fn num_sync_requests(&self) -> usize {
-		self.fork_targets.len()
+		self.fork_targets.values().filter(|f| f.number <= self.best_queued_number).count()
 	}
 
 	/// Number of downloaded blocks.
@@ -1421,22 +1422,35 @@ impl<B: BlockT> ChainSync<B> {
 		&mut self,
 		pre_validation_result: PreValidateBlockAnnounce<B::Header>,
 	) -> PollBlockAnnounceValidation<B::Header> {
-		trace!(
-			target: "sync",
-			"Finished block announce validation: {:?}",
-			pre_validation_result,
-		);
-
 		let (announce, is_best, who) = match pre_validation_result {
 			PreValidateBlockAnnounce::Failure { who, disconnect } => {
+				debug!(
+					target: "sync",
+					"Failed announce validation: {:?}, disconnect: {}",
+					who,
+					disconnect,
+				);
 				return PollBlockAnnounceValidation::Failure { who, disconnect }
 			},
 			PreValidateBlockAnnounce::Process { announce, is_new_best, who } => {
 				(announce, is_new_best, who)
 			},
-			PreValidateBlockAnnounce::Error { .. } | PreValidateBlockAnnounce::Skip =>
-				return PollBlockAnnounceValidation::Skip,
+			PreValidateBlockAnnounce::Error { .. } | PreValidateBlockAnnounce::Skip => {
+				debug!(
+					target: "sync",
+					"Ignored announce validation",
+				);
+				return PollBlockAnnounceValidation::Skip
+			},
 		};
+
+		trace!(
+			target: "sync",
+			"Finished block announce validation: from {:?}: {:?}. local_best={}",
+			announce.summary(),
+			who,
+			is_best,
+		);
 
 		let number = *announce.header.number();
 		let hash = announce.header.hash();
@@ -1508,25 +1522,22 @@ impl<B: BlockT> ChainSync<B> {
 			return PollBlockAnnounceValidation::ImportHeader { is_best, announce, who }
 		}
 
-		if number <= self.best_queued_number {
-			trace!(
-				target: "sync",
-				"Added sync target for block announced from {}: {} {:?}",
-				who,
-				hash,
-				announce.header,
-			);
-			self.fork_targets
-				.entry(hash.clone())
-				.or_insert_with(|| ForkTarget {
-					number,
-					parent_hash: Some(*announce.header.parent_hash()),
-					peers: Default::default(),
-				})
-				.peers.insert(who.clone());
-		}
+		trace!(
+			target: "sync",
+			"Added sync target for block announced from {}: {} {:?}",
+			who,
+			hash,
+			announce.summary(),
+		);
+		self.fork_targets
+			.entry(hash.clone())
+			.or_insert_with(|| ForkTarget {
+				number,
+				parent_hash: Some(*announce.header.parent_hash()),
+				peers: Default::default(),
+			})
+			.peers.insert(who.clone());
 
-		trace!(target: "sync", "Announce validation result is nothing");
 		PollBlockAnnounceValidation::Nothing { is_best, who, announce }
 	}
 

--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -505,8 +505,8 @@ impl<B: BlockT> ChainSync<B> {
 		}
 	}
 
-	/// Number of active forks requests. This inludes
-	/// request that are pending or can be issued right away.
+	/// Number of active forks requests. This includes
+	/// requests that are pending or could be issued right away.
 	pub fn num_sync_requests(&self) -> usize {
 		self.fork_targets.values().filter(|f| f.number <= self.best_queued_number).count()
 	}
@@ -1447,8 +1447,8 @@ impl<B: BlockT> ChainSync<B> {
 		trace!(
 			target: "sync",
 			"Finished block announce validation: from {:?}: {:?}. local_best={}",
-			announce.summary(),
 			who,
+			announce.summary(),
 			is_best,
 		);
 

--- a/client/network/test/src/lib.rs
+++ b/client/network/test/src/lib.rs
@@ -489,6 +489,11 @@ impl<D, B> Peer<D, B> where
 		&self.network.service()
 	}
 
+	/// Get a reference to the network worker.
+	pub fn network(&self) -> &NetworkWorker<Block, <Block as BlockT>::Hash> {
+		&self.network
+	}
+
 	/// Test helper to compare the blockchain state of multiple (networked)
 	/// clients.
 	pub fn blockchain_canon_equals(&self, other: &Self) -> bool {
@@ -985,12 +990,12 @@ pub trait TestNetFactory: Sized where <Self::BlockImport as BlockImport<Block>>:
 	/// Polls the testnet. Processes all the pending actions.
 	fn poll(&mut self, cx: &mut FutureContext) {
 		self.mut_peers(|peers| {
-			for peer in peers {
-				trace!(target: "sync", "-- Polling {}", peer.id());
+			for (i, peer) in peers.into_iter().enumerate() {
+				trace!(target: "sync", "-- Polling {}: {}", i, peer.id());
 				if let Poll::Ready(()) = peer.network.poll_unpin(cx) {
 					panic!("NetworkWorker has terminated unexpectedly.")
 				}
-				trace!(target: "sync", "-- Polling complete {}", peer.id());
+				trace!(target: "sync", "-- Polling complete {}: {}", i, peer.id());
 
 				// We poll `imported_blocks_stream`.
 				while let Poll::Ready(Some(notification)) = peer.imported_blocks_stream.as_mut().poll_next(cx) {


### PR DESCRIPTION
In rare cases a block announcement would be ignored if a peers that sends has an outstanding block request. This PR fixes this by adding all announcement to fork targets.