### PR TITLE
Change companion check order

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -78,7 +78,6 @@ if [ -z "$(jq -r -e '.[].state | select(. == "APPROVED")' < companion_pr_reviews
 fi
 
 boldprint "polkadot pr #${pr_companion} state APPROVED"
-exit 0
 
 curl -H "${github_header}" -sS -o companion_pr.json \
   ${github_api_polkadot_pull_url}/${pr_companion}
@@ -99,3 +98,5 @@ else
   boldprint "polkadot pr #${pr_companion} not mergeable"
   exit 1
 fi
+
+exit 0

--- a/.maintain/gitlab/check_polkadot_companion_status.sh
+++ b/.maintain/gitlab/check_polkadot_companion_status.sh
@@ -56,27 +56,7 @@ fi
 boldprint "companion pr: #${pr_companion}"
 
 # check the status of that pull request - needs to be
-# mergable and approved
-
-curl -H "${github_header}" -sS -o companion_pr.json \
-  ${github_api_polkadot_pull_url}/${pr_companion}
-
-pr_head_sha=$(jq -r -e '.head.sha' < companion_pr.json)
-boldprint "Polkadot PR's HEAD SHA: $pr_head_sha"
-
-if jq -e .merged < companion_pr.json >/dev/null
-then
-  boldprint "polkadot pr #${pr_companion} already merged"
-  exit 0
-fi
-
-if jq -e '.mergeable' < companion_pr.json >/dev/null
-then
-  boldprint "polkadot pr #${pr_companion} mergeable"
-else
-  boldprint "polkadot pr #${pr_companion} not mergeable"
-  exit 1
-fi
+# approved and mergable
 
 curl -H "${github_header}" -sS -o companion_pr_reviews.json \
   ${github_api_polkadot_pull_url}/${pr_companion}/reviews
@@ -100,4 +80,22 @@ fi
 boldprint "polkadot pr #${pr_companion} state APPROVED"
 exit 0
 
+curl -H "${github_header}" -sS -o companion_pr.json \
+  ${github_api_polkadot_pull_url}/${pr_companion}
 
+pr_head_sha=$(jq -r -e '.head.sha' < companion_pr.json)
+boldprint "Polkadot PR's HEAD SHA: $pr_head_sha"
+
+if jq -e .merged < companion_pr.json >/dev/null
+then
+  boldprint "polkadot pr #${pr_companion} already merged"
+  exit 0
+fi
+
+if jq -e '.mergeable' < companion_pr.json >/dev/null
+then
+  boldprint "polkadot pr #${pr_companion} mergeable"
+else
+  boldprint "polkadot pr #${pr_companion} not mergeable"
+  exit 1
+fi


### PR DESCRIPTION
Apparently if the pr isn't approved it counts as not mergable. However,
this is rahter confusing. To fix this, we just change the order.

