### PR TITLE
Add ss58 prefix 68 for Open Emoji Battler

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -586,6 +586,8 @@ ss58_address_format!(
 		(65, "aventus", "Aventus Chain mainnet, standard account (*25519).")
 	CrustAccount =>
 		(66, "crust", "Crust Network, standard account (*25519).")
+	OpenEmojiBattlerAccount =>
+		(68, "open-emoji-battler", "Open Emoji Battler, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 
 );

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -477,6 +477,15 @@
 			"decimals": [12],
 			"standardAccount": "*25519",
 			"website": "https://crust.network"
+		},
+		{
+			"prefix": 68,
+			"network": "open-emoji-battler",
+			"displayName": "Open Emoji Battler",
+			"symbols": null,
+			"decimals": null,
+			"standardAccount": "*25519",
+			"website": "https://game.open-emoji-battler.community"
 		}
 	]
 }


### PR DESCRIPTION
This adds ss58 prefix 68 for [Open Emoji Battler](https://game.open-emoji-battler.community) chain.