### PR TITLE
Use pathbuf for remote externalities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,22 +4636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-assets-freezer"
-version = "3.0.0"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "pallet-assets",
- "parity-scale-codec 2.0.1",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-atomic-swap"
 version = "3.0.0"
 dependencies = [

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -181,23 +181,19 @@ impl<B: BlockT> OnlineConfig<B> {
 /// Configuration of the state snapshot.
 #[derive(Clone)]
 pub struct SnapshotConfig {
-	// TODO: I could mix these two into one filed, but I think separate is better bc one can be
-	// configurable while one not.
-	/// File name.
-	pub name: String,
-	/// Base directory.
-	pub directory: String,
+	/// The path to the snapshot file.
+	pub path: PathBuf,
+}
+
+impl SnapshotConfig {
+	pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+		Self { path: path.into() }
+	}
 }
 
 impl Default for SnapshotConfig {
 	fn default() -> Self {
-		Self { name: "SNAPSHOT".into(), directory: ".".into() }
-	}
-}
-
-impl SnapshotConfig {
-	fn path(&self) -> PathBuf {
-		Path::new(&self.directory).join(self.name.clone())
+		Self { path: Path::new("SNAPSHOT").into() }
 	}
 }
 
@@ -319,12 +315,12 @@ impl<B: BlockT> Builder<B> {
 
 	async fn pre_build(mut self) -> Result<Vec<KeyPair>, &'static str> {
 		let mut base_kv = match self.mode.clone() {
-			Mode::Offline(config) => self.load_state_snapshot(&config.state_snapshot.path())?,
+			Mode::Offline(config) => self.load_state_snapshot(&config.state_snapshot.path)?,
 			Mode::Online(config) => {
 				self.init_remote_client().await?;
 				let kp = self.load_remote().await?;
 				if let Some(c) = config.state_snapshot {
-					self.save_state_snapshot(&kp, &c.path())?;
+					self.save_state_snapshot(&kp, &c.path)?;
 				}
 				kp
 			}

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -395,7 +395,7 @@ mod tests {
 		init_logger();
 		Builder::<Block>::new()
 			.mode(Mode::Offline(OfflineConfig {
-				state_snapshot: SnapshotConfig { name: "test_data/proxy_test".into(), ..Default::default() },
+				state_snapshot: SnapshotConfig { path: "test_data/proxy_test".into() },
 			}))
 			.build()
 			.await


### PR DESCRIPTION
Changes remote-externalities to use a `PathBuf` internally instead of a directory and file name and changes the cli sub-command try-runtime to take a single 'PathBuf' as well.

This is a follow-up to #8397.