### PR TITLE
client: fix justifications migration

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -561,10 +561,10 @@ impl<Block: BlockT> sc_client_api::blockchain::Backend<Block> for BlockchainDb<B
 
 	fn justifications(&self, id: BlockId<Block>) -> ClientResult<Option<Justifications>> {
 		match read_db(&*self.db, columns::KEY_LOOKUP, columns::JUSTIFICATIONS, id)? {
-			Some(justification) => match Decode::decode(&mut &justification[..]) {
-				Ok(justification) => Ok(Some(justification)),
+			Some(justifications) => match Decode::decode(&mut &justifications[..]) {
+				Ok(justifications) => Ok(Some(justifications)),
 				Err(err) => return Err(sp_blockchain::Error::Backend(
-					format!("Error decoding justification: {}", err)
+					format!("Error decoding justifications: {}", err)
 				)),
 			}
 			None => Ok(None),

--- a/client/db/src/upgrade.rs
+++ b/client/db/src/upgrade.rs
@@ -83,8 +83,11 @@ fn migrate_2_to_3<Block: BlockT>(db_path: &Path, _db_type: DatabaseType) -> sp_b
 	let mut transaction = db.transaction();
 	for key in keys {
 		if let Some(justification) = db.get(columns::JUSTIFICATIONS, &key).map_err(db_err)? {
-			// Tag each Justification with the hardcoded ID for GRANDPA. Avoid the dependency on the GRANDPA crate
-			let justifications = sp_runtime::Justifications::from((*b"FRNK", justification));
+			// Tag each justification with the hardcoded ID for GRANDPA to avoid the dependency on
+			// the GRANDPA crate.
+			// NOTE: when storing justifications the previous API would get a `Vec<u8>` and still
+			// call encode on it.
+			let justifications = sp_runtime::Justifications::from((*b"FRNK", justification.decode()));
 			transaction.put_vec(columns::JUSTIFICATIONS, &key, justifications.encode());
 		}
 	}


### PR DESCRIPTION
Justifications were double-encoded previously, we forgot to decode the justification we get from the database when migrating.

Nodes that had already run this migration will need to resync as it would be necessary to detect which justifications are in which format and that was dangerous and not worth it for something that was not released.