### PR TITLE
Fixed restoring state-db journals on startup

### DIFF
--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -89,6 +89,8 @@ pub enum Error<E: fmt::Debug> {
 	InvalidParent,
 	/// Invalid pruning mode specified. Contains expected mode.
 	InvalidPruningMode(String),
+	/// Too many unfinalized sibling blocks inserted.
+	TooManySiblingBlocks,
 }
 
 /// Pinning error type.
@@ -112,6 +114,7 @@ impl<E: fmt::Debug> fmt::Debug for Error<E> {
 			Error::InvalidBlockNumber => write!(f, "Trying to insert block with invalid number"),
 			Error::InvalidParent => write!(f, "Trying to insert block with unknown parent"),
 			Error::InvalidPruningMode(e) => write!(f, "Expected pruning mode: {}", e),
+			Error::TooManySiblingBlocks => write!(f, "Too many sibling blocks inserted"),
 		}
 	}
 }

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -31,7 +31,7 @@
 //! # Canonicalization vs Finality
 //! Database engine uses a notion of canonicality, rather then finality. A canonical block may not be yet finalized
 //! from the perspective of the consensus engine, but it still can't be reverted in the database. Most of the time
-//! during normal operation last canonical block is the same as lst finalized. However if finality stall for a
+//! during normal operation last canonical block is the same as last finalized. However if finality stall for a
 //! long duration for some reason, there's only a certain number of blocks that can fit in the non-canonical overlay,
 //! so canonicalization of an unfinalized block may be forced.
 //!

--- a/client/state-db/src/lib.rs
+++ b/client/state-db/src/lib.rs
@@ -16,16 +16,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! State database maintenance. Handles canonicalization and pruning in the database. The input to
-//! this module is a `ChangeSet` which is basically a list of key-value pairs (trie nodes) that
-//! were added or deleted during block execution.
+//! State database maintenance. Handles canonicalization and pruning in the database.
 //!
 //! # Canonicalization.
 //! Canonicalization window tracks a tree of blocks identified by header hash. The in-memory
-//! overlay allows to get any node that was inserted in any of the blocks within the window.
-//! The tree is journaled to the backing database and rebuilt on startup.
+//! overlay allows to get any trie node that was inserted in any of the blocks within the window.
+//! The overlay is journaled to the backing database and rebuilt on startup.
+//! There's a limit of 32 blocks that may have the same block number in the canonicalization window.
+//!
 //! Canonicalization function selects one root from the top of the tree and discards all other roots
-//! and their subtrees.
+//! and their subtrees. Upon canonicalization all trie nodes that were inserted in the block are added to
+//! the backing DB and block tracking is moved to the pruning window, where no forks are allowed.
+//!
+//! # Canonicalization vs Finality
+//! Database engine uses a notion of canonicality, rather then finality. A canonical block may not be yet finalized
+//! from the perspective of the consensus engine, but it still can't be reverted in the database. Most of the time
+//! during normal operation last canonical block is the same as lst finalized. However if finality stall for a
+//! long duration for some reason, there's only a certain number of blocks that can fit in the non-canonical overlay,
+//! so canonicalization of an unfinalized block may be forced.
 //!
 //! # Pruning.
 //! See `RefWindow` for pruning algorithm details. `StateDb` prunes on each canonicalization until


### PR DESCRIPTION
Currently when a block `N` is canonicalized, all discarded branches are removed from the canonicalization overlay immediately (unless pinned). They are also removed from the DB. The may lead to a situation, when out of two journals, for block `N+1` and `N+1'`, the former is discarded and the latter remains in the DB. 

On startup the journals are loaded by trying DB keys for each block number, increasing the journal sub-index starting from 0. So if sub-index 0 is missing and sub-index 1 is there, it won't be loaded. 

On kusama/polkadot this has low chance of happening, because forks of more than 1 block in length are rare and the node needs to be stopped/restarted on such a fork for the issue to happen. On rococo forks are more likely due to increased finality window and there are a lot of restart because of staling issues, which help finding this issue.

I've considered a fix that keeps track of journal counts for each block number, or involves organising journals in a linked list. Ultimately this requires updating an extra database key for each commit. So I've opted for a solution that tries a limited number of possible journals on startup. This very slightly increases startup time, but requires no extra writes when running.