### PR TITLE
Duplicate logging to stdout

### DIFF
--- a/client/tracing/src/logging/event_format.rs
+++ b/client/tracing/src/logging/event_format.rs
@@ -125,7 +125,6 @@ where
 		writer: &mut dyn fmt::Write,
 		event: &Event,
 	) -> fmt::Result {
-		self.format_event_custom(CustomFmtContext::FmtContext(ctx), writer, event)?;
 		if self.dup_to_stdout && (
 			event.metadata().level() == &Level::INFO ||
 			event.metadata().level() == &Level::WARN ||
@@ -133,9 +132,12 @@ where
 		) {
 			let mut out = String::new();
 			self.format_event_custom(CustomFmtContext::FmtContext(ctx), &mut out, event)?;
+			writer.write_str(&out)?;
 			print!("{}", out);
+			Ok(())
+		} else {
+			self.format_event_custom(CustomFmtContext::FmtContext(ctx), writer, event)
 		}
-		Ok(())
 	}
 }
 

--- a/client/tracing/src/logging/mod.rs
+++ b/client/tracing/src/logging/mod.rs
@@ -167,6 +167,7 @@ where
 		display_level: !simple,
 		display_thread_name: !simple,
 		enable_color,
+		dup_to_stdout: !atty::is(atty::Stream::Stderr) && atty::is(atty::Stream::Stdout),
 	};
 	let builder = FmtSubscriber::builder().with_env_filter(env_filter);
 


### PR DESCRIPTION
When logging to a file with additional logging targets set, it is useful to see basic progress and errors in the console. Substrate used to have this feature, but it was lost in a recent logging system refactoring. This PR restores it.