### PR TITLE
Making method rpc_interface public in sc-cli

### DIFF
--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -166,7 +166,7 @@ impl Into<sc_service::config::RpcMethods> for RpcMethods {
 }
 
 impl RpcMethods {
-	/// Choose and RPC interface based on the RPC method chosen by the user and a few flags:
+	/// Choose an RPC interface based on the RPC method chosen by the user and a few flags:
 	/// `is_external`, `is_unsafe_external` and `is_validator`.
 	pub fn choose_rpc_interface(
 		self,

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -166,6 +166,8 @@ impl Into<sc_service::config::RpcMethods> for RpcMethods {
 }
 
 impl RpcMethods {
+	/// Choose and RPC interface based on the RPC method chosen by the user and a few flags:
+	/// `is_external`, `is_unsafe_external` and `is_validator`.
 	pub fn choose_rpc_interface(
 		self,
 		is_external: bool,


### PR DESCRIPTION
I was discussing with @JoshOrndorff on https://github.com/paritytech/cumulus/pull/380 and he pointed out that the function `rpc_interface` in sc-cli can actually be useful for users who need to customize their RunCmd command.

I don't mind making it public but I think it would be better if it is attached to something that make sense instead of being a free public function. So I moved it to the cli's "arg enum" RpcMethods.