### PR TITLE
Fix documentation about BaseCallFilter

### DIFF
--- a/frame/scheduler/README.md
+++ b/frame/scheduler/README.md
@@ -12,9 +12,8 @@ specified block number or at a specified period. These scheduled dispatches
 may be named or anonymous and may be canceled.
 
 **NOTE:** The scheduled calls will be dispatched with the default filter
-for the origin: namely `frame_system::Config::BaseCallFilter` for all origin
-except root which will get no filter. And not the filter contained in origin
-use to call `fn schedule`.
+for the origin: namely `frame_system::Config::BaseCallFilter` for all
+origins and not the filter contained in origin use to call `fn schedule`.
 
 If a call is scheduled using proxy or whatever mecanism which adds filter,
 then those filter will not be used when dispatching the schedule call.

--- a/frame/scheduler/src/lib.rs
+++ b/frame/scheduler/src/lib.rs
@@ -30,8 +30,7 @@
 //!
 //! **NOTE:** The scheduled calls will be dispatched with the default filter
 //! for the origin: namely `frame_system::Config::BaseCallFilter` for all origin
-//! except root which will get no filter. And not the filter contained in origin
-//! use to call `fn schedule`.
+//! and not the filter contained in origin use to call `fn schedule`.
 //!
 //! If a call is scheduled using proxy or whatever mecanism which adds filter,
 //! then those filter will not be used when dispatching the schedule call.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -163,7 +163,7 @@ pub mod pallet {
 	#[pallet::disable_frame_system_supertrait_check]
 	pub trait Config: 'static + Eq + Clone {
 		/// The basic call filter to use in Origin. All origins are built with this filter as base,
-		/// except Root.
+		/// including Root.
 		type BaseCallFilter: Filter<Self::Call>;
 
 		/// Block & extrinsics weights: base values and limits.


### PR DESCRIPTION
There was a change in BaseCallFilter resulting in root not being able to call these calls anymore. 


