### PR TITLE
Introduce `node-bench-regression-guard` to Substrate's pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@
 stages:
   - check
   - test
+  - verify
   - build
   - publish
   - deploy
@@ -96,6 +97,18 @@ default:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
+.test-refs-no-trigger-no-master:   &test-refs-no-trigger-no-master
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: $CI_COMMIT_REF_NAME == "master"
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
 .build-refs:                       &build-refs
   rules:
     # .publish-refs with manual on PRs
@@ -123,6 +136,24 @@ default:
   rules:
     # this job runs only on nightly pipeline with the mentioned variable, against `master` branch
     - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "nightly"
+
+.merge-ref-into-master:            &merge-ref-into-master
+  before_script:
+      - git fetch origin +master:master
+      - git fetch origin +$CI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME
+      - git checkout master
+      - git config user.email "ci@gitlab.parity.io"
+      - git merge $CI_COMMIT_REF_NAME --verbose --no-edit
+
+.cargo-check-benches-script:       &cargo-check-benches-script
+  script:
+    - mkdir -p artifacts/benches/$CI_COMMIT_REF_NAME
+    - SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all
+    - 'cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small --json
+      | tee artifacts/benches/$CI_COMMIT_REF_NAME/::node::import::native::sr25519::transfer_keep_alive::paritydb::small.json'
+    - 'cargo run --release -p node-bench -- ::trie::read::small --json
+      | tee artifacts/benches/$CI_COMMIT_REF_NAME/::trie::read::small.json'
+    - sccache -s
 
 #### stage:                       .pre
 
@@ -223,11 +254,35 @@ cargo-check-benches:
   stage:                           test
   <<:                              *docker-env
   <<:                              *test-refs-no-trigger
+  <<:                              *cargo-check-benches-script
+  <<:                              *collect-artifacts
+
+cargo-check-benches-merged:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs-no-trigger-no-master
+  <<:                              *merge-ref-into-master
+  <<:                              *cargo-check-benches-script
+  <<:                              *collect-artifacts
+
+node-bench-regression-guard:
+  stage:                           verify
+  <<:                              *docker-env
+  <<:                              *test-refs-no-trigger-no-master
+  needs:
+    - job:                         cargo-check-benches-merged
+      artifacts:                   true
+    - project:                     $CI_PROJECT_PATH
+      job:                         cargo-check-benches
+      ref:                         master
+      artifacts:                   true
+  variables:
+    CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
+  before_script: [""]
   script:
-    - SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all
-    - cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small
-    - cargo run --release -p node-bench -- ::trie::read::small
-    - sccache -s
+    - node-bench-regression-guard --reference artifacts/benches/master --compare-with artifacts/benches/$CI_COMMIT_REF_NAME
+  # FIXME: remove this when master will be populated with bench results artifacts
+  allow_failure:                   true
 
 cargo-check-subkey:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@
 stages:
   - check
   - test
-  - verify
   - build
   - publish
   - deploy
@@ -61,12 +60,15 @@ default:
     - kubernetes-parity-build
   interruptible:                   true
 
+.rust-info-script:                 &rust-info-script
+  - rustup show
+  - cargo --version
+  - sccache -s
+
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"
   before_script:
-    - rustup show
-    - cargo --version
-    - sccache -s
+    - *rust-info-script
   retry:
     max: 2
     when:
@@ -97,17 +99,13 @@ default:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
-.test-refs-no-trigger-no-master:   &test-refs-no-trigger-no-master
+.test-refs-no-trigger-prs-only:   &test-refs-no-trigger-prs-only
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
-    - if: $CI_COMMIT_REF_NAME == "master"
-      when: never
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "tags"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 .build-refs:                       &build-refs
   rules:
@@ -137,23 +135,21 @@ default:
     # this job runs only on nightly pipeline with the mentioned variable, against `master` branch
     - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE == "schedule" && $PIPELINE == "nightly"
 
-.merge-ref-into-master:            &merge-ref-into-master
-  before_script:
-      - git fetch origin +master:master
-      - git fetch origin +$CI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME
-      - git checkout master
-      - git config user.email "ci@gitlab.parity.io"
-      - git merge $CI_COMMIT_REF_NAME --verbose --no-edit
+.merge-ref-into-master-script:     &merge-ref-into-master-script
+  - git fetch origin +master:master
+  - git fetch origin +$CI_COMMIT_REF_NAME:$CI_COMMIT_REF_NAME
+  - git checkout master
+  - git config user.email "ci@gitlab.parity.io"
+  - git merge $CI_COMMIT_REF_NAME --verbose --no-edit
 
 .cargo-check-benches-script:       &cargo-check-benches-script
-  script:
-    - mkdir -p artifacts/benches/$CI_COMMIT_REF_NAME
-    - SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all
-    - 'cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small --json
-      | tee artifacts/benches/$CI_COMMIT_REF_NAME/::node::import::native::sr25519::transfer_keep_alive::paritydb::small.json'
-    - 'cargo run --release -p node-bench -- ::trie::read::small --json
-      | tee artifacts/benches/$CI_COMMIT_REF_NAME/::trie::read::small.json'
-    - sccache -s
+  - mkdir -p artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA
+  - SKIP_WASM_BUILD=1 time cargo +nightly check --benches --all
+  - 'cargo run --release -p node-bench -- ::node::import::native::sr25519::transfer_keep_alive::paritydb::small --json
+    | tee artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::node::import::native::sr25519::transfer_keep_alive::paritydb::small.json'
+  - 'cargo run --release -p node-bench -- ::trie::read::small --json
+    | tee artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA/::trie::read::small.json'
+  - sccache -s
 
 #### stage:                       .pre
 
@@ -254,21 +250,28 @@ cargo-check-benches:
   stage:                           test
   <<:                              *docker-env
   <<:                              *test-refs-no-trigger
-  <<:                              *cargo-check-benches-script
   <<:                              *collect-artifacts
+  script:
+    - *cargo-check-benches-script
 
 cargo-check-benches-merged:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *test-refs-no-trigger-no-master
-  <<:                              *merge-ref-into-master
-  <<:                              *cargo-check-benches-script
+  <<:                              *test-refs-no-trigger-prs-only
   <<:                              *collect-artifacts
+  before_script:
+    - *merge-ref-into-master-script
+    - *rust-info-script
+  script:
+    - *cargo-check-benches-script
 
 node-bench-regression-guard:
-  stage:                           verify
+  # it's not belong to `build` semantically, but dag jobs can't depend on each other
+  # within the single stage - https://gitlab.com/gitlab-org/gitlab/-/issues/30632
+  # more: https://github.com/paritytech/substrate/pull/8519#discussion_r608012402
+  stage:                           build
   <<:                              *docker-env
-  <<:                              *test-refs-no-trigger-no-master
+  <<:                              *test-refs-no-trigger-prs-only
   needs:
     - job:                         cargo-check-benches-merged
       artifacts:                   true
@@ -280,7 +283,8 @@ node-bench-regression-guard:
     CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
   before_script: [""]
   script:
-    - node-bench-regression-guard --reference artifacts/benches/master --compare-with artifacts/benches/$CI_COMMIT_REF_NAME
+    - 'node-bench-regression-guard --reference artifacts/benches/master-* 
+       --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
   # FIXME: remove this when master will be populated with bench results artifacts
   allow_failure:                   true
 


### PR DESCRIPTION
Resolves paritytech/ci_cd#11 via itself and [`node-bench-regression-guard`](https://github.com/paritytech/scripts/tree/master/dockerfiles/node-bench-regression-guard) tool. 

This PR makes following changes to the project's pipeline:
* adds relevant `node-bench-regression-guard` job
* changes logic of `cargo-check-benches` job
* adds `cargo-check-benches-merged` job, which does the same thing as `cargo-check-benches`, but with PR's source branch already merged into `master`
* adds `verify` stage. `needs` is [unable](https://gitlab.com/gitlab-org/gitlab/-/issues/30632) to calculate the dependency graph when referring to the jobs in the same stage
* adds relevant YAML anchors

### Notes

`git fetch` with plus sign is used here for `cargo-check-benches-merged` to forcefully change needed refspecs to the actual ones. Runner [checkouts the specific pipeline's commit](https://gitlab.com/gitlab-org/gitlab/-/issues/15409), so, basically, the repository ends in the detached HEAD state. Additionally, default Runner's `GIT_STRATEGY` is to use `fetch`, so different runners have theirs own vision about what a current local `master` is.

`allow_failure` is needed for `node-bench-regression-guard` right now. There won't be any available artifacts for `master`'s bench results until this PR is merged, so the job will fail for the PR's pipelines. This directive will be removed shortly (via a separate PR) when `master` will be populated with bench results artifacts.

### Then how can I be sure that it works?

I've forked `substrate` on GitLab and merged these proposed changes to `master` there. Check it by yourself:
* ["This" PR](https://gitlab.parity.io/rcny/substrate/-/merge_requests/1)
* [Example PR](https://gitlab.parity.io/rcny/substrate/-/merge_requests/2) after `node-bench-regression-guard` introduction to Substrate's pipeline. [Relevant comparison job](https://gitlab.parity.io/rcny/substrate/-/jobs/879347)

More to it, `node-bench-regression-guard` has its own [test coverage](https://github.com/paritytech/scripts/blob/master/dockerfiles/node-bench-regression-guard/run-tests.rb).