### PR TITLE
Use `log::error!` for bad mandatory

### DIFF
--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -650,7 +650,7 @@ mod tests {
 	#[test]
 	#[should_panic(expected = "Invalid unsigned submission must produce invalid block and \
 	                           deprive validator from their authoring reward.: \
-	                           DispatchError::Module { index: 2, error: 1, message: \
+	                           Module { index: 2, error: 1, message: \
 	                           Some(\"PreDispatchWrongWinnerCount\") }")]
 	fn unfeasible_solution_panics() {
 		ExtBuilder::default().build_and_execute(|| {

--- a/frame/system/src/extensions/check_weight.rs
+++ b/frame/system/src/extensions/check_weight.rs
@@ -18,7 +18,7 @@
 use crate::{limits::BlockWeights, Config, Pallet};
 use codec::{Encode, Decode};
 use sp_runtime::{
-	traits::{SignedExtension, DispatchInfoOf, Dispatchable, PostDispatchInfoOf, Printable},
+	traits::{SignedExtension, DispatchInfoOf, Dispatchable, PostDispatchInfoOf},
 	transaction_validity::{
 		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
 		TransactionPriority,
@@ -248,9 +248,7 @@ impl<T: Config + Send + Sync> SignedExtension for CheckWeight<T> where
 		// to them actually being useful. Block producers are thus not allowed to include mandatory
 		// extrinsics that result in error.
 		if let (DispatchClass::Mandatory, Err(e)) = (info.class, result) {
-			"Bad mandatory".print();
-			e.print();
-
+			log::error!(target: "runtime::system", "Bad mandatory: {:?}", e);
 			Err(InvalidTransaction::BadMandatory)?
 		}
 

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -450,7 +450,7 @@ pub type DispatchResult = sp_std::result::Result<(), DispatchError>;
 pub type DispatchResultWithInfo<T> = sp_std::result::Result<T, DispatchErrorWithPostInfo<T>>;
 
 /// Reason why a dispatch call failed.
-#[derive(Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
+#[derive(Eq, Clone, Copy, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum DispatchError {
 	/// Some error occurred.
@@ -535,7 +535,7 @@ impl From<crate::traits::StoredMapError> for DispatchError {
 }
 
 /// Description of what went wrong when trying to complete an operation on a token.
-#[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug)]
+#[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum TokenError {
 	/// Funds are unavailable.


### PR DESCRIPTION
To make the life of people easier ;)

