### PR TITLE
Pin jsonrpsee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,13 +2919,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "124797a4ea7430d0675db78e065e53316e3f1a3cbf0ee4d6dbdd42db7b08e193"
+checksum = "9b15fc3a0ef2e02d770aa1a221d3412443dcaedc43e27d80c957dd5bbd65321b"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
  "hyper 0.13.10",
+ "hyper-rustls",
  "jsonrpsee-types",
  "jsonrpsee-utils",
  "log",
@@ -2938,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb3f732ccbeafd15cefb59c7c7b5ac6c553c2653613b63e5e7feb7f06a219e9"
+checksum = "6bb4afbda476e2ee11cc6245055c498c116fc8002d2d60fe8338b6ee15d84c3a"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -2950,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8cd20c190e75dc56f7543b9d5713c3186351b301b5507ea6b85d8c403aac78"
+checksum = "c42a82588b5f7830e94341bb7e79d15f46070ab6f64dde1e3b3719721b61c5bf"
 dependencies = [
  "async-trait",
  "futures 0.3.13",
@@ -2965,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-utils"
-version = "0.2.0-alpha"
+version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e45394ec3175a767c3c5bac584560e6ad9b56ebd73216c85ec8bab49619244"
+checksum = "e65c77838fce96bc554b4a3a159d0b9a2497319ae9305c66ee853998c7ed2fd3"
 dependencies = [
  "futures 0.3.13",
  "globset",

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-jsonrpsee-http-client = { version = "0.2.0-alpha", default-features = false, features = ["tokio02"] }
+jsonrpsee-http-client = { version = "=0.2.0-alpha.3", default-features = false, features = ["tokio02"] }
 # Needed by jsonrpsee-proc-macros: https://github.com/paritytech/jsonrpsee/issues/214
-jsonrpsee-types = "0.2.0-alpha.2"
-jsonrpsee-proc-macros = "0.2.0-alpha.2"
+jsonrpsee-types = "=0.2.0-alpha.3"
+jsonrpsee-proc-macros = "=0.2.0-alpha.3"
 
 hex-literal = "0.3.1"
 env_logger = "0.8.2"


### PR DESCRIPTION
When updating dependencies, Cargo brings the latest `0.2.0-alpha.4` version of jsonrpsee which contains breaking changes and a hard `tokio 1.0` dependency (https://github.com/paritytech/jsonrpsee/blob/2f6c8e9e859d52948ab065012db32652673cda23/utils/Cargo.toml#L21).