### PR TITLE
Add some trivial improvements to primitives runtime

### DIFF
--- a/primitives/runtime/src/curve.rs
+++ b/primitives/runtime/src/curve.rs
@@ -40,7 +40,7 @@ impl<'a> PiecewiseLinear<'a> {
 	{
 		let n = n.min(d.clone());
 
-		if self.points.len() == 0 {
+		if self.points.is_empty() {
 			return N::zero()
 		}
 

--- a/primitives/runtime/src/generic/digest.rs
+++ b/primitives/runtime/src/generic/digest.rs
@@ -210,12 +210,12 @@ impl<Hash> DigestItem<Hash> {
 	/// Returns a 'referencing view' for this digest item.
 	pub fn dref(&self) -> DigestItemRef<Hash> {
 		match *self {
-			DigestItem::ChangesTrieRoot(ref v) => DigestItemRef::ChangesTrieRoot(v),
-			DigestItem::PreRuntime(ref v, ref s) => DigestItemRef::PreRuntime(v, s),
-			DigestItem::Consensus(ref v, ref s) => DigestItemRef::Consensus(v, s),
-			DigestItem::Seal(ref v, ref s) => DigestItemRef::Seal(v, s),
-			DigestItem::ChangesTrieSignal(ref s) => DigestItemRef::ChangesTrieSignal(s),
-			DigestItem::Other(ref v) => DigestItemRef::Other(v),
+			Self::ChangesTrieRoot(ref v) => DigestItemRef::ChangesTrieRoot(v),
+			Self::PreRuntime(ref v, ref s) => DigestItemRef::PreRuntime(v, s),
+			Self::Consensus(ref v, ref s) => DigestItemRef::Consensus(v, s),
+			Self::Seal(ref v, ref s) => DigestItemRef::Seal(v, s),
+			Self::ChangesTrieSignal(ref s) => DigestItemRef::ChangesTrieSignal(s),
+			Self::Other(ref v) => DigestItemRef::Other(v),
 		}
 	}
 

--- a/primitives/runtime/src/generic/digest.rs
+++ b/primitives/runtime/src/generic/digest.rs
@@ -40,7 +40,7 @@ pub struct Digest<Hash> {
 
 impl<Item> Default for Digest<Item> {
 	fn default() -> Self {
-		Digest { logs: Vec::new(), }
+		Self { logs: Vec::new(), }
 	}
 }
 
@@ -70,7 +70,6 @@ impl<Hash> Digest<Hash> {
 		self.logs().iter().find_map(predicate)
 	}
 }
-
 
 /// Digest item that is able to encode/decode 'system' digest items and
 /// provide opaque access to other items.
@@ -209,7 +208,7 @@ pub enum OpaqueDigestItemId<'a> {
 
 impl<Hash> DigestItem<Hash> {
 	/// Returns a 'referencing view' for this digest item.
-	pub fn dref<'a>(&'a self) -> DigestItemRef<'a, Hash> {
+	pub fn dref(&self) -> DigestItemRef<Hash> {
 		match *self {
 			DigestItem::ChangesTrieRoot(ref v) => DigestItemRef::ChangesTrieRoot(v),
 			DigestItem::PreRuntime(ref v, ref s) => DigestItemRef::PreRuntime(v, s),
@@ -298,25 +297,25 @@ impl<Hash: Decode> Decode for DigestItem<Hash> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let item_type: DigestItemType = Decode::decode(input)?;
 		match item_type {
-			DigestItemType::ChangesTrieRoot => Ok(DigestItem::ChangesTrieRoot(
+			DigestItemType::ChangesTrieRoot => Ok(Self::ChangesTrieRoot(
 				Decode::decode(input)?,
 			)),
 			DigestItemType::PreRuntime => {
 				let vals: (ConsensusEngineId, Vec<u8>) = Decode::decode(input)?;
-				Ok(DigestItem::PreRuntime(vals.0, vals.1))
+				Ok(Self::PreRuntime(vals.0, vals.1))
 			},
 			DigestItemType::Consensus => {
 				let vals: (ConsensusEngineId, Vec<u8>) = Decode::decode(input)?;
-				Ok(DigestItem::Consensus(vals.0, vals.1))
+				Ok(Self::Consensus(vals.0, vals.1))
 			}
 			DigestItemType::Seal => {
 				let vals: (ConsensusEngineId, Vec<u8>) = Decode::decode(input)?;
-				Ok(DigestItem::Seal(vals.0, vals.1))
+				Ok(Self::Seal(vals.0, vals.1))
 			},
-			DigestItemType::ChangesTrieSignal => Ok(DigestItem::ChangesTrieSignal(
+			DigestItemType::ChangesTrieSignal => Ok(Self::ChangesTrieSignal(
 				Decode::decode(input)?,
 			)),
-			DigestItemType::Other => Ok(DigestItem::Other(
+			DigestItemType::Other => Ok(Self::Other(
 				Decode::decode(input)?,
 			)),
 		}
@@ -327,7 +326,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `ChangesTrieRoot`.
 	pub fn as_changes_trie_root(&self) -> Option<&'a Hash> {
 		match *self {
-			DigestItemRef::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
+			Self::ChangesTrieRoot(ref changes_trie_root) => Some(changes_trie_root),
 			_ => None,
 		}
 	}
@@ -335,7 +334,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `PreRuntime`
 	pub fn as_pre_runtime(&self) -> Option<(ConsensusEngineId, &'a [u8])> {
 		match *self {
-			DigestItemRef::PreRuntime(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
+			Self::PreRuntime(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
 			_ => None,
 		}
 	}
@@ -343,7 +342,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `Consensus`
 	pub fn as_consensus(&self) -> Option<(ConsensusEngineId, &'a [u8])> {
 		match *self {
-			DigestItemRef::Consensus(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
+			Self::Consensus(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
 			_ => None,
 		}
 	}
@@ -351,7 +350,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `Seal`
 	pub fn as_seal(&self) -> Option<(ConsensusEngineId, &'a [u8])> {
 		match *self {
-			DigestItemRef::Seal(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
+			Self::Seal(consensus_engine_id, ref data) => Some((*consensus_engine_id, data)),
 			_ => None,
 		}
 	}
@@ -359,7 +358,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `ChangesTrieSignal`.
 	pub fn as_changes_trie_signal(&self) -> Option<&'a ChangesTrieSignal> {
 		match *self {
-			DigestItemRef::ChangesTrieSignal(ref changes_trie_signal) => Some(changes_trie_signal),
+			Self::ChangesTrieSignal(ref changes_trie_signal) => Some(changes_trie_signal),
 			_ => None,
 		}
 	}
@@ -367,7 +366,7 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// Cast this digest item into `PreRuntime`
 	pub fn as_other(&self) -> Option<&'a [u8]> {
 		match *self {
-			DigestItemRef::Other(ref data) => Some(data),
+			Self::Other(ref data) => Some(data),
 			_ => None,
 		}
 	}
@@ -376,11 +375,11 @@ impl<'a, Hash> DigestItemRef<'a, Hash> {
 	/// return the opaque data it contains.
 	pub fn try_as_raw(&self, id: OpaqueDigestItemId) -> Option<&'a [u8]> {
 		match (id, self) {
-			(OpaqueDigestItemId::Consensus(w), &DigestItemRef::Consensus(v, s)) |
-				(OpaqueDigestItemId::Seal(w), &DigestItemRef::Seal(v, s)) |
-				(OpaqueDigestItemId::PreRuntime(w), &DigestItemRef::PreRuntime(v, s))
+			(OpaqueDigestItemId::Consensus(w), &Self::Consensus(v, s)) |
+				(OpaqueDigestItemId::Seal(w), &Self::Seal(v, s)) |
+				(OpaqueDigestItemId::PreRuntime(w), &Self::PreRuntime(v, s))
 				if v == w => Some(&s[..]),
-			(OpaqueDigestItemId::Other, &DigestItemRef::Other(s)) => Some(&s[..]),
+			(OpaqueDigestItemId::Other, &Self::Other(s)) => Some(&s[..]),
 			_ => None,
 		}
 	}
@@ -432,27 +431,27 @@ impl<'a, Hash: Encode> Encode for DigestItemRef<'a, Hash> {
 		let mut v = Vec::new();
 
 		match *self {
-			DigestItemRef::ChangesTrieRoot(changes_trie_root) => {
+			Self::ChangesTrieRoot(changes_trie_root) => {
 				DigestItemType::ChangesTrieRoot.encode_to(&mut v);
 				changes_trie_root.encode_to(&mut v);
 			},
-			DigestItemRef::Consensus(val, data) => {
+			Self::Consensus(val, data) => {
 				DigestItemType::Consensus.encode_to(&mut v);
 				(val, data).encode_to(&mut v);
 			},
-			DigestItemRef::Seal(val, sig) => {
+			Self::Seal(val, sig) => {
 				DigestItemType::Seal.encode_to(&mut v);
 				(val, sig).encode_to(&mut v);
 			},
-			DigestItemRef::PreRuntime(val, data) => {
+			Self::PreRuntime(val, data) => {
 				DigestItemType::PreRuntime.encode_to(&mut v);
 				(val, data).encode_to(&mut v);
 			},
-			DigestItemRef::ChangesTrieSignal(changes_trie_signal) => {
+			Self::ChangesTrieSignal(changes_trie_signal) => {
 				DigestItemType::ChangesTrieSignal.encode_to(&mut v);
 				changes_trie_signal.encode_to(&mut v);
 			},
-			DigestItemRef::Other(val) => {
+			Self::Other(val) => {
 				DigestItemType::Other.encode_to(&mut v);
 				val.encode_to(&mut v);
 			},
@@ -466,7 +465,7 @@ impl ChangesTrieSignal {
 	/// Try to cast this signal to NewConfiguration.
 	pub fn as_new_configuration(&self) -> Option<&Option<ChangesTrieConfiguration>> {
 		match self {
-			ChangesTrieSignal::NewConfiguration(config) => Some(config),
+			Self::NewConfiguration(config) => Some(config),
 		}
 	}
 }
@@ -488,7 +487,7 @@ mod tests {
 		};
 
 		assert_eq!(
-			::serde_json::to_string(&digest).unwrap(),
+			serde_json::to_string(&digest).unwrap(),
 			r#"{"logs":["0x0204000000","0x000c010203","0x05746573740c010203"]}"#
 		);
 	}

--- a/primitives/runtime/src/generic/header.rs
+++ b/primitives/runtime/src/generic/header.rs
@@ -91,7 +91,7 @@ impl<Number, Hash> Decode for Header<Number, Hash> where
 	Hash::Output: Decode,
 {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		Ok(Header {
+		Ok(Self {
 			parent_hash: Decode::decode(input)?,
 			number: <<Number as HasCompact>::Type>::decode(input)?.into(),
 			state_root: Decode::decode(input)?,
@@ -160,7 +160,7 @@ impl<Number, Hash> traits::Header for Header<Number, Hash> where
 		parent_hash: Self::Hash,
 		digest: Digest<Self::Hash>,
 	) -> Self {
-		Header {
+		Self {
 			number,
 			extrinsics_root,
 			state_root,

--- a/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -70,7 +70,7 @@ impl<Address, Call, Signature, Extra: SignedExtension>
 		signature: Signature,
 		extra: Extra
 	) -> Self {
-		UncheckedExtrinsic {
+		Self {
 			signature: Some((signed, signature, extra)),
 			function,
 		}
@@ -78,7 +78,7 @@ impl<Address, Call, Signature, Extra: SignedExtension>
 
 	/// New instance of an unsigned extrinsic aka "inherent".
 	pub fn new_unsigned(function: Call) -> Self {
-		UncheckedExtrinsic {
+		Self {
 			signature: None,
 			function,
 		}
@@ -102,9 +102,9 @@ impl<Address, Call, Signature, Extra: SignedExtension> Extrinsic
 
 	fn new(function: Call, signed_data: Option<Self::SignaturePayload>) -> Option<Self> {
 		Some(if let Some((address, signature, extra)) = signed_data {
-			UncheckedExtrinsic::new_signed(function, address, signature, extra)
+			Self::new_signed(function, address, signature, extra)
 		} else {
-			UncheckedExtrinsic::new_unsigned(function)
+			Self::new_unsigned(function)
 		})
 	}
 }
@@ -238,7 +238,7 @@ where
 			return Err("Invalid transaction version".into());
 		}
 
-		Ok(UncheckedExtrinsic {
+		Ok(Self {
 			signature: if is_signed { Some(Decode::decode(input)?) } else { None },
 			function: Decode::decode(input)?,
 		})
@@ -327,7 +327,7 @@ where
 	Extra: SignedExtension,
 {
 	fn from(extrinsic: UncheckedExtrinsic<Address, Call, Signature, Extra>) -> Self {
-		OpaqueExtrinsic::from_bytes(extrinsic.encode().as_slice())
+		Self::from_bytes(extrinsic.encode().as_slice())
 			.expect(
 				"both OpaqueExtrinsic and UncheckedExtrinsic have encoding that is compatible with \
 				raw Vec<u8> encoding; qed"

--- a/primitives/runtime/src/lib.rs
+++ b/primitives/runtime/src/lib.rs
@@ -245,7 +245,7 @@ pub enum MultiSignature {
 
 impl From<ed25519::Signature> for MultiSignature {
 	fn from(x: ed25519::Signature) -> Self {
-		MultiSignature::Ed25519(x)
+		Self::Ed25519(x)
 	}
 }
 
@@ -258,7 +258,7 @@ impl TryFrom<MultiSignature> for ed25519::Signature {
 
 impl From<sr25519::Signature> for MultiSignature {
 	fn from(x: sr25519::Signature) -> Self {
-		MultiSignature::Sr25519(x)
+		Self::Sr25519(x)
 	}
 }
 
@@ -271,7 +271,7 @@ impl TryFrom<MultiSignature> for sr25519::Signature {
 
 impl From<ecdsa::Signature> for MultiSignature {
 	fn from(x: ecdsa::Signature) -> Self {
-		MultiSignature::Ecdsa(x)
+		Self::Ecdsa(x)
 	}
 }
 
@@ -284,7 +284,7 @@ impl TryFrom<MultiSignature> for ecdsa::Signature {
 
 impl Default for MultiSignature {
 	fn default() -> Self {
-		MultiSignature::Ed25519(Default::default())
+		Self::Ed25519(Default::default())
 	}
 }
 
@@ -302,7 +302,7 @@ pub enum MultiSigner {
 
 impl Default for MultiSigner {
 	fn default() -> Self {
-		MultiSigner::Ed25519(Default::default())
+		Self::Ed25519(Default::default())
 	}
 }
 
@@ -317,9 +317,9 @@ impl<T: Into<H256>> crypto::UncheckedFrom<T> for MultiSigner {
 impl AsRef<[u8]> for MultiSigner {
 	fn as_ref(&self) -> &[u8] {
 		match *self {
-			MultiSigner::Ed25519(ref who) => who.as_ref(),
-			MultiSigner::Sr25519(ref who) => who.as_ref(),
-			MultiSigner::Ecdsa(ref who) => who.as_ref(),
+			Self::Ed25519(ref who) => who.as_ref(),
+			Self::Sr25519(ref who) => who.as_ref(),
+			Self::Ecdsa(ref who) => who.as_ref(),
 		}
 	}
 }
@@ -328,16 +328,16 @@ impl traits::IdentifyAccount for MultiSigner {
 	type AccountId = AccountId32;
 	fn into_account(self) -> AccountId32 {
 		match self {
-			MultiSigner::Ed25519(who) => <[u8; 32]>::from(who).into(),
-			MultiSigner::Sr25519(who) => <[u8; 32]>::from(who).into(),
-			MultiSigner::Ecdsa(who) => sp_io::hashing::blake2_256(&who.as_ref()[..]).into(),
+			Self::Ed25519(who) => <[u8; 32]>::from(who).into(),
+			Self::Sr25519(who) => <[u8; 32]>::from(who).into(),
+			Self::Ecdsa(who) => sp_io::hashing::blake2_256(who.as_ref()).into(),
 		}
 	}
 }
 
 impl From<ed25519::Public> for MultiSigner {
 	fn from(x: ed25519::Public) -> Self {
-		MultiSigner::Ed25519(x)
+		Self::Ed25519(x)
 	}
 }
 
@@ -350,7 +350,7 @@ impl TryFrom<MultiSigner> for ed25519::Public {
 
 impl From<sr25519::Public> for MultiSigner {
 	fn from(x: sr25519::Public) -> Self {
-		MultiSigner::Sr25519(x)
+		Self::Sr25519(x)
 	}
 }
 
@@ -363,7 +363,7 @@ impl TryFrom<MultiSigner> for sr25519::Public {
 
 impl From<ecdsa::Public> for MultiSigner {
 	fn from(x: ecdsa::Public) -> Self {
-		MultiSigner::Ecdsa(x)
+		Self::Ecdsa(x)
 	}
 }
 
@@ -378,9 +378,9 @@ impl TryFrom<MultiSigner> for ecdsa::Public {
 impl std::fmt::Display for MultiSigner {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
 		match *self {
-			MultiSigner::Ed25519(ref who) => write!(fmt, "ed25519: {}", who),
-			MultiSigner::Sr25519(ref who) => write!(fmt, "sr25519: {}", who),
-			MultiSigner::Ecdsa(ref who) => write!(fmt, "ecdsa: {}", who),
+			Self::Ed25519(ref who) => write!(fmt, "ed25519: {}", who),
+			Self::Sr25519(ref who) => write!(fmt, "sr25519: {}", who),
+			Self::Ecdsa(ref who) => write!(fmt, "ecdsa: {}", who),
 		}
 	}
 }
@@ -389,9 +389,9 @@ impl Verify for MultiSignature {
 	type Signer = MultiSigner;
 	fn verify<L: Lazy<[u8]>>(&self, mut msg: L, signer: &AccountId32) -> bool {
 		match (self, signer) {
-			(MultiSignature::Ed25519(ref sig), who) => sig.verify(msg, &ed25519::Public::from_slice(who.as_ref())),
-			(MultiSignature::Sr25519(ref sig), who) => sig.verify(msg, &sr25519::Public::from_slice(who.as_ref())),
-			(MultiSignature::Ecdsa(ref sig), who) => {
+			(Self::Ed25519(ref sig), who) => sig.verify(msg, &ed25519::Public::from_slice(who.as_ref())),
+			(Self::Sr25519(ref sig), who) => sig.verify(msg, &sr25519::Public::from_slice(who.as_ref())),
+			(Self::Ecdsa(ref sig), who) => {
 				let m = sp_io::hashing::blake2_256(msg.get());
 				match sp_io::crypto::secp256k1_ecdsa_recover_compressed(sig.as_ref(), &m) {
 					Ok(pubkey) =>
@@ -424,13 +424,13 @@ impl Verify for AnySignature {
 
 impl From<sr25519::Signature> for AnySignature {
 	fn from(s: sr25519::Signature) -> Self {
-		AnySignature(s.into())
+		Self(s.into())
 	}
 }
 
 impl From<ed25519::Signature> for AnySignature {
 	fn from(s: ed25519::Signature) -> Self {
-		AnySignature(s.into())
+		Self(s.into())
 	}
 }
 
@@ -573,13 +573,13 @@ impl From<TokenError> for &'static str {
 
 impl From<TokenError> for DispatchError {
 	fn from(e: TokenError) -> DispatchError {
-		DispatchError::Token(e)
+		Self::Token(e)
 	}
 }
 
 impl From<&'static str> for DispatchError {
 	fn from(err: &'static str) -> DispatchError {
-		DispatchError::Other(err)
+		Self::Other(err)
 	}
 }
 
@@ -764,7 +764,7 @@ pub struct OpaqueExtrinsic(Vec<u8>);
 impl OpaqueExtrinsic {
 	/// Convert an encoded extrinsic to an `OpaqueExtrinsic`.
 	pub fn from_bytes(mut bytes: &[u8]) -> Result<Self, codec::Error> {
-		OpaqueExtrinsic::decode(&mut bytes)
+		Self::decode(&mut bytes)
 	}
 }
 
@@ -786,7 +786,6 @@ impl sp_std::fmt::Debug for OpaqueExtrinsic {
 		Ok(())
 	}
 }
-
 
 #[cfg(feature = "std")]
 impl ::serde::Serialize for OpaqueExtrinsic {
@@ -813,7 +812,6 @@ impl traits::Extrinsic for OpaqueExtrinsic {
 pub fn print(print: impl traits::Printable) {
 	print.print();
 }
-
 
 /// Batching session.
 ///
@@ -946,7 +944,6 @@ mod tests {
 		let multi_signer = MultiSigner::from(pair.public());
 		assert!(multi_sig.verify(msg, &multi_signer.into_account()));
 	}
-
 
 	#[test]
 	#[should_panic(expected = "Signature verification has not been called")]

--- a/primitives/runtime/src/multiaddress.rs
+++ b/primitives/runtime/src/multiaddress.rs
@@ -45,9 +45,9 @@ where
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
 		use sp_core::hexdisplay::HexDisplay;
 		match self {
-			MultiAddress::Raw(inner) => write!(f, "MultiAddress::Raw({})", HexDisplay::from(inner)),
-			MultiAddress::Address32(inner) => write!(f, "MultiAddress::Address32({})", HexDisplay::from(inner)),
-			MultiAddress::Address20(inner) => write!(f, "MultiAddress::Address20({})", HexDisplay::from(inner)),
+			Self::Raw(inner) => write!(f, "MultiAddress::Raw({})", HexDisplay::from(inner)),
+			Self::Address32(inner) => write!(f, "MultiAddress::Address32({})", HexDisplay::from(inner)),
+			Self::Address20(inner) => write!(f, "MultiAddress::Address20({})", HexDisplay::from(inner)),
 			_ => write!(f, "{:?}", self),
 		}
 	}
@@ -55,12 +55,12 @@ where
 
 impl<AccountId, AccountIndex> From<AccountId> for MultiAddress<AccountId, AccountIndex> {
 	fn from(a: AccountId) -> Self {
-		MultiAddress::Id(a)
+		Self::Id(a)
 	}
 }
 
 impl<AccountId: Default, AccountIndex> Default for MultiAddress<AccountId, AccountIndex> {
 	fn default() -> Self {
-		MultiAddress::Id(Default::default())
+		Self::Id(Default::default())
 	}
 }

--- a/primitives/runtime/src/offchain/storage_lock.rs
+++ b/primitives/runtime/src/offchain/storage_lock.rs
@@ -158,7 +158,7 @@ impl<B: BlockNumberProvider> Clone for BlockAndTimeDeadline<B> {
 	fn clone(&self) -> Self {
 		Self {
 			block_number: self.block_number.clone(),
-			timestamp: self.timestamp.clone(),
+			timestamp: self.timestamp,
 		}
 	}
 }
@@ -202,7 +202,7 @@ impl<B: BlockNumberProvider> Default for BlockAndTime<B> {
 impl<B: BlockNumberProvider> Clone for BlockAndTime<B> {
 	fn clone(&self) -> Self {
 		Self {
-			expiration_block_number_offset: self.expiration_block_number_offset.clone(),
+			expiration_block_number_offset: self.expiration_block_number_offset,
 			expiration_duration: self.expiration_duration,
 			_phantom: core::marker::PhantomData::<B>,
 		}
@@ -386,7 +386,7 @@ impl<'a> StorageLock<'a, Time> {
 		Self {
 			value_ref: StorageValueRef::<'a>::persistent(key),
 			lockable: Time {
-				expiration_duration: expiration_duration,
+				expiration_duration,
 			},
 		}
 	}

--- a/primitives/runtime/src/traits.rs
+++ b/primitives/runtime/src/traits.rs
@@ -19,7 +19,6 @@
 
 use sp_std::prelude::*;
 use sp_std::{self, marker::PhantomData, convert::{TryFrom, TryInto}, fmt::Debug};
-use sp_io;
 #[cfg(feature = "std")]
 use std::fmt::Display;
 #[cfg(feature = "std")]
@@ -111,7 +110,7 @@ impl Verify for sp_core::ecdsa::Signature {
 			self.as_ref(),
 			&sp_io::hashing::blake2_256(msg.get()),
 		) {
-			Ok(pubkey) => &signer.as_ref()[..] == &pubkey[..],
+			Ok(pubkey) => signer.as_ref() == &pubkey[..],
 			_ => false,
 		}
 	}

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -81,18 +81,12 @@ pub enum InvalidTransaction {
 impl InvalidTransaction {
 	/// Returns if the reason for the invalidity was block resource exhaustion.
 	pub fn exhausted_resources(&self) -> bool {
-		match self {
-			Self::ExhaustsResources => true,
-			_ => false,
-		}
+		matches!(self, Self::ExhaustsResources)
 	}
 
 	/// Returns if the reason for the invalidity was a mandatory call failing.
 	pub fn was_mandatory(&self) -> bool {
-		match self {
-			Self::BadMandatory => true,
-			_ => false,
-		}
+		matches!(self, Self::BadMandatory)
 	}
 }
 
@@ -209,15 +203,15 @@ impl std::fmt::Display for TransactionValidityError {
 /// Information on a transaction's validity and, if valid, on how it relates to other transactions.
 pub type TransactionValidity = Result<ValidTransaction, TransactionValidityError>;
 
-impl Into<TransactionValidity> for InvalidTransaction {
-	fn into(self) -> TransactionValidity {
-		Err(self.into())
+impl From<InvalidTransaction> for TransactionValidity {
+	fn from(invalid_transaction: InvalidTransaction) -> Self {
+		Err(TransactionValidityError::Invalid(invalid_transaction))
 	}
 }
 
-impl Into<TransactionValidity> for UnknownTransaction {
-	fn into(self) -> TransactionValidity {
-		Err(self.into())
+impl From<UnknownTransaction> for TransactionValidity {
+	fn from(unknown_transaction: UnknownTransaction) -> Self {
+		Err(TransactionValidityError::Unknown(unknown_transaction))
 	}
 }
 

--- a/primitives/runtime/src/transaction_validity.rs
+++ b/primitives/runtime/src/transaction_validity.rs
@@ -279,7 +279,7 @@ pub struct ValidTransaction {
 
 impl Default for ValidTransaction {
 	fn default() -> Self {
-		ValidTransaction {
+		Self {
 			priority: 0,
 			requires: vec![],
 			provides: vec![],
@@ -305,7 +305,7 @@ impl ValidTransaction {
 	/// `provides` and `requires` tags, it will sum the priorities, take the minimum longevity and
 	/// the logic *And* of the propagate flags.
 	pub fn combine_with(mut self, mut other: ValidTransaction) -> Self {
-		ValidTransaction {
+		Self {
 			priority: self.priority.saturating_add(other.priority),
 			requires: { self.requires.append(&mut other.requires); self.requires },
 			provides: { self.provides.append(&mut other.provides); self.provides },


### PR DESCRIPTION
All changes in this PR are all trivial improvements to reduce some linter warnings when exploring the code:

-  Use `Self` instead of the type's name.
- Use `matches!`.
- Remove some extra empty lines.
- Impl `From` instead of `Into`.