### PR TITLE
Validator Damping Function

### DIFF
--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -287,6 +287,7 @@ pub struct ExtBuilder {
 	nominate: bool,
 	validator_count: u32,
 	minimum_validator_count: u32,
+	maximum_validator_count: u32,
 	fair: bool,
 	num_validators: Option<u32>,
 	invulnerables: Vec<AccountId>,
@@ -301,6 +302,7 @@ impl Default for ExtBuilder {
 			nominate: true,
 			validator_count: 2,
 			minimum_validator_count: 0,
+			maximum_validator_count: 2,
 			fair: true,
 			num_validators: None,
 			invulnerables: vec![],
@@ -329,6 +331,10 @@ impl ExtBuilder {
 	}
 	pub fn minimum_validator_count(mut self, count: u32) -> Self {
 		self.minimum_validator_count = count;
+		self
+	}
+	pub fn maximum_validator_count(mut self, count: u32) -> Self {
+		self.maximum_validator_count = count;
 		self
 	}
 	pub fn slash_defer_duration(self, eras: EraIndex) -> Self {
@@ -449,6 +455,7 @@ impl ExtBuilder {
 			stakers: stakers,
 			validator_count: self.validator_count,
 			minimum_validator_count: self.minimum_validator_count,
+			maximum_validator_count: self.maximum_validator_count,
 			invulnerables: self.invulnerables,
 			slash_reward_fraction: Perbill::from_percent(10),
 			..Default::default()


### PR DESCRIPTION
This pr replaces static functions to modify the validator count with use a dynamic damping function which will modify the target validator count based on the staking participation.

- [x] tests

Damping function:
 
Let x be the current number of validators, k be the minimum number of validators, and K be the maximum number of validators.

- If the bottom 1% of validators ( ceil( x / 100 ) ) have an average staked value greater than 40% of the global average, we want to increase the validator count by 1%. I.e. the final validator count should be: x = min(K, x + ceil( x / 100 ).

- If the bottom 2% of valiators ( 2 * ceil( x / 100 ) ) have an average staked value below 20% of the global average, we want to decrease the validator count by 1%. I.e. the final validator count should be: x = max(k, x - ceil( x / 100)).

Thus the following guarantees should be satisfied:

- The number of active validators in any era can only change by at most 1%.
- The number of valiators is always between the minimum and maximum number of desired validators. (k ≤ X ≤ K)
- The number of validators that we select is based on the current state of the staking system.

**Changes**

- Introduced new configuration value `maximum_validator_count` which is used by dumpling function. When configuration conditions are met (`maximum_validator_count > minimum_validator_count`) validator damping function is taken in to action at the end of each era.
 
**Follow-up**

One of the requirements says that change at the end of era is at most 1%. The existing staking pallet test suit mock is built in a small scale: 
- number of validators is limited (`num_validators <= 8`)
- pallet balances for the genesis configuration are around 20

So in order to have more comprehensive tests mock should be rewritten to work with a bigger set of validators and balances.
The damping functions makes sense at a bigger scale, starting from 100 validators. This will give ability to more correctly represent testing conditions:
- change at most 1%
- number of validators is always between the minimum and maximum number of desired validators
