### PR TITLE
Fix monthly tags

### DIFF
--- a/.github/workflows/monthly-tag.yml
+++ b/.github/workflows/monthly-tag.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: 'master'
+          fetch-depth: 0
       - name: Generate changelog
         id: changelog
         run: |
@@ -26,7 +27,7 @@ jobs:
           echo "" >> Changelog.md
           echo "## Changes since last snapshot (${{ steps.tags.outputs.old }})" >> Changelog.md
           echo "" >> Changelog.md
-          GITHUB_DEPLOY_TOKEN=${{ secrets.GITHUB_TOKEN }} ./.maintain/gitlab/generate_changelog.sh ${{ steps.tags.outputs.old }} >>  Changelog.md
+          ./.maintain/gitlab/generate_changelog.sh ${{ steps.tags.outputs.old }} >>  Changelog.md
       - name: Release snapshot
         id: release-snapshot
         uses: actions/create-release@latest

--- a/.maintain/gitlab/generate_changelog.sh
+++ b/.maintain/gitlab/generate_changelog.sh
@@ -32,7 +32,7 @@ $line"
     runtime_changes="$runtime_changes
 $line"
   fi
-  if has_label 'paritytech/substrate' "$pr_id" 'D1-runtime-migration'; then
+  if has_label 'paritytech/substrate' "$pr_id" 'E1-runtime-migration'; then
     migrations="$migrations
 $line"
   fi


### PR DESCRIPTION
Sets git fetch depth to 0 (i.e., all branches and tags). Also fixes issue with the GITHUB_TOKEN (no need for casting it to GITHUB_DEPLOY_TOKEN, since lib.sh will happily just accept it as-is). Also updated a label.