### PR TITLE
Add an INDEX to the Instance trait

### DIFF
--- a/frame/support/procedural/src/lib.rs
+++ b/frame/support/procedural/src/lib.rs
@@ -421,3 +421,7 @@ pub fn require_transactional(attr: TokenStream, input: TokenStream) -> TokenStre
 pub fn crate_to_pallet_version(input: TokenStream) -> TokenStream {
 	pallet_version::crate_to_pallet_version(input).unwrap_or_else(|e| e.to_compile_error()).into()
 }
+
+/// The number of module instances supported by the runtime, starting at index 1,
+/// and up to `NUMBER_OF_INSTANCE`.
+pub(crate) const NUMBER_OF_INSTANCE: u8 = 16;

--- a/frame/support/procedural/src/pallet/expand/instances.rs
+++ b/frame/support/procedural/src/pallet/expand/instances.rs
@@ -17,14 +17,15 @@
 
 use proc_macro2::Span;
 use crate::pallet::Def;
+use crate::NUMBER_OF_INSTANCE;
 
 /// * Provide inherent instance to be used by construct_runtime
-/// * Provide Instance0 .. Instance16 for instantiable pallet
+/// * Provide Instance1 ..= Instance16 for instantiable pallet
 pub fn expand_instances(def: &mut Def) -> proc_macro2::TokenStream {
 	let frame_support = &def.frame_support;
 	let inherent_ident = syn::Ident::new(crate::INHERENT_INSTANCE_NAME, Span::call_site());
 	let instances = if def.config.has_instance {
-		(0..16).map(|i| syn::Ident::new(&format!("Instance{}", i), Span::call_site())).collect()
+		(1..=NUMBER_OF_INSTANCE).map(|i| syn::Ident::new(&format!("Instance{}", i), Span::call_site())).collect()
 	} else {
 		vec![]
 	};

--- a/frame/support/procedural/src/storage/instance_trait.rs
+++ b/frame/support/procedural/src/storage/instance_trait.rs
@@ -21,8 +21,8 @@
 use proc_macro2::{TokenStream, Span};
 use quote::quote;
 use super::DeclStorageDefExt;
+use crate::NUMBER_OF_INSTANCE;
 
-const NUMBER_OF_INSTANCE: usize = 16;
 pub(crate) const INHERENT_INSTANCE_NAME: &str = "__InherentHiddenInstance";
 
 // Used to generate an instance implementation.
@@ -30,6 +30,8 @@ struct InstanceDef {
 	prefix: String,
 	instance_struct: syn::Ident,
 	doc: TokenStream,
+	// Index is same as instance number. Default is 0.
+	index: u8,
 }
 
 pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStream {
@@ -39,13 +41,14 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 
 	// Implementation of instances.
 	if let Some(module_instance) = &def.module_instance {
-		let instance_defs = (0..NUMBER_OF_INSTANCE)
+		let instance_defs = (1..=NUMBER_OF_INSTANCE)
 			.map(|i| {
 				let name = format!("Instance{}", i);
 				InstanceDef {
 					instance_struct: syn::Ident::new(&name, proc_macro2::Span::call_site()),
 					prefix: name,
 					doc: quote!(#[doc=r"Module instance"]),
+					index: i,
 				}
 			})
 			.chain(
@@ -53,6 +56,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 					prefix: String::new(),
 					instance_struct: ident.clone(),
 					doc: quote!(#[doc=r"Default module instance"]),
+					index: 0,
 				})
 			);
 
@@ -83,6 +87,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 				/// instance.
 				#[doc(hidden)]
 			),
+			index: 0,
 		};
 		impls.extend(create_and_impl_instance_struct(scrate, &instance_def, def));
 	}
@@ -116,6 +121,7 @@ fn create_and_impl_instance_struct(
 	let instance_struct = &instance_def.instance_struct;
 	let prefix = format!("{}{}", instance_def.prefix, def.crate_name.to_string());
 	let doc = &instance_def.doc;
+	let index = instance_def.index;
 
 	quote! {
 		// Those trait are derived because of wrong bounds for generics
@@ -129,6 +135,7 @@ fn create_and_impl_instance_struct(
 		pub struct #instance_struct;
 		impl #instance_trait for #instance_struct {
 			const PREFIX: &'static str = #prefix;
+			const INDEX: u8 = #index;
 		}
 	}
 }

--- a/frame/support/procedural/src/storage/instance_trait.rs
+++ b/frame/support/procedural/src/storage/instance_trait.rs
@@ -87,6 +87,7 @@ pub fn decl_and_impl(scrate: &TokenStream, def: &DeclStorageDefExt) -> TokenStre
 				/// instance.
 				#[doc(hidden)]
 			),
+			// This is just to make the type system happy. Not actually used.
 			index: 0,
 		};
 		impls.extend(create_and_impl_instance_struct(scrate, &instance_def, def));

--- a/frame/support/src/instances.rs
+++ b/frame/support/src/instances.rs
@@ -31,10 +31,6 @@
 //! NOTE: [`frame_support::pallet`] will reexport them inside the module, in order to make them
 //! accessible to [`frame_support::construct_runtime`].
 
-/// Instance0 to be used for instantiable pallet define with `pallet` macro.
-#[derive(Clone, Copy, PartialEq, Eq, crate::RuntimeDebugNoBound)]
-pub struct Instance0;
-
 /// Instance1 to be used for instantiable pallet define with `pallet` macro.
 #[derive(Clone, Copy, PartialEq, Eq, crate::RuntimeDebugNoBound)]
 pub struct Instance1;
@@ -94,3 +90,7 @@ pub struct Instance14;
 /// Instance15 to be used for instantiable pallet define with `pallet` macro.
 #[derive(Clone, Copy, PartialEq, Eq, crate::RuntimeDebugNoBound)]
 pub struct Instance15;
+
+/// Instance16 to be used for instantiable pallet define with `pallet` macro.
+#[derive(Clone, Copy, PartialEq, Eq, crate::RuntimeDebugNoBound)]
+pub struct Instance16;

--- a/frame/support/src/traits/storage.rs
+++ b/frame/support/src/traits/storage.rs
@@ -26,6 +26,8 @@
 pub trait Instance: 'static {
 	/// Unique module prefix. E.g. "InstanceNMyModule" or "MyModule"
 	const PREFIX: &'static str;
+	/// Unique numerical identifier for an instance.
+	const INDEX: u8;
 }
 
 /// An instance of a storage in a pallet.


### PR DESCRIPTION
This PR introduces a simple `const INDEX: u8;` to the Instance trait used for Pallets.

This is useful for getting a minimal unique identifier for different instances, for example using it as a seed to some unique account generation.

The `DefaultInstance` uses `index == 0`, so we deprecate `Instance0` (which wasn't used anywhere) and instead use instances `1 ..= 16`.