### PR TITLE
Add PoV Tracking to Benchmarking Pipeline

### DIFF
--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -542,7 +542,7 @@ mod test {
 
 	#[test]
 	fn read_to_main_and_child_tries() {
-		let bench_state = BenchmarkingState::<crate::tests::Block>::new(Default::default(), None)
+		let bench_state = BenchmarkingState::<crate::tests::Block>::new(Default::default(), None, false)
 			.unwrap();
 
 		for _ in 0..2 {

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -51,17 +51,16 @@ struct StorageDb<Block: BlockT> {
 
 impl<Block: BlockT> sp_state_machine::Storage<HashFor<Block>> for StorageDb<Block> {
 	fn get(&self, key: &Block::Hash, prefix: Prefix) -> Result<Option<DBValue>, String> {
+		let prefixed_key = prefixed_key::<HashFor<Block>>(key, prefix);
 		if let Some(recorder) = &self.proof_recorder {
 			if let Some(v) = recorder.read().get(&key) {
 				return Ok(v.clone());
 			}
-			let prefixed_key = prefixed_key::<HashFor<Block>>(key, prefix);
 			let backend_value = self.db.get(0, &prefixed_key)
 				.map_err(|e| format!("Database backend error: {:?}", e))?;
 			recorder.write().insert(key.clone(), backend_value.clone());
 			Ok(backend_value)
 		} else {
-			let prefixed_key = prefixed_key::<HashFor<Block>>(key, prefix);
 			self.db.get(0, &prefixed_key)
 				.map_err(|e| format!("Database backend error: {:?}", e))
 		}

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -23,7 +23,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
 use hash_db::{Prefix, Hasher};
-use sp_trie::{MemoryDB, prefixed_key};
+use sp_trie::{MemoryDB, prefixed_key, StorageProof};
 use sp_core::{
 	storage::{ChildInfo, TrackedStorageKey},
 	hexdisplay::HexDisplay
@@ -31,9 +31,10 @@ use sp_core::{
 use sp_runtime::traits::{Block as BlockT, HashFor};
 use sp_runtime::Storage;
 use sp_state_machine::{
-	DBValue, backend::Backend as StateBackend, StorageCollection, ChildStorageCollection
+	DBValue, backend::Backend as StateBackend, StorageCollection, ChildStorageCollection, ProofRecorder,
 };
 use kvdb::{KeyValueDB, DBTransaction};
+use codec::Encode;
 use crate::storage_cache::{CachingState, SharedCache, new_shared_cache};
 
 type DbState<B> = sp_state_machine::TrieBackend<
@@ -44,14 +45,26 @@ type State<B> = CachingState<DbState<B>, B>;
 
 struct StorageDb<Block: BlockT> {
 	db: Arc<dyn KeyValueDB>,
+	proof_recorder: Option<ProofRecorder<HashFor<Block>>>,
 	_block: std::marker::PhantomData<Block>,
 }
 
 impl<Block: BlockT> sp_state_machine::Storage<HashFor<Block>> for StorageDb<Block> {
 	fn get(&self, key: &Block::Hash, prefix: Prefix) -> Result<Option<DBValue>, String> {
-		let key = prefixed_key::<HashFor<Block>>(key, prefix);
-		self.db.get(0, &key)
-			.map_err(|e| format!("Database backend error: {:?}", e))
+		if let Some(recorder) = &self.proof_recorder {
+			if let Some(v) = recorder.read().get(&key) {
+				return Ok(v.clone());
+			}
+			let prefixed_key = prefixed_key::<HashFor<Block>>(key, prefix);
+			let backend_value = self.db.get(0, &prefixed_key)
+				.map_err(|e| format!("Database backend error: {:?}", e))?;
+			recorder.write().insert(key.clone(), backend_value.clone());
+			Ok(backend_value)
+		} else {
+			let prefixed_key = prefixed_key::<HashFor<Block>>(key, prefix);
+			self.db.get(0, &prefixed_key)
+				.map_err(|e| format!("Database backend error: {:?}", e))
+		}
 	}
 }
 
@@ -105,11 +118,12 @@ pub struct BenchmarkingState<B: BlockT> {
 	child_key_tracker: RefCell<HashMap<Vec<u8>, HashMap<Vec<u8>, KeyTracker>>>,
 	read_write_tracker: RefCell<ReadWriteTracker>,
 	whitelist: RefCell<Vec<TrackedStorageKey>>,
+	proof_recorder: Option<ProofRecorder<HashFor<B>>>,
 }
 
 impl<B: BlockT> BenchmarkingState<B> {
 	/// Create a new instance that creates a database in a temporary dir.
-	pub fn new(genesis: Storage, _cache_size_mb: Option<usize>) -> Result<Self, String> {
+	pub fn new(genesis: Storage, _cache_size_mb: Option<usize>, record_proof: bool) -> Result<Self, String> {
 		let mut root = B::Hash::default();
 		let mut mdb = MemoryDB::<HashFor<B>>::default();
 		sp_state_machine::TrieDBMut::<HashFor<B>>::new(&mut mdb, &mut root);
@@ -126,6 +140,7 @@ impl<B: BlockT> BenchmarkingState<B> {
 			child_key_tracker: Default::default(),
 			read_write_tracker: Default::default(),
 			whitelist: Default::default(),
+			proof_recorder: record_proof.then(Default::default),
 		};
 
 		state.add_whitelist_to_tracker();
@@ -153,7 +168,14 @@ impl<B: BlockT> BenchmarkingState<B> {
 			None => Arc::new(::kvdb_memorydb::create(1)),
 		};
 		self.db.set(Some(db.clone()));
-		let storage_db = Arc::new(StorageDb::<B> { db, _block: Default::default() });
+		if let Some(recorder) = &self.proof_recorder {
+			recorder.write().clear();
+		}
+		let storage_db = Arc::new(StorageDb::<B> {
+			db,
+			proof_recorder: self.proof_recorder.clone(),
+			_block: Default::default()
+		});
 		*self.state.borrow_mut() = Some(State::new(
 			DbState::<B>::new(storage_db, self.root.get()),
 			self.shared_cache.clone(),
@@ -494,6 +516,17 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 
 	fn usage_info(&self) -> sp_state_machine::UsageInfo {
 		self.state.borrow().as_ref().map_or(sp_state_machine::UsageInfo::empty(), |s| s.usage_info())
+	}
+
+	fn proof_size(&self) -> Option<u32> {
+		self.proof_recorder.as_ref().map(|recorder| {
+			let proof = StorageProof::new(recorder
+				.read()
+				.iter()
+				.filter_map(|(_k, v)| v.as_ref().map(|v| v.to_vec()))
+				.collect());
+			proof.encode().len() as u32
+		})
 	}
 }
 

--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -525,7 +525,7 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 				.iter()
 				.filter_map(|(_k, v)| v.as_ref().map(|v| v.to_vec()))
 				.collect());
-			proof.encode().len() as u32
+			proof.encoded_size() as u32
 		})
 	}
 }

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -38,6 +38,7 @@ pub enum BenchmarkSelector {
 	StorageRootTime,
 	Reads,
 	Writes,
+	ProofSize,
 }
 
 #[derive(Debug)]
@@ -86,6 +87,7 @@ impl Analysis {
 				BenchmarkSelector::StorageRootTime => result.storage_root_time,
 				BenchmarkSelector::Reads => result.reads.into(),
 				BenchmarkSelector::Writes => result.writes.into(),
+				BenchmarkSelector::ProofSize => result.proof_size.into(),
 			}
 		).collect();
 
@@ -126,6 +128,7 @@ impl Analysis {
 						BenchmarkSelector::StorageRootTime => result.storage_root_time,
 						BenchmarkSelector::Reads => result.reads.into(),
 						BenchmarkSelector::Writes => result.writes.into(),
+						BenchmarkSelector::ProofSize => result.proof_size.into(),
 					};
 					(result.components[i].1, data)
 				})
@@ -190,6 +193,7 @@ impl Analysis {
 					BenchmarkSelector::StorageRootTime => result.storage_root_time,
 					BenchmarkSelector::Reads => result.reads.into(),
 					BenchmarkSelector::Writes => result.writes.into(),
+					BenchmarkSelector::ProofSize => result.proof_size.into(),
 				})
 		}
 

--- a/frame/benchmarking/src/analysis.rs
+++ b/frame/benchmarking/src/analysis.rs
@@ -374,6 +374,7 @@ mod tests {
 			repeat_reads: 0,
 			writes,
 			repeat_writes: 0,
+			proof_size: 0,
 		}
 	}
 

--- a/frame/benchmarking/src/lib.rs
+++ b/frame/benchmarking/src/lib.rs
@@ -764,12 +764,21 @@ macro_rules! impl_benchmark {
 								"Start Benchmark: {:?}", c
 							);
 
+							let start_pov = $crate::benchmarking::proof_size();
 							let start_extrinsic = $crate::benchmarking::current_time();
 
 							closure_to_benchmark()?;
 
 							let finish_extrinsic = $crate::benchmarking::current_time();
-							let elapsed_extrinsic = finish_extrinsic - start_extrinsic;
+							let end_pov = $crate::benchmarking::proof_size();
+
+							// Calculate the diff caused by the benchmark.
+							let elapsed_extrinsic = finish_extrinsic.saturating_sub(start_extrinsic);
+							let diff_pov = match (start_pov, end_pov) {
+								(Some(start), Some(end)) => end.saturating_sub(start),
+								_ => Default::default(),
+							};
+
 							// Commit the changes to get proper write count
 							$crate::benchmarking::commit_db();
 							$crate::log::trace!(
@@ -796,6 +805,7 @@ macro_rules! impl_benchmark {
 								repeat_reads: read_write_count.1,
 								writes: read_write_count.2,
 								repeat_writes: read_write_count.3,
+								proof_size: diff_pov,
 							});
 						}
 

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -62,6 +62,7 @@ pub struct BenchmarkResults {
 	pub repeat_reads: u32,
 	pub writes: u32,
 	pub repeat_writes: u32,
+	pub proof_size: u32,
 }
 
 /// Configuration used to setup and run runtime benchmarks.
@@ -163,11 +164,10 @@ pub trait Benchmarking {
 		self.set_whitelist(whitelist);
 	}
 
-	/// Get current estimated proof size
+	/// Get current estimated proof size.
 	fn proof_size(&self) -> Option<u32> {
 		self.proof_size()
 	}
-
 }
 
 /// The pallet benchmarking trait.

--- a/frame/benchmarking/src/utils.rs
+++ b/frame/benchmarking/src/utils.rs
@@ -162,6 +162,12 @@ pub trait Benchmarking {
 		whitelist.retain(|x| x.key != remove);
 		self.set_whitelist(whitelist);
 	}
+
+	/// Get current estimated proof size
+	fn proof_size(&self) -> Option<u32> {
+		self.proof_size()
+	}
+
 }
 
 /// The pallet benchmarking trait.

--- a/primitives/externalities/src/lib.rs
+++ b/primitives/externalities/src/lib.rs
@@ -281,6 +281,16 @@ pub trait Externalities: ExtensionStore {
 	///
 	/// Adds new storage keys to the DB tracking whitelist.
 	fn set_whitelist(&mut self, new: Vec<TrackedStorageKey>);
+
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	/// Benchmarking related functionality and shouldn't be used anywhere else!
+	/// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	///
+	/// Returns estimated proof size for the state queries so far.
+	/// Proof is reset on commit and wipe.
+	fn proof_size(&self) -> Option<u32> {
+		None
+	}
 }
 
 /// Extension for the [`Externalities`] trait.

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -245,6 +245,11 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 
 	/// Update the whitelist for tracking db reads/writes
 	fn set_whitelist(&self, _: Vec<TrackedStorageKey>) {}
+
+	/// Estimate proof size
+	fn proof_size(&self) -> Option<u32> {
+		unimplemented!()
+	}
 }
 
 impl<'a, T: Backend<H>, H: Hasher> Backend<H> for &'a T {

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -712,6 +712,10 @@ where
 	fn set_whitelist(&mut self, new: Vec<TrackedStorageKey>) {
 		self.backend.set_whitelist(new)
 	}
+
+	fn proof_size(&self) -> Option<u32> {
+		self.backend.proof_size()
+	}
 }
 
 /// Implement `Encode` by forwarding the stored raw vec.

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -63,7 +63,7 @@ impl BenchmarkCmd {
 		let genesis_storage = spec.build_storage()?;
 		let mut changes = Default::default();
 		let cache_size = Some(self.database_cache_size as usize);
-		let state = BenchmarkingState::<BB>::new(genesis_storage, cache_size)?;
+		let state = BenchmarkingState::<BB>::new(genesis_storage, cache_size, self.record_proof)?;
 		let executor = NativeExecutor::<ExecDispatch>::new(
 			wasm_method,
 			self.heap_pages,

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -126,19 +126,20 @@ impl BenchmarkCmd {
 						// Print the table header
 						batch.results[0].components.iter().for_each(|param| print!("{:?},", param.0));
 
-						print!("extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes\n");
+						print!("extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes,proof_size\n");
 						// Print the values
 						batch.results.iter().for_each(|result| {
 							let parameters = &result.components;
 							parameters.iter().for_each(|param| print!("{:?},", param.1));
 							// Print extrinsic time and storage root time
-							print!("{:?},{:?},{:?},{:?},{:?},{:?}\n",
+							print!("{:?},{:?},{:?},{:?},{:?},{:?},{:?}\n",
 								result.extrinsic_time,
 								result.storage_root_time,
 								result.reads,
 								result.repeat_reads,
 								result.writes,
 								result.repeat_writes,
+								result.proof_size,
 							);
 						});
 

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -126,7 +126,7 @@ impl BenchmarkCmd {
 						// Print the table header
 						batch.results[0].components.iter().for_each(|param| print!("{:?},", param.0));
 
-						print!("extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes,proof_size\n");
+						print!("extrinsic_time_ns,storage_root_time_ns,reads,repeat_reads,writes,repeat_writes,proof_size_bytes\n");
 						// Print the values
 						batch.results.iter().for_each(|result| {
 							let parameters = &result.components;

--- a/utils/frame/benchmarking-cli/src/lib.rs
+++ b/utils/frame/benchmarking-cli/src/lib.rs
@@ -97,6 +97,10 @@ pub struct BenchmarkCmd {
 	#[structopt(long)]
 	pub extra: bool,
 
+	/// Estimate PoV size.
+	#[structopt(long)]
+	pub record_proof: bool,
+
 	#[allow(missing_docs)]
 	#[structopt(flatten)]
 	pub shared_params: sc_cli::SharedParams,

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -421,6 +421,7 @@ mod test {
 					repeat_reads: 0,
 					writes: (base + slope * i).into(),
 					repeat_writes: 0,
+					proof_size:0,
 				}
 			)
 		}

--- a/utils/frame/benchmarking-cli/src/writer.rs
+++ b/utils/frame/benchmarking-cli/src/writer.rs
@@ -421,7 +421,7 @@ mod test {
 					repeat_reads: 0,
 					writes: (base + slope * i).into(),
 					repeat_writes: 0,
-					proof_size:0,
+					proof_size: 0,
 				}
 			)
 		}


### PR DESCRIPTION
This PR introduces the PoV Tracking / Proof Recorder into the Runtime Benchmarking Pipeline.

In summary, when a parachain presents a new block for the relay chain to validate, it must also provide a minimal PoV block which contains all the necessary storage items which can be used to prove the validity of the state transition.

This means if you are trying to transfer a balance between two accounts on a parachain, you need to provide some subsection of the full state trie to the relay chain which contains those two account balances.

Due to the base-16 Patricia-Merkle trie used in Substrate, this can end up being a lot of extra data. We need to not only confirm that a block of extrinsics would execute in time, but also that the PoV block needed for all those extrinsics would fit within the limits of the relay chain.

When benchmarking for PoV block size, you need to ensure to follow the path of any extrinsic logic which touches the most storage items, especially those that are large, as this is likely to create the largest PoV block. Furthermore, you must populate the storage to have all of those storage items as full as they can be. Always benchmark the worst case scenario.

Initial tests from this PR show:

```
Pallet: "pallet_balances", Extrinsic: "transfer",
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes,proof_size
65000,13000,1,18,1,4,1806

Pallet: "pallet_balances", Extrinsic: "transfer_keep_alive",
extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes,proof_size
48000,4000,1,12,1,3,1571
```

So a balance transfer on an **empty** chain is around 1.6 - 1.8 kB.

Another benchmark which populates more data into the state:

```
Pallet: "pallet_collective", Extrinsic: "close_approved",
b,m,p,extrinsic_time,storage_root_time,reads,repeat_reads,writes,repeat_writes,proof_size
1,100,100,126000,3000,5,10,3,2,12554
103,100,100,148000,4000,5,10,3,2,12801
205,100,100,144000,4000,5,10,3,2,12761
307,100,100,113000,2000,5,10,3,2,12863
409,100,100,121000,3000,5,10,3,2,12965
511,100,100,121000,3000,5,10,3,2,12935
613,100,100,119000,3000,5,10,3,2,13103
715,100,100,124000,3000,5,10,3,2,13073
817,100,100,125000,4000,5,10,3,2,13713
919,100,100,125000,3000,5,10,3,2,13551
1021,100,100,126000,3000,5,10,3,2,13709
1024,4,100,83000,3000,5,10,3,2,7368
1024,13,100,88000,3000,5,10,3,2,7944
1024,22,100,214000,3000,5,10,3,2,8520
1024,31,100,106000,17000,5,10,3,2,9096
1024,40,100,96000,3000,5,10,3,2,9672
1024,49,100,99000,3000,5,10,3,2,10248
1024,58,100,100000,3000,5,10,3,2,10824
1024,67,100,106000,3000,5,10,3,2,11402
1024,76,100,111000,3000,5,10,3,2,11978
1024,85,100,113000,3000,5,10,3,2,12554
1024,94,100,115000,3000,5,10,3,2,13130
1024,100,1,88000,3000,5,10,3,2,8941
1024,100,10,108000,3000,5,10,3,2,9835
1024,100,19,97000,3000,5,10,3,2,10453
1024,100,28,110000,3000,5,10,3,2,10945
1024,100,37,104000,3000,5,10,3,2,11299
1024,100,46,113000,4000,5,10,3,2,11653
1024,100,55,115000,3000,5,10,3,2,12281
1024,100,64,117000,3000,5,10,3,2,12296
1024,100,73,153000,3000,5,10,3,2,12782
1024,100,82,115000,3000,5,10,3,2,12872
1024,100,91,119000,3000,5,10,3,2,13226
1024,100,100,122000,3000,5,10,3,2,13514
```

Here we see the PoV size of a `closed_approve` where we change the number of:
* `b`: bytes in the proposal
* `m`: members in the collective
* `p`: number of proposals in the system

Here we can see the proof size increases as the values of these things increases. Up to nearly 14 kB.

More analysis will be done to verify all of this benchmarking process is sane, and we will introduce processes in future PRs that will fill up the state for worst case PoV benchmarking.