### PR TITLE
remove real-overseer from polkadot compilation flags

### DIFF
--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -89,7 +89,7 @@ fi
 diener patch --crates-to-patch ../ --substrate --path Cargo.toml
 
 # Test Polkadot pr or master branch with this Substrate commit.
-time cargo test --all --release --verbose --features=real-overseer
+time cargo test --all --release --verbose
 
 cd parachain/test-parachains/adder/collator/
-time cargo test --release --verbose --locked --features=real-overseer
+time cargo test --release --verbose --locked

--- a/.maintain/gitlab/check_polkadot_companion_build.sh
+++ b/.maintain/gitlab/check_polkadot_companion_build.sh
@@ -90,6 +90,3 @@ diener patch --crates-to-patch ../ --substrate --path Cargo.toml
 
 # Test Polkadot pr or master branch with this Substrate commit.
 time cargo test --all --release --verbose
-
-cd parachain/test-parachains/adder/collator/
-time cargo test --release --verbose --locked


### PR DESCRIPTION
https://github.com/paritytech/polkadot/pull/2834 removes this feature, so we don't need it in Substrate anymore