### PR TITLE
Recursive ElectionProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,6 +4271,7 @@ name = "node-runtime"
 version = "2.0.1"
 dependencies = [
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-support",
  "frame-system",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -46,6 +46,7 @@ frame-system = { version = "3.0.0", default-features = false, path = "../../../f
 frame-system-benchmarking = { version = "3.0.0", default-features = false, path = "../../../frame/system/benchmarking", optional = true }
 frame-system-rpc-runtime-api = { version = "3.0.0", default-features = false, path = "../../../frame/system/rpc/runtime-api/" }
 frame-try-runtime = { version = "0.9.0", default-features = false, path = "../../../frame/try-runtime", optional = true }
+frame-election-provider-support = { version = "3.0.0", default-features = false, path = "../../../frame/election-provider-support" }
 pallet-assets = { version = "3.0.0", default-features = false, path = "../../../frame/assets" }
 pallet-authority-discovery = { version = "3.0.0", default-features = false, path = "../../../frame/authority-discovery" }
 pallet-authorship = { version = "3.0.0", default-features = false, path = "../../../frame/authorship" }
@@ -115,6 +116,7 @@ std = [
 	"pallet-democracy/std",
 	"pallet-elections-phragmen/std",
 	"frame-executive/std",
+	"frame-election-provider-support/std",
 	"pallet-gilt/std",
 	"pallet-grandpa/std",
 	"pallet-im-online/std",

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -504,10 +504,6 @@ parameter_types! {
 	pub const SignedPhase: u32 = EPOCH_DURATION_IN_BLOCKS / 4;
 	pub const UnsignedPhase: u32 = EPOCH_DURATION_IN_BLOCKS / 4;
 
-	// fallback: no need to do on-chain phragmen initially.
-	pub const Fallback: pallet_election_provider_multi_phase::FallbackStrategy =
-		pallet_election_provider_multi_phase::FallbackStrategy::OnChain;
-
 	pub SolutionImprovementThreshold: Perbill = Perbill::from_rational(1u32, 10_000);
 
 	// miner configs
@@ -543,7 +539,9 @@ impl pallet_election_provider_multi_phase::Config for Runtime {
 	type DataProvider = Staking;
 	type OnChainAccuracy = Perbill;
 	type CompactSolution = NposCompactSolution16;
-	type Fallback = Fallback;
+	type Fallback = frame_election_provider_support::onchain::OnChainSequentialPhragmen<
+		pallet_election_provider_multi_phase::OnChainConfig<Runtime>,
+	>;
 	type WeightInfo = pallet_election_provider_multi_phase::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = ();
 }

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -324,8 +324,8 @@ impl<Bn: PartialEq + Eq> Phase<Bn> {
 /// The type of `Computation` that provided this election data.
 #[derive(PartialEq, Eq, Clone, Copy, Encode, Decode, RuntimeDebug)]
 pub enum ElectionCompute {
-	/// Election was computed on-chain.
-	OnChain,
+	/// Election was computed using the fallback method.
+	Fallback,
 	/// Election was computed with a signed submission.
 	Signed,
 	/// Election was computed with an unsigned submission.
@@ -334,7 +334,7 @@ pub enum ElectionCompute {
 
 impl Default for ElectionCompute {
 	fn default() -> Self {
-		ElectionCompute::OnChain
+		ElectionCompute::Fallback
 	}
 }
 
@@ -1041,7 +1041,7 @@ impl<T: Config> Pallet<T> {
 	fn do_elect() -> Result<(Supports<T::AccountId>, Weight), ElectionError> {
 		<QueuedSolution<T>>::take()
 			.map_or_else(
-				|| Self::fallback().map(|(s, w)| (s, w, ElectionCompute::OnChain)),
+				|| Self::fallback().map(|(s, w)| (s, w, ElectionCompute::Fallback)),
 				|ReadySolution { supports, compute, .. }| Ok((
 					supports,
 					T::WeightInfo::elect_queued(),
@@ -1160,7 +1160,7 @@ mod feasibility_check {
 
 	use super::{mock::*, *};
 
-	const COMPUTE: ElectionCompute = ElectionCompute::OnChain;
+	const COMPUTE: ElectionCompute = ElectionCompute::Fallback;
 
 	#[test]
 	fn snapshot_is_there() {
@@ -1485,7 +1485,7 @@ mod tests {
 				multi_phase_events(),
 				vec![
 					Event::SignedPhaseStarted(1),
-					Event::ElectionFinalized(Some(ElectionCompute::OnChain))
+					Event::ElectionFinalized(Some(ElectionCompute::Fallback))
 				],
 			);
 			// all storage items must be cleared.


### PR DESCRIPTION
Related to https://github.com/paritytech/srlabs_findings/issues/79 and https://github.com/paritytech/srlabs_findings/issues/65.

The fundamental change here is that instead of assuming a hardcoded: 

```rust
enum Fallback {
  Nothing,
  OnChain,
} 
```

We leave this open: The `type Fallback` is merely another `ElectionProvider` that might be anything. 

Also, we ensure that a fallback method uses the snapshot that is created in the `multi-phase` pallet. In the past, the `DataProvider` of `Fallback` was `Staking`, meaning that we would need to re-query all validators and nominators from chain-state one by one to trigger the on-chain election. Now, we implement `ElectionDataProvider` for `multi_phase::Pallet<T>`, meaning that `multi_phase` can itself be the data provider of the fallback. 

This is beneficial if: The snapshot is created in `multi_phase`, but election fails. In this case, we use the snapshot and this is much more optimized in terms of storage operations. 
This is tricky if: Everything gets fails in `multi_phase`, and no snapshot exists there. An example of this is if the snapshot creation fails. In these cases, `multi_phase` has no snapshot to give to the fallback, and the fallback cannot do anything. 

We could code `impl DataProvider for multi_phase::Pallet` in such a way that first tries to return the data from its own snapshot, and if failure, fallback to its own `T::DataProvider` (staking). 