### PR TITLE
Allow lossless matching for Origin

### DIFF
--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -322,6 +322,7 @@ macro_rules! impl_outer_origin {
 				}
 			}
 		}
+
 		impl From<$system::Origin<$runtime>> for $name {
 			/// Convert to runtime origin:
 			/// * root origin is built with no filter

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -246,6 +246,13 @@ macro_rules! impl_outer_origin {
 				&self.caller
 			}
 
+			fn try_with_caller<R>(mut self, f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>) -> Result<R, Self> {
+				match f(self.caller) {
+					Ok(r) => Ok(r),
+					Err(caller) => { self.caller = caller; Err(self) }
+				}
+			}
+
 			/// Create with system none origin and `frame-system::Config::BaseCallFilter`.
 			fn none() -> Self {
 				$system::RawOrigin::None.into()
@@ -297,6 +304,19 @@ macro_rules! impl_outer_origin {
 		impl From<$system::Origin<$runtime>> for $caller_name {
 			fn from(x: $system::Origin<$runtime>) -> Self {
 				$caller_name::system(x)
+			}
+		}
+
+		impl $crate::sp_std::convert::TryFrom<$caller_name> for $system::Origin<$runtime> {
+			type Error = $caller_name;
+			fn try_from(x: $caller_name)
+				-> $crate::sp_std::result::Result<$system::Origin<$runtime>, $caller_name>
+			{
+				if let $caller_name::system(l) = x {
+					Ok(l)
+				} else {
+					Err(x)
+				}
 			}
 		}
 		impl From<$system::Origin<$runtime>> for $name {
@@ -373,6 +393,22 @@ macro_rules! impl_outer_origin {
 							Ok(l)
 						} else {
 							Err(self)
+						}
+					}
+				}
+
+				impl $crate::sp_std::convert::TryFrom<
+					$caller_name
+				> for $module::Origin < $( $generic )? $(, $module::$generic_instance )? > {
+					type Error = $caller_name;
+					fn try_from(x: $caller_name) -> $crate::sp_std::result::Result<
+						$module::Origin < $( $generic )? $(, $module::$generic_instance )? >,
+						$caller_name,
+					> {
+						if let $caller_name::[< $module $( _ $generic_instance )? >](l) = x {
+							Ok(l)
+						} else {
+							Err(x)
 						}
 					}
 				}

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -246,7 +246,10 @@ macro_rules! impl_outer_origin {
 				&self.caller
 			}
 
-			fn try_with_caller<R>(mut self, f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>) -> Result<R, Self> {
+			fn try_with_caller<R>(
+				mut self,
+				f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>,
+			) -> Result<R, Self> {
 				match f(self.caller) {
 					Ok(r) => Ok(r),
 					Err(caller) => { self.caller = caller; Err(self) }

--- a/frame/support/src/traits/dispatch.rs
+++ b/frame/support/src/traits/dispatch.rs
@@ -79,7 +79,7 @@ pub trait OriginTrait: Sized {
 	/// Do something with the caller, consuming self but returning it if the caller was unused.
 	fn try_with_caller<R>(
 		self,
-		f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>
+		f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>,
 	) -> Result<R, Self>;
 
 	/// Create with system none origin and `frame-system::Config::BaseCallFilter`.

--- a/frame/support/src/traits/dispatch.rs
+++ b/frame/support/src/traits/dispatch.rs
@@ -76,6 +76,12 @@ pub trait OriginTrait: Sized {
 	/// Get the caller.
 	fn caller(&self) -> &Self::PalletsOrigin;
 
+	/// Do something with the caller, consuming self but returning it if the caller was unused.
+	fn try_with_caller<R>(
+		self,
+		f: impl FnOnce(Self::PalletsOrigin) -> Result<R, Self::PalletsOrigin>
+	) -> Result<R, Self>;
+
 	/// Create with system none origin and `frame-system::Config::BaseCallFilter`.
 	fn none() -> Self;
 


### PR DESCRIPTION
Without these changes, it's difficult/impossible to not lose any filters when making fine-grained matches against origin.
