### PR TITLE
Disallow failure for `node-bench-regression-guard` job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -285,8 +285,6 @@ node-bench-regression-guard:
   script:
     - 'node-bench-regression-guard --reference artifacts/benches/master-* 
        --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
-  # FIXME: remove this when master will be populated with bench results artifacts
-  allow_failure:                   true
 
 cargo-check-subkey:
   stage:                           test


### PR DESCRIPTION
This PR accompanies paritytech/substrate#8519 and makes following changes:
* remove `allow_failure` directive from `node-bench-regression-guard` job as described [here](https://github.com/paritytech/substrate/pull/8519#issue-608012386)