### PR TITLE
Cap the warp sync proof by size, not by fragments

### DIFF
--- a/client/finality-grandpa-warp-sync/src/lib.rs
+++ b/client/finality-grandpa-warp-sync/src/lib.rs
@@ -66,7 +66,7 @@ pub fn generate_request_response_config(protocol_id: ProtocolId) -> RequestRespo
 	RequestResponseConfig {
 		name: generate_protocol_name(protocol_id).into(),
 		max_request_size: 32,
-		max_response_size: 16 * 1024 * 1024,
+		max_response_size: proof::MAX_WARP_SYNC_PROOF_SIZE as u64,
 		request_timeout: Duration::from_secs(10),
 		inbound_queue: None,
 	}

--- a/client/finality-grandpa-warp-sync/src/proof.rs
+++ b/client/finality-grandpa-warp-sync/src/proof.rs
@@ -163,10 +163,12 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 			true
 		};
 
-		Ok(WarpSyncProof {
+		let final_outcome = WarpSyncProof {
 			proofs,
 			is_finished,
-		})
+		};
+		debug_assert!(final_outcome.encoded_size() <= MAX_WARP_SYNC_PROOF_SIZE);
+		Ok(final_outcome)
 	}
 
 	/// Verifies the warp sync proof starting at the given set id and with the given authorities.


### PR DESCRIPTION
The proof we get for Kusama turns out to be larger than what the networking protocol allows.
This does it properly.