### PR TITLE
Backing/GetBacking: Abstraction over pluralistic origins for XCM.

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -55,7 +55,7 @@ use frame_support::{
 		PostDispatchInfo,
 	},
 	ensure,
-	traits::{ChangeMembers, EnsureOrigin, Get, InitializeMembers},
+	traits::{ChangeMembers, EnsureOrigin, Get, InitializeMembers, GetBacking, Backing},
 	weights::{DispatchClass, GetDispatchInfo, Weight, Pays},
 };
 use frame_system::{self as system, ensure_signed, ensure_root};
@@ -163,6 +163,15 @@ pub enum RawOrigin<AccountId, I> {
 	Member(AccountId),
 	/// Dummy to manage the fact we have instancing.
 	_Phantom(sp_std::marker::PhantomData<I>),
+}
+
+impl<AccountId, I> GetBacking for RawOrigin<AccountId, I> {
+	fn get_backing(&self) -> Option<Backing> {
+		match self {
+			RawOrigin::Members(n, d) => Some(Backing { approvals: *n, eligible: *d }),
+			_ => None,
+		}
+	}
 }
 
 /// Origin for the collective module.

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -46,7 +46,7 @@ pub use filter::{
 mod misc;
 pub use misc::{
 	Len, Get, GetDefault, HandleLifetime, TryDrop, Time, UnixTime, IsType, IsSubType, ExecuteBlock,
-	SameOrOther, OnNewAccount, OnKilledAccount, OffchainWorker,
+	SameOrOther, OnNewAccount, OnKilledAccount, OffchainWorker, GetBacking, Backing,
 };
 
 mod stored_map;

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -269,3 +269,17 @@ pub trait OffchainWorker<BlockNumber> {
 	fn offchain_worker(_n: BlockNumber) {}
 }
 
+/// Some amount of backing from a group. The precise defintion of what it means to "back" something
+/// is left flexible.
+pub struct Backing {
+	/// The number of members of the group that back some motion.
+	pub approvals: u32,
+	/// The number of members of the group that do not back the motion.
+	pub eligible: u32,
+}
+/// Retrieve the backing from an object's ref.
+pub trait GetBacking {
+	/// Returns `Some` `Backing` if `self` represents a fractional/groupwise backing of some
+	/// implicit motion. `None` if it does not.
+	fn get_backing(&self) -> Option<Backing>;
+}

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -277,6 +277,7 @@ pub struct Backing {
 	/// The total count of group members.
 	pub eligible: u32,
 }
+
 /// Retrieve the backing from an object's ref.
 pub trait GetBacking {
 	/// Returns `Some` `Backing` if `self` represents a fractional/groupwise backing of some

--- a/frame/support/src/traits/misc.rs
+++ b/frame/support/src/traits/misc.rs
@@ -274,7 +274,7 @@ pub trait OffchainWorker<BlockNumber> {
 pub struct Backing {
 	/// The number of members of the group that back some motion.
 	pub approvals: u32,
-	/// The number of members of the group that do not back the motion.
+	/// The total count of group members.
 	pub eligible: u32,
 }
 /// Retrieve the backing from an object's ref.


### PR DESCRIPTION
Small types an an integration into Collective pallet for them. This allows XCM to interpret Collective origins without needing to be exposed to the pallet. It also allows other n-of-m origins in the future to be automatically supported by XCM.