### PR TITLE
Fix for #8586 WithdrawReasons type change from i8 to u8

### DIFF
--- a/frame/support/src/traits/tokens/misc.rs
+++ b/frame/support/src/traits/tokens/misc.rs
@@ -126,7 +126,7 @@ pub enum BalanceStatus {
 bitflags::bitflags! {
 	/// Reasons for moving funds out of an account.
 	#[derive(Encode, Decode)]
-	pub struct WithdrawReasons: i8 {
+	pub struct WithdrawReasons: u8 {
 		/// In order to pay for (system) transaction costs.
 		const TRANSACTION_PAYMENT = 0b00000001;
 		/// In order to transfer ownership.


### PR DESCRIPTION
Fixes #8586 

It is part of the previous re-orgs of the files related to new token functionality implement by @shawntabrizi @gavofyork @bkchr - so could be reviewed by them.

There are no known breaking consequences to this change as the code that would break this is not implemented. However it restricts enhancements.

**Issue comments reproduced here for convenience:**
Using `i8` would produce an literal overflow error for values such as `0b10000000`. 

The error can be reproduced by attempting to compile with a test value:

```rust
bitflags::bitflags! {
	/// Reasons for moving funds out of an account.
	#[derive(Encode, Decode)]
	pub struct WithdrawReasons: i8 {
		/// In order to pay for (system) transaction costs.
		const TRANSACTION_PAYMENT = 0b00000001;
		/// In order to transfer ownership.
		const TRANSFER = 0b00000010;
		/// In order to reserve some funds for a later return or repatriation.
		const RESERVE = 0b00000100;
		/// In order to pay some other (higher-level) fees.
		const FEE = 0b00001000;
		/// In order to tip a validator for transaction inclusion.
		const TIP 	= 0b00010000;
		const TEST = 0b10000000;
	}
}
```

This would produce the following error:

```shell
error: literal out of range for `i8`
   --> frame/support/src/traits/tokens/misc.rs:144:17
    |
144 |         const TEST = 0b10000000;
    |                       ^^^^^^^^^^
    |
    = note: `#[deny(overflowing_literals)]` on by default
    = note: the literal `0b10000000` (decimal `128`) does not fit into the type `i8` and will become `-128i8`
    = help: consider using the type `u8` instead
```

The error is not produced when the type is `u8`.

**Justification**

Whilst additional values may not be foreseen in Substrate, future values can be added by teams implementing a workaround as we do in Totem Accounting (Substrate v3 Frame2 migration): [totem-lego/-/blob/master/frame/support/src/traits/tokens/misc/](https://gitlab.com/totem-tech/totem-lego/-/blob/master/frame/support/src/traits/tokens/misc/totem.rs#L1)

There does not appear to be a good reason to use type `i8` as it would prevent other teams from building more complex enhancements to the `WithdrawReasons` struct.