### PR TITLE
#8597 Update features resolver wasm build

### DIFF
--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -258,6 +258,7 @@ fn create_project_cargo_toml(
 	package.insert("name".into(), format!("{}-wasm", crate_name).into());
 	package.insert("version".into(), "1.0.0".into());
 	package.insert("edition".into(), "2018".into());
+	package.insert("resolver".into(), "2".into());
 
 	wasm_workspace_toml.insert("package".into(), package.into());
 
@@ -416,7 +417,7 @@ fn build_project(project: &Path, default_rustflags: &str, cargo_cmd: CargoComman
 		env::var(crate::WASM_BUILD_RUSTFLAGS_ENV).unwrap_or_default(),
 	);
 
-	build_cmd.args(&["-Zfeatures=build_dep", "rustc", "--target=wasm32-unknown-unknown"])
+	build_cmd.args(&["rustc", "--target=wasm32-unknown-unknown"])
 		.arg(format!("--manifest-path={}", manifest_path.display()))
 		.env("RUSTFLAGS", rustflags)
 		// Unset the `CARGO_TARGET_DIR` to prevent a cargo deadlock (cargo locks a target dir exclusive).


### PR DESCRIPTION
This is an update to the WASM build process and requires review - related to Issue #8597.

Although this is not specifically a bug in Substrate when using it alone, there is an impact when referencing Substrate-based runtime/pallets when cross-compiling with Cumulus (current Master). 

The scenario would be that a team is attempting to include their pallets and runtime via a git path to their Substrate-based chain.

A compile error is seen in these circumstances but can be resolved by this update. In any case the `-Zfeatures=build_dep` is no longer required due to features resolver 2 being stable it should be replaced. 

```shell
# EXAMPLE OF ERROR
error: failed to run custom build command for `cumulus-test-runtime v0.1.0 (/Users/chris/gitlab/totem-cumulus/test/runtime)`

Caused by:
  process didn't exit successfully: `/Users/chris/gitlab/totem-cumulus/target/release/build/cumulus-test-runtime-03ad4a258d54b069/build-script-build` (exit code: 1)
  --- stdout
  Information that should be included in a bug report.
  Executing build command: "/Users/chris/.rustup/toolchains/nightly-x86_64-apple-darwin/bin/cargo" "-Zfeatures=build_dep" "rustc" "--target=wasm32-unknown-unknown" "--manifest-path=/Users/chris/gitlab/totem-cumulus/target/release/wbuild/cumulus-test-runtime/Cargo.toml" "--color=always" "--release"
  Using rustc version: rustc 1.53.0-nightly (07e0e2ec2 2021-03-24)


  --- stderr
  warning: flag `-Z features` has been stabilized in the 1.51 release, and is no longer necessary
    The new feature resolver is now available by specifying `resolver = "2"` in Cargo.toml.
    See https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2 for more information.

```

**Justification:**
I believe this change will help head-off issues as teams begin their work towards integrating their runtimes and pallets with Cumulus 

This pull request replaces `-Zfeatures=build_dep` with `resolver = "2"` in the WASM build file.