### PR TITLE
Fix debug_assertion failing in authority discovery

### DIFF
--- a/client/authority-discovery/src/worker/addr_cache.rs
+++ b/client/authority-discovery/src/worker/addr_cache.rs
@@ -64,7 +64,7 @@ impl AddrCache {
 				Some(a) => a,
 				None => { debug_assert!(false); continue }
 			};
-			former_auth_addrs.retain(|a| peer_id_from_multiaddr(a).map_or(false, |p| p != peer_id));
+			former_auth_addrs.retain(|a| peer_id_from_multiaddr(a).map_or(true, |p| p != peer_id));
 		}
 
 		// Insert into `self.authority_id_to_addresses`.

--- a/client/authority-discovery/src/worker/addr_cache.rs
+++ b/client/authority-discovery/src/worker/addr_cache.rs
@@ -24,6 +24,9 @@ use sc_network::PeerId;
 
 /// Cache for [`AuthorityId`] -> [`Vec<Multiaddr>`] and [`PeerId`] -> [`AuthorityId`] mappings.
 pub(super) struct AddrCache {
+	// The addresses found in `authority_id_to_addresses` are guaranteed to always match
+	// the peerids found in `peer_id_to_authority_id`. In other words, these two hashmaps
+	// are similar to a bi-directional map.
 	authority_id_to_addresses: HashMap<AuthorityId, Vec<Multiaddr>>,
 	peer_id_to_authority_id: HashMap<PeerId, AuthorityId>,
 }
@@ -43,17 +46,44 @@ impl AddrCache {
 			return;
 		}
 
+		addresses.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+
 		// Insert into `self.peer_id_to_authority_id`.
 		let peer_ids = addresses.iter()
 			.map(|a| peer_id_from_multiaddr(a))
 			.filter_map(|peer_id| peer_id);
-		for peer_id in  peer_ids {
-			self.peer_id_to_authority_id.insert(peer_id, authority_id.clone());
+		for peer_id in peer_ids.clone() {
+			let former_auth = match self.peer_id_to_authority_id.insert(peer_id, authority_id.clone()) {
+				Some(a) if a != authority_id => a,
+				_ => continue,
+			};
+
+			// PeerId was associated to a different authority id before.
+			// Remove corresponding authority from `self.authority_id_to_addresses`.
+			let former_auth_addrs = match self.authority_id_to_addresses.get_mut(&former_auth) {
+				Some(a) => a,
+				None => { debug_assert!(false); continue }
+			};
+			former_auth_addrs.retain(|a| peer_id_from_multiaddr(a).map_or(false, |p| p != peer_id));
 		}
 
 		// Insert into `self.authority_id_to_addresses`.
-		addresses.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
-		self.authority_id_to_addresses.insert(authority_id, addresses);
+		for former_addr in
+			self.authority_id_to_addresses.insert(authority_id.clone(), addresses.clone()).unwrap_or_default()
+		{
+			// Must remove from `self.peer_id_to_authority_id` any PeerId formerly associated
+			// to that authority but that can't be found in its new addresses.
+
+			let peer_id = match peer_id_from_multiaddr(&former_addr) {
+				Some(p) => p,
+				None => { debug_assert!(false); continue },
+			};
+
+			if !peer_ids.clone().any(|p| p == peer_id) {
+				let _old_auth = self.peer_id_to_authority_id.remove(&peer_id);
+				debug_assert!(_old_auth.is_some());
+			}
+		}
 	}
 
 	/// Returns the number of authority IDs in the cache.
@@ -189,5 +219,57 @@ mod tests {
 		QuickCheck::new()
 			.max_tests(10)
 			.quickcheck(property as fn(_, _, _) -> TestResult)
+	}
+
+	#[test]
+	fn keeps_consistency_between_authority_id_and_peer_id() {
+		fn property(
+			authority1: TestAuthorityId,
+			authority2: TestAuthorityId,
+			multiaddr1: TestMultiaddr,
+			multiaddr2: TestMultiaddr,
+			multiaddr3: TestMultiaddr,
+		) -> TestResult {
+			let authority1 = authority1.0;
+			let authority2 = authority2.0;
+			let multiaddr1 = multiaddr1.0;
+			let multiaddr2 = multiaddr2.0;
+			let multiaddr3 = multiaddr3.0;
+
+			let mut cache = AddrCache::new();
+
+			cache.insert(authority1.clone(), vec![multiaddr1.clone()]);
+			cache.insert(authority1.clone(), vec![multiaddr2.clone(), multiaddr3.clone()]);
+
+			assert_eq!(
+				None,
+				cache.get_authority_id_by_peer_id(&peer_id_from_multiaddr(&multiaddr1).unwrap())
+			);
+			assert_eq!(
+				Some(&authority1),
+				cache.get_authority_id_by_peer_id(&peer_id_from_multiaddr(&multiaddr2).unwrap())
+			);
+			assert_eq!(
+				Some(&authority1),
+				cache.get_authority_id_by_peer_id(&peer_id_from_multiaddr(&multiaddr3).unwrap())
+			);
+
+			cache.insert(authority2.clone(), vec![multiaddr2.clone()]);
+
+			assert_eq!(
+				Some(&authority2),
+				cache.get_authority_id_by_peer_id(&peer_id_from_multiaddr(&multiaddr2).unwrap())
+			);
+			assert_eq!(
+				Some(&authority1),
+				cache.get_authority_id_by_peer_id(&peer_id_from_multiaddr(&multiaddr3).unwrap())
+			);
+
+			TestResult::passed()
+		}
+
+		QuickCheck::new()
+			.max_tests(10)
+			.quickcheck(property as fn(_, _, _, _, _) -> TestResult)
 	}
 }

--- a/client/authority-discovery/src/worker/addr_cache.rs
+++ b/client/authority-discovery/src/worker/addr_cache.rs
@@ -76,7 +76,7 @@ impl AddrCache {
 
 			let peer_id = match peer_id_from_multiaddr(&former_addr) {
 				Some(p) => p,
-				None => { debug_assert!(false); continue },
+				None => continue,
 			};
 
 			if !peer_ids.clone().any(|p| p == peer_id) {


### PR DESCRIPTION
The `debug_assertion` in `addr_cache.rs` line 95 was found to panic on our canary node.

This assertion seems to assume that there must always be a consistency between the two mappings (authority->peerids and peerid->authority). This isn't the case right now: if an authority changes `PeerId`, or if a `PeerId` is found to also be associated to another authority, there might be entries in one of the maps that aren't present in the other.

In addition, this makes me realize another problem: when an authority changes `PeerId`, the former entry in the peerid->authority map will never be removed. This is a very slow memory leak.

There are two ways to fix that: either add a guarantee of consistency between the two maps, or keep the code as is but remove the `debug_assert!`. I went for the first one because of the memory leak reason.
