### PR TITLE
expose set_timestamp for runtime benchmarks

### DIFF
--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -254,7 +254,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Set the timestamp to something in particular. Only used for tests.
-	#[cfg(any(feature = "runtime-benchmarks", test))]
+	#[cfg(any(feature = "runtime-benchmarks", feature = "std"))]
 	pub fn set_timestamp(now: T::Moment) {
 		Now::<T>::put(now);
 	}

--- a/frame/timestamp/src/lib.rs
+++ b/frame/timestamp/src/lib.rs
@@ -254,7 +254,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Set the timestamp to something in particular. Only used for tests.
-	#[cfg(feature = "std")]
+	#[cfg(any(feature = "runtime-benchmarks", test))]
 	pub fn set_timestamp(now: T::Moment) {
 		Now::<T>::put(now);
 	}


### PR DESCRIPTION
So we can use it in runtime benchmarks, which compiles to wasm.