### PR TITLE
Update dependencies of pallet_contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,8 +4777,8 @@ dependencies = [
  "paste 1.0.4",
  "pretty_assertions 0.7.2",
  "pwasm-utils 0.17.0",
- "rand 0.7.3",
- "rand_pcg",
+ "rand 0.8.3",
+ "rand_pcg 0.3.0",
  "serde",
  "sp-core",
  "sp-io",
@@ -6373,7 +6373,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -6475,6 +6475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de198537002b913568a3847e53535ace266f93526caf5c360ec41d72c5787f0"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +1803,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "paste 1.0.4",
- "pretty_assertions",
+ "pretty_assertions 0.6.1",
  "serde",
  "smallvec 1.6.1",
  "sp-arithmetic",
@@ -1850,7 +1856,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "pretty_assertions",
+ "pretty_assertions 0.6.1",
  "rustversion",
  "serde",
  "sp-core",
@@ -4202,7 +4208,7 @@ version = "2.0.0"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
- "pretty_assertions",
+ "pretty_assertions 0.6.1",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -4769,7 +4775,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm 0.42.2",
  "paste 1.0.4",
- "pretty_assertions",
+ "pretty_assertions 0.7.2",
  "pwasm-utils 0.17.0",
  "rand 0.7.3",
  "rand_pcg",
@@ -6097,6 +6103,18 @@ dependencies = [
  "ansi_term 0.11.0",
  "ctor",
  "difference",
+ "output_vt100",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
  "output_vt100",
 ]
 
@@ -8720,7 +8738,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.11.1",
- "pretty_assertions",
+ "pretty_assertions 0.6.1",
  "primitive-types",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -9076,7 +9094,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "pretty_assertions",
+ "pretty_assertions 0.6.1",
  "rand 0.7.3",
  "smallvec 1.6.1",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,10 +4767,10 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
  "paste 1.0.4",
  "pretty_assertions",
- "pwasm-utils 0.16.0",
+ "pwasm-utils 0.17.0",
  "rand 0.7.3",
  "rand_pcg",
  "serde",
@@ -4779,7 +4779,7 @@ dependencies = [
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
- "wasmi-validation",
+ "wasmi-validation 0.4.0",
  "wat",
 ]
 
@@ -5699,6 +5699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
 name = "parity-ws"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6257,13 +6263,13 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
+checksum = "51992bc74c0f34f759ff97fb303602e60343afc83693769c91aa17724442809e"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]
@@ -10733,7 +10739,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "parity-wasm 0.41.0",
- "wasmi-validation",
+ "wasmi-validation 0.3.0",
 ]
 
 [[package]]
@@ -10743,6 +10749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
  "parity-wasm 0.41.0",
+]
+
+[[package]]
+name = "wasmi-validation"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb8e860796d8be48efef530b60eebf84e74a88bce107374fffb0da97d504b8"
+dependencies = [
+ "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1", optional = true, features = ["derive"] }
 wasmi-validation = { version = "0.4", default-features = false }
 
 # Only used in benchmarking to generate random contract code
-rand = { version = "0.7", optional = true, default-features = false }
-rand_pcg = { version = "0.2", optional = true }
+rand = { version = "0.8", optional = true, default-features = false }
+rand_pcg = { version = "0.3", optional = true }
 
 # Substrate Dependencies
 frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -14,35 +14,39 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
+parity-wasm = { version = "0.42", default-features = false }
+pwasm-utils = { version = "0.17", default-features = false }
+serde = { version = "1", optional = true, features = ["derive"] }
+wasmi-validation = { version = "0.4", default-features = false }
+
+# Only used in benchmarking to generate random contract code
+rand = { version = "0.7", optional = true, default-features = false }
+rand_pcg = { version = "0.2", optional = true }
+
+# Substrate Dependencies
 frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "3.0.0", default-features = false, path = "../support" }
 frame-system = { version = "3.0.0", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "common" }
 pallet-contracts-proc-macro = { version = "3.0.0", path = "proc-macro" }
-parity-wasm = { version = "0.42.0", default-features = false }
-pwasm-utils = { version = "0.17", default-features = false }
-serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-core = { version = "3.0.0", default-features = false, path = "../../primitives/core" }
-sp-runtime = { version = "3.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-io = { version = "3.0.0", default-features = false, path = "../../primitives/io" }
-sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
+sp-runtime = { version = "3.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-sandbox = { version = "0.9.0", default-features = false, path = "../../primitives/sandbox" }
-wasmi-validation = { version = "0.4.0", default-features = false }
-log = { version = "0.4.14", default-features = false }
-
-# Only used in benchmarking to generate random contract code
-rand = { version = "0.7.0", optional = true, default-features = false }
-rand_pcg = { version = "0.2.1", optional = true }
+sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
 
 [dev-dependencies]
-assert_matches = "1.3.0"
-hex-literal = "0.3.1"
+assert_matches = "1"
+hex-literal = "0.3"
+paste = "1"
+pretty_assertions = "0.6"
+wat = "1"
+
+# Substrate Dependencies
 pallet-balances = { version = "3.0.0", path = "../balances" }
 pallet-timestamp = { version = "3.0.0", path = "../timestamp" }
 pallet-randomness-collective-flip = { version = "3.0.0", path = "../randomness-collective-flip" }
-paste = "1.0"
-pretty_assertions = "0.6.1"
-wat = "1.0"
 
 [features]
 default = ["std"]

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -40,7 +40,7 @@ sp-std = { version = "3.0.0", default-features = false, path = "../../primitives
 assert_matches = "1"
 hex-literal = "0.3"
 paste = "1"
-pretty_assertions = "0.6"
+pretty_assertions = "0.7"
 wat = "1"
 
 # Substrate Dependencies

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -19,15 +19,15 @@ frame-support = { version = "3.0.0", default-features = false, path = "../suppor
 frame-system = { version = "3.0.0", default-features = false, path = "../system" }
 pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "common" }
 pallet-contracts-proc-macro = { version = "3.0.0", path = "proc-macro" }
-parity-wasm = { version = "0.41.0", default-features = false }
-pwasm-utils = { version = "0.16", default-features = false }
+parity-wasm = { version = "0.42.0", default-features = false }
+pwasm-utils = { version = "0.17", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-core = { version = "3.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "3.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-io = { version = "3.0.0", default-features = false, path = "../../primitives/io" }
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
 sp-sandbox = { version = "0.9.0", default-features = false, path = "../../primitives/sandbox" }
-wasmi-validation = { version = "0.3.0", default-features = false }
+wasmi-validation = { version = "0.4.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 
 # Only used in benchmarking to generate random contract code

--- a/frame/contracts/common/Cargo.toml
+++ b/frame/contracts/common/Cargo.toml
@@ -13,13 +13,14 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-# This crate should not rely on any of the frame primitives.
 bitflags = "1.0"
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+serde = { version = "1", features = ["derive"], optional = true }
+
+# Substrate Dependencies (This crate should not rely on frame)
 sp-core = { version = "3.0.0", path = "../../../primitives/core", default-features = false }
 sp-std = { version = "3.0.0", default-features = false, path = "../../../primitives/std" }
 sp-runtime = { version = "3.0.0", default-features = false, path = "../../../primitives/runtime" }
-serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/frame/contracts/rpc/Cargo.toml
+++ b/frame/contracts/rpc/Cargo.toml
@@ -13,18 +13,20 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.0.0" }
-jsonrpc-core = "15.1.0"
-jsonrpc-core-client = "15.1.0"
-jsonrpc-derive = "15.1.0"
+codec = { package = "parity-scale-codec", version = "2" }
+jsonrpc-core = "15"
+jsonrpc-core-client = "15"
+jsonrpc-derive = "15"
+serde = { version = "1", features = ["derive"] }
+
+# Substrate Dependencies
+pallet-contracts-primitives = { version = "3.0.0", path = "../common" }
+pallet-contracts-rpc-runtime-api = { version = "3.0.0", path = "./runtime-api" }
+sp-api = { version = "3.0.0", path = "../../../primitives/api" }
 sp-blockchain = { version = "3.0.0", path = "../../../primitives/blockchain" }
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-rpc = { version = "3.0.0", path = "../../../primitives/rpc" }
-serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }
-sp-api = { version = "3.0.0", path = "../../../primitives/api" }
-pallet-contracts-primitives = { version = "3.0.0", path = "../common" }
-pallet-contracts-rpc-runtime-api = { version = "3.0.0", path = "./runtime-api" }
 
 [dev-dependencies]
-serde_json = "1.0.41"
+serde_json = "1"

--- a/frame/contracts/rpc/runtime-api/Cargo.toml
+++ b/frame/contracts/rpc/runtime-api/Cargo.toml
@@ -13,11 +13,13 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sp-api = { version = "3.0.0", default-features = false, path = "../../../../primitives/api" }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-sp-std = { version = "3.0.0", default-features = false, path = "../../../../primitives/std" }
-sp-runtime = { version = "3.0.0", default-features = false, path = "../../../../primitives/runtime" }
+codec = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+
+# Substrate Dependencies
 pallet-contracts-primitives = { version = "3.0.0", default-features = false, path = "../../common" }
+sp-api = { version = "3.0.0", default-features = false, path = "../../../../primitives/api" }
+sp-runtime = { version = "3.0.0", default-features = false, path = "../../../../primitives/runtime" }
+sp-std = { version = "3.0.0", default-features = false, path = "../../../../primitives/std" }
 
 [features]
 default = ["std"]

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -128,14 +128,14 @@ where
 		let mut contract = parity_wasm::builder::module()
 			// deploy function (first internal function)
 			.function()
-				.signature().with_return_type(None).build()
+				.signature().build()
 				.with_body(def.deploy_body.unwrap_or_else(||
 					FuncBody::new(Vec::new(), Instructions::empty())
 				))
 				.build()
 			// call function (second internal function)
 			.function()
-				.signature().with_return_type(None).build()
+				.signature().build()
 				.with_body(def.call_body.unwrap_or_else(||
 					FuncBody::new(Vec::new(), Instructions::empty())
 				))
@@ -147,7 +147,7 @@ where
 		if let Some(body) = def.aux_body {
 			let mut signature = contract
 				.function()
-				.signature().with_return_type(None);
+				.signature();
 			for _ in 0 .. def.aux_arg_num {
 				signature = signature.with_param(ValueType::I64);
 			}
@@ -166,7 +166,7 @@ where
 		for func in def.imported_functions {
 			let sig = parity_wasm::builder::signature()
 				.with_params(func.params)
-				.with_return_type(func.return_type)
+				.with_results(func.return_type.into_iter().collect())
 				.build_sig();
 			let sig = contract.push_signature(sig);
 			contract = contract.import()

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -450,11 +450,11 @@ pub mod body {
 						vec![Instruction::I32Const(current as i32)]
 					},
 					DynInstr::RandomUnaligned(low, high) => {
-						let unaligned = rng.gen_range(*low, *high) | 1;
+						let unaligned = rng.gen_range(*low..*high) | 1;
 						vec![Instruction::I32Const(unaligned as i32)]
 					},
 					DynInstr::RandomI32(low, high) => {
-						vec![Instruction::I32Const(rng.gen_range(*low, *high))]
+						vec![Instruction::I32Const(rng.gen_range(*low..*high))]
 					},
 					DynInstr::RandomI32Repeated(num) => {
 						(&mut rng).sample_iter(Standard).take(*num).map(|val|
@@ -469,19 +469,19 @@ pub mod body {
 						.collect()
 					},
 					DynInstr::RandomGetLocal(low, high) => {
-						vec![Instruction::GetLocal(rng.gen_range(*low, *high))]
+						vec![Instruction::GetLocal(rng.gen_range(*low..*high))]
 					},
 					DynInstr::RandomSetLocal(low, high) => {
-						vec![Instruction::SetLocal(rng.gen_range(*low, *high))]
+						vec![Instruction::SetLocal(rng.gen_range(*low..*high))]
 					},
 					DynInstr::RandomTeeLocal(low, high) => {
-						vec![Instruction::TeeLocal(rng.gen_range(*low, *high))]
+						vec![Instruction::TeeLocal(rng.gen_range(*low..*high))]
 					},
 					DynInstr::RandomGetGlobal(low, high) => {
-						vec![Instruction::GetGlobal(rng.gen_range(*low, *high))]
+						vec![Instruction::GetGlobal(rng.gen_range(*low..*high))]
 					},
 					DynInstr::RandomSetGlobal(low, high) => {
-						vec![Instruction::SetGlobal(rng.gen_range(*low, *high))]
+						vec![Instruction::SetGlobal(rng.gen_range(*low..*high))]
 					},
 				}
 			)

--- a/frame/contracts/src/tests.rs
+++ b/frame/contracts/src/tests.rs
@@ -836,16 +836,16 @@ fn signed_claim_surcharge_contract_removals() {
 #[test]
 fn claim_surcharge_malus() {
 	// Test surcharge malus for inherent
-	claim_surcharge(9, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), true);
 	claim_surcharge(8, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), true);
 	claim_surcharge(7, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), true);
-	claim_surcharge(6, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), false);
+	claim_surcharge(6, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), true);
+	claim_surcharge(5, |addr| Contracts::claim_surcharge(Origin::none(), addr, Some(ALICE)).is_ok(), false);
 
 	// Test surcharge malus for signed
-	claim_surcharge(9, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), true);
-	claim_surcharge(8, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), false);
+	claim_surcharge(8, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), true);
 	claim_surcharge(7, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), false);
 	claim_surcharge(6, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), false);
+	claim_surcharge(5, |addr| Contracts::claim_surcharge(Origin::signed(ALICE), addr, None).is_ok(), false);
 }
 
 /// Claim surcharge with the given trigger_call at the given blocks.
@@ -1732,7 +1732,7 @@ fn self_destruct_works() {
 				EventRecord {
 					phase: Phase::Initialization,
 					event: Event::pallet_balances(
-						pallet_balances::Event::Transfer(addr.clone(), DJANGO, 93_654)
+						pallet_balances::Event::Transfer(addr.clone(), DJANGO, 93_086)
 					),
 					topics: vec![],
 				},
@@ -1755,7 +1755,7 @@ fn self_destruct_works() {
 
 			// check that the beneficiary (django) got remaining balance
 			// some rent was deducted before termination
-			assert_eq!(Balances::free_balance(DJANGO), 1_093_654);
+			assert_eq!(Balances::free_balance(DJANGO), 1_093_086);
 		});
 }
 

--- a/frame/contracts/src/wasm/env_def/macros.rs
+++ b/frame/contracts/src/wasm/env_def/macros.rs
@@ -28,15 +28,15 @@ macro_rules! convert_args {
 macro_rules! gen_signature {
 	( ( $( $params: ty ),* ) ) => (
 		{
-			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), None)
+			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), vec![])
 		}
 	);
 
 	( ( $( $params: ty ),* ) -> $returns: ty ) => (
 		{
-			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), Some({
+			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), vec![{
 				use $crate::wasm::env_def::ConvertibleToWasm; <$returns>::VALUE_TYPE
-			}))
+			}])
 		}
 	);
 }
@@ -301,12 +301,12 @@ mod tests {
 	fn macro_gen_signature() {
 		assert_eq!(
 			gen_signature!((i32)),
-			FunctionType::new(vec![ValueType::I32], None),
+			FunctionType::new(vec![ValueType::I32], vec![]),
 		);
 
 		assert_eq!(
 			gen_signature!( (i32, u32) -> u32 ),
-			FunctionType::new(vec![ValueType::I32, ValueType::I32], Some(ValueType::I32)),
+			FunctionType::new(vec![ValueType::I32, ValueType::I32], vec![ValueType::I32]),
 		);
 	}
 
@@ -348,10 +348,10 @@ mod tests {
 		);
 
 		assert!(
-			Env::can_satisfy(b"seal0", b"seal_gas",&FunctionType::new(vec![ValueType::I32], None))
+			Env::can_satisfy(b"seal0", b"seal_gas",&FunctionType::new(vec![ValueType::I32], vec![]))
 		);
 		assert!(
-			!Env::can_satisfy(b"seal0", b"not_exists", &FunctionType::new(vec![], None))
+			!Env::can_satisfy(b"seal0", b"not_exists", &FunctionType::new(vec![], vec![]))
 		);
 	}
 }

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -152,8 +152,8 @@ impl<'a, T: Config> ContractModule<'a, T> {
 			for wasm_type in type_section.types() {
 				match wasm_type {
 					Type::Function(func_type) => {
-						let return_type = func_type.return_type();
-						for value_type in func_type.params().iter().chain(return_type.iter()) {
+						let return_type = func_type.results().get(0);
+						for value_type in func_type.params().iter().chain(return_type) {
 							match value_type {
 								ValueType::F32 | ValueType::F64 =>
 									return Err("use of floating point type in function types is forbidden"),
@@ -279,9 +279,7 @@ impl<'a, T: Config> ContractModule<'a, T> {
 			let Type::Function(ref func_ty) = types
 				.get(func_ty_idx as usize)
 				.ok_or_else(|| "function has a non-existent type")?;
-			if !func_ty.params().is_empty() ||
-				!(func_ty.return_type().is_none() ||
-					func_ty.return_type() == Some(ValueType::I32)) {
+			if !(func_ty.params().is_empty() && func_ty.results().is_empty()) {
 				return Err("entry point has wrong signature");
 			}
 		}


### PR DESCRIPTION
The contracts pallet depended on rather old versions of `pwasm-utils` and `parity-wasm`. This PR updates those to the newest version. While at it the `Cargo.toml` files got a cleanup, too. Additionally, two other dependencies `rand` and `pretty_assertions` are also bumped to the newest semver.