### PR TITLE
Allow disabling logging on the command line

### DIFF
--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -58,6 +58,7 @@ substrate-build-script-utils = { version = "3.0.0", path = "../../../utils/build
 
 [features]
 default = []
+disable-logging = ["node-template-runtime/disable-logging"]
 runtime-benchmarks = [
 	"node-template-runtime/runtime-benchmarks",
 ]

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -60,5 +60,4 @@ substrate-build-script-utils = { version = "3.0.0", path = "../../../utils/build
 default = []
 runtime-benchmarks = [
 	"node-template-runtime/runtime-benchmarks",
-	"sp-api/disable-logging",
 ]

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -60,4 +60,5 @@ substrate-build-script-utils = { version = "3.0.0", path = "../../../utils/build
 default = []
 runtime-benchmarks = [
 	"node-template-runtime/runtime-benchmarks",
+	"sp-api/disable-logging",
 ]

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -79,6 +79,7 @@ std = [
 	"sp-version/std",
 ]
 runtime-benchmarks = [
+	"sp-api/disable-logging",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking",

--- a/bin/node-template/runtime/Cargo.toml
+++ b/bin/node-template/runtime/Cargo.toml
@@ -51,6 +51,7 @@ substrate-wasm-builder = { version = "4.0.0", path = "../../../utils/wasm-builde
 
 [features]
 default = ["std"]
+disable-logging = ["sp-api/disable-logging"]
 std = [
 	"codec/std",
 	"frame-executive/std",
@@ -79,7 +80,6 @@ std = [
 	"sp-version/std",
 ]
 runtime-benchmarks = [
-	"sp-api/disable-logging",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking",

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -163,6 +163,7 @@ cli = [
 	"substrate-build-script-utils",
 	"try-runtime-cli",
 ]
+disable-logging = ["node-runtime/disable-logging"]
 runtime-benchmarks = [
 	"node-runtime/runtime-benchmarks",
 	"frame-benchmarking-cli",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -196,7 +196,6 @@ runtime-benchmarks = [
 	"pallet-session-benchmarking",
 	"frame-system-benchmarking",
 	"hex-literal",
-	"sp-api/disable-logging",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -196,6 +196,7 @@ runtime-benchmarks = [
 	"pallet-session-benchmarking",
 	"frame-system-benchmarking",
 	"hex-literal",
+	"sp-api/disable-logging",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -95,6 +95,7 @@ sp-io = { version = "3.0.0", path = "../../../primitives/io" }
 
 [features]
 default = ["std"]
+disable-logging = ["sp-api/disable-logging"]
 with-tracing = [ "frame-executive/with-tracing" ]
 std = [
 	"sp-authority-discovery/std",
@@ -161,7 +162,6 @@ std = [
 	"sp-npos-elections/std",
 ]
 runtime-benchmarks = [
-	"sp-api/disable-logging",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -161,6 +161,7 @@ std = [
 	"sp-npos-elections/std",
 ]
 runtime-benchmarks = [
+	"sp-api/disable-logging",
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
@@ -196,7 +197,6 @@ runtime-benchmarks = [
 	"pallet-session-benchmarking",
 	"frame-system-benchmarking",
 	"hex-literal",
-	"sp-api/disable-logging",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 linregress = { version = "0.4.0", optional = true }
 paste = "1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-sp-api = { version = "3.0.0", path = "../../primitives/api", default-features = false }
+sp-api = { version = "3.0.0", path = "../../primitives/api", default-features = false, features = ["disable-logging"] }
 sp-runtime-interface = { version = "3.0.0", path = "../../primitives/runtime-interface", default-features = false }
 sp-runtime = { version = "3.0.0", path = "../../primitives/runtime", default-features = false }
 sp-std = { version = "3.0.0", path = "../../primitives/std", default-features = false }

--- a/frame/benchmarking/Cargo.toml
+++ b/frame/benchmarking/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 linregress = { version = "0.4.0", optional = true }
 paste = "1.0"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-sp-api = { version = "3.0.0", path = "../../primitives/api", default-features = false, features = ["disable-logging"] }
+sp-api = { version = "3.0.0", path = "../../primitives/api", default-features = false }
 sp-runtime-interface = { version = "3.0.0", path = "../../primitives/runtime-interface", default-features = false }
 sp-runtime = { version = "3.0.0", path = "../../primitives/runtime", default-features = false }
 sp-std = { version = "3.0.0", path = "../../primitives/std", default-features = false }


### PR DESCRIPTION
Fixes #8611
Same for Polkadot: https://github.com/paritytech/polkadot/pull/2901
bench-bot: https://github.com/paritytech/bench-bot/pull/14

Currently, there is no way to compile out logging instructions from the runtime without modifying `Cargo.toml` files. This caused the situation in the linked issue.

In order to prevent such problems in the future we allow disabling logging on the command line by forwarding the feature from the `node-cli` to the runtime.

This means in order to run benchmarks properly the following command line needs to be supplied:
```
cargo run --release --features runtime-benchmarks,disable-logging -- benchmark
```

Please note that we cannot disable logging it automatically when benchmarking because our CI test supplies the `runtime-benchmark` feature in order to test the benchmarking code while at the same time relying on logging output.