### PR TITLE
client: remove time unit from block time loaded message

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -584,7 +584,7 @@ impl<T: Clone + Send + Sync + 'static> SlotDuration<T> {
 					cb(client.runtime_api(), &BlockId::number(Zero::zero()))?;
 
 				info!(
-					"⏱  Loaded block-time = {:?} milliseconds from genesis on first-launch",
+					"⏱  Loaded block-time = {:?} from genesis on first-launch",
 					genesis_slot_duration.slot_duration()
 				);
 


### PR DESCRIPTION
Was showing up like this:

```
2021-04-19 20:49:42  ⏱  Loaded block-time = 6s milliseconds from genesis on first-launch
```