### PR TITLE
Authority-discovery no longer publishes non-global IP addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,6 +6857,7 @@ dependencies = [
  "either",
  "futures 0.3.13",
  "futures-timer 3.0.2",
+ "ip_network",
  "libp2p",
  "log",
  "parity-scale-codec",

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -218,6 +218,7 @@ pub fn new_full_base(
 	} = new_partial(&config)?;
 
 	let shared_voter_state = rpc_setup;
+	let auth_disc_publish_non_global_ips = config.network.allow_non_globals_in_dht;
 
 	config.network.extra_sets.push(grandpa::grandpa_peers_set_config());
 
@@ -320,7 +321,11 @@ pub fn new_full_base(
 				Event::Dht(e) => Some(e),
 				_ => None,
 			}});
-		let (authority_discovery_worker, _service) = sc_authority_discovery::new_worker_and_service(
+		let (authority_discovery_worker, _service) = sc_authority_discovery::new_worker_and_service_with_config(
+			sc_authority_discovery::WorkerConfig {
+				publish_non_global_ips: auth_disc_publish_non_global_ips,
+				..Default::default()
+			},
 			client.clone(),
 			network.clone(),
 			Box::pin(dht_event_stream),

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -23,6 +23,7 @@ derive_more = "0.99.2"
 either = "1.5.3"
 futures = "0.3.9"
 futures-timer = "3.0.1"
+ip_network = "0.3.4"
 libp2p = { version = "0.37.1", default-features = false, features = ["kad"] }
 log = "0.4.8"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.9.0"}

--- a/client/authority-discovery/src/lib.rs
+++ b/client/authority-discovery/src/lib.rs
@@ -62,6 +62,14 @@ pub struct WorkerConfig {
 	///
 	/// By default this is set to 10 minutes.
 	pub max_query_interval: Duration,
+
+	/// If `false`, the local not won't publish on the DHT multiaddresses that contain non-global
+	/// IP addresses (such as 10.0.0.1).
+	///
+	/// Recommended: `false` for live chains, and `true` for local chains or for testing.
+	///
+	/// Defaults to `true` to avoid the surprise factor.
+	pub publish_non_global_ips: bool,
 }
 
 impl Default for WorkerConfig {
@@ -81,6 +89,7 @@ impl Default for WorkerConfig {
 			// comparing `authority_discovery_authority_addresses_requested_total` and
 			// `authority_discovery_dht_event_received`.
 			max_query_interval: Duration::from_secs(10 * 60),
+			publish_non_global_ips: true,
 		}
 	}
 }

--- a/client/authority-discovery/src/lib.rs
+++ b/client/authority-discovery/src/lib.rs
@@ -63,7 +63,7 @@ pub struct WorkerConfig {
 	/// By default this is set to 10 minutes.
 	pub max_query_interval: Duration,
 
-	/// If `false`, the local not won't publish on the DHT multiaddresses that contain non-global
+	/// If `false`, the node won't publish on the DHT multiaddresses that contain non-global
 	/// IP addresses (such as 10.0.0.1).
 	///
 	/// Recommended: `false` for live chains, and `true` for local chains or for testing.


### PR DESCRIPTION
The authority discover no longer publishes non-global IP addresses on the DHT, unless the user is running a local/dev chain or if `--discover-local` is passed.

polkadot companion: https://github.com/paritytech/polkadot/pull/2908