### PR TITLE
Properly handle poll_process with BothSidesClosed

### DIFF
--- a/client/network/src/protocol/notifications/handler.rs
+++ b/client/network/src/protocol/notifications/handler.rs
@@ -980,7 +980,7 @@ impl ProtocolsHandler for NotifsHandler {
 				State::OpenDesiredByRemote { in_substream, pending_opening, out_substream_closing } => {
 					match NotificationsInSubstream::poll_process(Pin::new(in_substream), cx) {
 						Poll::Pending => {},
-						Poll::Ready(Ok(void)) => match void {},
+						Poll::Ready(Ok(())) |
 						Poll::Ready(Err(_)) => {
 							self.protocols[protocol_index].state = State::Closed {
 								pending_opening: *pending_opening,
@@ -1020,8 +1020,7 @@ impl ProtocolsHandler for NotifsHandler {
 				} => {
 					match NotificationsInSubstream::poll_process(Pin::new(in_substream.as_mut().unwrap()), cx) {
 						Poll::Pending => {},
-						Poll::Ready(Ok(void)) => match void {},
-						Poll::Ready(Err(_)) => *in_substream = None,
+						Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => *in_substream = None,
 					}
 				}
 

--- a/client/network/src/protocol/notifications/upgrade/notifications.rs
+++ b/client/network/src/protocol/notifications/upgrade/notifications.rs
@@ -205,7 +205,8 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin,
 	/// Equivalent to `Stream::poll_next`, except that it only drives the handshake and is
 	/// guaranteed to not generate any notification.
 	///
-	/// Returns `Ready(Ok(()))` if the substream has been closed by the remote.
+	/// Returns `Ready(Ok(()))` if the substream has been completely closed, equivalent to when
+	/// `poll` returns `Poll::Ready(Ok(None))`.
 	pub fn poll_process(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), io::Error>> {
 		let mut this = self.project();
 

--- a/client/network/src/protocol/notifications/upgrade/notifications.rs
+++ b/client/network/src/protocol/notifications/upgrade/notifications.rs
@@ -41,7 +41,7 @@ use futures::prelude::*;
 use asynchronous_codec::Framed;
 use libp2p::core::{UpgradeInfo, InboundUpgrade, OutboundUpgrade, upgrade};
 use log::error;
-use std::{borrow::Cow, convert::{Infallible, TryFrom as _}, io, iter, mem, pin::Pin, task::{Context, Poll}};
+use std::{borrow::Cow, convert::TryFrom as _, io, iter, mem, pin::Pin, task::{Context, Poll}};
 use unsigned_varint::codec::UviBytes;
 
 /// Maximum allowed size of the two handshake messages, in bytes.


### PR DESCRIPTION
When `poll_process` detects `BothSidesClosed`, it returns `Poll::Pending`, meaning that the handler doesn't actually detect when the substream has been closed.

This fixes it.