### PR TITLE
move session handler traits to frame-support

### DIFF
--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -53,7 +53,7 @@ pub mod pallet {
 		Vec<AuthorityId>,
 		ValueQuery,
 	>;
-	
+
 	#[pallet::storage]
 	#[pallet::getter(fn next_keys)]
 	/// Keys of the next authority set.

--- a/frame/authority-discovery/src/lib.rs
+++ b/frame/authority-discovery/src/lib.rs
@@ -172,11 +172,11 @@ mod tests {
 	use super::*;
 	use sp_authority_discovery::AuthorityPair;
 	use sp_application_crypto::Pair;
-	use sp_core::{crypto::key_types, H256};
+	use sp_core::H256;
 	use sp_io::TestExternalities;
 	use sp_runtime::{
-		testing::{Header, UintAuthorityId}, traits::{ConvertInto, IdentityLookup, OpaqueKeys},
-		Perbill, KeyTypeId,
+		testing::{Header, UintAuthorityId}, traits::{ConvertInto, IdentityLookup},
+		Perbill,
 	};
 	use frame_support::parameter_types;
 
@@ -205,7 +205,7 @@ mod tests {
 		type SessionManager = ();
 		type Keys = UintAuthorityId;
 		type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-		type SessionHandler = TestSessionHandler;
+		type SessionHandler = frame_support::traits::TestSessionHandler;
 		type Event = Event;
 		type ValidatorId = AuthorityId;
 		type ValidatorIdOf = ConvertInto;
@@ -254,22 +254,6 @@ mod tests {
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 		type OnSetCode = ();
-	}
-
-	pub struct TestSessionHandler;
-	impl pallet_session::SessionHandler<AuthorityId> for TestSessionHandler {
-		const KEY_TYPE_IDS: &'static [KeyTypeId] = &[key_types::DUMMY];
-
-		fn on_new_session<Ks: OpaqueKeys>(
-			_changed: bool,
-			_validators: &[(AuthorityId, Ks)],
-			_queued_validators: &[(AuthorityId, Ks)],
-		) {
-		}
-
-		fn on_disabled(_validator_index: usize) {}
-
-		fn on_genesis_session<Ks: OpaqueKeys>(_validators: &[(AuthorityId, Ks)]) {}
 	}
 
 	#[test]

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -100,21 +100,6 @@ sp_runtime::impl_opaque_keys! {
 	}
 }
 
-pub struct TestSessionHandler;
-impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
-	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[];
-
-	fn on_genesis_session<Ks: sp_runtime::traits::OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
-
-	fn on_new_session<Ks: sp_runtime::traits::OpaqueKeys>(
-		_: bool,
-		_: &[(AccountId, Ks)],
-		_: &[(AccountId, Ks)],
-	) {}
-
-	fn on_disabled(_: usize) {}
-}
-
 parameter_types! {
 	pub const Period: u64 = 1;
 	pub const Offset: u64 = 0;
@@ -125,7 +110,7 @@ impl pallet_session::Config for Test {
 	type Keys = SessionKeys;
 	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
 	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
-	type SessionHandler = TestSessionHandler;
+	type SessionHandler = frame_support::traits::TestSessionHandler;
 	type Event = Event;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -102,27 +102,12 @@ sp_runtime::impl_opaque_keys! {
 	}
 }
 
-pub struct TestSessionHandler;
-impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
-	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[];
-
-	fn on_genesis_session<Ks: sp_runtime::traits::OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
-
-	fn on_new_session<Ks: sp_runtime::traits::OpaqueKeys>(
-		_: bool,
-		_: &[(AccountId, Ks)],
-		_: &[(AccountId, Ks)],
-	) {}
-
-	fn on_disabled(_: usize) {}
-}
-
 impl pallet_session::Config for Test {
 	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Test, Staking>;
 	type Keys = SessionKeys;
 	type ShouldEndSession = pallet_session::PeriodicSessions<(), ()>;
 	type NextSessionRotation = pallet_session::PeriodicSessions<(), ()>;
-	type SessionHandler = TestSessionHandler;
+	type SessionHandler = frame_support::traits::TestSessionHandler;
 	type Event = Event;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -22,7 +22,7 @@ use std::cell::RefCell;
 use frame_support::{parameter_types, BasicExternalities};
 use sp_core::{crypto::key_types::DUMMY, H256};
 use sp_runtime::{
-	Perbill, impl_opaque_keys,
+	Perbill, impl_opaque_keys, RuntimeAppPublic,
 	traits::{BlakeTwo256, IdentityLookup, ConvertInto},
 	testing::{Header, UintAuthorityId},
 };

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -119,7 +119,7 @@ impl ShouldEndSession<u64> for TestShouldEndSession {
 }
 
 pub struct TestSessionHandler;
-impl SessionHandler<u64> for TestSessionHandler {
+impl frame_support::traits::SessionHandler<u64> for TestSessionHandler {
 	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[UintAuthorityId::ID];
 	fn on_genesis_session<T: OpaqueKeys>(_validators: &[(u64, T)]) {}
 	fn on_new_session<T: OpaqueKeys>(

--- a/frame/staking/fuzzer/src/mock.rs
+++ b/frame/staking/fuzzer/src/mock.rs
@@ -105,27 +105,12 @@ sp_runtime::impl_opaque_keys! {
 	}
 }
 
-pub struct TestSessionHandler;
-impl pallet_session::SessionHandler<AccountId> for TestSessionHandler {
-	const KEY_TYPE_IDS: &'static [sp_runtime::KeyTypeId] = &[];
-
-	fn on_genesis_session<Ks: sp_runtime::traits::OpaqueKeys>(_validators: &[(AccountId, Ks)]) {}
-
-	fn on_new_session<Ks: sp_runtime::traits::OpaqueKeys>(
-		_: bool,
-		_: &[(AccountId, Ks)],
-		_: &[(AccountId, Ks)],
-	) {}
-
-	fn on_disabled(_: usize) {}
-}
-
 impl pallet_session::Config for Test {
 	type SessionManager = pallet_session::historical::NoteHistoricalRoot<Test, Staking>;
 	type Keys = SessionKeys;
 	type ShouldEndSession = pallet_session::PeriodicSessions<(), ()>;
 	type NextSessionRotation = pallet_session::PeriodicSessions<(), ()>;
-	type SessionHandler = TestSessionHandler;
+	type SessionHandler = frame_support::traits::TestSessionHandler;
 	type Event = Event;
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Test>;

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -648,7 +648,7 @@ impl<T: Config> SessionInterface<<T as frame_system::Config>::AccountId> for T w
 		FullIdentification = Exposure<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
 		FullIdentificationOf = ExposureOf<T>,
 	>,
-	T::SessionHandler: pallet_session::SessionHandler<<T as frame_system::Config>::AccountId>,
+	T::SessionHandler: frame_support::traits::SessionHandler<<T as frame_system::Config>::AccountId>,
 	T::SessionManager: pallet_session::SessionManager<<T as frame_system::Config>::AccountId>,
 	T::ValidatorIdOf:
 		Convert<<T as frame_system::Config>::AccountId, Option<<T as frame_system::Config>::AccountId>>,
@@ -2754,7 +2754,7 @@ where
 		FullIdentification = Exposure<<T as frame_system::Config>::AccountId, BalanceOf<T>>,
 		FullIdentificationOf = ExposureOf<T>,
 	>,
-	T::SessionHandler: pallet_session::SessionHandler<<T as frame_system::Config>::AccountId>,
+	T::SessionHandler: frame_support::traits::SessionHandler<<T as frame_system::Config>::AccountId>,
 	T::SessionManager: pallet_session::SessionManager<<T as frame_system::Config>::AccountId>,
 	T::ValidatorIdOf: Convert<
 		<T as frame_system::Config>::AccountId,

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -38,7 +38,7 @@ mod validation;
 pub use validation::{
 	ValidatorSet, ValidatorSetWithIdentification, OneSessionHandler, FindAuthor, VerifySeal,
 	EstimateNextNewSession, EstimateNextSessionRotation, KeyOwnerProofSystem, ValidatorRegistration,
-	Lateness, SessionHandler,
+	Lateness, SessionHandler, TestSessionHandler
 };
 
 mod filter;

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -38,7 +38,7 @@ mod validation;
 pub use validation::{
 	ValidatorSet, ValidatorSetWithIdentification, OneSessionHandler, FindAuthor, VerifySeal,
 	EstimateNextNewSession, EstimateNextSessionRotation, KeyOwnerProofSystem, ValidatorRegistration,
-	Lateness,
+	Lateness, SessionHandler,
 };
 
 mod filter;


### PR DESCRIPTION
Will help with https://github.com/paritytech/statemint/pull/43.

### Context

For a simple parachain like statemint, we are not going to use staking or session, as they are too complicated. But we still need to use `pallet-aura`. The only *easy* and _sensible_ way to communicate with `pallet-aura` is to register it in the list of `SessionHandler` somewhere. This is exactly how relay chains work. 

Now, I want a new pallet like `parachain-selection` to act like the combination of staking and session for a parachain, and select some collators in some simple way every `N` block and report them to `pallet-aura`. 

All of this works, but it has two flaws: 

1. `SessionHandler` trait was defined in `pallet-session` and in order to reuse it I had to import it, which was not good. 
2. I can imagine why `SessionHandler` was defined in `pallet-session`: its API is exposing `queued_validators` which is specific to `pallet-session`. And what I have done now is breaking this. I am not happy with this but in short term I think it is okay and I will make a follow up issue with further details. Essentially, we need to convert `SessionHandler` trait to something more generic, so that other chains can write their own custom `pallet-session`, but still be able to use our `aura` (and `grandpa`, `babe`, `authority-discovery` pallets). This will need to also change the `OneSessionHandler`. 

If it makes anyone happier, I can think of something like this, we could make the `queued_validator` an `Option` and that's already a good step, but tbh I felt like it doesn't make a big difference at this point and a big revamp is needed. 


--- 

I also removed a bunch of useless `TestSessionHandler`s here and there. 