### PR TITLE
WIP: Need to avoid first delay.

### DIFF
--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -31,7 +31,7 @@ use sp_inherents::InherentDataProviders;
 use sc_network::{Event, NetworkService};
 use sp_runtime::traits::Block as BlockT;
 use futures::prelude::*;
-use sc_client_api::{ExecutorProvider, RemoteBackend};
+use sc_client_api::{ExecutorProvider, RemoteBackend, BlockchainEvents};
 use node_executor::Executor;
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_consensus_babe::SlotProportion;
@@ -141,6 +141,9 @@ pub fn new_partial(
 
 		let babe_config = babe_link.config().clone();
 		let shared_epoch_changes = babe_link.epoch_changes().clone();
+
+		// @todo  we can create one here
+		//let import_notification_stream = client.import_notification_stream().fuse();
 
 		let client = client.clone();
 		let pool = transaction_pool.clone();

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -640,6 +640,7 @@ pub fn spawn_tasks<TBl, TBackend, TExPool, TRpc, TCl>(
 			client.clone(),
 			transaction_pool.clone(),
 			network_status_sinks.clone()
+			// @todo A2 spawning telemetry blocking thread
 		)
 	);
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -243,6 +243,8 @@ async fn build_network_future<
 						notification.header.number().clone(),
 					);
 				}
+
+				//TODO: trigger metrics update.
 			}
 
 			// List of blocks that the client has finalized.


### PR DESCRIPTION
Fixes #6902 . Will discuss with Ben and then clean up once approach agreed. 

Rather than clone Delay's waker and use that to trigger it (which does work), it seems nicer to select on the first future to return but as they're fused for select you can't update the delay so will have to muse on that. At the moment it would wait 5 seconds (or first block notification) before it triggers the metrics. Maybe that's acceptable?

( https://users.rust-lang.org/t/reset-inner-futures-timer-delay-inside-futures-fuse/33319/3 )