### PR TITLE
Upgrade `cargo_metadata` to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,6 +701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,10 +720,11 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
 dependencies = [
+ "camino",
  "cargo-platform",
  "semver 0.11.0",
  "semver-parser 0.10.2",

--- a/utils/wasm-builder/Cargo.toml
+++ b/utils/wasm-builder/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 build-helper = "0.1.1"
-cargo_metadata = "0.12.0"
+cargo_metadata = "0.13.1"
 tempfile = "3.1.0"
 toml = "0.5.4"
 walkdir = "2.3.1"

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -109,7 +109,7 @@ pub(crate) fn create_and_compile(
 		project_cargo_toml,
 		&wasm_workspace,
 		&crate_metadata,
-		&crate_metadata.workspace_root.canonicalize().expect("workspace root must exist"),
+		crate_metadata.workspace_root.as_ref(),
 		features_to_enable,
 	);
 

--- a/utils/wasm-builder/src/wasm_project.rs
+++ b/utils/wasm-builder/src/wasm_project.rs
@@ -109,7 +109,7 @@ pub(crate) fn create_and_compile(
 		project_cargo_toml,
 		&wasm_workspace,
 		&crate_metadata,
-		&crate_metadata.workspace_root,
+		&crate_metadata.workspace_root.canonicalize().expect("workspace root must exist"),
 		features_to_enable,
 	);
 


### PR DESCRIPTION
I ran into a strange panic in this crate when syncing `canvas-node` to Substrate. Upgrading this dependency seems to fix it.

The notable thing is that `crate_metadata.workspace_root` is a `Utf8PathBuf` now.