### PR TITLE
Add future transactions accessor to `ValidatedPool`

### DIFF
--- a/client/transaction-pool/graph/src/validated_pool.rs
+++ b/client/transaction-pool/graph/src/validated_pool.rs
@@ -610,6 +610,13 @@ impl<B: ChainApi> ValidatedPool<B> {
 		self.pool.read().ready()
 	}
 
+	/// Returns a Vec of hashes and extrinsics in the future pool.
+	pub fn futures(&self) -> Vec<(ExtrinsicHash<B>, ExtrinsicFor<B>)> {
+		self.pool.read().futures()
+			.map(|tx| (tx.hash.clone(), tx.data.clone()))
+			.collect()
+	}
+
 	/// Returns pool status.
 	pub fn status(&self) -> PoolStatus {
 		self.pool.read().status()


### PR DESCRIPTION
Currently we can read the `ready` queue and the `status` from the validated pool, but there is no way of reading future transactions.

This PR proposes allowing to do so by adding a public method that reads the pool and collects a vector of transaction hashes and extrinsic data.

The motivation for this is to be able to:

- Enable testing of future transactions in Frontier, so we can verify that this is correctly handled in the case of `pallet-ethereum`'s unchecked extrinsics.
- Implement commonly used ethereum RPC extensions like [geth's txpool](https://geth.ethereum.org/docs/rpc/ns-txpool).