### PR TITLE
subkey: display SS58 encoding of public key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9364,7 +9364,7 @@ dependencies = [
 
 [[package]]
 name = "subkey"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "sc-cli",
  "structopt",

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subkey"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/bin/utils/subkey/README.adoc
+++ b/bin/utils/subkey/README.adoc
@@ -20,10 +20,15 @@ You can inspect a given URI (mnemonic, seed, public key, or address) and recover
 
 ```bash
 subkey inspect <mnemonic,seed,pubkey,address>
-
-OUTPUT:
-  Public key (hex): 0x461edcf1ba99e43f50dec4bdeb3d1a2cf521ad7c3cd0eeee5cd3314e50fd424c
-  Address (SS58): 5DeeNqcAcaHDSed2HYnqMDK7JHcvxZ5QUE9EKmjc5snvU6wF
+```
+_Example Output_:
+```
+Secret Key URI `` is account:
+  Secret seed:       0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e
+  Public key (hex):  0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  Public key (SS58): 5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV
+  Account ID:        0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  SS58 Address:      5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV
 ```
 
 === Signing
@@ -32,8 +37,9 @@ OUTPUT:
 
 ```bash
 echo -n <msg> | subkey sign --suri <seed,mnemonic>
-
-OUTPUT:
+```
+_Example Output_:
+```
 a69da4a6ccbf81dbbbfad235fa12cf8528c18012b991ae89214de8d20d29c1280576ced6eb38b7406d1b7e03231df6dd4a5257546ddad13259356e1c3adfb509
 ```
 
@@ -73,11 +79,13 @@ Will output a signed and encoded `UncheckedMortalCompactExtrinsic` as hex.
 
 ```bash
 subkey module-id "py/trsry" --network kusama
-
-OUTPUT:
+```
+_Example Output_:
+```
 Public Key URI `F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29` is account:
   Network ID/version: kusama
   Public key (hex):   0x6d6f646c70792f74727372790000000000000000000000000000000000000000
+  Public key (SS58):  F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29
   Account ID:         0x6d6f646c70792f74727372790000000000000000000000000000000000000000
   SS58 Address:       F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29
 ```

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Subkey {
 	Verify(VerifyCmd),
 }
 
-/// Run the subkey command, given the apropriate runtime.
+/// Run the subkey command, given the appropriate runtime.
 pub fn run() -> Result<(), Error> {
 	match Subkey::from_args() {
 		Subkey::GenerateNodeKey(cmd) => cmd.run(),

--- a/client/cli/src/commands/utils.rs
+++ b/client/cli/src/commands/utils.rs
@@ -5,7 +5,7 @@
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or 
+// the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
@@ -17,15 +17,19 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! subcommand utilities
-use std::{io::Read, path::PathBuf, convert::TryFrom};
-use sp_core::{
-	Pair, hexdisplay::HexDisplay,
-	crypto::{Ss58Codec, Ss58AddressFormat},
+use crate::{
+	error::{self, Error},
+	OutputType,
 };
-use sp_runtime::{MultiSigner, traits::IdentifyAccount};
-use crate::{OutputType, error::{self, Error}};
 use serde_json::json;
-use sp_core::crypto::{SecretString, Zeroize, ExposeSecret};
+use sp_core::crypto::{ExposeSecret, SecretString, Zeroize};
+use sp_core::{
+	crypto::{Ss58AddressFormat, Ss58Codec},
+	hexdisplay::HexDisplay,
+	Pair,
+};
+use sp_runtime::{traits::IdentifyAccount, MultiSigner};
+use std::{convert::TryFrom, io::Read, path::PathBuf};
 
 /// Public key type for Runtime
 pub type PublicFor<P> = <P as sp_core::Pair>::Public;
@@ -37,9 +41,7 @@ pub fn read_uri(uri: Option<&String>) -> error::Result<String> {
 	let uri = if let Some(uri) = uri {
 		let file = PathBuf::from(&uri);
 		if file.is_file() {
-			std::fs::read_to_string(uri)?
-				.trim_end()
-				.to_owned()
+			std::fs::read_to_string(uri)?.trim_end().to_owned()
 		} else {
 			uri.into()
 		}
@@ -78,25 +80,34 @@ pub fn print_from_uri<Pair>(
 					"secretPhrase": uri,
 					"secretSeed": format_seed::<Pair>(seed),
 					"publicKey": format_public_key::<Pair>(public_key.clone()),
+					"ss58PublicKey": public_key.to_ss58check_with_version(network_override),
 					"accountId": format_account_id::<Pair>(public_key),
 					"ss58Address": pair.public().into().into_account().to_ss58check_with_version(network_override),
 				});
-				println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
-			},
+				println!(
+					"{}",
+					serde_json::to_string_pretty(&json).expect("Json pretty print failed")
+				);
+			}
 			OutputType::Text => {
 				println!(
 					"Secret phrase `{}` is account:\n  \
-					Secret seed:      {}\n  \
-					Public key (hex): {}\n  \
-					Account ID:       {}\n  \
-					SS58 Address:     {}",
+					Secret seed:       {}\n  \
+					Public key (hex):  {}\n  \
+					Public key (SS58): {}\n  \
+					Account ID:        {}\n  \
+					SS58 Address:      {}",
 					uri,
 					format_seed::<Pair>(seed),
 					format_public_key::<Pair>(public_key.clone()),
+					public_key.to_ss58check_with_version(network_override),
 					format_account_id::<Pair>(public_key),
-					pair.public().into().into_account().to_ss58check_with_version(network_override),
+					pair.public()
+						.into()
+						.into_account()
+						.to_ss58check_with_version(network_override),
 				);
-			},
+			}
 		}
 	} else if let Ok((pair, seed)) = Pair::from_string_with_seed(uri, password.clone()) {
 		let public_key = pair.public();
@@ -108,25 +119,38 @@ pub fn print_from_uri<Pair>(
 					"secretKeyUri": uri,
 					"secretSeed": if let Some(seed) = seed { format_seed::<Pair>(seed) } else { "n/a".into() },
 					"publicKey": format_public_key::<Pair>(public_key.clone()),
+					"ss58PublicKey": public_key.to_ss58check_with_version(network_override),
 					"accountId": format_account_id::<Pair>(public_key),
 					"ss58Address": pair.public().into().into_account().to_ss58check_with_version(network_override),
 				});
-				println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
-			},
+				println!(
+					"{}",
+					serde_json::to_string_pretty(&json).expect("Json pretty print failed")
+				);
+			}
 			OutputType::Text => {
 				println!(
 					"Secret Key URI `{}` is account:\n  \
-					Secret seed:      {}\n  \
-					Public key (hex): {}\n  \
-					Account ID:       {}\n  \
-					SS58 Address:     {}",
+					Secret seed:       {}\n  \
+					Public key (hex):  {}\n  \
+					Public key (SS58): {}\n  \
+					Account ID:        {}\n  \
+					SS58 Address:      {}",
 					uri,
-					if let Some(seed) = seed { format_seed::<Pair>(seed) } else { "n/a".into() },
+					if let Some(seed) = seed {
+						format_seed::<Pair>(seed)
+					} else {
+						"n/a".into()
+					},
 					format_public_key::<Pair>(public_key.clone()),
+					public_key.to_ss58check_with_version(network_override),
 					format_account_id::<Pair>(public_key),
-					pair.public().into().into_account().to_ss58check_with_version(network_override),
+					pair.public()
+						.into()
+						.into_account()
+						.to_ss58check_with_version(network_override),
 				);
-			},
+			}
 		}
 	} else if let Ok((public_key, network)) = Pair::Public::from_string_with_version(uri) {
 		let network_override = network_override.unwrap_or(network);
@@ -137,22 +161,28 @@ pub fn print_from_uri<Pair>(
 					"publicKeyUri": uri,
 					"networkId": String::from(network_override),
 					"publicKey": format_public_key::<Pair>(public_key.clone()),
+					"ss58PublicKey": public_key.to_ss58check_with_version(network_override),
 					"accountId": format_account_id::<Pair>(public_key.clone()),
 					"ss58Address": public_key.to_ss58check_with_version(network_override),
 				});
 
-				println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
-			},
+				println!(
+					"{}",
+					serde_json::to_string_pretty(&json).expect("Json pretty print failed")
+				);
+			}
 			OutputType::Text => {
 				println!(
 					"Public Key URI `{}` is account:\n  \
 					 Network ID/version: {}\n  \
 					 Public key (hex):   {}\n  \
+					 Public key (SS58):  {}\n  \
 					 Account ID:         {}\n  \
 					 SS58 Address:       {}",
 					uri,
 					String::from(network_override),
 					format_public_key::<Pair>(public_key.clone()),
+					public_key.to_ss58check_with_version(network_override),
 					format_account_id::<Pair>(public_key.clone()),
 					public_key.to_ss58check_with_version(network_override),
 				);
@@ -185,20 +215,26 @@ where
 			let json = json!({
 				"networkId": String::from(network_override),
 				"publicKey": format_public_key::<Pair>(public_key.clone()),
+				"ss58PublicKey": public_key.to_ss58check_with_version(network_override),
 				"accountId": format_account_id::<Pair>(public_key.clone()),
 				"ss58Address": public_key.to_ss58check_with_version(network_override),
 			});
 
-			println!("{}", serde_json::to_string_pretty(&json).expect("Json pretty print failed"));
-		},
+			println!(
+				"{}",
+				serde_json::to_string_pretty(&json).expect("Json pretty print failed")
+			);
+		}
 		OutputType::Text => {
 			println!(
 				"Network ID/version: {}\n  \
 				 Public key (hex):   {}\n  \
+				 Public key (SS58):  {}\n  \
 				 Account ID:         {}\n  \
 				 SS58 Address:       {}",
 				String::from(network_override),
 				format_public_key::<Pair>(public_key.clone()),
+				public_key.to_ss58check_with_version(network_override),
 				format_account_id::<Pair>(public_key.clone()),
 				public_key.to_ss58check_with_version(network_override),
 			);
@@ -234,10 +270,13 @@ fn format_public_key<P: sp_core::Pair>(public_key: PublicFor<P>) -> String {
 
 /// formats public key as accountId as hex
 fn format_account_id<P: sp_core::Pair>(public_key: PublicFor<P>) -> String
-	where
-		PublicFor<P>: Into<MultiSigner>,
+where
+	PublicFor<P>: Into<MultiSigner>,
 {
-	format!("0x{}", HexDisplay::from(&public_key.into().into_account().as_ref()))
+	format!(
+		"0x{}",
+		HexDisplay::from(&public_key.into().into_account().as_ref())
+	)
 }
 
 /// helper method for decoding hex
@@ -255,7 +294,7 @@ pub fn read_message(msg: Option<&String>, should_decode: bool) -> Result<Vec<u8>
 	match msg {
 		Some(m) => {
 			message = decode_hex(m)?;
-		},
+		}
 		None => {
 			std::io::stdin().lock().read_to_end(&mut message)?;
 			if should_decode {
@@ -265,7 +304,6 @@ pub fn read_message(msg: Option<&String>, should_decode: bool) -> Result<Vec<u8>
 	}
 	Ok(message)
 }
-
 
 /// Allows for calling $method with appropriate crypto impl.
 #[macro_export]


### PR DESCRIPTION
In case of sr25519 and ed25519 crypto, the account id matches public key, hence SS58 encoded account-id address is the same as SS58 public key encoding.

In case of ECDSA, we blake2 the public key to get the address (due to size difference 33 vs 32 bytes), so the SS58 encoding was different.

Why is SS58 encoding of public key necessary at all?

Default Ser/De implementation for public keys is using SS58 encoding, hence every time we use public keys in encoded form we are going to need it's SS58 encoding. A notable case is chain spec JSON file and encoding of session keys (most importantly BEEFY).

This PR adds display of SS58 encoding of raw public key to make it easy to add BEEFY keys to chain spec json file.

CC @NukeManDan 