### PR TITLE
Change to use the same subcommand syntax as subkey

### DIFF
--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -41,7 +41,7 @@ pub enum Subcommand {
 		name = "inspect",
 		about = "Decode given block or extrinsic using current native runtime."
 	)]
-	Inspect(node_inspect::cli::InspectCmd),
+	Inspect(node_inspect::cli::InspectKeyCmd),
 
 	/// The custom benchmark subcommmand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]

--- a/bin/node/inspect/src/cli.rs
+++ b/bin/node/inspect/src/cli.rs
@@ -24,7 +24,7 @@ use structopt::StructOpt;
 
 /// The `inspect` command used to print decoded chain data.
 #[derive(Debug, StructOpt)]
-pub struct InspectCmd {
+pub struct InspectKeyCmd {
 	#[allow(missing_docs)]
 	#[structopt(flatten)]
 	pub command: InspectSubCmd,

--- a/bin/node/inspect/src/command.rs
+++ b/bin/node/inspect/src/command.rs
@@ -18,14 +18,14 @@
 
 //! Command ran by the CLI
 
-use crate::cli::{InspectCmd, InspectSubCmd};
+use crate::cli::{InspectKeyCmd, InspectSubCmd};
 use crate::Inspector;
 use sc_cli::{CliConfiguration, ImportParams, Result, SharedParams};
 use sc_service::{new_full_client, Configuration, NativeExecutionDispatch};
 use sp_runtime::traits::Block;
 use std::str::FromStr;
 
-impl InspectCmd {
+impl InspectKeyCmd {
 	/// Run the inspect command, passing the inspector.
 	pub fn run<B, RA, EX>(&self, config: Configuration) -> Result<()>
 	where
@@ -54,7 +54,7 @@ impl InspectCmd {
 	}
 }
 
-impl CliConfiguration for InspectCmd {
+impl CliConfiguration for InspectKeyCmd {
 	fn shared_params(&self) -> &SharedParams {
 		&self.shared_params
 	}

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -18,7 +18,7 @@
 
 use structopt::StructOpt;
 use sc_cli::{
-	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectCmd,
+	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectKeyCmd,
 	InspectNodeKeyCmd
 };
 
@@ -37,7 +37,7 @@ pub enum Subkey {
 	Generate(GenerateCmd),
 
 	/// Gets a public key and a SS58 address from the provided Secret URI
-	Inspect(InspectCmd),
+	Inspect(InspectKeyCmd),
 
 	/// Print the peer ID corresponding to the node key in the given file
 	InspectNodeKey(InspectNodeKeyCmd),
@@ -52,7 +52,7 @@ pub enum Subkey {
 	Verify(VerifyCmd),
 }
 
-/// Run the subkey command, given the apropriate runtime.
+/// Run the subkey command, given the appropriate runtime.
 pub fn run() -> Result<(), Error> {
 	match Subkey::from_args() {
 		Subkey::GenerateNodeKey(cmd) => cmd.run(),

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -18,7 +18,7 @@
 
 use structopt::StructOpt;
 use sc_cli::{
-	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectKeyCmd,
+	Error, VanityCmd, SignCmd, VerifyCmd, GenerateNodeKeyCmd, GenerateCmd, InspectCmd,
 	InspectNodeKeyCmd
 };
 
@@ -37,7 +37,7 @@ pub enum Subkey {
 	Generate(GenerateCmd),
 
 	/// Gets a public key and a SS58 address from the provided Secret URI
-	Inspect(InspectKeyCmd),
+	Inspect(InspectCmd),
 
 	/// Print the peer ID corresponding to the node key in the given file
 	InspectNodeKey(InspectNodeKeyCmd),

--- a/client/cli/src/commands/inspect_key.rs
+++ b/client/cli/src/commands/inspect_key.rs
@@ -28,7 +28,7 @@ use structopt::StructOpt;
 	name = "inspect-key",
 	about = "Gets a public key and a SS58 address from the provided Secret URI"
 )]
-pub struct InspectKeyCmd {
+pub struct InspectCmd {
 	/// A Key URI to be inspected. May be a secret seed, secret URI
 	/// (with derivation paths and password), SS58, public URI or a hex encoded public key.
 	///
@@ -61,7 +61,7 @@ pub struct InspectKeyCmd {
 	pub crypto_scheme: CryptoSchemeFlag,
 }
 
-impl InspectKeyCmd {
+impl InspectCmd {
 	/// Run the command
 	pub fn run(&self) -> Result<(), Error> {
 		let uri = utils::read_uri(self.uri.as_ref())?;
@@ -104,10 +104,10 @@ mod tests {
 		let seed = "0xad1fb77243b536b90cfe5f0d351ab1b1ac40e3890b41dc64f766ee56340cfca5";
 
 		let inspect =
-			InspectKeyCmd::from_iter(&["inspect-key", words, "--password", "12345"]);
+			InspectCmd::from_iter(&["inspect-key", words, "--password", "12345"]);
 		assert!(inspect.run().is_ok());
 
-		let inspect = InspectKeyCmd::from_iter(&["inspect-key", seed]);
+		let inspect = InspectCmd::from_iter(&["inspect-key", seed]);
 		assert!(inspect.run().is_ok());
 	}
 
@@ -115,7 +115,7 @@ mod tests {
 	fn inspect_public_key() {
 		let public = "0x12e76e0ae8ce41b6516cce52b3f23a08dcb4cfeed53c6ee8f5eb9f7367341069";
 
-		let inspect = InspectKeyCmd::from_iter(&["inspect-key", "--public", public]);
+		let inspect = InspectCmd::from_iter(&["inspect-key", "--public", public]);
 		assert!(inspect.run().is_ok());
 	}
 }

--- a/client/cli/src/commands/inspect_key.rs
+++ b/client/cli/src/commands/inspect_key.rs
@@ -25,7 +25,7 @@ use structopt::StructOpt;
 /// The `inspect` command
 #[derive(Debug, StructOpt)]
 #[structopt(
-	name = "inspect-key",
+	name = "inspect",
 	about = "Gets a public key and a SS58 address from the provided Secret URI"
 )]
 pub struct InspectCmd {

--- a/client/cli/src/commands/inspect_key.rs
+++ b/client/cli/src/commands/inspect_key.rs
@@ -28,7 +28,7 @@ use structopt::StructOpt;
 	name = "inspect",
 	about = "Gets a public key and a SS58 address from the provided Secret URI"
 )]
-pub struct InspectCmd {
+pub struct InspectKeyCmd {
 	/// A Key URI to be inspected. May be a secret seed, secret URI
 	/// (with derivation paths and password), SS58, public URI or a hex encoded public key.
 	///
@@ -61,7 +61,7 @@ pub struct InspectCmd {
 	pub crypto_scheme: CryptoSchemeFlag,
 }
 
-impl InspectCmd {
+impl InspectKeyCmd {
 	/// Run the command
 	pub fn run(&self) -> Result<(), Error> {
 		let uri = utils::read_uri(self.uri.as_ref())?;
@@ -104,10 +104,10 @@ mod tests {
 		let seed = "0xad1fb77243b536b90cfe5f0d351ab1b1ac40e3890b41dc64f766ee56340cfca5";
 
 		let inspect =
-			InspectCmd::from_iter(&["inspect-key", words, "--password", "12345"]);
+			InspectKeyCmd::from_iter(&["inspect-key", words, "--password", "12345"]);
 		assert!(inspect.run().is_ok());
 
-		let inspect = InspectCmd::from_iter(&["inspect-key", seed]);
+		let inspect = InspectKeyCmd::from_iter(&["inspect-key", seed]);
 		assert!(inspect.run().is_ok());
 	}
 
@@ -115,7 +115,7 @@ mod tests {
 	fn inspect_public_key() {
 		let public = "0x12e76e0ae8ce41b6516cce52b3f23a08dcb4cfeed53c6ee8f5eb9f7367341069";
 
-		let inspect = InspectCmd::from_iter(&["inspect-key", "--public", public]);
+		let inspect = InspectKeyCmd::from_iter(&["inspect-key", "--public", public]);
 		assert!(inspect.run().is_ok());
 	}
 }

--- a/client/cli/src/commands/key.rs
+++ b/client/cli/src/commands/key.rs
@@ -22,7 +22,7 @@ use structopt::StructOpt;
 
 use super::{
 	insert_key::InsertKeyCmd,
-	inspect_key::InspectKeyCmd,
+	inspect_key::InspectCmd,
 	generate::GenerateCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	generate_node_key::GenerateNodeKeyCmd,
@@ -39,7 +39,7 @@ pub enum KeySubcommand {
 	Generate(GenerateCmd),
 
 	/// Gets a public key and a SS58 address from the provided Secret URI
-	InspectKey(InspectKeyCmd),
+	Inspect(InspectCmd),
 
 	/// Print the peer ID corresponding to the node key in the given file
 	InspectNodeKey(InspectNodeKeyCmd),
@@ -54,7 +54,7 @@ impl KeySubcommand {
 		match self {
 			KeySubcommand::GenerateNodeKey(cmd) => cmd.run(),
 			KeySubcommand::Generate(cmd) => cmd.run(),
-			KeySubcommand::InspectKey(cmd) => cmd.run(),
+			KeySubcommand::Inspect(cmd) => cmd.run(),
 			KeySubcommand::Insert(cmd) => cmd.run(cli),
 			KeySubcommand::InspectNodeKey(cmd) => cmd.run(),
 		}

--- a/client/cli/src/commands/key.rs
+++ b/client/cli/src/commands/key.rs
@@ -22,7 +22,7 @@ use structopt::StructOpt;
 
 use super::{
 	insert_key::InsertKeyCmd,
-	inspect_key::InspectCmd,
+	inspect_key::InspectKeyCmd,
 	generate::GenerateCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	generate_node_key::GenerateNodeKeyCmd,
@@ -39,7 +39,7 @@ pub enum KeySubcommand {
 	Generate(GenerateCmd),
 
 	/// Gets a public key and a SS58 address from the provided Secret URI
-	Inspect(InspectCmd),
+	Inspect(InspectKeyCmd),
 
 	/// Print the peer ID corresponding to the node key in the given file
 	InspectNodeKey(InspectNodeKeyCmd),

--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
 	sign::SignCmd,
 	generate::GenerateCmd,
 	insert_key::InsertKeyCmd,
-	inspect_key::InspectCmd,
+	inspect_key::InspectKeyCmd,
 	generate_node_key::GenerateNodeKeyCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	key::KeySubcommand,

--- a/client/cli/src/commands/mod.rs
+++ b/client/cli/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use self::{
 	sign::SignCmd,
 	generate::GenerateCmd,
 	insert_key::InsertKeyCmd,
-	inspect_key::InspectKeyCmd,
+	inspect_key::InspectCmd,
 	generate_node_key::GenerateNodeKeyCmd,
 	inspect_node_key::InspectNodeKeyCmd,
 	key::KeySubcommand,


### PR DESCRIPTION
For consistency between the two tools, the subcommand for `<node bin> key inspect-key` is changed to match `subkey` syntax ( `subkey inspect`)

This _may_ need modification of downstream dependencies in Polkadot and other code bases. I do not see this is the case, bu would be good to have a double-check on that and a companion PR made if so.

Alternatively to this PR, changing the subkey `inspect` command to `inspect-key` would have the same (but more verbose) effect.

Compliments/Related to #8674 