### PR TITLE
Make custom on runtime upgrade prior to pallet ones

### DIFF
--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -206,10 +206,10 @@ where
 	/// Execute all `OnRuntimeUpgrade` of this runtime, and return the aggregate weight.
 	pub fn execute_on_runtime_upgrade() -> frame_support::weights::Weight {
 		let mut weight = 0;
+		weight = weight.saturating_add(COnRuntimeUpgrade::on_runtime_upgrade());
 		weight = weight.saturating_add(
 			<frame_system::Pallet<System> as OnRuntimeUpgrade>::on_runtime_upgrade(),
 		);
-		weight = weight.saturating_add(COnRuntimeUpgrade::on_runtime_upgrade());
 		weight = weight.saturating_add(<AllPallets as OnRuntimeUpgrade>::on_runtime_upgrade());
 
 		weight


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/8683

## Breaking change:

All pallets runtime upgrade is now executed after the custom runtime upgrade provided to `Executive`.
(instead before, frame system pallet runtime upgrade was executed first).

## Additional notes

This doesn't deprecated the runtime upgrade of pallets (though I'm also in favor of deprecating them). This can be done in another PR, easiest implementation is just to rename `on_runtime_upgrade` to `deprecated_on_runtime_upgrade` for pallet on runtime upgrade hook.