### PR TITLE
DO NOT MERGE: demo a storage-aware helper for PoV size benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4751,6 +4751,7 @@ dependencies = [
  "pallet-balances",
  "pallet-treasury",
  "parity-scale-codec",
+ "rand 0.8.3",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/frame/bounties/Cargo.toml
+++ b/frame/bounties/Cargo.toml
@@ -21,7 +21,7 @@ frame-system = { version = "3.0.0", default-features = false, path = "../system"
 pallet-treasury = { version = "3.0.0", default-features = false, path = "../treasury" }
 
 frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }
-rand = "0.8.3"
+rand = { version = "0.8.3", features = [ "small_rng" ]}
 
 [dev-dependencies]
 sp-io ={ version = "3.0.0", path = "../../primitives/io" }

--- a/frame/bounties/Cargo.toml
+++ b/frame/bounties/Cargo.toml
@@ -21,6 +21,7 @@ frame-system = { version = "3.0.0", default-features = false, path = "../system"
 pallet-treasury = { version = "3.0.0", default-features = false, path = "../treasury" }
 
 frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }
+rand = "0.8.3"
 
 [dev-dependencies]
 sp-io ={ version = "3.0.0", path = "../../primitives/io" }

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -218,6 +218,17 @@ benchmarks! {
 		ensure!(missed_any == false, "Missed some");
 		assert_last_event::<T>(RawEvent::BountyBecameActive(b - 1).into())
 	}
+
+	#[extra]
+	bench_fill_storage {
+		let s in 1..10;
+
+		use rand::{SeedableRng, rngs::SmallRng};
+
+		let mut rng = SmallRng::seed_from_u64(s.into());
+	}: {
+		fill_storage::<_, T>(&mut rng);
+	}
 }
 
 impl_benchmark_test_suite!(

--- a/frame/bounties/src/lib.rs
+++ b/frame/bounties/src/lib.rs
@@ -253,10 +253,10 @@ mod benchmark_fill {
 	macro_rules! impl_randomize_for_primitive {
 		($t:ty) => {
 			impl Randomize for $t {
-																			fn random<R: Rng>(rng: &mut R) -> Self {
-																				rng.gen()
-																			}
-																		}
+				fn random<R: Rng>(rng: &mut R) -> Self {
+					rng.gen()
+				}
+			}
 		};
 	}
 


### PR DESCRIPTION
Alternative to #8667.

This method involves inventing our own random-item trait, and implementing
it pervasively for a set of appropriate types. It's somewhat more work,
but it suits our needs much better. It gives us a `fn fill_storage`, which
can be used to initialize plausible size benchmarks.

Open questions:

- Should `fill_storage` first clear storage, so it can be rerun without
  changing the total storage size?
- Should we provide some way for users to indicate semantic dependencies
  among the storage fields? (If yes: how?)
