### PR TITLE
[Companion] Update Cargo.toml subkey version, readme to reflect new output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9364,7 +9364,7 @@ dependencies = [
 
 [[package]]
 name = "subkey"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "sc-cli",
  "structopt",

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subkey"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/bin/utils/subkey/README.adoc
+++ b/bin/utils/subkey/README.adoc
@@ -20,10 +20,15 @@ You can inspect a given URI (mnemonic, seed, public key, or address) and recover
 
 ```bash
 subkey inspect <mnemonic,seed,pubkey,address>
-
-OUTPUT:
-  Public key (hex): 0x461edcf1ba99e43f50dec4bdeb3d1a2cf521ad7c3cd0eeee5cd3314e50fd424c
-  Address (SS58): 5DeeNqcAcaHDSed2HYnqMDK7JHcvxZ5QUE9EKmjc5snvU6wF
+```
+_Example Output_:
+```
+Secret Key URI `` is account:
+  Secret seed:       0xfac7959dbfe72f052e5a0c3c8d6530f202b02fd8f9f5ca3580ec8deb7797479e
+  Public key (hex):  0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  Public key (SS58): 5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV
+  Account ID:        0x46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a
+  SS58 Address:      5DfhGyQdFobKM8NsWvEeAKk5EQQgYe9AydgJ7rMB6E1EqRzV
 ```
 
 === Signing
@@ -32,8 +37,9 @@ OUTPUT:
 
 ```bash
 echo -n <msg> | subkey sign --suri <seed,mnemonic>
-
-OUTPUT:
+```
+_Example Output_:
+```
 a69da4a6ccbf81dbbbfad235fa12cf8528c18012b991ae89214de8d20d29c1280576ced6eb38b7406d1b7e03231df6dd4a5257546ddad13259356e1c3adfb509
 ```
 
@@ -73,11 +79,13 @@ Will output a signed and encoded `UncheckedMortalCompactExtrinsic` as hex.
 
 ```bash
 subkey module-id "py/trsry" --network kusama
-
-OUTPUT:
+```
+_Example Output_:
+```
 Public Key URI `F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29` is account:
   Network ID/version: kusama
   Public key (hex):   0x6d6f646c70792f74727372790000000000000000000000000000000000000000
+  Public key (SS58):  F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29
   Account ID:         0x6d6f646c70792f74727372790000000000000000000000000000000000000000
   SS58 Address:       F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29
 ```

--- a/bin/utils/subkey/src/lib.rs
+++ b/bin/utils/subkey/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Subkey {
 	Verify(VerifyCmd),
 }
 
-/// Run the subkey command, given the apropriate runtime.
+/// Run the subkey command, given the appropriate runtime.
 pub fn run() -> Result<(), Error> {
 	match Subkey::from_args() {
 		Subkey::GenerateNodeKey(cmd) => cmd.run(),


### PR DESCRIPTION
this will allow for installing subkey  with cargo as described here https://substrate.dev/docs/en/knowledgebase/integrate/subkey much easier.

This does not need to be published on crates.io, but it could be. Happy to open an issue if this would be simple to maintain. 