### PR TITLE
Added ss58 prefix for http://cycan.network

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -588,6 +588,8 @@ ss58_address_format!(
 		(66, "crust", "Crust Network, standard account (*25519).")
 	SoraAccount =>
 		(69, "sora", "SORA Network, standard account (*25519).")
+	SoraAccount =>
+		(80, "phoenix", "Phoenix Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -488,6 +488,15 @@
 			"website": "https://sora.org"
 		},
 		{
+			"prefix": 80,
+			"network": "phoenix-network",
+			"displayName": "Phoenix Network",
+			"symbols": ["PNX"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://cycan.network"
+		},
+		{
 			"prefix": 252,
 			"network": "social-network",
 			"displayName": "Social Network",
@@ -495,15 +504,6 @@
 			"decimals": [18],
 			"standardAccount": "*25519",
 			"website": "https://social.network"
-		},
-                {
-                        "prefix": 80,
-                        "network": "phoenix-network",
-                        "displayName": "Phoenix Network",
-                        "symbols": ["PNX"],
-                        "decimals": [12],
-                        "standardAccount": "*25519",
-                        "website": "https://cycan.network"
-                }
+		}
 	]
 }

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -495,6 +495,15 @@
 			"decimals": [18],
 			"standardAccount": "*25519",
 			"website": "https://social.network"
-		}
+		},
+                {
+                        "prefix": 80,
+                        "network": "phoenix-network",
+                        "displayName": "Phoenix Network",
+                        "symbols": ["PNX"],
+                        "decimals": [12],
+                        "standardAccount": "*25519",
+                        "website": "https://cycan.network"
+                }
 	]
 }


### PR DESCRIPTION
Thank you for your Pull Request!

Before you submitting, please check that:

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
Added ss58 prefix for http://cycan.network , 

                {
                        "prefix": 80,
                        "network": "phoenix-network",
                        "displayName": "Phoenix Network",
                        "symbols": ["PNX"],
                        "decimals": [12],
                        "standardAccount": "*25519",
                        "website": "https://cycan.network"
                },
