### PR TITLE
Add a JSON-RPC layer for reserved nodes

### DIFF
--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1015,12 +1015,9 @@ impl<B: BlockT> Protocol<B> {
 	}
 
 	/// Returns the list of reserved peers.
-	pub fn reserved_peers(&self) -> Vec<String> {
+	pub fn reserved_peers(&self, pending_response: oneshot::Sender<Vec<PeerId>>) {
 		self.peerset_handle
-			.get_reserved_peers(HARDCODED_PEERSETS_SYNC)
-			.into_iter()
-			.map(|peer_id| peer_id.to_base58())
-			.collect()
+			.get_reserved_peers(HARDCODED_PEERSETS_SYNC, pending_response)
 	}
 
 	/// Adds a `PeerId` to the list of reserved peers for syncing purposes.

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1014,6 +1014,15 @@ impl<B: BlockT> Protocol<B> {
 		self.peerset_handle.remove_reserved_peer(HARDCODED_PEERSETS_SYNC, peer.clone());
 	}
 
+	/// Returns the list of reserved peers.
+	pub fn reserved_peers(&self) -> Vec<String> {
+		self.peerset_handle
+			.get_reserved_peers(HARDCODED_PEERSETS_SYNC)
+			.into_iter()
+			.map(|peer_id| peer_id.to_base58())
+			.collect()
+	}
+
 	/// Adds a `PeerId` to the list of reserved peers for syncing purposes.
 	pub fn add_reserved_peer(&self, peer: PeerId) {
 		self.peerset_handle.add_reserved_peer(HARDCODED_PEERSETS_SYNC, peer.clone());

--- a/client/network/src/protocol.rs
+++ b/client/network/src/protocol.rs
@@ -1015,9 +1015,8 @@ impl<B: BlockT> Protocol<B> {
 	}
 
 	/// Returns the list of reserved peers.
-	pub fn reserved_peers(&self, pending_response: oneshot::Sender<Vec<PeerId>>) {
-		self.peerset_handle
-			.get_reserved_peers(HARDCODED_PEERSETS_SYNC, pending_response)
+	pub fn reserved_peers(&self) -> impl Iterator<Item = &PeerId> {
+		self.behaviour.reserved_peers(HARDCODED_PEERSETS_SYNC)
 	}
 
 	/// Adds a `PeerId` to the list of reserved peers for syncing purposes.

--- a/client/network/src/protocol/notifications/behaviour.rs
+++ b/client/network/src/protocol/notifications/behaviour.rs
@@ -555,6 +555,11 @@ impl Notifications {
 			.map(|((id, _), _)| id)
 	}
 
+	/// Returns the list of reserved peers.
+	pub fn reserved_peers<'a>(&'a self, set_id: sc_peerset::SetId) -> impl Iterator<Item = &'a PeerId> + 'a {
+		self.peerset.reserved_peers(set_id)
+	}
+
 	/// Sends a notification to a peer.
 	///
 	/// Has no effect if the custom protocol is not open with the given peer.

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -619,6 +619,11 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 	pub fn add_reserved_peer(&self, peer: String) -> Result<(), String> {
 		self.service.add_reserved_peer(peer)
 	}
+
+	/// Returns the list of resurved peers.
+	pub fn reserved_peers(&self) -> Vec<String> {
+		self.network_service.behaviour().user_protocol().reserved_peers()
+	}
 }
 
 impl<B: BlockT + 'static, H: ExHashT> NetworkService<B, H> {

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -620,9 +620,9 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 		self.service.add_reserved_peer(peer)
 	}
 
-	/// Returns the list of resurved peers.
-	pub fn reserved_peers(&self) -> Vec<String> {
-		self.network_service.behaviour().user_protocol().reserved_peers()
+	/// Returns the list of reserved peers.
+	pub fn reserved_peers(&self, pending_response: oneshot::Sender<Vec<PeerId>>) {
+		self.network_service.behaviour().user_protocol().reserved_peers(pending_response)
 	}
 }
 

--- a/client/network/src/service.rs
+++ b/client/network/src/service.rs
@@ -621,8 +621,8 @@ impl<B: BlockT + 'static, H: ExHashT> NetworkWorker<B, H> {
 	}
 
 	/// Returns the list of reserved peers.
-	pub fn reserved_peers(&self, pending_response: oneshot::Sender<Vec<PeerId>>) {
-		self.network_service.behaviour().user_protocol().reserved_peers(pending_response)
+	pub fn reserved_peers(&self) -> impl Iterator<Item = &PeerId> {
+		self.network_service.behaviour().user_protocol().reserved_peers()
 	}
 }
 

--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -147,6 +147,11 @@ impl PeersetHandle {
 		let _ = self.tx.unbounded_send(Action::SetReservedPeers(set_id, peer_ids));
 	}
 
+	/// Get the list of reserved peers for the given set.
+	pub fn get_reserved_peers(&self, _set_id: SetId) -> Vec<PeerId> {
+		vec![] // TODO
+	}
+
 	/// Reports an adjustment to the reputation of the given peer.
 	pub fn report_peer(&self, peer_id: PeerId, score_diff: ReputationChange) {
 		let _ = self.tx.unbounded_send(Action::ReportPeer(peer_id, score_diff));

--- a/client/rpc-api/src/system/mod.rs
+++ b/client/rpc-api/src/system/mod.rs
@@ -102,6 +102,10 @@ pub trait SystemApi<Hash, Number> {
 	fn system_remove_reserved_peer(&self, peer_id: String)
 		-> Compat<BoxFuture<'static, Result<(), jsonrpc_core::Error>>>;
 
+	/// Returns the list of reserved peers
+	#[rpc(name = "system_reservedPeers", returns = "Vec<String>")]
+	fn system_reserved_peers(&self) -> Receiver<Vec<String>>;
+
 	/// Returns the roles the node is running as.
 	#[rpc(name = "system_nodeRoles", returns = "Vec<NodeRole>")]
 	fn system_node_roles(&self) -> Receiver<Vec<NodeRole>>;

--- a/client/rpc/src/system/mod.rs
+++ b/client/rpc/src/system/mod.rs
@@ -66,6 +66,8 @@ pub enum Request<B: traits::Block> {
 	NetworkAddReservedPeer(String, oneshot::Sender<Result<()>>),
 	/// Must return any potential parse error.
 	NetworkRemoveReservedPeer(String, oneshot::Sender<Result<()>>),
+	/// Must return the list of reserved peers
+	NetworkReservedPeers(oneshot::Sender<Vec<String>>),
 	/// Must return the node role.
 	NodeRoles(oneshot::Sender<Vec<NodeRole>>),
 	/// Must return the state of the node syncing.
@@ -185,6 +187,12 @@ impl<B: traits::Block> SystemApi<B::Hash, <B::Header as HeaderT>::Number> for Sy
 				Err(_) => Err(rpc::Error::internal_error()),
 			}
 		}.boxed().compat()
+	}
+
+	fn system_reserved_peers(&self) -> Receiver<Vec<String>> {
+		let (tx, rx) = oneshot::channel();
+		let _ = self.send_back.unbounded_send(Request::NetworkReservedPeers(tx));
+		Receiver(Compat::new(rx))
 	}
 
 	fn system_node_roles(&self) -> Receiver<Vec<NodeRole>> {

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -105,7 +105,7 @@ fn api<T: Into<Option<Status>>>(sync: T) -> System<Block> {
 					};
 				}
 				Request::NetworkReservedPeers(sender) => {
-					let _ = sender.send(vec!["peer_A".to_string()]);
+					let _ = sender.send(vec!["QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string()]);
 				}
 				Request::NodeRoles(sender) => {
 					let _ = sender.send(vec![NodeRole::Authority]);
@@ -344,7 +344,7 @@ fn system_network_remove_reserved() {
 fn system_network_reserved_peers() {
 	assert_eq!(
 		wait_receiver(api(None).system_reserved_peers()),
-		vec!["peer_A".to_string()]
+		vec!["QmSk5HQbn6LhUwDiNMseVUjuRYhEtYj4aUZ6WfWoGURpdV".to_string()]
 	);
 }
 

--- a/client/rpc/src/system/tests.rs
+++ b/client/rpc/src/system/tests.rs
@@ -104,6 +104,9 @@ fn api<T: Into<Option<Status>>>(sync: T) -> System<Block> {
 						Err(s) => sender.send(Err(error::Error::MalformattedPeerArg(s.to_string()))),
 					};
 				}
+				Request::NetworkReservedPeers(sender) => {
+					let _ = sender.send(vec!["peer_A".to_string()]);
+				}
 				Request::NodeRoles(sender) => {
 					let _ = sender.send(vec![NodeRole::Authority]);
 				}
@@ -335,6 +338,14 @@ fn system_network_remove_reserved() {
 	let bad_fut = api(None).system_remove_reserved_peer(bad_peer_id.into());
 	assert_eq!(runtime.block_on(good_fut), Ok(()));
 	assert!(runtime.block_on(bad_fut).is_err());
+}
+
+#[test]
+fn system_network_reserved_peers() {
+	assert_eq!(
+		wait_receiver(api(None).system_reserved_peers()),
+		vec!["peer_A".to_string()]
+	);
 }
 
 #[test]

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -302,6 +302,9 @@ async fn build_network_future<
 							))),
 						};
 					}
+					sc_rpc::system::Request::NetworkReservedPeers(sender) => {
+						let _ = sender.send(vec![]); // TODO
+					}
 					sc_rpc::system::Request::NodeRoles(sender) => {
 						use sc_rpc::system::NodeRole;
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::task::Poll;
 
-use futures::{Future, FutureExt, Stream, StreamExt, stream, compat::*, channel::oneshot};
+use futures::{Future, FutureExt, Stream, StreamExt, stream, compat::*};
 use sc_network::{NetworkStatus, network_state::NetworkState, PeerId};
 use log::{warn, debug, error};
 use codec::{Encode, Decode};
@@ -303,12 +303,11 @@ async fn build_network_future<
 						};
 					}
 					sc_rpc::system::Request::NetworkReservedPeers(sender) => {
-						let (tx, rx) = oneshot::channel();
-						let _ = network.reserved_peers(tx);
-						let reserved_peers = rx.await.unwrap();
+						let reserved_peers = network.reserved_peers();
 						let reserved_peers = reserved_peers.into_iter()
 							.map(|peer_id| peer_id.to_base58())
 							.collect();
+
 						let _ = sender.send(reserved_peers);
 					}
 					sc_rpc::system::Request::NodeRoles(sender) => {

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -303,7 +303,8 @@ async fn build_network_future<
 						};
 					}
 					sc_rpc::system::Request::NetworkReservedPeers(sender) => {
-						let _ = sender.send(vec![]); // TODO
+						let reserved_peers = network.reserved_peers();
+						let _ = sender.send(reserved_peers);
 					}
 					sc_rpc::system::Request::NodeRoles(sender) => {
 						use sc_rpc::system::NodeRole;

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -304,7 +304,7 @@ async fn build_network_future<
 					}
 					sc_rpc::system::Request::NetworkReservedPeers(sender) => {
 						let reserved_peers = network.reserved_peers();
-						let reserved_peers = reserved_peers.into_iter()
+						let reserved_peers = reserved_peers
 							.map(|peer_id| peer_id.to_base58())
 							.collect();
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::task::Poll;
 
-use futures::{Future, FutureExt, Stream, StreamExt, stream, compat::*};
+use futures::{Future, FutureExt, Stream, StreamExt, stream, compat::*, channel::oneshot};
 use sc_network::{NetworkStatus, network_state::NetworkState, PeerId};
 use log::{warn, debug, error};
 use codec::{Encode, Decode};
@@ -303,7 +303,12 @@ async fn build_network_future<
 						};
 					}
 					sc_rpc::system::Request::NetworkReservedPeers(sender) => {
-						let reserved_peers = network.reserved_peers();
+						let (tx, rx) = oneshot::channel();
+						let _ = network.reserved_peers(tx);
+						let reserved_peers = rx.await.unwrap();
+						let reserved_peers = reserved_peers.into_iter()
+							.map(|peer_id| peer_id.to_base58())
+							.collect();
 						let _ = sender.send(reserved_peers);
 					}
 					sc_rpc::system::Request::NodeRoles(sender) => {


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/8147

Adds a `reservedPeers` rpc call to return peers added/removed through `addReservedPeer` and `removeReservedPeer`.


 > Is there something left for follow-up PRs?

Yes. The work is in progress