### PR TITLE
Manta Network ss58 address registration

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -588,6 +588,10 @@ ss58_address_format!(
 		(66, "crust", "Crust Network, standard account (*25519).")
 	SoraAccount =>
 		(69, "sora", "SORA Network, standard account (*25519).")
+	MantaAccount =>
+		(77, "manta", "Manta Network, standard account (*25519).")
+	CalamariAccount =>
+		(78, "calamari", "Manta canary network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -591,7 +591,7 @@ ss58_address_format!(
 	MantaAccount =>
 		(77, "manta", "Manta Network, standard account (*25519).")
 	CalamariAccount =>
-		(78, "calamari", "Manta canary network, standard account (*25519).")
+		(78, "calamari", "Manta Canary Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -488,6 +488,24 @@
 			"website": "https://sora.org"
 		},
 		{
+			"prefix": 77,
+			"network": "Manta",
+			"displayName": "Manta network",
+			"symbols": ["MA"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://manta.network"
+		},
+		{
+			"prefix": 78,
+			"network": "Calamari",
+			"displayName": "Calamari: Manta canary network",
+			"symbols": ["KMA"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://manta.network"
+		},
+		{
 			"prefix": 252,
 			"network": "social-network",
 			"displayName": "Social Network",

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -489,7 +489,7 @@
 		},
 		{
 			"prefix": 77,
-			"network": "Manta",
+			"network": "manta",
 			"displayName": "Manta network",
 			"symbols": ["MA"],
 			"decimals": [12],
@@ -498,8 +498,8 @@
 		},
 		{
 			"prefix": 78,
-			"network": "Calamari",
-			"displayName": "Calamari: Manta canary network",
+			"network": "calamari",
+			"displayName": "Calamari: Manta Canary Network",
 			"symbols": ["KMA"],
 			"decimals": [12],
 			"standardAccount": "*25519",


### PR DESCRIPTION
Add Manta Network (https://manta.network/) and Manta's canary network (Calamari)'s ss58 address prefix:

-  update `crypto.rs`
-  update `ss58-registry.json`


