### PR TITLE
Improve `BoundedVec` API

### DIFF
--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -214,7 +214,7 @@ impl<T: BoundedVecValue, S: Get<u32>, I: SliceIndex<[T]>> Index<I> for BoundedVe
 impl<T: BoundedVecValue, S: Get<u32>, I: SliceIndex<[T]>> IndexMut<I> for BoundedVec<T, S> {
 	#[inline]
 	fn index_mut(&mut self, index: I) -> &mut Self::Output {
-		IndexMut::index_mut(&mut **self, index)
+		self.0.index_mut(index)
 	}
 }
 

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -201,12 +201,6 @@ impl<T: BoundedVecValue, S: Get<u32>> sp_std::ops::Deref for BoundedVec<T, S> {
 	}
 }
 
-impl<T: BoundedVecValue, S: Get<u32>> sp_std::ops::DerefMut for BoundedVec<T, S> {
-    fn deref_mut(&mut self) -> &mut Vec<T> {
-        &mut self.0
-    }
-}
-
 // Allows for indexing similar to a normal `Vec`. Can panic if out of bound.
 impl<T: BoundedVecValue, S: Get<u32>, I: SliceIndex<[T]>> Index<I> for BoundedVec<T, S> {
 	type Output = I::Output;

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -207,7 +207,7 @@ impl<T: BoundedVecValue, S: Get<u32>, I: SliceIndex<[T]>> Index<I> for BoundedVe
 
 	#[inline]
 	fn index(&self, index: I) -> &Self::Output {
-		Index::index(&**self, index)
+		self.0.index(index)
 	}
 }
 


### PR DESCRIPTION
This adds some useful APIs for making the conversion from `Vec` to `BoundedVec` more seamless.