### PR TITLE
GamePower Network ss58 address registration

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -591,7 +591,9 @@ ss58_address_format!(
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
 	GamePowerAccount =>
-		(1337, "gamepower", "GamePower Network, standard account (*25519).")
+		(1337, "gamepower", "GamePower Network mainnet, standard account (*25519).")
+	GamePowerXAccount =>
+		(1338, "gamepowerx", "GamePower Canary Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -588,12 +588,12 @@ ss58_address_format!(
 		(66, "crust", "Crust Network, standard account (*25519).")
 	SoraAccount =>
 		(69, "sora", "SORA Network, standard account (*25519).")
+	GamePowerAccount =>
+		(100, "gamepower", "GamePower Network mainnet, standard account (*25519).")
+	GamePowerXAccount =>
+		(101, "gamepowerx", "GamePower Canary Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
-	GamePowerAccount =>
-		(1337, "gamepower", "GamePower Network mainnet, standard account (*25519).")
-	GamePowerXAccount =>
-		(1338, "gamepowerx", "GamePower Canary Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -590,6 +590,8 @@ ss58_address_format!(
 		(69, "sora", "SORA Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
+	GamePowerAccount =>
+		(1337, "gamepower", "GamePower Network, standard account (*25519).")
 	// Note: 16384 and above are reserved.
 );
 

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -495,6 +495,15 @@
 			"decimals": [18],
 			"standardAccount": "*25519",
 			"website": "https://social.network"
+		},
+		{
+			"prefix": 1337,
+			"network": "gamepower",
+			"displayName": "GamePower Network",
+			"symbols": ["GP"],
+			"decimals": [8],
+			"standardAccount": "*25519",
+			"website": "https://gamepower.network"
 		}
 	]
 }

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -488,16 +488,7 @@
 			"website": "https://sora.org"
 		},
 		{
-			"prefix": 252,
-			"network": "social-network",
-			"displayName": "Social Network",
-			"symbols": ["NET"],
-			"decimals": [18],
-			"standardAccount": "*25519",
-			"website": "https://social.network"
-		},
-		{
-			"prefix": 1337,
+			"prefix": 100,
 			"network": "gamepower",
 			"displayName": "GamePower Network",
 			"symbols": ["GP"],
@@ -506,13 +497,22 @@
 			"website": "https://gamepower.network"
 		},
 		{
-			"prefix": 1338,
+			"prefix": 101,
 			"network": "gamepowerx",
 			"displayName": "GamePowerX Network",
 			"symbols": ["GPX"],
 			"decimals": [8],
 			"standardAccount": "*25519",
 			"website": "https://gamepower.network"
+		}
+		{
+			"prefix": 252,
+			"network": "social-network",
+			"displayName": "Social Network",
+			"symbols": ["NET"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://social.network"
 		}
 	]
 }

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -504,6 +504,15 @@
 			"decimals": [8],
 			"standardAccount": "*25519",
 			"website": "https://gamepower.network"
+		},
+		{
+			"prefix": 1338,
+			"network": "gamepowerx",
+			"displayName": "GamePowerX Network",
+			"symbols": ["GPX"],
+			"decimals": [8],
+			"standardAccount": "*25519",
+			"website": "https://gamepower.network"
 		}
 	]
 }


### PR DESCRIPTION
Add GamePower Network (https://gamepower.network/) and GamePower's Canary Network (GamePower X)'s ss58 address prefix:

* update `crypto.rs`
* update `ss58-registry.json`

✄ -----------------------------------------------------------------------------

```
               {
			"prefix": 100,
			"network": "gamepower",
			"displayName": "GamePower Network",
			"symbols": ["GP"],
			"decimals": [8],
			"standardAccount": "*25519",
			"website": "https://gamepower.network"
		},
		{
			"prefix": 101,
			"network": "gamepowerx",
			"displayName": "GamePowerX Network",
			"symbols": ["GPX"],
			"decimals": [8],
			"standardAccount": "*25519",
			"website": "https://gamepower.network"
		}
```