### PR TITLE
Add some builder functions for NonDefaultSetConfig

### DIFF
--- a/client/network/src/config.rs
+++ b/client/network/src/config.rs
@@ -530,6 +530,9 @@ impl Default for SetConfig {
 }
 
 /// Extension to [`SetConfig`] for sets that aren't the default set.
+///
+/// > **Note**: As new fields might be added in the future, please consider using the `new` method
+/// >			and modifiers instead of creating this struct manually.
 #[derive(Clone, Debug)]
 pub struct NonDefaultSetConfig {
 	/// Name of the notifications protocols of this set. A substream on this set will be
@@ -542,6 +545,34 @@ pub struct NonDefaultSetConfig {
 	pub max_notification_size: u64,
 	/// Base configuration.
 	pub set_config: SetConfig,
+}
+
+impl NonDefaultSetConfig {
+	/// Creates a new [`NonDefaultSetConfig`]. Zero slots and accepts only reserved nodes.
+	pub fn new(notifications_protocol: Cow<'static, str>, max_notification_size: u64) -> Self {
+		NonDefaultSetConfig {
+			notifications_protocol,
+			max_notification_size,
+			set_config: SetConfig {
+				in_peers: 0,
+				out_peers: 0,
+				reserved_nodes: Vec::new(),
+				non_reserved_mode: NonReservedPeerMode::Deny,
+			},
+		}
+	}
+
+	/// Modifies the configuration to allow non-reserved nodes.
+	pub fn allow_non_reserved(&mut self, in_peers: u32, out_peers: u32) {
+		self.set_config.in_peers = in_peers;
+		self.set_config.out_peers = out_peers;
+		self.set_config.non_reserved_mode = NonReservedPeerMode::Accept;
+	}
+
+	/// Add a node to the list of reserved nodes.
+	pub fn add_reserved(&mut self, peer: MultiaddrWithPeerId) {
+		self.set_config.reserved_nodes.push(peer);
+	}
 }
 
 /// Configuration for the transport layer.


### PR DESCRIPTION
This needs to go in before we can merge https://github.com/paritytech/substrate/pull/8682

## Context

The Polkadot companion check in the CI of https://github.com/paritytech/substrate/pull/8682 fails because the `grandpa-bridge-gadget` library [manually creates a `NonDefaultSetConfig`](https://github.com/paritytech/grandpa-bridge-gadget/blob/4c7248ef67824cc2000d51a947f147bafe19f0aa/beefy-gadget/src/lib.rs#L48), while https://github.com/paritytech/substrate/pull/8682 modifies the definition of this struct.

In order to solve that, the idea is:

- Merge this PR (this one that you're reading right now)
- Modify `grandpa-beefy-gadget` to use the new API introduced in this PR.
- Merge https://github.com/paritytech/substrate/pull/8682 afterwards.
