### PR TITLE
Fix too generous error detection in behaviour.rs

### DIFF
--- a/client/network/src/protocol/notifications/behaviour.rs
+++ b/client/network/src/protocol/notifications/behaviour.rs
@@ -1703,6 +1703,7 @@ impl NetworkBehaviour for Notifications {
 
 				match self.peers.get_mut(&(source.clone(), set_id)) {
 					// Move the connection from `Closing` to `Closed`.
+					Some(PeerState::Incoming { connections, .. }) |
 					Some(PeerState::DisabledPendingEnable { connections, .. }) |
 					Some(PeerState::Disabled { connections, .. }) |
 					Some(PeerState::Enabled { connections, .. }) => {


### PR DESCRIPTION
Fix #8715 

If we have two active connections, one being closed, and one where the remote has tried re-opening a substream, then this will currently produce an error, even though this is a completely correct state.
Fixed that.

As to why there is no test: as always, it's super hard to test this because, since this is an internal state machine, it's hard to actually figure out which states are correct and which are not, as hard as actually reading/writing the code.
#7678 should eventually help with testing.
