### PR TITLE
Makes system migrations public

### DIFF
--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -655,7 +655,7 @@ pub mod pallet {
 	}
 }
 
-mod migrations {
+pub mod migrations {
 	use super::*;
 
 	#[allow(dead_code)]


### PR DESCRIPTION
Can we make all migrations public in the future? I don't see why this wouldn't be the default.