### PR TITLE
frame system: add event util functions for tests.

### DIFF
--- a/frame/assets/src/benchmarking.rs
+++ b/frame/assets/src/benchmarking.rs
@@ -120,19 +120,11 @@ fn add_approvals<T: Config<I>, I: 'static>(minter: T::AccountId, n: u32) {
 }
 
 fn assert_last_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 fn assert_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::Event) {
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	let events = frame_system::Pallet::<T>::events();
-	assert!(events.iter().any(|event_record| {
-		matches!(&event_record, frame_system::EventRecord { event, .. } if &system_event == event)
-	}));
+	frame_system::Pallet::<T>::assert_has_event(generic_event.into());
 }
 
 benchmarks_instance_pallet! {

--- a/frame/assets/src/tests.rs
+++ b/frame/assets/src/tests.rs
@@ -23,10 +23,6 @@ use sp_runtime::TokenError;
 use frame_support::{assert_ok, assert_noop, traits::Currency};
 use pallet_balances::Error as BalancesError;
 
-fn last_event() -> mock::Event {
-	frame_system::Pallet::<Test>::events().pop().expect("Event expected").event
-}
-
 #[test]
 fn basic_minting_should_work() {
 	new_test_ext().execute_with(|| {
@@ -401,10 +397,7 @@ fn transferring_less_than_one_unit_is_fine() {
 		assert_ok!(Assets::mint(Origin::signed(1), 0, 1, 100));
 		assert_eq!(Assets::balance(0, 1), 100);
 		assert_ok!(Assets::transfer(Origin::signed(1), 0, 2, 0));
-		assert_eq!(
-			last_event(),
-			mock::Event::pallet_assets(crate::Event::Transferred(0, 1, 2, 0)),
-		);
+		System::assert_last_event(mock::Event::pallet_assets(crate::Event::Transferred(0, 1, 2, 0)));
 	});
 }
 
@@ -603,7 +596,7 @@ fn force_asset_status_should_work(){
 		assert_ok!(Assets::mint(Origin::signed(1), 0, 1, 50));
 		assert_ok!(Assets::mint(Origin::signed(1), 0, 2, 150));
 
-		//force asset status to change min_balance > balance 
+		//force asset status to change min_balance > balance
 		assert_ok!(Assets::force_asset_status(Origin::root(), 0, 1, 1, 1, 1, 100, true, false));
 		assert_eq!(Assets::balance(0, 1), 50);
 

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -54,10 +54,6 @@ macro_rules! decl_tests {
 			evt
 		}
 
-		fn last_event() -> Event {
-			system::Pallet::<Test>::events().pop().expect("Event expected").event
-		}
-
 		#[test]
 		fn basic_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
@@ -467,9 +463,8 @@ macro_rules! decl_tests {
 				let _ = Balances::deposit_creating(&2, 1);
 				assert_ok!(Balances::reserve(&1, 110));
 				assert_ok!(Balances::repatriate_reserved(&1, &2, 41, Status::Free), 0);
-				assert_eq!(
-					last_event(),
-					Event::pallet_balances(crate::Event::ReserveRepatriated(1, 2, 41, Status::Free)),
+				System::assert_last_event(
+					Event::pallet_balances(crate::Event::ReserveRepatriated(1, 2, 41, Status::Free))
 				);
 				assert_eq!(Balances::reserved_balance(1), 69);
 				assert_eq!(Balances::free_balance(1), 0);
@@ -688,27 +683,18 @@ macro_rules! decl_tests {
 					System::set_block_number(2);
 					assert_ok!(Balances::reserve(&1, 10));
 
-					assert_eq!(
-						last_event(),
-						Event::pallet_balances(crate::Event::Reserved(1, 10)),
-					);
+					System::assert_last_event(Event::pallet_balances(crate::Event::Reserved(1, 10)));
 
 					System::set_block_number(3);
 					assert!(Balances::unreserve(&1, 5).is_zero());
 
-					assert_eq!(
-						last_event(),
-						Event::pallet_balances(crate::Event::Unreserved(1, 5)),
-					);
+					System::assert_last_event(Event::pallet_balances(crate::Event::Unreserved(1, 5)));
 
 					System::set_block_number(4);
 					assert_eq!(Balances::unreserve(&1, 6), 1);
 
 					// should only unreserve 5
-					assert_eq!(
-						last_event(),
-						Event::pallet_balances(crate::Event::Unreserved(1, 5)),
-					);
+					System::assert_last_event(Event::pallet_balances(crate::Event::Unreserved(1, 5)));
 				});
 		}
 

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -46,10 +46,6 @@ use frame_system::RawOrigin;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-fn last_event() -> Event {
-	system::Pallet::<Test>::events().pop().expect("Event expected").event
-}
-
 frame_support::construct_runtime!(
 	pub enum Test where
 		Block = Block,
@@ -189,23 +185,9 @@ fn transfer_dust_removal_tst1_should_work() {
 			// Number of events expected is 8
 			assert_eq!(System::events().len(), 11);
 
-			assert!(
-				System::events().iter().any(
-					|er|
-					er.event == Event::pallet_balances(
-						crate::Event::Transfer(2, 3, 450),
-					),
-				),
-			);
+			System::assert_has_event(Event::pallet_balances(crate::Event::Transfer(2, 3, 450)));
 
-			assert!(
-				System::events().iter().any(
-					|er|
-					er.event == Event::pallet_balances(
-						crate::Event::DustLost(2, 50)
-					),
-				),
-			);
+			System::assert_has_event(Event::pallet_balances(crate::Event::DustLost(2, 50)));
 		}
 	);
 }
@@ -236,23 +218,9 @@ fn transfer_dust_removal_tst2_should_work() {
 			// Number of events expected is 8
 			assert_eq!(System::events().len(), 9);
 
-			assert!(
-				System::events().iter().any(
-					|er|
-					er.event == Event::pallet_balances(
-						crate::Event::Transfer(2, 1, 450),
-					),
-				),
-			);
+			System::assert_has_event(Event::pallet_balances(crate::Event::Transfer(2, 1, 450)));
 
-			assert!(
-				System::events().iter().any(
-					|er|
-					er.event == Event::pallet_balances(
-						crate::Event::DustLost(2, 50),
-					),
-				),
-			);
+			System::assert_has_event(Event::pallet_balances(crate::Event::DustLost(2, 50)));
 		}
 	);
 }
@@ -292,20 +260,11 @@ fn repatriating_reserved_balance_dust_removal_should_work() {
 			// Number of events expected is 10
 			assert_eq!(System::events().len(), 10);
 
-			assert!(
-				System::events().iter().any(
-					|er|
-					er.event == Event::pallet_balances(
-						crate::Event::ReserveRepatriated(2, 1, 450, Status::Free),
-					),
-				),
-			);
+			System::assert_has_event(Event::pallet_balances(
+				crate::Event::ReserveRepatriated(2, 1, 450, Status::Free),
+			));
 
-			assert_eq!(
-				last_event(),
-				Event::pallet_balances(crate::Event::DustLost(2, 50)),
-			);
-
+			System::assert_last_event(Event::pallet_balances(crate::Event::DustLost(2, 50)));
 		}
 	);
 }

--- a/frame/balances/src/tests_reentrancy.rs
+++ b/frame/balances/src/tests_reentrancy.rs
@@ -186,7 +186,6 @@ fn transfer_dust_removal_tst1_should_work() {
 			assert_eq!(System::events().len(), 11);
 
 			System::assert_has_event(Event::pallet_balances(crate::Event::Transfer(2, 3, 450)));
-
 			System::assert_has_event(Event::pallet_balances(crate::Event::DustLost(2, 50)));
 		}
 	);
@@ -219,7 +218,6 @@ fn transfer_dust_removal_tst2_should_work() {
 			assert_eq!(System::events().len(), 9);
 
 			System::assert_has_event(Event::pallet_balances(crate::Event::Transfer(2, 1, 450)));
-
 			System::assert_has_event(Event::pallet_balances(crate::Event::DustLost(2, 50)));
 		}
 	);

--- a/frame/bounties/src/benchmarking.rs
+++ b/frame/bounties/src/benchmarking.rs
@@ -22,7 +22,7 @@
 use super::*;
 
 use sp_runtime::traits::Bounded;
-use frame_system::{EventRecord, RawOrigin};
+use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 use frame_support::traits::OnInitialize;
 
@@ -84,11 +84,7 @@ fn setup_pot_account<T: Config>() {
 }
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 const MAX_BYTES: u32 = 16384;

--- a/frame/collective/src/benchmarking.rs
+++ b/frame/collective/src/benchmarking.rs
@@ -20,7 +20,6 @@
 use super::*;
 
 use frame_system::RawOrigin as SystemOrigin;
-use frame_system::EventRecord;
 use frame_benchmarking::{
 	benchmarks_instance,
 	account,
@@ -39,11 +38,7 @@ const SEED: u32 = 0;
 const MAX_BYTES: u32 = 1_024;
 
 fn assert_last_event<T: Config<I>, I: Instance>(generic_event: <T as Config<I>>::Event) {
-	let events = System::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 benchmarks_instance! {

--- a/frame/democracy/src/benchmarking.rs
+++ b/frame/democracy/src/benchmarking.rs
@@ -25,7 +25,7 @@ use frame_support::{
 	traits::{Currency, Get, EnsureOrigin, OnInitialize, UnfilteredDispatchable,
         schedule::DispatchTime},
 };
-use frame_system::{RawOrigin, Pallet as System, self, EventRecord};
+use frame_system::{RawOrigin, Pallet as System, self};
 use sp_runtime::traits::{Bounded, One};
 
 use crate::Pallet as Democracy;
@@ -36,11 +36,7 @@ const MAX_SECONDERS: u32 = 100;
 const MAX_BYTES: u32 = 16_384;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = System::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 fn funded_account<T: Config>(name: &'static str, index: u32) -> T::AccountId {

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -2132,10 +2132,7 @@ mod tests {
 			System::set_block_number(5);
 			Elections::on_initialize(System::block_number());
 
-			assert_eq!(
-				System::events().iter().last().unwrap().event,
-				Event::elections_phragmen(super::Event::EmptyTerm),
-			)
+			System::assert_last_event(Event::elections_phragmen(super::Event::EmptyTerm));
 		})
 	}
 
@@ -2151,10 +2148,7 @@ mod tests {
 			System::set_block_number(5);
 			Elections::on_initialize(System::block_number());
 
-			assert_eq!(
-				System::events().iter().last().unwrap().event,
-				Event::elections_phragmen(super::Event::NewTerm(vec![(4, 40), (5, 50)])),
-			);
+			System::assert_last_event(Event::elections_phragmen(super::Event::NewTerm(vec![(4, 40), (5, 50)])));
 
 			assert_eq!(members_and_stake(), vec![(4, 40), (5, 50)]);
 			assert_eq!(runners_up_and_stake(), vec![]);
@@ -2165,10 +2159,7 @@ mod tests {
 			System::set_block_number(10);
 			Elections::on_initialize(System::block_number());
 
-			assert_eq!(
-				System::events().iter().last().unwrap().event,
-				Event::elections_phragmen(super::Event::NewTerm(vec![])),
-			);
+			System::assert_last_event(Event::elections_phragmen(super::Event::NewTerm(vec![])));
 
 			// outgoing have lost their bond.
 			assert_eq!(balances(&4), (37, 0));
@@ -2238,10 +2229,7 @@ mod tests {
 			assert_eq!(Elections::election_rounds(), 1);
 			assert!(members_ids().is_empty());
 
-			assert_eq!(
-				System::events().iter().last().unwrap().event,
-				Event::elections_phragmen(super::Event::NewTerm(vec![])),
-			)
+			System::assert_last_event(Event::elections_phragmen(super::Event::NewTerm(vec![])));
 		});
 	}
 
@@ -2599,9 +2587,7 @@ mod tests {
 			// 5 is an outgoing loser. will also get slashed.
 			assert_eq!(balances(&5), (45, 2));
 
-			assert!(System::events().iter().any(|event| {
-				event.event == Event::elections_phragmen(super::Event::NewTerm(vec![(4, 40), (5, 50)]))
-			}));
+			System::assert_has_event(Event::elections_phragmen(super::Event::NewTerm(vec![(4, 40), (5, 50)])));
 		})
 	}
 

--- a/frame/identity/src/benchmarking.rs
+++ b/frame/identity/src/benchmarking.rs
@@ -21,7 +21,7 @@
 
 use super::*;
 
-use frame_system::{EventRecord, RawOrigin};
+use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 use sp_runtime::traits::Bounded;
 use frame_support::{ensure, traits::Get};
@@ -30,11 +30,7 @@ use crate::Pallet as Identity;
 const SEED: u32 = 0;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 // Adds `r` registrars to the Identity Pallet. These registrars will have set fees and fields.

--- a/frame/multisig/src/tests.rs
+++ b/frame/multisig/src/tests.rs
@@ -124,14 +124,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn last_event() -> Event {
-	system::Pallet::<Test>::events().pop().map(|e| e.event).expect("Event expected")
-}
-
-fn expect_event<E: Into<Event>>(e: E) {
-	assert_eq!(last_event(), e.into());
-}
-
 fn now() -> Timepoint<u64> {
 	Multisig::timepoint()
 }
@@ -433,7 +425,7 @@ fn multisig_2_of_3_cannot_reissue_same_call() {
 		assert_ok!(Multisig::as_multi(Origin::signed(3), 2, vec![1, 2], Some(now()), data.clone(), false, call_weight));
 
 		let err = DispatchError::from(BalancesError::<Test, _>::InsufficientBalance).stripped();
-		expect_event(RawEvent::MultisigExecuted(3, now(), multi, hash, Err(err)));
+		System::assert_last_event(RawEvent::MultisigExecuted(3, now(), multi, hash, Err(err)).into());
 	});
 }
 

--- a/frame/proxy/src/benchmarking.rs
+++ b/frame/proxy/src/benchmarking.rs
@@ -20,7 +20,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use frame_system::{RawOrigin, EventRecord};
+use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 use sp_runtime::traits::Bounded;
 use crate::Pallet as Proxy;
@@ -28,11 +28,7 @@ use crate::Pallet as Proxy;
 const SEED: u32 = 0;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 fn add_proxies<T: Config>(n: u32, maybe_who: Option<T::AccountId>) -> Result<(), &'static str> {

--- a/frame/sudo/src/tests.rs
+++ b/frame/sudo/src/tests.rs
@@ -58,8 +58,7 @@ fn sudo_emits_events_correctly() {
 		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
 		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
 		assert_ok!(Sudo::sudo(Origin::signed(1), call));
-		let expected_event = TestEvent::sudo(Event::Sudid(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
+		System::assert_has_event(TestEvent::sudo(Event::Sudid(Ok(()))));
 	})
 }
 
@@ -97,8 +96,7 @@ fn sudo_unchecked_weight_emits_events_correctly() {
 		// Should emit event to indicate success when called with the root `key` and `call` is `Ok`.
 		let call = Box::new(Call::Logger(LoggerCall::privileged_i32_log(42, 1)));
 		assert_ok!(Sudo::sudo_unchecked_weight(Origin::signed(1), call, 1_000));
-		let expected_event = TestEvent::sudo(Event::Sudid(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
+		System::assert_has_event(TestEvent::sudo(Event::Sudid(Ok(()))));
 	})
 }
 
@@ -124,12 +122,10 @@ fn set_key_emits_events_correctly() {
 
 		// A root `key` can change the root `key`.
 		assert_ok!(Sudo::set_key(Origin::signed(1), 2));
-		let expected_event = TestEvent::sudo(Event::KeyChanged(1));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
+		System::assert_has_event(TestEvent::sudo(Event::KeyChanged(1)));
 		// Double check.
 		assert_ok!(Sudo::set_key(Origin::signed(2), 4));
-		let expected_event = TestEvent::sudo(Event::KeyChanged(2));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
+		System::assert_has_event(TestEvent::sudo(Event::KeyChanged(2)));
 	});
 }
 
@@ -164,7 +160,6 @@ fn sudo_as_emits_events_correctly() {
 		// A non-privileged function will work when passed to `sudo_as` with the root `key`.
 		let call = Box::new(Call::Logger(LoggerCall::non_privileged_log(42, 1)));
 		assert_ok!(Sudo::sudo_as(Origin::signed(1), 2, call));
-		let expected_event = TestEvent::sudo(Event::SudoAsDone(Ok(())));
-		assert!(System::events().iter().any(|a| a.event == expected_event));
+		System::assert_has_event(TestEvent::sudo(Event::SudoAsDone(Ok(()))));
 	});
 }

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1449,28 +1449,16 @@ impl<T: Config> Pallet<T> {
 		<EventTopics<T>>::remove_all();
 	}
 
-	/// Returns `true` if the given `event` exists.
-	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
-	pub fn has_event(event: T::Event) -> bool {
-		Self::events().iter().any(|record| record.event == event)
-	}
-
 	/// Assert the given `event` exists.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn assert_has_event(event: T::Event) {
-		assert!(Self::has_event(event))
-	}
-
-	/// Returns the last event.
-	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
-	pub fn last_event() -> T::Event {
-		Self::events().last().expect("events expected").event.clone()
+		assert!(Self::events().iter().any(|record| record.event == event))
 	}
 
 	/// Assert the last event equal to the given `event`.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn assert_last_event(event: T::Event) {
-		assert_eq!(Self::last_event(), event);
+		assert_eq!(Self::events().last().expect("events expected").event, event);
 	}
 
 	/// Return the chain's current runtime version.

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1449,6 +1449,30 @@ impl<T: Config> Pallet<T> {
 		<EventTopics<T>>::remove_all();
 	}
 
+	/// Returns `true` if the given `event` exists.
+	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	pub fn has_event(event: T::Event) -> bool {
+		Self::events().iter().any(|record| record.event == event)
+	}
+
+	/// Assert the given `event` exists.
+	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	pub fn assert_has_event(event: T::Event) {
+		assert!(Self::has_event(event))
+	}
+
+	/// Returns the last event.
+	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	pub fn last_event() -> T::Event {
+		Self::events().last().expect("events expected").event.clone()
+	}
+
+	/// Assert the last event equal to the given `event`.
+	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
+	pub fn assert_last_event(event: T::Event) {
+		assert_eq!(Self::last_event(), event);
+	}
+
 	/// Return the chain's current runtime version.
 	pub fn runtime_version() -> RuntimeVersion { T::Version::get() }
 

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -380,14 +380,8 @@ fn event_util_functions_should_work() {
 		System::set_block_number(1);
 		System::deposit_event(SysEvent::CodeUpdated);
 
-		assert!(System::has_event(SysEvent::CodeUpdated.into()));
 		System::assert_has_event(SysEvent::CodeUpdated.into());
-
-		assert_eq!(System::last_event(), SysEvent::CodeUpdated.into());
 		System::assert_last_event(SysEvent::CodeUpdated.into());
-
-		assert!(!System::has_event(SysEvent::NewAccount(1).into()));
-		assert_ne!(System::last_event(), SysEvent::NewAccount(1).into());
 	});
 }
 

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -375,6 +375,23 @@ fn deposit_event_topics() {
 }
 
 #[test]
+fn event_util_functions_should_work() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		System::deposit_event(SysEvent::CodeUpdated);
+
+		assert!(System::has_event(SysEvent::CodeUpdated.into()));
+		System::assert_has_event(SysEvent::CodeUpdated.into());
+
+		assert_eq!(System::last_event(), SysEvent::CodeUpdated.into());
+		System::assert_last_event(SysEvent::CodeUpdated.into());
+
+		assert!(!System::has_event(SysEvent::NewAccount(1).into()));
+		assert_ne!(System::last_event(), SysEvent::NewAccount(1).into());
+	});
+}
+
+#[test]
 fn prunes_block_hash_mappings() {
 	new_test_ext().execute_with(|| {
 		// simulate import of 15 blocks

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -1150,13 +1150,9 @@ mod tests {
 			);
 			assert_eq!(Balances::free_balance(2), 0);
 			// Transfer Event
-			assert!(System::events().iter().any(|event| {
-				event.event == Event::pallet_balances(pallet_balances::Event::Transfer(2, 3, 80))
-			}));
+			System::assert_has_event(Event::pallet_balances(pallet_balances::Event::Transfer(2, 3, 80)));
 			// Killed Event
-			assert!(System::events().iter().any(|event| {
-				event.event == Event::system(system::Event::KilledAccount(2))
-			}));
+			System::assert_has_event(Event::system(system::Event::KilledAccount(2)));
 		});
 	}
 

--- a/frame/utility/src/benchmarking.rs
+++ b/frame/utility/src/benchmarking.rs
@@ -20,17 +20,13 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
-use frame_system::{RawOrigin, EventRecord};
+use frame_system::RawOrigin;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 
 const SEED: u32 = 0;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
-	let events = frame_system::Pallet::<T>::events();
-	let system_event: <T as frame_system::Config>::Event = generic_event.into();
-	// compare to the last event record
-	let EventRecord { event, .. } = &events[events.len() - 1];
-	assert_eq!(event, &system_event);
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
 benchmarks! {

--- a/frame/utility/src/tests.rs
+++ b/frame/utility/src/tests.rs
@@ -171,14 +171,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	ext
 }
 
-fn last_event() -> Event {
-	frame_system::Pallet::<Test>::events().pop().map(|e| e.event).expect("Event expected")
-}
-
-fn expect_event<E: Into<Event>>(e: E) {
-	assert_eq!(last_event(), e.into());
-}
-
 #[test]
 fn as_derivative_works() {
 	new_test_ext().execute_with(|| {
@@ -313,7 +305,7 @@ fn batch_with_signed_filters() {
 				Call::Balances(pallet_balances::Call::transfer_keep_alive(2, 1))
 			]),
 		);
-		expect_event(utility::Event::BatchInterrupted(0, DispatchError::BadOrigin));
+		System::assert_last_event(utility::Event::BatchInterrupted(0, DispatchError::BadOrigin).into());
 	});
 }
 
@@ -387,7 +379,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
+		System::assert_last_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")).into());
 		// No weight is refunded
 		assert_eq!(extract_actual_weight(&result, &info), info.weight);
 
@@ -400,7 +392,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
+		System::assert_last_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")).into());
 		assert_eq!(extract_actual_weight(&result, &info), info.weight - diff * batch_len);
 
 		// Partial batch completion
@@ -411,7 +403,7 @@ fn batch_handles_weight_refund() {
 		let info = call.get_dispatch_info();
 		let result = call.dispatch(Origin::signed(1));
 		assert_ok!(result);
-		expect_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")));
+		System::assert_last_event(utility::Event::BatchInterrupted(1, DispatchError::Other("")).into());
 		assert_eq!(
 			extract_actual_weight(&result, &info),
 			// Real weight is 2 calls at end_weight


### PR DESCRIPTION
Add two functions for frame system events assertion, to make it easier to check expected events in unit tests and benchmarking.
- `assert_has_event` asserts the given `event` exists.
- `assert_last_event` asserts the last event is equal to the given one.

