### PR TITLE
remove patract ss58version for it's useless now

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -540,8 +540,6 @@ ss58_address_format!(
 		(25, "alphaville", "ZERO testnet, standard account (*25519).")
 	JupiterAccount =>
 		(26, "jupiter", "Jupiter testnet, standard account (*25519).")
-	PatractAccount =>
-		(27, "patract", "Patract mainnet, standard account (*25519).")
 	SubsocialAccount =>
 		(28, "subsocial", "Subsocial network, standard account (*25519).")
 	DhiwayAccount =>

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -254,15 +254,6 @@
 			"website": "https://jupiter.patract.io"
 		},
 		{
-			"prefix": 27,
-			"network": "patract",
-			"displayName": "Patract",
-			"symbols": ["pDOT", "pKSM"],
-			"decimals": [10, 12],
-			"standardAccount": "*25519",
-			"website": "https://patract.network"
-		},
-		{
 			"prefix": 28,
 			"network": "subsocial",
 			"displayName": "Subsocial",


### PR DESCRIPTION
This pr is used for removing ss58version for patract, which is not used anymore. We release this ss58version now.