### PR TITLE
BoundedVec MaxEncodedLen microoptimization

### DIFF
--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -357,7 +357,7 @@ where
 		// BoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
 		// plus each item in the slice:
 		// https://substrate.dev/rustdocs/v3.0.0/src/parity_scale_codec/codec.rs.html#798-808
-		codec::Compact::<u32>::max_encoded_len()
+		codec::Compact(S::get()).encoded_size()
 			.saturating_add(Self::bound().saturating_mul(T::max_encoded_len()))
 	}
 }


### PR DESCRIPTION
@shawntabrizi pointed out that the max encoded length of a bounded struct can be limited by the encoded size of the bound, not the max possible value for the bound's type.