### PR TITLE
Relax `BoundedVec` trait restrictions

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1238,7 +1238,7 @@ pub mod pallet_prelude {
 		dispatch::{DispatchResultWithPostInfo, Parameter, DispatchError, DispatchResult},
 		weights::{DispatchClass, Pays, Weight},
 		storage::types::{StorageValue, StorageMap, StorageDoubleMap, ValueQuery, OptionQuery},
-		storage::bounded_vec::{BoundedVec, BoundedVecValue},
+		storage::bounded_vec::BoundedVec,
 	};
 	pub use codec::{Encode, Decode};
 	pub use crate::inherent::{InherentData, InherentIdentifier, ProvideInherent};

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -20,10 +20,7 @@
 use sp_core::storage::ChildInfo;
 use sp_std::prelude::*;
 use codec::{FullCodec, FullEncode, Encode, EncodeLike, Decode};
-use crate::{
-	hash::{Twox128, StorageHasher, ReversibleStorageHasher},
-	traits::Get,
-};
+use crate::hash::{Twox128, StorageHasher, ReversibleStorageHasher};
 use sp_runtime::generic::{Digest, DigestItem};
 pub use sp_runtime::TransactionOutcome;
 
@@ -810,13 +807,13 @@ pub trait StorageDecodeLength: private::Sealed + codec::DecodeLength {
 /// outside of this crate.
 mod private {
 	use super::*;
-	use bounded_vec::{BoundedVecValue, BoundedVec};
+	use bounded_vec::BoundedVec;
 
 	pub trait Sealed {}
 
 	impl<T: Encode> Sealed for Vec<T> {}
 	impl<Hash: Encode> Sealed for Digest<Hash> {}
-	impl<T: BoundedVecValue, S: Get<u32>> Sealed for BoundedVec<T, S> {}
+	impl<T, S> Sealed for BoundedVec<T, S> {}
 }
 
 impl<T: Encode> StorageAppend<T> for Vec<T> {}

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -18,11 +18,11 @@
 //! Storage map type. Implements StorageDoubleMap, StorageIterableDoubleMap,
 //! StoragePrefixedDoubleMap traits and their methods directly.
 
-use codec::{FullCodec, Decode, EncodeLike, Encode};
+use codec::{Decode, Encode, EncodeLike, FullCodec};
 use crate::{
 	storage::{
 		StorageAppend, StorageDecodeLength,
-		bounded_vec::{BoundedVec, BoundedVecValue},
+		bounded_vec::BoundedVec,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
 	traits::{GetDefault, StorageInstance, Get},
@@ -121,7 +121,7 @@ impl<Prefix, Hasher1, Key1, Hasher2, Key2, QueryKind, OnEmpty, VecValue, VecBoun
 	Key2: FullCodec,
 	QueryKind: QueryKindTrait<BoundedVec<VecValue, VecBound>, OnEmpty>,
 	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
-	VecValue: BoundedVecValue,
+	VecValue: FullCodec,
 	VecBound: Get<u32>,
 {
 	/// Try and append the given item to the double map in the storage.

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -22,7 +22,7 @@ use codec::{FullCodec, Decode, EncodeLike, Encode};
 use crate::{
 	storage::{
 		StorageAppend, StorageDecodeLength,
-		bounded_vec::{BoundedVec, BoundedVecValue},
+		bounded_vec::BoundedVec,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
 	traits::{GetDefault, StorageInstance, Get},
@@ -100,7 +100,7 @@ where
 	Key: FullCodec,
 	QueryKind: QueryKindTrait<BoundedVec<VecValue, VecBound>, OnEmpty>,
 	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
-	VecValue: BoundedVecValue,
+	VecValue: FullCodec,
 	VecBound: Get<u32>,
 {
 	/// Try and append the given item to the map in the storage.

--- a/frame/support/src/storage/types/value.rs
+++ b/frame/support/src/storage/types/value.rs
@@ -21,7 +21,7 @@ use codec::{FullCodec, Decode, EncodeLike, Encode};
 use crate::{
 	storage::{
 		StorageAppend, StorageDecodeLength,
-		bounded_vec::{BoundedVec, BoundedVecValue},
+		bounded_vec::BoundedVec,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
 	traits::{GetDefault, StorageInstance, Get},
@@ -67,7 +67,7 @@ where
 	Prefix: StorageInstance,
 	QueryKind: QueryKindTrait<BoundedVec<VecValue, VecBound>, OnEmpty>,
 	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
-	VecValue: BoundedVecValue,
+	VecValue: FullCodec,
 	VecBound: Get<u32>,
 {
 	/// Try and append the given item to the value in the storage.


### PR DESCRIPTION
A normal `Vec<T>` can do many things without any particular trait
bounds on `T`. This PR relaxes the bounds on `BoundedVec<T, S>`
to give it similar capabilities.