### PR TITLE
pow: fix docs on mining worker

### DIFF
--- a/client/consensus/pow/README.md
+++ b/client/consensus/pow/README.md
@@ -5,8 +5,8 @@ To use this engine, you can need to have a struct that implements
 with other necessary client references to `import_queue` to setup
 the queue.
 
-This library also comes with an async miner worker, which can be
-started via the `start_miner_worker` function. It returns a worker
+This library also comes with an async mining worker, which can be
+started via the `start_mining_worker` function. It returns a worker
 handle together with a future. The future must be pulled. Through
 the worker handle, you can pull the metadata needed to start the
 mining process via `MiningWorker::metadata`, and then do the actual

--- a/client/consensus/pow/README.md
+++ b/client/consensus/pow/README.md
@@ -3,7 +3,15 @@ Proof of work consensus for Substrate.
 To use this engine, you can need to have a struct that implements
 `PowAlgorithm`. After that, pass an instance of the struct, along
 with other necessary client references to `import_queue` to setup
-the queue. Use the `start_mine` function for basic CPU mining.
+the queue.
+
+This library also comes with an async miner worker, which can be
+started via the `start_miner_worker` function. It returns a worker
+handle together with a future. The future must be pulled. Through
+the worker handle, you can pull the metadata needed to start the
+mining process via `MiningWorker::metadata`, and then do the actual
+mining on a standalone thread. Finally, when a seal is found, call
+`MiningWorker::submit` to build the block.
 
 The auxiliary storage for PoW engine only stores the total difficulty.
 For other storage requirements for particular PoW algorithm (such as

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -23,8 +23,8 @@
 //! with other necessary client references to `import_queue` to setup
 //! the queue.
 //!
-//! This library also comes with an async miner worker, which can be
-//! started via the `start_miner_worker` function. It returns a worker
+//! This library also comes with an async mining worker, which can be
+//! started via the `start_mining_worker` function. It returns a worker
 //! handle together with a future. The future must be pulled. Through
 //! the worker handle, you can pull the metadata needed to start the
 //! mining process via `MiningWorker::metadata`, and then do the actual

--- a/client/consensus/pow/src/lib.rs
+++ b/client/consensus/pow/src/lib.rs
@@ -21,7 +21,15 @@
 //! To use this engine, you can need to have a struct that implements
 //! `PowAlgorithm`. After that, pass an instance of the struct, along
 //! with other necessary client references to `import_queue` to setup
-//! the queue. Use the `start_mine` function for basic CPU mining.
+//! the queue.
+//!
+//! This library also comes with an async miner worker, which can be
+//! started via the `start_miner_worker` function. It returns a worker
+//! handle together with a future. The future must be pulled. Through
+//! the worker handle, you can pull the metadata needed to start the
+//! mining process via `MiningWorker::metadata`, and then do the actual
+//! mining on a standalone thread. Finally, when a seal is found, call
+//! `MiningWorker::submit` to build the block.
 //!
 //! The auxiliary storage for PoW engine only stores the total difficulty.
 //! For other storage requirements for particular PoW algorithm (such as


### PR DESCRIPTION
When the mining functionality was made async, the function name is changed from `start_mining` to `start_mining_worker`.