### PR TITLE
Remove unneeded trait bounds

### DIFF
--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -202,11 +202,7 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 		pub struct RuntimeApi {}
 		/// Implements all runtime apis for the client side.
 		#[cfg(any(feature = "std", test))]
-		pub struct RuntimeApiImpl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block> + 'static>
-			where
-				// Rust bug: https://github.com/rust-lang/rust/issues/24159
-				C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
-		{
+		pub struct RuntimeApiImpl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block> + 'static> {
 			call: &'static C,
 			commit_on_success: std::cell::RefCell<bool>,
 			initialized_block: std::cell::RefCell<Option<#crate_::BlockId<Block>>>,
@@ -223,25 +219,16 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 		#[cfg(any(feature = "std", test))]
 		unsafe impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> Send
 			for RuntimeApiImpl<Block, C>
-				where
-					// Rust bug: https://github.com/rust-lang/rust/issues/24159
-					C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
 		{}
 
 		#[cfg(any(feature = "std", test))]
 		unsafe impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> Sync
 			for RuntimeApiImpl<Block, C>
-				where
-					// Rust bug: https://github.com/rust-lang/rust/issues/24159
-					C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
 		{}
 
 		#[cfg(any(feature = "std", test))]
 		impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> #crate_::ApiExt<Block> for
 			RuntimeApiImpl<Block, C>
-				where
-					// Rust bug: https://github.com/rust-lang/rust/issues/24159
-					C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
 		{
 			type StateBackend = C::StateBackend;
 
@@ -319,8 +306,6 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 			for RuntimeApi
 				where
 					C: #crate_::CallApiAt<Block> + 'static,
-					// Rust bug: https://github.com/rust-lang/rust/issues/24159
-					C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
 		{
 			type RuntimeApi = RuntimeApiImpl<Block, C>;
 
@@ -339,11 +324,7 @@ fn generate_runtime_api_base_structures() -> Result<TokenStream> {
 		}
 
 		#[cfg(any(feature = "std", test))]
-		impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> RuntimeApiImpl<Block, C>
-			where
-				// Rust bug: https://github.com/rust-lang/rust/issues/24159
-				C::StateBackend: #crate_::StateBackend<#crate_::HashFor<Block>>,
-		{
+		impl<Block: #crate_::BlockT, C: #crate_::CallApiAt<Block>> RuntimeApiImpl<Block, C> {
 			fn call_api_at<
 				R: #crate_::Encode + #crate_::Decode + PartialEq,
 				F: FnOnce(

--- a/test-utils/runtime/client/src/block_builder_ext.rs
+++ b/test-utils/runtime/client/src/block_builder_ext.rs
@@ -20,7 +20,6 @@
 use sp_api::{ApiExt, ProvideRuntimeApi};
 use sp_core::ChangesTrieConfiguration;
 use sc_client_api::backend;
-use sp_runtime::traits::HashFor;
 
 use sc_block_builder::BlockBuilderApi;
 
@@ -49,9 +48,6 @@ impl<'a, A, B> BlockBuilderExt for sc_block_builder::BlockBuilder<'a, substrate_
 			StateBackend = backend::StateBackendFor<B, substrate_test_runtime::Block>
 		>,
 	B: backend::Backend<substrate_test_runtime::Block>,
-	// Rust bug: https://github.com/rust-lang/rust/issues/24159
-	backend::StateBackendFor<B, substrate_test_runtime::Block>:
-		sp_api::StateBackend<HashFor<substrate_test_runtime::Block>>,
 {
 	fn push_transfer(&mut self, transfer: substrate_test_runtime::Transfer) -> Result<(), sp_blockchain::Error> {
 		self.push(transfer.into_signed_tx())

--- a/test-utils/runtime/client/src/lib.rs
+++ b/test-utils/runtime/client/src/lib.rs
@@ -249,9 +249,6 @@ impl<B> TestClientBuilderExt<B> for TestClientBuilder<
 	B
 > where
 	B: sc_client_api::backend::Backend<substrate_test_runtime::Block> + 'static,
-	// Rust bug: https://github.com/rust-lang/rust/issues/24159
-	<B as sc_client_api::backend::Backend<substrate_test_runtime::Block>>::State:
-		sp_api::StateBackend<HashFor<substrate_test_runtime::Block>>,
 {
 	fn genesis_init_mut(&mut self) -> &mut GenesisParameters {
 		Self::genesis_init_mut(self)

--- a/test-utils/runtime/client/src/trait_tests.rs
+++ b/test-utils/runtime/client/src/trait_tests.rs
@@ -30,16 +30,13 @@ use sc_client_api::blockchain::{Backend as BlockChainBackendT, HeaderBackend};
 use sp_consensus::BlockOrigin;
 use substrate_test_runtime::{self, Transfer};
 use sp_runtime::generic::BlockId;
-use sp_runtime::traits::{Block as BlockT, HashFor};
+use sp_runtime::traits::Block as BlockT;
 use sc_block_builder::BlockBuilderProvider;
 use futures::executor::block_on;
 
 /// helper to test the `leaves` implementation for various backends
 pub fn test_leaves_for_backend<B: 'static>(backend: Arc<B>) where
 	B: backend::Backend<substrate_test_runtime::Block>,
-	// Rust bug: https://github.com/rust-lang/rust/issues/24159
-	backend::StateBackendFor<B, substrate_test_runtime::Block>:
-		sp_api::StateBackend<HashFor<substrate_test_runtime::Block>>,
 {
 	// block tree:
 	// G -> A1 -> A2 -> A3 -> A4 -> A5
@@ -206,9 +203,6 @@ pub fn test_leaves_for_backend<B: 'static>(backend: Arc<B>) where
 /// helper to test the `children` implementation for various backends
 pub fn test_children_for_backend<B: 'static>(backend: Arc<B>) where
 	B: backend::LocalBackend<substrate_test_runtime::Block>,
-	// Rust bug: https://github.com/rust-lang/rust/issues/24159
-	<B as backend::Backend<substrate_test_runtime::Block>>::State:
-		sp_api::StateBackend<HashFor<substrate_test_runtime::Block>>,
 {
 	// block tree:
 	// G -> A1 -> A2 -> A3 -> A4 -> A5
@@ -334,11 +328,9 @@ pub fn test_children_for_backend<B: 'static>(backend: Arc<B>) where
 	assert_eq!(vec![b3.hash(), c3.hash()], children4);
 }
 
-pub fn test_blockchain_query_by_number_gets_canonical<B: 'static>(backend: Arc<B>) where
+pub fn test_blockchain_query_by_number_gets_canonical<B: 'static>(backend: Arc<B>)
+where
 	B: backend::LocalBackend<substrate_test_runtime::Block>,
-	// Rust bug: https://github.com/rust-lang/rust/issues/24159
-	<B as backend::Backend<substrate_test_runtime::Block>>::State:
-		sp_api::StateBackend<HashFor<substrate_test_runtime::Block>>,
 {
 	// block tree:
 	// G -> A1 -> A2 -> A3 -> A4 -> A5


### PR DESCRIPTION
Before we required these trait bounds because of some bug in rustc, but
now as this bug is fixed they can be removed.
