### PR TITLE
Two bugfixes to authority-discovery

### DIFF
--- a/client/authority-discovery/src/worker/addr_cache.rs
+++ b/client/authority-discovery/src/worker/addr_cache.rs
@@ -42,10 +42,6 @@ impl AddrCache {
 	/// Inserts the given [`AuthorityId`] and [`Vec<Multiaddr>`] pair for future lookups by
 	/// [`AuthorityId`] or [`PeerId`].
 	pub fn insert(&mut self, authority_id: AuthorityId, mut addresses: Vec<Multiaddr>) {
-		if addresses.is_empty() {
-			return;
-		}
-
 		addresses.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
 
 		// Insert into `self.peer_id_to_authority_id`.
@@ -80,8 +76,7 @@ impl AddrCache {
 			};
 
 			if !peer_ids.clone().any(|p| p == peer_id) {
-				let _old_auth = self.peer_id_to_authority_id.remove(&peer_id);
-				debug_assert!(_old_auth.is_some());
+				self.peer_id_to_authority_id.remove(&peer_id);
 			}
 		}
 	}


### PR DESCRIPTION
Two bugfixes:

- When `addresses` is empty, we shouldn't just return at the beginning, as we need to erase the previous addresses. `insert` is really `insert_or_replace`, similar to what `HashMap::insert` does. Inserting `Vec::new()` should remove the previous value.

- When an authority says it has a certain `PeerId`, we remove that `PeerId` from any previous authority. If this previous authority had multiple addresses (with the same `PeerId`) we will call `self.peer_id_to_authority_id.remove(&peer_id)` multiple times with the same value in `peer_id`. This is fine, but the debug assert just below (`debug_assert!(_old_auth.is_some());`) is wrong, as it will fail the second time.

Fix https://github.com/paritytech/polkadot/issues/2998
