### PR TITLE
Increase the number of external IPs in cache

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -71,7 +71,7 @@ use sp_core::hexdisplay::HexDisplay;
 /// Maximum number of known external addresses that we will cache.
 /// This only affects whether we will log whenever we (re-)discover
 /// a given address.
-const MAX_KNOWN_EXTERNAL_ADDRESSES: usize = 32;
+const MAX_KNOWN_EXTERNAL_ADDRESSES: usize = 64;
 
 /// `DiscoveryBehaviour` configuration.
 ///


### PR DESCRIPTION
Fix #2997

When we detect a new external IP address, we print a message saying "Discovered new external IP address for our node".

This external IP address is kept in a list internally within rust-libp2p, where a small minigame keeps the addresses that are the most reported and kicks out addresses that haven't been reported for a long time.
Because of this small minigame, addresses constantly kick each other out.

In order to avoid re-printing the message over and over again, we actually maintain a separate cache, in Substrate, of the addresses that have been reported to the user. This is the `known_external_addresses` field.
This variable exists just to not spam the users with the same IP multiple times.
However, it seems that users are still getting spammed, so this PR increases the size of this cache.
