### PR TITLE
Make Allocator trait pub

### DIFF
--- a/primitives/io/src/lib.rs
+++ b/primitives/io/src/lib.rs
@@ -1051,7 +1051,7 @@ pub trait Offchain {
 
 /// Wasm only interface that provides functions for calling into the allocator.
 #[runtime_interface(wasm_only)]
-trait Allocator {
+pub trait Allocator {
 	/// Malloc the given number of bytes and return the pointer to the allocated memory location.
 	fn malloc(&mut self, size: u32) -> Pointer<u8> {
 		self.allocate_memory(size).expect("Failed to allocate memory")


### PR DESCRIPTION
We need this in order to be able to assemble more fine grained host
function sets.

E.g. we don't want to use `SubstrateHostFunctions` for PVF. We would
better whitelist certain host functions. However, we cannot do that
because we cannot refer to the `Allocator` runtime interface.

I have not been able to find the reason why it wasn't made `pub` in the
first place, but do not see any reason why not to.
