### PR TITLE
Don't remove addresses from known_external_addresses

### DIFF
--- a/client/network/src/discovery.rs
+++ b/client/network/src/discovery.rs
@@ -71,7 +71,7 @@ use sp_core::hexdisplay::HexDisplay;
 /// Maximum number of known external addresses that we will cache.
 /// This only affects whether we will log whenever we (re-)discover
 /// a given address.
-const MAX_KNOWN_EXTERNAL_ADDRESSES: usize = 64;
+const MAX_KNOWN_EXTERNAL_ADDRESSES: usize = 32;
 
 /// `DiscoveryBehaviour` configuration.
 ///
@@ -574,9 +574,8 @@ impl NetworkBehaviour for DiscoveryBehaviour {
 	}
 
 	fn inject_expired_external_addr(&mut self, addr: &Multiaddr) {
-		let with_peer_id = addr.clone()
-			.with(Protocol::P2p(self.local_peer_id.clone().into()));
-		self.known_external_addresses.remove(&with_peer_id);
+		// We intentionally don't remove the element from `known_external_addresses` in order
+		// to not print the log line again.
 
 		for k in self.kademlias.values_mut() {
 			NetworkBehaviour::inject_expired_external_addr(k, addr)

--- a/client/network/src/utils.rs
+++ b/client/network/src/utils.rs
@@ -59,11 +59,6 @@ impl<T: Hash + Eq> LruHashSet<T> {
 		}
 		false
 	}
-
-	/// Removes an element from the set if it is present.
-	pub fn remove(&mut self, e: &T) -> bool {
-		self.set.remove(e)
-	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This does https://github.com/paritytech/substrate/pull/8771 but differently.

I realized after merging https://github.com/paritytech/substrate/pull/8771 that it wasn't the correct fix.
The problem is that we remove entries from `known_external_addresses` when an address is considered expired. Addresses can become "expired" if they are replaced with another address.