### PR TITLE
Revert Changes: InspectKeyCmd back to InspectCmd where appropriate

### DIFF
--- a/bin/node/cli/src/cli.rs
+++ b/bin/node/cli/src/cli.rs
@@ -41,7 +41,7 @@ pub enum Subcommand {
 		name = "inspect",
 		about = "Decode given block or extrinsic using current native runtime."
 	)]
-	Inspect(node_inspect::cli::InspectKeyCmd),
+	Inspect(node_inspect::cli::InspectCmd),
 
 	/// The custom benchmark subcommmand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]

--- a/bin/node/inspect/src/cli.rs
+++ b/bin/node/inspect/src/cli.rs
@@ -24,7 +24,7 @@ use structopt::StructOpt;
 
 /// The `inspect` command used to print decoded chain data.
 #[derive(Debug, StructOpt)]
-pub struct InspectKeyCmd {
+pub struct InspectCmd {
 	#[allow(missing_docs)]
 	#[structopt(flatten)]
 	pub command: InspectSubCmd,

--- a/bin/node/inspect/src/command.rs
+++ b/bin/node/inspect/src/command.rs
@@ -18,14 +18,14 @@
 
 //! Command ran by the CLI
 
-use crate::cli::{InspectKeyCmd, InspectSubCmd};
+use crate::cli::{InspectCmd, InspectSubCmd};
 use crate::Inspector;
 use sc_cli::{CliConfiguration, ImportParams, Result, SharedParams};
 use sc_service::{new_full_client, Configuration, NativeExecutionDispatch};
 use sp_runtime::traits::Block;
 use std::str::FromStr;
 
-impl InspectKeyCmd {
+impl InspectCmd {
 	/// Run the inspect command, passing the inspector.
 	pub fn run<B, RA, EX>(&self, config: Configuration) -> Result<()>
 	where
@@ -54,7 +54,7 @@ impl InspectKeyCmd {
 	}
 }
 
-impl CliConfiguration for InspectKeyCmd {
+impl CliConfiguration for InspectCmd {
 	fn shared_params(&self) -> &SharedParams {
 		&self.shared_params
 	}


### PR DESCRIPTION
#8678 introduced an error renaming a struct to `InspectKeyCmd` incorrectly, this brings it back to `InspectCmd`

The struct is internal only, so no version bump or release notes are needed (I think?) 

This introduced [an issue](https://github.com/paritytech/parity-bridges-common/pull/958#discussion_r626059296) upstream that this PR will correct.

> So we'll need a Substrate PR to revert the changes, and then a PR which bumps Substrate in this repo (and in that PR changes the name back)

