### PR TITLE
grandpa: fix warp sync proof on missing data

### DIFF
--- a/client/finality-grandpa-warp-sync/src/lib.rs
+++ b/client/finality-grandpa-warp-sync/src/lib.rs
@@ -173,4 +173,6 @@ pub enum HandleRequestError {
 	InvalidProof(String),
 	#[display(fmt = "Failed to send response.")]
 	SendResponse,
+	#[display(fmt = "Missing required data to be able to answer request.")]
+	MissingData,
 }

--- a/client/finality-grandpa-warp-sync/src/proof.rs
+++ b/client/finality-grandpa-warp-sync/src/proof.rs
@@ -91,7 +91,10 @@ impl<Block: BlockT> WarpSyncProof<Block> {
 		let mut proofs_encoded_len = 0;
 		let mut proof_limit_reached = false;
 
-		for (_, last_block) in set_changes.iter_from(begin_number) {
+		let set_changes = set_changes.iter_from(begin_number)
+			.ok_or(HandleRequestError::MissingData)?;
+
+		for (_, last_block) in set_changes {
 			let header = blockchain.header(BlockId::Number(*last_block))?.expect(
 				"header number comes from previously applied set changes; must exist in db; qed.",
 			);


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/7339 introduced a new client-side auxiliary mapping from `set_id -> block_number`, this mapping is used when generating warp sync proofs. Since this code was added recently, nodes that didn't sync from scratch don't have it fully populated, in which case we need to detect it and avoid generating a warp sync proof when we have missing data.