### PR TITLE
[rpc]: enable all unsafe calls

### DIFF
--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -267,8 +267,8 @@ impl<Block, Client> State<Block, Client>
 		})?;
 
 		ctx_module.register_method("state_getMetadata", |params, state| {
-			let block = params.one().map_err(|_| JsonRpseeCallError::InvalidParams)?;
-			futures::executor::block_on(state.backend.metadata(block))
+			let maybe_block = params.one().ok();
+			futures::executor::block_on(state.backend.metadata(maybe_block))
 				.map_err(|e| to_jsonrpsee_call_error(e))
 		})?;
 

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -736,7 +736,7 @@ fn init_telemetry<TBl: BlockT, TCl: BlockBackend<TBl>>(
 // Maciej: This is very WIP, mocking the original `gen_handler`. All of the `jsonrpsee`
 // specific logic should be merged back to `gen_handler` down the road.
 fn gen_rpc_module<TBl, TBackend, TCl, TExPool>(
-	deny_unsafe: sc_rpc::DenyUnsafe,
+	_deny_unsafe: sc_rpc::DenyUnsafe,
 	spawn_handle: SpawnTaskHandle,
 	client: Arc<TCl>,
 	on_demand: Option<Arc<OnDemand<TBl>>>,
@@ -758,6 +758,8 @@ fn gen_rpc_module<TBl, TBackend, TCl, TExPool>(
 			sp_api::Metadata<TBl>,
 		TExPool: MaintainedTransactionPool<Block=TBl, Hash = <TBl as BlockT>::Hash> + 'static,
 {
+	// TODO(niklasad1): expose CORS to jsonrpsee to handle this propely.
+	let deny_unsafe = sc_rpc::DenyUnsafe::No;
 
 	let system_info = sc_rpc::system::SystemInfo {
 		chain_name: config.chain_spec.name().into(),


### PR DESCRIPTION
jsonrpsee ws server doesn't expose `CORS`yet let's allow for testing and so on.
