### PR TITLE
Extends ChildStateBackend and ChildStateAPI with ReadProofs

### DIFF
--- a/client/rpc-api/src/child_state/mod.rs
+++ b/client/rpc-api/src/child_state/mod.rs
@@ -76,6 +76,6 @@ pub trait ChildStateApi<Hash> {
 		&self,
 		child_storage_key: PrefixedStorageKey,
 		keys: Vec<StorageKey>,
-		hash: Option<Hash>
+		hash: Option<Hash>,
 	) -> FutureResult<ReadProof<Hash>>;
 }

--- a/client/rpc-api/src/child_state/mod.rs
+++ b/client/rpc-api/src/child_state/mod.rs
@@ -23,6 +23,7 @@ use sp_core::storage::{StorageKey, PrefixedStorageKey, StorageData};
 use crate::state::error::FutureResult;
 
 pub use self::gen_client::Client as ChildStateClient;
+use crate::state::ReadProof;
 
 /// Substrate child state API
 ///
@@ -68,4 +69,13 @@ pub trait ChildStateApi<Hash> {
 		key: StorageKey,
 		hash: Option<Hash>
 	) -> FutureResult<Option<u64>>;
+
+	/// Returns proof of storage for child key entries at a specific block's state.
+	#[rpc(name = "state_getChildReadProof")]
+	fn read_child_proof(
+		&self,
+		child_storage_key: PrefixedStorageKey,
+		keys: Vec<StorageKey>,
+		hash: Option<Hash>
+	) -> FutureResult<ReadProof<Hash>>;
 }

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -382,6 +382,14 @@ pub trait ChildStateBackend<Block: BlockT, Client>: Send + Sync + 'static
 		Block: BlockT + 'static,
 		Client: Send + Sync + 'static,
 {
+	/// Returns proof of storage for a child key entries at a specific block's state.
+	fn read_child_proof(
+		&self,
+		block: Option<Block::Hash>,
+		storage_key: PrefixedStorageKey,
+		keys: Vec<StorageKey>,
+	) -> FutureResult<ReadProof<Block::Hash>>;
+
 	/// Returns the keys with prefix from a child storage,
 	/// leave prefix empty to get all the keys.
 	fn storage_keys(
@@ -431,6 +439,15 @@ impl<Block, Client> ChildStateApi<Block::Hash> for ChildState<Block, Client>
 {
 	type Metadata = crate::Metadata;
 
+	fn read_child_proof(
+		&self,
+		child_storage_key: PrefixedStorageKey,
+		keys: Vec<StorageKey>,
+		block: Option<Block::Hash>,
+	) -> FutureResult<ReadProof<Block::Hash>> {
+		self.backend.read_child_proof(block, child_storage_key, keys)
+	}
+
 	fn storage(
 		&self,
 		storage_key: PrefixedStorageKey,
@@ -466,6 +483,8 @@ impl<Block, Client> ChildStateApi<Block::Hash> for ChildState<Block, Client>
 	) -> FutureResult<Option<u64>> {
 		self.backend.storage_size(block, storage_key, key)
 	}
+
+
 }
 
 fn client_err(err: sp_blockchain::Error) -> Error {

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -484,7 +484,6 @@ impl<Block, Client> ChildStateApi<Block::Hash> for ChildState<Block, Client>
 		self.backend.storage_size(block, storage_key, key)
 	}
 
-
 }
 
 fn client_err(err: sp_blockchain::Error) -> Error {

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -491,6 +491,15 @@ impl<Block, F, Client> ChildStateBackend<Block, Client> for LightState<Block, F,
 		Client: BlockchainEvents<Block> + HeaderBackend<Block> + Send + Sync + 'static,
 		F: Fetcher<Block> + 'static
 {
+	fn read_child_proof(
+		&self,
+		_block: Option<Block::Hash>,
+		_storage_key: PrefixedStorageKey,
+		_keys: Vec<StorageKey>,
+	) -> FutureResult<ReadProof<Block::Hash>> {
+		Box::new(result(Err(client_err(ClientError::NotAvailableOnLightClient))))
+	}
+
 	fn storage_keys(
 		&self,
 		_block: Option<Block::Hash>,


### PR DESCRIPTION
The following changes integrate the existing `read_child_proof` from the `ProofProvider` trait into the `ChildStateBackend`. 
To allow the generation of read proofs via RPCs on full nodes, the `ChildStateApi`
is extended with `read_child_proof`.

At the moment, especially useful for parachains who want to retrieve proof of contribution for crowdloan participants.