### PR TITLE
Migrate pallet-session and session-historical to pallet attribute macro

### DIFF
--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -28,7 +28,7 @@ use sp_runtime::{
 use frame_system::InitKind;
 use frame_support::{
 	parameter_types,
-	traits::{KeyOwnerProofSystem, OnInitialize},
+	traits::{KeyOwnerProofSystem, OnInitialize, GenesisBuild},
 };
 use sp_io;
 use sp_core::{H256, U256, crypto::{IsWrappedBy, KeyTypeId, Pair}};

--- a/frame/grandpa/src/lib.rs
+++ b/frame/grandpa/src/lib.rs
@@ -598,7 +598,7 @@ impl<T: Config> OneSessionHandler<T::AccountId> for Module<T>
 
 		// if we didn't issue a change, we update the mapping to note that the current
 		// set corresponds to the latest equivalent session (i.e. now).
-		let session_index = <pallet_session::Module<T>>::current_index();
+		let session_index = <pallet_session::Pallet<T>>::current_index();
 		SetIdSession::insert(current_set_id, &session_index);
 	}
 

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -24,7 +24,7 @@ use ::grandpa as finality_grandpa;
 use codec::Encode;
 use frame_support::{
 	parameter_types,
-	traits::{KeyOwnerProofSystem, OnFinalize, OnInitialize},
+	traits::{KeyOwnerProofSystem, OnFinalize, OnInitialize, GenesisBuild},
 };
 use pallet_staking::EraIndex;
 use sp_core::{crypto::KeyTypeId, H256};

--- a/frame/session/README.md
+++ b/frame/session/README.md
@@ -72,7 +72,7 @@ The [Staking pallet](https://docs.rs/pallet-staking/latest/pallet_staking/) uses
 use pallet_session as session;
 
 fn validators<T: pallet_session::Config>() -> Vec<<T as pallet_session::Config>::ValidatorId> {
-	<pallet_session::Module<T>>::validators()
+	<pallet_session::Pallet<T>>::validators()
 }
 ```
 

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -41,7 +41,7 @@ use sp_runtime::traits::{One, StaticLookup};
 
 const MAX_VALIDATORS: u32 = 1000;
 
-pub struct Pallet<T: Config>(pallet_session::Module<T>);
+pub struct Pallet<T: Config>(pallet_session::Pallet<T>);
 pub trait Config: pallet_session::Config + pallet_session::historical::Config + pallet_staking::Config {}
 
 impl<T: Config> OnInitialize<T::BlockNumber> for Pallet<T> {

--- a/frame/session/benchmarking/src/lib.rs
+++ b/frame/session/benchmarking/src/lib.rs
@@ -32,7 +32,7 @@ use frame_support::{
 	traits::{KeyOwnerProofSystem, OnInitialize},
 };
 use frame_system::RawOrigin;
-use pallet_session::{historical::Module as Historical, Module as Session, *};
+use pallet_session::{historical::Pallet as Historical, Pallet as Session, *};
 use pallet_staking::{
 	benchmarking::create_validator_with_nominators, testing_utils::create_validators,
 	RewardDestination,
@@ -46,7 +46,7 @@ pub trait Config: pallet_session::Config + pallet_session::historical::Config + 
 
 impl<T: Config> OnInitialize<T::BlockNumber> for Pallet<T> {
 	fn on_initialize(n: T::BlockNumber) -> frame_support::weights::Weight {
-		pallet_session::Module::<T>::on_initialize(n)
+		pallet_session::Pallet::<T>::on_initialize(n)
 	}
 }
 

--- a/frame/session/src/historical/mod.rs
+++ b/frame/session/src/historical/mod.rs
@@ -46,13 +46,13 @@ pub mod onchain;
 
 #[frame_support::pallet]
 pub mod pallet {
-    use super::*;
-    use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
 	#[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
-    pub struct Pallet<T>(_);
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
 
 	/// Config necessary for the historical module.
 	#[pallet::config]
@@ -72,27 +72,24 @@ pub mod pallet {
 
 	/// Mapping from historical session indices to session-data root hash and validator count.
 	#[pallet::storage]
-    #[pallet::getter(fn historical_root)]
-	pub type HistoricalSessions<T: Config> = StorageMap<_, 
-		Twox64Concat, SessionIndex, (T::Hash, ValidatorCount)>;
+	#[pallet::getter(fn historical_root)]
+	pub type HistoricalSessions<T: Config> =
+		StorageMap<_, Twox64Concat, SessionIndex, (T::Hash, ValidatorCount)>;
 
 	/// The range of historical sessions we store. [first, last)
 	#[pallet::storage]
 	pub type StoredRange<T: Config> = StorageValue<_, (SessionIndex, SessionIndex)>;
 
 	#[pallet::storage]
-	pub type CachedObsolete<T: Config> = StorageMap<_, 
-		Twox64Concat, SessionIndex, (T::ValidatorId, T::FullIdentification)>;
+	pub type CachedObsolete<T: Config> =
+		StorageMap<_, Twox64Concat, SessionIndex, (T::ValidatorId, T::FullIdentification)>;
 
 	#[pallet::hooks]
-    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {}
-
 }
-
-
 
 impl<T: Config> Pallet<T> {
 	/// Prune historical stored session roots up to (but not including)

--- a/frame/session/src/historical/mod.rs
+++ b/frame/session/src/historical/mod.rs
@@ -81,7 +81,8 @@ pub mod pallet {
 	pub type StoredRange<T: Config> = StorageValue<_, (SessionIndex, SessionIndex)>;
 
 	#[pallet::storage]
-	pub type CachedObsolete<T: Config> = StorageMap<_, Twox64Concat, SessionIndex, (T::ValidatorId, T::FullIdentification)>;
+	pub type CachedObsolete<T: Config> = StorageMap<_, 
+		Twox64Concat, SessionIndex, (T::ValidatorId, T::FullIdentification)>;
 
 	#[pallet::hooks]
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
@@ -197,7 +198,8 @@ impl<T: Config, I> crate::SessionManager<T::ValidatorId> for NoteHistoricalRoot<
 }
 
 /// A tuple of the validator's ID and their full identification.
-pub type IdentificationTuple<T> = (<T as crate::Config>::ValidatorId, <T as Config>::FullIdentification);
+pub type IdentificationTuple<T> = (<T as crate::Config>::ValidatorId, 
+		<T as Config>::FullIdentification);
 
 /// A trie instance for checking and generating proofs.
 pub struct ProvingTrie<T: Config> {

--- a/frame/session/src/historical/mod.rs
+++ b/frame/session/src/historical/mod.rs
@@ -85,6 +85,7 @@ pub mod pallet {
 		StorageMap<_, Twox64Concat, SessionIndex, (T::ValidatorId, T::FullIdentification)>;
 
 	#[pallet::hooks]
+	/// Deprecated.
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	#[pallet::call]
@@ -362,8 +363,8 @@ pub(crate) mod tests {
 		NEXT_VALIDATORS, force_new_session,
 		set_next_validators, Test, System, Session,
 	};
-	use frame_support::traits::{KeyOwnerProofSystem, OnInitialize};
-	use frame_support::{BasicExternalities, traits::GenesisBuild};
+	use frame_support::traits::{KeyOwnerProofSystem, OnInitialize, GenesisBuild};
+	use frame_support::BasicExternalities;
 
 	type Historical = Pallet<Test>;
 

--- a/frame/session/src/historical/offchain.rs
+++ b/frame/session/src/historical/offchain.rs
@@ -143,7 +143,7 @@ mod tests {
 		force_new_session, set_next_validators, Session, System, Test, NEXT_VALIDATORS,
 	};
 	use codec::Encode;
-	use frame_support::traits::{KeyOwnerProofSystem, OnInitialize};
+	use frame_support::traits::{KeyOwnerProofSystem, OnInitialize, GenesisBuild};
 	use sp_core::crypto::key_types::DUMMY;
 	use sp_core::offchain::{
 		testing::TestOffchainExt,
@@ -153,7 +153,7 @@ mod tests {
 	};
 
 	use sp_runtime::testing::UintAuthorityId;
-	use frame_support::{BasicExternalities, traits::GenesisBuild};
+	use frame_support::BasicExternalities;
 
 	type Historical = Pallet<Test>;
 

--- a/frame/session/src/historical/offchain.rs
+++ b/frame/session/src/historical/offchain.rs
@@ -137,7 +137,7 @@ pub fn keep_newest<T: Config>(n_to_keep: usize) {
 
 #[cfg(test)]
 mod tests {
-	use super::super::{onchain, Module};
+	use super::super::{onchain, Pallet};
 	use super::*;
 	use crate::mock::{
 		force_new_session, set_next_validators, Session, System, Test, NEXT_VALIDATORS,
@@ -153,9 +153,9 @@ mod tests {
 	};
 
 	use sp_runtime::testing::UintAuthorityId;
-	use frame_support::BasicExternalities;
+	use frame_support::{BasicExternalities, traits::GenesisBuild};
 
-	type Historical = Module<Test>;
+	type Historical = Pallet<Test>;
 
 	pub fn new_test_ext() -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default()

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -490,11 +490,13 @@ pub mod pallet {
     					session config keys to generate initial validator set.");
     				self.keys.iter().map(|x| x.1.clone()).collect()
     			});
-    		assert!(!initial_validators_0.is_empty(), "Empty validator set for session 0 in genesis block!");
+    		assert!(!initial_validators_0.is_empty(), 
+				"Empty validator set for session 0 in genesis block!");
 
     		let initial_validators_1 = T::SessionManager::new_session(1)
     			.unwrap_or_else(|| initial_validators_0.clone());
-    		assert!(!initial_validators_1.is_empty(), "Empty validator set for session 1 in genesis block!");
+    		assert!(!initial_validators_1.is_empty(), 
+				"Empty validator set for session 1 in genesis block!");
 
     		let queued_keys: Vec<_> = initial_validators_1
     			.iter()

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -15,14 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Session Module
+//! # Session Pallet
 //!
-//! The Session module allows validators to manage their session keys, provides a function for
+//! The Session Pallet allows validators to manage their session keys, provides a function for
 //! changing the session length, and handles session rotation.
 //!
 //! - [`Config`]
 //! - [`Call`]
-//! - [`Module`]
+//! - [`Pallet`]
 //!
 //! ## Overview
 //!
@@ -95,12 +95,12 @@
 //! use pallet_session as session;
 //!
 //! fn validators<T: pallet_session::Config>() -> Vec<<T as pallet_session::Config>::ValidatorId> {
-//! <pallet_session::Module<T>>::validators()
+//! <pallet_session::Pallet<T>>::validators()
 //! }
 //! # fn main(){}
 //! ```
 //!
-//! ## Related Modules
+//! ## Related Pallets
 //!
 //! - [Staking](../pallet_staking/index.html)
 
@@ -122,7 +122,7 @@ use sp_runtime::{
 };
 use sp_staking::SessionIndex;
 use frame_support::{
-	ensure, decl_module, decl_event, decl_storage, decl_error, ConsensusEngineId, Parameter,
+	ensure, ConsensusEngineId, Parameter,
 	traits::{
 		Get, FindAuthor, ValidatorRegistration, EstimateNextSessionRotation, EstimateNextNewSession,
 		OneSessionHandler, ValidatorSet,
@@ -132,6 +132,7 @@ use frame_support::{
 };
 use frame_system::ensure_signed;
 pub use weights::WeightInfo;
+pub use pallet::*;
 
 /// Decides whether the session should be ended.
 pub trait ShouldEndSession<BlockNumber> {
@@ -228,7 +229,7 @@ pub trait SessionManager<ValidatorId> {
 	///
 	/// Even if the validator-set is the same as before, if any underlying economic conditions have
 	/// changed (i.e. stake-weights), the new validator set must be returned. This is necessary for
-	/// consensus engines making use of the session module to issue a validator-set change so
+	/// consensus engines making use of the session Pallet to issue a validator-set change so
 	/// misbehavior can be provably associated with the new economic conditions as opposed to the
 	/// old. The returned validator set, if any, will not be applied until `new_index`. `new_index`
 	/// is strictly greater than from previous call.
@@ -270,7 +271,7 @@ pub trait SessionHandler<ValidatorId> {
 	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(ValidatorId, Ks)]);
 
 	/// Session set has changed; act appropriately. Note that this can be called
-	/// before initialization of your module.
+	/// before initialization of your Pallet.
 	///
 	/// `changed` is true whenever any of the session keys or underlying economic
 	/// identities or weightings behind those keys has changed.
@@ -350,234 +351,275 @@ impl<AId> SessionHandler<AId> for TestSessionHandler {
 	fn on_disabled(_: usize) {}
 }
 
-impl<T: Config> ValidatorRegistration<T::ValidatorId> for Module<T> {
+impl<T: Config> ValidatorRegistration<T::ValidatorId> for Pallet<T> {
 	fn is_registered(id: &T::ValidatorId) -> bool {
 		Self::load_keys(id).is_some()
 	}
 }
 
-pub trait Config: frame_system::Config {
-	/// The overarching event type.
-	type Event: From<Event> + Into<<Self as frame_system::Config>::Event>;
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
 
-	/// A stable ID for a validator.
-	type ValidatorId: Member + Parameter;
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(_);
 
-	/// A conversion from account ID to validator ID.
-	///
-	/// Its cost must be at most one storage read.
-	type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
+    /// The pallet's config trait.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The overarching event type.
+        type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 
-	/// Indicator for when to end the session.
-	type ShouldEndSession: ShouldEndSession<Self::BlockNumber>;
+        /// A stable ID for a validator.
+        type ValidatorId: Member + Parameter + MaybeSerializeDeserialize;
 
-	/// Something that can predict the next session rotation. This should typically come from the
-	/// same logical unit that provides [`ShouldEndSession`], yet, it gives a best effort estimate.
-	/// It is helpful to implement [`EstimateNextNewSession`].
-	type NextSessionRotation: EstimateNextSessionRotation<Self::BlockNumber>;
+        /// A conversion from account ID to validator ID.
+        ///
+        /// Its cost must be at most one storage read.
+        type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
 
-	/// Handler for managing new session.
-	type SessionManager: SessionManager<Self::ValidatorId>;
+        /// Indicator for when to end the session.
+        type ShouldEndSession: ShouldEndSession<Self::BlockNumber>;
 
-	/// Handler when a session has changed.
-	type SessionHandler: SessionHandler<Self::ValidatorId>;
+        /// Something that can predict the next session rotation. This should typically come from the
+        /// same logical unit that provides [`ShouldEndSession`], yet, it gives a best effort estimate.
+        /// It is helpful to implement [`EstimateNextNewSession`].
+        type NextSessionRotation: EstimateNextSessionRotation<Self::BlockNumber>;
 
-	/// The keys.
-	type Keys: OpaqueKeys + Member + Parameter + Default;
+        /// Handler for managing new session.
+        type SessionManager: SessionManager<Self::ValidatorId>;
 
-	/// The fraction of validators set that is safe to be disabled.
-	///
-	/// After the threshold is reached `disabled` method starts to return true,
-	/// which in combination with `pallet_staking` forces a new era.
-	type DisabledValidatorsThreshold: Get<Perbill>;
+        /// Handler when a session has changed.
+        type SessionHandler: SessionHandler<Self::ValidatorId>;
 
-	/// Weight information for extrinsics in this pallet.
-	type WeightInfo: WeightInfo;
-}
+        /// The keys.
+        type Keys: OpaqueKeys + Member + Parameter + Default + MaybeSerializeDeserialize;
 
-decl_storage! {
-	trait Store for Module<T: Config> as Session {
-		/// The current set of validators.
-		Validators get(fn validators): Vec<T::ValidatorId>;
+        /// The fraction of validators set that is safe to be disabled.
+        ///
+        /// After the threshold is reached `disabled` method starts to return true,
+        /// which in combination with `pallet_staking` forces a new era.
+        type DisabledValidatorsThreshold: Get<Perbill>;
 
-		/// Current index of the session.
-		CurrentIndex get(fn current_index): SessionIndex;
+        /// Weight information for extrinsics in this pallet.
+        type WeightInfo: WeightInfo;
+    }
 
-		/// True if the underlying economic identities or weighting behind the validators
-		/// has changed in the queued validator set.
-		QueuedChanged: bool;
+    /// The current set of validators.
+    #[pallet::storage]
+    #[pallet::getter(fn validators)]
+    pub type Validators<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
-		/// The queued keys for the next session. When the next session begins, these keys
-		/// will be used to determine the validator's session keys.
-		QueuedKeys get(fn queued_keys): Vec<(T::ValidatorId, T::Keys)>;
+    /// Current index of the session.
+    #[pallet::storage]
+    #[pallet::getter(fn current_index)]
+    pub type CurrentIndex<T: Config> = StorageValue<_, SessionIndex, ValueQuery>;
 
-		/// Indices of disabled validators.
-		///
-		/// The set is cleared when `on_session_ending` returns a new set of identities.
-		DisabledValidators get(fn disabled_validators): Vec<u32>;
+    /// True if the underlying economic identities or weighting behind the validators
+    /// has changed in the queued validator set.
+    #[pallet::storage]
+    pub type QueuedChanged<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-		/// The next session keys for a validator.
-		NextKeys: map hasher(twox_64_concat) T::ValidatorId => Option<T::Keys>;
+    /// The queued keys for the next session. When the next session begins, these keys
+    /// will be used to determine the validator's session keys.
+    #[pallet::storage]
+    #[pallet::getter(fn queued_keys)]
+    pub type QueuedKeys<T: Config> = StorageValue<_, Vec<(T::ValidatorId, T::Keys)>, ValueQuery>;
 
-		/// The owner of a key. The key is the `KeyTypeId` + the encoded key.
-		KeyOwner: map hasher(twox_64_concat) (KeyTypeId, Vec<u8>) => Option<T::ValidatorId>;
+    /// Indices of disabled validators.
+    ///
+    /// The set is cleared when `on_session_ending` returns a new set of identities.
+    #[pallet::storage]
+    #[pallet::getter(fn disabled_validators)]
+    pub type DisabledValidators<T: Config> = StorageValue<_, Vec<u32>, ValueQuery>;
+
+    /// The next session keys for a validator.
+    #[pallet::storage]
+    pub type NextKeys<T: Config> = StorageMap<_, Twox64Concat, T::ValidatorId, T::Keys>;
+
+    /// The owner of a key. The key is the `KeyTypeId` + the encoded key.
+    #[pallet::storage]
+    pub type KeyOwner<T: Config> =
+        StorageMap<_, Twox64Concat, (KeyTypeId, Vec<u8>), T::ValidatorId>;
+
+    #[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		pub keys : Vec<(T::AccountId, T::ValidatorId, T::Keys)>,
 	}
-	add_extra_genesis {
-		config(keys): Vec<(T::AccountId, T::ValidatorId, T::Keys)>;
-		build(|config: &GenesisConfig<T>| {
-			if T::SessionHandler::KEY_TYPE_IDS.len() != T::Keys::key_ids().len() {
-				panic!("Number of keys in session handler and session keys does not match");
-			}
 
-			T::SessionHandler::KEY_TYPE_IDS.iter().zip(T::Keys::key_ids()).enumerate()
-				.for_each(|(i, (sk, kk))| {
-					if sk != kk {
-						panic!(
-							"Session handler and session key expect different key type at index: {}",
-							i,
-						);
-					}
-				});
-
-			for (account, val, keys) in config.keys.iter().cloned() {
-				<Module<T>>::inner_set_keys(&val, keys)
-					.expect("genesis config must not contain duplicates; qed");
-				assert!(
-					frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
-					"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
-					account,
-				);
-			}
-
-			let initial_validators_0 = T::SessionManager::new_session(0)
-				.unwrap_or_else(|| {
-					frame_support::print("No initial validator provided by `SessionManager`, use \
-						session config keys to generate initial validator set.");
-					config.keys.iter().map(|x| x.1.clone()).collect()
-				});
-			assert!(!initial_validators_0.is_empty(), "Empty validator set for session 0 in genesis block!");
-
-			let initial_validators_1 = T::SessionManager::new_session(1)
-				.unwrap_or_else(|| initial_validators_0.clone());
-			assert!(!initial_validators_1.is_empty(), "Empty validator set for session 1 in genesis block!");
-
-			let queued_keys: Vec<_> = initial_validators_1
-				.iter()
-				.cloned()
-				.map(|v| (
-					v.clone(),
-					<Module<T>>::load_keys(&v).unwrap_or_default(),
-				))
-				.collect();
-
-			// Tell everyone about the genesis session keys
-			T::SessionHandler::on_genesis_session::<T::Keys>(&queued_keys);
-
-			<Validators<T>>::put(initial_validators_0);
-			<QueuedKeys<T>>::put(queued_keys);
-
-			T::SessionManager::start_session(0);
-		});
-	}
-}
-
-decl_event!(
-	pub enum Event {
-		/// New session has happened. Note that the argument is the \[session_index\], not the block
-		/// number as the type might suggest.
-		NewSession(SessionIndex),
-	}
-);
-
-decl_error! {
-	/// Error for the session module.
-	pub enum Error for Module<T: Config> {
-		/// Invalid ownership proof.
-		InvalidProof,
-		/// No associated validator ID for account.
-		NoAssociatedValidatorId,
-		/// Registered duplicate key.
-		DuplicatedKey,
-		/// No keys are associated with this account.
-		NoKeys,
-		/// Key setting account is not live, so it's impossible to associate keys.
-		NoAccount,
-	}
-}
-
-decl_module! {
-	pub struct Module<T: Config> for enum Call where origin: T::Origin {
-		type Error = Error<T>;
-
-		fn deposit_event() = default;
-
-		/// Sets the session key(s) of the function caller to `keys`.
-		/// Allows an account to set its session key prior to becoming a validator.
-		/// This doesn't take effect until the next session.
-		///
-		/// The dispatch origin of this function must be signed.
-		///
-		/// # <weight>
-		/// - Complexity: `O(1)`
-		///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
-		/// - DbReads: `origin account`, `T::ValidatorIdOf`, `NextKeys`
-		/// - DbWrites: `origin account`, `NextKeys`
-		/// - DbReads per key id: `KeyOwner`
-		/// - DbWrites per key id: `KeyOwner`
-		/// # </weight>
-		#[weight = T::WeightInfo::set_keys()]
-		pub fn set_keys(origin, keys: T::Keys, proof: Vec<u8>) -> dispatch::DispatchResult {
-			let who = ensure_signed(origin)?;
-
-			ensure!(keys.ownership_proof_is_valid(&proof), Error::<T>::InvalidProof);
-
-			Self::do_set_keys(&who, keys)?;
-
-			Ok(())
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self { keys: Vec::new() }
 		}
+	}
 
-		/// Removes any session key(s) of the function caller.
-		/// This doesn't take effect until the next session.
-		///
-		/// The dispatch origin of this function must be signed.
-		///
-		/// # <weight>
-		/// - Complexity: `O(1)` in number of key types.
-		///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
-		/// - DbReads: `T::ValidatorIdOf`, `NextKeys`, `origin account`
-		/// - DbWrites: `NextKeys`, `origin account`
-		/// - DbWrites per key id: `KeyOwnder`
-		/// # </weight>
-		#[weight = T::WeightInfo::purge_keys()]
-		pub fn purge_keys(origin) {
-			let who = ensure_signed(origin)?;
-			Self::do_purge_keys(&who)?;
-		}
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
+		fn build(&self) {
+            if T::SessionHandler::KEY_TYPE_IDS.len() != T::Keys::key_ids().len() {
+    			panic!("Number of keys in session handler and session keys does not match");
+    		}
 
+    		T::SessionHandler::KEY_TYPE_IDS.iter().zip(T::Keys::key_ids()).enumerate()
+    			.for_each(|(i, (sk, kk))| {
+    				if sk != kk {
+    					panic!(
+    						"Session handler and session key expect different key type at index: {}",
+    						i,
+    					);
+    				}
+    			});
+
+    		for (account, val, keys) in self.keys.iter().cloned() {
+    			<Pallet<T>>::inner_set_keys(&val, keys)
+    				.expect("genesis config must not contain duplicates; qed");
+    			assert!(
+    				frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
+    				"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
+    				account,
+    			);
+    		}
+
+    		let initial_validators_0 = T::SessionManager::new_session(0)
+    			.unwrap_or_else(|| {
+    				frame_support::print("No initial validator provided by `SessionManager`, use \
+    					session config keys to generate initial validator set.");
+    				self.keys.iter().map(|x| x.1.clone()).collect()
+    			});
+    		assert!(!initial_validators_0.is_empty(), "Empty validator set for session 0 in genesis block!");
+
+    		let initial_validators_1 = T::SessionManager::new_session(1)
+    			.unwrap_or_else(|| initial_validators_0.clone());
+    		assert!(!initial_validators_1.is_empty(), "Empty validator set for session 1 in genesis block!");
+
+    		let queued_keys: Vec<_> = initial_validators_1
+    			.iter()
+    			.cloned()
+    			.map(|v| (
+    				v.clone(),
+    				<Pallet<T>>::load_keys(&v).unwrap_or_default(),
+    			))
+    			.collect();
+
+    		// Tell everyone about the genesis session keys
+    		T::SessionHandler::on_genesis_session::<T::Keys>(&queued_keys);
+
+    		<Validators<T>>::put(initial_validators_0);
+    		<QueuedKeys<T>>::put(queued_keys);
+
+    		T::SessionManager::start_session(0);
+	    }
+    }
+
+    /// Events type.
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event {
+        /// New session has happened. Note that the argument is the \[session_index\], not the block
+        /// number as the type might suggest.
+        NewSession(SessionIndex),
+    }
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		/// Called when a block is initialized. Will rotate session if it is the last
-		/// block of the current session.
-		fn on_initialize(n: T::BlockNumber) -> Weight {
-			if T::ShouldEndSession::should_end_session(n) {
-				Self::rotate_session();
-				T::BlockWeights::get().max_block
-			} else {
-				// NOTE: the non-database part of the weight for `should_end_session(n)` is
-				// included as weight for empty block, the database part is expected to be in
-				// cache.
-				0
-			}
-		}
+        /// block of the current session.
+        fn on_initialize(n: T::BlockNumber) -> Weight {
+        	if T::ShouldEndSession::should_end_session(n) {
+        		Self::rotate_session();
+        		T::BlockWeights::get().max_block
+        	} else {
+        		// NOTE: the non-database part of the weight for `should_end_session(n)` is
+        		// included as weight for empty block, the database part is expected to be in
+        		// cache.
+        		0
+        	}
+        }
 	}
+
+    /// Error for the session pallet.
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Invalid ownership proof.
+        InvalidProof,
+        /// No associated validator ID for account.
+        NoAssociatedValidatorId,
+        /// Registered duplicate key.
+        DuplicatedKey,
+        /// No keys are associated with this account.
+        NoKeys,
+        /// Key setting account is not live, so it's impossible to associate keys.
+        NoAccount,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Sets the session key(s) of the function caller to `keys`.
+        /// Allows an account to set its session key prior to becoming a validator.
+        /// This doesn't take effect until the next session.
+        ///
+        /// The dispatch origin of this function must be signed.
+        ///
+        /// # <weight>
+        /// - Complexity: `O(1)`
+        ///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
+        /// - DbReads: `origin account`, `T::ValidatorIdOf`, `NextKeys`
+        /// - DbWrites: `origin account`, `NextKeys`
+        /// - DbReads per key id: `KeyOwner`
+        /// - DbWrites per key id: `KeyOwner`
+        /// # </weight>
+        #[pallet::weight(T::WeightInfo::set_keys())]
+        pub fn set_keys(
+            origin: OriginFor<T>,
+            keys: T::Keys,
+            proof: Vec<u8>,
+        ) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+
+            ensure!(
+                keys.ownership_proof_is_valid(&proof),
+                Error::<T>::InvalidProof
+            );
+
+            Self::do_set_keys(&who, keys)?;
+
+            Ok(())
+        }
+
+        /// Removes any session key(s) of the function caller.
+        /// This doesn't take effect until the next session.
+        ///
+        /// The dispatch origin of this function must be signed.
+        ///
+        /// # <weight>
+        /// - Complexity: `O(1)` in number of key types.
+        ///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
+        /// - DbReads: `T::ValidatorIdOf`, `NextKeys`, `origin account`
+        /// - DbWrites: `NextKeys`, `origin account`
+        /// - DbWrites per key id: `KeyOwnder`
+        /// # </weight>
+        #[pallet::weight(T::WeightInfo::purge_keys())]
+        pub fn purge_keys(origin: OriginFor<T>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            Self::do_purge_keys(&who)?;
+			Ok(())
+        }
+
+    }
 }
 
-impl<T: Config> Module<T> {
+impl<T: Config> Pallet<T> {
 	/// Move on to next session. Register new validator set and session keys. Changes
 	/// to the validator set have a session of delay to take effect. This allows for
 	/// equivocation punishment after a fork.
 	pub fn rotate_session() {
-		let session_index = CurrentIndex::get();
+		let session_index = CurrentIndex::<T>::get();
 
-		let changed = QueuedChanged::get();
+		let changed = QueuedChanged::<T>::get();
 
 		// Inform the session handlers that a session is going to end.
 		T::SessionHandler::on_before_session_ending();
@@ -593,12 +635,12 @@ impl<T: Config> Module<T> {
 
 		if changed {
 			// reset disabled validators
-			DisabledValidators::take();
+			DisabledValidators::<T>::take();
 		}
 
 		// Increment session index.
 		let session_index = session_index + 1;
-		CurrentIndex::put(session_index);
+		CurrentIndex::<T>::put(session_index);
 
 		T::SessionManager::start_session(session_index);
 
@@ -646,7 +688,7 @@ impl<T: Config> Module<T> {
 		};
 
 		<QueuedKeys<T>>::put(queued_amalgamated.clone());
-		QueuedChanged::put(next_changed);
+		QueuedChanged::<T>::put(next_changed);
 
 		// Record that this happened.
 		Self::deposit_event(Event::NewSession(session_index));
@@ -664,7 +706,7 @@ impl<T: Config> Module<T> {
 	/// Returns `true` if this causes a `DisabledValidatorsThreshold` of validators
 	/// to be already disabled.
 	pub fn disable_index(i: usize) -> bool {
-		let (fire_event, threshold_reached) = DisabledValidators::mutate(|disabled| {
+		let (fire_event, threshold_reached) = DisabledValidators::<T>::mutate(|disabled| {
 			let i = i as u32;
 			if let Err(index) = disabled.binary_search(&i) {
 				let count = <Validators<T>>::decode_len().unwrap_or(0) as u32;
@@ -683,12 +725,12 @@ impl<T: Config> Module<T> {
 		threshold_reached
 	}
 
-	/// Disable the validator identified by `c`. (If using with the staking module,
+	/// Disable the validator identified by `c`. (If using with the staking Pallet,
 	/// this would be their *stash* account.)
 	///
 	/// Returns `Ok(true)` if more than `DisabledValidatorsThreshold` validators in current
 	/// session is already disabled.
-	/// If used with the staking module it allows to force a new era in such case.
+	/// If used with the staking Pallet it allows to force a new era in such case.
 	pub fn disable(c: &T::ValidatorId) -> sp_std::result::Result<bool, ()> {
 		Self::validators().iter().position(|i| i == c).map(Self::disable_index).ok_or(())
 	}
@@ -702,7 +744,7 @@ impl<T: Config> Module<T> {
 	///
 	/// Care should be taken that the raw versions of the
 	/// added keys are unique for every `ValidatorId, KeyTypeId` combination.
-	/// This is an invariant that the session module typically maintains internally.
+	/// This is an invariant that the session Pallet typically maintains internally.
 	///
 	/// As the actual values of the keys are typically not known at runtime upgrade,
 	/// it's recommended to initialize the keys to a (unique) dummy value with the expectation
@@ -837,16 +879,16 @@ impl<T: Config> Module<T> {
 	}
 }
 
-impl<T: Config> ValidatorSet<T::AccountId> for Module<T> {
+impl<T: Config> ValidatorSet<T::AccountId> for Pallet<T> {
 	type ValidatorId = T::ValidatorId;
 	type ValidatorIdOf = T::ValidatorIdOf;
 
 	fn session_index() -> sp_staking::SessionIndex {
-		Module::<T>::current_index()
+		Pallet::<T>::current_index()
 	}
 
 	fn validators() -> Vec<Self::ValidatorId> {
-		Module::<T>::validators()
+		Pallet::<T>::validators()
 	}
 }
 
@@ -863,17 +905,17 @@ impl<T: Config, Inner: FindAuthor<u32>> FindAuthor<T::ValidatorId>
 	{
 		let i = Inner::find_author(digests)?;
 
-		let validators = <Module<T>>::validators();
+		let validators = <Pallet<T>>::validators();
 		validators.get(i as usize).map(|k| k.clone())
 	}
 }
 
-impl<T: Config> EstimateNextNewSession<T::BlockNumber> for Module<T> {
+impl<T: Config> EstimateNextNewSession<T::BlockNumber> for Pallet<T> {
 	fn average_session_length() -> T::BlockNumber {
 		T::NextSessionRotation::average_session_length()
 	}
 
-	/// This session module always calls new_session and next_session at the same time, hence we
+	/// This session Pallet always calls new_session and next_session at the same time, hence we
 	/// do a simple proxy and pass the function to next rotation.
 	fn estimate_next_new_session(now: T::BlockNumber) -> (Option<T::BlockNumber>, Weight) {
 		T::NextSessionRotation::estimate_next_session_rotation(now)

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -471,9 +471,9 @@ pub mod pallet {
 				.for_each(|(i, (sk, kk))| {
 					if sk != kk {
 						panic!(
-    						"Session handler and session key expect different key type at index: {}",
-    						i,
-    					);
+							"Session handler and session key expect different key type at index: {}",
+							i,
+						);
 					}
 				});
 
@@ -490,7 +490,7 @@ pub mod pallet {
 			let initial_validators_0 = T::SessionManager::new_session(0).unwrap_or_else(|| {
 				frame_support::print(
 					"No initial validator provided by `SessionManager`, use \
-    					session config keys to generate initial validator set.",
+						session config keys to generate initial validator set.",
 				);
 				self.keys.iter().map(|x| x.1.clone()).collect()
 			});
@@ -564,59 +564,59 @@ pub mod pallet {
 	}
 
 	#[pallet::call]
-    impl<T: Config> Pallet<T> {
-        /// Sets the session key(s) of the function caller to `keys`.
-        /// Allows an account to set its session key prior to becoming a validator.
-        /// This doesn't take effect until the next session.
-        ///
-        /// The dispatch origin of this function must be signed.
-        ///
-        /// # <weight>
-        /// - Complexity: `O(1)`
-        ///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
-        /// - DbReads: `origin account`, `T::ValidatorIdOf`, `NextKeys`
-        /// - DbWrites: `origin account`, `NextKeys`
-        /// - DbReads per key id: `KeyOwner`
-        /// - DbWrites per key id: `KeyOwner`
-        /// # </weight>
-        #[pallet::weight(T::WeightInfo::set_keys())]
-        pub fn set_keys(
-            origin: OriginFor<T>,
-            keys: T::Keys,
-            proof: Vec<u8>,
-        ) -> DispatchResult {
-            let who = ensure_signed(origin)?;
+	impl<T: Config> Pallet<T> {
+		/// Sets the session key(s) of the function caller to `keys`.
+		/// Allows an account to set its session key prior to becoming a validator.
+		/// This doesn't take effect until the next session.
+		///
+		/// The dispatch origin of this function must be signed.
+		///
+		/// # <weight>
+		/// - Complexity: `O(1)`
+		///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
+		/// - DbReads: `origin account`, `T::ValidatorIdOf`, `NextKeys`
+		/// - DbWrites: `origin account`, `NextKeys`
+		/// - DbReads per key id: `KeyOwner`
+		/// - DbWrites per key id: `KeyOwner`
+		/// # </weight>
+		#[pallet::weight(T::WeightInfo::set_keys())]
+		pub fn set_keys(
+			origin: OriginFor<T>,
+			keys: T::Keys,
+			proof: Vec<u8>,
+		) -> DispatchResult {
+			let who = ensure_signed(origin)?;
 
-            ensure!(
-                keys.ownership_proof_is_valid(&proof),
-                Error::<T>::InvalidProof
-            );
+			ensure!(
+				keys.ownership_proof_is_valid(&proof),
+				Error::<T>::InvalidProof
+			);
 
-            Self::do_set_keys(&who, keys)?;
+			Self::do_set_keys(&who, keys)?;
 
-            Ok(())
-        }
-
-        /// Removes any session key(s) of the function caller.
-        /// This doesn't take effect until the next session.
-        ///
-        /// The dispatch origin of this function must be signed.
-        ///
-        /// # <weight>
-        /// - Complexity: `O(1)` in number of key types.
-        ///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
-        /// - DbReads: `T::ValidatorIdOf`, `NextKeys`, `origin account`
-        /// - DbWrites: `NextKeys`, `origin account`
-        /// - DbWrites per key id: `KeyOwnder`
-        /// # </weight>
-        #[pallet::weight(T::WeightInfo::purge_keys())]
-        pub fn purge_keys(origin: OriginFor<T>) -> DispatchResult {
-            let who = ensure_signed(origin)?;
-            Self::do_purge_keys(&who)?;
 			Ok(())
-        }
+		}
 
-    }
+		/// Removes any session key(s) of the function caller.
+		/// This doesn't take effect until the next session.
+		///
+		/// The dispatch origin of this function must be signed.
+		///
+		/// # <weight>
+		/// - Complexity: `O(1)` in number of key types.
+		///   Actual cost depends on the number of length of `T::Keys::key_ids()` which is fixed.
+		/// - DbReads: `T::ValidatorIdOf`, `NextKeys`, `origin account`
+		/// - DbWrites: `NextKeys`, `origin account`
+		/// - DbWrites per key id: `KeyOwnder`
+		/// # </weight>
+		#[pallet::weight(T::WeightInfo::purge_keys())]
+		pub fn purge_keys(origin: OriginFor<T>) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			Self::do_purge_keys(&who)?;
+			Ok(())
+		}
+
+	}
 }
 
 impl<T: Config> Pallet<T> {

--- a/frame/session/src/lib.rs
+++ b/frame/session/src/lib.rs
@@ -359,95 +359,95 @@ impl<T: Config> ValidatorRegistration<T::ValidatorId> for Pallet<T> {
 
 #[frame_support::pallet]
 pub mod pallet {
-    use super::*;
-    use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
 
-    #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
-    pub struct Pallet<T>(_);
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
 
-    /// The pallet's config trait.
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
-        /// The overarching event type.
-        type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
+	/// The pallet's config trait.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
 
-        /// A stable ID for a validator.
-        type ValidatorId: Member + Parameter + MaybeSerializeDeserialize;
+		/// A stable ID for a validator.
+		type ValidatorId: Member + Parameter + MaybeSerializeDeserialize;
 
-        /// A conversion from account ID to validator ID.
-        ///
-        /// Its cost must be at most one storage read.
-        type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
+		/// A conversion from account ID to validator ID.
+		///
+		/// Its cost must be at most one storage read.
+		type ValidatorIdOf: Convert<Self::AccountId, Option<Self::ValidatorId>>;
 
-        /// Indicator for when to end the session.
-        type ShouldEndSession: ShouldEndSession<Self::BlockNumber>;
+		/// Indicator for when to end the session.
+		type ShouldEndSession: ShouldEndSession<Self::BlockNumber>;
 
-        /// Something that can predict the next session rotation. This should typically come from the
-        /// same logical unit that provides [`ShouldEndSession`], yet, it gives a best effort estimate.
-        /// It is helpful to implement [`EstimateNextNewSession`].
-        type NextSessionRotation: EstimateNextSessionRotation<Self::BlockNumber>;
+		/// Something that can predict the next session rotation. This should typically come from the
+		/// same logical unit that provides [`ShouldEndSession`], yet, it gives a best effort estimate.
+		/// It is helpful to implement [`EstimateNextNewSession`].
+		type NextSessionRotation: EstimateNextSessionRotation<Self::BlockNumber>;
 
-        /// Handler for managing new session.
-        type SessionManager: SessionManager<Self::ValidatorId>;
+		/// Handler for managing new session.
+		type SessionManager: SessionManager<Self::ValidatorId>;
 
-        /// Handler when a session has changed.
-        type SessionHandler: SessionHandler<Self::ValidatorId>;
+		/// Handler when a session has changed.
+		type SessionHandler: SessionHandler<Self::ValidatorId>;
 
-        /// The keys.
-        type Keys: OpaqueKeys + Member + Parameter + Default + MaybeSerializeDeserialize;
+		/// The keys.
+		type Keys: OpaqueKeys + Member + Parameter + Default + MaybeSerializeDeserialize;
 
-        /// The fraction of validators set that is safe to be disabled.
-        ///
-        /// After the threshold is reached `disabled` method starts to return true,
-        /// which in combination with `pallet_staking` forces a new era.
-        type DisabledValidatorsThreshold: Get<Perbill>;
+		/// The fraction of validators set that is safe to be disabled.
+		///
+		/// After the threshold is reached `disabled` method starts to return true,
+		/// which in combination with `pallet_staking` forces a new era.
+		type DisabledValidatorsThreshold: Get<Perbill>;
 
-        /// Weight information for extrinsics in this pallet.
-        type WeightInfo: WeightInfo;
-    }
+		/// Weight information for extrinsics in this pallet.
+		type WeightInfo: WeightInfo;
+	}
 
-    /// The current set of validators.
-    #[pallet::storage]
-    #[pallet::getter(fn validators)]
-    pub type Validators<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
+	/// The current set of validators.
+	#[pallet::storage]
+	#[pallet::getter(fn validators)]
+	pub type Validators<T: Config> = StorageValue<_, Vec<T::ValidatorId>, ValueQuery>;
 
-    /// Current index of the session.
-    #[pallet::storage]
-    #[pallet::getter(fn current_index)]
-    pub type CurrentIndex<T: Config> = StorageValue<_, SessionIndex, ValueQuery>;
+	/// Current index of the session.
+	#[pallet::storage]
+	#[pallet::getter(fn current_index)]
+	pub type CurrentIndex<T: Config> = StorageValue<_, SessionIndex, ValueQuery>;
 
-    /// True if the underlying economic identities or weighting behind the validators
-    /// has changed in the queued validator set.
-    #[pallet::storage]
-    pub type QueuedChanged<T: Config> = StorageValue<_, bool, ValueQuery>;
+	/// True if the underlying economic identities or weighting behind the validators
+	/// has changed in the queued validator set.
+	#[pallet::storage]
+	pub type QueuedChanged<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-    /// The queued keys for the next session. When the next session begins, these keys
-    /// will be used to determine the validator's session keys.
-    #[pallet::storage]
-    #[pallet::getter(fn queued_keys)]
-    pub type QueuedKeys<T: Config> = StorageValue<_, Vec<(T::ValidatorId, T::Keys)>, ValueQuery>;
+	/// The queued keys for the next session. When the next session begins, these keys
+	/// will be used to determine the validator's session keys.
+	#[pallet::storage]
+	#[pallet::getter(fn queued_keys)]
+	pub type QueuedKeys<T: Config> = StorageValue<_, Vec<(T::ValidatorId, T::Keys)>, ValueQuery>;
 
-    /// Indices of disabled validators.
-    ///
-    /// The set is cleared when `on_session_ending` returns a new set of identities.
-    #[pallet::storage]
-    #[pallet::getter(fn disabled_validators)]
-    pub type DisabledValidators<T: Config> = StorageValue<_, Vec<u32>, ValueQuery>;
+	/// Indices of disabled validators.
+	///
+	/// The set is cleared when `on_session_ending` returns a new set of identities.
+	#[pallet::storage]
+	#[pallet::getter(fn disabled_validators)]
+	pub type DisabledValidators<T: Config> = StorageValue<_, Vec<u32>, ValueQuery>;
 
-    /// The next session keys for a validator.
-    #[pallet::storage]
-    pub type NextKeys<T: Config> = StorageMap<_, Twox64Concat, T::ValidatorId, T::Keys>;
+	/// The next session keys for a validator.
+	#[pallet::storage]
+	pub type NextKeys<T: Config> = StorageMap<_, Twox64Concat, T::ValidatorId, T::Keys>;
 
-    /// The owner of a key. The key is the `KeyTypeId` + the encoded key.
-    #[pallet::storage]
-    pub type KeyOwner<T: Config> =
-        StorageMap<_, Twox64Concat, (KeyTypeId, Vec<u8>), T::ValidatorId>;
+	/// The owner of a key. The key is the `KeyTypeId` + the encoded key.
+	#[pallet::storage]
+	pub type KeyOwner<T: Config> =
+		StorageMap<_, Twox64Concat, (KeyTypeId, Vec<u8>), T::ValidatorId>;
 
-    #[pallet::genesis_config]
+	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub keys : Vec<(T::AccountId, T::ValidatorId, T::Keys)>,
+		pub keys: Vec<(T::AccountId, T::ValidatorId, T::Keys)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -460,105 +460,110 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-            if T::SessionHandler::KEY_TYPE_IDS.len() != T::Keys::key_ids().len() {
-    			panic!("Number of keys in session handler and session keys does not match");
-    		}
+			if T::SessionHandler::KEY_TYPE_IDS.len() != T::Keys::key_ids().len() {
+				panic!("Number of keys in session handler and session keys does not match");
+			}
 
-    		T::SessionHandler::KEY_TYPE_IDS.iter().zip(T::Keys::key_ids()).enumerate()
-    			.for_each(|(i, (sk, kk))| {
-    				if sk != kk {
-    					panic!(
+			T::SessionHandler::KEY_TYPE_IDS
+				.iter()
+				.zip(T::Keys::key_ids())
+				.enumerate()
+				.for_each(|(i, (sk, kk))| {
+					if sk != kk {
+						panic!(
     						"Session handler and session key expect different key type at index: {}",
     						i,
     					);
-    				}
-    			});
+					}
+				});
 
-    		for (account, val, keys) in self.keys.iter().cloned() {
-    			<Pallet<T>>::inner_set_keys(&val, keys)
-    				.expect("genesis config must not contain duplicates; qed");
-    			assert!(
-    				frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
-    				"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
-    				account,
-    			);
-    		}
+			for (account, val, keys) in self.keys.iter().cloned() {
+				<Pallet<T>>::inner_set_keys(&val, keys)
+					.expect("genesis config must not contain duplicates; qed");
+				assert!(
+					frame_system::Pallet::<T>::inc_consumers(&account).is_ok(),
+					"Account ({:?}) does not exist at genesis to set key. Account not endowed?",
+					account,
+				);
+			}
 
-    		let initial_validators_0 = T::SessionManager::new_session(0)
-    			.unwrap_or_else(|| {
-    				frame_support::print("No initial validator provided by `SessionManager`, use \
-    					session config keys to generate initial validator set.");
-    				self.keys.iter().map(|x| x.1.clone()).collect()
-    			});
-    		assert!(!initial_validators_0.is_empty(), 
-				"Empty validator set for session 0 in genesis block!");
+			let initial_validators_0 = T::SessionManager::new_session(0).unwrap_or_else(|| {
+				frame_support::print(
+					"No initial validator provided by `SessionManager`, use \
+    					session config keys to generate initial validator set.",
+				);
+				self.keys.iter().map(|x| x.1.clone()).collect()
+			});
+			assert!(
+				!initial_validators_0.is_empty(),
+				"Empty validator set for session 0 in genesis block!"
+			);
 
-    		let initial_validators_1 = T::SessionManager::new_session(1)
-    			.unwrap_or_else(|| initial_validators_0.clone());
-    		assert!(!initial_validators_1.is_empty(), 
-				"Empty validator set for session 1 in genesis block!");
+			let initial_validators_1 =
+				T::SessionManager::new_session(1).unwrap_or_else(|| initial_validators_0.clone());
+			assert!(
+				!initial_validators_1.is_empty(),
+				"Empty validator set for session 1 in genesis block!"
+			);
 
-    		let queued_keys: Vec<_> = initial_validators_1
-    			.iter()
-    			.cloned()
-    			.map(|v| (
-    				v.clone(),
-    				<Pallet<T>>::load_keys(&v).unwrap_or_default(),
-    			))
-    			.collect();
+			let queued_keys: Vec<_> = initial_validators_1
+				.iter()
+				.cloned()
+				.map(|v| (v.clone(), <Pallet<T>>::load_keys(&v).unwrap_or_default()))
+				.collect();
 
-    		// Tell everyone about the genesis session keys
-    		T::SessionHandler::on_genesis_session::<T::Keys>(&queued_keys);
+			// Tell everyone about the genesis session keys
+			T::SessionHandler::on_genesis_session::<T::Keys>(&queued_keys);
 
-    		<Validators<T>>::put(initial_validators_0);
-    		<QueuedKeys<T>>::put(queued_keys);
+			<Validators<T>>::put(initial_validators_0);
+			<QueuedKeys<T>>::put(queued_keys);
 
-    		T::SessionManager::start_session(0);
-	    }
-    }
-
-    /// Events type.
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event {
-        /// New session has happened. Note that the argument is the \[session_index\], not the block
-        /// number as the type might suggest.
-        NewSession(SessionIndex),
-    }
-
-    #[pallet::hooks]
-    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		/// Called when a block is initialized. Will rotate session if it is the last
-        /// block of the current session.
-        fn on_initialize(n: T::BlockNumber) -> Weight {
-        	if T::ShouldEndSession::should_end_session(n) {
-        		Self::rotate_session();
-        		T::BlockWeights::get().max_block
-        	} else {
-        		// NOTE: the non-database part of the weight for `should_end_session(n)` is
-        		// included as weight for empty block, the database part is expected to be in
-        		// cache.
-        		0
-        	}
-        }
+			T::SessionManager::start_session(0);
+		}
 	}
 
-    /// Error for the session pallet.
-    #[pallet::error]
-    pub enum Error<T> {
-        /// Invalid ownership proof.
-        InvalidProof,
-        /// No associated validator ID for account.
-        NoAssociatedValidatorId,
-        /// Registered duplicate key.
-        DuplicatedKey,
-        /// No keys are associated with this account.
-        NoKeys,
-        /// Key setting account is not live, so it's impossible to associate keys.
-        NoAccount,
-    }
+	/// Events type.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event {
+		/// New session has happened. Note that the argument is the \[session_index\], not the block
+		/// number as the type might suggest.
+		NewSession(SessionIndex),
+	}
 
-    #[pallet::call]
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		/// Called when a block is initialized. Will rotate session if it is the last
+		/// block of the current session.
+		fn on_initialize(n: T::BlockNumber) -> Weight {
+			if T::ShouldEndSession::should_end_session(n) {
+				Self::rotate_session();
+				T::BlockWeights::get().max_block
+			} else {
+				// NOTE: the non-database part of the weight for `should_end_session(n)` is
+				// included as weight for empty block, the database part is expected to be in
+				// cache.
+				0
+			}
+		}
+	}
+
+	/// Error for the session pallet.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// Invalid ownership proof.
+		InvalidProof,
+		/// No associated validator ID for account.
+		NoAssociatedValidatorId,
+		/// Registered duplicate key.
+		DuplicatedKey,
+		/// No keys are associated with this account.
+		NoKeys,
+		/// Key setting account is not live, so it's impossible to associate keys.
+		NoAccount,
+	}
+
+	#[pallet::call]
     impl<T: Config> Pallet<T> {
         /// Sets the session key(s) of the function caller to `keys`.
         /// Allows an account to set its session key prior to becoming a validator.

--- a/frame/session/src/mock.rs
+++ b/frame/session/src/mock.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 use std::cell::RefCell;
-use frame_support::{parameter_types, BasicExternalities};
+use frame_support::{parameter_types, BasicExternalities, traits::GenesisBuild};
 use sp_core::{crypto::key_types::DUMMY, H256};
 use sp_runtime::{
 	Perbill, impl_opaque_keys,

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -654,15 +654,15 @@ impl<T: Config> SessionInterface<<T as frame_system::Config>::AccountId> for T w
 		Convert<<T as frame_system::Config>::AccountId, Option<<T as frame_system::Config>::AccountId>>,
 {
 	fn disable_validator(validator: &<T as frame_system::Config>::AccountId) -> Result<bool, ()> {
-		<pallet_session::Module<T>>::disable(validator)
+		<pallet_session::Pallet<T>>::disable(validator)
 	}
 
 	fn validators() -> Vec<<T as frame_system::Config>::AccountId> {
-		<pallet_session::Module<T>>::validators()
+		<pallet_session::Pallet<T>>::validators()
 	}
 
 	fn prune_historical_up_to(up_to: SessionIndex) {
-		<pallet_session::historical::Module<T>>::prune_up_to(up_to);
+		<pallet_session::historical::Pallet<T>>::prune_up_to(up_to);
 	}
 }
 

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -21,7 +21,7 @@ use crate::*;
 use crate as staking;
 use frame_support::{
 	assert_ok, parameter_types,
-	traits::{Currency, FindAuthor, Get, OnFinalize, OnInitialize, OneSessionHandler},
+	traits::{Currency, FindAuthor, Get, OnFinalize, OnInitialize, OneSessionHandler, GenesisBuild},
 	weights::constants::RocksDbWeight,
 	IterableStorageMap, StorageDoubleMap, StorageMap, StorageValue,
 };

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -35,6 +35,7 @@ use sp_runtime::{
 use sp_staking::offence::{OffenceDetails, OnOffenceHandler};
 use std::{cell::RefCell, collections::HashSet};
 use frame_election_provider_support::onchain;
+use pallet_session::historical as pallet_session_historical;
 
 pub const INIT_TIMESTAMP: u64 = 30_000;
 pub const BLOCK_TIME: u64 = 1000;
@@ -101,6 +102,7 @@ frame_support::construct_runtime!(
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Staking: staking::{Pallet, Call, Config<T>, Storage, Event<T>},
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>},
+		Historical: pallet_session_historical::{Pallet},
 	}
 );
 


### PR DESCRIPTION
Part of #7882.

Converts the `session` and `session-historical` pallet to the new pallet attribute macro introduced in #6877.

Following the upgrade guidelines here: https://crates.parity.io/frame_support/attr.pallet.html#upgrade-guidelines.

⚠️ Breaking Change ⚠️

```
From https://crates.parity.io/frame_support/attr.pallet.html#checking-upgrade-guidelines

storages now use PalletInfo for module_prefix instead of the one given to decl_storage: Thus any use of this pallet in construct_runtime! should be careful to update name in order not to break storage or to upgrade storage (moreover for instantiable pallet). If pallet is published, make sure to warn about this breaking change.
```