### PR TITLE
frame/session/benchmarking: fix invalid feature declaration

### DIFF
--- a/frame/session/benchmarking/Cargo.toml
+++ b/frame/session/benchmarking/Cargo.toml
@@ -38,7 +38,6 @@ default = ["std"]
 std = [
 	"sp-std/std",
 	"sp-session/std",
-	"frame-election-provider-support/std",
 	"sp-runtime/std",
 	"frame-system/std",
 	"frame-benchmarking/std",


### PR DESCRIPTION
The `pallet-session-benchmarking` is used only for runtime benchmarks (?), but with no default features: https://github.com/paritytech/substrate/blob/8d02bb0bfc6136f6a3c805db19f51e43090a7cd4/bin/node/runtime/Cargo.toml#L76.
`frame-election-provider-support` has `std` enabled by default.
I've heard this was causing troubles with cargo unleash: https://gitlab.parity.io/parity/substrate/-/jobs/927455, which tries to strip all dev-dependencies.