### PR TITLE
Add names to offchain worker threads

### DIFF
--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -94,7 +94,7 @@ impl<Client, Block: traits::Block> OffchainWorkers<Client, Block> {
 		Self {
 			client,
 			_block: PhantomData,
-			thread_pool: Mutex::new(ThreadPool::new(num_cpus::get())),
+			thread_pool: Mutex::new(ThreadPool::with_name("offchain-worker", num_cpus::get())),
 			shared_client,
 		}
 	}

--- a/client/offchain/src/lib.rs
+++ b/client/offchain/src/lib.rs
@@ -94,7 +94,7 @@ impl<Client, Block: traits::Block> OffchainWorkers<Client, Block> {
 		Self {
 			client,
 			_block: PhantomData,
-			thread_pool: Mutex::new(ThreadPool::with_name("offchain-worker", num_cpus::get())),
+			thread_pool: Mutex::new(ThreadPool::with_name("offchain-worker".into(), num_cpus::get())),
 			shared_client,
 		}
 	}


### PR DESCRIPTION
When we're stumbling upon a situation where some specific thread(s) panic or use a lot of CPU, it's useful for threads to be named.
This is what this PR does.

Note that a proper situation would be to use the "spawner" system in the service, but this would be a way bigger change.
