### PR TITLE
Initialize New Accounts to Block Number

### DIFF
--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -260,14 +260,13 @@ macro_rules! decl_tests {
 				.monied(true)
 				.build()
 				.execute_with(|| {
-					System::set_block_number(2);
 					System::inc_account_nonce(&2);
 					assert_eq!(Balances::total_balance(&2), 256 * 20);
 
 					assert_ok!(Balances::reserve(&2, 256 * 19 + 1)); // account 2 becomes mostly reserved
 					assert_eq!(Balances::free_balance(2), 255); // "free" account deleted."
 					assert_eq!(Balances::total_balance(&2), 256 * 20); // reserve still exists.
-					assert_eq!(System::account_nonce(&2), 2);
+					assert_eq!(System::account_nonce(&2), 1);
 
 					// account 4 tries to take index 1 for account 5.
 					assert_ok!(Balances::transfer(Some(4).into(), 5, 256 * 1 + 0x69));
@@ -301,9 +300,8 @@ macro_rules! decl_tests {
 				.monied(true)
 				.build()
 				.execute_with(|| {
-					System::set_block_number(2);
 					System::inc_account_nonce(&2);
-					assert_eq!(System::account_nonce(&2), 2);
+					assert_eq!(System::account_nonce(&2), 1);
 					assert_eq!(Balances::total_balance(&2), 2000);
 					 // index 1 (account 2) becomes zombie
 					assert_ok!(Balances::transfer(Some(2).into(), 5, 1901));

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -260,13 +260,14 @@ macro_rules! decl_tests {
 				.monied(true)
 				.build()
 				.execute_with(|| {
+					System::set_block_number(2);
 					System::inc_account_nonce(&2);
 					assert_eq!(Balances::total_balance(&2), 256 * 20);
 
 					assert_ok!(Balances::reserve(&2, 256 * 19 + 1)); // account 2 becomes mostly reserved
 					assert_eq!(Balances::free_balance(2), 255); // "free" account deleted."
 					assert_eq!(Balances::total_balance(&2), 256 * 20); // reserve still exists.
-					assert_eq!(System::account_nonce(&2), 1);
+					assert_eq!(System::account_nonce(&2), 2);
 
 					// account 4 tries to take index 1 for account 5.
 					assert_ok!(Balances::transfer(Some(4).into(), 5, 256 * 1 + 0x69));
@@ -300,8 +301,9 @@ macro_rules! decl_tests {
 				.monied(true)
 				.build()
 				.execute_with(|| {
+					System::set_block_number(2);
 					System::inc_account_nonce(&2);
-					assert_eq!(System::account_nonce(&2), 1);
+					assert_eq!(System::account_nonce(&2), 2);
 					assert_eq!(Balances::total_balance(&2), 2000);
 					 // index 1 (account 2) becomes zombie
 					assert_ok!(Balances::transfer(Some(2).into(), 5, 1901));

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1473,14 +1473,10 @@ impl<T: Config> Pallet<T> {
 	/// If an account is new, set the nonce to its block number
 	pub fn inc_account_nonce(who: impl EncodeLike<T::AccountId>) {
 		Account::<T>::mutate(who, |a| {
-			if a.nonce > T::Index::zero() {
+			if a.nonce > T::Index::zero() || Self::block_number().is_zero() {
 				a.nonce += T::Index::one();
 			} else {
-				if Self::block_number().is_zero() {
-					a.nonce = T::Index::one();
-				} else {
-					a.nonce = Self::block_number().saturated_into::<u32>().into();
-				}
+				a.nonce = Self::block_number().saturated_into::<u32>().into();
 			}
 		});
 	}
@@ -1702,4 +1698,3 @@ pub mod pallet_prelude {
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
-

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1481,8 +1481,6 @@ impl<T: Config> Pallet<T> {
 		});
 	}
 
-
-
 	/// Note what the extrinsic data of the current extrinsic index is.
 	///
 	/// This is required to be called before applying an extrinsic. The data will used

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1478,8 +1478,6 @@ impl<T: Config> Pallet<T> {
 				a.nonce += T::Index::one();
 			}
 			else {
-				//set nonce to block number if we are initializing the account
-				//need to convert block number into u32 and then convert that into an Index
 				if let Some(b) = TryInto::<u32>::try_into(Self::block_number()).ok() {
 					a.nonce = b.into();
 				} else {

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -82,7 +82,6 @@ use sp_runtime::{
 	},
 	offchain::storage_lock::BlockNumberProvider,
 };
-use core::convert::TryInto;
 
 use sp_core::{ChangesTrieConfiguration, storage::well_known_keys};
 use frame_support::{
@@ -1478,12 +1477,7 @@ impl<T: Config> Pallet<T> {
 				a.nonce += T::Index::one();
 			}
 			else {
-				if let Some(b) = TryInto::<u32>::try_into(Self::block_number()).ok() {
-					a.nonce = b.into();
-				} else {
-					let b = Self::block_number().saturated_into::<u32>();
-					a.nonce = b.into(); 
-				}
+				a.nonce = Self::block_number().saturated_into::<u32>().into();
 			}
 		});
 	}

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1448,7 +1448,7 @@ impl<T: Config> Pallet<T> {
 		EventCount::<T>::kill();
 		<EventTopics<T>>::remove_all();
 	}
-	
+
 	/// Assert the given `event` exists.
 	#[cfg(any(feature = "std", feature = "runtime-benchmarks", test))]
 	pub fn assert_has_event(event: T::Event) {
@@ -1468,21 +1468,24 @@ impl<T: Config> Pallet<T> {
 	pub fn account_nonce(who: impl EncodeLike<T::AccountId>) -> T::Index {
 		Account::<T>::get(who).nonce
 	}
-    
+
 	/// Increment a particular account's nonce by 1.
 	/// If an account is new, set the nonce to its block number
 	pub fn inc_account_nonce(who: impl EncodeLike<T::AccountId>) {
 		Account::<T>::mutate(who, |a| {
 			if a.nonce > T::Index::zero() {
 				a.nonce += T::Index::one();
-			}
-			else {
-				a.nonce = Self::block_number().saturated_into::<u32>().into();
+			} else {
+				if Self::block_number().is_zero() {
+					a.nonce = T::Index::one();
+				} else {
+					a.nonce = Self::block_number().saturated_into::<u32>().into();
+				}
 			}
 		});
 	}
 
-	
+
 
 	/// Note what the extrinsic data of the current extrinsic index is.
 	///
@@ -1699,4 +1702,3 @@ pub mod pallet_prelude {
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
-

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -1702,3 +1702,4 @@ pub mod pallet_prelude {
 	/// Type alias for the `BlockNumber` associated type of system config.
 	pub type BlockNumberFor<T> = <T as crate::Config>::BlockNumber;
 }
+

--- a/frame/system/src/tests.rs
+++ b/frame/system/src/tests.rs
@@ -62,15 +62,18 @@ fn stored_map_works() {
 #[test]
 fn inc_account_nonce_works() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(2);
 		System::inc_account_nonce(&0);
-		//initial call sets nonce to the block number
-		assert_eq!(System::account_nonce(&0), 2);
+		//initial call when block number is 0 set nonce to 1
+		assert_eq!(System::account_nonce(&0), 1);
 		//subsequent calls increment nonce
 		System::inc_account_nonce(&0);
-		assert_eq!(System::account_nonce(&0), 3);
-		System::inc_account_nonce(&0);
-		assert_eq!(System::account_nonce(&0), 4);
+		assert_eq!(System::account_nonce(&0), 2);
+		//testing behavior when block number is non zero
+		System::set_block_number(2);
+		System::inc_account_nonce(&1);
+		assert_eq!(System::account_nonce(&1), 2);
+		System::inc_account_nonce(&1);
+		assert_eq!(System::account_nonce(&1), 3);
 	});
 }
 
@@ -78,24 +81,23 @@ fn inc_account_nonce_works() {
 fn provider_ref_handover_to_self_sufficient_ref_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Created);
-		System::set_block_number(2);
 		System::inc_account_nonce(&0);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// a second reference coming and going doesn't change anything.
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_sufficients(&0), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// a provider reference coming and going doesn't change anything.
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// decreasing the providers with a self-sufficient present should not delete the account
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// decreasing the sufficients should delete the account
 		assert_eq!(System::dec_sufficients(&0), DecRefStatus::Reaped);
@@ -107,24 +109,23 @@ fn provider_ref_handover_to_self_sufficient_ref_works() {
 fn self_sufficient_ref_handover_to_provider_ref_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Created);
-		System::set_block_number(2);
 		System::inc_account_nonce(&0);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// a second reference coming and going doesn't change anything.
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// a sufficient reference coming and going doesn't change anything.
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_sufficients(&0), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// decreasing the sufficients with a provider present should not delete the account
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_sufficients(&0), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		// decreasing the providers should delete the account
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Reaped);
@@ -136,7 +137,6 @@ fn self_sufficient_ref_handover_to_provider_ref_works() {
 fn sufficient_cannot_support_consumer() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(System::inc_sufficients(&0), IncRefStatus::Created);
-		System::set_block_number(1);
 		System::inc_account_nonce(&0);
 		assert_eq!(System::account_nonce(&0), 1);
 		assert_noop!(System::inc_consumers(&0), IncRefError::NoProviders);
@@ -153,13 +153,12 @@ fn provider_required_to_support_consumer() {
 		assert_noop!(System::inc_consumers(&0), IncRefError::NoProviders);
 
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Created);
-		System::set_block_number(2);
 		System::inc_account_nonce(&0);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		assert_eq!(System::inc_providers(&0), IncRefStatus::Existed);
 		assert_eq!(System::dec_providers(&0).unwrap(), DecRefStatus::Exists);
-		assert_eq!(System::account_nonce(&0), 2);
+		assert_eq!(System::account_nonce(&0), 1);
 
 		assert_ok!(System::inc_consumers(&0));
 		assert_noop!(System::dec_providers(&0), DecRefError::ConsumerRemaining);


### PR DESCRIPTION
Related to #8457 
This pull request changes the behavior of ```inc_account_nonce``` so that if the account nonce is zero (no transactions have been made yet), then the account nonce is set to the block number. Otherwise, the account nonce is incremented by one. In order to convert the block number to the Index type, the block number is first converted into a ```u32``` type, as according to Substrate docs block numbers will typically be u32. The nonce is then derived from this number. Please note that the existing documentation on Substrate describing account initialization will need to be adjusted, as we should now mention that nonce will be initialized to the block number, not 0. 
