### PR TITLE
Ensure election offchain workers don't overlap

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -284,7 +284,7 @@ pub fn testnet_genesis(
 			}).collect::<Vec<_>>(),
 		},
 		pallet_staking: StakingConfig {
-			validator_count: initial_authorities.len() as u32 * 2,
+			validator_count: initial_authorities.len() as u32,
 			minimum_validator_count: initial_authorities.len() as u32,
 			invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
 			slash_reward_fraction: Perbill::from_percent(10),

--- a/frame/election-provider-multi-phase/Cargo.toml
+++ b/frame/election-provider-multi-phase/Cargo.toml
@@ -22,6 +22,7 @@ frame-system = { version = "3.0.0", default-features = false, path = "../system"
 
 sp-io = { version = "3.0.0", default-features = false, path = "../../primitives/io" }
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
+sp-core = { version = "3.0.0", default-features = false, path = "../../primitives/core" }
 sp-runtime = { version = "3.0.0", default-features = false, path = "../../primitives/runtime" }
 sp-npos-elections = { version = "3.0.0", default-features = false, path = "../../primitives/npos-elections" }
 sp-arithmetic = { version = "3.0.0", default-features = false, path = "../../primitives/arithmetic" }
@@ -56,6 +57,7 @@ std = [
 
 	"sp-io/std",
 	"sp-std/std",
+	"sp-core/std",
 	"sp-runtime/std",
 	"sp-npos-elections/std",
 	"sp-arithmetic/std",

--- a/frame/election-provider-multi-phase/src/lib.rs
+++ b/frame/election-provider-multi-phase/src/lib.rs
@@ -661,7 +661,7 @@ pub mod pallet {
 						acquired = true;
 						Self::mine_check_save_submit()
 					});
-					log!(debug, "initial OCW output: {:?}", initial_output);
+					log!(debug, "initial offchain thread output: {:?}", initial_output);
 				}
 				Phase::Unsigned((true, opened)) if opened < now => {
 					// try and resubmit the cached solution, and recompute ONLY if it is not
@@ -670,7 +670,7 @@ pub mod pallet {
 						acquired = true;
 						Self::restore_or_compute_then_maybe_submit()
 					});
-					log!(debug, "resubmit OCW output: {:?}", resubmit_output);
+					log!(debug, "resubmit offchain thread output: {:?}", resubmit_output);
 				}
 				_ => {}
 			}

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -619,7 +619,7 @@ impl<T: Config> Pallet<T> {
 		let mutate_stat =
 			guard.mutate::<_, &'static str, _>(|maybe_running: Option<Option<bool>>| {
 				match maybe_running {
-					Some(Some(running)) if !running => {
+					Some(Some(false)) => {
 						// no one else is running. Set it, and return Ok.
 						Ok(true)
 					}

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -623,7 +623,7 @@ impl<T: Config> Pallet<T> {
 						// no one else is running. Set it, and return Ok.
 						Ok(true)
 					}
-					Some(Some(running)) if running => {
+					Some(Some(true)) => {
 						// another thread is currently running.
 						Err("still running.")
 					}

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -750,7 +750,6 @@ mod tests {
 		mock::{
 			Call as OuterCall, ExtBuilder, Extrinsic, MinerMaxWeight, MultiPhase, Origin, Runtime,
 			TestCompact, TrimHelpers, roll_to, roll_to_with_ocw, trim_helpers, witness,
-			BlockNumber,
 		},
 	};
 	use frame_benchmarking::Zero;

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -129,8 +129,8 @@ pub(super) fn kill_ocw_solution<T: Config>() {
 ///
 /// After calling this, the next offchain worker is guaranteed to work, with respect to the
 /// frequency repeat.
-fn clear_offchain_repeat_frequency() -> {
-	let last_block = StorageValueRef::persistent(&OFFCHAIN_LAST_BLOCK);
+fn clear_offchain_repeat_frequency() {
+	let mut last_block = StorageValueRef::persistent(&OFFCHAIN_LAST_BLOCK);
 	last_block.clear();
 }
 
@@ -181,6 +181,7 @@ impl<T: Config> Pallet<T> {
 						// may be) we mine a new one.
 						kill_ocw_solution::<T>();
 						clear_offchain_repeat_frequency();
+						Err(error)
 					},
 					_ => {
 						// nothing to do. Return the error as-is.

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -105,7 +105,7 @@ fn save_solution<T: Config>(call: &Call<T>) -> Result<(), MinerError> {
 		Err(_) => {
 			// this branch should be unreachable according to the definition of
 			// `StorageValueRef::mutate`: that function should only ever `Err` if the closure we
-			// pass it return an error. however, for safety in case the definition changes, we do
+			// pass it returns an error. however, for safety in case the definition changes, we do
 			// not optimize the branch away or panic.
 			Err(MinerError::FailedToStoreSolution)
 		},

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -1105,7 +1105,7 @@ mod tests {
 
 	#[test]
 	fn ocw_lock_prevents_overlapping_execution() {
-		use crate::mock::BlockNumber;
+		use crate::mock::{System, BlockNumber};
 		use sp_runtime::offchain::storage_lock::{StorageLock, BlockAndTime};
 
 		{

--- a/frame/election-provider-multi-phase/src/unsigned.rs
+++ b/frame/election-provider-multi-phase/src/unsigned.rs
@@ -583,7 +583,6 @@ impl<T: Config> Pallet<T> {
 		let threshold = T::OffchainRepeat::get();
 		let last_block = StorageValueRef::persistent(&OFFCHAIN_LAST_BLOCK);
 
-		// first, make sure that we are okay with the last block threshold.
 		let mutate_stat = last_block.mutate::<_, &'static str, _>(
 			|maybe_head: Option<Option<T::BlockNumber>>| {
 				match maybe_head {
@@ -607,7 +606,7 @@ impl<T: Config> Pallet<T> {
 			// all good
 			Ok(Ok(_)) => Ok(()),
 			// failed to write.
-			Ok(Err(_)) => Err(MinerError::Lock("failed to write to offchain db [repeat].")),
+			Ok(Err(_)) => Err(MinerError::Lock("failed to write to offchain db.")),
 			// fork etc.
 			Err(why) => Err(MinerError::Lock(why)),
 		}
@@ -1140,7 +1139,7 @@ mod tests {
 				assert!(MultiPhase::current_phase().is_unsigned());
 
 				// artificially set the value, as if another thread is mid-way.
-				let mut lock = StorageLock::<'_, BlockAndTime<MultiPhase>>::with_block_deadline(
+				let mut lock = StorageLock::<BlockAndTime<System>>::with_block_deadline(
 					OFFCHAIN_LOCK,
 					crate::mock::UnsignedPhase::get().saturated_into(),
 				);

--- a/primitives/runtime/src/offchain/storage_lock.rs
+++ b/primitives/runtime/src/offchain/storage_lock.rs
@@ -66,6 +66,7 @@ use crate::traits::AtLeast32BitUnsigned;
 use codec::{Codec, Decode, Encode};
 use sp_core::offchain::{Duration, Timestamp};
 use sp_io::offchain;
+use sp_std::fmt;
 
 /// Default expiry duration for time based locks in milliseconds.
 const STORAGE_LOCK_DEFAULT_EXPIRY_DURATION: Duration = Duration::from_millis(20_000);
@@ -170,6 +171,19 @@ impl<B: BlockNumberProvider> Default for BlockAndTimeDeadline<B> {
 			block_number: B::current_block_number() + STORAGE_LOCK_DEFAULT_EXPIRY_BLOCKS.into(),
 			timestamp: offchain::timestamp().add(STORAGE_LOCK_DEFAULT_EXPIRY_DURATION),
 		}
+	}
+}
+
+impl<B: BlockNumberProvider> fmt::Debug for BlockAndTimeDeadline<B>
+	where <B as BlockNumberProvider>::BlockNumber: fmt::Debug
+{
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(
+			f,
+			"BlockAndTimeDeadline(block_number={:?}, time={:?})",
+			self.block_number,
+			self.timestamp,
+		)
 	}
 }
 

--- a/primitives/runtime/src/offchain/storage_lock.rs
+++ b/primitives/runtime/src/offchain/storage_lock.rs
@@ -178,12 +178,10 @@ impl<B: BlockNumberProvider> fmt::Debug for BlockAndTimeDeadline<B>
 	where <B as BlockNumberProvider>::BlockNumber: fmt::Debug
 {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(
-			f,
-			"BlockAndTimeDeadline(block_number={:?}, time={:?})",
-			self.block_number,
-			self.timestamp,
-		)
+		f.debug_struct("BlockAndTimeDeadline")
+			.field("block_number", &self.block_number)
+			.field("timestamp", &self.timestamp)
+			.finish()
 	}
 }
 


### PR DESCRIPTION
+ make sure we only recompute if
  1. no solution was cached
  2. the cached solution was not feasible. 
 
The most common scenario is that we have a cached solution, and it has a worse score. In this case, we do nothing from now on. 