### PR TITLE
add trigger for monitoring job in cloud-infra repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -210,13 +210,6 @@ test-prometheus-alerting-rules:
     - promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
     - cat .maintain/monitoring/alerting-rules/alerting-rules.yaml |
         promtool test rules .maintain/monitoring/alerting-rules/alerting-rule-tests.yaml
-    - echo SUBSTRATE_MONITORING_RULES=`cat .maintain/monitoring/alerting-rules/alerting-rules.yaml |
-        sed 's/^/  /;1s/^/spec:\n/' | base64 | tr -d '\n'` > substrate-monitoring-rules.env
-  artifacts:
-    reports:
-      dotenv:
-        - substrate-monitoring-rules.env
-
 
 #### stage:                        test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -671,6 +671,7 @@ deploy-prometheus-alerting-rules:
   needs:
     - job:                         test-prometheus-alerting-rules
       artifacts:                   false
+  allow_failure:                   true
   trigger:
     project:  parity/infrastructure/cloud-infra
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -210,6 +210,13 @@ test-prometheus-alerting-rules:
     - promtool check rules .maintain/monitoring/alerting-rules/alerting-rules.yaml
     - cat .maintain/monitoring/alerting-rules/alerting-rules.yaml |
         promtool test rules .maintain/monitoring/alerting-rules/alerting-rule-tests.yaml
+    - echo SUBSTRATE_MONITORING_RULES=`cat .maintain/monitoring/alerting-rules/alerting-rules.yaml |
+        sed 's/^/  /;1s/^/spec:\n/' | base64 | tr -d '\n'` > substrate-monitoring-rules.env
+  artifacts:
+    reports:
+      dotenv:
+        - substrate-monitoring-rules.env
+
 
 #### stage:                        test
 
@@ -671,21 +678,13 @@ deploy-prometheus-alerting-rules:
   needs:
     - job:                         test-prometheus-alerting-rules
       artifacts:                   false
-  interruptible:                   true
-  retry:                           1
-  tags:
-    - kubernetes-parity-build
-  image:                           paritytech/kubetools:latest
-  environment:
-    name: parity-mgmt-polkadot-alerting
+  trigger:
+    project:  parity/infrastructure/cloud-infra
+    strategy: depend
   variables:
-    NAMESPACE:                     monitoring
-    PROMETHEUSRULE:                prometheus-k8s-rules-polkadot-alerting
-    RULES:                         .maintain/monitoring/alerting-rules/alerting-rules.yaml
-  script:
-    - echo "deploying prometheus alerting rules"
-    - kubectl -n ${NAMESPACE} patch prometheusrule ${PROMETHEUSRULE}
-        --type=merge --patch "$(sed 's/^/  /;1s/^/spec:\n/' ${RULES})"
+    SUBSTRATE_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
+    SUBSTRATE_CI_COMMIT_REF:        "${CI_COMMIT_SHORT_SHA}"
+    UPSTREAM_TRIGGER_PROJECT:       "${CI_PROJECT_PATH}"
   rules:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -674,7 +674,6 @@ deploy-prometheus-alerting-rules:
   allow_failure:                   true
   trigger:
     project:  parity/infrastructure/cloud-infra
-    strategy: depend
   variables:
     SUBSTRATE_CI_COMMIT_NAME:       "${CI_COMMIT_REF_NAME}"
     SUBSTRATE_CI_COMMIT_REF:        "${CI_COMMIT_SHORT_SHA}"


### PR DESCRIPTION
add trigger for monitoring job in cloud-infra repository to apply substrate prometheus rules for all ci enabled projects.
https://github.com/paritytech/devops/issues/882