### PR TITLE
Add CryptoStore::ecdsa_sign_prehashed()

### DIFF
--- a/client/keystore/src/local.rs
+++ b/client/keystore/src/local.rs
@@ -148,7 +148,7 @@ impl CryptoStore for LocalKeystore {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> std::result::Result<Option<Vec<u8>>, TraitError> {
+	) -> std::result::Result<Option<ecdsa::Signature>, TraitError> {
 		SyncCryptoStore::ecdsa_sign_prehashed(self, id, public, msg)
 	}
 }
@@ -316,12 +316,11 @@ impl SyncCryptoStore for LocalKeystore {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> std::result::Result<Option<Vec<u8>>, TraitError> {
+	) -> std::result::Result<Option<ecdsa::Signature>, TraitError> {
 		let pair = self.0.read()
-			.key_pair_by_type::<ecdsa::Pair>(public, id)
-			.map_err(|e| TraitError::from(e))?;
+			.key_pair_by_type::<ecdsa::Pair>(public, id)?;
 		
-		pair.map(|k| k.sign_prehashed(msg).encode()).map(Ok).transpose()
+		pair.map(|k| k.sign_prehashed(msg)).map(Ok).transpose()
 	}
 }
 

--- a/primitives/keystore/src/lib.rs
+++ b/primitives/keystore/src/lib.rs
@@ -194,6 +194,20 @@ pub trait CryptoStore: Send + Sync {
 		public: &sr25519::Public,
 		transcript_data: VRFTranscriptData,
 	) -> Result<Option<VRFSignature>, Error>;
+
+	/// Sign pre-hashed
+	///
+	/// Signs a pre-hashed message with the private key that matches
+	/// the ECDSA public key passed.
+	///
+	/// Returns the SCALE encoded signature if key is found and supported,
+	/// `None` if the key doesn't exist or an error when something failed.
+	async fn ecdsa_sign_prehashed(
+		&self,
+		id: KeyTypeId,
+		public: &ecdsa::Public,
+		msg: &[u8; 32],
+	) -> Result<Option<Vec<u8>>, Error>;
 }
 
 /// Sync version of the CryptoStore
@@ -353,6 +367,20 @@ pub trait SyncCryptoStore: CryptoStore + Send + Sync {
 		public: &sr25519::Public,
 		transcript_data: VRFTranscriptData,
 	) -> Result<Option<VRFSignature>, Error>;
+
+	/// Sign pre-hashed
+	///
+	/// Signs a pre-hashed message with the private key that matches
+	/// the ECDSA public key passed.
+	///
+	/// Returns the SCALE encoded signature if key is found and supported,
+	/// `None` if the key doesn't exist or an error when something failed.
+	fn ecdsa_sign_prehashed(
+		&self,
+		id: KeyTypeId,
+		public: &ecdsa::Public,
+		msg: &[u8; 32],
+	) -> Result<Option<Vec<u8>>, Error>;
 }
 
 /// A pointer to a keystore.

--- a/primitives/keystore/src/lib.rs
+++ b/primitives/keystore/src/lib.rs
@@ -207,7 +207,7 @@ pub trait CryptoStore: Send + Sync {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> Result<Option<Vec<u8>>, Error>;
+	) -> Result<Option<ecdsa::Signature>, Error>;
 }
 
 /// Sync version of the CryptoStore
@@ -380,7 +380,7 @@ pub trait SyncCryptoStore: CryptoStore + Send + Sync {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> Result<Option<Vec<u8>>, Error>;
+	) -> Result<Option<ecdsa::Signature>, Error>;
 }
 
 /// A pointer to a keystore.

--- a/primitives/keystore/src/testing.rs
+++ b/primitives/keystore/src/testing.rs
@@ -151,7 +151,7 @@ impl CryptoStore for KeyStore {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> Result<Option<Vec<u8>>, Error> {
+	) -> Result<Option<ecdsa::Signature>, Error> {
 		SyncCryptoStore::ecdsa_sign_prehashed(self, id, public, msg)
 	}
 }
@@ -341,11 +341,9 @@ impl SyncCryptoStore for KeyStore {
 		id: KeyTypeId,
 		public: &ecdsa::Public,
 		msg: &[u8; 32],
-	) -> Result<Option<Vec<u8>>, Error> {
-		use codec::Encode;
-
+	) -> Result<Option<ecdsa::Signature>, Error> {
 		let pair = self.ecdsa_key_pair(id, public);
-		pair.map(|k| k.sign_prehashed(msg).encode()).map(Ok).transpose()
+		pair.map(|k| k.sign_prehashed(msg)).map(Ok).transpose()
 	}
 }
 


### PR DESCRIPTION
Addresses: [Allow hasher configuration before signing with app-crypto](https://github.com/paritytech/grandpa-bridge-gadget/issues/82)

- add `ecdsa::Pair::sign_prehashed()`
- add `CryptoStore::ecdsa_sign_prehashed()`
- impl for `LocalKeystore`
- tests
