### PR TITLE
Introduce WeakBoundedVec, StorageTryAppend, and improve BoundedVec API

### DIFF
--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -321,6 +321,7 @@ macro_rules! parameter_types {
 	(IMPL_CONST $name:ident, $type:ty, $value:expr) => {
 		impl $name {
 			/// Returns the value of this parameter type.
+			#[allow(unused)]
 			pub const fn get() -> $type {
 				$value
 			}
@@ -335,6 +336,7 @@ macro_rules! parameter_types {
 	(IMPL $name:ident, $type:ty, $value:expr) => {
 		impl $name {
 			/// Returns the value of this parameter type.
+			#[allow(unused)]
 			pub fn get() -> $type {
 				$value
 			}
@@ -349,6 +351,7 @@ macro_rules! parameter_types {
 	(IMPL_STORAGE $name:ident, $type:ty, $value:expr) => {
 		impl $name {
 			/// Returns the key for this parameter type.
+			#[allow(unused)]
 			pub fn key() -> [u8; 16] {
 				$crate::sp_io::hashing::twox_128(
 					concat!(":", stringify!($name), ":").as_bytes()
@@ -359,6 +362,7 @@ macro_rules! parameter_types {
 			///
 			/// This needs to be executed in an externalities provided
 			/// environment.
+			#[allow(unused)]
 			pub fn set(value: &$type) {
 				$crate::storage::unhashed::put(&Self::key(), value);
 			}
@@ -367,6 +371,7 @@ macro_rules! parameter_types {
 			///
 			/// This needs to be executed in an externalities provided
 			/// environment.
+			#[allow(unused)]
 			pub fn get() -> $type {
 				$crate::storage::unhashed::get(&Self::key()).unwrap_or_else(|| $value)
 			}

--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -32,12 +32,28 @@ use codec::{Encode, Decode};
 /// B-Trees represent a fundamental compromise between cache-efficiency and actually minimizing
 /// the amount of work performed in a search. See [`BTreeMap`] for more details.
 ///
-/// Unlike a standard `BTreeMap`, there is a mostly enforced upper limit to the number of items
-/// in the map.
-/// The upper limit is not strictly enforced. Decoding a btree map with more element that the bound
-/// is accepted, and some method allow to bypass the restriction with warnings.
-#[derive(Encode, Decode)]
+/// Unlike a standard `BTreeMap`, there is an enforced upper limit to the number of items in the
+/// map. All internal operations ensure this bound is respected.
+#[derive(Encode)]
 pub struct BoundedBTreeMap<K, V, S>(BTreeMap<K, V>, PhantomData<S>);
+
+impl<K, V, S> Decode for BoundedBTreeMap<K, V, S>
+where
+	BTreeMap<K, V>: Decode,
+	S: Get<u32>,
+{
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let inner = BTreeMap::<K, V>::decode(input)?;
+		if inner.len() > S::get() as usize {
+			return Err("BoundedBTreeMap exceeds its limit".into());
+		}
+		Ok(Self(inner, PhantomData))
+	}
+
+	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
+		BTreeMap::<K, V>::skip(input)
+	}
+}
 
 impl<K, V, S> BoundedBTreeMap<K, V, S>
 where
@@ -59,44 +75,6 @@ where
 	/// Does not allocate.
 	pub fn new() -> Self {
 		BoundedBTreeMap(BTreeMap::new(), PhantomData)
-	}
-
-	/// Create `Self` from a primitive `BTreeMap` without any checks.
-	fn unchecked_from(map: BTreeMap<K, V>) -> Self {
-		Self(map, Default::default())
-	}
-
-	/// Create `Self` from a primitive `BTreeMap` without any checks.
-	///
-	/// Logs warnings if the bound is not being respected. The scope is mentioned in the log message
-	/// to indicate where overflow is happening.
-	///
-	/// # Example
-	///
-	/// ```
-	/// # use sp_std::collections::btree_map::BTreeMap;
-	/// # use frame_support::{parameter_types, storage::bounded_btree_map::BoundedBTreeMap};
-	/// parameter_types! {
-	/// 	pub const Size: u32 = 5;
-	/// }
-	/// let mut map = BTreeMap::new();
-	/// map.insert("foo", 1);
-	/// map.insert("bar", 2);
-	/// let bounded_map = BoundedBTreeMap::<_, _, Size>::force_from(map, "demo");
-	/// ```
-	pub fn force_from<Scope>(map: BTreeMap<K, V>, scope: Scope) -> Self
-	where
-		Scope: Into<Option<&'static str>>,
-	{
-		if map.len() > Self::bound() {
-			log::warn!(
-				target: crate::LOG_TARGET,
-				"length of a bounded btreemap in scope {} is not respected.",
-				scope.into().unwrap_or("UNKNOWN"),
-			);
-		}
-
-		Self::unchecked_from(map)
 	}
 
 	/// Consume self, and return the inner `BTreeMap`.
@@ -419,5 +397,14 @@ pub mod test {
 	fn btree_map_eq_works() {
 		let bounded = boundedmap_from_keys::<u32, Seven>(&[1, 2, 3, 4, 5, 6]);
 		assert_eq!(bounded, map_from_keys(&[1, 2, 3, 4, 5, 6]));
+	}
+
+	#[test]
+	fn too_big_fail_to_decode() {
+		let v: Vec<(u32, u32)> = vec![(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)];
+		assert_eq!(
+			BoundedBTreeMap::<u32, u32, Four>::decode(&mut &v.encode()[..]),
+			Err("BoundedBTreeMap exceeds its limit".into()),
+		);
 	}
 }

--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -32,8 +32,10 @@ use codec::{Encode, Decode};
 /// B-Trees represent a fundamental compromise between cache-efficiency and actually minimizing
 /// the amount of work performed in a search. See [`BTreeMap`] for more details.
 ///
-/// Unlike a standard `BTreeMap`, there is a static, enforced upper limit to the number of items
-/// in the map. All internal operations ensure this bound is respected.
+/// Unlike a standard `BTreeMap`, there is a mostly enforced upper limit to the number of items
+/// in the map.
+/// The upper limit is not strictly enforced. Decoding a btree map with more element that the bound
+/// is accepted, and some method allow to bypass the restriction with warnings.
 #[derive(Encode, Decode)]
 pub struct BoundedBTreeMap<K, V, S>(BTreeMap<K, V>, PhantomData<S>);
 
@@ -60,7 +62,7 @@ where
 	}
 
 	/// Create `Self` from a primitive `BTreeMap` without any checks.
-	unsafe fn unchecked_from(map: BTreeMap<K, V>) -> Self {
+	fn unchecked_from(map: BTreeMap<K, V>) -> Self {
 		Self(map, Default::default())
 	}
 
@@ -80,9 +82,9 @@ where
 	/// let mut map = BTreeMap::new();
 	/// map.insert("foo", 1);
 	/// map.insert("bar", 2);
-	/// let bounded_map = unsafe {BoundedBTreeMap::<_, _, Size>::force_from(map, "demo")};
+	/// let bounded_map = BoundedBTreeMap::<_, _, Size>::force_from(map, "demo");
 	/// ```
-	pub unsafe fn force_from<Scope>(map: BTreeMap<K, V>, scope: Scope) -> Self
+	pub fn force_from<Scope>(map: BTreeMap<K, V>, scope: Scope) -> Self
 	where
 		Scope: Into<Option<&'static str>>,
 	{

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -32,12 +32,28 @@ use codec::{Encode, Decode};
 /// B-Trees represent a fundamental compromise between cache-efficiency and actually minimizing
 /// the amount of work performed in a search. See [`BTreeSet`] for more details.
 ///
-/// Unlike a standard `BTreeSet`, there is a mostly enforced upper limit to the number of items in
-/// the set.
-/// The upper limit is not strictly enforced. Decoding a btree set with more element that the bound
-/// is accepted, and some method allow to bypass the restriction with warnings.
-#[derive(Encode, Decode)]
+/// Unlike a standard `BTreeSet`, there is an enforced upper limit to the number of items in the
+/// set. All internal operations ensure this bound is respected.
+#[derive(Encode)]
 pub struct BoundedBTreeSet<T, S>(BTreeSet<T>, PhantomData<S>);
+
+impl<T, S> Decode for BoundedBTreeSet<T, S>
+where
+	BTreeSet<T>: Decode,
+	S: Get<u32>,
+{
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let inner = BTreeSet::<T>::decode(input)?;
+		if inner.len() > S::get() as usize {
+			return Err("BoundedBTreeSet exceeds its limit".into());
+		}
+		Ok(Self(inner, PhantomData))
+	}
+
+	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
+		BTreeSet::<T>::skip(input)
+	}
+}
 
 impl<T, S> BoundedBTreeSet<T, S>
 where
@@ -59,44 +75,6 @@ where
 	/// Does not allocate.
 	pub fn new() -> Self {
 		BoundedBTreeSet(BTreeSet::new(), PhantomData)
-	}
-
-	/// Create `Self` from a primitive `BTreeSet` without any checks.
-	fn unchecked_from(set: BTreeSet<T>) -> Self {
-		Self(set, Default::default())
-	}
-
-	/// Create `Self` from a primitive `BTreeSet` without any checks.
-	///
-	/// Logs warnings if the bound is not being respected. The scope is mentioned in the log message
-	/// to indicate where overflow is happening.
-	///
-	/// # Example
-	///
-	/// ```
-	/// # use sp_std::collections::btree_set::BTreeSet;
-	/// # use frame_support::{parameter_types, storage::bounded_btree_set::BoundedBTreeSet};
-	/// parameter_types! {
-	/// 	pub const Size: u32 = 5;
-	/// }
-	/// let mut set = BTreeSet::new();
-	/// set.insert("foo");
-	/// set.insert("bar");
-	/// let bounded_set = BoundedBTreeSet::<_, Size>::force_from(set, "demo");
-	/// ```
-	pub fn force_from<Scope>(set: BTreeSet<T>, scope: Scope) -> Self
-	where
-		Scope: Into<Option<&'static str>>,
-	{
-		if set.len() > Self::bound() {
-			log::warn!(
-				target: crate::LOG_TARGET,
-				"length of a bounded btreeset in scope {} is not respected.",
-				scope.into().unwrap_or("UNKNOWN"),
-			);
-		}
-
-		Self::unchecked_from(set)
 	}
 
 	/// Consume self, and return the inner `BTreeSet`.
@@ -405,5 +383,14 @@ pub mod test {
 	fn btree_map_eq_works() {
 		let bounded = boundedmap_from_keys::<u32, Seven>(&[1, 2, 3, 4, 5, 6]);
 		assert_eq!(bounded, map_from_keys(&[1, 2, 3, 4, 5, 6]));
+	}
+
+	#[test]
+	fn too_big_fail_to_decode() {
+		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
+		assert_eq!(
+			BoundedBTreeSet::<u32, Four>::decode(&mut &v.encode()[..]),
+			Err("BoundedBTreeSet exceeds its limit".into()),
+		);
 	}
 }

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -32,8 +32,10 @@ use codec::{Encode, Decode};
 /// B-Trees represent a fundamental compromise between cache-efficiency and actually minimizing
 /// the amount of work performed in a search. See [`BTreeSet`] for more details.
 ///
-/// Unlike a standard `BTreeSet`, there is a static, enforced upper limit to the number of items
-/// in the set. All internal operations ensure this bound is respected.
+/// Unlike a standard `BTreeSet`, there is a mostly enforced upper limit to the number of items in
+/// the set.
+/// The upper limit is not strictly enforced. Decoding a btree set with more element that the bound
+/// is accepted, and some method allow to bypass the restriction with warnings.
 #[derive(Encode, Decode)]
 pub struct BoundedBTreeSet<T, S>(BTreeSet<T>, PhantomData<S>);
 
@@ -60,7 +62,7 @@ where
 	}
 
 	/// Create `Self` from a primitive `BTreeSet` without any checks.
-	unsafe fn unchecked_from(set: BTreeSet<T>) -> Self {
+	fn unchecked_from(set: BTreeSet<T>) -> Self {
 		Self(set, Default::default())
 	}
 
@@ -80,9 +82,9 @@ where
 	/// let mut set = BTreeSet::new();
 	/// set.insert("foo");
 	/// set.insert("bar");
-	/// let bounded_set = unsafe {BoundedBTreeSet::<_, Size>::force_from(set, "demo")};
+	/// let bounded_set = BoundedBTreeSet::<_, Size>::force_from(set, "demo");
 	/// ```
-	pub unsafe fn force_from<Scope>(set: BTreeSet<T>, scope: Scope) -> Self
+	pub fn force_from<Scope>(set: BTreeSet<T>, scope: Scope) -> Self
 	where
 		Scope: Into<Option<&'static str>>,
 	{

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -147,7 +147,7 @@ impl<T, S: Get<u32>> BoundedVec<T, S> {
 impl<T, S> Default for BoundedVec<T, S> {
 	fn default() -> Self {
 		// the bound cannot be below 0, which is satisfied by an empty vector
-		unsafe { Self::unchecked_from(Vec::default()) }
+		Self::unchecked_from(Vec::default())
 	}
 }
 
@@ -168,7 +168,7 @@ where
 {
 	fn clone(&self) -> Self {
 		// bound is retained
-		unsafe { Self::unchecked_from(self.0.clone()) }
+		Self::unchecked_from(self.0.clone())
 	}
 }
 
@@ -177,7 +177,7 @@ impl<T, S: Get<u32>> TryFrom<Vec<T>> for BoundedVec<T, S> {
 	fn try_from(t: Vec<T>) -> Result<Self, Self::Error> {
 		if t.len() <= Self::bound() {
 			// explicit check just above
-			Ok(unsafe { Self::unchecked_from(t) })
+			Ok(Self::unchecked_from(t))
 		} else {
 			Err(())
 		}
@@ -472,13 +472,15 @@ pub mod test {
 			// append to a non-existing
 			assert!(FooMap::get(2).is_none());
 			assert_ok!(FooMap::try_append(2, 4));
-			assert_eq!(FooMap::get(2).unwrap(), unsafe {
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4])
-			});
+			assert_eq!(
+				FooMap::get(2).unwrap(),
+				BoundedVec::<u32, Seven>::unchecked_from(vec![4]),
+			);
 			assert_ok!(FooMap::try_append(2, 5));
-			assert_eq!(FooMap::get(2).unwrap(), unsafe {
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5])
-			});
+			assert_eq!(
+				FooMap::get(2).unwrap(),
+				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
+			);
 		});
 
 		TestExternalities::default().execute_with(|| {
@@ -495,13 +497,15 @@ pub mod test {
 			// append to a non-existing
 			assert!(FooDoubleMap::get(2, 1).is_none());
 			assert_ok!(FooDoubleMap::try_append(2, 1, 4));
-			assert_eq!(FooDoubleMap::get(2, 1).unwrap(), unsafe {
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4])
-			});
+			assert_eq!(
+				FooDoubleMap::get(2, 1).unwrap(),
+				BoundedVec::<u32, Seven>::unchecked_from(vec![4]),
+			);
 			assert_ok!(FooDoubleMap::try_append(2, 1, 5));
-			assert_eq!(FooDoubleMap::get(2, 1).unwrap(), unsafe {
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5])
-			});
+			assert_eq!(
+				FooDoubleMap::get(2, 1).unwrap(),
+				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
+			);
 		});
 	}
 

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -35,14 +35,14 @@ use crate::{
 /// It has implementations for efficient append and length decoding, as with a normal `Vec<_>`, once
 /// put into storage as a raw value, map or double-map.
 ///
-/// As the name suggests, the length of the queue is always bounded. All internal operations ensure
-/// this bound is respected.
+/// The length of the vec is not strictly bounded. Decoding a vec with more element that the bound
+/// is accepted, and some method allow to bypass the restriction with warnings.
 #[derive(Encode, Decode)]
 pub struct BoundedVec<T, S>(Vec<T>, PhantomData<S>);
 
 impl<T, S> BoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.
-	unsafe fn unchecked_from(t: Vec<T>) -> Self {
+	fn unchecked_from(t: Vec<T>) -> Self {
 		Self(t, Default::default())
 	}
 
@@ -89,7 +89,7 @@ impl<T, S: Get<u32>> BoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks. Logs warnings if the bound is not being
 	/// respected. The additional scope can be used to indicate where a potential overflow is
 	/// happening.
-	pub unsafe fn force_from(t: Vec<T>, scope: Option<&'static str>) -> Self {
+	pub fn force_from(t: Vec<T>, scope: Option<&'static str>) -> Self {
 		if t.len() > Self::bound() {
 			log::warn!(
 				target: crate::LOG_TARGET,

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -285,7 +285,7 @@ where
 	BoundedVec<T, S>: Encode,
 {
 	fn max_encoded_len() -> usize {
-		// WeakBoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
+		// BoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
 		// plus each item in the slice:
 		// https://substrate.dev/rustdocs/v3.0.0/src/parity_scale_codec/codec.rs.html#798-808
 		codec::Compact(S::get())

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1013,7 +1013,8 @@ impl<T: Encode> StorageDecodeLength for Vec<T> {}
 /// format ever changes, we need to remove this here.
 impl<Hash: Encode> StorageAppend<DigestItem<Hash>> for Digest<Hash> {}
 
-/// Marker trait that will be implemented for types that support the `storage::try_append` api.
+/// Marker trait that is implemented for types that support the `storage::append` api with a limit
+/// on the number of element.
 ///
 /// This trait is sealed.
 pub trait StorageTryAppend<Item>: StorageDecodeLength + private::Sealed {

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -1021,7 +1021,7 @@ pub trait StorageTryAppend<Item>: StorageDecodeLength + private::Sealed {
 	fn bound() -> usize;
 }
 
-/// Storage value that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+/// Storage value that is capable of [`StorageTryAppend`](crate::storage::StorageTryAppend).
 pub trait TryAppendValue<T: StorageTryAppend<I>, I: Encode> {
 	/// Try and append the `item` into the storage item.
 	///
@@ -1050,7 +1050,7 @@ where
 	}
 }
 
-/// Storage map that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+/// Storage map that is capable of [`StorageTryAppend`](crate::storage::StorageTryAppend).
 pub trait TryAppendMap<K: Encode, T: StorageTryAppend<I>, I: Encode> {
 	/// Try and append the `item` into the storage map at the given `key`.
 	///
@@ -1084,7 +1084,7 @@ where
 	}
 }
 
-/// Storage double map that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+/// Storage double map that is capable of [`StorageTryAppend`](crate::storage::StorageTryAppend).
 pub trait TryAppendDoubleMap<K1: Encode, K2: Encode, T: StorageTryAppend<I>, I: Encode> {
 	/// Try and append the `item` into the storage double map at the given `key`.
 	///

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -36,6 +36,7 @@ pub mod hashed;
 pub mod bounded_btree_map;
 pub mod bounded_btree_set;
 pub mod bounded_vec;
+pub mod weak_bounded_vec;
 pub mod child;
 #[doc(hidden)]
 pub mod generator;
@@ -965,12 +966,14 @@ pub trait StorageDecodeLength: private::Sealed + codec::DecodeLength {
 mod private {
 	use super::*;
 	use bounded_vec::BoundedVec;
+	use weak_bounded_vec::WeakBoundedVec;
 
 	pub trait Sealed {}
 
 	impl<T: Encode> Sealed for Vec<T> {}
 	impl<Hash: Encode> Sealed for Digest<Hash> {}
 	impl<T, S> Sealed for BoundedVec<T, S> {}
+	impl<T, S> Sealed for WeakBoundedVec<T, S> {}
 	impl<K, V, S> Sealed for bounded_btree_map::BoundedBTreeMap<K, V, S> {}
 	impl<T, S> Sealed for bounded_btree_set::BoundedBTreeSet<T, S> {}
 
@@ -1009,6 +1012,121 @@ impl<T: Encode> StorageDecodeLength for Vec<T> {}
 /// internal vec and we can append to this vec. We have a test that ensures that if the `Digest`
 /// format ever changes, we need to remove this here.
 impl<Hash: Encode> StorageAppend<DigestItem<Hash>> for Digest<Hash> {}
+
+/// Marker trait that will be implemented for types that support the `storage::try_append` api.
+///
+/// This trait is sealed.
+pub trait StorageTryAppend<Item>: StorageDecodeLength + private::Sealed {
+	fn bound() -> usize;
+}
+
+/// Storage value that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+pub trait TryAppendValue<T: StorageTryAppend<I>, I: Encode> {
+	/// Try and append the `item` into the storage item.
+	///
+	/// This might fail if bounds are not respected.
+	fn try_append<LikeI: EncodeLike<I>>(item: LikeI) -> Result<(), ()>;
+}
+
+impl<T, I, StorageValueT> TryAppendValue<T, I> for StorageValueT
+where
+	I: Encode,
+	T: FullCodec + StorageTryAppend<I>,
+	StorageValueT: generator::StorageValue<T>,
+{
+	fn try_append<LikeI: EncodeLike<I>>(item: LikeI) -> Result<(), ()> {
+		let bound = T::bound();
+		let current = Self::decode_len().unwrap_or_default();
+		if current < bound {
+			// NOTE: we cannot reuse the implementation for `Vec<T>` here because we never want to
+			// mark `BoundedVec<T, S>` as `StorageAppend`.
+			let key = Self::storage_value_final_key();
+			sp_io::storage::append(&key, item.encode());
+			Ok(())
+		} else {
+			Err(())
+		}
+	}
+}
+
+/// Storage map that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+pub trait TryAppendMap<K: Encode, T: StorageTryAppend<I>, I: Encode> {
+	/// Try and append the `item` into the storage map at the given `key`.
+	///
+	/// This might fail if bounds are not respected.
+	fn try_append<LikeK: EncodeLike<K> + Clone, LikeI: EncodeLike<I>>(
+		key: LikeK,
+		item: LikeI,
+	) -> Result<(), ()>;
+}
+
+impl<K, T, I, StorageMapT> TryAppendMap<K, T, I> for StorageMapT
+where
+	K: FullCodec,
+	T: FullCodec + StorageTryAppend<I>,
+	I: Encode,
+	StorageMapT: generator::StorageMap<K, T>,
+{
+	fn try_append<LikeK: EncodeLike<K> + Clone, LikeI: EncodeLike<I>>(
+		key: LikeK,
+		item: LikeI,
+	) -> Result<(), ()> {
+		let bound = T::bound();
+		let current = Self::decode_len(key.clone()).unwrap_or_default();
+		if current < bound {
+			let key = Self::storage_map_final_key(key);
+			sp_io::storage::append(&key, item.encode());
+			Ok(())
+		} else {
+			Err(())
+		}
+	}
+}
+
+/// Storage double map that is *maybe* capable of [`StorageAppend`](crate::storage::StorageAppend).
+pub trait TryAppendDoubleMap<K1: Encode, K2: Encode, T: StorageTryAppend<I>, I: Encode> {
+	/// Try and append the `item` into the storage double map at the given `key`.
+	///
+	/// This might fail if bounds are not respected.
+	fn try_append<
+		LikeK1: EncodeLike<K1> + Clone,
+		LikeK2: EncodeLike<K2> + Clone,
+		LikeI: EncodeLike<I>,
+	>(
+		key1: LikeK1,
+		key2: LikeK2,
+		item: LikeI,
+	) -> Result<(), ()>;
+}
+
+impl<K1, K2, T, I, StorageDoubleMapT> TryAppendDoubleMap<K1, K2, T, I> for StorageDoubleMapT
+where
+	K1: FullCodec,
+	K2: FullCodec,
+	T: FullCodec + StorageTryAppend<I>,
+	I: Encode,
+	StorageDoubleMapT: generator::StorageDoubleMap<K1, K2, T>,
+{
+	fn try_append<
+		LikeK1: EncodeLike<K1> + Clone,
+		LikeK2: EncodeLike<K2> + Clone,
+		LikeI: EncodeLike<I>,
+	>(
+		key1: LikeK1,
+		key2: LikeK2,
+		item: LikeI,
+	) -> Result<(), ()> {
+		let bound = T::bound();
+		let current = Self::decode_len(key1.clone(), key2.clone()).unwrap_or_default();
+		if current < bound {
+			let double_map_key = Self::storage_double_map_final_key(key1, key2);
+			sp_io::storage::append(&double_map_key, item.encode());
+			Ok(())
+		} else {
+			Err(())
+		}
+	}
+}
 
 #[cfg(test)]
 mod test {

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -21,8 +21,7 @@
 use codec::{FullCodec, Decode, EncodeLike, Encode};
 use crate::{
 	storage::{
-		StorageAppend, StorageDecodeLength, StoragePrefixedMap,
-		bounded_vec::BoundedVec,
+		StorageAppend, StorageTryAppend, StorageDecodeLength, StoragePrefixedMap,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
 	traits::{GetDefault, StorageInstance, Get, MaxEncodedLen, StorageInfo},
@@ -95,35 +94,6 @@ where
 	}
 	fn storage_prefix() -> &'static [u8] {
 		<Self as crate::storage::generator::StorageMap<Key, Value>>::storage_prefix()
-	}
-}
-
-impl<Prefix, Hasher, Key, QueryKind, OnEmpty, MaxValues, VecValue, VecBound>
-	StorageMap<Prefix, Hasher, Key, BoundedVec<VecValue, VecBound>, QueryKind, OnEmpty, MaxValues>
-where
-	Prefix: StorageInstance,
-	Hasher: crate::hash::StorageHasher,
-	Key: FullCodec,
-	QueryKind: QueryKindTrait<BoundedVec<VecValue, VecBound>, OnEmpty>,
-	OnEmpty: Get<QueryKind::Query> + 'static,
-	MaxValues: Get<Option<u32>>,
-	VecValue: FullCodec,
-	VecBound: Get<u32>,
-{
-	/// Try and append the given item to the map in the storage.
-	///
-	/// Is only available if `Value` of the map is [`BoundedVec`].
-	pub fn try_append<EncodeLikeItem, EncodeLikeKey>(
-		key: EncodeLikeKey,
-		item: EncodeLikeItem,
-	) -> Result<(), ()>
-	where
-		EncodeLikeKey: EncodeLike<Key> + Clone,
-		EncodeLikeItem: EncodeLike<VecValue>,
-	{
-		<Self as crate::storage::bounded_vec::TryAppendMap<Key, VecValue, VecBound>>::try_append(
-			key, item,
-		)
 	}
 }
 
@@ -288,6 +258,24 @@ where
 	/// This would typically be called inside the module implementation of on_runtime_upgrade.
 	pub fn translate_values<OldValue: Decode, F: FnMut(OldValue) -> Option<Value>>(f: F) {
 		<Self as crate::storage::StoragePrefixedMap<Value>>::translate_values(f)
+	}
+
+	/// Try and append the given item to the value in the storage.
+	///
+	/// Is only available if `Value` of the storage implements [`StorageTryAppend`].
+	pub fn try_append<KArg, Item, EncodeLikeItem>(
+		key: KArg,
+		item: EncodeLikeItem,
+	) -> Result<(), ()>
+	where
+		KArg: EncodeLike<Key> + Clone,
+		Item: Encode,
+		EncodeLikeItem: EncodeLike<Item>,
+		Value: StorageTryAppend<Item>,
+	{
+		<
+			Self as crate::storage::TryAppendMap<Key, Value, Item>
+		>::try_append(key, item)
 	}
 }
 

--- a/frame/support/src/storage/types/value.rs
+++ b/frame/support/src/storage/types/value.rs
@@ -20,11 +20,10 @@
 use codec::{FullCodec, Decode, EncodeLike, Encode};
 use crate::{
 	storage::{
-		StorageAppend, StorageDecodeLength,
-		bounded_vec::BoundedVec,
+		StorageAppend, StorageTryAppend, StorageDecodeLength,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
-	traits::{GetDefault, StorageInstance, Get, MaxEncodedLen, StorageInfo},
+	traits::{GetDefault, StorageInstance, MaxEncodedLen, StorageInfo},
 };
 use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 use sp_arithmetic::traits::SaturatedConversion;
@@ -60,26 +59,6 @@ where
 	}
 	fn from_query_to_optional_value(v: Self::Query) -> Option<Value> {
 		QueryKind::from_query_to_optional_value(v)
-	}
-}
-
-impl<Prefix, QueryKind, OnEmpty, VecValue, VecBound>
-	StorageValue<Prefix, BoundedVec<VecValue, VecBound>, QueryKind, OnEmpty>
-where
-	Prefix: StorageInstance,
-	QueryKind: QueryKindTrait<BoundedVec<VecValue, VecBound>, OnEmpty>,
-	OnEmpty: crate::traits::Get<QueryKind::Query> + 'static,
-	VecValue: FullCodec,
-	VecBound: Get<u32>,
-{
-	/// Try and append the given item to the value in the storage.
-	///
-	/// Is only available if `Value` of the storage is [`BoundedVec`].
-	pub fn try_append<EncodeLikeItem>(item: EncodeLikeItem) -> Result<(), ()>
-	where
-		EncodeLikeItem: EncodeLike<VecValue>,
-	{
-		<Self as crate::storage::bounded_vec::TryAppendValue<VecValue, VecBound>>::try_append(item)
 	}
 }
 
@@ -191,6 +170,18 @@ where
 	/// ignored by this function.
 	pub fn decode_len() -> Option<usize> where Value: StorageDecodeLength {
 		<Self as crate::storage::StorageValue<Value>>::decode_len()
+	}
+
+	/// Try and append the given item to the value in the storage.
+	///
+	/// Is only available if `Value` of the storage implements [`StorageTryAppend`].
+	pub fn try_append<Item, EncodeLikeItem>(item: EncodeLikeItem) -> Result<(), ()>
+	where
+		Item: Encode,
+		EncodeLikeItem: EncodeLike<Item>,
+		Value: StorageTryAppend<Item>,
+	{
+		<Self as crate::storage::TryAppendValue<Value, Item>>::try_append(item)
 	}
 }
 

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -43,13 +43,7 @@ pub struct WeakBoundedVec<T, S>(Vec<T>, PhantomData<S>);
 impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		let inner = Vec::<T>::decode(input)?;
-		if inner.len() > S::get() as usize {
-			log::warn!(
-				target: crate::LOG_TARGET,
-				"length of a weakly bounded vector is not respected.",
-			);
-		}
-		Ok(Self(inner, PhantomData))
+		Ok(Self::force_from(inner, Some("decode")))
 	}
 
 	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -30,21 +30,24 @@ use crate::{
 	storage::{StorageDecodeLength, StorageTryAppend},
 };
 
-/// A bounded vector.
+/// A weakly bounded vector.
 ///
 /// It has implementations for efficient append and length decoding, as with a normal `Vec<_>`, once
 /// put into storage as a raw value, map or double-map.
 ///
-/// As the name suggests, the length of the queue is always bounded. All internal operations ensure
-/// this bound is respected.
+/// The length of the vec is not strictly bounded. Decoding a vec with more element that the bound
+/// is accepted, and some method allow to bypass the restriction with warnings.
 #[derive(Encode)]
-pub struct BoundedVec<T, S>(Vec<T>, PhantomData<S>);
+pub struct WeakBoundedVec<T, S>(Vec<T>, PhantomData<S>);
 
-impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
+impl<T: Decode, S: Get<u32>> Decode for WeakBoundedVec<T, S> {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
 		let inner = Vec::<T>::decode(input)?;
 		if inner.len() > S::get() as usize {
-			return Err("BoundedVec exceeds its limit".into());
+			log::warn!(
+				target: crate::LOG_TARGET,
+				"length of a weakly bounded vector is not respected.",
+			);
 		}
 		Ok(Self(inner, PhantomData))
 	}
@@ -54,7 +57,7 @@ impl<T: Decode, S: Get<u32>> Decode for BoundedVec<T, S> {
 	}
 }
 
-impl<T, S> BoundedVec<T, S> {
+impl<T, S> WeakBoundedVec<T, S> {
 	/// Create `Self` from `t` without any checks.
 	fn unchecked_from(t: Vec<T>) -> Self {
 		Self(t, Default::default())
@@ -65,7 +68,7 @@ impl<T, S> BoundedVec<T, S> {
 	/// be used.
 	///
 	/// This is useful for cases if you need access to an internal API of the inner `Vec<_>` which
-	/// is not provided by the wrapper `BoundedVec`.
+	/// is not provided by the wrapper `WeakBoundedVec`.
 	pub fn into_inner(self) -> Vec<T> {
 		self.0
 	}
@@ -94,10 +97,25 @@ impl<T, S> BoundedVec<T, S> {
 	}
 }
 
-impl<T, S: Get<u32>> BoundedVec<T, S> {
+impl<T, S: Get<u32>> WeakBoundedVec<T, S> {
 	/// Get the bound of the type in `usize`.
 	pub fn bound() -> usize {
 		S::get() as usize
+	}
+
+	/// Create `Self` from `t` without any checks. Logs warnings if the bound is not being
+	/// respected. The additional scope can be used to indicate where a potential overflow is
+	/// happening.
+	pub fn force_from(t: Vec<T>, scope: Option<&'static str>) -> Self {
+		if t.len() > Self::bound() {
+			log::warn!(
+				target: crate::LOG_TARGET,
+				"length of a bounded vector in scope {} is not respected.",
+				scope.unwrap_or("UNKNOWN"),
+			);
+		}
+
+		Self::unchecked_from(t)
 	}
 
 	/// Consumes self and mutates self via the given `mutate` function.
@@ -143,7 +161,7 @@ impl<T, S: Get<u32>> BoundedVec<T, S> {
 	}
 }
 
-impl<T, S> Default for BoundedVec<T, S> {
+impl<T, S> Default for WeakBoundedVec<T, S> {
 	fn default() -> Self {
 		// the bound cannot be below 0, which is satisfied by an empty vector
 		Self::unchecked_from(Vec::default())
@@ -151,17 +169,17 @@ impl<T, S> Default for BoundedVec<T, S> {
 }
 
 #[cfg(feature = "std")]
-impl<T, S> fmt::Debug for BoundedVec<T, S>
+impl<T, S> fmt::Debug for WeakBoundedVec<T, S>
 where
 	T: fmt::Debug,
 	S: Get<u32>,
 {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.debug_tuple("BoundedVec").field(&self.0).field(&Self::bound()).finish()
+		f.debug_tuple("WeakBoundedVec").field(&self.0).field(&Self::bound()).finish()
 	}
 }
 
-impl<T, S> Clone for BoundedVec<T, S>
+impl<T, S> Clone for WeakBoundedVec<T, S>
 where
 	T: Clone,
 {
@@ -171,7 +189,7 @@ where
 	}
 }
 
-impl<T, S: Get<u32>> TryFrom<Vec<T>> for BoundedVec<T, S> {
+impl<T, S: Get<u32>> TryFrom<Vec<T>> for WeakBoundedVec<T, S> {
 	type Error = ();
 	fn try_from(t: Vec<T>) -> Result<Self, Self::Error> {
 		if t.len() <= Self::bound() {
@@ -184,26 +202,26 @@ impl<T, S: Get<u32>> TryFrom<Vec<T>> for BoundedVec<T, S> {
 }
 
 // It is okay to give a non-mutable reference of the inner vec to anyone.
-impl<T, S> AsRef<Vec<T>> for BoundedVec<T, S> {
+impl<T, S> AsRef<Vec<T>> for WeakBoundedVec<T, S> {
 	fn as_ref(&self) -> &Vec<T> {
 		&self.0
 	}
 }
 
-impl<T, S> AsRef<[T]> for BoundedVec<T, S> {
+impl<T, S> AsRef<[T]> for WeakBoundedVec<T, S> {
 	fn as_ref(&self) -> &[T] {
 		&self.0
 	}
 }
 
-impl<T, S> AsMut<[T]> for BoundedVec<T, S> {
+impl<T, S> AsMut<[T]> for WeakBoundedVec<T, S> {
 	fn as_mut(&mut self) -> &mut [T] {
 		&mut self.0
 	}
 }
 
-// will allow for immutable all operations of `Vec<T>` on `BoundedVec<T>`.
-impl<T, S> Deref for BoundedVec<T, S> {
+// will allow for immutable all operations of `Vec<T>` on `WeakBoundedVec<T>`.
+impl<T, S> Deref for WeakBoundedVec<T, S> {
 	type Target = Vec<T>;
 
 	fn deref(&self) -> &Self::Target {
@@ -212,7 +230,7 @@ impl<T, S> Deref for BoundedVec<T, S> {
 }
 
 // Allows for indexing similar to a normal `Vec`. Can panic if out of bound.
-impl<T, S, I> Index<I> for BoundedVec<T, S>
+impl<T, S, I> Index<I> for WeakBoundedVec<T, S>
 where
 	I: SliceIndex<[T]>,
 {
@@ -224,7 +242,7 @@ where
 	}
 }
 
-impl<T, S, I> IndexMut<I> for BoundedVec<T, S>
+impl<T, S, I> IndexMut<I> for WeakBoundedVec<T, S>
 where
 	I: SliceIndex<[T]>,
 {
@@ -234,7 +252,7 @@ where
 	}
 }
 
-impl<T, S> sp_std::iter::IntoIterator for BoundedVec<T, S> {
+impl<T, S> sp_std::iter::IntoIterator for WeakBoundedVec<T, S> {
 	type Item = T;
 	type IntoIter = sp_std::vec::IntoIter<T>;
 	fn into_iter(self) -> Self::IntoIter {
@@ -242,18 +260,18 @@ impl<T, S> sp_std::iter::IntoIterator for BoundedVec<T, S> {
 	}
 }
 
-impl<T, S> codec::DecodeLength for BoundedVec<T, S> {
+impl<T, S> codec::DecodeLength for WeakBoundedVec<T, S> {
 	fn len(self_encoded: &[u8]) -> Result<usize, codec::Error> {
-		// `BoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in
+		// `WeakBoundedVec<T, _>` stored just a `Vec<T>`, thus the length is at the beginning in
 		// `Compact` form, and same implementation as `Vec<T>` can be used.
 		<Vec<T> as codec::DecodeLength>::len(self_encoded)
 	}
 }
 
 // NOTE: we could also implement this as:
-// impl<T: Value, S1: Get<u32>, S2: Get<u32>> PartialEq<BoundedVec<T, S2>> for BoundedVec<T, S1>
+// impl<T: Value, S1: Get<u32>, S2: Get<u32>> PartialEq<WeakBoundedVec<T, S2>> for WeakBoundedVec<T, S1>
 // to allow comparison of bounded vectors with different bounds.
-impl<T, S> PartialEq for BoundedVec<T, S>
+impl<T, S> PartialEq for WeakBoundedVec<T, S>
 where
 	T: PartialEq,
 {
@@ -262,27 +280,27 @@ where
 	}
 }
 
-impl<T: PartialEq, S: Get<u32>> PartialEq<Vec<T>> for BoundedVec<T, S> {
+impl<T: PartialEq, S: Get<u32>> PartialEq<Vec<T>> for WeakBoundedVec<T, S> {
 	fn eq(&self, other: &Vec<T>) -> bool {
 		&self.0 == other
 	}
 }
 
-impl<T, S> Eq for BoundedVec<T, S> where T: Eq {}
+impl<T, S> Eq for WeakBoundedVec<T, S> where T: Eq {}
 
-impl<T, S> StorageDecodeLength for BoundedVec<T, S> {}
+impl<T, S> StorageDecodeLength for WeakBoundedVec<T, S> {}
 
-impl<I, T, S: Get<u32>> StorageTryAppend<I> for BoundedVec<T, S> {
+impl<I, T, S: Get<u32>> StorageTryAppend<I> for WeakBoundedVec<T, S> {
 	fn bound() -> usize {
 		S::get() as usize
 	}
 }
 
-impl<T, S> MaxEncodedLen for BoundedVec<T, S>
+impl<T, S> MaxEncodedLen for WeakBoundedVec<T, S>
 where
 	T: MaxEncodedLen,
 	S: Get<u32>,
-	BoundedVec<T, S>: Encode,
+	WeakBoundedVec<T, S>: Encode,
 {
 	fn max_encoded_len() -> usize {
 		// WeakBoundedVec<T, S> encodes like Vec<T> which encodes like [T], which is a compact u32
@@ -306,23 +324,23 @@ pub mod test {
 		pub const Four: u32 = 4;
 	}
 
-	crate::generate_storage_alias! { Prefix, Foo => Value<BoundedVec<u32, Seven>> }
-	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), BoundedVec<u32, Seven>> }
+	crate::generate_storage_alias! { Prefix, Foo => Value<WeakBoundedVec<u32, Seven>> }
+	crate::generate_storage_alias! { Prefix, FooMap => Map<(u32, Twox128), WeakBoundedVec<u32, Seven>> }
 	crate::generate_storage_alias! {
 		Prefix,
-		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), BoundedVec<u32, Seven>>
+		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), WeakBoundedVec<u32, Seven>>
 	}
 
 	#[test]
 	fn decode_len_works() {
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			Foo::put(bounded);
 			assert_eq!(Foo::decode_len().unwrap(), 3);
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			FooMap::insert(1, bounded);
 			assert_eq!(FooMap::decode_len(1).unwrap(), 3);
 			assert!(FooMap::decode_len(0).is_none());
@@ -330,7 +348,7 @@ pub mod test {
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			FooDoubleMap::insert(1, 1, bounded);
 			assert_eq!(FooDoubleMap::decode_len(1, 1).unwrap(), 3);
 			assert!(FooDoubleMap::decode_len(2, 1).is_none());
@@ -342,7 +360,7 @@ pub mod test {
 	#[test]
 	fn try_append_works() {
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			Foo::put(bounded);
 			assert_ok!(Foo::try_append(4));
 			assert_ok!(Foo::try_append(5));
@@ -353,7 +371,7 @@ pub mod test {
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			FooMap::insert(1, bounded);
 
 			assert_ok!(FooMap::try_append(1, 4));
@@ -368,17 +386,17 @@ pub mod test {
 			assert_ok!(FooMap::try_append(2, 4));
 			assert_eq!(
 				FooMap::get(2).unwrap(),
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4]),
+				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4]),
 			);
 			assert_ok!(FooMap::try_append(2, 5));
 			assert_eq!(
 				FooMap::get(2).unwrap(),
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
+				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
 			);
 		});
 
 		TestExternalities::default().execute_with(|| {
-			let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 			FooDoubleMap::insert(1, 1, bounded);
 
 			assert_ok!(FooDoubleMap::try_append(1, 1, 4));
@@ -393,19 +411,19 @@ pub mod test {
 			assert_ok!(FooDoubleMap::try_append(2, 1, 4));
 			assert_eq!(
 				FooDoubleMap::get(2, 1).unwrap(),
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4]),
+				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4]),
 			);
 			assert_ok!(FooDoubleMap::try_append(2, 1, 5));
 			assert_eq!(
 				FooDoubleMap::get(2, 1).unwrap(),
-				BoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
+				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
 			);
 		});
 	}
 
 	#[test]
 	fn try_insert_works() {
-		let mut bounded: BoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_insert(1, 0).unwrap();
 		assert_eq!(*bounded, vec![1, 0, 2, 3]);
 
@@ -416,13 +434,13 @@ pub mod test {
 	#[test]
 	#[should_panic(expected = "insertion index (is 9) should be <= len (is 3)")]
 	fn try_inert_panics_if_oob() {
-		let mut bounded: BoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_insert(9, 0).unwrap();
 	}
 
 	#[test]
 	fn try_push_works() {
-		let mut bounded: BoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
+		let mut bounded: WeakBoundedVec<u32, Four> = vec![1, 2, 3].try_into().unwrap();
 		bounded.try_push(0).unwrap();
 		assert_eq!(*bounded, vec![1, 2, 3, 0]);
 
@@ -431,7 +449,7 @@ pub mod test {
 
 	#[test]
 	fn deref_coercion_works() {
-		let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
 		// these methods come from deref-ed vec.
 		assert_eq!(bounded.len(), 3);
 		assert!(bounded.iter().next().is_some());
@@ -440,7 +458,7 @@ pub mod test {
 
 	#[test]
 	fn try_mutate_works() {
-		let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		let bounded = bounded.try_mutate(|v| v.push(7)).unwrap();
 		assert_eq!(bounded.len(), 7);
 		assert!(bounded.try_mutate(|v| v.push(8)).is_none());
@@ -448,22 +466,20 @@ pub mod test {
 
 	#[test]
 	fn slice_indexing_works() {
-		let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		assert_eq!(&bounded[0..=2], &[1, 2, 3]);
 	}
 
 	#[test]
 	fn vec_eq_works() {
-		let bounded: BoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
+		let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3, 4, 5, 6].try_into().unwrap();
 		assert_eq!(bounded, vec![1, 2, 3, 4, 5, 6]);
 	}
 
 	#[test]
-	fn too_big_vec_fail_to_decode() {
+	fn too_big_succeed_to_decode() {
 		let v: Vec<u32> = vec![1, 2, 3, 4, 5];
-		assert_eq!(
-			BoundedVec::<u32, Four>::decode(&mut &v.encode()[..]),
-			Err("BoundedVec exceeds its limit".into()),
-		);
+		let w = WeakBoundedVec::<u32, Four>::decode(&mut &v.encode()[..]).unwrap();
+		assert_eq!(v, *w);
 	}
 }

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -290,7 +290,7 @@ impl<T, S> Eq for WeakBoundedVec<T, S> where T: Eq {}
 
 impl<T, S> StorageDecodeLength for WeakBoundedVec<T, S> {}
 
-impl<I, T, S: Get<u32>> StorageTryAppend<I> for WeakBoundedVec<T, S> {
+impl<T, S: Get<u32>> StorageTryAppend<T> for WeakBoundedVec<T, S> {
 	fn bound() -> usize {
 		S::get() as usize
 	}
@@ -317,7 +317,7 @@ pub mod test {
 	use super::*;
 	use sp_io::TestExternalities;
 	use sp_std::convert::TryInto;
-	use crate::{assert_ok, Twox128};
+	use crate::Twox128;
 
 	crate::parameter_types! {
 		pub const Seven: u32 = 7;
@@ -329,6 +329,11 @@ pub mod test {
 	crate::generate_storage_alias! {
 		Prefix,
 		FooDoubleMap => DoubleMap<(u32, Twox128), (u32, Twox128), WeakBoundedVec<u32, Seven>>
+	}
+
+	#[test]
+	fn try_append_is_correct() {
+		assert_eq!(WeakBoundedVec::<u32, Seven>::bound(), 7);
 	}
 
 	#[test]
@@ -354,70 +359,6 @@ pub mod test {
 			assert!(FooDoubleMap::decode_len(2, 1).is_none());
 			assert!(FooDoubleMap::decode_len(1, 2).is_none());
 			assert!(FooDoubleMap::decode_len(2, 2).is_none());
-		});
-	}
-
-	#[test]
-	fn try_append_works() {
-		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
-			Foo::put(bounded);
-			assert_ok!(Foo::try_append(4));
-			assert_ok!(Foo::try_append(5));
-			assert_ok!(Foo::try_append(6));
-			assert_ok!(Foo::try_append(7));
-			assert_eq!(Foo::decode_len().unwrap(), 7);
-			assert!(Foo::try_append(8).is_err());
-		});
-
-		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
-			FooMap::insert(1, bounded);
-
-			assert_ok!(FooMap::try_append(1, 4));
-			assert_ok!(FooMap::try_append(1, 5));
-			assert_ok!(FooMap::try_append(1, 6));
-			assert_ok!(FooMap::try_append(1, 7));
-			assert_eq!(FooMap::decode_len(1).unwrap(), 7);
-			assert!(FooMap::try_append(1, 8).is_err());
-
-			// append to a non-existing
-			assert!(FooMap::get(2).is_none());
-			assert_ok!(FooMap::try_append(2, 4));
-			assert_eq!(
-				FooMap::get(2).unwrap(),
-				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4]),
-			);
-			assert_ok!(FooMap::try_append(2, 5));
-			assert_eq!(
-				FooMap::get(2).unwrap(),
-				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
-			);
-		});
-
-		TestExternalities::default().execute_with(|| {
-			let bounded: WeakBoundedVec<u32, Seven> = vec![1, 2, 3].try_into().unwrap();
-			FooDoubleMap::insert(1, 1, bounded);
-
-			assert_ok!(FooDoubleMap::try_append(1, 1, 4));
-			assert_ok!(FooDoubleMap::try_append(1, 1, 5));
-			assert_ok!(FooDoubleMap::try_append(1, 1, 6));
-			assert_ok!(FooDoubleMap::try_append(1, 1, 7));
-			assert_eq!(FooDoubleMap::decode_len(1, 1).unwrap(), 7);
-			assert!(FooDoubleMap::try_append(1, 1, 8).is_err());
-
-			// append to a non-existing
-			assert!(FooDoubleMap::get(2, 1).is_none());
-			assert_ok!(FooDoubleMap::try_append(2, 1, 4));
-			assert_eq!(
-				FooDoubleMap::get(2, 1).unwrap(),
-				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4]),
-			);
-			assert_ok!(FooDoubleMap::try_append(2, 1, 5));
-			assert_eq!(
-				FooDoubleMap::get(2, 1).unwrap(),
-				WeakBoundedVec::<u32, Seven>::unchecked_from(vec![4, 5]),
-			);
 		});
 	}
 

--- a/frame/treasury/src/lib.rs
+++ b/frame/treasury/src/lib.rs
@@ -66,7 +66,7 @@ pub mod weights;
 use sp_std::prelude::*;
 use frame_support::{
 	decl_module, decl_storage, decl_event, ensure, print, decl_error,
-	PalletId, BoundedVec, bounded_vec::TryAppendValue,
+	PalletId, BoundedVec, storage::TryAppendValue,
 };
 use frame_support::traits::{
 	Currency, Get, Imbalance, OnUnbalanced, ExistenceRequirement::KeepAlive,


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/8839

This PR does:
* introduce `WeakBoundedVec`: it is exactly same as BoundedVec previous to this PR, i.e. the lenght is not enforced by `force_from` nor `decode`, but it warns when exceeded.
* improve `BoundedVec` API: `force_from` is removed and `decode` only accept vec with correct size.
* introduce `StorageTryAppend`: allow to specify that a storage value have a maximum bound. It is used to implement try_append on storage value, storage map and storage double map now.
  Previous to this PR, try_append was only implemented for `BoundedVec` explicitly. The `StorageTryAppend` allow to implement `try_append` on various types, such as `BoundedVec` and `WeakBoundedVec`.