### PR TITLE
Emit wasm sections only when compiling to wasm

### DIFF
--- a/primitives/api/proc-macro/src/impl_runtime_apis.rs
+++ b/primitives/api/proc-macro/src/impl_runtime_apis.rs
@@ -675,6 +675,7 @@ fn generate_runtime_api_versions(impls: &[ItemImpl]) -> Result<TokenStream> {
 			#( #attrs )*
 			const _: () = {
 				// All sections with the same name are going to be merged by concatenation.
+				#[cfg(not(feature = "std"))]
 				#[link_section = "runtime_apis"]
 				static SECTION_CONTENTS: [u8; 12] = #c::serialize_runtime_api_info(#id, #version);
 			};

--- a/primitives/version/proc-macro/src/decl_runtime_version.rs
+++ b/primitives/version/proc-macro/src/decl_runtime_version.rs
@@ -238,6 +238,7 @@ fn generate_emit_link_section_decl(contents: &[u8], section_name: &str) -> Token
 	let len = contents.len();
 	quote! {
 		const _: () = {
+			#[cfg(not(feature = "std"))]
 			#[link_section = #section_name]
 			static SECTION_CONTENTS: [u8; #len] = [#(#contents),*];
 		};

--- a/primitives/version/src/lib.rs
+++ b/primitives/version/src/lib.rs
@@ -45,6 +45,8 @@ use sp_runtime::{traits::Block as BlockT, generic::BlockId};
 /// A shortcoming of this macro is that it is unable to embed information regarding supported APIs.
 /// This is supported by the `construct_runtime!` macro.
 ///
+/// # Usage
+///
 /// This macro accepts a const item like the following:
 ///
 /// ```rust
@@ -78,6 +80,18 @@ use sp_runtime::{traits::Block as BlockT, generic::BlockId};
 /// - `apis` doesn't have any specific constraints. This is because this information doesn't get into
 ///   the custom section and is not parsed.
 ///
+/// # Compilation Target & "std" feature
+///
+/// This macro assumes it will be used within a runtime. By convention, a runtime crate defines a
+/// feature named "std". This feature is enabled when the runtime is compiled to native code and
+/// disabled when it is compiled to the wasm code.
+///
+/// The custom section can only be emitted while compiling to wasm. In order to detect the compilation
+/// target we use the "std" feature. This macro will emit the custom section only if the "std" feature
+/// is **not** enabled.
+///
+/// Including this macro in the context where there is no "std" feature and the code is not compiled
+/// to wasm can lead to cryptic linking errors.
 pub use sp_version_proc_macro::runtime_version;
 
 /// The identity of a particular API interface that the runtime might provide.


### PR DESCRIPTION
A follow-up for #8688 

This PR limits emitting the runtime version sections only to when the runtime is compiled to wasm.