### PR TITLE
make the default wasm execution method compiled

### DIFF
--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -18,10 +18,10 @@ name = "node-template"
 [dependencies]
 structopt = "0.3.8"
 
-sc-cli = { version = "0.9.0", path = "../../../client/cli", features = ["wasmtime"] }
+sc-cli = { version = "0.9.0", path = "../../../client/cli" }
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
-sc-executor = { version = "0.9.0", path = "../../../client/executor", features = ["wasmtime"] }
-sc-service = { version = "0.9.0", path = "../../../client/service", features = ["wasmtime"] }
+sc-executor = { version = "0.9.0", path = "../../../client/executor" }
+sc-service = { version = "0.9.0", path = "../../../client/service" }
 sc-telemetry = { version = "3.0.0", path = "../../../client/telemetry" }
 sc-keystore = { version = "3.0.0", path = "../../../client/keystore" }
 sp-inherents = { version = "3.0.0", path = "../../../primitives/inherents" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -110,9 +110,6 @@ browser-utils = { package = "substrate-browser-utils", path = "../../../utils/br
 libp2p-wasm-ext = { version = "0.28", features = ["websocket"], optional = true }
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
-node-executor = { version = "2.0.0", path = "../executor", features = [ "wasmtime" ] }
-sc-cli = { version = "0.9.0", optional = true, path = "../../../client/cli", features = [ "wasmtime" ] }
-sc-service = { version = "0.9.0", default-features = false, path = "../../../client/service", features = [ "wasmtime" ] }
 sp-trie = { version = "3.0.0", default-features = false, path = "../../../primitives/trie", features = ["memory-tracker"] }
 
 [dev-dependencies]

--- a/bin/node/executor/Cargo.toml
+++ b/bin/node/executor/Cargo.toml
@@ -47,9 +47,6 @@ wat = "1.0"
 futures = "0.3.9"
 
 [features]
-wasmtime = [
-	"sc-executor/wasmtime",
-]
 wasmi-errno = [
 	"sc-executor/wasmi-errno",
 ]

--- a/bin/node/executor/benches/bench.rs
+++ b/bin/node/executor/benches/bench.rs
@@ -212,7 +212,6 @@ fn bench_execute_block(c: &mut Criterion) {
 		vec![
 			ExecutionMethod::Native,
 			ExecutionMethod::Wasm(WasmExecutionMethod::Interpreted),
-			#[cfg(feature = "wasmtime")]
 			ExecutionMethod::Wasm(WasmExecutionMethod::Compiled),
 		],
 	);

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -32,7 +32,7 @@ pallet-session = { version = "3.0.0", path = "../../../frame/session" }
 pallet-society = { version = "3.0.0", path = "../../../frame/society" }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }
 pallet-staking = { version = "3.0.0", path = "../../../frame/staking" }
-sc-executor = { version = "0.9.0", path = "../../../client/executor", features = ["wasmtime"] }
+sc-executor = { version = "0.9.0", path = "../../../client/executor" }
 sp-consensus = { version = "0.9.0", path = "../../../primitives/consensus/common" }
 frame-system = { version = "3.0.0", path = "../../../frame/system" }
 substrate-test-client = { version = "2.0.0", path = "../../../test-utils/client" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -49,8 +49,3 @@ rpassword = "5.0.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"
-
-[features]
-wasmtime = [
-	"sc-service/wasmtime",
-]

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -38,7 +38,6 @@ impl WasmExecutionMethod {
 		Self::variants()
 			.iter()
 			.cloned()
-			.filter(|&name| cfg!(feature = "wasmtime") || name != "Compiled")
 			.collect()
 	}
 }
@@ -49,12 +48,7 @@ impl Into<sc_service::config::WasmExecutionMethod> for WasmExecutionMethod {
 			WasmExecutionMethod::Interpreted => {
 				sc_service::config::WasmExecutionMethod::Interpreted
 			}
-			#[cfg(feature = "wasmtime")]
 			WasmExecutionMethod::Compiled => sc_service::config::WasmExecutionMethod::Compiled,
-			#[cfg(not(feature = "wasmtime"))]
-			WasmExecutionMethod::Compiled => panic!(
-				"Substrate must be compiled with \"wasmtime\" feature for compiled Wasm execution"
-			),
 		}
 	}
 }

--- a/client/cli/src/params/import_params.rs
+++ b/client/cli/src/params/import_params.rs
@@ -52,7 +52,7 @@ pub struct ImportParams {
 		value_name = "METHOD",
 		possible_values = &WasmExecutionMethod::enabled_variants(),
 		case_insensitive = true,
-		default_value = "Interpreted"
+		default_value = "Compiled",
 	)]
 	pub wasm_method: WasmExecutionMethod,
 

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -32,7 +32,7 @@ sp-runtime-interface = { version = "3.0.0", path = "../../primitives/runtime-int
 sp-externalities = { version = "0.9.0", path = "../../primitives/externalities" }
 sc-executor-common = { version = "0.9.0", path = "common" }
 sc-executor-wasmi = { version = "0.9.0", path = "wasmi" }
-sc-executor-wasmtime = { version = "0.9.0", path = "wasmtime", optional = true }
+sc-executor-wasmtime = { version = "0.9.0", path = "wasmtime" }
 parking_lot = "0.11.1"
 log = "0.4.8"
 libsecp256k1 = "0.3.4"
@@ -56,9 +56,6 @@ default = [ "std" ]
 # This crate does not have `no_std` support, we just require this for tests
 std = []
 wasm-extern-trace = []
-wasmtime = [
-	"sc-executor-wasmtime",
-]
 wasmi-errno = [
 	"wasmi/errno"
 ]

--- a/client/executor/src/integration_tests/mod.rs
+++ b/client/executor/src/integration_tests/mod.rs
@@ -49,7 +49,6 @@ macro_rules! test_wasm_execution {
 			}
 
 			#[test]
-			#[cfg(feature = "wasmtime")]
 			fn [<$method_name _compiled>]() {
 				$method_name(WasmExecutionMethod::Compiled);
 			}
@@ -120,7 +119,6 @@ fn call_not_existing_function(wasm_method: WasmExecutionMethod) {
 					&format!("{:?}", e),
 					"\"Trap: Trap { kind: Host(Other(\\\"Function `missing_external` is only a stub. Calling a stub is not allowed.\\\")) }\""
 				),
-				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled => assert!(
 					format!("{:?}", e).contains("Wasm execution trapped: call to a missing function env:missing_external")
 				),
@@ -147,7 +145,6 @@ fn call_yet_another_not_existing_function(wasm_method: WasmExecutionMethod) {
 					&format!("{:?}", e),
 					"\"Trap: Trap { kind: Host(Other(\\\"Function `yet_another_missing_external` is only a stub. Calling a stub is not allowed.\\\")) }\""
 				),
-				#[cfg(feature = "wasmtime")]
 				WasmExecutionMethod::Compiled => assert!(
 					format!("{:?}", e).contains("Wasm execution trapped: call to a missing function env:yet_another_missing_external")
 				),

--- a/client/executor/src/wasm_runtime.rs
+++ b/client/executor/src/wasm_runtime.rs
@@ -42,7 +42,6 @@ pub enum WasmExecutionMethod {
 	/// Uses the Wasmi interpreter.
 	Interpreted,
 	/// Uses the Wasmtime compiled runtime.
-	#[cfg(feature = "wasmtime")]
 	Compiled,
 }
 
@@ -318,7 +317,6 @@ pub fn create_wasm_runtime_with_code(
 			)
 			.map(|runtime| -> Arc<dyn WasmModule> { Arc::new(runtime) })
 		}
-		#[cfg(feature = "wasmtime")]
 		WasmExecutionMethod::Compiled => {
 			sc_executor_wasmtime::create_runtime(
 				sc_executor_wasmtime::CodeSupplyMode::Verbatim { blob },

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -17,9 +17,6 @@ default = ["db"]
 # The RocksDB feature activates the RocksDB database backend. If it is not activated, and you pass
 # a path to a database, an error will be produced at runtime.
 db = ["sc-client-db/with-kvdb-rocksdb", "sc-client-db/with-parity-db"]
-wasmtime = [
-	"sc-executor/wasmtime",
-]
 # exposes the client type
 test-helpers = []
 


### PR DESCRIPTION
This promotes using `wasmtime` instead of `wasmi` for the majority of users.

Note: this PR removes the `wasmtime` feature entirely, and includes that dependency always.

Previous note, now obsolete: ~~in principle it is possible for this default to result in a panic shortly after startup if a user has compiled their node without the `wasmtime` feature~~.