### PR TITLE
Improve pallet macro error message by deriving codec with no bound for `Call` enum

### DIFF
--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.1.0", default-features = false, features = ["derive"] }
 frame-metadata = { version = "13.0.0", default-features = false, path = "../metadata" }
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
 sp-io = { version = "3.0.0", default-features = false, path = "../../primitives/io" }

--- a/frame/support/procedural/src/pallet/expand/call.rs
+++ b/frame/support/procedural/src/pallet/expand/call.rs
@@ -89,6 +89,8 @@ pub fn expand_call(def: &mut Def) -> proc_macro2::TokenStream {
 			#frame_support::codec::Encode,
 			#frame_support::codec::Decode,
 		)]
+		#[codec(encode_bound())]
+		#[codec(decode_bound())]
 		#[allow(non_camel_case_types)]
 		pub enum #call_ident<#type_decl_bounded_gen> #where_clause {
 			#[doc(hidden)]

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is
 20  |         fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                           ^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
     |
-   ::: /home/thiolliere/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:277:18
+   ::: /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:277:18
     |
 277 |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
     |                  ----- required by this bound in `pallet::_::_parity_scale_codec::Decode::decode`
@@ -17,7 +17,7 @@ error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is
 20  |         fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
     |                                           ^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
     |
-   ::: /home/thiolliere/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:216:21
+   ::: /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:216:21
     |
 216 |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
     |                     ------ required by this bound in `encode_to`

--- a/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
+++ b/frame/support/test/tests/pallet_ui/call_argument_invalid_bound_2.stderr
@@ -1,24 +1,28 @@
-error[E0277]: the trait bound `pallet::Call<T>: Decode` is not satisfied
-  --> $DIR/call_argument_invalid_bound_2.rs:17:12
-   |
-17 |     #[pallet::call]
-   |               ^^^^ the trait `Decode` is not implemented for `pallet::Call<T>`
-   |
-  ::: $WORKSPACE/frame/support/src/dispatch.rs
-   |
-   |     type Call: UnfilteredDispatchable + Codec + Clone + PartialEq + Eq;
-   |                                         ----- required by this bound in `frame_support::Callable::Call`
+error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeDecode` is not satisfied
+   --> $DIR/call_argument_invalid_bound_2.rs:20:37
+    |
+20  |         fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
+    |                                           ^ the trait `WrapperTypeDecode` is not implemented for `<T as pallet::Config>::Bar`
+    |
+   ::: /home/thiolliere/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:277:18
+    |
+277 |     fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
+    |                  ----- required by this bound in `pallet::_::_parity_scale_codec::Decode::decode`
+    |
+    = note: required because of the requirements on the impl of `Decode` for `<T as pallet::Config>::Bar`
 
-error[E0277]: the trait bound `pallet::Call<T>: pallet::_::_parity_scale_codec::Encode` is not satisfied
-  --> $DIR/call_argument_invalid_bound_2.rs:17:12
-   |
-17 |     #[pallet::call]
-   |               ^^^^ the trait `pallet::_::_parity_scale_codec::Encode` is not implemented for `pallet::Call<T>`
-   |
-  ::: $WORKSPACE/frame/support/src/dispatch.rs
-   |
-   |     type Call: UnfilteredDispatchable + Codec + Clone + PartialEq + Eq;
-   |                                         ----- required by this bound in `frame_support::Callable::Call`
+error[E0277]: the trait bound `<T as pallet::Config>::Bar: WrapperTypeEncode` is not satisfied
+   --> $DIR/call_argument_invalid_bound_2.rs:20:37
+    |
+20  |         fn foo(origin: OriginFor<T>, bar: T::Bar) -> DispatchResultWithPostInfo {
+    |                                           ^ the trait `WrapperTypeEncode` is not implemented for `<T as pallet::Config>::Bar`
+    |
+   ::: /home/thiolliere/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-scale-codec-2.1.0/src/codec.rs:216:21
+    |
+216 |     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    |                     ------ required by this bound in `encode_to`
+    |
+    = note: required because of the requirements on the impl of `pallet::_::_parity_scale_codec::Encode` for `<T as pallet::Config>::Bar`
 
 error[E0369]: binary operation `==` cannot be applied to type `&<T as pallet::Config>::Bar`
   --> $DIR/call_argument_invalid_bound_2.rs:20:37


### PR DESCRIPTION
By deriving codec on the Call enum without any bound, we can have better span for when some type doesn't implement codec. see the error message change.

Note that Call enum must implement codec in order to be usable by the runtime, thus implementing codec conditionally (as it is before this PR) shouldn't be of any use.