### PR TITLE
Allow separate max-heap-pages for offchain execution context.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
  "linregress",
  "log",
  "parity-scale-codec",
- "paste 1.0.4",
+ "paste 1.0.5",
  "serde",
  "sp-api",
  "sp-io",
@@ -1813,7 +1813,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parity-util-mem",
- "paste 1.0.4",
+ "paste 1.0.5",
  "pretty_assertions 0.6.1",
  "serde",
  "smallvec 1.6.1",
@@ -4793,7 +4793,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
- "paste 1.0.4",
+ "paste 1.0.5",
  "pretty_assertions 0.7.2",
  "pwasm-utils 0.17.0",
  "rand 0.8.3",
@@ -4893,7 +4893,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "paste 1.0.4",
+ "paste 1.0.5",
  "rand 0.7.3",
  "sp-arithmetic",
  "sp-core",
@@ -5405,7 +5405,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parking_lot 0.11.1",
- "paste 1.0.4",
+ "paste 1.0.5",
  "rand_chacha 0.2.2",
  "serde",
  "sp-application-crypto",
@@ -5841,9 +5841,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d65c4d95931acda4498f675e332fcbdc9a06705cd07086c510e9b6009cd1c1"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "paste-impl"
@@ -6983,6 +6983,7 @@ dependencies = [
  "log",
  "names",
  "parity-scale-codec",
+ "paste 1.0.5",
  "rand 0.7.3",
  "regex",
  "rpassword",
@@ -7343,7 +7344,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm 0.41.0",
  "parking_lot 0.11.1",
- "paste 1.0.4",
+ "paste 1.0.5",
  "sc-executor-common",
  "sc-executor-wasmi",
  "sc-executor-wasmtime",
@@ -9011,7 +9012,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parity-util-mem",
- "paste 1.0.4",
+ "paste 1.0.5",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -10879,7 +10880,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "paste 1.0.4",
+ "paste 1.0.5",
  "region",
  "rustc-demangle",
  "serde",

--- a/bin/node/testing/src/bench.rs
+++ b/bin/node/testing/src/bench.rs
@@ -55,8 +55,8 @@ use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_inherents::InherentData;
 use sc_client_api::{
-	ExecutionStrategy, BlockBackend,
-	execution_extensions::{ExecutionExtensions, ExecutionStrategies},
+	ExecutionStrategy, BlockBackend, ExecutionConfig,
+	execution_extensions::{ExecutionExtensions, ExecutionConfigs},
 };
 use sc_block_builder::BlockBuilderProvider;
 use futures::executor;
@@ -424,7 +424,7 @@ impl BenchDb {
 			&keyring.generate_genesis(),
 			None,
 			None,
-			ExecutionExtensions::new(profile.into_execution_strategies(), None, None),
+			ExecutionExtensions::new(profile.into_execution_configs(), None, None),
 			Box::new(task_executor.clone()),
 			None,
 			None,
@@ -616,7 +616,7 @@ impl BenchKeyring {
 	}
 }
 
-/// Profile for exetion strategies.
+/// Profile for execution configurations.
 #[derive(Clone, Copy, Debug)]
 pub enum Profile {
 	/// As native as possible.
@@ -626,22 +626,24 @@ pub enum Profile {
 }
 
 impl Profile {
-	fn into_execution_strategies(self) -> ExecutionStrategies {
+	fn into_execution_configs(self) -> ExecutionConfigs {
 		match self {
-			Profile::Wasm => ExecutionStrategies {
-				syncing: ExecutionStrategy::AlwaysWasm,
-				importing: ExecutionStrategy::AlwaysWasm,
-				block_construction: ExecutionStrategy::AlwaysWasm,
-				offchain_worker: ExecutionStrategy::AlwaysWasm,
-				other: ExecutionStrategy::AlwaysWasm,
+			Profile::Wasm => ExecutionConfigs {
+				syncing: ExecutionConfig::new_offchain(ExecutionStrategy::AlwaysWasm),
+				importing: ExecutionConfig::new_offchain(ExecutionStrategy::AlwaysWasm),
+				block_construction: ExecutionConfig::new_offchain(ExecutionStrategy::AlwaysWasm),
+				offchain_worker: ExecutionConfig::new_offchain(ExecutionStrategy::AlwaysWasm),
+				other: ExecutionConfig::new_offchain(ExecutionStrategy::AlwaysWasm),
 			},
-			Profile::Native => ExecutionStrategies {
-				syncing: ExecutionStrategy::NativeElseWasm,
-				importing: ExecutionStrategy::NativeElseWasm,
-				block_construction: ExecutionStrategy::NativeElseWasm,
-				offchain_worker: ExecutionStrategy::NativeElseWasm,
-				other: ExecutionStrategy::NativeElseWasm,
-			}
+			Profile::Native => ExecutionConfigs {
+				syncing: ExecutionConfig::new_offchain(ExecutionStrategy::NativeElseWasm),
+				importing: ExecutionConfig::new_offchain(ExecutionStrategy::NativeElseWasm),
+				block_construction: ExecutionConfig::new_offchain(
+					ExecutionStrategy::NativeElseWasm,
+				),
+				offchain_worker: ExecutionConfig::new_offchain(ExecutionStrategy::NativeElseWasm),
+				other: ExecutionConfig::new_offchain(ExecutionStrategy::NativeElseWasm),
+			},
 		}
 	}
 }

--- a/client/api/src/call_executor.rs
+++ b/client/api/src/call_executor.rs
@@ -21,11 +21,10 @@
 use std::{panic::UnwindSafe, result, cell::RefCell};
 use codec::{Encode, Decode};
 use sp_runtime::{
-	generic::BlockId, traits::{Block as BlockT, HashFor},
+	generic::BlockId,
+	traits::{Block as BlockT, HashFor},
 };
-use sp_state_machine::{
-	OverlayedChanges, ExecutionManager, ExecutionStrategy, StorageProof,
-};
+use sp_state_machine::{OverlayedChanges, ExecutionManager, ExecutionConfig, StorageProof};
 use sc_executor::{RuntimeVersion, NativeVersion};
 use sp_externalities::Extensions;
 use sp_core::NativeOrEncoded;
@@ -61,7 +60,7 @@ pub trait CallExecutor<B: BlockT> {
 		id: &BlockId<B>,
 		method: &str,
 		call_data: &[u8],
-		strategy: ExecutionStrategy,
+		config: ExecutionConfig,
 		extensions: Option<Extensions>,
 	) -> Result<Vec<u8>, sp_blockchain::Error>;
 

--- a/client/api/src/lib.rs
+++ b/client/api/src/lib.rs
@@ -39,10 +39,9 @@ pub use light::*;
 pub use notifications::*;
 pub use proof_provider::*;
 
-pub use sp_state_machine::{StorageProof, ExecutionStrategy};
+pub use sp_state_machine::{StorageProof, ExecutionStrategy, ExecutionConfig, ExecutionContext};
 
 /// Usage Information Provider interface
-///
 pub trait UsageProvider<Block: sp_runtime::traits::Block> {
 	/// Get usage info about current client.
 	fn usage_info(&self) -> ClientInfo<Block>;

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -43,6 +43,7 @@ sc-tracing = { version = "3.0.0", path = "../tracing" }
 chrono = "0.4.10"
 serde = "1.0.111"
 thiserror = "1.0.21"
+paste = "1.0.5"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 rpassword = "5.0.0"

--- a/client/cli/src/arg_enums.rs
+++ b/client/cli/src/arg_enums.rs
@@ -18,6 +18,7 @@
 // NOTE: we allow missing docs here because arg_enum! creates the function variants without doc
 #![allow(missing_docs)]
 
+use sc_client_api::ExecutionContext;
 use structopt::clap::arg_enum;
 
 /// How to execute Wasm runtime code.
@@ -232,15 +233,22 @@ arg_enum! {
 	}
 }
 
-/// Default value for the `--execution-syncing` parameter.
-pub const DEFAULT_EXECUTION_SYNCING: ExecutionStrategy = ExecutionStrategy::NativeElseWasm;
-/// Default value for the `--execution-import-block` parameter.
-pub const DEFAULT_EXECUTION_IMPORT_BLOCK: ExecutionStrategy = ExecutionStrategy::NativeElseWasm;
-/// Default value for the `--execution-import-block` parameter when the node is a validator.
-pub const DEFAULT_EXECUTION_IMPORT_BLOCK_VALIDATOR: ExecutionStrategy = ExecutionStrategy::Wasm;
-/// Default value for the `--execution-block-construction` parameter.
-pub const DEFAULT_EXECUTION_BLOCK_CONSTRUCTION: ExecutionStrategy = ExecutionStrategy::Wasm;
-/// Default value for the `--execution-offchain-worker` parameter.
-pub const DEFAULT_EXECUTION_OFFCHAIN_WORKER: ExecutionStrategy = ExecutionStrategy::Native;
-/// Default value for the `--execution-other` parameter.
-pub const DEFAULT_EXECUTION_OTHER: ExecutionStrategy = ExecutionStrategy::Native;
+macro_rules! generate_config_const {
+	($( $role:ident => $strategy:ident, $context:ident ),*) => {
+		paste::paste! {
+			$(
+				pub const [<DEFAULT_STRATEGY_ $role:snake:upper>]: ExecutionStrategy = ExecutionStrategy::$strategy;
+				pub const [<DEFAULT_CONTEXT_ $role:snake:upper>]: ExecutionContext = ExecutionContext::$context;
+			)*
+		}
+	};
+}
+
+generate_config_const!(
+	syncing => NativeElseWasm, Consensus,
+	import_block => NativeElseWasm, Consensus,
+	import_block_validator => Wasm, Consensus,
+	block_construction => Wasm, Consensus,
+	offchain_worker => Native, Offchain,
+	other => Native, Consensus
+);

--- a/client/cli/src/config.rs
+++ b/client/cli/src/config.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 use log::warn;
 use names::{Generator, Name};
-use sc_client_api::execution_extensions::ExecutionStrategies;
+use sc_client_api::execution_extensions::ExecutionConfigs;
 use sc_service::config::{
 	BasePath, Configuration, DatabaseConfig, ExtTransport, KeystoreConfig, NetworkConfiguration,
 	NodeKeyConfig, OffchainWorkerConfig, PrometheusConfig, PruningMode, Role, RpcMethods,
@@ -310,15 +310,11 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 	/// Get the execution strategies.
 	///
 	/// By default this is retrieved from `ImportParams` if it is available. Otherwise its
-	/// `ExecutionStrategies::default()`.
-	fn execution_strategies(
-		&self,
-		is_dev: bool,
-		is_validator: bool,
-	) -> Result<ExecutionStrategies> {
+	/// `ExecutionConfigs::default()`.
+	fn execution_configs(&self, is_dev: bool, is_validator: bool) -> Result<ExecutionConfigs> {
 		Ok(self
 			.import_params()
-			.map(|x| x.execution_strategies(is_dev, is_validator))
+			.map(|x| x.execution_configs(is_dev, is_validator))
 			.unwrap_or_default())
 	}
 
@@ -520,7 +516,7 @@ pub trait CliConfiguration<DCV: DefaultConfigurationValues = ()>: Sized {
 			transaction_storage: self.database_transaction_storage()?,
 			wasm_method: self.wasm_method()?,
 			wasm_runtime_overrides: self.wasm_runtime_overrides(),
-			execution_strategies: self.execution_strategies(is_dev, is_validator)?,
+			execution_configs: self.execution_configs(is_dev, is_validator)?,
 			rpc_http: self.rpc_http(DCV::rpc_http_listen_port())?,
 			rpc_ws: self.rpc_ws(DCV::rpc_ws_listen_port())?,
 			rpc_ipc: self.rpc_ipc()?,

--- a/client/finality-grandpa/src/lib.rs
+++ b/client/finality-grandpa/src/lib.rs
@@ -475,8 +475,10 @@ pub trait GenesisAuthoritySetProvider<Block: BlockT> {
 	fn get(&self) -> Result<AuthorityList, ClientError>;
 }
 
-impl<Block: BlockT, E> GenesisAuthoritySetProvider<Block> for Arc<dyn ExecutorProvider<Block, Executor = E>>
-	where E: CallExecutor<Block>,
+impl<Block: BlockT, E> GenesisAuthoritySetProvider<Block>
+	for Arc<dyn ExecutorProvider<Block, Executor = E>>
+where
+	E: CallExecutor<Block>,
 {
 	fn get(&self) -> Result<AuthorityList, ClientError> {
 		// This implementation uses the Grandpa runtime API instead of reading directly from the
@@ -487,7 +489,7 @@ impl<Block: BlockT, E> GenesisAuthoritySetProvider<Block> for Arc<dyn ExecutorPr
 				&BlockId::Number(Zero::zero()),
 				"GrandpaApi_grandpa_authorities",
 				&[],
-				ExecutionStrategy::NativeElseWasm,
+				sc_client_api::ExecutionConfig::new_consensus(ExecutionStrategy::NativeElseWasm),
 				None,
 			)
 			.and_then(|call_result| {

--- a/client/light/src/call_executor.rs
+++ b/client/light/src/call_executor.rs
@@ -31,8 +31,8 @@ use sp_runtime::{
 };
 use sp_externalities::Extensions;
 use sp_state_machine::{
-	self, Backend as StateBackend, OverlayedChanges, ExecutionStrategy, create_proof_check_backend,
-	execution_proof_check_on_trie_backend, ExecutionManager, StorageProof,
+	self, Backend as StateBackend, OverlayedChanges, ExecutionConfig, create_proof_check_backend,
+	execution_proof_check_on_trie_backend, ExecutionManager, ExecutionStrategy, StorageProof,
 };
 use hash_db::Hasher;
 
@@ -71,12 +71,11 @@ impl<B, L: Clone> Clone for GenesisCallExecutor<B, L> {
 	}
 }
 
-impl<Block, B, Local> CallExecutor<Block> for
-	GenesisCallExecutor<B, Local>
-	where
-		Block: BlockT,
-		B: RemoteBackend<Block>,
-		Local: CallExecutor<Block>,
+impl<Block, B, Local> CallExecutor<Block> for GenesisCallExecutor<B, Local>
+where
+	Block: BlockT,
+	B: RemoteBackend<Block>,
+	Local: CallExecutor<Block>,
 {
 	type Error = ClientError;
 
@@ -87,7 +86,7 @@ impl<Block, B, Local> CallExecutor<Block> for
 		id: &BlockId<Block>,
 		method: &str,
 		call_data: &[u8],
-		strategy: ExecutionStrategy,
+		strategy: ExecutionConfig,
 		extensions: Option<Extensions>,
 	) -> ClientResult<Vec<u8>> {
 		match self.backend.is_local_state_available(id) {
@@ -101,7 +100,7 @@ impl<Block, B, Local> CallExecutor<Block> for
 		IB: Fn() -> ClientResult<()>,
 		EM: Fn(
 			Result<NativeOrEncoded<R>, Self::Error>,
-			Result<NativeOrEncoded<R>, Self::Error>
+			Result<NativeOrEncoded<R>, Self::Error>,
 		) -> Result<NativeOrEncoded<R>, Self::Error>,
 		R: Encode + Decode + PartialEq,
 		NC: FnOnce() -> result::Result<R, sp_api::ApiError> + UnwindSafe,
@@ -140,7 +139,7 @@ impl<Block, B, Local> CallExecutor<Block> for
 				changes,
 				None,
 				initialize_block,
-				ExecutionManager::NativeWhenPossible,
+				ExecutionConfig::new_consensus(ExecutionStrategy::NativeWhenPossible).get_manager(), // TODO: why are we not using the given manager.
 				native_call,
 				recorder,
 				extensions,
@@ -256,12 +255,12 @@ pub fn check_execution_proof_with_make_header<Header, E, H, MakeNextHeader>(
 	remote_proof: StorageProof,
 	make_next_header: MakeNextHeader,
 ) -> ClientResult<Vec<u8>>
-	where
-		E: CodeExecutor + Clone + 'static,
-		H: Hasher,
-		Header: HeaderT,
-		H::Out: Ord + codec::Codec + 'static,
-		MakeNextHeader: Fn(&Header) -> Header,
+where
+	E: CodeExecutor + Clone + 'static,
+	H: Hasher,
+	Header: HeaderT,
+	H::Out: Ord + codec::Codec + 'static,
+	MakeNextHeader: Fn(&Header) -> Header,
 {
 	let local_state_root = request.header.state_root();
 	let root: H::Out = convert_hash(&local_state_root);
@@ -273,7 +272,8 @@ pub fn check_execution_proof_with_make_header<Header, E, H, MakeNextHeader>(
 
 	// TODO: Remove when solved: https://github.com/paritytech/substrate/issues/5047
 	let backend_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&trie_backend);
-	let runtime_code = backend_runtime_code.runtime_code()
+	let runtime_code = backend_runtime_code
+		.runtime_code(sp_state_machine::ExecutionContext::Consensus) // TODO: ? which one is it, and I should get this maybe from `E`.
 		.map_err(|_e| ClientError::RuntimeCodeMissing)?;
 
 	execution_proof_check_on_trie_backend::<H, Header::Number, _, _>(

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -71,11 +71,13 @@ pub struct FullState<BE, Block: BlockT, Client> {
 }
 
 impl<BE, Block: BlockT, Client> FullState<BE, Block, Client>
-	where
-		BE: Backend<Block>,
-		Client: StorageProvider<Block, BE> + HeaderBackend<Block> + BlockBackend<Block>
-			+ HeaderMetadata<Block, Error = sp_blockchain::Error>,
-		Block: BlockT + 'static,
+where
+	BE: Backend<Block>,
+	Client: StorageProvider<Block, BE>
+		+ HeaderBackend<Block>
+		+ BlockBackend<Block>
+		+ HeaderMetadata<Block, Error = sp_blockchain::Error>,
+	Block: BlockT + 'static,
 {
 	/// Create new state API backend for full nodes.
 	pub fn new(client: Arc<Client>, subscriptions: SubscriptionManager) -> Self {
@@ -222,15 +224,22 @@ impl<BE, Block: BlockT, Client> FullState<BE, Block, Client>
 	}
 }
 
-impl<BE, Block, Client> StateBackend<Block, Client> for FullState<BE, Block, Client> where
+impl<BE, Block, Client> StateBackend<Block, Client> for FullState<BE, Block, Client>
+where
 	Block: BlockT + 'static,
 	BE: Backend<Block> + 'static,
-	Client: ExecutorProvider<Block> + StorageProvider<Block, BE>
-		+ ProofProvider<Block> + HeaderBackend<Block>
-		+ HeaderMetadata<Block, Error = sp_blockchain::Error> + BlockchainEvents<Block>
-		+ CallApiAt<Block> + ProvideRuntimeApi<Block>
+	Client: ExecutorProvider<Block>
+		+ StorageProvider<Block, BE>
+		+ ProofProvider<Block>
+		+ HeaderBackend<Block>
+		+ HeaderMetadata<Block, Error = sp_blockchain::Error>
+		+ BlockchainEvents<Block>
+		+ CallApiAt<Block>
+		+ ProvideRuntimeApi<Block>
 		+ BlockBackend<Block>
-		+ Send + Sync + 'static,
+		+ Send
+		+ Sync
+		+ 'static,
 	Client::Api: Metadata<Block>,
 {
 	fn call(
@@ -247,7 +256,7 @@ impl<BE, Block, Client> StateBackend<Block, Client> for FullState<BE, Block, Cli
 					&BlockId::Hash(block),
 					&method,
 					&*call_data,
-					self.client.execution_extensions().strategies().other,
+					self.client.execution_extensions().configs().other,
 					None,
 				)
 				.map(Into::into)

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -303,7 +303,8 @@ pub fn new_full_client<TBl, TRtApi, TExecDisp>(
 pub fn new_full_parts<TBl, TRtApi, TExecDisp>(
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
-) -> Result<TFullParts<TBl, TRtApi, TExecDisp>,	Error> where
+) -> Result<TFullParts<TBl, TRtApi, TExecDisp>, Error>
+where
 	TBl: BlockT,
 	TExecDisp: NativeExecutionDispatch + 'static,
 {
@@ -340,11 +341,10 @@ pub fn new_full_parts<TBl, TRtApi, TExecDisp>(
 			transaction_storage: config.transaction_storage.clone(),
 		};
 
-
 		let backend = new_db_backend(db_config)?;
 
 		let extensions = sc_client_api::execution_extensions::ExecutionExtensions::new(
-			config.execution_strategies.clone(),
+			config.execution_configs.clone(),
 			Some(keystore_container.sync_keystore()),
 			sc_offchain::OffchainDb::factory_from_backend(&*backend),
 		);

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -19,13 +19,15 @@
 //! Service configuration.
 
 pub use sc_client_db::{
-	Database, PruningMode, DatabaseSettingsSrc as DatabaseConfig,
-	KeepBlocks, TransactionStorageMode
+	Database, PruningMode, DatabaseSettingsSrc as DatabaseConfig, KeepBlocks,
+	TransactionStorageMode,
 };
 pub use sc_network::Multiaddr;
-pub use sc_network::config::{ExtTransport, MultiaddrWithPeerId, NetworkConfiguration, Role, NodeKeyConfig};
+pub use sc_network::config::{
+	ExtTransport, MultiaddrWithPeerId, NetworkConfiguration, Role, NodeKeyConfig,
+};
 pub use sc_executor::WasmExecutionMethod;
-use sc_client_api::execution_extensions::ExecutionStrategies;
+use sc_client_api::execution_extensions::ExecutionConfigs;
 
 use std::{io, future::Future, path::{PathBuf, Path}, pin::Pin, net::SocketAddr, sync::Arc};
 pub use sc_transaction_pool::txpool::Options as TransactionPoolOptions;
@@ -76,7 +78,7 @@ pub struct Configuration {
 	/// disable overrides (default).
 	pub wasm_runtime_overrides: Option<PathBuf>,
 	/// Execution strategies.
-	pub execution_strategies: ExecutionStrategies,
+	pub execution_configs: ExecutionConfigs,
 	/// RPC over HTTP binding address. `None` if disabled.
 	pub rpc_http: Option<SocketAddr>,
 	/// RPC over Websockets binding address. `None` if disabled.
@@ -106,7 +108,8 @@ pub struct Configuration {
 	pub disable_grandpa: bool,
 	/// Development key seed.
 	///
-	/// When running in development mode, the seed will be used to generate authority keys by the keystore.
+	/// When running in development mode, the seed will be used to generate authority keys by the
+	/// keystore.
 	///
 	/// Should only be set when `node` is running development mode.
 	pub dev_key_seed: Option<String>,

--- a/client/service/test/src/client/light.rs
+++ b/client/service/test/src/client/light.rs
@@ -202,7 +202,7 @@ impl CallExecutor<Block> for DummyCallExecutor {
 		_id: &BlockId<Block>,
 		_method: &str,
 		_call_data: &[u8],
-		_strategy: ExecutionStrategy,
+		_strategy: Execution,
 		_extensions: Option<Extensions>,
 	) -> Result<Vec<u8>, ClientError> {
 		Ok(vec![42])

--- a/client/service/test/src/lib.rs
+++ b/client/service/test/src/lib.rs
@@ -208,8 +208,7 @@ fn node_config<G: RuntimeGenesis + 'static, E: ChainSpecExtension + Clone + 'sta
 	key_seed: Option<String>,
 	base_port: u16,
 	root: &TempDir,
-) -> Configuration
-{
+) -> Configuration {
 	let root = root.path().join(format!("node-{}", index));
 
 	let mut network_config = NetworkConfiguration::new(
@@ -257,7 +256,7 @@ fn node_config<G: RuntimeGenesis + 'static, E: ChainSpecExtension + Clone + 'sta
 		chain_spec: Box::new((*spec).clone()),
 		wasm_method: sc_service::config::WasmExecutionMethod::Interpreted,
 		wasm_runtime_overrides: Default::default(),
-		execution_strategies: Default::default(),
+		execution_configs: Default::default(),
 		rpc_http: None,
 		rpc_ipc: None,
 		rpc_ws: None,

--- a/frame/merkle-mountain-range/src/lib.rs
+++ b/frame/merkle-mountain-range/src/lib.rs
@@ -54,7 +54,6 @@
 //!	from on-chain storage.
 //!
 //! NOTE This pallet is experimental and not proven to work in production.
-//!
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::Encode;
@@ -154,7 +153,7 @@ decl_storage! {
 decl_module! {
 	/// A public part of the pallet.
 	pub struct Module<T: Config<I>, I: Instance = DefaultInstance> for enum Call where origin: T::Origin {
-		fn on_initialize(n: T::BlockNumber) -> Weight {
+		fn on_initialize(_n: T::BlockNumber) -> Weight {
 			use primitives::LeafDataProvider;
 			let leaves = Self::mmr_leaves();
 			let peaks_before = mmr::utils::NodesUtils::new(leaves).number_of_peaks();

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -27,8 +27,8 @@
 //! The System pallet defines the core data types used in a Substrate runtime.
 //! It also provides several utility functions (see [`Pallet`]) for other FRAME pallets.
 //!
-//! In addition, it manages the storage items for extrinsics data, indexes, event records, and digest items,
-//! among other things that support the execution of the current block.
+//! In addition, it manages the storage items for extrinsics data, indexes, event records, and
+//! digest items, among other things that support the execution of the current block.
 //!
 //! It also handles low-level tasks like depositing logs, basic set up and take down of
 //! temporary storage entries, and access to previous block hashes.
@@ -54,10 +54,10 @@
 //!   - [`CheckEra`]: Checks the era of the transaction. Contains a single payload of type `Era`.
 //!   - [`CheckGenesis`]: Checks the provided genesis hash of the transaction. Must be a part of the
 //!     signed payload of the transaction.
-//!   - [`CheckSpecVersion`]: Checks that the runtime version is the same as the one used to sign the
-//!     transaction.
-//!   - [`CheckTxVersion`]: Checks that the transaction version is the same as the one used to sign the
-//!     transaction.
+//!   - [`CheckSpecVersion`]: Checks that the runtime version is the same as the one used to sign
+//!     the transaction.
+//!   - [`CheckTxVersion`]: Checks that the transaction version is the same as the one used to sign
+//!     the transaction.
 //!
 //! Lookup the runtime aggregator file (e.g. `node/runtime`) to see the full list of signed
 //! extensions included in a chain.
@@ -317,15 +317,11 @@ pub mod pallet {
 		}
 
 		/// Set the number of pages in the WebAssembly environment's heap.
-		///
-		/// # <weight>
-		/// - `O(1)`
-		/// - 1 storage write.
-		/// - Base Weight: 1.405 µs
-		/// - 1 write to HEAP_PAGES
-		/// # </weight>
 		#[pallet::weight((T::SystemWeightInfo::set_heap_pages(), DispatchClass::Operational))]
-		pub(crate) fn set_heap_pages(origin: OriginFor<T>, pages: u64) -> DispatchResultWithPostInfo {
+		pub(crate) fn set_heap_pages(
+			origin: OriginFor<T>,
+			pages: u64,
+		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			storage::unhashed::put_raw(well_known_keys::HEAP_PAGES, &pages.encode());
 			Ok(().into())
@@ -467,16 +463,22 @@ pub mod pallet {
 		}
 
 		/// Make some on-chain remark and emit event.
-		///
-		/// # <weight>
-		/// - `O(b)` where b is the length of the remark.
-		/// - 1 event.
-		/// # </weight>
 		#[pallet::weight(T::SystemWeightInfo::remark_with_event(remark.len() as u32))]
 		pub(crate) fn remark_with_event(origin: OriginFor<T>, remark: Vec<u8>) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
 			let hash = T::Hashing::hash(&remark[..]);
 			Self::deposit_event(Event::Remarked(who, hash));
+			Ok(().into())
+		}
+
+		/// Set the number of pages in the WebAssembly environment's heap, in offchain context.
+		#[pallet::weight((T::SystemWeightInfo::set_heap_pages(), DispatchClass::Operational))]
+		pub(crate) fn set_heap_pages_offchain(
+			origin: OriginFor<T>,
+			pages: u64,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			storage::unhashed::put_raw(well_known_keys::OFFCHAIN_HEAP_PAGES, &pages.encode());
 			Ok(().into())
 		}
 	}

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -163,7 +163,14 @@ pub mod well_known_keys {
 	/// Number of wasm linear memory pages required for execution of the runtime.
 	///
 	/// The type of this value is encoded `u64`.
+	///
+	/// Note that this value is used for consensus-related runtime operations, such as block import.
 	pub const HEAP_PAGES: &'static [u8] = b":heappages";
+
+	/// Number of wasm linear memory pages given to offchain workers.
+	///
+	/// The type of this value is encoded `u64`.
+	pub const OFFCHAIN_HEAP_PAGES: &'static [u8] = b":offchain_heappages";
 
 	/// Current extrinsic index (u32) is stored under this key.
 	pub const EXTRINSIC_INDEX: &'static [u8] = b":extrinsic_index";
@@ -194,7 +201,6 @@ pub mod well_known_keys {
 			CHILD_STORAGE_KEY_PREFIX.starts_with(key)
 		}
 	}
-
 }
 
 /// Information related to a child state.

--- a/test-utils/test-runner/src/lib.rs
+++ b/test-utils/test-runner/src/lib.rs
@@ -22,15 +22,15 @@
 //! Allows you to test
 //! <br />
 //!
-//! -   Migrations
-//! -   Runtime Upgrades
-//! -   Pallets and general runtime functionality.
+//! - Migrations
+//! - Runtime Upgrades
+//! - Pallets and general runtime functionality.
 //!
 //! This works by running a full node with a Manual Seal-BABE™ hybrid consensus for block authoring.
 //!
 //! <h2>Note</h2>
-//! The running node has no signature verification, which allows us author extrinsics for any account on chain.
-//!     <br/>
+//! The running node has no signature verification, which allows us author extrinsics for any
+//! account on chain.     <br/>
 //!     <br/>
 //!
 //! <h2>How do I Use this?</h2>
@@ -55,7 +55,7 @@
 //! use sp_runtime::{traits::IdentifyAccount, MultiSigner, generic::Era};
 //! use sc_executor::WasmExecutionMethod;
 //! use sc_network::{multiaddr, config::TransportConfig};
-//! use sc_client_api::execution_extensions::ExecutionStrategies;
+//! use sc_client_api::execution_extensions::ExecutionConfigs;
 //! use sc_informant::OutputFormat;
 //! use sp_api::TransactionFor;
 //!
@@ -186,12 +186,12 @@
 //! fn simple_balances_test() {
 //! 	// given
 //! 	let config = NodeConfig {
-//!			execution_strategies: ExecutionStrategies {
-//!				syncing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-//!				importing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-//!				block_construction: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-//!				offchain_worker: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-//!				other: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+//! 			execution_configs: ExecutionConfigs {
+//! 				syncing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+//! 				importing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+//! 				block_construction: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+//! 				offchain_worker: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+//! 				other: sc_client_api::ExecutionStrategy::NativeWhenPossible,
 //! 		},
 //! 		chain_spec: Box::new(development_config()),
 //! 		log_targets: vec![],

--- a/test-utils/test-runner/src/utils.rs
+++ b/test-utils/test-runner/src/utils.rs
@@ -26,7 +26,7 @@ use sc_network::{multiaddr, config::{NetworkConfiguration, TransportConfig, Role
 use sc_informant::OutputFormat;
 use sc_service::config::KeystoreConfig;
 use sc_executor::WasmExecutionMethod;
-use sc_client_api::execution_extensions::ExecutionStrategies;
+use sc_client_api::execution_extensions::ExecutionConfigs;
 
 /// Base db path gotten from env
 pub fn base_path() -> BasePath {
@@ -67,7 +67,10 @@ where
 }
 
 /// Produces a default configuration object, suitable for use with most set ups.
-pub fn default_config(task_executor: TaskExecutor, mut chain_spec: Box<dyn ChainSpec>) -> Configuration {
+pub fn default_config(
+	task_executor: TaskExecutor,
+	mut chain_spec: Box<dyn ChainSpec>,
+) -> Configuration {
 	let base_path = base_path();
 	let root_path = base_path.path().to_path_buf().join("chains").join(chain_spec.id());
 
@@ -113,12 +116,12 @@ pub fn default_config(task_executor: TaskExecutor, mut chain_spec: Box<dyn Chain
 		state_cache_child_ratio: None,
 		chain_spec,
 		wasm_method: WasmExecutionMethod::Interpreted,
-		execution_strategies: ExecutionStrategies {
-			syncing: sc_client_api::ExecutionStrategy::AlwaysWasm,
-			importing: sc_client_api::ExecutionStrategy::AlwaysWasm,
-			block_construction: sc_client_api::ExecutionStrategy::AlwaysWasm,
-			offchain_worker: sc_client_api::ExecutionStrategy::AlwaysWasm,
-			other: sc_client_api::ExecutionStrategy::AlwaysWasm,
+		execution_configs: ExecutionConfigs {
+			syncing: sc_client_api::ExecutionConfig::new_offchain(sc_client_api::ExecutionStrategy::AlwaysWasm),
+			importing: sc_client_api::ExecutionConfig::new_offchain(sc_client_api::ExecutionStrategy::AlwaysWasm),
+			block_construction: sc_client_api::ExecutionConfig::new_offchain(sc_client_api::ExecutionStrategy::AlwaysWasm),
+			offchain_worker: sc_client_api::ExecutionConfig::new_offchain(sc_client_api::ExecutionStrategy::AlwaysWasm),
+			other: sc_client_api::ExecutionConfig::new_offchain(sc_client_api::ExecutionStrategy::AlwaysWasm),
 		},
 		rpc_http: None,
 		rpc_ws: None,

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -87,7 +87,7 @@ where
 		default_heap_pages: Default::default(),
 		dev_key_seed: Default::default(),
 		disable_grandpa: Default::default(),
-		execution_strategies: Default::default(),
+		execution_configs: Default::default(),
 		force_authoring: Default::default(),
 		impl_name: String::from("parity-substrate"),
 		impl_version: String::from("0.0.0"),

--- a/utils/frame/benchmarking-cli/src/command.rs
+++ b/utils/frame/benchmarking-cli/src/command.rs
@@ -92,14 +92,15 @@ impl BenchmarkCmd {
 				self.extra,
 			).encode(),
 			extensions,
-			&sp_state_machine::backend::BackendRuntimeCode::new(&state).runtime_code()?,
+			&sp_state_machine::backend::BackendRuntimeCode::new(&state).runtime_code(sp_state_machine::ExecutionContext::Offchain)?,
 			sp_core::testing::TaskExecutor::new(),
 		)
-		.execute(strategy.into())
+		.execute(sp_state_machine::ExecutionConfig::new_offchain(strategy.into()))
 		.map_err(|e| format!("Error executing runtime benchmark: {:?}", e))?;
 
-		let results = <std::result::Result<Vec<BenchmarkBatch>, String> as Decode>::decode(&mut &result[..])
-			.map_err(|e| format!("Failed to decode benchmark results: {:?}", e))?;
+		let results =
+			<std::result::Result<Vec<BenchmarkBatch>, String> as Decode>::decode(&mut &result[..])
+				.map_err(|e| format!("Failed to decode benchmark results: {:?}", e))?;
 
 		match results {
 			Ok(batches) => {

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -188,10 +188,10 @@ impl TryRuntimeCmd {
 			&[],
 			ext.extensions,
 			&sp_state_machine::backend::BackendRuntimeCode::new(&ext.backend)
-				.runtime_code()?,
+				.runtime_code(sp_state_machine::ExecutionContext::Offchain)?,
 			sp_core::testing::TaskExecutor::new(),
 		)
-		.execute(execution.into())
+		.execute(sp_state_machine::ExecutionConfig::new_offchain(execution.into()))
 		.map_err(|e| format!("failed to execute 'TryRuntime_on_runtime_upgrade' due to {:?}", e))?;
 
 		let (weight, total_weight) = <(u64, u64) as Decode>::decode(&mut &*encoded_result)


### PR DESCRIPTION
PR not done yet. Could use some more cleanup + tests need to compile. 

Opening a draft, to allow people to check my new namings: 

- previous `ExexutionStrategy` is now wrapped in `ExecutionConfig`, which is the strategy and a `ExecutionContext`. This propagated to a lot of `strategy -> config` replacements. I like the outcome. 

