### PR TITLE
More sc-service config reexports

### DIFF
--- a/client/api/src/execution_extensions.rs
+++ b/client/api/src/execution_extensions.rs
@@ -33,7 +33,8 @@ use sp_runtime::{
 	generic::BlockId,
 	traits,
 };
-use sp_state_machine::{ExecutionStrategy, ExecutionManager, DefaultHandler};
+use sp_state_machine::{ExecutionManager, DefaultHandler};
+pub use sp_state_machine::ExecutionStrategy;
 use sp_externalities::Extensions;
 use parking_lot::RwLock;
 

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -23,7 +23,11 @@ pub use sc_client_db::{
 	KeepBlocks, TransactionStorageMode
 };
 pub use sc_network::Multiaddr;
-pub use sc_network::config::{ExtTransport, MultiaddrWithPeerId, NetworkConfiguration, Role, NodeKeyConfig};
+pub use sc_network::config::{
+	ExtTransport, MultiaddrWithPeerId, NetworkConfiguration, Role, NodeKeyConfig,
+	SetConfig, NonDefaultSetConfig, TransportConfig,
+	RequestResponseConfig, IncomingRequest, OutgoingResponse,
+};
 pub use sc_executor::WasmExecutionMethod;
 pub use sc_client_api::execution_extensions::{ExecutionStrategies, ExecutionStrategy};
 

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -25,7 +25,7 @@ pub use sc_client_db::{
 pub use sc_network::Multiaddr;
 pub use sc_network::config::{ExtTransport, MultiaddrWithPeerId, NetworkConfiguration, Role, NodeKeyConfig};
 pub use sc_executor::WasmExecutionMethod;
-use sc_client_api::execution_extensions::ExecutionStrategies;
+pub use sc_client_api::execution_extensions::{ExecutionStrategies, ExecutionStrategy};
 
 use std::{io, future::Future, path::{PathBuf, Path}, pin::Pin, net::SocketAddr, sync::Arc};
 pub use sc_transaction_pool::txpool::Options as TransactionPoolOptions;


### PR DESCRIPTION
This PR simply reexports some of the code units that `sc_service::Configuration` depends on internally. As of now, it is not possible to construct the `sc_service::Configuration` using just the `sc-service` crate, but I wanted to do this and figured it would be convenient to apply some changes that I needed as a patch.

This PR does not change any fundamental rules about the code structure, it only adheres to existing ones and solves current issues with them, so I assume it won't be difficult to merge.