### PR TITLE
make remote-ext work with ws and safe RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6672,7 +6672,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "tokio 0.2.25",
+ "tokio 1.6.0",
 ]
 
 [[package]]
@@ -9994,8 +9994,19 @@ dependencies = [
  "pin-project-lite 0.1.12",
  "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.6",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+dependencies = [
+ "autocfg",
+ "pin-project-lite 0.2.6",
+ "tokio-macros 1.2.0",
 ]
 
 [[package]]
@@ -10067,6 +10078,17 @@ name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
+name = "async-tls"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f23d769dbf1838d5df5156e7b1ad404f4c463d1ac2c6aeb6cd943630f8a8400"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "rustls 0.19.0",
+ "webpki 0.21.4",
+ "webpki-roots",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +2116,7 @@ checksum = "3a1387e07917c711fb4ee4f48ea0adb04a3c9739e53ef85bf43ae1edc2937a8b"
 dependencies = [
  "futures-io",
  "rustls 0.19.0",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2579,7 +2592,7 @@ dependencies = [
  "rustls-native-certs",
  "tokio 0.2.25",
  "tokio-rustls",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2967,6 +2980,28 @@ dependencies = [
  "futures-util",
  "hyper 0.13.10",
  "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6fdb4390bd25358c62e8b778652a564a1723ba07dca0feb3da439c2253fe59f"
+dependencies = [
+ "async-std",
+ "async-tls",
+ "async-trait",
+ "fnv",
+ "futures 0.3.13",
+ "jsonrpsee-types",
+ "log",
+ "pin-project 1.0.5",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "url 2.2.1",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -6662,6 +6697,7 @@ dependencies = [
  "hex-literal",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
+ "jsonrpsee-ws-client",
  "log",
  "parity-scale-codec",
  "sp-core",
@@ -6779,7 +6815,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -6792,7 +6828,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -10109,7 +10145,7 @@ dependencies = [
  "futures-core",
  "rustls 0.18.1",
  "tokio 0.2.25",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -11105,12 +11141,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,25 +2924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-http-client"
-version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2737440f37efa10e5ef7beeec43d059d29dc92640978be21fcdcef481a2edb0d"
-dependencies = [
- "async-trait",
- "fnv",
- "hyper 0.13.10",
- "hyper-rustls",
- "jsonrpsee-types",
- "jsonrpsee-utils",
- "log",
- "serde",
- "serde_json",
- "thiserror",
- "url 2.2.1",
-]
-
-[[package]]
 name = "jsonrpsee-proc-macros"
 version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,17 +2950,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "jsonrpsee-utils"
-version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63cf4d423614e71fd144a8691208539d2b23d8373e069e2fbe023c5eba5e922"
-dependencies = [
- "futures-util",
- "hyper 0.13.10",
- "jsonrpsee-types",
 ]
 
 [[package]]
@@ -6695,7 +6665,6 @@ version = "0.9.0"
 dependencies = [
  "env_logger 0.8.3",
  "hex-literal",
- "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-ws-client",
  "log",

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 jsonrpsee-http-client = { version = "=0.2.0-alpha.6", default-features = false, features = ["tokio02"] }
+jsonrpsee-ws-client = { version = "=0.2.0-alpha.6", default-features = false }
 jsonrpsee-proc-macros = "=0.2.0-alpha.6"
 
 hex-literal = "0.3.1"

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -26,7 +26,7 @@ sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.6.0", features = ["macros", "rt"] }
 
 [features]
 remote-test = []

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -297,9 +297,10 @@ impl<B: BlockT> Builder<'_, B> {
 				error!(target: LOG_TARGET, "Error = {:?}", e);
 				"rpc get_keys failed"
 			})?;
-			all_keys.extend(page.clone());
+			let page_len = page.len();
+			all_keys.extend(page);
 
-			if page.len() < (PAGE as usize) {
+			if page_len < PAGE as usize {
 				debug!(target: LOG_TARGET, "last page received: {}", page.len());
 				break all_keys;
 			} else {

--- a/utils/frame/remote-externalities/src/lib.rs
+++ b/utils/frame/remote-externalities/src/lib.rs
@@ -301,7 +301,7 @@ impl<B: BlockT> Builder<'_, B> {
 			all_keys.extend(page);
 
 			if page_len < PAGE as usize {
-				debug!(target: LOG_TARGET, "last page received: {}", page.len());
+				debug!(target: LOG_TARGET, "last page received: {}", page_len);
 				break all_keys;
 			} else {
 				let new_last_key =

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -166,12 +166,9 @@ impl TryRuntimeCmd {
 					block_at,
 					modules
 				} => Builder::<B>::new().mode(Mode::Online(OnlineConfig {
-					transport: url[..].into(),
+					transport: url.to_owned().into(),
 					state_snapshot: snapshot_path.as_ref().map(SnapshotConfig::new),
-					modules: modules
-						.as_ref()
-						.map(|m| m.into_iter().map(|x| x.as_ref()).collect::<Vec<_>>())
-						.unwrap_or_default(),
+					modules: modules.to_owned().unwrap_or_default(),
 					at: block_at.as_ref()
 						.map(|b| b.parse().map_err(|e| format!("Could not parse hash: {:?}", e))).transpose()?,
 					..Default::default()

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -86,7 +86,7 @@ pub enum State {
 		modules: Option<Vec<String>>,
 
 		/// The url to connect to.
-		#[structopt(default_value = "http://localhost:9933", parse(try_from_str = parse_url))]
+		#[structopt(default_value = "ws://localhost:9944", parse(try_from_str = parse_url))]
 		url: String,
 	},
 }
@@ -109,11 +109,11 @@ fn parse_hash(block_number: &str) -> Result<String, String> {
 }
 
 fn parse_url(s: &str) -> Result<String, &'static str> {
-	if s.starts_with("http://") {
+	if s.starts_with("ws://") || s.starts_with("wss://") {
 		// could use Url crate as well, but lets keep it simple for now.
 		Ok(s.to_string())
 	} else {
-		Err("not a valid HTTP url: must start with 'http://'")
+		Err("not a valid WS(S) url: must start with 'ws://' or 'wss://'")
 	}
 }
 

--- a/utils/frame/try-runtime/cli/src/lib.rs
+++ b/utils/frame/try-runtime/cli/src/lib.rs
@@ -166,9 +166,12 @@ impl TryRuntimeCmd {
 					block_at,
 					modules
 				} => Builder::<B>::new().mode(Mode::Online(OnlineConfig {
-					uri: url.into(),
+					transport: url[..].into(),
 					state_snapshot: snapshot_path.as_ref().map(SnapshotConfig::new),
-					modules: modules.clone().unwrap_or_default(),
+					modules: modules
+						.as_ref()
+						.map(|m| m.into_iter().map(|x| x.as_ref()).collect::<Vec<_>>())
+						.unwrap_or_default(),
 					at: block_at.as_ref()
 						.map(|b| b.parse().map_err(|e| format!("Could not parse hash: {:?}", e))).transpose()?,
 					..Default::default()


### PR DESCRIPTION
switches remote-externalities to use the safe rpcs via ws, instead of unsafe RPCs and http. 

cc @joao-paulo-parity 

polkadot companion: https://github.com/paritytech/polkadot/pull/3096