### PR TITLE
Add Bholdus network SS58 Address

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -579,6 +579,8 @@ ss58_address_format!(
 		(67, "equilibrium", "Equilibrium Network, standard account (*25519).")
 	SoraAccount =>
 		(69, "sora", "SORA Network, standard account (*25519).")
+	BholdusAccount =>
+		(84, "bholdus", "BHoldus Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
 

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -477,8 +477,8 @@
 			"decimals": [0,9,9,9,9,9,9,9],
 			"standardAccount": "*25519",
 			"website": "https://equilibrium.io"
-    },
-    {
+		},
+		{
 			"prefix": 69,
 			"network": "sora",
 			"displayName": "SORA Network",
@@ -486,6 +486,15 @@
 			"decimals": [18],
 			"standardAccount": "*25519",
 			"website": "https://sora.org"
+		},
+		{
+			"prefix": 84,
+			"network": "bholdus",
+			"displayName": "BHoldus Network",
+			"symbols": ["BHO"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://bholdus.com"
 		},
 		{
 			"prefix": 252,


### PR DESCRIPTION
Thank you for your Pull Request!

Before you submitting, please check that:

- [x] You added a brief description of the PR, e.g.:
  - This PR adds an account prefix for Bholdus network.
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
