### PR TITLE
Removes unnecessary blank impl for Backend

### DIFF
--- a/client/db/src/bench.rs
+++ b/client/db/src/bench.rs
@@ -507,7 +507,7 @@ impl<B: BlockT> StateBackend<HashFor<B>> for BenchmarkingState<B> {
 		*self.whitelist.borrow_mut() = new;
 	}
 
-	fn register_overlay_stats(&mut self, stats: &sp_state_machine::StateMachineStats) {
+	fn register_overlay_stats(&self, stats: &sp_state_machine::StateMachineStats) {
 		self.state.borrow_mut().as_mut().map(|s| s.register_overlay_stats(stats));
 	}
 

--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -259,7 +259,7 @@ impl<B: BlockT> StateBackend<HashFor<B>> for RefTrackingState<B> {
 		self.state.as_trie_backend()
 	}
 
-	fn register_overlay_stats(&mut self, stats: &StateMachineStats) {
+	fn register_overlay_stats(&self, stats: &StateMachineStats) {
 		self.state.register_overlay_stats(stats);
 	}
 

--- a/client/db/src/storage_cache.rs
+++ b/client/db/src/storage_cache.rs
@@ -677,7 +677,7 @@ impl<S: StateBackend<HashFor<B>>, B: BlockT> StateBackend<HashFor<B>> for Cachin
 		self.state.as_trie_backend()
 	}
 
-	fn register_overlay_stats(&mut self, stats: &sp_state_machine::StateMachineStats) {
+	fn register_overlay_stats(&self, stats: &sp_state_machine::StateMachineStats) {
 		self.overlay_stats.add(stats);
 	}
 
@@ -862,7 +862,7 @@ impl<S: StateBackend<HashFor<B>>, B: BlockT> StateBackend<HashFor<B>> for Syncin
 			.as_trie_backend()
 	}
 
-	fn register_overlay_stats(&mut self, stats: &sp_state_machine::StateMachineStats) {
+	fn register_overlay_stats(&self, stats: &sp_state_machine::StateMachineStats) {
 		self.caching_state().register_overlay_stats(stats);
 	}
 

--- a/client/light/src/backend.rs
+++ b/client/light/src/backend.rs
@@ -526,7 +526,7 @@ impl<H: Hasher> StateBackend<H> for GenesisOrUnavailableState<H>
 		}
 	}
 
-	fn register_overlay_stats(&mut self, _stats: &sp_state_machine::StateMachineStats) { }
+	fn register_overlay_stats(&self, _stats: &sp_state_machine::StateMachineStats) { }
 
 	fn usage_info(&self) -> sp_state_machine::UsageInfo {
 		sp_state_machine::UsageInfo::empty()

--- a/client/service/src/client/call_executor.rs
+++ b/client/service/src/client/call_executor.rs
@@ -210,7 +210,7 @@ where
 						Box::new(sp_state_machine::ExecutionError::UnableToGenerateProof) as Box<dyn sp_state_machine::Error>
 					)?;
 
-				let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&trie_state);
+				let state_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(trie_state);
 				// It is important to extract the runtime code here before we create the proof
 				// recorder.
 				let runtime_code = state_runtime_code.runtime_code()

--- a/client/service/test/src/client/mod.rs
+++ b/client/service/test/src/client/mod.rs
@@ -167,7 +167,7 @@ fn construct_block(
 	};
 	let hash = header.hash();
 	let mut overlay = OverlayedChanges::default();
-	let backend_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(&backend);
+	let backend_runtime_code = sp_state_machine::backend::BackendRuntimeCode::new(backend);
 	let runtime_code = backend_runtime_code.runtime_code().expect("Code is part of the backend");
 	let task_executor = Box::new(TaskExecutor::new());
 

--- a/primitives/state-machine/src/backend.rs
+++ b/primitives/state-machine/src/backend.rs
@@ -204,7 +204,7 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 	/// Register stats from overlay of state machine.
 	///
 	/// By default nothing is registered.
-	fn register_overlay_stats(&mut self, _stats: &crate::stats::StateMachineStats);
+	fn register_overlay_stats(&self, _stats: &crate::stats::StateMachineStats);
 
 	/// Query backend usage statistics (i/o, memory)
 	///
@@ -249,86 +249,6 @@ pub trait Backend<H: Hasher>: sp_std::fmt::Debug {
 	/// Estimate proof size
 	fn proof_size(&self) -> Option<u32> {
 		unimplemented!()
-	}
-}
-
-impl<'a, T: Backend<H>, H: Hasher> Backend<H> for &'a T {
-	type Error = T::Error;
-	type Transaction = T::Transaction;
-	type TrieBackendStorage = T::TrieBackendStorage;
-
-	fn storage(&self, key: &[u8]) -> Result<Option<StorageKey>, Self::Error> {
-		(*self).storage(key)
-	}
-
-	fn child_storage(
-		&self,
-		child_info: &ChildInfo,
-		key: &[u8],
-	) -> Result<Option<StorageKey>, Self::Error> {
-		(*self).child_storage(child_info, key)
-	}
-
-	fn apply_to_child_keys_while<F: FnMut(&[u8]) -> bool>(
-		&self,
-		child_info: &ChildInfo,
-		f: F,
-	) {
-		(*self).apply_to_child_keys_while(child_info, f)
-	}
-
-	fn next_storage_key(&self, key: &[u8]) -> Result<Option<StorageKey>, Self::Error> {
-		(*self).next_storage_key(key)
-	}
-
-	fn next_child_storage_key(
-		&self,
-		child_info: &ChildInfo,
-		key: &[u8],
-	) -> Result<Option<StorageKey>, Self::Error> {
-		(*self).next_child_storage_key(child_info, key)
-	}
-
-	fn for_keys_with_prefix<F: FnMut(&[u8])>(&self, prefix: &[u8], f: F) {
-		(*self).for_keys_with_prefix(prefix, f)
-	}
-
-	fn for_child_keys_with_prefix<F: FnMut(&[u8])>(
-		&self,
-		child_info: &ChildInfo,
-		prefix: &[u8],
-		f: F,
-	) {
-		(*self).for_child_keys_with_prefix(child_info, prefix, f)
-	}
-
-	fn storage_root<'b>(
-		&self,
-		delta: impl Iterator<Item=(&'b [u8], Option<&'b [u8]>)>,
-	) -> (H::Out, Self::Transaction) where H::Out: Ord {
-		(*self).storage_root(delta)
-	}
-
-	fn child_storage_root<'b>(
-		&self,
-		child_info: &ChildInfo,
-		delta: impl Iterator<Item=(&'b [u8], Option<&'b [u8]>)>,
-	) -> (H::Out, bool, Self::Transaction) where H::Out: Ord {
-		(*self).child_storage_root(child_info, delta)
-	}
-
-	fn pairs(&self) -> Vec<(StorageKey, StorageValue)> {
-		(*self).pairs()
-	}
-
-	fn for_key_values_with_prefix<F: FnMut(&[u8], &[u8])>(&self, prefix: &[u8], f: F) {
-		(*self).for_key_values_with_prefix(prefix, f);
-	}
-
-	fn register_overlay_stats(&mut self, _stats: &crate::stats::StateMachineStats) {	}
-
-	fn usage_info(&self) -> UsageInfo {
-		(*self).usage_info()
 	}
 }
 

--- a/primitives/state-machine/src/ext.rs
+++ b/primitives/state-machine/src/ext.rs
@@ -682,7 +682,7 @@ where
 			self.overlay.rollback_transaction().expect(BENCHMARKING_FN);
 		}
 		self.overlay.drain_storage_changes(
-			&self.backend,
+			self.backend,
 			#[cfg(feature = "std")]
 			None,
 			Default::default(),
@@ -700,7 +700,7 @@ where
 			self.overlay.commit_transaction().expect(BENCHMARKING_FN);
 		}
 		let changes = self.overlay.drain_storage_changes(
-			&self.backend,
+			self.backend,
 			#[cfg(feature = "std")]
 			None,
 			Default::default(),

--- a/primitives/state-machine/src/proving_backend.rs
+++ b/primitives/state-machine/src/proving_backend.rs
@@ -328,7 +328,7 @@ impl<'a, S, H> Backend<H> for ProvingBackend<'a, S, H>
 		self.0.child_storage_root(child_info, delta)
 	}
 
-	fn register_overlay_stats(&mut self, _stats: &crate::stats::StateMachineStats) { }
+	fn register_overlay_stats(&self, _stats: &crate::stats::StateMachineStats) { }
 
 	fn usage_info(&self) -> crate::stats::UsageInfo {
 		self.0.usage_info()

--- a/primitives/state-machine/src/trie_backend.rs
+++ b/primitives/state-machine/src/trie_backend.rs
@@ -236,7 +236,7 @@ impl<S: TrieBackendStorage<H>, H: Hasher> Backend<H> for TrieBackend<S, H> where
 		Some(self)
 	}
 
-	fn register_overlay_stats(&mut self, _stats: &crate::stats::StateMachineStats) { }
+	fn register_overlay_stats(&self, _stats: &crate::stats::StateMachineStats) { }
 
 	fn usage_info(&self) -> crate::UsageInfo {
 		crate::UsageInfo::empty()


### PR DESCRIPTION
I think this is solely cosmetic but I stumbled upon this impl and thought it is a bit misleading.

This removes a from my perspective unnecessary implementation
for `&T` which implements `Backend`.

The current implementation exists (again from my perspective) solely
to satisfy a methods `&mut self` parameters (i.e. allows to satisfy
this for an & reference via using `&mut &Backend`).

As all implementors use a `RefCell` with `borrow_mut()` where actually
calling the mentioned &mut self method and then forward to the
`{}` implementation of either `TrieBackend` or `ProvingBackend`, the
current &mut self seems to be not needed.

**NOTE:**

It might be possible to remove the `RefCell`s from the client/db section now. 