### PR TITLE
Gift Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,6 +4988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-gift"
+version = "3.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-gilt"
 version = "3.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
 	"frame/example-offchain-worker",
 	"frame/example-parallel",
 	"frame/executive",
+	"frame/gift",
 	"frame/gilt",
 	"frame/grandpa",
 	"frame/identity",

--- a/frame/gift/Cargo.toml
+++ b/frame/gift/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "pallet-gift"
+version = "3.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Apache-2.0"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME for sending tokens to new users."
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+frame-support = { version = "3.0.0", default-features = false, path = "../support" }
+frame-system = { version = "3.0.0", default-features = false, path = "../system" }
+sp-core = { version = "3.0.0", default-features = false, path = "../../primitives/core" }
+frame-benchmarking = { version = "3.0.0", default-features = false, path = "../benchmarking", optional = true }
+
+[dev-dependencies]
+sp-io = { version = "3.0.0", path = "../../primitives/io" }
+sp-runtime = { version = "3.0.0", path = "../../primitives/runtime" }
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'sp-core/std',
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/frame/gift/src/lib.rs
+++ b/frame/gift/src/lib.rs
@@ -1,0 +1,212 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{Currency, ExistenceRequirement, ReservableCurrency},
+		weights::Pays,
+		sp_runtime::traits::{CheckedAdd, Saturating, Zero},
+	};
+	use frame_system::pallet_prelude::*;
+
+	type BalanceOf<T> = <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		/// The Balances of your system.
+		type Currency: ReservableCurrency<Self::AccountId>;
+		/// The additional deposit needed to place a gift. Should be greater than the existential
+		/// deposit to avoid killing the gifter account.
+		type GiftDeposit: Get<BalanceOf<Self>>;
+		/// The minimum gift amount. Should be greater than the existential deposit.
+		type MinimumGift: Get<BalanceOf<Self>>;
+
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	#[derive(Encode, Decode)]
+	pub struct GiftInfo<AccountId, Balance> {
+		gifter: AccountId,
+		deposit: Balance,
+		amount: Balance,
+	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn gifts)]
+	pub type Gifts<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		T::AccountId,
+		GiftInfo<T::AccountId, BalanceOf<T>>,
+		OptionQuery
+	>;
+
+	#[pallet::event]
+	#[pallet::metadata(T::AccountId = "AccountId", BalanceOf<T> = "Balance")]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A gift has been created! [amount, claimer]
+		GiftCreated(BalanceOf<T>, T::AccountId),
+		/// A gift has been claimed! [claimer, amount, to]
+		GiftClaimed(T::AccountId, BalanceOf<T>, T::AccountId),
+		/// A gift has been removed :( [to]
+		GiftRemoved(T::AccountId),
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// User already has a pending gift.
+		PendingGift,
+		/// Don't be cheap... Get your friend a good gift!
+		GiftTooSmall,
+		/// An overflow has occurred.
+		Overflow,
+		/// A gift does not exist for this user.
+		NoGift,
+		/// You are not the owner of this gift.
+		NotGifter,
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
+	// These functions materialize as "extrinsics", which are often compared to transactions.
+	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
+	#[pallet::call]
+	impl<T:Config> Pallet<T> {
+		/// An example dispatchable that takes a singles value as a parameter, writes the value to
+		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
+		#[pallet::weight(0)]
+		fn gift(origin: OriginFor<T>, amount: BalanceOf<T>, to: T::AccountId) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+			ensure!(!Gifts::<T>::contains_key(&to), Error::<T>::PendingGift);
+			ensure!(amount >= T::MinimumGift::get(), Error::<T>::GiftTooSmall);
+
+			let deposit = T::GiftDeposit::get();
+			let total_reserve = amount.checked_add(&deposit).ok_or(Error::<T>::Overflow)?;
+			T::Currency::reserve(&who, total_reserve)?;
+
+			// All checks have passed, so let's create the gift.
+			let gift = GiftInfo {
+				gifter: who,
+				deposit,
+				amount,
+			};
+
+			Gifts::<T>::insert(&to, gift);
+			Self::deposit_event(Event::<T>::GiftCreated(amount, to));
+			Ok(().into())
+		}
+
+		#[pallet::weight((0, Pays::No))] // Does not pay fee, so we MUST prevalidate this function
+		fn claim(origin: OriginFor<T>, to: T::AccountId) -> DispatchResultWithPostInfo {
+			// In the pre-validation function we confirmed that this user has a gift,
+			// and this signed transaction is enough for them to claim it to whomever.
+			let who = ensure_signed(origin)?;
+
+			// They should 100% have a gift, but no reason not to handle the error anyway.
+			let gift = Gifts::<T>::take(&who).ok_or(Error::<T>::NoGift)?;
+
+			let err_amount = T::Currency::unreserve(&gift.gifter, gift.deposit.saturating_add(gift.amount));
+			// Should always have enough reserved unless there is a bug somewhere.
+			debug_assert!(err_amount.is_zero());
+			let res = T::Currency::transfer(&gift.gifter, &to, gift.amount, ExistenceRequirement::AllowDeath);
+			// Should never fail because we unreserve more than this above.
+			debug_assert!(res.is_ok());
+
+			Self::deposit_event(Event::<T>::GiftClaimed(who, gift.amount, to));
+			Ok(().into())
+		}
+
+		#[pallet::weight(0)]
+		fn remove(origin: OriginFor<T>, to: T::AccountId) -> DispatchResultWithPostInfo {
+			let who = ensure_signed(origin)?;
+
+			let gift = Gifts::<T>::get(&to).ok_or(Error::<T>::NoGift)?;
+			ensure!(gift.gifter == who, Error::<T>::NotGifter);
+
+			let err_amount = T::Currency::unreserve(&gift.gifter, gift.deposit.saturating_add(gift.amount));
+			// Should always have enough reserved unless there is a bug somewhere.
+			debug_assert!(err_amount.is_zero());
+
+			Gifts::<T>::remove(&to);
+
+			Self::deposit_event(Event::<T>::GiftRemoved(to));
+			Ok(().into())
+		}
+	}
+}
+
+use codec::{Encode, Decode};
+use frame_support::{
+	pallet_prelude::*,
+	traits::IsSubType,
+	sp_runtime::traits::{DispatchInfoOf, SignedExtension},
+};
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
+pub struct PrevalidateGiftClaim<T: Config + Send + Sync>(core::marker::PhantomData<T>) where
+	<T as frame_system::Config>::Call: IsSubType<Call<T>>;
+
+impl<T: Config + Send + Sync> core::fmt::Debug for PrevalidateGiftClaim<T> where
+	<T as frame_system::Config>::Call: IsSubType<Call<T>>
+{
+	#[cfg(feature = "std")]
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		write!(f, "PrevalidateGiftClaim")
+	}
+
+	#[cfg(not(feature = "std"))]
+	fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+		Ok(())
+	}
+}
+
+impl<T: Config + Send + Sync> PrevalidateGiftClaim<T> where
+	<T as frame_system::Config>::Call: IsSubType<Call<T>>
+{
+	pub fn new() -> Self {
+		Self(core::marker::PhantomData)
+	}
+}
+
+impl<T: Config + Send + Sync> SignedExtension for PrevalidateGiftClaim<T> where
+	<T as frame_system::Config>::Call: IsSubType<Call<T>>
+{
+	type AccountId = T::AccountId;
+	type Call = <T as frame_system::Config>::Call;
+	type AdditionalSigned = ();
+	type Pre = ();
+	const IDENTIFIER: &'static str = "PrevalidateGiftClaim";
+
+	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+		Ok(())
+	}
+
+	fn validate(
+		&self,
+		who: &Self::AccountId,
+		call: &Self::Call,
+		_info: &DispatchInfoOf<Self::Call>,
+		_len: usize,
+	) -> TransactionValidity {
+		if let Some(local_call) = call.is_sub_type() {
+			if let Call::claim(_to) = local_call {
+				// All we need to check is that the caller has a gift they own.
+				Gifts::<T>::get(who).ok_or(InvalidTransaction::BadProof)?;
+			}
+		}
+		Ok(ValidTransaction::default())
+	}
+}

--- a/frame/gift/src/lib.rs
+++ b/frame/gift/src/lib.rs
@@ -47,7 +47,6 @@ pub mod pallet {
 	use frame_support::{
 		pallet_prelude::*,
 		traits::{Currency, ExistenceRequirement, ReservableCurrency},
-		weights::Pays,
 		sp_runtime::traits::{CheckedAdd, Saturating, Zero},
 	};
 	use frame_system::pallet_prelude::*;
@@ -87,7 +86,6 @@ pub mod pallet {
 		Blake2_128Concat,
 		T::AccountId,
 		GiftInfo<T::AccountId, BalanceOf<T>>,
-		OptionQuery
 	>;
 
 	#[pallet::event]
@@ -116,9 +114,6 @@ pub mod pallet {
 		/// You are not the owner of this gift.
 		NotGifter,
 	}
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
 	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
 	// These functions materialize as "extrinsics", which are often compared to transactions.

--- a/frame/gift/src/lib.rs
+++ b/frame/gift/src/lib.rs
@@ -1,3 +1,43 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2019-2021 Parity Technologies (UK) Ltd. SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+//! # Gift Pallet
+//! A pallet allowing existing users to onboard new users by sending them tokens before they have
+//! created an account.
+//!
+//! ## Overview
+//!
+//! Alice wants to send DOT to Bob as a gift for this birthday, but Bob is not really familiar with
+//! Polkadot and does not have a Polkadot account.
+//!
+//! Alice uses the Gift pallet to reserve some funds in her account, and allows access to a "shared
+//! account" to transfer those funds away from Alice. (similar to transfer approvals)
+//!
+//! Alice then shares the private key of the shared account with Bob, who can then generate a brand
+//! new account that Alice has no idea about, and then use the shared account to finally transfer
+//! balance to Bob's final account.
+//!
+//! ## Design
+//!
+//! This pallet is designed to solve the following problems:
+//! * Allow Alice to send gift to a user who does not have an account (yet)
+//! * Allow a new user to safely claim those funds without exposing or involving anyone else for
+//!   account creation
+//! * Allow the new user to make that claim without needing to have any initial funds (a free
+//!   transaction)
+//!
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;
@@ -111,8 +151,8 @@ pub mod pallet {
 
 		#[pallet::weight((0, Pays::No))] // Does not pay fee, so we MUST prevalidate this function
 		fn claim(origin: OriginFor<T>, to: T::AccountId) -> DispatchResultWithPostInfo {
-			// In the pre-validation function we confirmed that this user has a gift,
-			// and this signed transaction is enough for them to claim it to whomever.
+			// In the pre-validation function we confirmed that this user has a gift, and this
+			// signed transaction is enough for them to claim it to whomever.
 			let who = ensure_signed(origin)?;
 
 			// They should 100% have a gift, but no reason not to handle the error anyway.

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -26,7 +26,7 @@ pub use tokens::currency::{
 	Currency, LockIdentifier, LockableCurrency, ReservableCurrency, VestingSchedule,
 };
 pub use tokens::imbalance::{Imbalance, OnUnbalanced, SignedImbalance};
-pub use tokens::{ExistenceRequirement, WithdrawReasons, BalanceStatus};
+pub use tokens::{ExistenceRequirement, WithdrawReasons, BalanceStatus, OnTransfer};
 
 mod members;
 pub use members::{

--- a/frame/support/src/traits/tokens.rs
+++ b/frame/support/src/traits/tokens.rs
@@ -24,5 +24,6 @@ pub mod imbalance;
 mod misc;
 pub use misc::{
 	WithdrawConsequence, DepositConsequence, ExistenceRequirement, BalanceStatus, WithdrawReasons,
+	OnTransfer,
 };
 pub use imbalance::Imbalance;

--- a/frame/support/src/traits/tokens/misc.rs
+++ b/frame/support/src/traits/tokens/misc.rs
@@ -167,3 +167,10 @@ impl<T: FullCodec + Copy + Default + Eq + PartialEq + Debug> AssetId for T {}
 /// Simple amalgamation trait to collect together properties for a Balance under one roof.
 pub trait Balance: AtLeast32BitUnsigned + FullCodec + Copy + Default + Debug {}
 impl<T: AtLeast32BitUnsigned + FullCodec + Copy + Default + Debug> Balance for T {}
+
+/// A simple hook allowing pallets to trigger some functionality when a balance transfer (or
+/// equivalent operation) has been made.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait OnTransfer<AccountId, Balance> {
+	fn on_transfer(sender: &AccountId, recipient: &AccountId, amount: &Balance);
+}


### PR DESCRIPTION
This PR introduces a Gift pallet which allows existing token holders to onboard new users to the network by transferring tokens into a holding account which can later be claimed by a brand new account.

User Story:

Alice wants to send DOT to Bob as a gift for this birthday, but Bob is not really familiar with Polkadot and does not have a Polkadot account.

Alice uses the Gift pallet to reserve some funds in her account, and allows access to a "shared account" to transfer those funds away from Alice. (similar to transfer approvals)

Alice then shares the private key of the shared account with Bob, who can then generate a brand new account that Alice has no idea about, and then use the shared account to finally transfer balance to Bob's final account.

By claiming a gift, Bob can gain access to certain blockchain features using the `OnGift` hook, for example a voucher to register their identity for free.

What this pallet aims to solve:

* Allow Alice to send gift to a user who does not have an account (yet)
* Allow a new user to safely claim those funds without exposing or involving anyone else for account creation
* Allow the new user to make that claim without needing to have any initial funds (a free transaction)

Why do we even need this pallet?

Couldn't we just transfer funds into a shared account, and then again into a final account.

This pallet is better:

* No chance of that shared account being "lost" and the funds disappearing since the original sender can always revoke the gift without any proof of the shared account credentials.
* The recipient of a gift does not need to pay any fees out of their gift. This is all accounted for by the gifter.
* OnGift hook

TODO:

- [ ] Preliminary Review
- [ ] Tests
- [ ] Benchmarks
- [ ] Docs
