### PR TITLE
Revert "Fix stderr in new Rust nightly"

### DIFF
--- a/frame/support/test/tests/derive_no_bound_ui/eq.stderr
+++ b/frame/support/test/tests/derive_no_bound_ui/eq.stderr
@@ -7,6 +7,6 @@ error[E0277]: can't compare `Foo<T>` with `Foo<T>`
    ::: $RUST/core/src/cmp.rs
     |
     | pub trait Eq: PartialEq<Self> {
-    |               --------------- required by this bound in `std::cmp::Eq`
+    |               --------------- required by this bound in `Eq`
     |
     = help: the trait `PartialEq` is not implemented for `Foo<T>`

--- a/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
+++ b/primitives/api/test/tests/ui/impl_incorrect_method_signature.stderr
@@ -23,8 +23,8 @@ error[E0053]: method `Api_test_runtime_api_impl` has an incompatible type for tr
 17 |   sp_api::impl_runtime_apis! {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found struct `std::string::String`
    |
-   = note: expected fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<u64>, Vec<_>) -> Result<_, _>`
-              found fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<std::string::String>, Vec<_>) -> Result<_, _>`
+   = note: expected fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<u64>, Vec<_>) -> std::result::Result<_, _>`
+              found fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<std::string::String>, Vec<_>) -> std::result::Result<_, _>`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types

--- a/primitives/api/test/tests/ui/mock_only_self_reference.stderr
+++ b/primitives/api/test/tests/ui/mock_only_self_reference.stderr
@@ -24,8 +24,8 @@ error[E0053]: method `Api_test_runtime_api_impl` has an incompatible type for tr
 12 |   sp_api::mock_impl_runtime_apis! {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `()`
    |
-   = note: expected fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<u64>, Vec<_>) -> Result<_, _>`
-              found fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<()>, Vec<_>) -> Result<_, _>`
+   = note: expected fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<u64>, Vec<_>) -> std::result::Result<_, _>`
+              found fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<()>, Vec<_>) -> std::result::Result<_, _>`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0053]: method `Api_test2_runtime_api_impl` has an incompatible type for trait
@@ -42,6 +42,6 @@ error[E0053]: method `Api_test2_runtime_api_impl` has an incompatible type for t
 12 |   sp_api::mock_impl_runtime_apis! {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `()`
    |
-   = note: expected fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<u64>, Vec<_>) -> Result<_, _>`
-              found fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<()>, Vec<_>) -> Result<_, _>`
+   = note: expected fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<u64>, Vec<_>) -> std::result::Result<_, _>`
+              found fn pointer `fn(&MockApi, &BlockId<sp_runtime::generic::block::Block<sp_runtime::generic::header::Header<u64, sp_runtime::traits::BlakeTwo256>, Extrinsic>>, ExecutionContext, Option<()>, Vec<_>) -> std::result::Result<_, _>`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
+++ b/primitives/api/test/tests/ui/type_reference_in_impl_runtime_apis_call.stderr
@@ -23,8 +23,8 @@ error[E0053]: method `Api_test_runtime_api_impl` has an incompatible type for tr
 17 |   sp_api::impl_runtime_apis! {
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `&u64`
    |
-   = note: expected fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<u64>, Vec<_>) -> Result<_, _>`
-              found fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<&u64>, Vec<_>) -> Result<_, _>`
+   = note: expected fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<u64>, Vec<_>) -> std::result::Result<_, _>`
+              found fn pointer `fn(&RuntimeApiImpl<__SR_API_BLOCK__, RuntimeApiImplCall>, &BlockId<__SR_API_BLOCK__>, ExecutionContext, std::option::Option<&u64>, Vec<_>) -> std::result::Result<_, _>`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types


### PR DESCRIPTION
Reverts paritytech/substrate#8904

Had to roll back the previously updated latest nightly as `cargo-check-benches` was failing.