### PR TITLE
emergency mode: allow governance origin to set the election result in case of failure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6669,6 +6669,8 @@ dependencies = [
  "jsonrpsee-ws-client",
  "log",
  "parity-scale-codec",
+ "serde",
+ "serde_json",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6669,7 +6669,6 @@ dependencies = [
  "jsonrpsee-ws-client",
  "log",
  "parity-scale-codec",
- "serde",
  "serde_json",
  "sp-core",
  "sp-io",

--- a/primitives/storage/src/lib.rs
+++ b/primitives/storage/src/lib.rs
@@ -107,10 +107,12 @@ impl PrefixedStorageKey {
 
 /// Storage data associated to a [`StorageKey`].
 #[derive(PartialEq, Eq, RuntimeDebug)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Hash, PartialOrd, Ord, Clone, Encode, Decode))]
+#[cfg_attr(
+	feature = "std",
+	derive(Serialize, Deserialize, Hash, PartialOrd, Ord, Clone, Encode, Decode, Default)
+)]
 pub struct StorageData(
-	#[cfg_attr(feature = "std", serde(with="impl_serde::serialize"))]
-	pub Vec<u8>,
+	#[cfg_attr(feature = "std", serde(with = "impl_serde::serialize"))] pub Vec<u8>,
 );
 
 /// Map of data to use in a storage, it is a collection of

--- a/utils/frame/remote-externalities/Cargo.toml
+++ b/utils/frame/remote-externalities/Cargo.toml
@@ -21,6 +21,8 @@ env_logger = "0.8.2"
 log = "0.4.11"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 
+serde_json = "1.0"
+
 sp-io = { version = "3.0.0", path = "../../../primitives/io" }
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }


### PR DESCRIPTION
Pretty simple one, to be merged on top of https://github.com/paritytech/substrate/pull/8912. 

It should be pretty simple, and important to test this: We can spawn a substrate dev-chain with a lot of nominators and set the `DesiredTarget` the number of available authorities + 1. Then all the OCW solutions will fails. Finally, we will 

once this and https://github.com/paritytech/substrate/pull/8912 is merged we must also change the fallback election to `NoFallback`.