### PR TITLE
Bump `parity-wasm` and `pwasm-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-clonable"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,10 +4803,9 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-wasm 0.42.2",
  "paste 1.0.4",
  "pretty_assertions 0.7.2",
- "pwasm-utils 0.17.0",
+ "pwasm-utils",
  "rand 0.8.3",
  "rand_pcg 0.3.0",
  "serde",
@@ -4810,7 +4815,7 @@ dependencies = [
  "sp-runtime",
  "sp-sandbox",
  "sp-std",
- "wasmi-validation 0.4.0",
+ "wasmi-validation",
  "wat",
 ]
 
@@ -5725,12 +5730,6 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
@@ -6295,20 +6294,9 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.41.0",
-]
-
-[[package]]
-name = "pwasm-utils"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51992bc74c0f34f759ff97fb303602e60343afc83693769c91aa17724442809e"
+checksum = "a0e517f47d9964362883182404b68d0b6949382c0baa40aa5ffca94f5f1e3481"
 dependencies = [
  "byteorder",
  "log",
@@ -7346,7 +7334,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
  "parking_lot 0.11.1",
  "paste 1.0.4",
  "sc-executor-common",
@@ -7381,8 +7369,7 @@ version = "0.9.0"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
- "parity-wasm 0.41.0",
- "pwasm-utils 0.14.0",
+ "pwasm-utils",
  "sp-allocator",
  "sp-core",
  "sp-maybe-compressed-blob",
@@ -7413,8 +7400,7 @@ dependencies = [
  "assert_matches",
  "log",
  "parity-scale-codec",
- "parity-wasm 0.41.0",
- "pwasm-utils 0.14.0",
+ "parity-wasm 0.42.2",
  "sc-executor-common",
  "scoped-tls",
  "sp-allocator",
@@ -10856,26 +10842,18 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.6.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf617d864d25af3587aa745529f7aaa541066c876d57e050c0d0c85c61c92aff"
+checksum = "d2ee05bba3d1d994652079893941a2ef9324d2b58a63c31b40678fb7eddd7a5a"
 dependencies = [
+ "downcast-rs",
  "errno",
  "libc",
  "memory_units",
  "num-rational",
  "num-traits",
- "parity-wasm 0.41.0",
- "wasmi-validation 0.3.0",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
-dependencies = [
- "parity-wasm 0.41.0",
+ "parity-wasm 0.42.2",
+ "wasmi-validation",
 ]
 
 [[package]]

--- a/client/executor/Cargo.toml
+++ b/client/executor/Cargo.toml
@@ -23,8 +23,8 @@ sp-trie = { version = "3.0.0", path = "../../primitives/trie" }
 sp-serializer = { version = "3.0.0", path = "../../primitives/serializer" }
 sp-version = { version = "3.0.0", path = "../../primitives/version" }
 sp-panic-handler = { version = "3.0.0", path = "../../primitives/panic-handler" }
-wasmi = "0.6.2"
-parity-wasm = "0.41.0"
+wasmi = "0.9.0"
+parity-wasm = "0.42.0"
 lazy_static = "1.4.0"
 sp-api = { version = "3.0.0", path = "../../primitives/api" }
 sp-wasm-interface = { version = "3.0.0", path = "../../primitives/wasm-interface" }

--- a/client/executor/common/Cargo.toml
+++ b/client/executor/common/Cargo.toml
@@ -15,10 +15,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 derive_more = "0.99.2"
-parity-wasm = "0.41.0"
-pwasm-utils = "0.14.0"
+pwasm-utils = "0.18.0"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
-wasmi = "0.6.2"
+wasmi = "0.9.0"
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-allocator = { version = "3.0.0", path = "../../../primitives/allocator" }
 sp-wasm-interface = { version = "3.0.0", path = "../../../primitives/wasm-interface" }

--- a/client/executor/common/src/runtime_blob/data_segments_snapshot.rs
+++ b/client/executor/common/src/runtime_blob/data_segments_snapshot.rs
@@ -19,7 +19,7 @@
 use crate::error::{self, Error};
 use super::RuntimeBlob;
 use std::mem;
-use parity_wasm::elements::Instruction;
+use pwasm_utils::parity_wasm::elements::Instruction;
 
 /// This is a snapshot of data segments specialzied for a particular instantiation.
 ///

--- a/client/executor/wasmi/Cargo.toml
+++ b/client/executor/wasmi/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 log = "0.4.8"
-wasmi = "0.6.2"
+wasmi = "0.9.0"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.9.0", path = "../common" }
 sp-wasm-interface = { version = "3.0.0", path = "../../../primitives/wasm-interface" }

--- a/client/executor/wasmtime/Cargo.toml
+++ b/client/executor/wasmtime/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 log = "0.4.8"
 scoped-tls = "1.0"
-parity-wasm = "0.41.0"
+parity-wasm = "0.42.0"
 codec = { package = "parity-scale-codec", version = "2.0.0" }
 sc-executor-common = { version = "0.9.0", path = "../common" }
 sp-wasm-interface = { version = "3.0.0", path = "../../../primitives/wasm-interface" }
@@ -23,7 +23,6 @@ sp-runtime-interface = { version = "3.0.0", path = "../../../primitives/runtime-
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-allocator = { version = "3.0.0", path = "../../../primitives/allocator" }
 wasmtime = "0.24.0"
-pwasm-utils = "0.14.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/frame/contracts/Cargo.toml
+++ b/frame/contracts/Cargo.toml
@@ -15,8 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
-parity-wasm = { version = "0.42", default-features = false }
-pwasm-utils = { version = "0.17", default-features = false }
+pwasm-utils = { version = "0.18", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 smallvec = { version = "1", default-features = false, features = ["const_generics"] }
 wasmi-validation = { version = "0.4", default-features = false }
@@ -61,7 +60,6 @@ std = [
 	"sp-sandbox/std",
 	"frame-support/std",
 	"frame-system/std",
-	"parity-wasm/std",
 	"pwasm-utils/std",
 	"wasmi-validation/std",
 	"pallet-contracts-primitives/std",

--- a/frame/contracts/src/benchmarking/code.rs
+++ b/frame/contracts/src/benchmarking/code.rs
@@ -25,10 +25,16 @@
 //! compiles it down into a `WasmModule` that can be used as a contract's code.
 
 use crate::Config;
-use parity_wasm::elements::{
-	Instruction, Instructions, FuncBody, ValueType, BlockType, Section, CustomSection,
+use pwasm_utils::{
+	stack_height::inject_limiter,
+	parity_wasm::{
+		elements::{
+			self, Instruction, Instructions, FuncBody, ValueType, BlockType, Section,
+			CustomSection,
+		},
+		builder,
+	},
 };
-use pwasm_utils::stack_height::inject_limiter;
 use sp_core::crypto::UncheckedFrom;
 use sp_runtime::traits::Hash;
 use sp_sandbox::{EnvironmentDefinitionBuilder, Memory};
@@ -127,7 +133,7 @@ where
 		let func_offset = u32::try_from(def.imported_functions.len()).unwrap();
 
 		// Every contract must export "deploy" and "call" functions
-		let mut contract = parity_wasm::builder::module()
+		let mut contract = builder::module()
 			// deploy function (first internal function)
 			.function()
 				.signature().build()
@@ -166,7 +172,7 @@ where
 
 		// Import supervisor functions. They start with idx 0.
 		for func in def.imported_functions {
-			let sig = parity_wasm::builder::signature()
+			let sig = builder::signature()
 				.with_params(func.params)
 				.with_results(func.return_type.into_iter().collect())
 				.build_sig();
@@ -174,7 +180,7 @@ where
 			contract = contract.import()
 				.module(func.module)
 				.field(func.name)
-				.with_external(parity_wasm::elements::External::Function(sig))
+				.with_external(elements::External::Function(sig))
 				.build();
 		}
 
@@ -264,7 +270,7 @@ where
 	/// `instantiate_with_code` for different sizes of wasm modules. The generated module maximizes
 	/// instrumentation runtime by nesting blocks as deeply as possible given the byte budget.
 	pub fn sized(target_bytes: u32) -> Self {
-		use parity_wasm::elements::Instruction::{If, I32Const, Return, End};
+		use self::elements::Instruction::{If, I32Const, Return, End};
 		// Base size of a contract is 63 bytes and each expansion adds 6 bytes.
 		// We do one expansion less to account for the code section and function body
 		// size fields inside the binary wasm module representation which are leb128 encoded
@@ -496,7 +502,7 @@ pub mod body {
 
 	/// Replace the locals of the supplied `body` with `num` i64 locals.
 	pub fn inject_locals(body: &mut FuncBody, num: u32) {
-		use parity_wasm::elements::Local;
+		use self::elements::Local;
 		*body.locals_mut() = (0..num).map(|i| Local::new(i, ValueType::I64)).collect()
 	}
 }

--- a/frame/contracts/src/benchmarking/mod.rs
+++ b/frame/contracts/src/benchmarking/mod.rs
@@ -39,7 +39,7 @@ use self::{
 use codec::Encode;
 use frame_benchmarking::{benchmarks, account, whitelisted_caller, impl_benchmark_test_suite};
 use frame_system::{Pallet as System, RawOrigin};
-use parity_wasm::elements::{Instruction, ValueType, BlockType};
+use pwasm_utils::parity_wasm::elements::{Instruction, ValueType, BlockType, BrTableData};
 use sp_runtime::traits::{Hash, Bounded, Zero};
 use sp_std::{default::Default, convert::{TryInto}, vec::Vec, vec};
 use pallet_contracts_primitives::RentProjection;
@@ -1934,7 +1934,7 @@ benchmarks! {
 	// 1 * w_param + 0.5 * 2 * w_param + 0.25 * 4 * w_param
 	instr_br_table {
 		let r in 0 .. INSTR_BENCHMARK_BATCHES;
-		let table = Box::new(parity_wasm::elements::BrTableData {
+		let table = Box::new(BrTableData {
 			table: Box::new([0, 1, 2]),
 			default: 1,
 		});
@@ -1968,7 +1968,7 @@ benchmarks! {
 			.cloned()
 			.cycle()
 			.take((e / 2) as usize).collect();
-		let table = Box::new(parity_wasm::elements::BrTableData {
+		let table = Box::new(BrTableData {
 			table: entry.into_boxed_slice(),
 			default: 0,
 		});

--- a/frame/contracts/src/schedule.rs
+++ b/frame/contracts/src/schedule.rs
@@ -26,8 +26,7 @@ use pallet_contracts_proc_macro::{ScheduleDebug, WeightDebug};
 use frame_support::{DefaultNoBound, weights::Weight};
 use sp_std::{marker::PhantomData, vec::Vec};
 use codec::{Encode, Decode};
-use parity_wasm::elements;
-use pwasm_utils::rules;
+use pwasm_utils::{parity_wasm::elements, rules};
 use sp_runtime::RuntimeDebug;
 
 /// How many API calls are executed in a single batch. The reason for increasing the amount
@@ -635,7 +634,7 @@ impl<T: Config> Schedule<T> {
 
 impl<'a, T: Config> rules::Rules for ScheduleRules<'a, T> {
 	fn instruction_cost(&self, instruction: &elements::Instruction) -> Option<u32> {
-		use parity_wasm::elements::Instruction::*;
+		use self::elements::Instruction::*;
 		let w = &self.schedule.instruction_weights;
 		let max_params = self.schedule.limits.parameters;
 

--- a/frame/contracts/src/wasm/env_def/macros.rs
+++ b/frame/contracts/src/wasm/env_def/macros.rs
@@ -28,15 +28,18 @@ macro_rules! convert_args {
 macro_rules! gen_signature {
 	( ( $( $params: ty ),* ) ) => (
 		{
-			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), vec![])
+			pwasm_utils::parity_wasm::elements::FunctionType::new(
+				convert_args!($($params),*), vec![],
+			)
 		}
 	);
 
 	( ( $( $params: ty ),* ) -> $returns: ty ) => (
 		{
-			parity_wasm::elements::FunctionType::new(convert_args!($($params),*), vec![{
-				use $crate::wasm::env_def::ConvertibleToWasm; <$returns>::VALUE_TYPE
-			}])
+			pwasm_utils::parity_wasm::elements::FunctionType::new(
+				convert_args!($($params),*),
+				vec![{use $crate::wasm::env_def::ConvertibleToWasm; <$returns>::VALUE_TYPE}],
+			)
 		}
 	);
 }
@@ -214,7 +217,12 @@ macro_rules! define_env {
 		pub struct $init_name;
 
 		impl $crate::wasm::env_def::ImportSatisfyCheck for $init_name {
-			fn can_satisfy(module: &[u8], name: &[u8], func_type: &parity_wasm::elements::FunctionType) -> bool {
+			fn can_satisfy(
+				module: &[u8],
+				name: &[u8],
+				func_type: &pwasm_utils::parity_wasm::elements::FunctionType,
+			) -> bool
+			{
 				#[cfg(not(feature = "unstable-interface"))]
 				if module == b"__unstable__" {
 					return false;
@@ -247,8 +255,7 @@ macro_rules! define_env {
 
 #[cfg(test)]
 mod tests {
-	use parity_wasm::elements::FunctionType;
-	use parity_wasm::elements::ValueType;
+	use pwasm_utils::parity_wasm::elements::{FunctionType, ValueType};
 	use sp_runtime::traits::Zero;
 	use sp_sandbox::{ReturnValue, Value};
 	use crate::{

--- a/frame/contracts/src/wasm/env_def/mod.rs
+++ b/frame/contracts/src/wasm/env_def/mod.rs
@@ -19,7 +19,7 @@ use super::Runtime;
 use crate::exec::Ext;
 
 use sp_sandbox::Value;
-use parity_wasm::elements::{FunctionType, ValueType};
+use pwasm_utils::parity_wasm::elements::{FunctionType, ValueType};
 
 #[macro_use]
 pub mod macros;

--- a/frame/contracts/src/wasm/prepare.rs
+++ b/frame/contracts/src/wasm/prepare.rs
@@ -24,7 +24,7 @@ use crate::{
 	chain_extension::ChainExtension,
 	wasm::{PrefabWasmModule, env_def::ImportSatisfyCheck},
 };
-use parity_wasm::elements::{self, Internal, External, MemoryType, Type, ValueType};
+use pwasm_utils::parity_wasm::elements::{self, Internal, External, MemoryType, Type, ValueType};
 use sp_runtime::traits::Hash;
 use sp_std::prelude::*;
 
@@ -105,7 +105,7 @@ impl<'a, T: Config> ContractModule<'a, T> {
 			return Ok(());
 		};
 		for instr in code_section.bodies().iter().flat_map(|body| body.code().elements()) {
-			use parity_wasm::elements::Instruction::BrTable;
+			use self::elements::Instruction::BrTable;
 			if let BrTable(table) = instr {
 				if table.table.len() > limit as usize {
 					return Err("BrTable's immediate value is too big.")
@@ -484,7 +484,7 @@ pub fn reinstrument_contract<T: Config>(
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking {
 	use super::*;
-	use parity_wasm::elements::FunctionType;
+	use super::elements::FunctionType;
 
 	impl ImportSatisfyCheck for () {
 		fn can_satisfy(_module: &[u8], _name: &[u8], _func_type: &FunctionType) -> bool {

--- a/frame/contracts/src/wasm/runtime.rs
+++ b/frame/contracts/src/wasm/runtime.rs
@@ -24,7 +24,7 @@ use crate::{
 	wasm::env_def::ConvertibleToWasm,
 	schedule::HostFnWeights,
 };
-use parity_wasm::elements::ValueType;
+use pwasm_utils::parity_wasm::elements::ValueType;
 use frame_support::{dispatch::DispatchError, ensure, traits::Get, weights::Weight};
 use sp_std::prelude::*;
 use codec::{Decode, DecodeAll, Encode};

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
 primitive-types = { version = "0.9.0", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.3.0", optional = true }
-wasmi = { version = "0.6.2", optional = true }
+wasmi = { version = "0.9.0", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 base58 = { version = "0.1.0", optional = true }

--- a/primitives/sandbox/Cargo.toml
+++ b/primitives/sandbox/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-wasmi = { version = "0.6.2", optional = true }
+wasmi = { version = "0.9.0", optional = true }
 sp-core = { version = "3.0.0", default-features = false, path = "../core" }
 sp-std = { version = "3.0.0", default-features = false, path = "../std" }
 sp-io = { version = "3.0.0", default-features = false, path = "../io" }

--- a/primitives/wasm-interface/Cargo.toml
+++ b/primitives/wasm-interface/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-wasmi = { version = "0.6.2", optional = true }
+wasmi = { version = "0.9.0", optional = true }
 impl-trait-for-tuples = "0.2.1"
 sp-std = { version = "3.0.0", path = "../std", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This PR bumps all users of `parity-wasm` to the current version so that we no longer have duplicates in our node binary.

* parity-wasm
* pwasm-utils
* wasmi