### PR TITLE
Strongly Bounded Locks in Balances

### DIFF
--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -151,10 +151,11 @@ impl pallet_timestamp::Config for Test {
 
 parameter_types! {
 	pub const ExistentialDeposit: u128 = 1;
+	pub const MaxLocks: u32 = 10;
 }
 
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type Balance = u128;
 	type DustRemoval = ();
 	type Event = Event;

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1646,17 +1646,17 @@ where
 
 	type MaxLocks = T::MaxLocks;
 
-	// Checks if `set_lock` or `extend_lock` would fail.
-	// Specifically if adding a lock with `id` would push us over the `MaxLocks` limit.
+	// Checks if `set_lock` or `extend_lock` would fail. Specifically if adding a lock with `id`
+	// would push us over the `MaxLocks` limit.
 	fn can_add_lock(id: LockIdentifier, who: &T::AccountId) -> bool {
 		let locks = Self::locks(who);
 		let length = locks.len();
-		if length as u32 == u32::max_value() { return false }
-		if length < T::MaxLocks::get() { return true }
-		let new_locks_len = if locks
-			.into_iter()
-			.any(|l| l.id == id) { length } else { length + 1 };
-		new_locks_len as u32 <= T::MaxLocks::get()
+		// If length < MaxLocks, we can always add one more new lock
+		if (length as u32) < T::MaxLocks::get() { return true }
+		// If `length == T::MaxLocks::get()`, and we check if this id is already used, which
+		// means we can "add" this lock since it would update an existing id.
+		if locks.into_iter().any(|l| l.id == id) { return true }
+		return false
 	}
 
 	// Set a lock on the balance of `who`.

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1646,6 +1646,26 @@ where
 
 	type MaxLocks = T::MaxLocks;
 
+	// Checks if `set_lock` or `extend_lock` would fail.
+	// Specifically if adding a lock with `id` would push us
+	// over the `MaxLocks` limit.
+	fn can_add_lock(id: LockIdentifier, who: &T::AccountId) -> bool {
+		let mut new_lock = Some(BalanceLock {
+			id,
+			amount: Default::default(),
+			reasons: Reasons::All,
+		});
+		let mut locks = Self::locks(who).into_iter()
+			.filter_map(|l| if l.id == id { new_lock.take() } else { Some(l) })
+			.collect::<Vec<_>>();
+		if let Some(lock) = new_lock {
+			locks.push(lock)
+		}
+		BoundedVec::<_, T::MaxLocks>::try_from(
+			locks.to_vec(),
+		).is_ok()
+	}
+
 	// Set a lock on the balance of `who`.
 	// Is a no-op if lock amount is zero or `reasons` `is_none()`.
 	fn set_lock(

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1652,6 +1652,7 @@ where
 		let locks = Self::locks(who);
 		let length = locks.len();
 		if length as u32 == u32::max_value() { return false }
+		if length < T::MaxLocks::get() { return true }
 		let new_locks_len = if locks
 			.into_iter()
 			.any(|l| l.id == id) { length } else { length + 1 };

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -1652,7 +1652,7 @@ where
 		let locks = Self::locks(who);
 		let length = locks.len();
 		if length as u32 == u32::max_value() { return false }
-		let new_locks_len =  if Self::locks(who)
+		let new_locks_len = if locks
 			.into_iter()
 			.any(|l| l.id == id) { length } else { length + 1 };
 		new_locks_len as u32 <= T::MaxLocks::get()

--- a/frame/balances/src/tests.rs
+++ b/frame/balances/src/tests.rs
@@ -58,7 +58,7 @@ macro_rules! decl_tests {
 		fn basic_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
 				assert_eq!(Balances::free_balance(1), 10);
-				Balances::set_lock(ID_1, &1, 9, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, 9, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 5, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
@@ -79,7 +79,7 @@ macro_rules! decl_tests {
 		#[test]
 		fn partial_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all()));
 				assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 			});
 		}
@@ -87,7 +87,7 @@ macro_rules! decl_tests {
 		#[test]
 		fn lock_removal_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::all()));
 				Balances::remove_lock(ID_1, &1);
 				assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 			});
@@ -96,8 +96,8 @@ macro_rules! decl_tests {
 		#[test]
 		fn lock_replacement_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::all());
-				Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::all()));
+				assert_ok!(Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all()));
 				assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 			});
 		}
@@ -105,8 +105,8 @@ macro_rules! decl_tests {
 		#[test]
 		fn double_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all());
-				Balances::set_lock(ID_2, &1, 5, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all()));
+				assert_ok!(Balances::set_lock(ID_2, &1, 5, WithdrawReasons::all()));
 				assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 			});
 		}
@@ -114,8 +114,8 @@ macro_rules! decl_tests {
 		#[test]
 		fn combination_locking_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::empty());
-				Balances::set_lock(ID_2, &1, 0, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, u64::max_value(), WithdrawReasons::empty()));
+				assert_ok!(Balances::set_lock(ID_2, &1, 0, WithdrawReasons::all()));
 				assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 			});
 		}
@@ -123,17 +123,17 @@ macro_rules! decl_tests {
 		#[test]
 		fn lock_value_extension_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, 5, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
-				Balances::extend_lock(ID_1, &1, 2, WithdrawReasons::all());
+				assert_ok!(Balances::extend_lock(ID_1, &1, 2, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
-				Balances::extend_lock(ID_1, &1, 8, WithdrawReasons::all());
+				assert_ok!(Balances::extend_lock(ID_1, &1, 8, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 3, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
@@ -149,7 +149,7 @@ macro_rules! decl_tests {
 				.build()
 				.execute_with(|| {
 					pallet_transaction_payment::NextFeeMultiplier::put(Multiplier::saturating_from_integer(1));
-					Balances::set_lock(ID_1, &1, 10, WithdrawReasons::RESERVE);
+					assert_ok!(Balances::set_lock(ID_1, &1, 10, WithdrawReasons::RESERVE));
 					assert_noop!(
 						<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath),
 						Error::<$test, _>::LiquidityRestrictions
@@ -173,7 +173,7 @@ macro_rules! decl_tests {
 						1,
 					));
 
-					Balances::set_lock(ID_1, &1, 10, WithdrawReasons::TRANSACTION_PAYMENT);
+					assert_ok!(Balances::set_lock(ID_1, &1, 10, WithdrawReasons::TRANSACTION_PAYMENT));
 					assert_ok!(<Balances as Currency<_>>::transfer(&1, &2, 1, AllowDeath));
 					assert_ok!(<Balances as ReservableCurrency<_>>::reserve(&1, 1));
 					assert!(<ChargeTransactionPayment<$test> as SignedExtension>::pre_dispatch(
@@ -196,18 +196,18 @@ macro_rules! decl_tests {
 		#[test]
 		fn lock_block_number_extension_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, 10, WithdrawReasons::all());
+				assert_ok!(Balances::set_lock(ID_1, &1, 10, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
-				Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::all());
+				assert_ok!(Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
 				System::set_block_number(2);
-				Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::all());
+				assert_ok!(Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::all()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 3, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
@@ -218,17 +218,17 @@ macro_rules! decl_tests {
 		#[test]
 		fn lock_reasons_extension_should_work() {
 			<$ext_builder>::default().existential_deposit(1).monied(true).build().execute_with(|| {
-				Balances::set_lock(ID_1, &1, 10, WithdrawReasons::TRANSFER);
+				assert_ok!(Balances::set_lock(ID_1, &1, 10, WithdrawReasons::TRANSFER));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
-				Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::empty());
+				assert_ok!(Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::empty()));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions
 				);
-				Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::RESERVE);
+				assert_ok!(Balances::extend_lock(ID_1, &1, 10, WithdrawReasons::RESERVE));
 				assert_noop!(
 					<Balances as Currency<_>>::transfer(&1, &2, 6, AllowDeath),
 					Error::<$test, _>::LiquidityRestrictions

--- a/frame/balances/src/tests_composite.rs
+++ b/frame/balances/src/tests_composite.rs
@@ -87,13 +87,17 @@ impl pallet_transaction_payment::Config for Test {
 	type FeeMultiplierUpdate = ();
 }
 
+parameter_types! {
+	pub const MaxLocks: u32 = 10;
+}
+
 impl Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
 	type Event = Event;
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = frame_system::Pallet<Test>;
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type WeightInfo = ();
 }
 

--- a/frame/elections-phragmen/src/lib.rs
+++ b/frame/elections-phragmen/src/lib.rs
@@ -338,7 +338,7 @@ pub mod pallet {
 				&who,
 				locked_stake,
 				WithdrawReasons::all(),
-			).expect("can_add_lock returned true above");
+			).expect("can_add_lock returned true above, thus this cannot fail.");
 
 			Voting::<T>::insert(&who, Voter { votes, deposit: new_deposit, stake: locked_stake });
 			Ok(None.into())

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -341,6 +341,8 @@ decl_error! {
 		ZeroCandidates,
 		/// No approval changes during presentation period.
 		ApprovalPresentation,
+		/// Could not create a new lock for an account.
+		TooManyLocks,
 	}
 }
 
@@ -833,6 +835,8 @@ impl<T: Config> Module<T> {
 		);
 		ensure!(value >= T::MinimumVotingLock::get(), Error::<T>::InsufficientLockedValue);
 
+		ensure!(T::Currency::can_add_lock(T::PalletId::get(), &who), Error::<T>::TooManyLocks);
+
 		// Amount to be locked up.
 		let mut locked_balance = value.min(T::Currency::total_balance(&who));
 		let mut pot_to_set = Zero::zero();
@@ -894,7 +898,7 @@ impl<T: Config> Module<T> {
 			&who,
 			locked_balance,
 			WithdrawReasons::all(),
-		);
+		).expect("can_add_lock returned true above");
 
 		<VoterInfoOf<T>>::insert(
 			&who,

--- a/frame/elections/src/lib.rs
+++ b/frame/elections/src/lib.rs
@@ -898,7 +898,7 @@ impl<T: Config> Module<T> {
 			&who,
 			locked_balance,
 			WithdrawReasons::all(),
-		).expect("can_add_lock returned true above");
+		).expect("can_add_lock returned true above, thus this cannot fail");
 
 		<VoterInfoOf<T>>::insert(
 			&who,

--- a/frame/elections/src/mock.rs
+++ b/frame/elections/src/mock.rs
@@ -63,9 +63,10 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const ExistentialDeposit: u64 = 1;
+	pub const MaxLocks: u32 = 10;
 }
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type Balance = u64;
 	type DustRemoval = ();
 	type Event = Event;

--- a/frame/executive/src/lib.rs
+++ b/frame/executive/src/lib.rs
@@ -535,7 +535,7 @@ mod tests {
 		},
 	};
 	use frame_support::{
-		assert_err, parameter_types,
+		assert_err, parameter_types, assert_ok,
 		weights::{Weight, RuntimeDbWeight, IdentityFee, WeightToFeePolynomial},
 		traits::{Currency, LockIdentifier, LockableCurrency, WithdrawReasons},
 	};
@@ -713,6 +713,7 @@ mod tests {
 	type Balance = u64;
 	parameter_types! {
 		pub const ExistentialDeposit: Balance = 1;
+		pub const MaxLocks: u32 = 10;
 	}
 	impl pallet_balances::Config for Runtime {
 		type Balance = Balance;
@@ -720,7 +721,7 @@ mod tests {
 		type DustRemoval = ();
 		type ExistentialDeposit = ExistentialDeposit;
 		type AccountStore = System;
-		type MaxLocks = ();
+		type MaxLocks = MaxLocks;
 		type WeightInfo = ();
 	}
 
@@ -1024,12 +1025,12 @@ mod tests {
 		let execute_with_lock = |lock: WithdrawReasons| {
 			let mut t = new_test_ext(1);
 			t.execute_with(|| {
-				<pallet_balances::Pallet<Runtime> as LockableCurrency<Balance>>::set_lock(
+				assert_ok!(<pallet_balances::Pallet<Runtime> as LockableCurrency<Balance>>::set_lock(
 					id,
 					&1,
 					110,
 					lock,
-				);
+				));
 				let xt = TestXt::new(
 					Call::System(SystemCall::remark(vec![1u8])),
 					sign_extra(1, 0, 0),

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -146,10 +146,11 @@ impl pallet_authorship::Config for Test {
 
 parameter_types! {
 	pub const ExistentialDeposit: u128 = 1;
+	pub const MaxLocks: u32 = 10;
 }
 
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type Balance = u128;
 	type DustRemoval = ();
 	type Event = Event;

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -69,9 +69,10 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;
+	pub const MaxLocks: u32 = 10;
 }
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type Balance = Balance;
 	type Event = Event;
 	type DustRemoval = ();

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -71,9 +71,10 @@ impl frame_system::Config for Test {
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 10;
+	pub const MaxLocks: u32 = 10;
 }
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
+	type MaxLocks = MaxLocks;
 	type Balance = Balance;
 	type Event = Event;
 	type DustRemoval = ();

--- a/frame/support/src/traits/tokens/currency/lockable.rs
+++ b/frame/support/src/traits/tokens/currency/lockable.rs
@@ -34,6 +34,12 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// The maximum number of locks a user should have on their account.
 	type MaxLocks: Get<u32>;
 
+	/// Checks if a lock with `id` can be placed on account `who`.
+	///
+	/// This function returning `true` must imply that `set_lock` and `extend_lock`
+	/// cannot fail.
+	fn can_add_lock(id: LockIdentifier, who: &AccountId) -> bool;
+
 	/// Create a new balance lock on account `who`.
 	///
 	/// If the new lock is valid (i.e. not already expired), it will push the struct to

--- a/frame/support/src/traits/tokens/currency/lockable.rs
+++ b/frame/support/src/traits/tokens/currency/lockable.rs
@@ -40,12 +40,15 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// the `Locks` vec in storage. Note that you can lock more funds than a user has.
 	///
 	/// If the lock `id` already exists, this will update it.
-	fn set_lock(
+	///
+	/// This function will return `Err` if adding a new lock would set a user to have
+	/// more than `MaxLocks`.
+	fn set_lock (
 		id: LockIdentifier,
 		who: &AccountId,
 		amount: Self::Balance,
 		reasons: WithdrawReasons,
-	);
+	) -> DispatchResult;
 
 	/// Changes a balance lock (selected by `id`) so that it becomes less liquid in all
 	/// parameters or creates a new one if it does not exist.
@@ -55,12 +58,15 @@ pub trait LockableCurrency<AccountId>: Currency<AccountId> {
 	/// with the new parameters. As in, `extend_lock` will set:
 	/// - maximum `amount`
 	/// - bitwise mask of all `reasons`
+	///
+	/// This function will return `Err` if adding a new lock would set a user to have
+	/// more than `MaxLocks`.
 	fn extend_lock(
 		id: LockIdentifier,
 		who: &AccountId,
 		amount: Self::Balance,
 		reasons: WithdrawReasons,
-	);
+	) -> DispatchResult;
 
 	/// Remove an existing lock.
 	fn remove_lock(

--- a/frame/vesting/src/benchmarking.rs
+++ b/frame/vesting/src/benchmarking.rs
@@ -36,7 +36,8 @@ fn add_locks<T: Config>(who: &T::AccountId, n: u8) {
 		let lock_id = [id; 8];
 		let locked = 100u32;
 		let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
-		T::Currency::set_lock(lock_id, who, locked.into(), reasons);
+		T::Currency::set_lock(lock_id, who, locked.into(), reasons)
+			.expect("problem adding lock in vesting benchmarks");
 	}
 }
 
@@ -59,7 +60,7 @@ fn add_vesting_schedule<T: Config>(who: &T::AccountId) -> Result<(), &'static st
 
 benchmarks! {
 	vest_locked {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let caller = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
@@ -83,7 +84,7 @@ benchmarks! {
 	}
 
 	vest_unlocked {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let caller = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
@@ -107,7 +108,7 @@ benchmarks! {
 	}
 
 	vest_other_locked {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let other: T::AccountId = account("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
@@ -134,7 +135,7 @@ benchmarks! {
 	}
 
 	vest_other_unlocked {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let other: T::AccountId = account("other", 0, SEED);
 		let other_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(other.clone());
@@ -161,7 +162,7 @@ benchmarks! {
 	}
 
 	vested_transfer {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let caller: T::AccountId = whitelisted_caller();
 		T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
@@ -192,7 +193,7 @@ benchmarks! {
 	}
 
 	force_vested_transfer {
-		let l in 0 .. MaxLocksOf::<T>::get();
+		let l in 0 .. MaxLocksOf::<T>::get() - 1;
 
 		let source: T::AccountId = account("source", 0, SEED);
 		let source_lookup: <T::Lookup as StaticLookup>::Source = T::Lookup::unlookup(source.clone());

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
 					starting_block: begin
 				});
 				let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
-				T::Currency::set_lock(VESTING_ID, who, locked, reasons);
+				T::Currency::set_lock(VESTING_ID, who, locked, reasons).expect("problem adding lock in vesting genesis");
 			}
 		}
 	}
@@ -340,7 +340,7 @@ impl<T: Config> Pallet<T> {
 			Self::deposit_event(Event::<T>::VestingCompleted(who));
 		} else {
 			let reasons = WithdrawReasons::TRANSFER | WithdrawReasons::RESERVE;
-			T::Currency::set_lock(VESTING_ID, &who, locked_now, reasons);
+			T::Currency::set_lock(VESTING_ID, &who, locked_now, reasons)?;
 			Self::deposit_event(Event::<T>::VestingUpdated(who, locked_now));
 		}
 		Ok(())


### PR DESCRIPTION
This changes the API around setting Balance locks such that it can return a `Result`.

This allows us to return an error when we hit the limit of balance locks for a user, and allows us to drop the use of `WeakBoundedVec`.

This is a breaking change to the API, and any pallets which use locks will need to update.

A helper function `can_add_lock` is introduced which can ensure that the "verify first, write last" principle is always enforced.

polkadot companion: https://github.com/paritytech/polkadot/pull/3137