### PR TITLE
READY Update simnet tests to v5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -571,11 +571,11 @@ build-rust-doc:
     - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
-    - echo "${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
+    - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
     - echo "VERSION is ${VERSION}"
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"
-    - echo "IMAGE_TAG=${VERSION}" >> ./artifacts/$PRODUCT/build.env
+    - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
 
 publish-docker-substrate:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -697,7 +697,7 @@ trigger-simnet:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         publish-docker-substrate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -569,7 +569,7 @@ build-rust-doc:
     - buildah push --format=v2s2 "$IMAGE_NAME:latest"
   after_script:
     - buildah logout "$IMAGE_NAME"
-    # pass artifacts to the trigger-simnet job
+    # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
     - echo "${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
     - echo "VERSION is ${VERSION}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -567,16 +567,18 @@ build-rust-doc:
     - buildah info
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:latest"
+  after_script:
+    - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
     - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
+    - ls -la
+    - VERSION="$(cat ./artifacts/$PRODUCT/VERSION)"
     - echo "VERSION is ${VERSION}"
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"
     - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
     - cat ./artifacts/$PRODUCT/build.env
-  after_script:
-    - buildah logout "$IMAGE_NAME"
 
 publish-docker-substrate:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -567,17 +567,16 @@ build-rust-doc:
     - buildah info
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
     - buildah push --format=v2s2 "$IMAGE_NAME:latest"
-  after_script:
-    - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
     - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
-    - VERSION="$(cat ./VERSION)"
     - echo "VERSION is ${VERSION}"
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"
     - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
     - cat ./artifacts/$PRODUCT/build.env
+  after_script:
+    - buildah logout "$IMAGE_NAME"
 
 publish-docker-substrate:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -569,7 +569,7 @@ build-rust-doc:
   after_script:
     - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job 
-    - echo "IMAGE_NAME=${IMAGE_NAME}" | tee    ./artifacts/$PRODUCT/build.env
+    - echo "IMAGE_NAME=${IMAGE_NAME}" | tee -a ./artifacts/$PRODUCT/build.env
     - IMAGE_TAG="$(cat ./artifacts/$PRODUCT/VERSION)"
     - echo "IMAGE_TAG=${IMAGE_TAG}"   | tee -a ./artifacts/$PRODUCT/build.env
     - cat ./artifacts/$PRODUCT/build.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -576,6 +576,7 @@ build-rust-doc:
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"
     - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
+    - cat ./artifacts/$PRODUCT/build.env
 
 publish-docker-substrate:
   stage:                           publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,7 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    - if: $CI_COMMIT_MESSAGE  =~ /.*build-for-simnet.*/
 
 .nightly-pipeline:                 &nightly-pipeline
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -572,6 +572,7 @@ build-rust-doc:
     # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
     - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
+    - VERSION="$(cat ./VERSION)"
     - echo "VERSION is ${VERSION}"
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -704,7 +704,6 @@ trigger-simnet:
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/   # PRs   # FIXME: revert me 
   needs:
     - job:                         publish-docker-substrate
   # `build.env` brings here `$IMAGE_NAME` and `$IMAGE_TAG` (`$VERSION` here, 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -585,7 +585,7 @@ publish-docker-substrate:
   <<:                              *build-push-docker-image
   <<:                              *build-refs
   needs:
-    #- job:                         build-linux-substrate
+    - job:                         build-linux-substrate
       artifacts:                   true
   variables:
     <<:                            *docker-build-vars

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -570,7 +570,11 @@ build-rust-doc:
   after_script:
     - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job
-    - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
+    - echo "IMAGE_NAME is ${IMAGE_NAME}"
+    - echo "${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
+    - echo "VERSION is ${VERSION}"
+    - IMAGE_TAG="${VERSION}"
+    - echo "IMAGE_TAG is ${IMAGE_TAG}"
     - echo "IMAGE_TAG=${VERSION}" >> ./artifacts/$PRODUCT/build.env
 
 publish-docker-substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -696,6 +696,7 @@ trigger-simnet:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         publish-docker-substrate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -572,9 +572,7 @@ build-rust-doc:
     # pass artifacts to the trigger-simnet job 
     - echo "IMAGE_NAME is ${IMAGE_NAME}"
     - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
-    - ls -la
     - VERSION="$(cat ./artifacts/$PRODUCT/VERSION)"
-    - echo "VERSION is ${VERSION}"
     - IMAGE_TAG="${VERSION}"
     - echo "IMAGE_TAG is ${IMAGE_TAG}"
     - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
@@ -705,8 +703,8 @@ trigger-simnet:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/   # PRs # FIXME: revert me
   needs:
     - job:                         publish-docker-substrate
   # `build.env` brings here `$IMAGE_NAME` and `$IMAGE_TAG` (`$VERSION` here, 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -355,6 +355,7 @@ test-frame-examples-compile-to-wasm:
 
 test-linux-stable-int:
   <<:                              *test-linux
+  stage:                           test
   script:
     - echo "___Logs will be partly shown at the end in case of failure.___"
     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
@@ -696,7 +697,7 @@ trigger-simnet:
     - if: $CI_PIPELINE_SOURCE == "pipeline"
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                        # PRs
     - if: $CI_COMMIT_REF_NAME == "master"
   needs:
     - job:                         publish-docker-substrate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,7 +114,6 @@ default:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_MESSAGE  =~ /.*build-for-simnet.*/
 
 .nightly-pipeline:                 &nightly-pipeline
   rules:
@@ -570,12 +569,9 @@ build-rust-doc:
   after_script:
     - buildah logout "$IMAGE_NAME"
     # pass artifacts to the trigger-simnet job 
-    - echo "IMAGE_NAME is ${IMAGE_NAME}"
-    - echo "IMAGE_NAME=${IMAGE_NAME}" > ./artifacts/$PRODUCT/build.env
-    - VERSION="$(cat ./artifacts/$PRODUCT/VERSION)"
-    - IMAGE_TAG="${VERSION}"
-    - echo "IMAGE_TAG is ${IMAGE_TAG}"
-    - echo "IMAGE_TAG=${IMAGE_TAG}" >> ./artifacts/$PRODUCT/build.env
+    - echo "IMAGE_NAME=${IMAGE_NAME}" | tee    ./artifacts/$PRODUCT/build.env
+    - IMAGE_TAG="$(cat ./artifacts/$PRODUCT/VERSION)"
+    - echo "IMAGE_TAG=${IMAGE_TAG}"   | tee -a ./artifacts/$PRODUCT/build.env
     - cat ./artifacts/$PRODUCT/build.env
 
 publish-docker-substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,208 +216,208 @@ test-prometheus-alerting-rules:
 
 #### stage:                        test
 
-cargo-deny:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *nightly-pipeline
-  script:
-    - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
-  after_script:
-    - echo "___The complete log is in the artifacts___"
-    - cargo deny check -c .maintain/deny.toml 2> deny.log
-  artifacts:
-    name:                          $CI_COMMIT_SHORT_SHA
-    expire_in:                     3 days
-    when:                          always
-    paths:
-      - deny.log
-  # FIXME: Temorarily allow to fail.
-  allow_failure:                   true
-
-cargo-check-benches:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  <<:                              *collect-artifacts
-  before_script:
-    # merges in the master branch on PRs
-    - *merge-ref-into-master-script
-    - *rust-info-script
-  script:
-    - *cargo-check-benches-script
-
-node-bench-regression-guard:
-  # it's not belong to `build` semantically, but dag jobs can't depend on each other
-  # within the single stage - https://gitlab.com/gitlab-org/gitlab/-/issues/30632
-  # more: https://github.com/paritytech/substrate/pull/8519#discussion_r608012402
-  stage:                           build
-  <<:                              *docker-env
-  <<:                              *test-refs-no-trigger-prs-only
-  needs:
-    # this is a DAG
-    - job:                         cargo-check-benches
-      artifacts:                   true
-    # this does not like a DAG, just polls the artifact
-    - project:                     $CI_PROJECT_PATH
-      job:                         cargo-check-benches
-      ref:                         master
-      artifacts:                   true
-  variables:
-    CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
-  before_script: [""]
-  script:
-    - 'node-bench-regression-guard --reference artifacts/benches/master-* 
-       --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
-
-cargo-check-subkey:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  script:
-    - cd ./bin/utils/subkey
-    - SKIP_WASM_BUILD=1 time cargo check --release
-    - sccache -s
-
-cargo-check-try-runtime:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  script:
-    - time cargo check --features try-runtime
-    - sccache -s
-
-test-deterministic-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  variables:
-    <<:                            *default-vars
-    WASM_BUILD_NO_COLOR:           1
-  script:
-    # build runtime
-    - cargo build --verbose --release -p node-runtime
-    # make checksum
-    - sha256sum target/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
-    # clean up – FIXME: can we reuse some of the artifacts?
-    - cargo clean
-    # build again
-    - cargo build --verbose --release -p node-runtime
-    # confirm checksum
-    - sha256sum -c checksum.sha256
-    - sccache -s
-
-test-linux-stable:                 &test-linux
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  variables:
-    <<:                            *default-vars
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
-    RUST_BACKTRACE:                1
-    WASM_BUILD_NO_COLOR:           1
-  script:
-    # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
-    - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml # does not reuse cache 1 min 44 sec
-    - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
-    - sccache -s
-
-unleash-check:
-  stage:                           test
-  <<:                              *docker-env
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "pipeline"
-      when: never
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-  script:
-    - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
-    - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
-
-test-frame-examples-compile-to-wasm:
-  # into one job
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  variables:
-    <<:                            *default-vars
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS:                     "-Cdebug-assertions=y"
-    RUST_BACKTRACE: 1
-  script:
-    - cd frame/example-offchain-worker/
-    - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
-    - cd ../example
-    - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
-    - sccache -s
-
-test-linux-stable-int:
-  <<:                              *test-linux
-  stage:                           test
-  script:
-    - echo "___Logs will be partly shown at the end in case of failure.___"
-    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
-    - WASM_BUILD_NO_COLOR=1
-      RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-        time cargo test -p node-cli --release --verbose --locked -- --ignored
-        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-    - sccache -s
-  after_script:
-    - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
-  artifacts:
-    name:                          $CI_COMMIT_SHORT_SHA
-    when:                          on_failure
-    expire_in:                     3 days
-    paths:
-      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
-
-check-web-wasm:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  script:
-    # WASM support is in progress. As more and more crates support WASM, we
-    # should add entries here. See https://github.com/paritytech/substrate/issues/2416
-    # Note: we don't need to test crates imported in `bin/node/cli`
-    - time cargo build --manifest-path=client/consensus/aura/Cargo.toml --target=wasm32-unknown-unknown --features getrandom
-    # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
-    - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown
-    # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
-    - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features
-    - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features --features=with-tracing
-    - sccache -s
-
-test-full-crypto-feature:
-  stage:                           test
-  <<:                              *docker-env
-  <<:                              *test-refs
-  variables:
-    <<:                            *default-vars
-    # Enable debug assertions since we are running optimized builds for testing
-    # but still want to have debug assertions.
-    RUSTFLAGS:                     "-Cdebug-assertions=y"
-    RUST_BACKTRACE: 1
-  script:
-    - cd primitives/core/
-    - time cargo +nightly build --verbose --no-default-features --features full_crypto
-    - cd ../application-crypto
-    - time cargo +nightly build --verbose --no-default-features --features full_crypto
-    - sccache -s
-
-cargo-check-macos:
-  stage:                           test
-  # shell runner on mac ignores the image set in *docker-env
-  <<:                              *docker-env
-  <<:                              *test-refs-no-trigger
-  script:
-    - SKIP_WASM_BUILD=1 time cargo check --release
-    - sccache -s
-  tags:
-    - osx
-
+        # cargo-deny:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *nightly-pipeline
+        #   script:
+        #     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
+        #   after_script:
+        #     - echo "___The complete log is in the artifacts___"
+        #     - cargo deny check -c .maintain/deny.toml 2> deny.log
+        #   artifacts:
+        #     name:                          $CI_COMMIT_SHORT_SHA
+        #     expire_in:                     3 days
+        #     when:                          always
+        #     paths:
+        #       - deny.log
+        #   # FIXME: Temorarily allow to fail.
+        #   allow_failure:                   true
+        # 
+        # cargo-check-benches:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   <<:                              *collect-artifacts
+        #   before_script:
+        #     # merges in the master branch on PRs
+        #     - *merge-ref-into-master-script
+        #     - *rust-info-script
+        #   script:
+        #     - *cargo-check-benches-script
+        # 
+        # node-bench-regression-guard:
+        #   # it's not belong to `build` semantically, but dag jobs can't depend on each other
+        #   # within the single stage - https://gitlab.com/gitlab-org/gitlab/-/issues/30632
+        #   # more: https://github.com/paritytech/substrate/pull/8519#discussion_r608012402
+        #   stage:                           build
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs-no-trigger-prs-only
+        #   needs:
+        #     # this is a DAG
+        #     - job:                         cargo-check-benches
+        #       artifacts:                   true
+        #     # this does not like a DAG, just polls the artifact
+        #     - project:                     $CI_PROJECT_PATH
+        #       job:                         cargo-check-benches
+        #       ref:                         master
+        #       artifacts:                   true
+        #   variables:
+        #     CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
+        #   before_script: [""]
+        #   script:
+        #     - 'node-bench-regression-guard --reference artifacts/benches/master-* 
+        #        --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
+        # 
+        # cargo-check-subkey:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   script:
+        #     - cd ./bin/utils/subkey
+        #     - SKIP_WASM_BUILD=1 time cargo check --release
+        #     - sccache -s
+        # 
+        # cargo-check-try-runtime:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   script:
+        #     - time cargo check --features try-runtime
+        #     - sccache -s
+        # 
+        # test-deterministic-wasm:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   variables:
+        #     <<:                            *default-vars
+        #     WASM_BUILD_NO_COLOR:           1
+        #   script:
+        #     # build runtime
+        #     - cargo build --verbose --release -p node-runtime
+        #     # make checksum
+        #     - sha256sum target/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
+        #     # clean up – FIXME: can we reuse some of the artifacts?
+        #     - cargo clean
+        #     # build again
+        #     - cargo build --verbose --release -p node-runtime
+        #     # confirm checksum
+        #     - sha256sum -c checksum.sha256
+        #     - sccache -s
+        # 
+        # test-linux-stable:                 &test-linux
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   variables:
+        #     <<:                            *default-vars
+        #     # Enable debug assertions since we are running optimized builds for testing
+        #     # but still want to have debug assertions.
+        #     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+        #     RUST_BACKTRACE:                1
+        #     WASM_BUILD_NO_COLOR:           1
+        #   script:
+        #     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
+        #     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
+        #     - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml # does not reuse cache 1 min 44 sec
+        #     - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+        #     - sccache -s
+        # 
+        # unleash-check:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   rules:
+        #     - if: $CI_PIPELINE_SOURCE == "pipeline"
+        #       when: never
+        #     - if: $CI_COMMIT_REF_NAME == "master"
+        #     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+        #   script:
+        #     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
+        #     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
+        # 
+        # test-frame-examples-compile-to-wasm:
+        #   # into one job
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   variables:
+        #     <<:                            *default-vars
+        #     # Enable debug assertions since we are running optimized builds for testing
+        #     # but still want to have debug assertions.
+        #     RUSTFLAGS:                     "-Cdebug-assertions=y"
+        #     RUST_BACKTRACE: 1
+        #   script:
+        #     - cd frame/example-offchain-worker/
+        #     - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
+        #     - cd ../example
+        #     - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
+        #     - sccache -s
+        # 
+        # test-linux-stable-int:
+        #   <<:                              *test-linux
+        #   stage:                           test
+        #   script:
+        #     - echo "___Logs will be partly shown at the end in case of failure.___"
+        #     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
+        #     - WASM_BUILD_NO_COLOR=1
+        #       RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+        #         time cargo test -p node-cli --release --verbose --locked -- --ignored
+        #         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+        #     - sccache -s
+        #   after_script:
+        #     - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
+        #   artifacts:
+        #     name:                          $CI_COMMIT_SHORT_SHA
+        #     when:                          on_failure
+        #     expire_in:                     3 days
+        #     paths:
+        #       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
+        # 
+        # check-web-wasm:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   script:
+        #     # WASM support is in progress. As more and more crates support WASM, we
+        #     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
+        #     # Note: we don't need to test crates imported in `bin/node/cli`
+        #     - time cargo build --manifest-path=client/consensus/aura/Cargo.toml --target=wasm32-unknown-unknown --features getrandom
+        #     # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
+        #     - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown
+        #     # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
+        #     - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features
+        #     - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features --features=with-tracing
+        #     - sccache -s
+        # 
+        # test-full-crypto-feature:
+        #   stage:                           test
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs
+        #   variables:
+        #     <<:                            *default-vars
+        #     # Enable debug assertions since we are running optimized builds for testing
+        #     # but still want to have debug assertions.
+        #     RUSTFLAGS:                     "-Cdebug-assertions=y"
+        #     RUST_BACKTRACE: 1
+        #   script:
+        #     - cd primitives/core/
+        #     - time cargo +nightly build --verbose --no-default-features --features full_crypto
+        #     - cd ../application-crypto
+        #     - time cargo +nightly build --verbose --no-default-features --features full_crypto
+        #     - sccache -s
+        # 
+        # cargo-check-macos:
+        #   stage:                           test
+        #   # shell runner on mac ignores the image set in *docker-env
+        #   <<:                              *docker-env
+        #   <<:                              *test-refs-no-trigger
+        #   script:
+        #     - SKIP_WASM_BUILD=1 time cargo check --release
+        #     - sccache -s
+        #   tags:
+        #     - osx
+        # 
 #### stage:                        build
 
 check-polkadot-companion-status:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,208 +216,208 @@ test-prometheus-alerting-rules:
 
 #### stage:                        test
 
-        # cargo-deny:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *nightly-pipeline
-        #   script:
-        #     - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
-        #   after_script:
-        #     - echo "___The complete log is in the artifacts___"
-        #     - cargo deny check -c .maintain/deny.toml 2> deny.log
-        #   artifacts:
-        #     name:                          $CI_COMMIT_SHORT_SHA
-        #     expire_in:                     3 days
-        #     when:                          always
-        #     paths:
-        #       - deny.log
-        #   # FIXME: Temorarily allow to fail.
-        #   allow_failure:                   true
-        # 
-        # cargo-check-benches:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   <<:                              *collect-artifacts
-        #   before_script:
-        #     # merges in the master branch on PRs
-        #     - *merge-ref-into-master-script
-        #     - *rust-info-script
-        #   script:
-        #     - *cargo-check-benches-script
-        # 
-        # node-bench-regression-guard:
-        #   # it's not belong to `build` semantically, but dag jobs can't depend on each other
-        #   # within the single stage - https://gitlab.com/gitlab-org/gitlab/-/issues/30632
-        #   # more: https://github.com/paritytech/substrate/pull/8519#discussion_r608012402
-        #   stage:                           build
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs-no-trigger-prs-only
-        #   needs:
-        #     # this is a DAG
-        #     - job:                         cargo-check-benches
-        #       artifacts:                   true
-        #     # this does not like a DAG, just polls the artifact
-        #     - project:                     $CI_PROJECT_PATH
-        #       job:                         cargo-check-benches
-        #       ref:                         master
-        #       artifacts:                   true
-        #   variables:
-        #     CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
-        #   before_script: [""]
-        #   script:
-        #     - 'node-bench-regression-guard --reference artifacts/benches/master-* 
-        #        --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
-        # 
-        # cargo-check-subkey:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   script:
-        #     - cd ./bin/utils/subkey
-        #     - SKIP_WASM_BUILD=1 time cargo check --release
-        #     - sccache -s
-        # 
-        # cargo-check-try-runtime:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   script:
-        #     - time cargo check --features try-runtime
-        #     - sccache -s
-        # 
-        # test-deterministic-wasm:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   variables:
-        #     <<:                            *default-vars
-        #     WASM_BUILD_NO_COLOR:           1
-        #   script:
-        #     # build runtime
-        #     - cargo build --verbose --release -p node-runtime
-        #     # make checksum
-        #     - sha256sum target/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
-        #     # clean up – FIXME: can we reuse some of the artifacts?
-        #     - cargo clean
-        #     # build again
-        #     - cargo build --verbose --release -p node-runtime
-        #     # confirm checksum
-        #     - sha256sum -c checksum.sha256
-        #     - sccache -s
-        # 
-        # test-linux-stable:                 &test-linux
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   variables:
-        #     <<:                            *default-vars
-        #     # Enable debug assertions since we are running optimized builds for testing
-        #     # but still want to have debug assertions.
-        #     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
-        #     RUST_BACKTRACE:                1
-        #     WASM_BUILD_NO_COLOR:           1
-        #   script:
-        #     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
-        #     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-        #     - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml # does not reuse cache 1 min 44 sec
-        #     - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
-        #     - sccache -s
-        # 
-        # unleash-check:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   rules:
-        #     - if: $CI_PIPELINE_SOURCE == "pipeline"
-        #       when: never
-        #     - if: $CI_COMMIT_REF_NAME == "master"
-        #     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-        #   script:
-        #     - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
-        #     - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
-        # 
-        # test-frame-examples-compile-to-wasm:
-        #   # into one job
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   variables:
-        #     <<:                            *default-vars
-        #     # Enable debug assertions since we are running optimized builds for testing
-        #     # but still want to have debug assertions.
-        #     RUSTFLAGS:                     "-Cdebug-assertions=y"
-        #     RUST_BACKTRACE: 1
-        #   script:
-        #     - cd frame/example-offchain-worker/
-        #     - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
-        #     - cd ../example
-        #     - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
-        #     - sccache -s
-        # 
-        # test-linux-stable-int:
-        #   <<:                              *test-linux
-        #   stage:                           test
-        #   script:
-        #     - echo "___Logs will be partly shown at the end in case of failure.___"
-        #     - echo "___Full log will be saved to the job artifacts only in case of failure.___"
-        #     - WASM_BUILD_NO_COLOR=1
-        #       RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
-        #         time cargo test -p node-cli --release --verbose --locked -- --ignored
-        #         &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
-        #     - sccache -s
-        #   after_script:
-        #     - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
-        #   artifacts:
-        #     name:                          $CI_COMMIT_SHORT_SHA
-        #     when:                          on_failure
-        #     expire_in:                     3 days
-        #     paths:
-        #       - ${CI_COMMIT_SHORT_SHA}_int_failure.log
-        # 
-        # check-web-wasm:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   script:
-        #     # WASM support is in progress. As more and more crates support WASM, we
-        #     # should add entries here. See https://github.com/paritytech/substrate/issues/2416
-        #     # Note: we don't need to test crates imported in `bin/node/cli`
-        #     - time cargo build --manifest-path=client/consensus/aura/Cargo.toml --target=wasm32-unknown-unknown --features getrandom
-        #     # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
-        #     - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown
-        #     # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
-        #     - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features
-        #     - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features --features=with-tracing
-        #     - sccache -s
-        # 
-        # test-full-crypto-feature:
-        #   stage:                           test
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs
-        #   variables:
-        #     <<:                            *default-vars
-        #     # Enable debug assertions since we are running optimized builds for testing
-        #     # but still want to have debug assertions.
-        #     RUSTFLAGS:                     "-Cdebug-assertions=y"
-        #     RUST_BACKTRACE: 1
-        #   script:
-        #     - cd primitives/core/
-        #     - time cargo +nightly build --verbose --no-default-features --features full_crypto
-        #     - cd ../application-crypto
-        #     - time cargo +nightly build --verbose --no-default-features --features full_crypto
-        #     - sccache -s
-        # 
-        # cargo-check-macos:
-        #   stage:                           test
-        #   # shell runner on mac ignores the image set in *docker-env
-        #   <<:                              *docker-env
-        #   <<:                              *test-refs-no-trigger
-        #   script:
-        #     - SKIP_WASM_BUILD=1 time cargo check --release
-        #     - sccache -s
-        #   tags:
-        #     - osx
-        # 
+cargo-deny:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *nightly-pipeline
+  script:
+    - cargo deny check --hide-inclusion-graph -c .maintain/deny.toml
+  after_script:
+    - echo "___The complete log is in the artifacts___"
+    - cargo deny check -c .maintain/deny.toml 2> deny.log
+  artifacts:
+    name:                          $CI_COMMIT_SHORT_SHA
+    expire_in:                     3 days
+    when:                          always
+    paths:
+      - deny.log
+  # FIXME: Temorarily allow to fail.
+  allow_failure:                   true
+
+cargo-check-benches:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  <<:                              *collect-artifacts
+  before_script:
+    # merges in the master branch on PRs
+    - *merge-ref-into-master-script
+    - *rust-info-script
+  script:
+    - *cargo-check-benches-script
+
+node-bench-regression-guard:
+  # it's not belong to `build` semantically, but dag jobs can't depend on each other
+  # within the single stage - https://gitlab.com/gitlab-org/gitlab/-/issues/30632
+  # more: https://github.com/paritytech/substrate/pull/8519#discussion_r608012402
+  stage:                           build
+  <<:                              *docker-env
+  <<:                              *test-refs-no-trigger-prs-only
+  needs:
+    # this is a DAG
+    - job:                         cargo-check-benches
+      artifacts:                   true
+    # this does not like a DAG, just polls the artifact
+    - project:                     $CI_PROJECT_PATH
+      job:                         cargo-check-benches
+      ref:                         master
+      artifacts:                   true
+  variables:
+    CI_IMAGE:                      "paritytech/node-bench-regression-guard:latest"
+  before_script: [""]
+  script:
+    - 'node-bench-regression-guard --reference artifacts/benches/master-* 
+       --compare-with artifacts/benches/$CI_COMMIT_REF_NAME-$CI_COMMIT_SHORT_SHA'
+
+cargo-check-subkey:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  script:
+    - cd ./bin/utils/subkey
+    - SKIP_WASM_BUILD=1 time cargo check --release
+    - sccache -s
+
+cargo-check-try-runtime:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  script:
+    - time cargo check --features try-runtime
+    - sccache -s
+
+test-deterministic-wasm:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    <<:                            *default-vars
+    WASM_BUILD_NO_COLOR:           1
+  script:
+    # build runtime
+    - cargo build --verbose --release -p node-runtime
+    # make checksum
+    - sha256sum target/release/wbuild/node-runtime/target/wasm32-unknown-unknown/release/node_runtime.wasm > checksum.sha256
+    # clean up – FIXME: can we reuse some of the artifacts?
+    - cargo clean
+    # build again
+    - cargo build --verbose --release -p node-runtime
+    # confirm checksum
+    - sha256sum -c checksum.sha256
+    - sccache -s
+
+test-linux-stable:                 &test-linux
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    <<:                            *default-vars
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+    RUST_BACKTRACE:                1
+    WASM_BUILD_NO_COLOR:           1
+  script:
+    # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
+    - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
+    - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml # does not reuse cache 1 min 44 sec
+    - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
+    - sccache -s
+
+unleash-check:
+  stage:                           test
+  <<:                              *docker-env
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "pipeline"
+      when: never
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+  script:
+    - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
+    - cargo unleash check ${CARGO_UNLEASH_PKG_DEF}
+
+test-frame-examples-compile-to-wasm:
+  # into one job
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    <<:                            *default-vars
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS:                     "-Cdebug-assertions=y"
+    RUST_BACKTRACE: 1
+  script:
+    - cd frame/example-offchain-worker/
+    - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
+    - cd ../example
+    - cargo +nightly build --target=wasm32-unknown-unknown --no-default-features
+    - sccache -s
+
+test-linux-stable-int:
+  <<:                              *test-linux
+  stage:                           test
+  script:
+    - echo "___Logs will be partly shown at the end in case of failure.___"
+    - echo "___Full log will be saved to the job artifacts only in case of failure.___"
+    - WASM_BUILD_NO_COLOR=1
+      RUST_LOG=sync=trace,consensus=trace,client=trace,state-db=trace,db=trace,forks=trace,state_db=trace,storage_cache=trace
+        time cargo test -p node-cli --release --verbose --locked -- --ignored
+        &> ${CI_COMMIT_SHORT_SHA}_int_failure.log
+    - sccache -s
+  after_script:
+    - awk '/FAILED|^error\[/,0' ${CI_COMMIT_SHORT_SHA}_int_failure.log
+  artifacts:
+    name:                          $CI_COMMIT_SHORT_SHA
+    when:                          on_failure
+    expire_in:                     3 days
+    paths:
+      - ${CI_COMMIT_SHORT_SHA}_int_failure.log
+
+check-web-wasm:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  script:
+    # WASM support is in progress. As more and more crates support WASM, we
+    # should add entries here. See https://github.com/paritytech/substrate/issues/2416
+    # Note: we don't need to test crates imported in `bin/node/cli`
+    - time cargo build --manifest-path=client/consensus/aura/Cargo.toml --target=wasm32-unknown-unknown --features getrandom
+    # Note: the command below is a bit weird because several Cargo issues prevent us from compiling the node in a more straight-forward way.
+    - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown
+    # with-tracing must be explicitly activated, we run a test to ensure this works as expected in both cases
+    - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features
+    - time cargo +nightly test --manifest-path primitives/tracing/Cargo.toml --no-default-features --features=with-tracing
+    - sccache -s
+
+test-full-crypto-feature:
+  stage:                           test
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    <<:                            *default-vars
+    # Enable debug assertions since we are running optimized builds for testing
+    # but still want to have debug assertions.
+    RUSTFLAGS:                     "-Cdebug-assertions=y"
+    RUST_BACKTRACE: 1
+  script:
+    - cd primitives/core/
+    - time cargo +nightly build --verbose --no-default-features --features full_crypto
+    - cd ../application-crypto
+    - time cargo +nightly build --verbose --no-default-features --features full_crypto
+    - sccache -s
+
+cargo-check-macos:
+  stage:                           test
+  # shell runner on mac ignores the image set in *docker-env
+  <<:                              *docker-env
+  <<:                              *test-refs-no-trigger
+  script:
+    - SKIP_WASM_BUILD=1 time cargo check --release
+    - sccache -s
+  tags:
+    - osx
+
 #### stage:                        build
 
 check-polkadot-companion-status:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -585,7 +585,7 @@ publish-docker-substrate:
   <<:                              *build-push-docker-image
   <<:                              *build-refs
   needs:
-    - job:                         build-linux-substrate
+    #- job:                         build-linux-substrate
       artifacts:                   true
   variables:
     <<:                            *docker-build-vars

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -704,7 +704,7 @@ trigger-simnet:
       when: never
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/   # PRs # FIXME: revert me
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/   # PRs   # FIXME: revert me 
   needs:
     - job:                         publish-docker-substrate
   # `build.env` brings here `$IMAGE_NAME` and `$IMAGE_TAG` (`$VERSION` here, 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -716,4 +716,4 @@ trigger-simnet:
     DWNSTRM_ID:                    332
   script:
     # API trigger for a simnet job
-    - .maintain/gitlab/trigger_pipeline.sh
+    - .maintain/gitlab/trigger_pipeline.sh --simnet-version=${SIMNET_REF}

--- a/.maintain/gitlab/trigger_pipeline.sh
+++ b/.maintain/gitlab/trigger_pipeline.sh
@@ -8,7 +8,7 @@ echo "Triggering Simnet pipeline."
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=v3" `# trigger the pinned version of simnet CI config` \
+    -F "ref=v4" `# trigger the pinned version of simnet CI config` \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \

--- a/.maintain/gitlab/trigger_pipeline.sh
+++ b/.maintain/gitlab/trigger_pipeline.sh
@@ -1,30 +1,181 @@
 #!/bin/bash
 
-set -eu
+set -eou pipefail
 
-# API trigger another project's pipeline
-echo "Triggering Simnet pipeline."
+# This script is to trigger Simnet pipeline.
+# See help article for more details.
 
-curl --silent \
-    -X POST \
-    -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=v4" `# trigger the pinned version of simnet CI config` \
-    -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
-    -F "variables[TRGR_REF]=${TRGR_REF}" \
-    -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \
-    -F "variables[IMAGE_TAG]=${IMAGE_TAG}" \
-    "https://${CI_SERVER_HOST}/api/v4/projects/${DWNSTRM_ID}/trigger/pipeline" | \
-        tee pipeline
+SCRIPT_NAME="$0"
+SCRIPT_PATH=$(dirname "$0")               # relative
+SCRIPT_PATH=$(cd "${SCRIPT_PATH}" && pwd) # absolutized and normalized
+SIMNET_VERSION=""
 
-PIPELINE_ID=$(cat pipeline | jq ".id")
-PIPELINE_URL=$(cat pipeline | jq ".web_url")
-echo
-echo "Simnet pipeline ${PIPELINE_URL} was successfully triggered."
-echo "Now we're polling it to obtain the distinguished status."
+function usage {
+  cat << EOF
+This script is to trigger Simnet pipeline.
+It's designed to be launched locally and from CI.
+The required argumants for both cases are listed below.
 
-# This is a workaround for a Gitlab bug, waits here until
-# https://gitlab.com/gitlab-org/gitlab/-/issues/326137 gets fixed.
-# The timeout is 360 curls with 8 sec interval, roughly an hour.
+Usage: ${SCRIPT_NAME} OPTION
+
+OPTIONS
+
+    -h, --help                  Print this help message.
+
+  Mandatory in both cases:
+
+    -s, --simnet-version        Simnet version to trigger.
+                                E.g.: v4
+
+    -u, --upstream-project      Triggering project.
+                                E.g.: substrate
+
+    -r, --upstream-ref          The branch or tag name for which project is built.
+                                E.g.: master
+
+    -d, --downstream-id         Downstream project's ID to trigger.
+                                E.g.: 332 (simnet project id)
+
+    -n, --image-name            Name of image to test.
+                                E.g.: docker.io/paritypr/synth-wave
+
+    -i, --image-tag             Tag of the image to test.
+                                E.g.: master
+
+    -c, --collator-image-tag    Tag of collator image. Image name is hardcoded.
+                                E.g.: master
+
+  Required for local launch:
+
+    -g, --ci-server-fqdn        FQDN of your gitlab server.
+                                E.g.: gitlab.parity.io
+
+    -t, --trigger-token         Gitlab trigger token. This must be defined in
+                                project -> settings -> CI/CD -> Pipeline triggers
+                                Defaults to CI_JOB_TOKEN
+                                https://stackoverflow.com/questions/42746634/gitlab-trigger-api-returns-404
+
+    -a, --access-token          Gitlab  peronal access token or it defaults to
+                                PIPELINE_TOKEN (gitlab variable)
+                                https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
+
+EXAMPLES
+  ${SCRIPT_NAME} -s v4
+  ${SCRIPT_NAME} --simnet-version=v4
+
+  Local test example. You need to set the 2 vars before running: TR_TOKEN and PERS_TOKEN
+  ${SCRIPT_NAME} --simnet-version=v4 \\
+                 --upstream-project=substrate \\
+                 --upstream-ref=master \\
+                 --image-name=docker.io/paritypr/synth-wave \\
+                 --image-tag=master \\
+                 --collator-image-tag=master \\
+                 --ci-server-fqdn=gitlab.parity.io \\
+                 --downstream-id=332 \\
+                 --trigger-token="\${TR_TOKEN}" \\
+                 --access-token="\${PERS_TOKEN}"
+EOF
+}
+
+function main {
+  # Main entry point for the script.
+  parse_args "$@"
+  check_args
+  trigger_pipeline
+  check_pipeline
+  poll_pipeline
+}
+
+function parse_args {
+  # shellcheck disable=SC2214
+  while getopts c:u:r:i:n:g:t:r:a:s:h-: OPT; do
+    # support long options: https://stackoverflow.com/a/28466267/519360
+    if [ "${OPT}" = "-" ]; then   # long option: reformulate OPT and OPTARG
+      OPT="${OPTARG%%=*}"         # extract long option name
+      OPTARG="${OPTARG#$OPT}"     # extract long option argument (may be empty)
+      OPTARG="${OPTARG#=}"        # if long option argument, remove assigning `=`
+    fi
+    case "${OPT}" in
+      h | help )                usage     ; exit 0 ;;
+      s | simnet-version )      needs_arg ; SIMNET_VERSION="${OPTARG}" ;;
+      u | upstream-project )    needs_arg ; TRGR_PROJECT="${OPTARG}" ;;
+      r | upstream-ref )        needs_arg ; TRGR_REF="${OPTARG}" ;;
+      n | image-name )          needs_arg ; IMAGE_NAME="${OPTARG}" ;;
+      i | image-tag )           needs_arg ; IMAGE_TAG="${OPTARG}" ;;
+      c | collator-image-tag )  needs_arg ; COLLATOR_IMAGE_TAG="${OPTARG}" ;;
+      g | ci-server-fqdn )      needs_arg ; CI_SERVER_HOST="${OPTARG}" ;;
+      d | downstream-id )       needs_arg ; DWNSTRM_ID="${OPTARG}" ;;
+      t | trigger-token )       needs_arg ; CI_JOB_TOKEN="${OPTARG}" ;;
+      a | access-token )        needs_arg ; PIPELINE_TOKEN="${OPTARG}" ;;
+      ??* )                     log DIE "Illegal option --${OPT}" ;;  # bad long option
+      ? )                       exit 2 ;;  # bad short option (error reported via getopts)
+    esac
+  done
+  shift $((OPTIND-1)) # remove parsed options and args from $@ list
+
+}
+
+function check_args {
+  if [[ -z "${SIMNET_VERSION}" ]] ; then
+    log DIE "Must specify value for mandatory argument -s,--simnet-version
+
+$(usage)"
+  fi
+}
+
+function needs_arg {
+  if [ -z "${OPTARG}" ]; then
+    log DIE "No arg for --${OPT} option"
+  fi
+}
+
+function trigger_pipeline {
+  # API trigger another project's pipeline.
+  log INFO "Triggering Simnet pipeline."
+
+  curl --silent \
+      -X POST \
+      -F "token=${CI_JOB_TOKEN}" \
+      -F "ref=${SIMNET_VERSION}" \
+      -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
+      -F "variables[TRGR_REF]=${TRGR_REF}" \
+      -F "variables[IMAGE_NAME]=${IMAGE_NAME}" \
+      -F "variables[IMAGE_TAG]=${IMAGE_TAG}" \
+      "https://${CI_SERVER_HOST}/api/v4/projects/${DWNSTRM_ID}/trigger/pipeline" | \
+          tee pipeline;
+}
+
+function check_pipeline {
+  PIPELINE_ID=$(jq ".id" pipeline)
+  PIPELINE_URL=$(jq ".web_url" pipeline)
+  echo
+  log INFO "Simnet pipeline ${PIPELINE_URL} was successfully triggered."
+  log INFO "Now we're polling it to obtain the distinguished status."
+}
+
+function poll_pipeline {
+  # This is a workaround for a Gitlab bug, waits here until
+  # https://gitlab.com/gitlab-org/gitlab/-/issues/326137 gets fixed.
+  # The timeout is 360 curls with 8 sec interval, roughly an hour.
+  log INFO "Waiting on ${PIPELINE_ID} status..."
+
+# shellcheck disable=SC2034
+  for i in {1..360}; do
+      STATUS=$(get_status);
+      log INFO "Triggered pipeline status is ${STATUS}";
+      if [[ ${STATUS} =~ ^(pending|running|created)$ ]]; then
+          echo;
+      elif [[ ${STATUS} =~ ^(failed|canceled|skipped|manual)$ ]]; then
+          log DIE "Something's broken in: ${PIPELINE_URL}";
+      elif [[ ${STATUS} =~ ^(success)$ ]]; then
+          log INFO "Look how green it is: ${PIPELINE_URL}"
+          exit 0
+      else
+          log DIE "Something else has happened in ${PIPELINE_URL}"
+      fi
+  sleep 8;
+  done
+}
 
 function get_status() {
     curl --silent \
@@ -33,19 +184,18 @@ function get_status() {
             jq --raw-output ".status";
 }
 
-echo "Waiting on ${PIPELINE_ID} status..."
+function log {
+  local lvl msg fmt
+  lvl=$1 msg=$2
+  fmt='+%Y-%m-%d %H:%M:%S'
+  lg_date=$(date "${fmt}")
+  if [[ "${lvl}" = "DIE" ]] ; then
+    lvl="ERROR"
+    echo  "${lg_date} - ${lvl} - ${msg}"
+    exit 1
+  else
+    echo "${lg_date} - ${lvl} - ${msg}"
+  fi
+}
 
-for i in $(seq 1 360); do
-    STATUS=$(get_status);
-    echo "Triggered pipeline status is ${STATUS}";
-    if [[ ${STATUS} =~ ^(pending|running|created)$ ]]; then
-        echo;
-    elif [[ ${STATUS} =~ ^(failed|canceled|skipped|manual)$ ]]; then
-        echo "Something's broken in: ${PIPELINE_URL}"; exit 1;
-    elif [[ ${STATUS} =~ ^(success)$ ]]; then
-        echo "Look how green it is: ${PIPELINE_URL}"; exit 0;
-    else
-        echo "Something else has happened in ${PIPELINE_URL}"; exit 1;
-    fi
-sleep 8;
-done
+main "$@"


### PR DESCRIPTION
This PR updates simnet tests to v5 version.

After discussion with @TriplEight  I edited this PR to update to simnet v5.

trigger_pipeline.sh was copied  from  https://github.com/paritytech/polkadot/blob/master/scripts/gitlab/trigger_pipeline.sh
and adapted.

We reviewed together https://github.com/paritytech/polkadot/blob/master/scripts/gitlab/trigger_pipeline.sh
last week 

Pipeline is green.
https://gitlab.parity.io/parity/substrate/-/pipelines/141040 
