### PR TITLE
update ss58 type to u16

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -186,7 +186,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u16 = 42;
 }
 
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -266,7 +266,7 @@ pub mod pallet {
 		/// that the runtime should know about the prefix in order to make use of it as
 		/// an identifier of the chain.
 		#[pallet::constant]
-		type SS58Prefix: Get<u8>;
+		type SS58Prefix: Get<u16>;
 
 		/// What to do if the user wants the code set to something. Just use `()` unless you are in
 		/// cumulus.


### PR DESCRIPTION
Since we've run out of ss58 the prefix size was increased to u16 but Substrate didn't account for this yet. This PR should address this. I have a couple of questions regarding this:

1. Do I need to increase spec_version of Substrate (Polkadot,Westend...)? The type changed from u8 to u16 it's stored as a constant, is that something that is actually stored in the genesis or is it provided by the node / runtime itself? If it's stored in genesis do we need to do a migration?
2. Do we need companion to Polkadot?
3. Do we change all the types in tests? (u8 fits into u16 but it might be nicer to have it synced?)