### PR TITLE
Add `D3-trivial 🧸` to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    labels: ["A2-insubstantial", "B0-silent", "C1-low 📌"]
+    labels: ["A2-insubstantial", "B0-silent", "C1-low 📌", "D3-trivial 🧸"]
     schedule:
       interval: "daily"


### PR DESCRIPTION
See https://github.com/paritytech/substrate/pull/8977/checks?check_run_id=2718325830.

Or should this be added manually?