### PR TITLE
Fix initial era in staking

### DIFF
--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2529,15 +2529,7 @@ impl<T: Config> Pallet<T> {
 					exposures.len(),
 					Self::minimum_validator_count(),
 				),
-				None => {
-					// The initial era is allowed to have no exposures.
-					// In this case the SessionManager is expected to choose a sensible validator
-					// set.
-					// TODO: this should be simplified #8911
-					CurrentEra::<T>::put(0);
-					ErasStartSessionIndex::<T>::insert(&0, &start_session_index);
-				},
-				_ => ()
+				_ => (),
 			}
 
 			Self::deposit_event(Event::StakingElectionFailed);


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/8911

# Breaking change

The election for the initial era must be successful to create the initial era.
In the past a failing initial election would generate an initial era with no stakers
Now a failing initial election will generate no initial era.

# Done

* refactor test in order not to use this initial era created from failing election.

# To do

* look at pallet session if no initial era can result in unexpected logic.