### PR TITLE
Update WeakBoundedVec's remove and swap_remove

### DIFF
--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -72,8 +72,8 @@ impl<T, S> WeakBoundedVec<T, S> {
 	/// # Panics
 	///
 	/// Panics if `index` is out of bounds.
-	pub fn remove(&mut self, index: usize) {
-		self.0.remove(index);
+	pub fn remove(&mut self, index: usize) -> T {
+		self.0.remove(index)
 	}
 
 	/// Exactly the same semantics as [`Vec::swap_remove`].
@@ -81,8 +81,8 @@ impl<T, S> WeakBoundedVec<T, S> {
 	/// # Panics
 	///
 	/// Panics if `index` is out of bounds.
-	pub fn swap_remove(&mut self, index: usize) {
-		self.0.swap_remove(index);
+	pub fn swap_remove(&mut self, index: usize) -> T {
+		self.0.swap_remove(index)
 	}
 
 	/// Exactly the same semantics as [`Vec::retain`].


### PR DESCRIPTION
Makes `WeakBoundedVec::remove` and `WeakBoundedVec::swap_remove` return the removed element as in the original Vec implementation.