### PR TITLE
Convert another instance of Into impl to From in the macros

### DIFF
--- a/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -227,13 +227,13 @@ pub fn expand_outer_origin(
 			}
 		}
 
-		impl Into<#scrate::sp_std::result::Result<#system_path::Origin<#runtime>, Origin>> for Origin {
+		impl From<Origin> for #scrate::sp_std::result::Result<#system_path::Origin<#runtime>, Origin> {
 			/// NOTE: converting to pallet origin loses the origin filter information.
-			fn into(self) -> #scrate::sp_std::result::Result<#system_path::Origin<#runtime>, Self> {
-				if let OriginCaller::system(l) = self.caller {
+			fn from(val: Origin) -> Self {
+				if let OriginCaller::system(l) = val.caller {
 					Ok(l)
 				} else {
-					Err(self)
+					Err(val)
 				}
 			}
 		}
@@ -314,13 +314,13 @@ fn expand_origin_pallet_conversions(
 			}
 		}
 
-		impl Into<#scrate::sp_std::result::Result<#pallet_origin, Origin>> for Origin {
+		impl From<Origin> for #scrate::sp_std::result::Result<#pallet_origin, Origin> {
 			/// NOTE: converting to pallet origin loses the origin filter information.
-			fn into(self) -> #scrate::sp_std::result::Result<#pallet_origin, Self> {
-				if let OriginCaller::#variant(l) = self.caller {
+			fn from(val: Origin) -> Self {
+				if let OriginCaller::#variant(l) = val.caller {
 					Ok(l)
 				} else {
-					Err(self)
+					Err(val)
 				}
 			}
 		}

--- a/frame/support/src/origin.rs
+++ b/frame/support/src/origin.rs
@@ -382,21 +382,17 @@ macro_rules! impl_outer_origin {
 						x.into()
 					}
 				}
-				impl Into<
-					$crate::sp_std::result::Result<
+				impl From<$name> for $crate::sp_std::result::Result<
 						$module::Origin < $( $generic )? $(, $module::$generic_instance )? >,
 						$name,
-					>>
-				for $name {
+					>
+				{
 					/// NOTE: converting to pallet origin loses the origin filter information.
-					fn into(self) -> $crate::sp_std::result::Result<
-						$module::Origin < $( $generic )? $(, $module::$generic_instance )? >,
-						Self,
-					> {
-						if let $caller_name::[< $module $( _ $generic_instance )? >](l) = self.caller {
+					fn from(val: $name) -> Self {
+						if let $caller_name::[< $module $( _ $generic_instance )? >](l) = val.caller {
 							Ok(l)
 						} else {
-							Err(self)
+							Err(val)
 						}
 					}
 				}


### PR DESCRIPTION
An addition to #8900. There was another instance of an `Into` impl there.

UPD: found two more instances.

This time I checked the branch, and am sure the linter is happy.