### PR TITLE
Don't connect to reserved nodes if they're banned

### DIFF
--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -440,6 +440,8 @@ impl Peerset {
 					set_id: SetId(set_index),
 					peer_id: peer.into_peer_id(),
 				});
+
+				self.alloc_slots(SetId(set_index));
 			}
 		}
 	}
@@ -519,6 +521,14 @@ impl Peerset {
 				peersstate::Peer::NotConnected(n) => n,
 				peersstate::Peer::Connected(_) => continue,
 			};
+
+			// Don't connect to nodes with an abysmal reputation, even if they're reserved.
+			// This is a rather opinionated behaviour, and it wouldn't be fundamentally wrong to
+			// remove that check. If necessary, the peerset should be refactored to give more
+			// control over what happens in that situation.
+			if entry.reputation() < BANNED_THRESHOLD {
+				break;
+			}
 
 			match entry.try_outgoing() {
 				Ok(conn) => self.message_queue.push_back(Message::Connect {


### PR DESCRIPTION
This PR is an alternative to https://github.com/paritytech/substrate/pull/9003. We should either merge this one or https://github.com/paritytech/substrate/pull/9003, but not both.

This PR changes `alloc_slots` to not open substreams with reserved nodes if they are banned.
Since reputations apply globally, this would mean that for example the sync code can ban a node due to an anomaly, and it would close the collation and validation substreams as well.

It also makes sure that `alloc_slots` is immediately called if a node gets disconnected because it is banned, which we didn't do before. This change is also in https://github.com/paritytech/substrate/pull/9003