### PR TITLE
Bump parity-db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5691,9 +5691,9 @@ dependencies = [
 
 [[package]]
 name = "parity-db"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495197c078e54b8735181aa35c00a327f7f3a3cc00a1ee8c95926dd010f0ec6b"
+checksum = "2e337f62db341435f0da05b8f6b97e984ef4ea5800510cd07c2d624688c40b47"
 dependencies = [
  "blake2-rfc",
  "crc32fast",

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -38,6 +38,6 @@ hex = "0.4.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 lazy_static = "1.4.0"
 parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
-parity-db = { version = "0.2.2" }
+parity-db = { version = "0.2.4" }
 sc-transaction-pool = { version = "3.0.0", path = "../../../client/transaction-pool" }
 futures = { version = "0.3.4", features = ["thread-pool"] }

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -35,7 +35,7 @@ sp-trie = { version = "3.0.0", path = "../../primitives/trie" }
 sp-consensus = { version = "0.9.0", path = "../../primitives/consensus/common" }
 sp-blockchain = { version = "3.0.0", path = "../../primitives/blockchain" }
 sp-database = { version = "3.0.0", path = "../../primitives/database" }
-parity-db = { version = "0.2.3", optional = true }
+parity-db = { version = "0.2.4", optional = true }
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.9.0", path = "../../utils/prometheus" }
 
 [dev-dependencies]


### PR DESCRIPTION
Bump `parity-db` to `v0.2.4` so that downstream projects can use `clippy` again.