### PR TITLE
Adds moonbeam, moonriver to ss58 registry

### DIFF
--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -586,9 +586,9 @@ ss58_address_format!(
 		(78, "calamari", "Manta Canary Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
-	SocialAccount =>
+	Moonbeam =>
 		(1284, "moonbeam", "Moonbeam, session key (*25519).")
-	SocialAccount =>
+	Moonriver =>
 		(1285, "moonriver", "Moonriver, session key (*25519).")
 	BasiliskAccount =>
 		(10041, "basilisk", "Basilisk standard account (*25519).")

--- a/primitives/core/src/crypto.rs
+++ b/primitives/core/src/crypto.rs
@@ -586,6 +586,10 @@ ss58_address_format!(
 		(78, "calamari", "Manta Canary Network, standard account (*25519).")
 	SocialAccount =>
 		(252, "social-network", "Social Network, standard account (*25519).")
+	SocialAccount =>
+		(1284, "moonbeam", "Moonbeam, session key (*25519).")
+	SocialAccount =>
+		(1285, "moonriver", "Moonriver, session key (*25519).")
 	BasiliskAccount =>
 		(10041, "basilisk", "Basilisk standard account (*25519).")
 

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -515,6 +515,24 @@
 			"website": "https://social.network"
 		},
 		{
+			"prefix": 1284,
+			"network": "moonbeam",
+			"displayName": "Moonbeam",
+			"symbols": ["GLMR"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://moonbeam.network"
+		},
+		{
+			"prefix": 1285,
+			"network": "moonriver",
+			"displayName": "Moonriver",
+			"symbols": ["MOVR"],
+			"decimals": [18],
+			"standardAccount": "*25519",
+			"website": "https://moonbeam.network"
+		},
+		{
 			"prefix": 10041,
 			"network": "basilisk",
 			"displayName": "Basilisk",


### PR DESCRIPTION
This adds the Moonbeam (1284) and Moonriver (1285) SS58 prefix,
It will be used to generate the session keys, as the main account format is ECDSA(Keccak256) which is not supported by default on substrate.

(As a follow-up we might add ECDSA/Keccak256 support)
