### PR TITLE
cherrypicked update ss58 type to u16 (#8955) to polkadot 0.9.4 release

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -186,7 +186,7 @@ parameter_types! {
 		})
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u16 = 42;
 }
 
 const_assert!(NORMAL_DISPATCH_RATIO.deconstruct() >= AVERAGE_ON_INITIALIZE_RATIO.deconstruct());

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -266,7 +266,7 @@ pub mod pallet {
 		/// that the runtime should know about the prefix in order to make use of it as
 		/// an identifier of the chain.
 		#[pallet::constant]
-		type SS58Prefix: Get<u8>;
+		type SS58Prefix: Get<u16>;
 
 		/// What to do if the user wants the code set to something. Just use `()` unless you are in
 		/// cumulus.


### PR DESCRIPTION
this is required for the launch of our parachain with ss58 prefix 10041

cherry picked from commit e98aca335f066d84d7a5cbabf280392f39e1cc99

and pull request #8955 


