### PR TITLE
Store a linked list of nominators in order of stake to avoid OOM when getting top N voters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5521,6 +5521,7 @@ dependencies = [
  "sp-tracing",
  "static_assertions",
  "substrate-test-utils",
+ "thiserror",
 ]
 
 [[package]]
@@ -10037,18 +10038,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/frame/staking/Cargo.toml
+++ b/frame/staking/Cargo.toml
@@ -28,6 +28,7 @@ sp-application-crypto = { version = "3.0.0", default-features = false, path = ".
 frame-election-provider-support = { version = "3.0.0", default-features = false, path = "../election-provider-support" }
 log = { version = "0.4.14", default-features = false }
 paste = "1.0"
+thiserror = "1.0.25"
 
 # Optional imports for benchmarking
 frame-benchmarking = { version = "3.1.0", default-features = false, path = "../benchmarking", optional = true }

--- a/frame/staking/src/benchmarking.rs
+++ b/frame/staking/src/benchmarking.rs
@@ -561,14 +561,14 @@ benchmarks! {
 	}
 
 	get_npos_voters {
-		// number of validator intention.
-		let v in 200 .. 400;
-		// number of nominator intention.
-		let n in 200 .. 400;
+		// total number of voters (validators + nominators)
+		let v in 400 .. 800;
 		// total number of slashing spans. Assigned to validators randomly.
 		let s in 1 .. 20;
 
-		let validators = create_validators_with_nominators_for_era::<T>(v, n, T::MAX_NOMINATIONS as usize, false, None)?
+		// this isn't ideal, but as we don't store the numbers of nominators and validators
+		// distinctly, we can't really parametrize this function with different quantities of each
+		let validators = create_validators_with_nominators_for_era::<T>(v / 2, n / 2, T::MAX_NOMINATIONS as usize, false, None)?
 			.into_iter()
 			.map(|v| T::Lookup::lookup(v).unwrap())
 			.collect::<Vec<_>>();

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -2558,8 +2558,8 @@ impl<T: Config> frame_election_provider_support::ElectionDataProvider<T::Account
 
 		let slashing_span_count = <SlashingSpans<T>>::iter().count();
 		let weight = T::WeightInfo::get_npos_voters(
-			nominator_count as u32,
 			validator_count as u32,
+			nominator_count as u32,
 			slashing_span_count as u32,
 		);
 		Ok((Self::get_npos_voters(), weight))

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -276,6 +276,7 @@ pub mod testing_utils;
 #[cfg(any(feature = "runtime-benchmarks", test))]
 pub mod benchmarking;
 
+pub mod nominator_list;
 pub mod slashing;
 pub mod inflation;
 pub mod weights;

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -995,6 +995,19 @@ decl_storage! {
 		///
 		/// This is set to v6.0.0 for new networks.
 		StorageVersion build(|_: &GenesisConfig<T>| Releases::V6_0_0): Releases;
+
+		// The next three storage items collectively comprise the `nominator_list::NominatorList`
+		// data structure. They should not be accessed individually, but only through the interface
+		// provided by that type.
+
+		/// Count of nominators. Size of `NominatorList`.
+		NominatorCount: u32;
+
+		/// Linked list of nominators, sorted in decreasing order of stake.
+		NominatorList: nominator_list::NominatorList<T>;
+
+		/// Map of nodes in the nominator list.
+		NominatorNodes: map hasher(twox_64_concat) T::AccountId => nominator_list::Node<T>;
 	}
 	add_extra_genesis {
 		config(stakers):

--- a/frame/staking/src/nominator_list.rs
+++ b/frame/staking/src/nominator_list.rs
@@ -1,0 +1,44 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Provide a linked list of nominators, sorted by stake.
+
+use crate::Config;
+
+// TODOS:
+//
+// - storage map for nodes
+// - storage value for list
+// - shorthand access to the list itself
+// - basic operations
+//   - shorthand access for the account, prev, next
+// - iterator or cursor
+// - update `ElectionDataProvider` impl to use the nominator list to count off the top N
+
+type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+
+/// Linked list of nominstors, sorted by stake.
+pub struct NominatorList<T: Config> {
+	head: Option<AccountIdOf<T>>,
+	tail: Option<AccountIdOf<T>>,
+}
+
+struct Node<T: Config> {
+	account: AccountIdOf<T>,
+	prev: Option<AccountIdOf<T>>,
+	next: Option<AccountIdOf<T>>,
+}

--- a/frame/staking/src/voter_list.rs
+++ b/frame/staking/src/voter_list.rs
@@ -49,7 +49,7 @@ pub struct Voter<AccountId> {
 
 impl<T: Config> Pallet<T> {
 	/// `Self` accessor for `NominatorList<T>`
-	pub fn nominator_list() -> NominatorList<T> {
+	pub fn voter_list() -> VoterList<T> {
 		crate::NominatorList::<T>::get()
 	}
 }
@@ -57,12 +57,12 @@ impl<T: Config> Pallet<T> {
 /// Linked list of nominstors, sorted by stake.
 #[derive(DefaultNoBound, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct NominatorList<T: Config> {
+pub struct VoterList<T: Config> {
 	head: Option<AccountIdOf<T>>,
 	tail: Option<AccountIdOf<T>>,
 }
 
-impl<T: Config> NominatorList<T> {
+impl<T: Config> VoterList<T> {
 	/// Decode the length of this list without actually iterating over it.
 	pub fn decode_len() -> Option<usize> {
 		crate::NominatorCount::try_get().ok().map(|n| n.saturated_into())

--- a/frame/staking/src/weights.rs
+++ b/frame/staking/src/weights.rs
@@ -35,7 +35,6 @@
 // --output=./frame/staking/src/weights.rs
 // --template=./.maintain/frame-weight-template.hbs
 
-
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
@@ -66,10 +65,10 @@ pub trait WeightInfo {
 	fn payout_stakers_alive_staked(n: u32, ) -> Weight;
 	fn rebond(l: u32, ) -> Weight;
 	fn set_history_depth(e: u32, ) -> Weight;
-	fn reap_stash(s: u32, ) -> Weight;
-	fn new_era(v: u32, n: u32, ) -> Weight;
-	fn get_npos_voters(v: u32, n: u32, s: u32, ) -> Weight;
-	fn get_npos_targets(v: u32, ) -> Weight;
+	fn reap_stash(s: u32) -> Weight;
+	fn new_era(v: u32, n: u32) -> Weight;
+	fn get_npos_voters(v: u32, s: u32) -> Weight;
+	fn get_npos_targets(v: u32) -> Weight;
 }
 
 /// Weights for pallet_staking using the Substrate node and recommended hardware.
@@ -219,7 +218,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
-	fn new_era(v: u32, n: u32, ) -> Weight {
+	fn new_era(v: u32, n: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 1_462_000
 			.saturating_add((393_007_000 as Weight).saturating_mul(v as Weight))
@@ -231,20 +230,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
-	fn get_npos_voters(v: u32, n: u32, s: u32, ) -> Weight {
+	fn get_npos_voters(v: u32, s: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 235_000
 			.saturating_add((35_212_000 as Weight).saturating_mul(v as Weight))
-			// Standard Error: 235_000
-			.saturating_add((38_391_000 as Weight).saturating_mul(n as Weight))
 			// Standard Error: 3_200_000
 			.saturating_add((31_130_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(v as Weight)))
-			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
 	}
-	fn get_npos_targets(v: u32, ) -> Weight {
+	fn get_npos_targets(v: u32) -> Weight {
 		(52_314_000 as Weight)
 			// Standard Error: 71_000
 			.saturating_add((15_195_000 as Weight).saturating_mul(v as Weight))
@@ -399,7 +395,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
 			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(s as Weight)))
 	}
-	fn new_era(v: u32, n: u32, ) -> Weight {
+	fn new_era(v: u32, n: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 1_462_000
 			.saturating_add((393_007_000 as Weight).saturating_mul(v as Weight))
@@ -411,20 +407,17 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(9 as Weight))
 			.saturating_add(RocksDbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
-	fn get_npos_voters(v: u32, n: u32, s: u32, ) -> Weight {
+	fn get_npos_voters(v: u32, s: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 235_000
 			.saturating_add((35_212_000 as Weight).saturating_mul(v as Weight))
-			// Standard Error: 235_000
-			.saturating_add((38_391_000 as Weight).saturating_mul(n as Weight))
 			// Standard Error: 3_200_000
 			.saturating_add((31_130_000 as Weight).saturating_mul(s as Weight))
 			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
 			.saturating_add(RocksDbWeight::get().reads((3 as Weight).saturating_mul(v as Weight)))
-			.saturating_add(RocksDbWeight::get().reads((3 as Weight).saturating_mul(n as Weight)))
 			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(s as Weight)))
 	}
-	fn get_npos_targets(v: u32, ) -> Weight {
+	fn get_npos_targets(v: u32) -> Weight {
 		(52_314_000 as Weight)
 			// Standard Error: 71_000
 			.saturating_add((15_195_000 as Weight).saturating_mul(v as Weight))


### PR DESCRIPTION
Problem: there are too many nominators, we can't keep all of them.
Solution: truncate the list by stake.

Problem: an attacker can kick out as many people as they can afford to; those people at the low end would need to re-nominate.
Solution: don't actually take them out of the nominator set, but compute the top N members at runtime.

Problem: computing the top N at runtime is expensive.
Solution: use an ordered linked list which is pre-sorted. Anytime someone wants to nominate, they have to specify where in the list they fall. That's cheap to verify, and the frontend handles the cost of computing it.

Problem: staked amounts can vary due to rewards and slashes.
Solution: add a transaction that anyone can call to update someone's position in the list. Still cheap to verify. Doesn't need an explicit reward, because nominators low on the list have incentive to take down anyone higher than them, to increase their own chance of getting onto the official list of voters when the election is called.

# Todo

Do we even need a doubly-linked list? We might be able to get away with just singly-linking it.