### PR TITLE
disable unused schnorrkel feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8264,7 +8264,6 @@ dependencies = [
  "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "zeroize",

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -101,7 +101,6 @@ std = [
 	"rand",
 	"sha2/std",
 	"schnorrkel/std",
-	"schnorrkel/serde",
 	"regex",
 	"num-traits/std",
 	"tiny-keccak",

--- a/primitives/keystore/Cargo.toml
+++ b/primitives/keystore/Cargo.toml
@@ -34,5 +34,4 @@ default = ["std"]
 std = [
 	"serde",
 	"schnorrkel/std",
-	"schnorrkel/serde",
 ]

--- a/primitives/keystore/src/vrf.rs
+++ b/primitives/keystore/src/vrf.rs
@@ -40,7 +40,6 @@ pub struct VRFTranscriptData {
 	pub items: Vec<(&'static str, VRFTranscriptValue)>,
 }
 /// VRF signature data
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct VRFSignature {
 	/// The VRFOutput serialized
 	pub output: VRFOutput,


### PR DESCRIPTION
Doesn't seem to be used in polkadot or in substrate. FYI this is a semver-breaking change.
Closes #9072.