### PR TITLE
Add function to test whether function is exported in wasm blob

### DIFF
--- a/client/executor/common/src/runtime_blob/runtime_blob.rs
+++ b/client/executor/common/src/runtime_blob/runtime_blob.rs
@@ -81,6 +81,23 @@ impl RuntimeBlob {
 		export_mutable_globals(&mut self.raw_module, "exported_internal_global");
 	}
 
+	/// Perform an instrumentation that makes sure that a specific function `entry_point` is exported
+	pub fn entry_point_exists(blob: &RuntimeBlob, entry_point: &str) -> bool {
+		if let Some(entries) = blob.raw_module.export_section().map(|e| e.entries()) {
+			if entries.iter().any(|e| {
+				if let Internal::Function(_) = e.internal() {
+					e.field() == entry_point
+				} else {
+					false
+				}
+			}) {
+				return true;
+			}
+		}
+
+		false
+	}
+
 	/// Returns an iterator of all globals which were exported by [`expose_mutable_globals`].
 	pub(super) fn exported_internal_global_names<'module>(
 		&'module self,

--- a/client/executor/common/src/runtime_blob/runtime_blob.rs
+++ b/client/executor/common/src/runtime_blob/runtime_blob.rs
@@ -83,15 +83,11 @@ impl RuntimeBlob {
 
 	/// Perform an instrumentation that makes sure that a specific function `entry_point` is exported
 	pub fn entry_point_exists(&self, entry_point: &str) -> bool {
-		if let Some(v) = self.raw_module.export_section().map(|e| {
+		self.raw_module.export_section().map(|e| {
 			e.entries()
 			.iter()
 			.any(|e| matches!(e.internal(), Internal::Function(_)) && e.field() == entry_point)
-		}) {
-			v
-		} else {
-			false
-		}
+		}).unwrap_or_default()
 	}
 
 	/// Returns an iterator of all globals which were exported by [`expose_mutable_globals`].

--- a/client/executor/common/src/runtime_blob/runtime_blob.rs
+++ b/client/executor/common/src/runtime_blob/runtime_blob.rs
@@ -82,20 +82,16 @@ impl RuntimeBlob {
 	}
 
 	/// Perform an instrumentation that makes sure that a specific function `entry_point` is exported
-	pub fn entry_point_exists(blob: &RuntimeBlob, entry_point: &str) -> bool {
-		if let Some(entries) = blob.raw_module.export_section().map(|e| e.entries()) {
-			if entries.iter().any(|e| {
-				if let Internal::Function(_) = e.internal() {
-					e.field() == entry_point
-				} else {
-					false
-				}
-			}) {
-				return true;
-			}
+	pub fn entry_point_exists(&self, entry_point: &str) -> bool {
+		if let Some(v) = self.raw_module.export_section().map(|e| {
+			e.entries()
+			.iter()
+			.any(|e| matches!(e.internal(), Internal::Function(_)) && e.field() == entry_point)
+		}) {
+			v
+		} else {
+			false
 		}
-
-		false
 	}
 
 	/// Returns an iterator of all globals which were exported by [`expose_mutable_globals`].


### PR DESCRIPTION
This PR adds a small helper function that enables testing whether a specific function name is exported in the RuntimeBlob. Since the raw_module is private, it is not possible to test whether a specific blob exports a function.

This is particularly useful when validating PVF WASM blobs which are assumed to export the "validate-block" function.
