### PR TITLE
Emit warning when a pallet part is used before being imported in construct_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5758,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f518afaa5a47d0d6386229b0a6e01e86427291d643aa4cabb4992219f504f8"
+checksum = "b310f220c335f9df1b3d2e9fbe3890bbfeef5030dad771620f48c5c229877cd3"
 dependencies = [
  "arrayvec 0.7.0",
  "bitvec",
@@ -5771,11 +5771,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.1.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c5f94427bd0b5076e8f7e15ca3f60a4d8ac0077e4793884e6fdfd8915344e"
+checksum = "81038e13ca2c32587201d544ea2e6b6c47120f1e4eae04478f9f60b6bcb89145"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.1.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.1.3", default-features = false, features = ["derive"] }
 frame-metadata = { version = "13.0.0", default-features = false, path = "../metadata" }
 max-encoded-len = { version = "3.0.0", default-features = false, path = "../../max-encoded-len", features = [ "derive" ] }
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }

--- a/frame/support/procedural/src/construct_runtime/expand/config.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/config.rs
@@ -43,7 +43,7 @@ pub fn expand_outer_config(
 			build_storage_calls.extend(expand_config_build_storage_call(scrate, runtime, decl, &field_name));
 		} else {
 			let deprecation_note = format!("`{}` does not have the `Config` part imported in \
-				construct_runtime, perhaps you have forgotten to include it?", pallet_name);
+				`construct_runtime`, perhaps you have forgotten to include it?", pallet_name);
 
 			types.extend(quote! {
 				#[deprecated = #deprecation_note]

--- a/frame/support/procedural/src/construct_runtime/expand/event.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/event.rs
@@ -54,6 +54,15 @@ pub fn expand_outer_event(
 
 			event_variants.extend(expand_event_variant(runtime, pallet_decl, index, instance, generics));
 			event_conversions.extend(expand_event_conversion(scrate, pallet_decl, &pallet_event));
+		} else {
+			let pallet_name = &pallet_decl.name;
+			let deprecation_note = format!("`{}` does not have the `Event` part imported in \
+				`construct_runtime`, perhaps you have forgotten to include it?", pallet_name);
+
+			event_variants.extend(quote! {
+				#[deprecated(note = #deprecation_note)]
+				#pallet_name,
+			});
 		}
 	}
 
@@ -64,6 +73,7 @@ pub fn expand_outer_event(
 			#scrate::codec::Decode,
 			#scrate::RuntimeDebug,
 		)]
+		#[allow(deprecated)]
 		#[allow(non_camel_case_types)]
 		pub enum Event {
 			#event_variants

--- a/frame/support/procedural/src/construct_runtime/expand/origin.rs
+++ b/frame/support/procedural/src/construct_runtime/expand/origin.rs
@@ -58,6 +58,15 @@ pub fn expand_outer_origin(
 			pallet_conversions.extend(
 				expand_origin_pallet_conversions(scrate, runtime, pallet_decl, instance, generics),
 			);
+		} else {
+			let variant_name = &pallet_decl.name;
+			let deprecation_note = format!("`{}` does not have the `Origin` part included in \
+				`construct_runtime`, perhaps you have forgotten to include it?", variant_name);
+
+			caller_variants.extend(quote! {
+				#[deprecated = #deprecation_note]
+				#variant_name,
+			});
 		}
 	}
 
@@ -156,6 +165,7 @@ pub fn expand_outer_origin(
 
 		#[derive(Clone, PartialEq, Eq, #scrate::RuntimeDebug, #scrate::codec::Encode, #scrate::codec::Decode)]
 		#[allow(non_camel_case_types)]
+		#[allow(deprecated)]
 		pub enum OriginCaller {
 			#[codec(index = #system_index)]
 			system(#system_path::Origin<#runtime>),

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -13,7 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.1.3", default-features = false, features = ["derive"] }
 sp-io = { version = "3.0.0", path = "../../../primitives/io", default-features = false }
 sp-state-machine = { version = "0.9.0", optional = true, path = "../../../primitives/state-machine" }
 frame-support = { version = "3.0.0", default-features = false, path = "../" }

--- a/frame/support/test/tests/construct_runtime_ui/unimported_call_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_call_part.rs
@@ -1,0 +1,47 @@
+#![deny(deprecated)]
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(0)]
+        pub fn foo(_origin: OriginFor<T>) -> DispatchResult {
+            Ok(())
+        }
+	}
+}
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+impl pallet::Config for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		Pallet: pallet::{Pallet},
+	}
+}
+
+fn main() {
+	let _ = Call::Pallet(pallet::Call::<Runtime>::foo());
+}

--- a/frame/support/test/tests/construct_runtime_ui/unimported_call_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_call_part.stderr
@@ -1,0 +1,44 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_call_part.rs:40:11
+   |
+40 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
+   |                 ^^^^^^ use of undeclared crate or module `system`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_call_part.rs:34:1
+   |
+34 | / construct_runtime! {
+35 | |     pub enum Runtime where
+36 | |         Block = Block,
+37 | |         NodeBlock = Block,
+...  |
+42 | |     }
+43 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+2  | use frame_system::RawOrigin;
+   |
+
+error: use of deprecated unit variant `Call::Pallet`: `Pallet` does not have the `Call` part imported in `construct_runtime`, perhaps you have forgotten to include it?
+  --> $DIR/unimported_call_part.rs:46:10
+   |
+46 |     let _ = Call::Pallet(pallet::Call::<Runtime>::foo());
+   |             ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unimported_call_part.rs:1:9
+   |
+1  | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
+  --> $DIR/unimported_call_part.rs:32:6
+   |
+12 |     pub trait Config: frame_system::Config {}
+   |                       -------------------- required by this bound in `pallet::Config`
+...
+32 | impl pallet::Config for Runtime {}
+   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`

--- a/frame/support/test/tests/construct_runtime_ui/unimported_config_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_config_part.rs
@@ -1,0 +1,57 @@
+#![deny(deprecated)]
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig {
+        foo: u32,
+    }
+
+    #[cfg(feature = "std")]
+    impl Default for GenesisConfig {
+        fn default() -> Self {
+            Self { foo: 0 }
+        }
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> GenesisBuild<T> for GenesisConfig {
+        fn build(&self) {
+            self.foo = 42;
+        }
+    }
+}
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+impl pallet::Config for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		Pallet: pallet::{Pallet},
+	}
+}
+
+fn main() {
+	let _ = PalletConfig { foo: 1 };
+}

--- a/frame/support/test/tests/construct_runtime_ui/unimported_config_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_config_part.stderr
@@ -1,0 +1,44 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_config_part.rs:50:11
+   |
+50 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
+   |                 ^^^^^^ use of undeclared crate or module `system`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_config_part.rs:44:1
+   |
+44 | / construct_runtime! {
+45 | |     pub enum Runtime where
+46 | |         Block = Block,
+47 | |         NodeBlock = Block,
+...  |
+52 | |     }
+53 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+2  | use frame_system::RawOrigin;
+   |
+
+error: use of deprecated struct `PalletConfig`: `Pallet` does not have the `Config` part imported in construct_runtime, perhaps you have forgotten to include it?
+  --> $DIR/unimported_config_part.rs:56:10
+   |
+56 |     let _ = PalletConfig { foo: 1 };
+   |             ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unimported_config_part.rs:1:9
+   |
+1  | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
+  --> $DIR/unimported_config_part.rs:42:6
+   |
+11 |     pub trait Config: frame_system::Config {}
+   |                       -------------------- required by this bound in `pallet::Config`
+...
+42 | impl pallet::Config for Runtime {}
+   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`

--- a/frame/support/test/tests/construct_runtime_ui/unimported_event_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_event_part.rs
@@ -1,0 +1,45 @@
+#![deny(deprecated)]
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::IsType;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event> + IsType<<Self as frame_system::Config>::Event>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	pub enum Event {
+		Foo,
+	}
+}
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+impl pallet::Config for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		Pallet: pallet::{Pallet},
+	}
+}
+
+fn main() {
+	let _ = Event::Pallet(pallet::Event::Foo);
+}

--- a/frame/support/test/tests/construct_runtime_ui/unimported_event_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_event_part.stderr
@@ -1,0 +1,44 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_event_part.rs:38:11
+   |
+38 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
+   |                 ^^^^^^ use of undeclared crate or module `system`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_event_part.rs:32:1
+   |
+32 | / construct_runtime! {
+33 | |     pub enum Runtime where
+34 | |         Block = Block,
+35 | |         NodeBlock = Block,
+...  |
+40 | |     }
+41 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+2  | use frame_system::RawOrigin;
+   |
+
+error: use of deprecated unit variant `Event::Pallet`: `Pallet` does not have the `Event` part imported in `construct_runtime`, perhaps you have forgotten to include it?
+  --> $DIR/unimported_event_part.rs:44:10
+   |
+44 |     let _ = Event::Pallet(pallet::Event::Foo);
+   |             ^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unimported_event_part.rs:1:9
+   |
+1  | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
+  --> $DIR/unimported_event_part.rs:30:6
+   |
+11 |     pub trait Config: frame_system::Config {
+   |                       -------------------- required by this bound in `pallet::Config`
+...
+30 | impl pallet::Config for Runtime {}
+   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`

--- a/frame/support/test/tests/construct_runtime_ui/unimported_origin_part.rs
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_origin_part.rs
@@ -1,0 +1,39 @@
+#![deny(deprecated)]
+use frame_support::construct_runtime;
+use sp_runtime::{generic, traits::BlakeTwo256};
+use sp_core::sr25519;
+
+#[frame_support::pallet]
+mod pallet {
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::origin]
+	pub struct Origin<T>(sp_std::marker::PhantomData<T>);
+}
+
+pub type Signature = sr25519::Signature;
+pub type BlockNumber = u64;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<u32, Call, Signature, ()>;
+
+impl pallet::Config for Runtime {}
+
+construct_runtime! {
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: system::{Pallet, Call, Storage, Config, Event<T>},
+		Pallet: pallet::{Pallet},
+	}
+}
+
+fn main() {
+	let _ = OriginCaller::Pallet(pallet::Origin::<Runtime>::new());
+}

--- a/frame/support/test/tests/construct_runtime_ui/unimported_origin_part.stderr
+++ b/frame/support/test/tests/construct_runtime_ui/unimported_origin_part.stderr
@@ -1,0 +1,44 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_origin_part.rs:32:11
+   |
+32 |         System: system::{Pallet, Call, Storage, Config, Event<T>},
+   |                 ^^^^^^ use of undeclared crate or module `system`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `system`
+  --> $DIR/unimported_origin_part.rs:26:1
+   |
+26 | / construct_runtime! {
+27 | |     pub enum Runtime where
+28 | |         Block = Block,
+29 | |         NodeBlock = Block,
+...  |
+34 | |     }
+35 | | }
+   | |_^ not found in `system`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this enum
+   |
+2  | use frame_system::RawOrigin;
+   |
+
+error: use of deprecated unit variant `OriginCaller::Pallet`: `Pallet` does not have the `Origin` part included in `construct_runtime`, perhaps you have forgotten to include it?
+  --> $DIR/unimported_origin_part.rs:38:10
+   |
+38 |     let _ = OriginCaller::Pallet(pallet::Origin::<Runtime>::new());
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unimported_origin_part.rs:1:9
+   |
+1  | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `Runtime: frame_system::Config` is not satisfied
+  --> $DIR/unimported_origin_part.rs:24:6
+   |
+9  |     pub trait Config: frame_system::Config {}
+   |                       -------------------- required by this bound in `pallet::Config`
+...
+24 | impl pallet::Config for Runtime {}
+   |      ^^^^^^^^^^^^^^ the trait `frame_system::Config` is not implemented for `Runtime`


### PR DESCRIPTION
The warning/error message looks like the following:

```
error: use of deprecated unit variant `Event::Pallet`: `Pallet` does not have the `Event` part imported in `construct_runtime`, perhaps you have forgotten to include it?
  --> $DIR/unimported_event_part.rs:44:10
   |
44 |     let _ = Event::Pallet(pallet::Event::Foo);
   |             ^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> $DIR/unimported_event_part.rs:1:9
   |
1  | #![deny(deprecated)]
   |         ^^^^^^^^^^
```

This change however will need a patch to parity scale codec since enabling such a warning message produces spurious warnings from the derive trait implementations.

~~Blocked on paritytech/parity-scale-codec#272~~ Codec has now been updated so that spurious warning messages don't pop up.

After this PR is merged, it would henceforth be advisable to tag the module that contains `construct_runtime!` with `#![deny(deprecated)]` in order to emit compilation errors about accidental usages of pallet parts that were not imported.