### PR TITLE
double the allocator limit

### DIFF
--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -44,6 +44,24 @@
 //!
 //! Upon deallocation we get the order of the allocation from its header and then add that
 //! allocation to the linked list for the respective order.
+//!
+//! # Caveats
+//!
+//! This is a fast allocator but it is also dumb. There are specifically two main shortcomings
+//! that the user should keep in mind:
+//!
+//! - Once the bump allocator space is exhausted, there is no way to reclaim the memory. This means
+//!   that it's possible to end up in a situation where there are no live allocations yet a new
+//!   allocation will fail.
+//!
+//!   Let's look into an example. Given a heap of 32 MiB. The user makes a 32 MiB allocation that we
+//!   call `X` . Now the heap is full. Then user deallocates `X`. Since all the space in the bump
+//!   allocator was consumed by the 32 MiB allocation, allocations of all sizes except 32 MiB will
+//!   fail.
+//!
+//! - Sizes of allocations are rounded up to the nearest order. That is, an allocation of 2,00001 MiB
+//!   will be put into the bucket of 4 MiB. Therefore, typically more than half of the space in allocation
+//!   will be wasted. This is more pronounced with larger allocation sizes.
 
 use crate::Error;
 use sp_std::{mem, convert::{TryFrom, TryInto}, ops::{Range, Index, IndexMut}};

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -86,7 +86,7 @@ macro_rules! trace {
 // This number corresponds to the number of powers between the minimum possible allocation and
 // maximum possible allocation, or: 2^3...2^24 (both ends inclusive, hence 22).
 const N_ORDERS: usize = 22;
-const MAX_POSSIBLE_ALLOCATION: u32 = 16777216; // 2^24 bytes, 16 MiB
+const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
 const MIN_POSSIBLE_ALLOCATION: u32 = 8; // 2^3 bytes, 8 bytes
 
 /// The exponent for the power of two sized block adjusted to the minimum size.
@@ -100,6 +100,7 @@ const MIN_POSSIBLE_ALLOCATION: u32 = 8; // 2^3 bytes, 8 bytes
 /// 64                | 3
 /// ...
 /// 16777216          | 21
+/// 33554432          | 22
 ///
 /// and so on.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/primitives/allocator/src/freeing_bump.rs
+++ b/primitives/allocator/src/freeing_bump.rs
@@ -36,7 +36,7 @@
 //!
 //! For implementing freeing we maintain a linked lists for each order. The maximum supported
 //! allocation size is capped, therefore the number of orders and thus the linked lists is as well
-//! limited. Currently, the maximum size of an allocation is 16 MiB.
+//! limited. Currently, the maximum size of an allocation is 32 MiB.
 //!
 //! When the allocator serves an allocation request it first checks the linked list for the respective
 //! order. If it doesn't have any free chunks, the allocator requests memory from the bump allocator.
@@ -78,14 +78,14 @@ macro_rules! trace {
 // The minimum possible allocation size is chosen to be 8 bytes because in that case we would have
 // easier time to provide the guaranteed alignment of 8.
 //
-// The maximum possible allocation size was chosen rather arbitrary. 16 MiB should be enough for
+// The maximum possible allocation size was chosen rather arbitrary. 32 MiB should be enough for
 // everybody.
 //
 // N_ORDERS - represents the number of orders supported.
 //
 // This number corresponds to the number of powers between the minimum possible allocation and
-// maximum possible allocation, or: 2^3...2^24 (both ends inclusive, hence 22).
-const N_ORDERS: usize = 22;
+// maximum possible allocation, or: 2^3...2^25 (both ends inclusive, hence 23).
+const N_ORDERS: usize = 23;
 const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
 const MIN_POSSIBLE_ALLOCATION: u32 = 8; // 2^3 bytes, 8 bytes
 
@@ -330,7 +330,7 @@ impl FreeingBumpHeapAllocator {
 	}
 
 	/// Gets requested number of bytes to allocate and returns a pointer.
-	/// The maximum size which can be allocated at once is 16 MiB.
+	/// The maximum size which can be allocated at once is 32 MiB.
 	/// There is no minimum size, but whatever size is passed into
 	/// this function is rounded to the next power of two. If the requested
 	/// size is below 8 bytes it will be rounded up to 8 bytes.
@@ -814,7 +814,7 @@ mod tests {
 	#[test]
 	fn should_get_max_item_size_from_index() {
 		// given
-		let raw_order = 21;
+		let raw_order = 22;
 
 		// when
 		let item_size = Order::from_raw(raw_order).unwrap().size();


### PR DESCRIPTION
This is a burn-in request for a potential patch to the current, rather inefficient, staking system. 

Of the first bottlenecks that we might hit is reaching the 16MiB allocator limit when we dump all nominators into a single vector (see [here](https://github.com/paritytech/substrate/blob/master/frame/staking/src/lib.rs#L2692)). This PRs examines how the system will work if we double this limit to buy us more time. 

I've had a discussion with @pepyakin and he noted that there are some potential performance penalties in this. We are basically adding a 21's bucket to the allocator. There are two potential caveats to this: 

1. @pepyakin explained it best: 

> That means the following. Assume you allocate 16 MiB chunks up to the heap <s>element</s> limit. Then you deallocate them all at once so the heap is empty in the sense there are no allocated objects. Then you try to allocate 16 bytes and the allocation will fail. This is because the free list for 16 bytes is empty and the allocator will try to reserve from the unlayouted area but it is already gobbled up by the 16 MiB chunks

2. An allocation will most often not use the entire bucket size. For example, an allocation of `2,00001MiB` will go into the bucket of 4MiB and almost 2MiB is wasted. 

As far as I can see, this change does not significantly worsen either of the two. The second caveat is slightly worse now, as up to `16MiB - 1byte` of space can go to waste (in the past this was `8MiB - 1byte`), but that's just the consequence of how the allocator works. 

Otherwise I expect this burnin to go well.

It should initially be deployed on full nodes. Once we verify that it works well, it should also live on a pair of validators to examine the block builder code path.

burnin for polkadot: https://github.com/paritytech/polkadot/pull/3244