### PR TITLE
Execute system integrity_test

### DIFF
--- a/frame/support/procedural/src/construct_runtime/mod.rs
+++ b/frame/support/procedural/src/construct_runtime/mod.rs
@@ -367,7 +367,7 @@ fn decl_integrity_test(scrate: &TokenStream2) -> TokenStream2 {
 
 			#[test]
 			pub fn runtime_integrity_tests() {
-				<AllPallets as #scrate::traits::IntegrityTest>::integrity_test();
+				<AllPalletsWithSystem as #scrate::traits::IntegrityTest>::integrity_test();
 			}
 		}
 	)


### PR DESCRIPTION
Instead of executing integrity_test for all pallet but system pallet we execute for pallet and system pallet.

one test environment wasn't correctly set in polkadot, so there is a need for this companion: https://github.com/paritytech/polkadot/pull/3240