### PR TITLE
Do not run pallet_ui test with conditional-storage feature

### DIFF
--- a/frame/support/test/tests/pallet_ui.rs
+++ b/frame/support/test/tests/pallet_ui.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
-#[cfg(not(feature = "conditional-compilation"))]
+#[cfg(not(feature = "conditional-storage"))]
 #[test]
 fn pallet_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/pallet_ui.rs
+++ b/frame/support/test/tests/pallet_ui.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
+#[cfg(not(feature = "conditional-compilation"))]
 #[test]
 fn pallet_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.rs
@@ -1,28 +1,27 @@
-// #[frame_support::pallet]
-// mod pallet {
-// 	use frame_support::pallet_prelude::{Hooks, StorageNMap, Twox64Concat, NMapKey};
-// 	use frame_system::pallet_prelude::BlockNumberFor;
+#[frame_support::pallet]
+mod pallet {
+	use frame_support::pallet_prelude::{Hooks, StorageNMap, Twox64Concat, NMapKey};
+	use frame_system::pallet_prelude::BlockNumberFor;
 
-// 	#[pallet::config]
-// 	pub trait Config: frame_system::Config {}
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
 
-// 	#[pallet::pallet]
-// 	#[pallet::generate_storage_info]
-// 	pub struct Pallet<T>(core::marker::PhantomData<T>);
+	#[pallet::pallet]
+	#[pallet::generate_storage_info]
+	pub struct Pallet<T>(core::marker::PhantomData<T>);
 
-// 	#[pallet::hooks]
-// 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
 
-// 	#[pallet::call]
-// 	impl<T: Config> Pallet<T> {}
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
 
-// 	#[derive(codec::Encode, codec::Decode)]
-// 	struct Bar;
+	#[derive(codec::Encode, codec::Decode)]
+	struct Bar;
 
-// 	#[pallet::storage]
-// 	type Foo<T> = StorageNMap<_, NMapKey<Twox64Concat, Bar>, u32>;
-// }
+	#[pallet::storage]
+	type Foo<T> = StorageNMap<_, NMapKey<Twox64Concat, Bar>, u32>;
+}
 
 fn main() {
-	compile_error!("Temporarily disabled due to test flakiness");
 }

--- a/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
+++ b/frame/support/test/tests/pallet_ui/storage_info_unsatisfied_nmap.stderr
@@ -1,5 +1,9 @@
-error: Temporarily disabled due to test flakiness
-  --> $DIR/storage_info_unsatisfied_nmap.rs:27:2
+error[E0277]: the trait bound `Bar: MaxEncodedLen` is not satisfied
+  --> $DIR/storage_info_unsatisfied_nmap.rs:10:12
    |
-27 |     compile_error!("Temporarily disabled due to test flakiness");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+10 |     #[pallet::generate_storage_info]
+   |               ^^^^^^^^^^^^^^^^^^^^^ the trait `MaxEncodedLen` is not implemented for `Bar`
+   |
+   = note: required because of the requirements on the impl of `KeyGeneratorMaxEncodedLen` for `NMapKey<frame_support::Twox64Concat, Bar>`
+   = note: required because of the requirements on the impl of `StorageInfoTrait` for `frame_support::pallet_prelude::StorageNMap<_GeneratedPrefixForStorageFoo<T>, NMapKey<frame_support::Twox64Concat, Bar>, u32>`
+   = note: required by `storage_info`


### PR DESCRIPTION
Fix https://github.com/paritytech/substrate/issues/9120

CI run test for frame-support-test with the feature conditional-storage and without.
For UI test this is not necessary, also we can't feature-gate the output of the UI test.

This PR prevent running UI test when conditional-compilation feature is activated.