### PR TITLE
Avoid running some test 2 times when unneeded

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,7 +319,7 @@ test-linux-stable:                 &test-linux
   script:
     # this job runs all tests in former runtime-benchmarks, frame-staking and wasmtime tests
     - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml # does not reuse cache 1 min 44 sec
+    - time cargo test -p frame-support-test --features=conditional-storage --manifest-path frame/support/test/Cargo.toml --test pallet # does not reuse cache 1 min 44 sec
     - SUBSTRATE_TEST_TIMEOUT=1 time cargo test -p substrate-test-utils --release --verbose --locked -- --ignored timeout
     - sccache -s
 

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -41,5 +41,5 @@ std = [
 ]
 try-runtime = ["frame-support/try-runtime"]
 # WARNING: CI only execute pallet test with this feature,
-# if the feature intended to be used outside, CI and this message needs to be updated.
+# if the feature intended to be used outside, CI and this message need to be updated.
 conditional-storage = []

--- a/frame/support/test/Cargo.toml
+++ b/frame/support/test/Cargo.toml
@@ -40,4 +40,6 @@ std = [
 	"sp-state-machine",
 ]
 try-runtime = ["frame-support/try-runtime"]
+# WARNING: CI only execute pallet test with this feature,
+# if the feature intended to be used outside, CI and this message needs to be updated.
 conditional-storage = []

--- a/frame/support/test/tests/pallet_ui.rs
+++ b/frame/support/test/tests/pallet_ui.rs
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 #[rustversion::attr(not(stable), ignore)]
-#[cfg(not(feature = "conditional-storage"))]
 #[test]
 fn pallet_ui() {
 	// As trybuild is using `cargo check`, we don't need the real WASM binaries.


### PR DESCRIPTION
This PR makes CI execute only the pallet test with conditional-storage.

In case some other test takes some times this is more efficient. Otherwise we can simply ignore all UI test and execute all other test 2 times.