### PR TITLE
Make New Staking Counter Backwards Compatible with CountedMap

### DIFF
--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -498,8 +498,8 @@ fn post_conditions() {
 fn check_count() {
 	let nominator_count = Nominators::<Test>::iter().count() as u32;
 	let validator_count = Validators::<Test>::iter().count() as u32;
-	assert_eq!(nominator_count, CurrentNominatorsCount::<Test>::get());
-	assert_eq!(validator_count, CurrentValidatorsCount::<Test>::get());
+	assert_eq!(nominator_count, CounterForNominators::<Test>::get());
+	assert_eq!(validator_count, CounterForValidators::<Test>::get());
 }
 
 fn check_ledgers() {

--- a/frame/staking/src/testing_utils.rs
+++ b/frame/staking/src/testing_utils.rs
@@ -30,9 +30,9 @@ const SEED: u32 = 0;
 /// This function removes all validators and nominators from storage.
 pub fn clear_validators_and_nominators<T: Config>() {
 	Validators::<T>::remove_all(None);
-	CurrentValidatorsCount::<T>::kill();
+	CounterForValidators::<T>::kill();
 	Nominators::<T>::remove_all(None);
-	CurrentNominatorsCount::<T>::kill();
+	CounterForNominators::<T>::kill();
 }
 
 /// Grab a funded user.

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -4107,9 +4107,9 @@ mod election_data_provider {
 	#[test]
 	fn capped_stakers_works() {
 		ExtBuilder::default().build_and_execute(|| {
-			let validator_count = CurrentValidatorsCount::<Test>::get();
+			let validator_count = CounterForValidators::<Test>::get();
 			assert_eq!(validator_count, 3);
-			let nominator_count = CurrentNominatorsCount::<Test>::get();
+			let nominator_count = CounterForNominators::<Test>::get();
 			assert_eq!(nominator_count, 1);
 
 			// Change the maximums


### PR DESCRIPTION
This PR simply updates the names for the new Validator and Nominator counter storage items so they will be backwards compatible with the `CountedMap` we will migrate these storage to.

https://github.com/paritytech/substrate/pull/9125/files
