### PR TITLE
Aura: Skip initialize block & remove cache

### DIFF
--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -45,7 +45,7 @@ use sp_consensus::{
 	BlockOrigin, Error as ConsensusError, SelectChain,
 };
 use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
-use sp_blockchain::{Result as CResult, well_known_cache_keys, ProvideCache, HeaderBackend};
+use sp_blockchain::{Result as CResult, ProvideCache, HeaderBackend};
 use sp_core::crypto::Public;
 use sp_application_crypto::{AppKey, AppPublic};
 use sp_runtime::{generic::BlockId, traits::NumberFor};
@@ -546,14 +546,9 @@ fn authorities<A, B, C>(client: &C, at: &BlockId<B>) -> Result<Vec<A>, Consensus
 	C: ProvideRuntimeApi<B> + BlockOf + ProvideCache<B>,
 	C::Api: AuraApi<B, A>,
 {
-	client
-		.cache()
-		.and_then(|cache| cache
-			.get_at(&well_known_cache_keys::AUTHORITIES, at)
-			.unwrap_or(None)
-			.and_then(|(_, _, v)| Decode::decode(&mut &v[..]).ok())
-		)
-		.or_else(|| AuraApi::authorities(&*client.runtime_api(), at).ok())
+	client.runtime_api()
+		.authorities(at)
+		.ok()
 		.ok_or_else(|| sp_consensus::Error::InvalidAuthoritiesSet.into())
 }
 

--- a/primitives/consensus/aura/src/lib.rs
+++ b/primitives/consensus/aura/src/lib.rs
@@ -90,6 +90,7 @@ sp_api::decl_runtime_apis! {
 		fn slot_duration() -> SlotDuration;
 
 		// Return the current set of authorities.
+		#[skip_initialize_block]
 		fn authorities() -> Vec<AuthorityId>;
 	}
 }


### PR DESCRIPTION
This instructs the Aura runtime api to skip initialize block, when
requesting the authorities. This is important, as we don't want to use
the new authorities that should be used from the next block on.
Besides that, it removes the caching stuff. The cache is not available
on full nodes anyway. In the future we should store the authorities
probably in the aux store.

