### PR TITLE
WIP Add option to specify if you want to run quick or long test for subst…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -711,4 +711,15 @@ trigger-simnet:
     DWNSTRM_ID:                    332
   script:
     # API trigger for a simnet job
-    - .maintain/gitlab/trigger_pipeline.sh --simnet-version=${SIMNET_REF}
+    # use the -v operator to explicitly test if a variable is set
+    # use the -n operator to test if variable is empty string
+    - if [[ -v FEATURES && -n "${FEATURES}" ]]  ; then 
+        echo "Testing only ${FEATURES}" ;
+        SUBSTRATE_FEATURES="--features=${FEATURES}"   ;
+      else  
+        echo "Value for FEATURES not specified, all tests will run" ;
+        SUBSTRATE_FEATURES="" ;
+      fi
+
+    - .maintain/gitlab/trigger_pipeline.sh --simnet-version=${SIMNET_REF} 
+                                           "${SUBSTRATE_FEATURES}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -720,6 +720,5 @@ trigger-simnet:
         echo "Value for FEATURES not specified, all tests will run" ;
         SUBSTRATE_FEATURES="" ;
       fi
-
     - .maintain/gitlab/trigger_pipeline.sh --simnet-version=${SIMNET_REF} 
                                            "${SUBSTRATE_FEATURES}"

--- a/.maintain/gitlab/trigger_pipeline.sh
+++ b/.maintain/gitlab/trigger_pipeline.sh
@@ -91,7 +91,7 @@ function main {
 
 function parse_args {
   # shellcheck disable=SC2214
-  while getopts c:u:r:i:n:g:f:t:r:a:s:h-: OPT; do
+  while getopts f:r:a:c:t:u:r:i:n:g:s:h-: OPT; do
     # support long options: https://stackoverflow.com/a/28466267/519360
     if [ "${OPT}" = "-" ]; then   # long option: reformulate OPT and OPTARG
       OPT="${OPTARG%%=*}"         # extract long option name


### PR DESCRIPTION
Add the possibility to specify which kind of test to run for substrate. 
There are quick tests, like the ["smoke test"](https://gitlab.parity.io/parity/simnet/-/blob/master/testing/substrate_tests/tests/quick/001-smoketest.feature), or longer tests, like the ["load test"](https://gitlab.parity.io/parity/simnet/-/blob/master/testing/substrate_tests/tests/long/002-loadtest.feature)

For PRs we might want to run the quick tests, while for the nightly scheduled job the long test

