### PR TITLE
slots: slot lenience must take into account block proposal portion

### DIFF
--- a/bin/node-template/node/src/service.rs
+++ b/bin/node-template/node/src/service.rs
@@ -245,6 +245,7 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 				sync_oracle: network.clone(),
 				justification_sync_link: network.clone(),
 				block_proposal_slot_portion: SlotProportion::new(2f32 / 3f32),
+				max_block_proposal_slot_portion: None,
 				telemetry: telemetry.as_ref().map(|x| x.handle()),
 			},
 		)?;

--- a/bin/node/cli/src/service.rs
+++ b/bin/node/cli/src/service.rs
@@ -333,6 +333,7 @@ pub fn new_full_base(
 			babe_link,
 			can_author_with,
 			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
 			telemetry: telemetry.as_ref().map(|x| x.handle()),
 		};
 

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -472,7 +472,7 @@ where
 			parent_slot,
 			slot_info,
 			&self.block_proposal_slot_portion,
-			&self.max_block_proposal_slot_portion,
+			self.max_block_proposal_slot_portion.as_ref(),
 			sc_consensus_slots::SlotLenienceType::Exponential,
 			self.logging_target(),
 		)

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -747,6 +747,7 @@ mod tests {
 				keystore,
 				can_author_with: sp_consensus::AlwaysCanAuthor,
 				block_proposal_slot_portion: SlotProportion::new(0.5),
+				max_block_proposal_slot_portion: None,
 				telemetry: None,
 			}).expect("Starts aura"));
 		}
@@ -811,6 +812,7 @@ mod tests {
 			telemetry: None,
 			_key_type: PhantomData::<AuthorityPair>,
 			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
 		};
 
 		let head = Header::new(
@@ -861,6 +863,7 @@ mod tests {
 			telemetry: None,
 			_key_type: PhantomData::<AuthorityPair>,
 			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
 		};
 
 		let head = client.header(&BlockId::Number(0)).unwrap().unwrap();

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -140,6 +140,9 @@ pub struct StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, CAW> {
 	/// slot. However, the proposing can still take longer when there is some lenience factor applied,
 	/// because there were no blocks produced for some slots.
 	pub block_proposal_slot_portion: SlotProportion,
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied.
+	/// due to no blocks being produced.
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
 	/// Telemetry instance used to report telemetry metrics.
 	pub telemetry: Option<TelemetryHandle>,
 }
@@ -160,9 +163,11 @@ pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, CAW, Error>(
 		keystore,
 		can_author_with,
 		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
 		telemetry,
 	}: StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, CAW>,
-) -> Result<impl Future<Output = ()>, sp_consensus::Error> where
+) -> Result<impl Future<Output = ()>, sp_consensus::Error>
+where
 	P: Pair + Send + Sync,
 	P::Public: AppPublic + Hash + Member + Encode + Decode,
 	P::Signature: TryFrom<Vec<u8>> + Hash + Member + Encode + Decode,
@@ -192,6 +197,7 @@ pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, CAW, Error>(
 		backoff_authoring_blocks,
 		telemetry,
 		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
 	});
 
 	Ok(sc_consensus_slots::start_slot_worker(
@@ -228,6 +234,9 @@ pub struct BuildAuraWorkerParams<C, I, PF, SO, L, BS> {
 	/// slot. However, the proposing can still take longer when there is some lenience factor applied,
 	/// because there were no blocks produced for some slots.
 	pub block_proposal_slot_portion: SlotProportion,
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied
+	/// due to no blocks being produced.
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
 	/// Telemetry instance used to report telemetry metrics.
 	pub telemetry: Option<TelemetryHandle>,
 }
@@ -245,10 +254,12 @@ pub fn build_aura_worker<P, B, C, PF, I, SO, L, BS, Error>(
 		backoff_authoring_blocks,
 		keystore,
 		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
 		telemetry,
 		force_authoring,
 	}: BuildAuraWorkerParams<C, I, PF, SO, L, BS>,
-) -> impl sc_consensus_slots::SlotWorker<B, <PF::Proposer as Proposer<B>>::Proof> where
+) -> impl sc_consensus_slots::SlotWorker<B, <PF::Proposer as Proposer<B>>::Proof>
+where
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + BlockOf + ProvideCache<B> + AuxStore + HeaderBackend<B> + Send + Sync,
 	C::Api: AuraApi<B, AuthorityId<P>>,
@@ -274,6 +285,7 @@ pub fn build_aura_worker<P, B, C, PF, I, SO, L, BS, Error>(
 		backoff_authoring_blocks,
 		telemetry,
 		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
 		_key_type: PhantomData::<P>,
 	}
 }
@@ -288,6 +300,7 @@ struct AuraWorker<C, E, I, P, SO, L, BS> {
 	force_authoring: bool,
 	backoff_authoring_blocks: Option<BS>,
 	block_proposal_slot_portion: SlotProportion,
+	max_block_proposal_slot_portion: Option<SlotProportion>,
 	telemetry: Option<TelemetryHandle>,
 	_key_type: PhantomData<P>,
 }
@@ -452,42 +465,17 @@ where
 		self.telemetry.clone()
 	}
 
-	fn proposing_remaining_duration(
-		&self,
-		slot_info: &SlotInfo<B>,
-	) -> std::time::Duration {
-		let max_proposing = slot_info.duration.mul_f32(self.block_proposal_slot_portion.get());
+	fn proposing_remaining_duration(&self, slot_info: &SlotInfo<B>) -> std::time::Duration {
+		let parent_slot = find_pre_digest::<B, P::Signature>(&slot_info.chain_head).ok();
 
-		let slot_remaining = slot_info.ends_at
-			.checked_duration_since(std::time::Instant::now())
-			.unwrap_or_default();
-
-		let proposing_duration = std::cmp::min(slot_remaining, max_proposing);
-
-		// If parent is genesis block, we don't require any lenience factor.
-		if slot_info.chain_head.number().is_zero() {
-			return proposing_duration;
-		}
-
-		let parent_slot = match find_pre_digest::<B, P::Signature>(&slot_info.chain_head) {
-			Err(_) => return proposing_duration,
-			Ok(d) => d,
-		};
-
-		if let Some(slot_lenience) =
-			sc_consensus_slots::slot_lenience_exponential(parent_slot, slot_info)
-		{
-			debug!(
-				target: "aura",
-				"No block for {} slots. Applying exponential lenience of {}s",
-				slot_info.slot.saturating_sub(parent_slot + 1),
-				slot_lenience.as_secs(),
-			);
-
-			proposing_duration + (slot_lenience.mul_f32(self.block_proposal_slot_portion.get()))
-		} else {
-			proposing_duration
-		}
+		sc_consensus_slots::proposing_remaining_duration(
+			parent_slot,
+			slot_info,
+			&self.block_proposal_slot_portion,
+			&self.max_block_proposal_slot_portion,
+			sc_consensus_slots::SlotLenienceType::Exponential,
+			self.logging_target(),
+		)
 	}
 }
 

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -140,7 +140,7 @@ pub struct StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, CAW> {
 	/// slot. However, the proposing can still take longer when there is some lenience factor applied,
 	/// because there were no blocks produced for some slots.
 	pub block_proposal_slot_portion: SlotProportion,
-	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied.
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied
 	/// due to no blocks being produced.
 	pub max_block_proposal_slot_portion: Option<SlotProportion>,
 	/// Telemetry instance used to report telemetry metrics.

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -839,15 +839,15 @@ where
 			.checked_duration_since(std::time::Instant::now())
 			.unwrap_or_default();
 
-		let slot_remaining = std::cmp::min(slot_remaining, max_proposing);
+		let proposing_duration = std::cmp::min(slot_remaining, max_proposing);
 
 		// If parent is genesis block, we don't require any lenience factor.
 		if slot_info.chain_head.number().is_zero() {
-			return slot_remaining
+			return proposing_duration;
 		}
 
 		let parent_slot = match find_pre_digest::<B>(&slot_info.chain_head) {
-			Err(_) => return slot_remaining,
+			Err(_) => return proposing_duration,
 			Ok(d) => d.slot(),
 		};
 
@@ -861,9 +861,9 @@ where
 				slot_lenience.as_secs(),
 			);
 
-			slot_remaining + slot_lenience
+			proposing_duration + (slot_lenience.mul_f32(self.block_proposal_slot_portion.get()))
 		} else {
-			slot_remaining
+			proposing_duration
 		}
 	}
 }

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -409,30 +409,35 @@ pub struct BabeParams<B: BlockT, C, SC, E, I, SO, L, CIDP, BS, CAW> {
 	/// because there were no blocks produced for some slots.
 	pub block_proposal_slot_portion: SlotProportion,
 
+	/// The maximum proportion of the slot dedicated to proposing with any lenience factor applied
+	/// due to no blocks being produced.
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
+
 	/// Handle use to report telemetries.
 	pub telemetry: Option<TelemetryHandle>,
 }
 
 /// Start the babe worker.
-pub fn start_babe<B, C, SC, E, I, SO, CIDP, BS, CAW, L, Error>(BabeParams {
-	keystore,
-	client,
-	select_chain,
-	env,
-	block_import,
-	sync_oracle,
-	justification_sync_link,
-	create_inherent_data_providers,
-	force_authoring,
-	backoff_authoring_blocks,
-	babe_link,
-	can_author_with,
-	block_proposal_slot_portion,
-	telemetry,
-}: BabeParams<B, C, SC, E, I, SO, L, CIDP, BS, CAW>) -> Result<
-	BabeWorker<B>,
-	sp_consensus::Error,
-> where
+pub fn start_babe<B, C, SC, E, I, SO, CIDP, BS, CAW, L, Error>(
+	BabeParams {
+		keystore,
+		client,
+		select_chain,
+		env,
+		block_import,
+		sync_oracle,
+		justification_sync_link,
+		create_inherent_data_providers,
+		force_authoring,
+		backoff_authoring_blocks,
+		babe_link,
+		can_author_with,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		telemetry,
+	}: BabeParams<B, C, SC, E, I, SO, L, CIDP, BS, CAW>,
+) -> Result<BabeWorker<B>, sp_consensus::Error>
+where
 	B: BlockT,
 	C: ProvideRuntimeApi<B>
 		+ ProvideCache<B>
@@ -477,6 +482,7 @@ pub fn start_babe<B, C, SC, E, I, SO, CIDP, BS, CAW, L, Error>(BabeParams {
 		slot_notification_sinks: slot_notification_sinks.clone(),
 		config: config.clone(),
 		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
 		telemetry,
 	};
 
@@ -627,6 +633,7 @@ struct BabeSlotWorker<B: BlockT, C, E, I, SO, L, BS> {
 	slot_notification_sinks: SlotNotificationSinks<B>,
 	config: Config,
 	block_proposal_slot_portion: SlotProportion,
+	max_block_proposal_slot_portion: Option<SlotProportion>,
 	telemetry: Option<TelemetryHandle>,
 }
 
@@ -634,10 +641,10 @@ impl<B, C, E, I, Error, SO, L, BS> sc_consensus_slots::SimpleSlotWorker<B>
 	for BabeSlotWorker<B, C, E, I, SO, L, BS>
 where
 	B: BlockT,
-	C: ProvideRuntimeApi<B> +
-		ProvideCache<B> +
-		HeaderBackend<B> +
-		HeaderMetadata<B, Error = ClientError>,
+	C: ProvideRuntimeApi<B>
+		+ ProvideCache<B>
+		+ HeaderBackend<B>
+		+ HeaderMetadata<B, Error = ClientError>,
 	C::Api: BabeApi<B>,
 	E: Environment<B, Error = Error>,
 	E::Proposer: Proposer<B, Error = Error, Transaction = sp_api::TransactionFor<C, B>>,
@@ -829,42 +836,17 @@ where
 		self.telemetry.clone()
 	}
 
-	fn proposing_remaining_duration(
-		&self,
-		slot_info: &SlotInfo<B>,
-	) -> std::time::Duration {
-		let max_proposing = slot_info.duration.mul_f32(self.block_proposal_slot_portion.get());
+	fn proposing_remaining_duration(&self, slot_info: &SlotInfo<B>) -> std::time::Duration {
+		let parent_slot = find_pre_digest::<B>(&slot_info.chain_head).ok().map(|d| d.slot());
 
-		let slot_remaining = slot_info.ends_at
-			.checked_duration_since(std::time::Instant::now())
-			.unwrap_or_default();
-
-		let proposing_duration = std::cmp::min(slot_remaining, max_proposing);
-
-		// If parent is genesis block, we don't require any lenience factor.
-		if slot_info.chain_head.number().is_zero() {
-			return proposing_duration;
-		}
-
-		let parent_slot = match find_pre_digest::<B>(&slot_info.chain_head) {
-			Err(_) => return proposing_duration,
-			Ok(d) => d.slot(),
-		};
-
-		if let Some(slot_lenience) =
-			sc_consensus_slots::slot_lenience_exponential(parent_slot, slot_info)
-		{
-			debug!(
-				target: "babe",
-				"No block for {} slots. Applying exponential lenience of {}s",
-				slot_info.slot.saturating_sub(parent_slot + 1),
-				slot_lenience.as_secs(),
-			);
-
-			proposing_duration + (slot_lenience.mul_f32(self.block_proposal_slot_portion.get()))
-		} else {
-			proposing_duration
-		}
+		sc_consensus_slots::proposing_remaining_duration(
+			parent_slot,
+			slot_info,
+			&self.block_proposal_slot_portion,
+			&self.max_block_proposal_slot_portion,
+			sc_consensus_slots::SlotLenienceType::Exponential,
+			self.logging_target(),
+		)
 	}
 }
 

--- a/client/consensus/babe/src/lib.rs
+++ b/client/consensus/babe/src/lib.rs
@@ -843,7 +843,7 @@ where
 			parent_slot,
 			slot_info,
 			&self.block_proposal_slot_portion,
-			&self.max_block_proposal_slot_portion,
+			self.max_block_proposal_slot_portion.as_ref(),
 			sc_consensus_slots::SlotLenienceType::Exponential,
 			self.logging_target(),
 		)

--- a/client/consensus/babe/src/tests.rs
+++ b/client/consensus/babe/src/tests.rs
@@ -473,6 +473,7 @@ fn run_one_test(mutator: impl Fn(&mut TestHeader, Stage) + Send + Sync + 'static
 			can_author_with: sp_consensus::AlwaysCanAuthor,
 			justification_sync_link: (),
 			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
 			telemetry: None,
 		}).expect("Starts babe"));
 	}

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -666,6 +666,91 @@ impl SlotProportion {
 	}
 }
 
+/// The strategy used to calculate the slot lenience used to increase the block proposal time when
+/// slots have been skipped with no blocks authored.
+pub enum SlotLenienceType {
+	/// Increase the lenience linearly with the number of skipped slots.
+	Linear,
+	/// Increase the lenience exponentially with the number of skipped slots.
+	Exponential,
+}
+
+impl SlotLenienceType {
+	fn as_str(&self) -> &'static str {
+		match self {
+			SlotLenienceType::Linear => "linear",
+			SlotLenienceType::Exponential => "exponential",
+		}
+	}
+}
+
+/// Calculate the remaining duration for block proposal taking into account whether any slots have
+/// been skipped and applying the given lenience strategy. If `max_block_proposal_slot_portion` is
+/// not none this method guarantees that the returned duration must be lower or equal to
+/// `slot_info.duration * max_block_proposal_slot_portion`.
+pub fn proposing_remaining_duration<Block: BlockT>(
+	parent_slot: Option<Slot>,
+	slot_info: &SlotInfo<Block>,
+	block_proposal_slot_portion: &SlotProportion,
+	max_block_proposal_slot_portion: &Option<SlotProportion>,
+	slot_lenience_type: SlotLenienceType,
+	log_target: &str,
+) -> Duration {
+	use sp_runtime::traits::Zero;
+
+	let proposing_duration = slot_info
+		.duration
+		.mul_f32(block_proposal_slot_portion.get());
+
+	let slot_remaining = slot_info
+		.ends_at
+		.checked_duration_since(std::time::Instant::now())
+		.unwrap_or_default();
+
+	let proposing_duration = std::cmp::min(slot_remaining, proposing_duration);
+
+	// If parent is genesis block, we don't require any lenience factor.
+	if slot_info.chain_head.number().is_zero() {
+		return proposing_duration;
+	}
+
+	let parent_slot = match parent_slot {
+		Some(parent_slot) => parent_slot,
+		None => return proposing_duration,
+	};
+
+	let slot_lenience = match slot_lenience_type {
+		SlotLenienceType::Exponential => slot_lenience_exponential(parent_slot, slot_info),
+		SlotLenienceType::Linear => slot_lenience_linear(parent_slot, slot_info),
+	};
+
+	if let Some(slot_lenience) = slot_lenience {
+		debug!(
+			target: log_target,
+			"No block for {} slots. Applying {} lenience of {}s",
+			slot_info.slot.saturating_sub(parent_slot + 1),
+			slot_lenience_type.as_str(),
+			slot_lenience.as_secs(),
+		);
+
+		let lenient_proposing_duration =
+			proposing_duration + (slot_lenience.mul_f32(block_proposal_slot_portion.get()));
+
+		// if we defined a maximum portion of the slot for proposal then we must make sure the
+		// lenience doesn't go over it
+		if let Some(ref max_block_proposal_slot_portion) = max_block_proposal_slot_portion {
+			std::cmp::min(
+				lenient_proposing_duration,
+				proposing_duration.mul_f32(max_block_proposal_slot_portion.get()),
+			)
+		} else {
+			lenient_proposing_duration
+		}
+	} else {
+		proposing_duration
+	}
+}
+
 /// Calculate a slot duration lenience based on the number of missed slots from current
 /// to parent. If the number of skipped slots is greated than 0 this method will apply
 /// an exponential backoff of at most `2^7 * slot_duration`, if no slots were skipped
@@ -703,7 +788,7 @@ pub fn slot_lenience_exponential<Block: BlockT>(
 /// a linear backoff of at most `20 * slot_duration`, if no slots were skipped
 /// this method will return `None.`
 pub fn slot_lenience_linear<Block: BlockT>(
-	parent_slot: u64,
+	parent_slot: Slot,
 	slot_info: &SlotInfo<Block>,
 ) -> Option<Duration> {
 	// never give more than 20 times more lenience.


### PR DESCRIPTION
The slot lenience calculation was being done on the original slot duration without accounting for the block proposal portion. This PR fixes that and additionally adds a `max_block_proposal_slot_portion` so that the block proposal duration is never exceeded regardless of the slot lenience. 

polkadot companion: https://github.com/paritytech/polkadot/pull/3294