### PR TITLE
Add `substrate-rpc-subscription` to exceptions in alert

### DIFF
--- a/.maintain/monitoring/alerting-rules/alerting-rules.yaml
+++ b/.maintain/monitoring/alerting-rules/alerting-rules.yaml
@@ -134,7 +134,7 @@ groups:
   ##############################################################################
 
   - alert: ContinuousTaskEnded
-    expr: '(polkadot_tasks_spawned_total{task_name != "basic-authorship-proposer"} == 1)
+    expr: '(polkadot_tasks_spawned_total{task_name != "basic-authorship-proposer", task_name != "substrate-rpc-subscription"} == 1)
         - on(instance, task_name) group_left() (polkadot_tasks_ended_total == 1)'
     for: 5m
     labels:


### PR DESCRIPTION
This task is obviously not continuous, so it's not worth alerting about.

Normally the alert rule is loose enough that this kind of task doesn't trigger the alert, but we apparently have some validators that trigger it, most likely because of a script querying information from the node.
