### PR TITLE
Introduce `MaxEncodedLenNoBound`

### DIFF
--- a/max-encoded-len/src/lib.rs
+++ b/max-encoded-len/src/lib.rs
@@ -48,6 +48,11 @@ use primitive_types::{H160, H256, H512};
 #[cfg(feature = "derive")]
 pub use max_encoded_len_derive::MaxEncodedLen;
 
+/// Same as `MaxEncodedLen`, but without bounding the generics on the derived type with
+/// `MaxEncodedLen`.
+#[cfg(feature = "derive")]
+pub use max_encoded_len_derive::MaxEncodedLenNoBound;
+
 /// Items implementing `MaxEncodedLen` have a statically known maximum encoded size.
 ///
 /// Some containers, such as `BoundedVec`, have enforced size limits and this trait

--- a/max-encoded-len/tests/max_encoded_len.rs
+++ b/max-encoded-len/tests/max_encoded_len.rs
@@ -19,7 +19,8 @@
 
 #![cfg(feature = "derive")]
 
-use max_encoded_len::MaxEncodedLen;
+use max_encoded_len::{MaxEncodedLen, MaxEncodedLenNoBound};
+use std::marker::PhantomData;
 use codec::{Compact, Encode};
 
 // These structs won't even compile if the macro isn't working right.
@@ -74,6 +75,16 @@ fn two_generics_max_length() {
 		TwoGenerics::<Compact<u64>, [u16; 8]>::max_encoded_len(),
 		Compact::<u64>::max_encoded_len() + <[u16; 8]>::max_encoded_len()
 	);
+}
+
+#[derive(Encode, MaxEncodedLenNoBound)]
+struct NoBoundGeneric<T> {
+	one: PhantomData<T>,
+}
+
+#[test]
+fn no_bound_generic() {
+	assert_eq!(NoBoundGeneric::<u8>::max_encoded_len(), 0);
 }
 
 #[derive(Encode, MaxEncodedLen)]


### PR DESCRIPTION
This will be very useful in structs containing `BoundedVec`,
where the second type parameter does not need to have any
trait bounds, since it represents the max supported length
of the `BoundedVec`.