### PR TITLE
Reorganize max encoded len import

### DIFF
--- a/frame/support/procedural/src/storage/storage_struct.rs
+++ b/frame/support/procedural/src/storage/storage_struct.rs
@@ -267,7 +267,7 @@ pub fn decl_and_impl(def: &DeclStorageDefExt) -> TokenStream {
 								use #scrate::sp_runtime::SaturatedConversion;
 
 								let max_size = <
-									#value_type as #scrate::traits::MaxEncodedLen
+									#value_type as #scrate::codec::MaxEncodedLen
 								>::max_encoded_len()
 									.saturated_into();
 
@@ -301,7 +301,7 @@ pub fn decl_and_impl(def: &DeclStorageDefExt) -> TokenStream {
 								>::Hasher::max_len::<#key>();
 
 								let max_size = <
-									#value_type as #scrate::traits::MaxEncodedLen
+									#value_type as #scrate::codec::MaxEncodedLen
 								>::max_encoded_len()
 									.saturating_add(key_max_size)
 									.saturated_into();
@@ -342,7 +342,7 @@ pub fn decl_and_impl(def: &DeclStorageDefExt) -> TokenStream {
 								>::Hasher2::max_len::<#key2>();
 
 								let max_size = <
-									#value_type as #scrate::traits::MaxEncodedLen
+									#value_type as #scrate::codec::MaxEncodedLen
 								>::max_encoded_len()
 									.saturating_add(key1_max_size)
 									.saturating_add(key2_max_size)
@@ -378,7 +378,7 @@ pub fn decl_and_impl(def: &DeclStorageDefExt) -> TokenStream {
 								>::key_max_encoded_len();
 
 								let max_size = <
-									#value_type as #scrate::traits::MaxEncodedLen
+									#value_type as #scrate::codec::MaxEncodedLen
 								>::max_encoded_len()
 									.saturating_add(key_max_size)
 									.saturated_into();

--- a/frame/support/src/hash.rs
+++ b/frame/support/src/hash.rs
@@ -17,10 +17,9 @@
 
 //! Hash utilities.
 
-use codec::Codec;
+use codec::{Codec, MaxEncodedLen};
 use sp_std::prelude::Vec;
 use sp_io::hashing::{blake2_128, blake2_256, twox_64, twox_128, twox_256};
-use crate::traits::MaxEncodedLen;
 
 // This trait must be kept coherent with frame-support-procedural HasherKind usage
 pub trait Hashable: Sized {

--- a/frame/support/src/lib.rs
+++ b/frame/support/src/lib.rs
@@ -1245,7 +1245,7 @@ pub mod pallet_prelude {
 		RuntimeDebug, storage,
 		traits::{
 			Get, Hooks, IsType, GetPalletVersion, EnsureOrigin, PalletInfoAccess, StorageInfoTrait,
-			ConstU32, GetDefault, MaxEncodedLen,
+			ConstU32, GetDefault,
 		},
 		dispatch::{DispatchResultWithPostInfo, Parameter, DispatchError, DispatchResult},
 		weights::{DispatchClass, Pays, Weight},
@@ -1255,7 +1255,7 @@ pub mod pallet_prelude {
 		},
 		storage::bounded_vec::BoundedVec,
 	};
-	pub use codec::{Encode, Decode};
+	pub use codec::{Encode, Decode, MaxEncodedLen};
 	pub use crate::inherent::{InherentData, InherentIdentifier, ProvideInherent};
 	pub use sp_runtime::{
 		traits::{MaybeSerializeDeserialize, Member, ValidateUnsigned},

--- a/frame/support/src/storage/bounded_btree_map.rs
+++ b/frame/support/src/storage/bounded_btree_map.rs
@@ -23,9 +23,9 @@ use sp_std::{
 };
 use crate::{
 	storage::StorageDecodeLength,
-	traits::{Get, MaxEncodedLen},
+	traits::Get,
 };
-use codec::{Encode, Decode};
+use codec::{Encode, Decode, MaxEncodedLen};
 
 /// A bounded map based on a B-Tree.
 ///

--- a/frame/support/src/storage/bounded_btree_set.rs
+++ b/frame/support/src/storage/bounded_btree_set.rs
@@ -23,9 +23,9 @@ use sp_std::{
 };
 use crate::{
 	storage::StorageDecodeLength,
-	traits::{Get, MaxEncodedLen},
+	traits::Get,
 };
-use codec::{Encode, Decode};
+use codec::{Encode, Decode, MaxEncodedLen};
 
 /// A bounded set based on a B-Tree.
 ///

--- a/frame/support/src/storage/bounded_vec.rs
+++ b/frame/support/src/storage/bounded_vec.rs
@@ -20,13 +20,13 @@
 
 use sp_std::prelude::*;
 use sp_std::{convert::TryFrom, fmt, marker::PhantomData};
-use codec::{Encode, Decode, EncodeLike};
+use codec::{Encode, Decode, EncodeLike, MaxEncodedLen};
 use core::{
 	ops::{Deref, Index, IndexMut},
 	slice::SliceIndex,
 };
 use crate::{
-	traits::{Get, MaxEncodedLen},
+	traits::Get,
 	storage::{StorageDecodeLength, StorageTryAppend},
 };
 

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -18,13 +18,13 @@
 //! Storage map type. Implements StorageDoubleMap, StorageIterableDoubleMap,
 //! StoragePrefixedDoubleMap traits and their methods directly.
 
-use codec::{Decode, Encode, EncodeLike, FullCodec};
+use codec::{Decode, Encode, EncodeLike, FullCodec, MaxEncodedLen};
 use crate::{
 	storage::{
 		StorageAppend, StorageTryAppend, StorageDecodeLength, StoragePrefixedMap,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
-	traits::{GetDefault, StorageInstance, Get, MaxEncodedLen, StorageInfo},
+	traits::{GetDefault, StorageInstance, Get, StorageInfo},
 };
 use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 use sp_arithmetic::traits::SaturatedConversion;

--- a/frame/support/src/storage/types/key.rs
+++ b/frame/support/src/storage/types/key.rs
@@ -17,8 +17,8 @@
 
 //! Storage key type.
 
-use crate::{hash::{ReversibleStorageHasher, StorageHasher}, traits::MaxEncodedLen};
-use codec::{Encode, EncodeLike, FullCodec};
+use crate::hash::{ReversibleStorageHasher, StorageHasher};
+use codec::{Encode, EncodeLike, FullCodec, MaxEncodedLen};
 use paste::paste;
 use sp_std::prelude::*;
 

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -18,13 +18,13 @@
 //! Storage map type. Implements StorageMap, StorageIterableMap, StoragePrefixedMap traits and their
 //! methods directly.
 
-use codec::{FullCodec, Decode, EncodeLike, Encode};
+use codec::{FullCodec, Decode, EncodeLike, Encode, MaxEncodedLen};
 use crate::{
 	storage::{
 		StorageAppend, StorageTryAppend, StorageDecodeLength, StoragePrefixedMap,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
-	traits::{GetDefault, StorageInstance, Get, MaxEncodedLen, StorageInfo},
+	traits::{GetDefault, StorageInstance, Get, StorageInfo},
 };
 use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 use sp_arithmetic::traits::SaturatedConversion;

--- a/frame/support/src/storage/types/nmap.rs
+++ b/frame/support/src/storage/types/nmap.rs
@@ -26,9 +26,9 @@ use crate::{
 		},
 		KeyGenerator, PrefixIterator, StorageAppend, StorageDecodeLength, StoragePrefixedMap,
 	},
-	traits::{Get, GetDefault, StorageInstance, StorageInfo, MaxEncodedLen},
+	traits::{Get, GetDefault, StorageInstance, StorageInfo},
 };
-use codec::{Decode, Encode, EncodeLike, FullCodec};
+use codec::{Decode, Encode, EncodeLike, FullCodec, MaxEncodedLen};
 use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 use sp_runtime::SaturatedConversion;
 use sp_std::prelude::*;

--- a/frame/support/src/storage/types/value.rs
+++ b/frame/support/src/storage/types/value.rs
@@ -17,13 +17,13 @@
 
 //! Storage value type. Implements StorageValue trait and its method directly.
 
-use codec::{FullCodec, Decode, EncodeLike, Encode};
+use codec::{FullCodec, Decode, EncodeLike, Encode, MaxEncodedLen};
 use crate::{
 	storage::{
 		StorageAppend, StorageTryAppend, StorageDecodeLength,
 		types::{OptionQuery, QueryKindTrait, OnEmptyGetter},
 	},
-	traits::{GetDefault, StorageInstance, MaxEncodedLen, StorageInfo},
+	traits::{GetDefault, StorageInstance, StorageInfo},
 };
 use frame_metadata::{DefaultByteGetter, StorageEntryModifier};
 use sp_arithmetic::traits::SaturatedConversion;

--- a/frame/support/src/storage/weak_bounded_vec.rs
+++ b/frame/support/src/storage/weak_bounded_vec.rs
@@ -20,13 +20,13 @@
 
 use sp_std::prelude::*;
 use sp_std::{convert::TryFrom, fmt, marker::PhantomData};
-use codec::{Encode, Decode};
+use codec::{Encode, Decode, MaxEncodedLen};
 use core::{
 	ops::{Deref, Index, IndexMut},
 	slice::SliceIndex,
 };
 use crate::{
-	traits::{Get, MaxEncodedLen},
+	traits::Get,
 	storage::{StorageDecodeLength, StorageTryAppend},
 };
 

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -81,6 +81,3 @@ pub use dispatch::{EnsureOrigin, OriginTrait, UnfilteredDispatchable};
 
 mod voting;
 pub use voting::{CurrencyToVote, SaturatingCurrencyToVote, U128CurrencyToVote};
-
-// for backwards-compatibility with existing imports
-pub use codec::MaxEncodedLen;

--- a/frame/support/src/traits/tokens/currency.rs
+++ b/frame/support/src/traits/tokens/currency.rs
@@ -22,7 +22,7 @@ use sp_runtime::traits::MaybeSerializeDeserialize;
 use crate::dispatch::{DispatchResult, DispatchError};
 use super::misc::{Balance, WithdrawReasons, ExistenceRequirement};
 use super::imbalance::{Imbalance, SignedImbalance};
-use frame_support::traits::MaxEncodedLen;
+use codec::MaxEncodedLen;
 
 mod reservable;
 pub use reservable::{ReservableCurrency, NamedReservableCurrency};

--- a/frame/system/src/lib.rs
+++ b/frame/system/src/lib.rs
@@ -88,7 +88,7 @@ use frame_support::{
 	Parameter, storage,
 	traits::{
 		SortedMembers, Get, PalletInfo, OnNewAccount, OnKilledAccount, HandleLifetime,
-		StoredMap, EnsureOrigin, OriginTrait, Filter, MaxEncodedLen,
+		StoredMap, EnsureOrigin, OriginTrait, Filter,
 	},
 	weights::{
 		Weight, RuntimeDbWeight, DispatchInfo, DispatchClass,
@@ -96,7 +96,7 @@ use frame_support::{
 	},
 	dispatch::{DispatchResultWithPostInfo, DispatchResult},
 };
-use codec::{Encode, Decode, FullCodec, EncodeLike};
+use codec::{Encode, Decode, FullCodec, EncodeLike, MaxEncodedLen};
 
 #[cfg(feature = "std")]
 use frame_support::traits::GenesisBuild;


### PR DESCRIPTION
Built on top of https://github.com/paritytech/substrate/pull/9163

this remove the reexport of MaxEncodedLen in frame_support::traits