### PR TITLE
Use MIN associated const

### DIFF
--- a/client/network/src/protocol/sync.rs
+++ b/client/network/src/protocol/sync.rs
@@ -105,7 +105,7 @@ mod rep {
 
 	/// Reputation change when a peer sent us a status message with a different
 	/// genesis than us.
-	pub const GENESIS_MISMATCH: Rep = Rep::new(i32::min_value(), "Genesis mismatch");
+	pub const GENESIS_MISMATCH: Rep = Rep::new(i32::MIN, "Genesis mismatch");
 
 	/// Reputation change for peers which send us a block with an incomplete header.
 	pub const INCOMPLETE_HEADER: Rep = Rep::new(-(1 << 20), "Incomplete header");

--- a/client/network/src/state_request_handler.rs
+++ b/client/network/src/state_request_handler.rs
@@ -42,7 +42,7 @@ mod rep {
 	use super::ReputationChange as Rep;
 
 	/// Reputation change when a peer sent us the same request multiple times.
-	pub const SAME_REQUEST: Rep = Rep::new(i32::min_value(), "Same state request multiple times");
+	pub const SAME_REQUEST: Rep = Rep::new(i32::MIN, "Same state request multiple times");
 }
 
 /// Generates a [`ProtocolConfig`] for the block request protocol, refusing incoming requests.

--- a/client/peerset/src/lib.rs
+++ b/client/peerset/src/lib.rs
@@ -45,7 +45,7 @@ use sp_utils::mpsc::{tracing_unbounded, TracingUnboundedSender, TracingUnbounded
 pub use libp2p::PeerId;
 
 /// We don't accept nodes whose reputation is under this value.
-const BANNED_THRESHOLD: i32 = 82 * (i32::min_value() / 100);
+const BANNED_THRESHOLD: i32 = 82 * (i32::MIN / 100);
 /// Reputation change for a node when we get disconnected from it.
 const DISCONNECT_REPUTATION_CHANGE: i32 = -256;
 /// Amount of time between the moment we disconnect from a node and the moment we remove it from
@@ -107,7 +107,7 @@ impl ReputationChange {
 
 	/// New reputation change that forces minimum possible reputation.
 	pub const fn new_fatal(reason: &'static str) -> ReputationChange {
-		ReputationChange { value: i32::min_value(), reason }
+		ReputationChange { value: i32::MIN, reason }
 	}
 }
 

--- a/client/peerset/tests/fuzz.rs
+++ b/client/peerset/tests/fuzz.rs
@@ -120,7 +120,7 @@ fn test_once() {
 				// If we generate 2, adjust a random reputation.
 				2 => {
 					if let Some(id) = known_nodes.iter().choose(&mut rng) {
-						let val = Uniform::new_inclusive(i32::min_value(), i32::MAX)
+						let val = Uniform::new_inclusive(i32::MIN, i32::MAX)
 							.sample(&mut rng);
 						peerset_handle.report_peer(id.clone(), ReputationChange::new(val, ""));
 					}

--- a/primitives/arithmetic/src/fixed_point.rs
+++ b/primitives/arithmetic/src/fixed_point.rs
@@ -640,7 +640,7 @@ macro_rules! implement_fixed {
 				};
 
 				// Min value fits.
-				assert_eq!(from_i129::<i128>(a), Some(i128::min_value()));
+				assert_eq!(from_i129::<i128>(a), Some(i128::MIN));
 
 				let a = I129 {
 					value: i128::MAX as u128 + 1,
@@ -677,13 +677,13 @@ macro_rules! implement_fixed {
 				let b = -1i32;
 
 				// Pos + Neg => Min.
-				assert_eq!(to_bound::<_, _, i32>(a, b), i32::min_value());
+				assert_eq!(to_bound::<_, _, i32>(a, b), i32::MIN);
 
 				let a = -1i32;
 				let b = 1i32;
 
 				// Neg + Pos => Min.
-				assert_eq!(to_bound::<_, _, i32>(a, b), i32::min_value());
+				assert_eq!(to_bound::<_, _, i32>(a, b), i32::MIN);
 
 				let a = 1i32;
 				let b = -1i32;
@@ -1092,29 +1092,29 @@ macro_rules! implement_fixed {
 
 				if $name::SIGNED {
 					// Min - 1.
-					assert_eq!(a.checked_mul_int((i128::min_value() + 1) / 2), Some(i128::min_value() + 2));
+					assert_eq!(a.checked_mul_int((i128::MIN + 1) / 2), Some(i128::MIN + 2));
 					// Min.
-					assert_eq!(a.checked_mul_int(i128::min_value() / 2), Some(i128::min_value()));
+					assert_eq!(a.checked_mul_int(i128::MIN / 2), Some(i128::MIN));
 					// Min + 1 => None.
-					assert_eq!(a.checked_mul_int(i128::min_value() / 2 - 1), None);
+					assert_eq!(a.checked_mul_int(i128::MIN / 2 - 1), None);
 
 					let b = $name::saturating_from_rational(1, -2);
 					assert_eq!(b.checked_mul_int(42i128), Some(-21));
 					assert_eq!(b.checked_mul_int(u128::MAX), None);
 					assert_eq!(b.checked_mul_int(i128::MAX), Some(i128::MAX / -2));
-					assert_eq!(b.checked_mul_int(i128::min_value()), Some(i128::min_value() / -2));
+					assert_eq!(b.checked_mul_int(i128::MIN), Some(i128::MIN / -2));
 				}
 
 				let a = $name::saturating_from_rational(1, 2);
 				assert_eq!(a.checked_mul_int(42i128), Some(21));
 				assert_eq!(a.checked_mul_int(i128::MAX), Some(i128::MAX / 2));
-				assert_eq!(a.checked_mul_int(i128::min_value()), Some(i128::min_value() / 2));
+				assert_eq!(a.checked_mul_int(i128::MIN), Some(i128::MIN / 2));
 
 				let c = $name::saturating_from_integer(255);
 				assert_eq!(c.checked_mul_int(2i8), None);
 				assert_eq!(c.checked_mul_int(2i128), Some(510));
 				assert_eq!(c.checked_mul_int(i128::MAX), None);
-				assert_eq!(c.checked_mul_int(i128::min_value()), None);
+				assert_eq!(c.checked_mul_int(i128::MIN), None);
 			}
 
 			#[test]
@@ -1128,30 +1128,30 @@ macro_rules! implement_fixed {
 				assert_eq!(a.saturating_mul_int(i128::MAX / 2 + 1), i128::MAX);
 
 				// Min - 1.
-				assert_eq!(a.saturating_mul_int((i128::min_value() + 1) / 2), i128::min_value() + 2);
+				assert_eq!(a.saturating_mul_int((i128::MIN + 1) / 2), i128::MIN + 2);
 				// Min.
-				assert_eq!(a.saturating_mul_int(i128::min_value() / 2), i128::min_value());
+				assert_eq!(a.saturating_mul_int(i128::MIN / 2), i128::MIN);
 				// Min + 1 => saturates to min.
-				assert_eq!(a.saturating_mul_int(i128::min_value() / 2 - 1), i128::min_value());
+				assert_eq!(a.saturating_mul_int(i128::MIN / 2 - 1), i128::MIN);
 
 				if $name::SIGNED {
 					let b = $name::saturating_from_rational(1, -2);
 					assert_eq!(b.saturating_mul_int(42i32), -21);
 					assert_eq!(b.saturating_mul_int(i128::MAX), i128::MAX / -2);
-					assert_eq!(b.saturating_mul_int(i128::min_value()), i128::min_value() / -2);
-					assert_eq!(b.saturating_mul_int(u128::MAX), u128::min_value());
+					assert_eq!(b.saturating_mul_int(i128::MIN), i128::MIN / -2);
+					assert_eq!(b.saturating_mul_int(u128::MAX), u128::MIN);
 				}
 
 				let a = $name::saturating_from_rational(1, 2);
 				assert_eq!(a.saturating_mul_int(42i32), 21);
 				assert_eq!(a.saturating_mul_int(i128::MAX), i128::MAX / 2);
-				assert_eq!(a.saturating_mul_int(i128::min_value()), i128::min_value() / 2);
+				assert_eq!(a.saturating_mul_int(i128::MIN), i128::MIN / 2);
 
 				let c = $name::saturating_from_integer(255);
 				assert_eq!(c.saturating_mul_int(2i8), i8::MAX);
-				assert_eq!(c.saturating_mul_int(-2i8), i8::min_value());
+				assert_eq!(c.saturating_mul_int(-2i8), i8::MIN);
 				assert_eq!(c.saturating_mul_int(i128::MAX), i128::MAX);
-				assert_eq!(c.saturating_mul_int(i128::min_value()), i128::min_value());
+				assert_eq!(c.saturating_mul_int(i128::MIN), i128::MIN);
 			}
 
 			#[test]
@@ -1232,13 +1232,13 @@ macro_rules! implement_fixed {
 					// Not executed by unsigned inners.
 					assert_eq!(a.checked_div_int(0.saturating_sub(2)), Some(0.saturating_sub(inner_max / (2 * accuracy))));
 					assert_eq!(a.checked_div_int(0.saturating_sub(inner_max / accuracy)), Some(0.saturating_sub(1)));
-					assert_eq!(b.checked_div_int(i128::min_value()), Some(0));
+					assert_eq!(b.checked_div_int(i128::MIN), Some(0));
 					assert_eq!(b.checked_div_int(inner_min / accuracy), Some(1));
 					assert_eq!(b.checked_div_int(1i8), None);
 					assert_eq!(b.checked_div_int(0.saturating_sub(2)), Some(0.saturating_sub(inner_min / (2 * accuracy))));
 					assert_eq!(b.checked_div_int(0.saturating_sub(inner_min / accuracy)), Some(0.saturating_sub(1)));
-					assert_eq!(c.checked_div_int(i128::min_value()), Some(0));
-					assert_eq!(d.checked_div_int(i32::min_value()), Some(0));
+					assert_eq!(c.checked_div_int(i128::MIN), Some(0));
+					assert_eq!(d.checked_div_int(i32::MIN), Some(0));
 				}
 
 				assert_eq!(b.checked_div_int(2), Some(inner_min / (2 * accuracy)));
@@ -1304,10 +1304,10 @@ macro_rules! implement_fixed {
 				assert_eq!($name::one().saturating_mul_acc_int(42i8), 2 * 42i8);
 
 				assert_eq!($name::one().saturating_mul_acc_int(i128::MAX), i128::MAX);
-				assert_eq!($name::one().saturating_mul_acc_int(i128::min_value()), i128::min_value());
+				assert_eq!($name::one().saturating_mul_acc_int(i128::MIN), i128::MIN);
 
 				assert_eq!($name::one().saturating_mul_acc_int(u128::MAX / 2), u128::MAX - 1);
-				assert_eq!($name::one().saturating_mul_acc_int(u128::min_value()), u128::min_value());
+				assert_eq!($name::one().saturating_mul_acc_int(u128::MIN), u128::MIN);
 
 				if $name::SIGNED {
 					let a = $name::saturating_from_rational(-1, 2);

--- a/primitives/arithmetic/src/lib.rs
+++ b/primitives/arithmetic/src/lib.rs
@@ -499,16 +499,16 @@ mod threshold_compare_tests {
 
 	#[test]
 	fn saturating_mul_works() {
-		assert_eq!(Saturating::saturating_mul(2, i32::min_value()), i32::min_value());
+		assert_eq!(Saturating::saturating_mul(2, i32::MIN), i32::MIN);
 		assert_eq!(Saturating::saturating_mul(2, i32::MAX), i32::MAX);
 	}
 
 	#[test]
 	fn saturating_pow_works() {
-		assert_eq!(Saturating::saturating_pow(i32::min_value(), 0), 1);
+		assert_eq!(Saturating::saturating_pow(i32::MIN, 0), 1);
 		assert_eq!(Saturating::saturating_pow(i32::MAX, 0), 1);
-		assert_eq!(Saturating::saturating_pow(i32::min_value(), 3), i32::min_value());
-		assert_eq!(Saturating::saturating_pow(i32::min_value(), 2), i32::MAX);
+		assert_eq!(Saturating::saturating_pow(i32::MIN, 3), i32::MIN);
+		assert_eq!(Saturating::saturating_pow(i32::MIN, 2), i32::MAX);
 		assert_eq!(Saturating::saturating_pow(i32::MAX, 2), i32::MAX);
 	}
 }

--- a/primitives/runtime-interface/test-wasm/src/lib.rs
+++ b/primitives/runtime-interface/test-wasm/src/lib.rs
@@ -230,7 +230,7 @@ wasm_export_functions! {
 			assert_eq!(*val, test_api::get_and_return_u128(*val));
 		}
 
-		for val in &[i128::MAX, i128::min_value(), 1i128, 5000i128, u64::MAX as i128] {
+		for val in &[i128::MAX, i128::MIN, 1i128, 5000i128, u64::MAX as i128] {
 			assert_eq!(*val, test_api::get_and_return_i128(*val));
 		}
 	}


### PR DESCRIPTION
Companion PR to https://github.com/paritytech/substrate/pull/9189
min_value() is deprecared.