### PR TITLE
add functionality to stop the jsonrpc servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "jsonrpsee-http-client",
  "jsonrpsee-http-server",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-http-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "async-trait",
  "fnv",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-http-server"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-proc-macros"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-types"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "async-trait",
  "beef",
@@ -3041,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-utils"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-ws-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "async-trait",
  "fnv",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "jsonrpsee-ws-server"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/jsonrpsee?branch=master#26b061360791c08c5ddde9663bf7de60a4bdb89c"
+source = "git+https://github.com/paritytech/jsonrpsee?branch=master#c93b1e7a4640ae60a0e89b2e7344ea37e631e080"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7991,6 +7991,7 @@ dependencies = [
 name = "sc-rpc-server"
 version = "3.0.0"
 dependencies = [
+ "futures-channel",
  "jsonrpsee",
  "log",
  "serde",

--- a/client/rpc-servers/Cargo.toml
+++ b/client/rpc-servers/Cargo.toml
@@ -20,5 +20,6 @@ serde_json = "1.0.41"
 sp-runtime = { version = "3.0.0", path = "../../primitives/runtime" }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
+futures-channel = "0.3"
 jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", branch = "master", features = ["server"] }
 tokio = { version = "1", features = ["full"] }

--- a/client/rpc-servers/src/lib.rs
+++ b/client/rpc-servers/src/lib.rs
@@ -46,7 +46,6 @@ mod inner {
 		RpcModule
 	};
 
-
 	/// Type alias for http server
 	pub type HttpServer = HttpStopHandle;
 	/// Type alias for ws server

--- a/client/rpc-servers/src/lib.rs
+++ b/client/rpc-servers/src/lib.rs
@@ -22,8 +22,6 @@
 
 // mod middleware;
 
-use std::io;
-
 const MEGABYTE: usize = 1024 * 1024;
 
 /// Maximal payload accepted by RPC servers.
@@ -41,37 +39,63 @@ pub use self::inner::*;
 #[cfg(not(target_os = "unknown"))]
 mod inner {
 	use super::*;
-	use jsonrpsee::{ws_server::WsServerBuilder, http_server::HttpServerBuilder, RpcModule};
+	use futures_channel::oneshot;
+	use jsonrpsee::{
+		ws_server::{WsServerBuilder, WsStopHandle},
+		http_server::{HttpServerBuilder, HttpStopHandle},
+		RpcModule
+	};
+
+
+	/// Type alias for http server
+	pub type HttpServer = HttpStopHandle;
+	/// Type alias for ws server
+	pub type WsServer = HttpStopHandle;
 
 	/// Start HTTP server listening on given address.
 	///
 	/// **Note**: Only available if `not(target_os = "unknown")`.
-	// TODO: return handle here.
-	pub fn start_http<M: Send + Sync + 'static>(
+	pub async fn start_http<M: Send + Sync + 'static>(
 		addr: std::net::SocketAddr,
 		worker_threads: Option<usize>,
 		_cors: Option<&Vec<String>>,
 		maybe_max_payload_mb: Option<usize>,
 		module: RpcModule<M>,
-	) -> io::Result<()>  {
+	) -> Result<HttpStopHandle, String>  {
 
+		let (tx, rx) = oneshot::channel::<Result<HttpStopHandle, String>>();
 		let max_request_body_size = maybe_max_payload_mb.map(|mb| mb.saturating_mul(MEGABYTE))
 			.unwrap_or(RPC_MAX_PAYLOAD_DEFAULT);
+
 		std::thread::spawn(move || {
-			let rt = tokio::runtime::Builder::new_multi_thread()
+			let rt = match tokio::runtime::Builder::new_multi_thread()
 				.worker_threads(worker_threads.unwrap_or(HTTP_THREADS))
 				.thread_name("substrate jsonrpc http server")
 				.enable_all()
 				.build()
-				.unwrap();
+			{
+				Ok(rt) => rt,
+				Err(e) => {
+					let _ = tx.send(Err(e.to_string()));
+					return;
+				}
+			};
 
 			rt.block_on(async move {
-				let mut server = HttpServerBuilder::default()
+				let mut server = match HttpServerBuilder::default()
 					.max_request_body_size(max_request_body_size as u32)
 					.build(addr)
-					.unwrap();
+				{
+					Ok(server) => server,
+					Err(e) => {
+						let _ = tx.send(Err(e.to_string()));
+						return;
+					}
+				};
 
-				server.register_module(module).unwrap();
+				let handle = server.stop_handle();
+
+				server.register_module(module).expect("infallible already checked; qed");
 				let mut methods_api = RpcModule::new(());
 				let mut methods = server.method_names();
 				methods.sort();
@@ -81,48 +105,63 @@ mod inner {
 						"version": 1,
 						"methods": methods,
 					}))
-				}).unwrap();
+				}).expect("infallible all other methods have their own address space; qed");
 
 				server.register_module(methods_api).unwrap();
+				let _ = tx.send(Ok(handle));
 				let _ = server.start().await;
 			});
 		});
 
-		Ok(())
+		rx.await.unwrap_or(Err("Channel closed".to_string()))
 	}
 
 	/// Start WS server listening on given address.
 	///
 	/// **Note**: Only available if `not(target_os = "unknown")`.
-	pub fn start_ws<M: Send + Sync + 'static>(
+	pub async fn start_ws<M: Send + Sync + 'static>(
 		addr: std::net::SocketAddr,
 		worker_threads: Option<usize>,
 		max_connections: Option<usize>,
 		_cors: Option<&Vec<String>>,
 		maybe_max_payload_mb: Option<usize>,
 		module: RpcModule<M>,
-	) -> io::Result<()> {
+	) -> Result<WsStopHandle, String> {
+		let (tx, rx) = oneshot::channel::<Result<WsStopHandle, String>>();
 		let max_request_body_size = maybe_max_payload_mb.map(|mb| mb.saturating_mul(MEGABYTE))
 			.unwrap_or(RPC_MAX_PAYLOAD_DEFAULT);
 		let max_connections = max_connections.unwrap_or(WS_MAX_CONNECTIONS);
 
 		std::thread::spawn(move || {
-			let rt = tokio::runtime::Builder::new_multi_thread()
+			let rt = match tokio::runtime::Builder::new_multi_thread()
 				.worker_threads(worker_threads.unwrap_or(HTTP_THREADS))
 				.thread_name("substrate jsonrpc ws server")
 				.enable_all()
 				.build()
-				.unwrap();
+			{
+				Ok(rt) => rt,
+				Err(e) => {
+					let _ = tx.send(Err(e.to_string()));
+					return;
+				}
+			};
 
 			rt.block_on(async move {
-				let mut server = WsServerBuilder::default()
+				let mut server = match WsServerBuilder::default()
 					.max_request_body_size(max_request_body_size as u32)
 					.max_connections(max_connections as u64)
 					.build(addr)
 					.await
-					.unwrap();
+				{
+					Ok(server) => server,
+					Err(e) => {
+						let _ = tx.send(Err(e.to_string()));
+						return;
+					}
+				};
 
-				server.register_module(module).unwrap();
+				let handle = server.stop_handle();
+				server.register_module(module).expect("infallible already checked; qed");
 				let mut methods_api = RpcModule::new(());
 				let mut methods = server.method_names();
 				methods.sort();
@@ -132,14 +171,15 @@ mod inner {
 						"version": 1,
 						"methods": methods,
 					}))
-				}).unwrap();
+				}).expect("infallible all other methods have their own address space; qed");
 
 				server.register_module(methods_api).unwrap();
-
+				let _ = tx.send(Ok(handle));
 				let _ = server.start().await;
 			});
 		});
-		Ok(())
+
+		rx.await.unwrap_or(Err("Channel closed".to_string()))
 	}
 
 	// TODO: CORS and host filtering.

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -684,7 +684,6 @@ pub fn spawn_tasks<TBl, TBackend, TExPool, TRpc, TCl>(
 
 	// TODO(niklasad1): this will block the current thread until the servers have been started
 	// we could spawn it in the background but then the errors must be handled via a channel or something
-	// must be passed around to be checked somewhere else.
 	let rpc = futures::executor::block_on(start_rpc_servers(&config, gen_rpc_module))?;
 
 	// NOTE(niklasad1): dummy type for now.

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -682,7 +682,7 @@ pub fn spawn_tasks<TBl, TBackend, TExPool, TRpc, TCl>(
 		)
 	};
 
-	// TODO(niklasad1): the will block the current thread until the servers have been started
+	// TODO(niklasad1): this will block the current thread until the servers have been started
 	// we could spawn it in the background but then errors can be handled or a channel or something
 	// must be passed around to be checked somewhere else.
 	let rpc = futures::executor::block_on(start_rpc_servers(&config, gen_rpc_module))?;

--- a/client/service/src/builder.rs
+++ b/client/service/src/builder.rs
@@ -683,7 +683,7 @@ pub fn spawn_tasks<TBl, TBackend, TExPool, TRpc, TCl>(
 	};
 
 	// TODO(niklasad1): this will block the current thread until the servers have been started
-	// we could spawn it in the background but then errors can be handled or a channel or something
+	// we could spawn it in the background but then the errors must be handled via a channel or something
 	// must be passed around to be checked somewhere else.
 	let rpc = futures::executor::block_on(start_rpc_servers(&config, gen_rpc_module))?;
 

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -297,19 +297,23 @@ async fn build_network_future<
 // TODO(niklasad1): WsSocket server is not fully "closeable" at the moment.
 mod waiting {
 	pub struct HttpServer(pub Option<sc_rpc_server::HttpServer>);
+
 	impl Drop for HttpServer {
 		fn drop(&mut self) {
-			if let Some(server) = self.0.take() {
-				futures::executor::block_on(server.wait_for_stop())
+			if let Some(mut server) = self.0.take() {
+				futures::executor::block_on(server.stop());
+				futures::executor::block_on(server.wait_for_stop());
 			}
 		}
 	}
 
 	pub struct WsServer(pub Option<sc_rpc_server::WsServer>);
+
 	impl Drop for WsServer {
 		fn drop(&mut self) {
-			if let Some(server) = self.0.take() {
-				futures::executor::block_on(server.wait_for_stop())
+			if let Some(mut server) = self.0.take() {
+				futures::executor::block_on(server.stop());
+				futures::executor::block_on(server.wait_for_stop());
 			}
 		}
 	}

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -294,13 +294,31 @@ async fn build_network_future<
 
 #[cfg(not(target_os = "unknown"))]
 // Wrapper for HTTP and WS servers that makes sure they are properly shut down.
-// TODO(niklasad1): not supported yet.
-mod waiting {}
+// TODO(niklasad1): WsSocket server is not fully "closeable" at the moment.
+mod waiting {
+	pub struct HttpServer(pub Option<sc_rpc_server::HttpServer>);
+	impl Drop for HttpServer {
+		fn drop(&mut self) {
+			if let Some(server) = self.0.take() {
+				futures::executor::block_on(server.wait_for_stop())
+			}
+		}
+	}
+
+	pub struct WsServer(pub Option<sc_rpc_server::WsServer>);
+	impl Drop for WsServer {
+		fn drop(&mut self) {
+			if let Some(server) = self.0.take() {
+				futures::executor::block_on(server.wait_for_stop())
+			}
+		}
+	}
+}
 
 /// Starts RPC servers that run in their own thread, and returns an opaque object that keeps them alive.
 /// Once this is called, no more methods can be added to the server.
 #[cfg(not(target_os = "unknown"))]
-fn start_rpc_servers<R>(
+async fn start_rpc_servers<R>(
 	config: &Configuration,
 	gen_rpc_module: R,
 ) -> Result<Box<dyn std::any::Any + Send + Sync>, error::Error>
@@ -317,7 +335,7 @@ where
 		config.rpc_cors.as_ref(),
 		config.rpc_max_payload,
 		module.clone(),
-	);
+	).await?;
 
 	let ws = sc_rpc_server::start_ws(
 		ws_addr,
@@ -326,7 +344,7 @@ where
 		config.rpc_cors.as_ref(),
 		config.rpc_max_payload,
 		module,
-	);
+	).await?;
 
 	Ok(Box::new((http, ws)))
 }


### PR DESCRIPTION
Add functionality for stopping the servers, note the `WsServer` won't terminate the current background task for the connection which we should fix in jsonrpsee but this more or less follows the previous design except that initializing is done inside of async methods.