### PR TITLE
Remove `txpool` as an export of `sc_transaction_pool`, exporting the used components instead.

### DIFF
--- a/client/consensus/manual-seal/src/lib.rs
+++ b/client/consensus/manual-seal/src/lib.rs
@@ -29,7 +29,7 @@ use sp_blockchain::HeaderBackend;
 use sp_inherents::CreateInherentDataProviders;
 use sp_runtime::{traits::Block as BlockT, Justifications, ConsensusEngineId};
 use sc_client_api::backend::{Backend as ClientBackend, Finalizer};
-use sc_transaction_pool::txpool;
+use sc_transaction_pool::{ChainApi, Pool};
 use std::{sync::Arc, marker::PhantomData};
 use prometheus_endpoint::Registry;
 
@@ -94,7 +94,7 @@ pub fn import_queue<Block, Transaction>(
 }
 
 /// Params required to start the instant sealing authorship task.
-pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpool::ChainApi, SC, CS, CIDP> {
+pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: ChainApi, SC, CS, CIDP> {
 	/// Block import instance for well. importing blocks.
 	pub block_import: BI,
 
@@ -105,7 +105,7 @@ pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpool
 	pub client: Arc<C>,
 
 	/// Shared reference to the transaction pool.
-	pub pool: Arc<txpool::Pool<A>>,
+	pub pool: Arc<Pool<A>>,
 
 	/// Stream<Item = EngineCommands>, Basically the receiving end of a channel for sending commands to
 	/// the authorship task.
@@ -122,7 +122,7 @@ pub struct ManualSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpool
 }
 
 /// Params required to start the manual sealing authorship task.
-pub struct InstantSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpool::ChainApi, SC, CIDP> {
+pub struct InstantSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: ChainApi, SC, CIDP> {
 	/// Block import instance for well. importing blocks.
 	pub block_import: BI,
 
@@ -133,7 +133,7 @@ pub struct InstantSealParams<B: BlockT, BI, E, C: ProvideRuntimeApi<B>, A: txpoo
 	pub client: Arc<C>,
 
 	/// Shared reference to the transaction pool.
-	pub pool: Arc<txpool::Pool<A>>,
+	pub pool: Arc<Pool<A>>,
 
 	/// SelectChain strategy.
 	pub select_chain: SC,
@@ -159,7 +159,7 @@ pub async fn run_manual_seal<B, BI, CB, E, C, A, SC, CS, CIDP>(
 	}: ManualSealParams<B, BI, E, C, A, SC, CS, CIDP>
 )
 	where
-		A: txpool::ChainApi<Block=B> + 'static,
+		A: ChainApi<Block=B> + 'static,
 		B: BlockT + 'static,
 		BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
 			+ Send + Sync + 'static,
@@ -227,7 +227,7 @@ pub async fn run_instant_seal<B, BI, CB, E, C, A, SC, CIDP>(
 	}: InstantSealParams<B, BI, E, C, A, SC, CIDP>
 )
 	where
-		A: txpool::ChainApi<Block=B> + 'static,
+		A: ChainApi<Block=B> + 'static,
 		B: BlockT + 'static,
 		BI: BlockImport<B, Error = sp_consensus::Error, Transaction = sp_api::TransactionFor<C, B>>
 			+ Send + Sync + 'static,
@@ -275,7 +275,7 @@ mod tests {
 		AccountKeyring::*,
 		TestClientBuilder,
 	};
-	use sc_transaction_pool::{BasicPool, RevalidationType, txpool::Options};
+	use sc_transaction_pool::{BasicPool, RevalidationType, Options};
 	use substrate_test_runtime_transaction_pool::{TestApi, uxt};
 	use sp_transaction_pool::{TransactionPool, MaintainedTransactionPool, TransactionSource};
 	use sp_runtime::generic::BlockId;

--- a/client/consensus/manual-seal/src/seal_block.rs
+++ b/client/consensus/manual-seal/src/seal_block.rs
@@ -25,7 +25,7 @@ use sp_runtime::{
 	generic::BlockId,
 };
 use futures::prelude::*;
-use sc_transaction_pool::txpool;
+use sc_transaction_pool::{ChainApi, Pool};
 use sp_consensus::{
 	self, BlockImport, Environment, Proposer, ForkChoiceStrategy,
 	BlockImportParams, BlockOrigin, ImportResult, SelectChain, StateAction,
@@ -40,7 +40,7 @@ use sp_api::{ProvideRuntimeApi, TransactionFor};
 pub const MAX_PROPOSAL_DURATION: u64 = 10;
 
 /// params for sealing a new block
-pub struct SealBlockParams<'a, B: BlockT, BI, SC, C: ProvideRuntimeApi<B>, E, P: txpool::ChainApi, CIDP> {
+pub struct SealBlockParams<'a, B: BlockT, BI, SC, C: ProvideRuntimeApi<B>, E, P: ChainApi, CIDP> {
 	/// if true, empty blocks(without extrinsics) will be created.
 	/// otherwise, will return Error::EmptyTransactionPool.
 	pub create_empty: bool,
@@ -51,7 +51,7 @@ pub struct SealBlockParams<'a, B: BlockT, BI, SC, C: ProvideRuntimeApi<B>, E, P:
 	/// sender to report errors/success to the rpc.
 	pub sender: rpc::Sender<CreatedBlock<<B as BlockT>::Hash>>,
 	/// transaction pool
-	pub pool: Arc<txpool::Pool<P>>,
+	pub pool: Arc<Pool<P>>,
 	/// header backend
 	pub client: Arc<C>,
 	/// Environment trait object for creating a proposer
@@ -90,7 +90,7 @@ pub async fn seal_block<B, BI, SC, C, E, P, CIDP>(
 	C: HeaderBackend<B> + ProvideRuntimeApi<B>,
 	E: Environment<B>,
 	E::Proposer: Proposer<B, Transaction = TransactionFor<C, B>>,
-	P: txpool::ChainApi<Block = B>,
+	P: ChainApi<Block = B>,
 	SC: SelectChain<B>,
 	TransactionFor<C, B>: 'static,
 	CIDP: CreateInherentDataProviders<B, ()>,

--- a/client/service/src/config.rs
+++ b/client/service/src/config.rs
@@ -32,7 +32,7 @@ pub use sc_executor::WasmExecutionMethod;
 pub use sc_client_api::execution_extensions::{ExecutionStrategies, ExecutionStrategy};
 
 use std::{io, future::Future, path::{PathBuf, Path}, pin::Pin, net::SocketAddr, sync::Arc};
-pub use sc_transaction_pool::txpool::Options as TransactionPoolOptions;
+pub use sc_transaction_pool::Options as TransactionPoolOptions;
 use sc_chain_spec::ChainSpec;
 use sp_core::crypto::SecretString;
 pub use sc_telemetry::TelemetryEndpoints;

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -65,7 +65,7 @@ pub use sc_chain_spec::{
 	NoExtension, ChainType,
 };
 pub use sp_transaction_pool::{TransactionPool, InPoolTransaction, error::IntoPoolError};
-pub use sc_transaction_pool::txpool::Options as TransactionPoolOptions;
+pub use sc_transaction_pool::Options as TransactionPoolOptions;
 pub use sc_rpc::Metadata as RpcMetadata;
 pub use sc_executor::NativeExecutionDispatch;
 #[doc(hidden)]

--- a/client/transaction-pool/src/lib.rs
+++ b/client/transaction-pool/src/lib.rs
@@ -31,7 +31,7 @@ pub mod error;
 #[cfg(test)]
 pub mod testing;
 
-pub use sc_transaction_graph as txpool;
+pub use sc_transaction_graph::{ChainApi, Options, Pool};
 pub use crate::api::{FullChainApi, LightChainApi};
 
 use std::{collections::{HashMap, HashSet}, sync::Arc, pin::Pin, convert::TryInto};
@@ -48,7 +48,7 @@ use sp_transaction_pool::{
 	TransactionStatusStreamFor, MaintainedTransactionPool, PoolFuture, ChainEvent,
 	TransactionSource,
 };
-use sc_transaction_graph::{ChainApi, ExtrinsicHash};
+use sc_transaction_graph::{IsValidator, ExtrinsicHash};
 use wasm_timer::Instant;
 
 use prometheus_endpoint::Registry as PrometheusRegistry;
@@ -191,7 +191,7 @@ impl<PoolApi, Block> BasicPool<PoolApi, Block>
 	/// revalidation type.
 	pub fn with_revalidation_type(
 		options: sc_transaction_graph::Options,
-		is_validator: txpool::IsValidator,
+		is_validator: IsValidator,
 		pool_api: Arc<PoolApi>,
 		prometheus: Option<&PrometheusRegistry>,
 		revalidation_type: RevalidationType,
@@ -397,7 +397,7 @@ where
 	/// Create new basic transaction pool for a full node with the provided api.
 	pub fn new_full(
 		options: sc_transaction_graph::Options,
-		is_validator: txpool::IsValidator,
+		is_validator: IsValidator,
 		prometheus: Option<&PrometheusRegistry>,
 		spawner: impl SpawnEssentialNamed,
 		client: Arc<Client>,

--- a/client/transaction-pool/src/testing/pool.rs
+++ b/client/transaction-pool/src/testing/pool.rs
@@ -19,7 +19,6 @@
 use crate::*;
 use sp_transaction_pool::TransactionStatus;
 use futures::executor::{block_on, block_on_stream};
-use txpool::{self, Pool};
 use sp_runtime::{
 	generic::BlockId,
 	transaction_validity::{ValidTransaction, TransactionSource, InvalidTransaction},


### PR DESCRIPTION
Closes #9216.