### PR TITLE
Add public accessor for tip amount

### DIFF
--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -525,8 +525,8 @@ impl<T: Config> ChargeTransactionPayment<T> where
 		Self(fee)
 	}
 
-	/// Public accessor to get the amount of the tip that will be applied.
-	pub fn tip_amount(&self) -> BalanceOf<T> {
+	/// Returns the tip as being choosen by the transaction sender.
+	pub fn tip(&self) -> BalanceOf<T> {
 		self.0
 	}
 

--- a/frame/transaction-payment/src/lib.rs
+++ b/frame/transaction-payment/src/lib.rs
@@ -525,6 +525,11 @@ impl<T: Config> ChargeTransactionPayment<T> where
 		Self(fee)
 	}
 
+	/// Public accessor to get the amount of the tip that will be applied.
+	pub fn tip_amount(&self) -> BalanceOf<T> {
+		self.0
+	}
+
 	fn withdraw_fee(
 		&self,
 		who: &T::AccountId,


### PR DESCRIPTION
This PR adds a public accessor function to the `ChargeTransactionPayment` struct. This is useful in chains using https://github.com/paritytech/frontier/ to be able to properly prioritize "normal" FRAME transactions alongside ethereum transactions.