### PR TITLE
Implement `iter_keys` function for all types of storage maps

### DIFF
--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -377,10 +377,6 @@ impl<
 		iterator
 	}
 
-	fn drain_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator {
-		Self::iter_key_prefix(k1).drain()
-	}
-
 	fn iter() -> Self::Iterator {
 		let prefix = G::prefix_hash();
 		Self::Iterator {
@@ -417,10 +413,6 @@ impl<
 		let mut iterator = Self::iter();
 		iterator.drain = true;
 		iterator
-	}
-
-	fn drain_keys() -> Self::KeyIterator {
-		Self::iter_keys().drain()
 	}
 
 	fn translate<O: Decode, F: FnMut(K1, K2, O) -> Option<V>>(mut f: F) {

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -18,7 +18,7 @@
 use sp_std::prelude::*;
 use sp_std::borrow::Borrow;
 use codec::{FullCodec, FullEncode, Decode, Encode, EncodeLike};
-use crate::{storage::{self, unhashed, StorageAppend, PrefixIterator}, Never};
+use crate::{storage::{self, unhashed, KeyPrefixIterator, StorageAppend, PrefixIterator}, Never};
 use crate::hash::{StorageHasher, Twox128, ReversibleStorageHasher};
 
 /// Generator for `StorageDoubleMap` used by `decl_storage`.
@@ -340,7 +340,9 @@ impl<
 	G::Hasher1: ReversibleStorageHasher,
 	G::Hasher2: ReversibleStorageHasher
 {
+	type KeyPrefixIterator = KeyPrefixIterator<K2>;
 	type PrefixIterator = PrefixIterator<(K2, V)>;
+	type KeyIterator = KeyPrefixIterator<(K1, K2)>;
 	type Iterator = PrefixIterator<(K1, K2, V)>;
 
 	fn iter_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator {
@@ -356,10 +358,27 @@ impl<
 		}
 	}
 
+	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator {
+		let prefix = G::storage_double_map_final_key1(k1);
+		Self::KeyPrefixIterator {
+			prefix: prefix.clone(),
+			previous_key: prefix,
+			drain: false,
+			closure: |raw_key_without_prefix| {
+				let mut key_material = G::Hasher2::reverse(raw_key_without_prefix);
+				K2::decode(&mut key_material)
+			}
+		}
+	}
+
 	fn drain_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator {
 		let mut iterator = Self::iter_prefix(k1);
 		iterator.drain = true;
 		iterator
+	}
+
+	fn drain_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator {
+		Self::iter_key_prefix(k1).drain()
 	}
 
 	fn iter() -> Self::Iterator {
@@ -378,10 +397,30 @@ impl<
 		}
 	}
 
+	fn iter_keys() -> Self::KeyIterator {
+		let prefix = G::prefix_hash();
+		Self::KeyIterator {
+			prefix: prefix.clone(),
+			previous_key: prefix,
+			drain: false,
+			closure: |raw_key_without_prefix| {
+				let mut k1_k2_material = G::Hasher1::reverse(raw_key_without_prefix);
+				let k1 = K1::decode(&mut k1_k2_material)?;
+				let mut k2_material = G::Hasher2::reverse(k1_k2_material);
+				let k2 = K2::decode(&mut k2_material)?;
+				Ok((k1, k2))
+			}
+		}
+	}
+
 	fn drain() -> Self::Iterator {
 		let mut iterator = Self::iter();
 		iterator.drain = true;
 		iterator
+	}
+
+	fn drain_keys() -> Self::KeyIterator {
+		Self::iter_keys().drain()
 	}
 
 	fn translate<O: Decode, F: FnMut(K1, K2, O) -> Option<V>>(mut f: F) {
@@ -486,6 +525,11 @@ mod test_iterators {
 			);
 
 			assert_eq!(
+				DoubleMap::iter_keys().collect::<Vec<_>>(),
+				vec![(3, 3), (0, 0), (2, 2), (1, 1)],
+			);
+
+			assert_eq!(
 				DoubleMap::iter_values().collect::<Vec<_>>(),
 				vec![3, 0, 2, 1],
 			);
@@ -513,6 +557,11 @@ mod test_iterators {
 			assert_eq!(
 				DoubleMap::iter_prefix(k1).collect::<Vec<_>>(),
 				vec![(1, 1), (2, 2), (0, 0), (3, 3)],
+			);
+
+			assert_eq!(
+				DoubleMap::iter_key_prefix(k1).collect::<Vec<_>>(),
+				vec![1, 2, 0, 3],
 			);
 
 			assert_eq!(

--- a/frame/support/src/storage/generator/double_map.rs
+++ b/frame/support/src/storage/generator/double_map.rs
@@ -340,9 +340,9 @@ impl<
 	G::Hasher1: ReversibleStorageHasher,
 	G::Hasher2: ReversibleStorageHasher
 {
-	type KeyPrefixIterator = KeyPrefixIterator<K2>;
+	type PartialKeyIterator = KeyPrefixIterator<K2>;
 	type PrefixIterator = PrefixIterator<(K2, V)>;
-	type KeyIterator = KeyPrefixIterator<(K1, K2)>;
+	type FullKeyIterator = KeyPrefixIterator<(K1, K2)>;
 	type Iterator = PrefixIterator<(K1, K2, V)>;
 
 	fn iter_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator {
@@ -358,9 +358,9 @@ impl<
 		}
 	}
 
-	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator {
+	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::PartialKeyIterator {
 		let prefix = G::storage_double_map_final_key1(k1);
-		Self::KeyPrefixIterator {
+		Self::PartialKeyIterator {
 			prefix: prefix.clone(),
 			previous_key: prefix,
 			drain: false,
@@ -393,9 +393,9 @@ impl<
 		}
 	}
 
-	fn iter_keys() -> Self::KeyIterator {
+	fn iter_keys() -> Self::FullKeyIterator {
 		let prefix = G::prefix_hash();
-		Self::KeyIterator {
+		Self::FullKeyIterator {
 			prefix: prefix.clone(),
 			previous_key: prefix,
 			drain: false,

--- a/frame/support/src/storage/generator/map.rs
+++ b/frame/support/src/storage/generator/map.rs
@@ -177,11 +177,6 @@ impl<
 		iterator
 	}
 
-	/// Enumerate all keys in the map.
-	fn drain_keys() -> Self::KeyIterator {
-		Self::iter_keys().drain()
-	}
-
 	fn translate<O: Decode, F: FnMut(K, O) -> Option<V>>(mut f: F) {
 		let prefix = G::prefix_hash();
 		let mut previous_key = prefix.clone();

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -351,13 +351,6 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		iter
 	}
 
-	fn drain_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
-	where
-		K: HasReversibleKeyPrefix<KP>,
-	{
-		Self::iter_key_prefix(kp).drain()
-	}
-
 	fn iter() -> Self::Iterator {
 		let prefix = G::prefix_hash();
 		Self::Iterator {
@@ -388,10 +381,6 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		let mut iterator = Self::iter();
 		iterator.drain = true;
 		iterator
-	}
-
-	fn drain_keys() -> Self::KeyIterator {
-		Self::iter_keys().drain()
 	}
 
 	fn translate<O: Decode, F: FnMut(K::Key, O) -> Option<V>>(mut f: F) {

--- a/frame/support/src/storage/generator/nmap.rs
+++ b/frame/support/src/storage/generator/nmap.rs
@@ -37,7 +37,7 @@ use crate::{
 			EncodeLikeTuple, HasKeyPrefix, HasReversibleKeyPrefix, KeyGenerator,
 			ReversibleKeyGenerator, TupleToEncodedIter,
 		},
-		unhashed, PrefixIterator, StorageAppend,
+		unhashed, KeyPrefixIterator, PrefixIterator, StorageAppend,
 	},
 	Never,
 };
@@ -310,6 +310,7 @@ where
 impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 	storage::IterableStorageNMap<K, V> for G
 {
+	type KeyIterator = KeyPrefixIterator<K::Key>;
 	type Iterator = PrefixIterator<(K::Key, V)>;
 
 	fn iter_prefix<KP>(kp: KP) -> PrefixIterator<(<K as HasKeyPrefix<KP>>::Suffix, V)>
@@ -328,6 +329,19 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		}
 	}
 
+	fn iter_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
+	where
+		K: HasReversibleKeyPrefix<KP>,
+	{
+		let prefix = G::storage_n_map_partial_key(kp);
+		KeyPrefixIterator {
+			prefix: prefix.clone(),
+			previous_key: prefix,
+			drain: false,
+			closure: K::decode_partial_key,
+		}
+	}
+
 	fn drain_prefix<KP>(kp: KP) -> PrefixIterator<(<K as HasKeyPrefix<KP>>::Suffix, V)>
 	where
 		K: HasReversibleKeyPrefix<KP>,
@@ -335,6 +349,13 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		let mut iter = Self::iter_prefix(kp);
 		iter.drain = true;
 		iter
+	}
+
+	fn drain_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
+	where
+		K: HasReversibleKeyPrefix<KP>,
+	{
+		Self::iter_key_prefix(kp).drain()
 	}
 
 	fn iter() -> Self::Iterator {
@@ -350,10 +371,27 @@ impl<K: ReversibleKeyGenerator, V: FullCodec, G: StorageNMap<K, V>>
 		}
 	}
 
+	fn iter_keys() -> Self::KeyIterator {
+		let prefix = G::prefix_hash();
+		Self::KeyIterator {
+			prefix: prefix.clone(),
+			previous_key: prefix,
+			drain: false,
+			closure: |raw_key_without_prefix| {
+				let (final_key, _) = K::decode_final_key(raw_key_without_prefix)?;
+				Ok(final_key)
+			}
+		}
+	}
+
 	fn drain() -> Self::Iterator {
 		let mut iterator = Self::iter();
 		iterator.drain = true;
 		iterator
+	}
+
+	fn drain_keys() -> Self::KeyIterator {
+		Self::iter_keys().drain()
 	}
 
 	fn translate<O: Decode, F: FnMut(K::Key, O) -> Option<V>>(mut f: F) {
@@ -471,6 +509,11 @@ mod test_iterators {
 				vec![((3, 3), 3), ((0, 0), 0), ((2, 2), 2), ((1, 1), 1)],
 			);
 
+			assert_eq!(
+				NMap::iter_keys().collect::<Vec<_>>(),
+				vec![(3, 3), (0, 0), (2, 2), (1, 1)],
+			);
+
 			assert_eq!(NMap::iter_values().collect::<Vec<_>>(), vec![3, 0, 2, 1],);
 
 			assert_eq!(
@@ -499,6 +542,11 @@ mod test_iterators {
 			assert_eq!(
 				NMap::iter_prefix((k1,)).collect::<Vec<_>>(),
 				vec![(1, 1), (2, 2), (0, 0), (3, 3)],
+			);
+
+			assert_eq!(
+				NMap::iter_key_prefix((k1,)).collect::<Vec<_>>(),
+				vec![1, 2, 0, 3],
 			);
 
 			assert_eq!(

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -343,13 +343,13 @@ pub trait IterableStorageDoubleMap<
 	V: FullCodec
 >: StorageDoubleMap<K1, K2, V> {
 	/// The type that iterates over all `key2`.
-	type KeyPrefixIterator: Iterator<Item = K2>;
+	type PartialKeyIterator: Iterator<Item = K2>;
 
 	/// The type that iterates over all `(key2, value)`.
 	type PrefixIterator: Iterator<Item = (K2, V)>;
 
 	/// The type that iterates over all `(key1, key2)`.
-	type KeyIterator: Iterator<Item = (K1, K2)>;
+	type FullKeyIterator: Iterator<Item = (K1, K2)>;
 
 	/// The type that iterates over all `(key1, key2, value)`.
 	type Iterator: Iterator<Item = (K1, K2, V)>;
@@ -362,7 +362,7 @@ pub trait IterableStorageDoubleMap<
 	/// Enumerate all second keys `k2` in the map with the same first key `k1` in no particular
 	/// order. If you add or remove values whose first key is `k1` to the map while doing this,
 	/// you'll get undefined results.
-	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator;
+	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::PartialKeyIterator;
 
 	/// Remove all elements from the map with first key `k1` and iterate through them in no
 	/// particular order. If you add elements with first key `k1` to the map while doing this,
@@ -375,7 +375,7 @@ pub trait IterableStorageDoubleMap<
 	
 	/// Enumerate all keys `k1` and `k2` in the map in no particular order. If you add or remove
 	/// values to the map while doing this, you'll get undefined results.
-	fn iter_keys() -> Self::KeyIterator;
+	fn iter_keys() -> Self::FullKeyIterator;
 
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -314,14 +314,24 @@ pub trait StorageMap<K: FullEncode, V: FullCodec> {
 pub trait IterableStorageMap<K: FullEncode, V: FullCodec>: StorageMap<K, V> {
 	/// The type that iterates over all `(key, value)`.
 	type Iterator: Iterator<Item = (K, V)>;
+	/// The type that itereates over all `key`s.
+	type KeyIterator: Iterator<Item = K>;
 
 	/// Enumerate all elements in the map in no particular order. If you alter the map while doing
 	/// this, you'll get undefined results.
 	fn iter() -> Self::Iterator;
 
+	/// Enumerate all keys in the map in no particular order, skipping over the elements. If you
+	/// alter the map while doing this, you'll get undefined results.
+	fn iter_keys() -> Self::KeyIterator;
+
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
+
+	/// Remove all elements from the map and iterate through only the keys in no particular order.
+	/// If you add elements to the map while doing this. you'll get undefined results.
+	fn drain_keys() -> Self::KeyIterator;
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
@@ -336,8 +346,14 @@ pub trait IterableStorageDoubleMap<
 	K2: FullCodec,
 	V: FullCodec
 >: StorageDoubleMap<K1, K2, V> {
+	/// The type that iterates over all `key2`.
+	type KeyPrefixIterator: Iterator<Item = K2>;
+
 	/// The type that iterates over all `(key2, value)`.
 	type PrefixIterator: Iterator<Item = (K2, V)>;
+
+	/// The type that iterates over all `(key1, key2)`.
+	type KeyIterator: Iterator<Item = (K1, K2)>;
 
 	/// The type that iterates over all `(key1, key2, value)`.
 	type Iterator: Iterator<Item = (K1, K2, V)>;
@@ -347,18 +363,37 @@ pub trait IterableStorageDoubleMap<
 	/// results.
 	fn iter_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator;
 
+	/// Enumerate all second keys `k2` in the map with the same first key `k1` in no particular
+	/// order. If you add or remove values whose first key is `k1` to the map while doing this,
+	/// you'll get undefined results.
+	fn iter_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator;
+
 	/// Remove all elements from the map with first key `k1` and iterate through them in no
 	/// particular order. If you add elements with first key `k1` to the map while doing this,
 	/// you'll get undefined results.
 	fn drain_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator;
 
+	/// Remove all elements from the map with the same first key `k1` and iterate through the
+	/// second key `k2` in no particular order. If you add elements with first key `k1` to the map
+	/// while doing this, you'll get undefined results.
+	fn drain_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator;
+
 	/// Enumerate all elements in the map in no particular order. If you add or remove values to
 	/// the map while doing this, you'll get undefined results.
 	fn iter() -> Self::Iterator;
+	
+	/// Enumerate all keys `k1` and `k2` in the map in no particular order. If you add or remove
+	/// values to the map while doing this, you'll get undefined results.
+	fn iter_keys() -> Self::KeyIterator;
 
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
+
+	/// Remove all elements from the map and iterate through the first and second keys `k1`, `k2`
+	/// in no particular order. If you add elements to the map while doing this, you'll get
+	/// undefined results.
+	fn drain_keys() -> Self::KeyIterator;
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
@@ -370,7 +405,10 @@ pub trait IterableStorageDoubleMap<
 /// A strongly-typed map with arbitrary number of keys in storage whose keys and values can be
 /// iterated over.
 pub trait IterableStorageNMap<K: ReversibleKeyGenerator, V: FullCodec>: StorageNMap<K, V> {
-	/// The type that iterates over all `(key1, (key2, (key3, ... (keyN, ()))), value)` tuples
+	/// The type that iterates over all `(key1, key2, key3, ... keyN)` tuples.
+	type KeyIterator: Iterator<Item = K::Key>;
+
+	/// The type that iterates over all `(key1, key2, key3, ... keyN), value)` tuples.
 	type Iterator: Iterator<Item = (K::Key, V)>;
 
 	/// Enumerate all elements in the map with prefix key `kp` in no particular order. If you add or
@@ -379,19 +417,39 @@ pub trait IterableStorageNMap<K: ReversibleKeyGenerator, V: FullCodec>: StorageN
 	fn iter_prefix<KP>(kp: KP) -> PrefixIterator<(<K as HasKeyPrefix<KP>>::Suffix, V)>
 	where K: HasReversibleKeyPrefix<KP>;
 
+	/// Enumerate all suffix keys in the map with prefix key `kp` in no particular order. If you
+	/// add or remove values whose prefix is `kp` to the map while doing this, you'll get undefined
+	/// results.
+	fn iter_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
+	where K: HasReversibleKeyPrefix<KP>;
+
 	/// Remove all elements from the map with prefix key `kp` and iterate through them in no
 	/// particular order. If you add elements with prefix key `kp` to the map while doing this,
 	/// you'll get undefined results.
 	fn drain_prefix<KP>(kp: KP) -> PrefixIterator<(<K as HasKeyPrefix<KP>>::Suffix, V)>
 	where K: HasReversibleKeyPrefix<KP>;
 
+	/// Remove all elements from the map with prefix key `kp` and iterate through the suffix keys
+	/// in no particular order. If you add elements with prefix key `kp` to the map while doing
+	/// this, you'll get undefined results.
+	fn drain_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
+	where K: HasReversibleKeyPrefix<KP>;
+
 	/// Enumerate all elements in the map in no particular order. If you add or remove values to
 	/// the map while doing this, you'll get undefined results.
 	fn iter() -> Self::Iterator;
 
+	/// Enumerate all keys in the map in no particular order. If you add or remove values to the
+	/// map while doing this, you'll get undefined results.
+	fn iter_keys() -> Self::KeyIterator;
+
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
+
+	/// Remove all elements from the map and iterate through the keys in no particular order. If
+	/// you add elements to the map while doing this, you'll get undefined results.
+	fn drain_keys() -> Self::KeyIterator;
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
@@ -722,6 +780,61 @@ impl<T> Iterator for PrefixIterator<T> {
 								e,
 							);
 							continue
+						}
+					};
+
+					Some(item)
+				}
+				None => None,
+			}
+		}
+	}
+}
+
+/// Iterate over a prefix and decode raw_key into `T`.
+///
+/// If any decoding fails it skips it and continues to the next key.
+pub struct KeyPrefixIterator<T> {
+	prefix: Vec<u8>,
+	previous_key: Vec<u8>,
+	/// If true then value are removed while iterating
+	drain: bool,
+	/// Function that take `raw_key_without_prefix` and decode `T`.
+	/// `raw_key_without_prefix` is the raw storage key without the prefix iterated on.
+	closure: fn(&[u8]) -> Result<T, codec::Error>,
+}
+
+impl<T> KeyPrefixIterator<T> {
+	/// Mutate this iterator into a draining iterator; items iterated are removed from storage.
+	pub fn drain(mut self) -> Self {
+		self.drain = true;
+		self
+	}
+}
+
+impl<T> Iterator for KeyPrefixIterator<T> {
+	type Item = T;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		loop {
+			let maybe_next = sp_io::storage::next_key(&self.previous_key)
+				.filter(|n| n.starts_with(&self.prefix));
+			break match maybe_next {
+				Some(next) => {
+					self.previous_key = next;
+					if self.drain {
+						unhashed::kill(&self.previous_key);
+					}
+					let raw_key_without_prefix = &self.previous_key[self.prefix.len()..];
+					let item = match (self.closure)(raw_key_without_prefix) {
+						Ok(item) => item,
+						Err(e) => {
+							log::error!(
+								"key failed to decode at {:?}: {:?}",
+								self.previous_key,
+								e,
+							);
+							continue;
 						}
 					};
 

--- a/frame/support/src/storage/mod.rs
+++ b/frame/support/src/storage/mod.rs
@@ -329,10 +329,6 @@ pub trait IterableStorageMap<K: FullEncode, V: FullCodec>: StorageMap<K, V> {
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
 
-	/// Remove all elements from the map and iterate through only the keys in no particular order.
-	/// If you add elements to the map while doing this. you'll get undefined results.
-	fn drain_keys() -> Self::KeyIterator;
-
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
 	///
@@ -373,11 +369,6 @@ pub trait IterableStorageDoubleMap<
 	/// you'll get undefined results.
 	fn drain_prefix(k1: impl EncodeLike<K1>) -> Self::PrefixIterator;
 
-	/// Remove all elements from the map with the same first key `k1` and iterate through the
-	/// second key `k2` in no particular order. If you add elements with first key `k1` to the map
-	/// while doing this, you'll get undefined results.
-	fn drain_key_prefix(k1: impl EncodeLike<K1>) -> Self::KeyPrefixIterator;
-
 	/// Enumerate all elements in the map in no particular order. If you add or remove values to
 	/// the map while doing this, you'll get undefined results.
 	fn iter() -> Self::Iterator;
@@ -389,11 +380,6 @@ pub trait IterableStorageDoubleMap<
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
-
-	/// Remove all elements from the map and iterate through the first and second keys `k1`, `k2`
-	/// in no particular order. If you add elements to the map while doing this, you'll get
-	/// undefined results.
-	fn drain_keys() -> Self::KeyIterator;
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.
@@ -429,12 +415,6 @@ pub trait IterableStorageNMap<K: ReversibleKeyGenerator, V: FullCodec>: StorageN
 	fn drain_prefix<KP>(kp: KP) -> PrefixIterator<(<K as HasKeyPrefix<KP>>::Suffix, V)>
 	where K: HasReversibleKeyPrefix<KP>;
 
-	/// Remove all elements from the map with prefix key `kp` and iterate through the suffix keys
-	/// in no particular order. If you add elements with prefix key `kp` to the map while doing
-	/// this, you'll get undefined results.
-	fn drain_key_prefix<KP>(kp: KP) -> KeyPrefixIterator<<K as HasKeyPrefix<KP>>::Suffix>
-	where K: HasReversibleKeyPrefix<KP>;
-
 	/// Enumerate all elements in the map in no particular order. If you add or remove values to
 	/// the map while doing this, you'll get undefined results.
 	fn iter() -> Self::Iterator;
@@ -446,10 +426,6 @@ pub trait IterableStorageNMap<K: ReversibleKeyGenerator, V: FullCodec>: StorageN
 	/// Remove all elements from the map and iterate through them in no particular order. If you
 	/// add elements to the map while doing this, you'll get undefined results.
 	fn drain() -> Self::Iterator;
-
-	/// Remove all elements from the map and iterate through the keys in no particular order. If
-	/// you add elements to the map while doing this, you'll get undefined results.
-	fn drain_keys() -> Self::KeyIterator;
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	/// By returning `None` from `f` for an element, you'll remove it from the map.

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -387,6 +387,15 @@ where
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::iter_prefix(k1)
 	}
 
+	/// Enumerate all second keys `k2` in the map with the same first key `k1` in no particular
+	/// order.
+	///
+	/// If you add or remove values whose first key is `k1` to the map while doing this, you'll get
+	/// undefined results.
+	pub fn iter_key_prefix(k1: impl EncodeLike<Key1>) -> crate::storage::KeyPrefixIterator<Key2> {
+		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::iter_key_prefix(k1)
+	}
+
 	/// Remove all elements from the map with first key `k1` and iterate through them in no
 	/// particular order.
 	///
@@ -396,6 +405,15 @@ where
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_prefix(k1)
 	}
 
+	/// Remove all elements from the map with first key `k1` and iterate through the second key
+	/// `k2` in no particular order.
+	///
+	/// If you add elements with first key `k1` to the map while doing this, you'll get undefined
+	/// results.
+	pub fn drain_key_prefix(k1: impl EncodeLike<Key1>) -> crate::storage::KeyPrefixIterator<Key2> {
+		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_key_prefix(k1)
+	}
+
 	/// Enumerate all elements in the map in no particular order.
 	///
 	/// If you add or remove values to the map while doing this, you'll get undefined results.
@@ -403,11 +421,26 @@ where
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::iter()
 	}
 
+	/// Enumerate all keys `k1` and `k2` in the map in no particular order.
+	///
+	/// If you add or remove values to the map while doing this, you'll get undefined results.
+	pub fn iter_keys() -> crate::storage::KeyPrefixIterator<(Key1, Key2)> {
+		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::iter_keys()
+	}
+
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key1, Key2, Value)> {
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain()
+	}
+
+	/// Remove all elements from the map and iterate through the keys `k1` and `k2` in no
+	/// particular order.
+	///
+	/// If you add elements to the map while doing this, you'll get undefined results.
+	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<(Key1, Key2)> {
+		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_keys()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.

--- a/frame/support/src/storage/types/double_map.rs
+++ b/frame/support/src/storage/types/double_map.rs
@@ -405,15 +405,6 @@ where
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_prefix(k1)
 	}
 
-	/// Remove all elements from the map with first key `k1` and iterate through the second key
-	/// `k2` in no particular order.
-	///
-	/// If you add elements with first key `k1` to the map while doing this, you'll get undefined
-	/// results.
-	pub fn drain_key_prefix(k1: impl EncodeLike<Key1>) -> crate::storage::KeyPrefixIterator<Key2> {
-		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_key_prefix(k1)
-	}
-
 	/// Enumerate all elements in the map in no particular order.
 	///
 	/// If you add or remove values to the map while doing this, you'll get undefined results.
@@ -433,14 +424,6 @@ where
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key1, Key2, Value)> {
 		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain()
-	}
-
-	/// Remove all elements from the map and iterate through the keys `k1` and `k2` in no
-	/// particular order.
-	///
-	/// If you add elements to the map while doing this, you'll get undefined results.
-	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<(Key1, Key2)> {
-		<Self as crate::storage::IterableStorageDoubleMap<Key1, Key2, Value>>::drain_keys()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -311,13 +311,6 @@ where
 		<Self as crate::storage::IterableStorageMap<Key, Value>>::drain()
 	}
 
-	/// Remove all elements from the map and iterate through only the keys in no particular order.
-	///
-	/// If you add elements to the map while doing this, you'll get undefined results.
-	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<Key> {
-		<Self as crate::storage::IterableStorageMap<Key, Value>>::drain_keys()
-	}
-
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.
 	///
 	/// By returning `None` from `f` for an element, you'll remove it from the map.

--- a/frame/support/src/storage/types/map.rs
+++ b/frame/support/src/storage/types/map.rs
@@ -297,11 +297,25 @@ where
 		<Self as crate::storage::IterableStorageMap<Key, Value>>::iter()
 	}
 
+	/// Enumerate all keys in the map in no particular order.
+	///
+	/// If you alter the map while doing this, you'll get undefined results.
+	pub fn iter_keys() -> crate::storage::KeyPrefixIterator<Key> {
+		<Self as crate::storage::IterableStorageMap<Key, Value>>::iter_keys()
+	}
+
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key, Value)> {
 		<Self as crate::storage::IterableStorageMap<Key, Value>>::drain()
+	}
+
+	/// Remove all elements from the map and iterate through only the keys in no particular order.
+	///
+	/// If you add elements to the map while doing this, you'll get undefined results.
+	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<Key> {
+		<Self as crate::storage::IterableStorageMap<Key, Value>>::drain_keys()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.

--- a/frame/support/src/storage/types/nmap.rs
+++ b/frame/support/src/storage/types/nmap.rs
@@ -318,6 +318,19 @@ where
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::iter_prefix(kp)
 	}
 
+	/// Enumerate all suffix keys in the map with prefix key `kp` in no particular order.
+	///
+	/// If you add or remove values whose prefix key is `kp` to the map while doing this, you'll get
+	/// undefined results.
+	pub fn iter_key_prefix<KP>(
+		kp: KP,
+	) -> crate::storage::KeyPrefixIterator<<Key as HasKeyPrefix<KP>>::Suffix>
+	where
+		Key: HasReversibleKeyPrefix<KP>,
+	{
+		<Self as crate::storage::IterableStorageNMap<Key, Value>>::iter_key_prefix(kp)
+	}
+
 	/// Remove all elements from the map with prefix key `kp` and iterate through them in no
 	/// particular order.
 	///
@@ -332,6 +345,20 @@ where
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_prefix(kp)
 	}
 
+	/// Remove all elements from the map with prefix key `kp` and iterate through the suffix keys
+	/// in no particular order.
+	///
+	/// If you add elements with prefix key `k1` to the map while doing this, you'll get undefined
+	/// results.
+	pub fn drain_key_prefix<KP>(
+		kp: KP,
+	) -> crate::storage::KeyPrefixIterator<<Key as HasKeyPrefix<KP>>::Suffix>
+	where
+		Key: HasReversibleKeyPrefix<KP>,
+	{
+		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_key_prefix(kp)
+	}
+
 	/// Enumerate all elements in the map in no particular order.
 	///
 	/// If you add or remove values to the map while doing this, you'll get undefined results.
@@ -339,11 +366,25 @@ where
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::iter()
 	}
 
+	/// Enumerate all keys in the map in no particular order.
+	///
+	/// If you add or remove values to the map while doing this, you'll get undefined results.
+	pub fn iter_keys() -> crate::storage::KeyPrefixIterator<Key::Key> {
+		<Self as crate::storage::IterableStorageNMap<Key, Value>>::iter_keys()
+	}
+
 	/// Remove all elements from the map and iterate through them in no particular order.
 	///
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key::Key, Value)> {
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain()
+	}
+
+	/// Remove all elements from the map and iterate through the keys in no particular order.
+	///
+	/// If you add elements to the map while doing this, you'll get undefined results.
+	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<Key::Key> {
+		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_keys()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.

--- a/frame/support/src/storage/types/nmap.rs
+++ b/frame/support/src/storage/types/nmap.rs
@@ -345,20 +345,6 @@ where
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_prefix(kp)
 	}
 
-	/// Remove all elements from the map with prefix key `kp` and iterate through the suffix keys
-	/// in no particular order.
-	///
-	/// If you add elements with prefix key `k1` to the map while doing this, you'll get undefined
-	/// results.
-	pub fn drain_key_prefix<KP>(
-		kp: KP,
-	) -> crate::storage::KeyPrefixIterator<<Key as HasKeyPrefix<KP>>::Suffix>
-	where
-		Key: HasReversibleKeyPrefix<KP>,
-	{
-		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_key_prefix(kp)
-	}
-
 	/// Enumerate all elements in the map in no particular order.
 	///
 	/// If you add or remove values to the map while doing this, you'll get undefined results.
@@ -378,13 +364,6 @@ where
 	/// If you add elements to the map while doing this, you'll get undefined results.
 	pub fn drain() -> crate::storage::PrefixIterator<(Key::Key, Value)> {
 		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain()
-	}
-
-	/// Remove all elements from the map and iterate through the keys in no particular order.
-	///
-	/// If you add elements to the map while doing this, you'll get undefined results.
-	pub fn drain_keys() -> crate::storage::KeyPrefixIterator<Key::Key> {
-		<Self as crate::storage::IterableStorageNMap<Key, Value>>::drain_keys()
 	}
 
 	/// Translate the values of all elements by a function `f`, in the map in no particular order.


### PR DESCRIPTION
Fixes #9118.