### PR TITLE
Enable colored help in CLI

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -139,6 +139,7 @@ pub trait SubstrateCli: Sized {
 				AppSettings::GlobalVersion,
 				AppSettings::ArgsNegateSubcommands,
 				AppSettings::SubcommandsNegateReqs,
+				AppSettings::ColoredHelp,
 			]);
 
 		let matches = match app.get_matches_from_safe(iter) {


### PR DESCRIPTION
Since it's already there, why not give it a chance :P

Before:
<img width="1206" alt="截屏2021-07-01 下午2 37 56" src="https://user-images.githubusercontent.com/8850248/124077293-f0284100-da79-11eb-95ab-eb0c6e94a1a9.png">

After:
<img width="1171" alt="截屏2021-07-01 下午2 35 03" src="https://user-images.githubusercontent.com/8850248/124076985-89a32300-da79-11eb-85fe-3b51c0e4f85f.png">

