### PR TITLE
Add `Chilled` event to staking chill extrinsics

### DIFF
--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -209,7 +209,12 @@ fn make_offenders_im_online<T: Config>(num_offenders: u32, num_nominators: u32) 
 #[cfg(test)]
 fn check_events<T: Config, I: Iterator<Item = <T as SystemConfig>::Event>>(expected: I) {
 	let events = System::<T>::events() .into_iter()
-		.map(|frame_system::EventRecord { event, .. }| event).collect::<Vec<_>>();
+		.map(|frame_system::EventRecord { event, .. }| event)
+		.filter(|event| match event {
+			<T as StakingConfig>::Event::from(StakingEvent::<T>::Chilled(_)) => false,
+			_ => true
+		})
+		.collect::<Vec<_>>();
 	let expected = expected.collect::<Vec<_>>();
 	let lengths = (events.len(), expected.len());
 	let length_mismatch = if lengths.0 != lengths.1 {

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -393,4 +393,3 @@ impl_benchmark_test_suite!(
 	crate::mock::new_test_ext(),
 	crate::mock::Test,
 );
-

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -208,12 +208,9 @@ fn make_offenders_im_online<T: Config>(num_offenders: u32, num_nominators: u32) 
 
 #[cfg(test)]
 fn check_events<T: Config, I: Iterator<Item = <T as SystemConfig>::Event>>(expected: I) {
-	let events = System::<T>::events() .into_iter()
+	let events = System::<T>::events()
+		.into_iter()
 		.map(|frame_system::EventRecord { event, .. }| event)
-		.filter(|event| match event {
-			<T as StakingConfig>::Event::from(StakingEvent::<T>::Chilled(_)) => false,
-			_ => true
-		})
 		.collect::<Vec<_>>();
 	let expected = expected.collect::<Vec<_>>();
 	let lengths = (events.len(), expected.len());
@@ -278,13 +275,19 @@ benchmarks! {
 		let bond_amount: u32 = UniqueSaturatedInto::<u32>::unique_saturated_into(bond_amount::<T>());
 		let slash_amount = slash_fraction * bond_amount;
 		let reward_amount = slash_amount * (1 + n) / 2;
+		let slash = |id| core::iter::once(
+			<T as StakingConfig>::Event::from(StakingEvent::<T>::Slash(id, BalanceOf::<T>::from(slash_amount)))
+		);
+		let chill = |id| core::iter::once(
+			<T as StakingConfig>::Event::from(StakingEvent::<T>::Chilled(id))
+		);
 		let mut slash_events = raw_offenders.into_iter()
 			.flat_map(|offender| {
-				core::iter::once(offender.stash).chain(offender.nominator_stashes.into_iter())
+				let nom_slashes = offender.nominator_stashes.into_iter().flat_map(|nom| slash(nom));
+				chill(offender.stash.clone())
+				.chain(slash(offender.stash))
+				.chain(nom_slashes)
 			})
-			.map(|stash| <T as StakingConfig>::Event::from(
-				StakingEvent::<T>::Slash(stash, BalanceOf::<T>::from(slash_amount))
-			))
 			.collect::<Vec<_>>();
 		let reward_events = reporters.into_iter()
 			.flat_map(|reporter| vec![
@@ -294,8 +297,9 @@ benchmarks! {
 				).into()
 			]);
 
-		// rewards are applied after first offender and it's nominators
-		let slash_rest = slash_events.split_off(1 + n as usize);
+		// Rewards are applied after first offender and it's nominators.
+		// We split after: offender slash + offender chill + nominator slashes.
+		let slash_rest = slash_events.split_off(2 + n as usize);
 
 		// make sure that all slashes have been applied
 		#[cfg(test)]
@@ -343,6 +347,7 @@ benchmarks! {
 			+ 1 // offence
 			+ 2 // reporter (reward + endowment)
 			+ 1 // offenders slashed
+			+ 1 // offenders chilled
 			+ n // nominators slashed
 		);
 	}
@@ -377,6 +382,7 @@ benchmarks! {
 			+ 1 // offence
 			+ 2 // reporter (reward + endowment)
 			+ 1 // offenders slashed
+			+ 1 // offenders chilled
 			+ n // nominators slashed
 		);
 	}

--- a/frame/offences/benchmarking/src/lib.rs
+++ b/frame/offences/benchmarking/src/lib.rs
@@ -393,3 +393,4 @@ impl_benchmark_test_suite!(
 	crate::mock::new_test_ext(),
 	crate::mock::Test,
 );
+

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -1329,6 +1329,9 @@ pub mod pallet {
 		Kicked(T::AccountId, T::AccountId),
 		/// The election failed. No new era is planned.
 		StakingElectionFailed,
+		/// An account has stopped participating as either a validator or nominator.
+		/// \[stash\]
+		Chilled(T::AccountId),
 	}
 
 	#[pallet::error]
@@ -2523,8 +2526,11 @@ impl<T: Config> Pallet<T> {
 
 	/// Chill a stash account.
 	fn chill_stash(stash: &T::AccountId) {
-		Self::do_remove_validator(stash);
-		Self::do_remove_nominator(stash);
+		let chilled_as_validator = Self::do_remove_validator(stash);
+		let chilled_as_nominator = Self::do_remove_nominator(stash);
+		if chilled_as_validator || chilled_as_nominator {
+			Self::deposit_event(Event::<T>::Chilled(stash.clone()));
+		}
 	}
 
 	/// Actually make a payment to a staker. This uses the currency's reward function
@@ -3014,10 +3020,13 @@ impl<T: Config> Pallet<T> {
 
 	/// This function will remove a nominator from the `Nominators` storage map,
 	/// and keep track of the `CounterForNominators`.
-	pub fn do_remove_nominator(who: &T::AccountId) {
+	pub fn do_remove_nominator(who: &T::AccountId) -> bool {
 		if Nominators::<T>::contains_key(who) {
 			Nominators::<T>::remove(who);
 			CounterForNominators::<T>::mutate(|x| x.saturating_dec());
+			true
+		} else {
+			false
 		}
 	}
 
@@ -3034,10 +3043,13 @@ impl<T: Config> Pallet<T> {
 
 	/// This function will remove a validator from the `Validators` storage map,
 	/// and keep track of the `CounterForValidators`.
-	pub fn do_remove_validator(who: &T::AccountId) {
+	pub fn do_remove_validator(who: &T::AccountId) -> bool {
 		if Validators::<T>::contains_key(who) {
 			Validators::<T>::remove(who);
 			CounterForValidators::<T>::mutate(|x| x.saturating_dec());
+			true
+		} else {
+			false
 		}
 	}
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -3020,6 +3020,8 @@ impl<T: Config> Pallet<T> {
 
 	/// This function will remove a nominator from the `Nominators` storage map,
 	/// and keep track of the `CounterForNominators`.
+	///
+	/// Returns true if `who` was removed from `Nominators`, otherwise false.
 	pub fn do_remove_nominator(who: &T::AccountId) -> bool {
 		if Nominators::<T>::contains_key(who) {
 			Nominators::<T>::remove(who);
@@ -3043,6 +3045,8 @@ impl<T: Config> Pallet<T> {
 
 	/// This function will remove a validator from the `Validators` storage map,
 	/// and keep track of the `CounterForValidators`.
+	///
+	/// Returns true if `who` was removed from `Validators`, otherwise false.
 	pub fn do_remove_validator(who: &T::AccountId) -> bool {
 		if Validators::<T>::contains_key(who) {
 			Validators::<T>::remove(who);


### PR DESCRIPTION
closes #9242

This PR adds a `Chilled(stash_account)` event to `chill_stash` which is the underlying call used by the `chill` and `chill_other` extrinsic.