### PR TITLE
fix prometheus log message terminology

### DIFF
--- a/utils/prometheus/src/lib.rs
+++ b/utils/prometheus/src/lib.rs
@@ -127,7 +127,7 @@ mod known_os {
 			.await
 			.map_err(|_| Error::PortInUse(prometheus_addr))?;
 
-		log::info!("〽️ Prometheus server started at {}", prometheus_addr);
+		log::info!("〽️ Prometheus exporter started at {}", prometheus_addr);
 
 		let service = make_service_fn(move |_| {
 			let registry = registry.clone();


### PR DESCRIPTION
A prometheus "server" typically refers to the prometheus process running
on a central server which connects to various prometheus "exporters" and
collects metrics. What is implemented here in substrate is a prometheus
exporter.

This patch fixes the associated log message to avoid confusion for new
users.

- [x] You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points reviewers should know?
  - Is there something left for follow-up PRs?
- [ ] You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github's project assignment
- [ ] You mentioned a related issue if this PR related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] You asked any particular reviewers to review. If you aren't sure, start with GH suggestions.
- [x] Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers have a proof or removed.
- [ ] You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] You updated any rustdocs which may have changed
- [ ] Has the PR altered the external API or interfaces used by Polkadot? Do you have the corresponding Polkadot PR ready?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
