### PR TITLE
bump a bunch of deps in parity-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,9 +6271,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+checksum = "e90f6931e6b3051e208a449c342246cb7c786ef300789b95619f46f1dd75d9b0"
 dependencies = [
  "fixed-hash",
  "impl-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 dependencies = [
  "gloo-timers",
- "send_wrapper 0.4.0",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -2372,7 +2383,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.4",
 ]
 
 [[package]]
@@ -2701,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2735,7 +2755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -2746,9 +2766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3061,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8891bd853eff90e33024195d79d578dc984c82f9e0715fcd2b525a0c19d52811"
+checksum = "45a3f58dc069ec0e205a27f5b45920722a46faed802a0541538241af6228f512"
 dependencies = [
  "parity-util-mem",
  "smallvec 1.6.1",
@@ -3071,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a0da8e08caf08d384a620ec19bb6c9b85c84137248e202617fb91881f25912"
+checksum = "c3b6b85fc643f5acd0bffb2cc8a6d150209379267af0d41db72170021841f9f5"
 dependencies = [
  "kvdb",
  "parity-util-mem",
@@ -3082,9 +3099,9 @@ dependencies = [
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34446c373ccc494c2124439281c198c7636ccdc2752c06722bbffd56d459c1e4"
+checksum = "431ca65516efab86e65d96281f750ebb54277dec656fcf6c027f3d1c0cb69e4c"
 dependencies = [
  "fs-swap",
  "kvdb",
@@ -3096,24 +3113,6 @@ dependencies = [
  "regex",
  "rocksdb",
  "smallvec 1.6.1",
-]
-
-[[package]]
-name = "kvdb-web"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1e98ba343d0b35f9009a8844cd2b87fa3192f7e79033ac05b00aeae0f3b0b5"
-dependencies = [
- "futures 0.3.15",
- "js-sys",
- "kvdb",
- "kvdb-memorydb",
- "log",
- "parity-util-mem",
- "parking_lot 0.11.1",
- "send_wrapper 0.5.0",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3716,7 +3715,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -3847,12 +3846,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814bbecfc0451fc314eeea34f05bbcd5b98a7ad7af37faee088b86a1e633f1d4"
+checksum = "de006e09d04fc301a5f7e817b75aa49801c4479a8af753764416b085337ddcc5"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "parity-util-mem",
 ]
 
@@ -5759,24 +5758,25 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f518afaa5a47d0d6386229b0a6e01e86427291d643aa4cabb4992219f504f8"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
 dependencies = [
  "arrayvec 0.7.0",
  "bitvec",
  "byte-slice-cast",
+ "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c5f94427bd0b5076e8f7e15ca3f60a4d8ac0077e4793884e6fdfd8915344e"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
 dependencies = [
- "proc-macro-crate 0.1.5",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5809,12 +5809,12 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664a8c6b8e62d8f9f2f937e391982eb433ab285b4cd9545b342441e04a906e42"
+checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown",
+ "hashbrown 0.11.2",
  "impl-trait-for-tuples",
  "parity-util-mem-derive",
  "parking_lot 0.11.1",
@@ -6259,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -6824,9 +6824,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+checksum = "c749134fda8bfc90d0de643d59bfc841dcb3ac8a1062e12b6754bd60235c48b3"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -8415,12 +8415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
-name = "send_wrapper"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
-
-[[package]]
 name = "serde"
 version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9621,7 +9615,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "getrandom 0.2.3",
  "js-sys",
- "kvdb-web",
+ "kvdb-memorydb",
  "libp2p-wasm-ext",
  "log",
  "rand 0.7.3",
@@ -10527,9 +10521,9 @@ checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trie-bench"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568257edb909a5c532b1f4ab38ee6b5dedfbf8775be6a55a29020513ebe3e072"
+checksum = "4edd9bdf0c2e08fd77c0fb2608179cac7ebed997ae18f58d47a2d96425ff51f0"
 dependencies = [
  "criterion",
  "hash-db",
@@ -10543,12 +10537,12 @@ dependencies = [
 
 [[package]]
 name = "trie-db"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd81fe0c8bc2b528a51c9d2c31dae4483367a26a723a3c9a4a8120311d7774e3"
+checksum = "9eac131e334e81b6b3be07399482042838adcd7957aa0010231d0813e39e02fa"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.11.2",
  "log",
  "rustc-hex",
  "smallvec 1.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5770,25 +5770,24 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "e0f518afaa5a47d0d6386229b0a6e01e86427291d643aa4cabb4992219f504f8"
 dependencies = [
  "arrayvec 0.7.0",
  "bitvec",
  "byte-slice-cast",
- "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "f44c5f94427bd0b5076e8f7e15ca3f60a4d8ac0077e4793884e6fdfd8915344e"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,6 +2757,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4156,6 +4159,7 @@ dependencies = [
  "jsonrpc-core",
  "libp2p",
  "node-cli",
+ "parking_lot 0.11.1",
  "sc-rpc-api",
  "serde",
  "serde_json",

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -21,8 +21,8 @@ serde = "1.0.101"
 serde_json = "1.0.41"
 structopt = "0.3"
 derive_more = "0.99.2"
-kvdb = "0.9.0"
-kvdb-rocksdb = "0.11.0"
+kvdb = "0.10.0"
+kvdb-rocksdb = "0.12.0"
 sp-trie = { version = "3.0.0", path = "../../../primitives/trie" }
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-consensus = { version = "0.9.0", path = "../../../primitives/consensus/common" }
@@ -37,7 +37,7 @@ fs_extra = "1"
 hex = "0.4.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 lazy_static = "1.4.0"
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 parity-db = { version = "0.2.4" }
 sc-transaction-pool = { version = "3.0.0", path = "../../../client/transaction-pool" }
 futures = { version = "0.3.4", features = ["thread-pool"] }

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -19,3 +19,5 @@ futures = "0.3.9"
 
 node-cli = { path = "../cli", default-features = false, features = ["browser"], version = "2.0.0"}
 sc-rpc-api = { path = "../../../client/rpc-api", version = "0.9.0"}
+
+parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }

--- a/bin/node/browser-testing/Cargo.toml
+++ b/bin/node/browser-testing/Cargo.toml
@@ -20,4 +20,6 @@ futures = "0.3.9"
 node-cli = { path = "../cli", default-features = false, features = ["browser"], version = "2.0.0"}
 sc-rpc-api = { path = "../../../client/rpc-api", version = "0.9.0"}
 
+# This is a HACK to make browser tests pass.
+# enables [`instant/wasm_bindgen`]
 parking_lot = { version = "0.11.1", features = ["wasm-bindgen"] }

--- a/bin/node/browser-testing/src/lib.rs
+++ b/bin/node/browser-testing/src/lib.rs
@@ -56,7 +56,6 @@ fn deserialize_rpc_result<T: DeserializeOwned>(js_value: JsValue) -> T {
 #[wasm_bindgen_test]
 async fn runs() {
 	let mut client = node_cli::start_client(None, "info".into())
-			.await
 			.unwrap();
 
 	// Check that the node handles rpc calls.

--- a/bin/node/cli/src/browser.rs
+++ b/bin/node/cli/src/browser.rs
@@ -26,13 +26,12 @@ use browser_utils::{
 
 /// Starts the client.
 #[wasm_bindgen]
-pub async fn start_client(chain_spec: Option<String>, log_level: String) -> Result<Client, JsValue> {
+pub fn start_client(chain_spec: Option<String>, log_level: String) -> Result<Client, JsValue> {
 	start_inner(chain_spec, log_level)
-		.await
 		.map_err(|err| JsValue::from_str(&err.to_string()))
 }
 
-async fn start_inner(
+fn start_inner(
 	chain_spec: Option<String>,
 	log_directives: String,
 ) -> Result<Client, Box<dyn std::error::Error>> {
@@ -44,7 +43,7 @@ async fn start_inner(
 		None => crate::chain_spec::development_config(),
 	};
 
-	let config = browser_configuration(chain_spec).await?;
+	let config = browser_configuration(chain_spec)?;
 
 	info!("Substrate browser node");
 	info!("✌️  version {}", config.impl_version);

--- a/client/api/Cargo.toml
+++ b/client/api/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3.1"
 hash-db = { version = "0.15.2", default-features = false }
 sp-blockchain = { version = "3.0.0", path = "../../primitives/blockchain" }
 sp-inherents = { version = "3.0.0", default-features = false, path = "../../primitives/inherents" }
-kvdb = "0.9.0"
+kvdb = "0.10.0"
 log = "0.4.8"
 parking_lot = "0.11.1"
 lazy_static =  "1.4.0"
@@ -43,7 +43,7 @@ sp-transaction-pool = { version = "3.0.0", path = "../../primitives/transaction-
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", version = "0.9.0", path = "../../utils/prometheus" }
 
 [dev-dependencies]
-kvdb-memorydb = "0.9.0"
+kvdb-memorydb = "0.10.0"
 sp-test-primitives = { version = "2.0.0", path = "../../primitives/test-primitives" }
 substrate-test-runtime = { version = "2.0.0", path = "../../test-utils/runtime"  }
 thiserror = "1.0.21"

--- a/client/db/Cargo.toml
+++ b/client/db/Cargo.toml
@@ -15,12 +15,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 parking_lot = "0.11.1"
 log = "0.4.8"
-kvdb = "0.9.0"
-kvdb-rocksdb = { version = "0.11.0", optional = true }
-kvdb-memorydb = "0.9.0"
+kvdb = "0.10.0"
+kvdb-rocksdb = { version = "0.12.0", optional = true }
+kvdb-memorydb = "0.10.0"
 linked-hash-map = "0.5.2"
 hash-db = "0.15.2"
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["std"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["std"] }
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 blake2-rfc = "0.2.18"
 
@@ -43,7 +43,7 @@ sp-keyring = { version = "3.0.0", path = "../../primitives/keyring" }
 sp-tracing = { version = "3.0.0", path = "../../primitives/tracing" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 quickcheck = "1.0.3"
-kvdb-rocksdb = "0.11.0"
+kvdb-rocksdb = "0.12.0"
 tempfile = "3"
 
 [features]

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -17,7 +17,7 @@ ansi_term = "0.12.1"
 futures = "0.3.9"
 futures-timer = "3.0.1"
 log = "0.4.8"
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 sc-client-api = { version = "3.0.0", path = "../api" }
 sc-network = { version = "0.9.0", path = "../network" }
 sp-blockchain = { version = "3.0.0", path = "../../primitives/blockchain" }

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -79,7 +79,7 @@ sc-tracing = { version = "3.0.0", path = "../tracing" }
 sp-tracing = { version = "3.0.0", path = "../../primitives/tracing" }
 tracing = "0.1.25"
 tracing-futures = { version = "0.2.4" }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 async-trait = "0.1.42"
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]

--- a/client/state-db/Cargo.toml
+++ b/client/state-db/Cargo.toml
@@ -19,5 +19,5 @@ log = "0.4.11"
 sc-client-api = { version = "3.0.0", path = "../api" }
 sp-core = { version = "3.0.0", path = "../../primitives/core" }
 codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 parity-util-mem-derive = "0.1.0"

--- a/client/transaction-pool/Cargo.toml
+++ b/client/transaction-pool/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.21"
 futures = { version = "0.3.1", features = ["compat"] }
 intervalier = "0.4.0"
 log = "0.4.8"
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 parking_lot = "0.11.1"
 prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../../utils/prometheus", version = "0.9.0"}
 sc-client-api = { version = "3.0.0", path = "../api" }

--- a/client/transaction-pool/graph/Cargo.toml
+++ b/client/transaction-pool/graph/Cargo.toml
@@ -25,7 +25,7 @@ sp-utils = { version = "3.0.0", path = "../../../primitives/utils" }
 sp-core = { version = "3.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "3.0.0", path = "../../../primitives/runtime" }
 sp-transaction-pool = { version = "3.0.0", path = "../../../primitives/transaction-pool" }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 linked-hash-map = "0.5.2"
 retain_mut = "0.1.3"
 

--- a/frame/support/Cargo.toml
+++ b/frame/support/Cargo.toml
@@ -37,7 +37,7 @@ log = { version = "0.4.14", default-features = false }
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 frame-system = { version = "3.0.0", path = "../system" }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 
 [features]
 default = ["std"]

--- a/max-encoded-len/Cargo.toml
+++ b/max-encoded-len/Cargo.toml
@@ -13,7 +13,7 @@ description = "Trait MaxEncodedLen bounds the max encoded length of an item."
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 max-encoded-len-derive = { package = "max-encoded-len-derive", version = "3.0.0", path = "derive", default-features = false, optional = true }
-primitive-types = { version = "0.9.0", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [ "derive" ] }

--- a/max-encoded-len/Cargo.toml
+++ b/max-encoded-len/Cargo.toml
@@ -13,7 +13,7 @@ description = "Trait MaxEncodedLen bounds the max encoded length of an item."
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 impl-trait-for-tuples = "0.2.1"
 max-encoded-len-derive = { package = "max-encoded-len-derive", version = "3.0.0", path = "derive", default-features = false, optional = true }
-primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.10.0", default-features = false, features = ["codec"] }
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = [ "derive" ] }

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -27,7 +27,7 @@ sp-debug-derive = { version = "3.0.0", default-features = false, path = "../debu
 rand = "0.7.2"
 criterion = "0.3"
 serde_json = "1.0"
-primitive-types = "0.9.0"
+primitive-types = "0.10.1"
 
 [features]
 default = ["std"]

--- a/primitives/arithmetic/Cargo.toml
+++ b/primitives/arithmetic/Cargo.toml
@@ -27,7 +27,7 @@ sp-debug-derive = { version = "3.0.0", default-features = false, path = "../debu
 rand = "0.7.2"
 criterion = "0.3"
 serde_json = "1.0"
-primitive-types = "0.10.1"
+primitive-types = "0.10.0"
 
 [features]
 default = ["std"]

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-arithmetic = { version = "3.0.0", path = ".." }
 honggfuzz = "0.5.49"
-primitive-types = "0.9.0"
+primitive-types = "0.10.1"
 num-bigint = "0.2"
 num-traits = "0.2"
 

--- a/primitives/arithmetic/fuzzer/Cargo.toml
+++ b/primitives/arithmetic/fuzzer/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sp-arithmetic = { version = "3.0.0", path = ".." }
 honggfuzz = "0.5.49"
-primitive-types = "0.10.1"
+primitive-types = "0.10.0"
 num-bigint = "0.2"
 num-traits = "0.2"
 

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 log = { version = "0.4.11", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
-primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.10.0", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.3.0", optional = true }
 wasmi = { version = "0.9.0", optional = true }
 hash-db = { version = "0.15.2", default-features = false }

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -18,7 +18,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 log = { version = "0.4.11", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.2", default-features = false }
-primitive-types = { version = "0.9.0", default-features = false, features = ["codec"] }
+primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
 impl-serde = { version = "0.3.0", optional = true }
 wasmi = { version = "0.9.0", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
@@ -36,7 +36,7 @@ parking_lot = { version = "0.11.1", optional = true }
 sp-debug-derive = { version = "3.0.0", path = "../debug-derive" }
 sp-externalities = { version = "0.9.0", optional = true, path = "../externalities" }
 sp-storage = { version = "3.0.0", default-features = false, path = "../storage" }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 futures = { version = "0.3.1", optional = true }
 dyn-clonable = { version = "0.9.0", optional = true }
 thiserror = { version = "1.0.21", optional = true }

--- a/primitives/database/Cargo.toml
+++ b/primitives/database/Cargo.toml
@@ -12,5 +12,5 @@ readme = "README.md"
 
 [dependencies]
 parking_lot = "0.11.1"
-kvdb = "0.9.0"
+kvdb = "0.10.0"
 

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -21,7 +21,7 @@ sp-runtime-interface-proc-macro = { version = "3.0.0", path = "proc-macro" }
 sp-externalities = { version = "0.9.0", optional = true, path = "../externalities" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 static_assertions = "1.0.0"
-primitive-types = { version = "0.9.0", default-features = false }
+primitive-types = { version = "0.10.1", default-features = false }
 sp-storage = { version = "3.0.0", default-features = false, path = "../storage" }
 impl-trait-for-tuples = "0.2.1"
 

--- a/primitives/runtime-interface/Cargo.toml
+++ b/primitives/runtime-interface/Cargo.toml
@@ -21,7 +21,7 @@ sp-runtime-interface-proc-macro = { version = "3.0.0", path = "proc-macro" }
 sp-externalities = { version = "0.9.0", optional = true, path = "../externalities" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 static_assertions = "1.0.0"
-primitive-types = { version = "0.10.1", default-features = false }
+primitive-types = { version = "0.10.0", default-features = false }
 sp-storage = { version = "3.0.0", default-features = false, path = "../storage" }
 impl-trait-for-tuples = "0.2.1"
 

--- a/primitives/runtime/Cargo.toml
+++ b/primitives/runtime/Cargo.toml
@@ -26,7 +26,7 @@ log = { version = "0.4.14", default-features = false }
 paste = "1.0"
 rand = { version = "0.7.2", optional = true }
 impl-trait-for-tuples = "0.2.1"
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 hash256-std-hasher = { version = "0.15.2", default-features = false }
 either = { version = "1.5", default-features = false }
 max-encoded-len = { version = "3.0.0", default-features = false, path = "../../max-encoded-len", features = [ "derive" ] }

--- a/primitives/state-machine/Cargo.toml
+++ b/primitives/state-machine/Cargo.toml
@@ -18,7 +18,7 @@ log = { version = "0.4.11", optional = true }
 thiserror = { version = "1.0.21", optional = true }
 parking_lot = { version = "0.11.1", optional = true }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.22.2", default-features = false }
+trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
 sp-trie = { version = "3.0.0", path = "../trie", default-features = false }
 sp-core = { version = "3.0.0", path = "../core", default-features = false }

--- a/primitives/test-primitives/Cargo.toml
+++ b/primitives/test-primitives/Cargo.toml
@@ -17,7 +17,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 sp-core = { version = "3.0.0", default-features = false, path = "../core" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 sp-runtime = { version = "3.0.0", default-features = false, path = "../runtime" }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 
 [features]
 default = [

--- a/primitives/trie/Cargo.toml
+++ b/primitives/trie/Cargo.toml
@@ -21,13 +21,13 @@ harness = false
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
 sp-std = { version = "3.0.0", default-features = false, path = "../std" }
 hash-db = { version = "0.15.2", default-features = false }
-trie-db = { version = "0.22.5", default-features = false }
+trie-db = { version = "0.22.6", default-features = false }
 trie-root = { version = "0.16.0", default-features = false }
-memory-db = { version = "0.26.0", default-features = false }
+memory-db = { version = "0.27.0", default-features = false }
 sp-core = { version = "3.0.0", default-features = false, path = "../core" }
 
 [dev-dependencies]
-trie-bench = "0.27.0"
+trie-bench = "0.28.0"
 trie-standardmap = "0.15.2"
 criterion = "0.3.3"
 hex-literal = "0.3.1"

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -20,7 +20,7 @@ sp-block-builder = { version = "3.0.0", default-features = false, path = "../../
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 sp-inherents = { version = "3.0.0", default-features = false, path = "../../primitives/inherents" }
 sp-keyring = { version = "3.0.0", optional = true, path = "../../primitives/keyring" }
-memory-db = { version = "0.26.0", default-features = false }
+memory-db = { version = "0.27.0", default-features = false }
 sp-offchain = { path = "../../primitives/offchain", default-features = false, version = "3.0.0"}
 sp-core = { version = "3.0.0", default-features = false, path = "../../primitives/core" }
 sp-std = { version = "3.0.0", default-features = false, path = "../../primitives/std" }
@@ -38,8 +38,8 @@ pallet-timestamp = { version = "3.0.0", default-features = false, path = "../../
 sp-finality-grandpa = { version = "3.0.0", default-features = false, path = "../../primitives/finality-grandpa" }
 sp-trie = { version = "3.0.0", default-features = false, path = "../../primitives/trie" }
 sp-transaction-pool = { version = "3.0.0", default-features = false, path = "../../primitives/transaction-pool" }
-trie-db = { version = "0.22.2", default-features = false }
-parity-util-mem = { version = "0.9.0", default-features = false, features = ["primitive-types"] }
+trie-db = { version = "0.22.6", default-features = false }
+parity-util-mem = { version = "0.10.0", default-features = false, features = ["primitive-types"] }
 sc-service = { version = "0.9.0", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 sp-state-machine = { version = "0.9.0", default-features = false, path = "../../primitives/state-machine" }
 sp-externalities = { version = "0.9.0", default-features = false, path = "../../primitives/externalities" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -21,7 +21,7 @@ console_error_panic_hook = "0.1.6"
 js-sys = "0.3.34"
 wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "0.4.18"
-kvdb-web = "0.9.0"
+kvdb-memorydb = "0.10.0"
 sp-database = { version = "3.0.0", path = "../../primitives/database" }
 sc-informant = { version = "0.9.0", path = "../../client/informant" }
 sc-service = { version = "0.9.0", path = "../../client/service", default-features = false }

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -78,7 +78,7 @@ where
 		role: Role::Light,
 		database: {
 			info!("Opening Indexed DB database '{}'...", name);
-			let db = kvdb_web::Database::open(name, 10).await?;
+			let db = kvdb_memorydb::create(10);
 
 			DatabaseConfig::Custom(sp_database::as_database(db))
 		},

--- a/utils/browser/src/lib.rs
+++ b/utils/browser/src/lib.rs
@@ -43,7 +43,7 @@ pub fn init_logging(pattern: &str) -> Result<(), sc_tracing::logging::Error> {
 /// Create a service configuration from a chain spec.
 ///
 /// This configuration contains good defaults for a browser light client.
-pub async fn browser_configuration<G, E>(
+pub fn browser_configuration<G, E>(
 	chain_spec: GenericChainSpec<G, E>,
 ) -> Result<Configuration, Box<dyn std::error::Error>>
 where


### PR DESCRIPTION
I'm not sure if db in utils/browser is needed at all, but did a minimal change. `kvdb-web` is decommissioned now.

polkadot companion: https://github.com/paritytech/polkadot/pull/3402