### PR TITLE
Fix storage info for decl_storage

### DIFF
--- a/frame/support/procedural/src/storage/storage_info.rs
+++ b/frame/support/procedural/src/storage/storage_info.rs
@@ -22,10 +22,6 @@ use quote::quote;
 use super::DeclStorageDefExt;
 
 pub fn impl_storage_info(def: &DeclStorageDefExt) -> TokenStream {
-	if !def.generate_storage_info {
-		return Default::default()
-	}
-
 	let scrate = &def.hidden_crate;
 
 	let mut res_append_storage = TokenStream::new();

--- a/frame/support/test/tests/decl_storage.rs
+++ b/frame/support/test/tests/decl_storage.rs
@@ -651,6 +651,47 @@ mod test2 {
 	}
 
 	impl Config for TraitImpl {}
+
+	#[test]
+	fn storage_info() {
+		use frame_support::{
+			StorageHasher,
+			traits::{StorageInfoTrait, StorageInfo},
+			pallet_prelude::*,
+		};
+		let prefix = |pallet_name, storage_name| {
+			let mut res = [0u8; 32];
+			res[0..16].copy_from_slice(&Twox128::hash(pallet_name));
+			res[16..32].copy_from_slice(&Twox128::hash(storage_name));
+			res
+		};
+		pretty_assertions::assert_eq!(
+			<Module<TraitImpl>>::storage_info(),
+			vec![
+				StorageInfo {
+					prefix: prefix(b"TestStorage", b"SingleDef"),
+					max_values: Some(1),
+					max_size: None,
+				},
+				StorageInfo {
+					prefix: prefix(b"TestStorage", b"PairDef"),
+					max_values: Some(1),
+					max_size: None,
+				},
+				StorageInfo {
+					prefix: prefix(b"TestStorage", b"Single"),
+					max_values: Some(1),
+					max_size: None,
+				},
+				StorageInfo {
+					prefix: prefix(b"TestStorage", b"Pair"),
+					max_values: Some(1),
+					max_size: None,
+				},
+			],
+		);
+	}
+
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`decl_storage` still doesn't generate storage info (in case of partial storage info).

I missed to remove the early return in the macro in https://github.com/paritytech/substrate/pull/9246

This fix it and test it is correct.