### PR TITLE
Impl InherentDataProviderExt for more tuples

### DIFF
--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -457,7 +457,7 @@ pub trait InherentDataProviderExt {
 /// Small macro for implementing `InherentDataProviderExt` for inherent data provider tuple.
 macro_rules! impl_inherent_data_provider_ext_tuple {
 	( T, S, $($TN:ident),* ) => {
-		impl<T, S, $( $TN ),*>  InherentDataProviderExt for (T, S, $($TN),* )
+		impl<T, S, $( $TN ),*>  InherentDataProviderExt for (T, S, $($TN),*)
 		where
 			T: Deref<Target = Timestamp>,
 			S: Deref<Target = Slot>,

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -454,47 +454,36 @@ pub trait InherentDataProviderExt {
 	fn slot(&self) -> Slot;
 }
 
-impl<T, S, P> InherentDataProviderExt for (T, S, P)
-where
-	T: Deref<Target = Timestamp>,
-	S: Deref<Target = Slot>,
-{
-	fn timestamp(&self) -> Timestamp {
-		*self.0.deref()
-	}
+/// Small macro for implementing `InherentDataProviderExt` for inherent data provider tuple.
+macro_rules! impl_inherent_data_provider_ext_tuple {
+	( T, S, $($TN:ident),* ) => {
+		impl<T, S, $( $TN ),*>  InherentDataProviderExt for (T, S, $($TN),* )
+		where
+			T: Deref<Target = Timestamp>,
+			S: Deref<Target = Slot>,
+		{
+			fn timestamp(&self) -> Timestamp {
+				*self.0.deref()
+			}
 
-	fn slot(&self) -> Slot {
-		*self.1.deref()
+			fn slot(&self) -> Slot {
+				*self.1.deref()
+			}
+		}
 	}
 }
 
-impl<T, S, P, R> InherentDataProviderExt for (T, S, P, R)
-where
-	T: Deref<Target = Timestamp>,
-	S: Deref<Target = Slot>,
-{
-	fn timestamp(&self) -> Timestamp {
-		*self.0.deref()
-	}
-
-	fn slot(&self) -> Slot {
-		*self.1.deref()
-	}
-}
-
-impl<T, S> InherentDataProviderExt for (T, S)
-where
-	T: Deref<Target = Timestamp>,
-	S: Deref<Target = Slot>,
-{
-	fn timestamp(&self) -> Timestamp {
-		*self.0.deref()
-	}
-
-	fn slot(&self) -> Slot {
-		*self.1.deref()
-	}
-}
+impl_inherent_data_provider_ext_tuple!(T, S,);
+impl_inherent_data_provider_ext_tuple!(T, S, A);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E, F);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E, F, G);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E, F, G, H);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E, F, G, H, I);
+impl_inherent_data_provider_ext_tuple!(T, S, A, B, C, D, E, F, G, H, I, J);
 
 /// Start a new slot worker.
 ///

--- a/client/consensus/slots/src/lib.rs
+++ b/client/consensus/slots/src/lib.rs
@@ -456,7 +456,7 @@ pub trait InherentDataProviderExt {
 
 /// Small macro for implementing `InherentDataProviderExt` for inherent data provider tuple.
 macro_rules! impl_inherent_data_provider_ext_tuple {
-	( T, S, $($TN:ident),* ) => {
+	( T, S $(, $TN:ident)* $( , )?) => {
 		impl<T, S, $( $TN ),*>  InherentDataProviderExt for (T, S, $($TN),*)
 		where
 			T: Deref<Target = Timestamp>,
@@ -473,7 +473,7 @@ macro_rules! impl_inherent_data_provider_ext_tuple {
 	}
 }
 
-impl_inherent_data_provider_ext_tuple!(T, S,);
+impl_inherent_data_provider_ext_tuple!(T, S);
 impl_inherent_data_provider_ext_tuple!(T, S, A);
 impl_inherent_data_provider_ext_tuple!(T, S, A, B);
 impl_inherent_data_provider_ext_tuple!(T, S, A, B, C);


### PR DESCRIPTION
Currently, the inherent data provider only supports up to 4 entries due to the limit of
`InherentDataProviderExt`. This patch simply implements `InherentDataProviderExt` for more tuples as a chain can certainly have more than 4 inherent data providers.