### PR TITLE
Remove incorrect debug assertion in state-db

### DIFF
--- a/client/state-db/src/noncanonical.rs
+++ b/client/state-db/src/noncanonical.rs
@@ -524,7 +524,8 @@ impl<BlockHash: Hash, Key: Hash> NonCanonicalOverlay<BlockHash, Key> {
 	/// Pin state values in memory
 	pub fn pin(&mut self, hash: &BlockHash) {
 		if self.pending_insertions.contains(hash) {
-			debug_assert!(false, "Trying to pin pending state");
+			// Pinning pending state is not implemented. Pending states
+			// won't be pruned for quite some time anyway, so it's not a big deal.
 			return;
 		}
 		let refs = self.pinned.entry(hash.clone()).or_default();


### PR DESCRIPTION
This removes an assertion that pending state can't be pinned. There's a race that allows for such states to be accessed indeed. Since in-memory changes to state-db are applied after the blockchain metadata changes. Pinning such states is a no-op anyway, since all pins are short-lived and by the time metadata changes are applied it is guaranteed that the state won't be reverted.
See https://github.com/paritytech/polkadot/issues/3414 for context.