### PR TITLE
Remove depracated storage_key rpc.

### DIFF
--- a/client/rpc-api/src/child_state/mod.rs
+++ b/client/rpc-api/src/child_state/mod.rs
@@ -34,16 +34,6 @@ pub trait ChildStateApi<Hash> {
 	/// RPC Metadata
 	type Metadata;
 
-	/// DEPRECATED: Please use `childstate_getKeysPaged` with proper paging support.
-	/// Returns the keys with prefix from a child storage, leave empty to get all the keys
-	#[rpc(name = "childstate_getKeys")]
-	fn storage_keys(
-		&self,
-		child_storage_key: PrefixedStorageKey,
-		prefix: StorageKey,
-		hash: Option<Hash>
-	) -> FutureResult<Vec<StorageKey>>;
-
 	/// Returns the keys with prefix from a child storage with pagination support.
 	/// Up to `count` keys will be returned.
 	/// If `start_key` is passed, return next keys in storage in lexicographic order.

--- a/client/rpc-api/src/state/mod.rs
+++ b/client/rpc-api/src/state/mod.rs
@@ -42,11 +42,6 @@ pub trait StateApi<Hash> {
 	#[rpc(name = "state_call", alias("state_callAt"))]
 	fn call(&self, name: String, bytes: Bytes, hash: Option<Hash>) -> FutureResult<Bytes>;
 
-	/// DEPRECATED: Please use `state_getKeysPaged` with proper paging support.
-	/// Returns the keys with prefix, leave empty to get all the keys.
-	#[rpc(name = "state_getKeys")]
-	fn storage_keys(&self, prefix: StorageKey, hash: Option<Hash>) -> FutureResult<Vec<StorageKey>>;
-
 	/// Returns the keys with prefix, leave empty to get all the keys
 	#[rpc(name = "state_getPairs")]
 	fn storage_pairs(&self, prefix: StorageKey, hash: Option<Hash>) -> FutureResult<Vec<(StorageKey, StorageData)>>;

--- a/client/rpc/src/state/mod.rs
+++ b/client/rpc/src/state/mod.rs
@@ -61,13 +61,6 @@ pub trait StateBackend<Block: BlockT, Client>: Send + Sync + 'static
 		call_data: Bytes,
 	) -> FutureResult<Bytes>;
 
-	/// Returns the keys with prefix, leave empty to get all the keys.
-	fn storage_keys(
-		&self,
-		block: Option<Block::Hash>,
-		prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>>;
-
 	/// Returns the keys with prefix along with their values, leave empty to get all the pairs.
 	fn storage_pairs(
 		&self,
@@ -253,14 +246,6 @@ impl<Block, Client> StateApi<Block::Hash> for State<Block, Client>
 		self.backend.call(block, method, data)
 	}
 
-	fn storage_keys(
-		&self,
-		key_prefix: StorageKey,
-		block: Option<Block::Hash>,
-	) -> FutureResult<Vec<StorageKey>> {
-		self.backend.storage_keys(block, key_prefix)
-	}
-
 	fn storage_pairs(
 		&self,
 		key_prefix: StorageKey,
@@ -393,15 +378,6 @@ pub trait ChildStateBackend<Block: BlockT, Client>: Send + Sync + 'static
 		keys: Vec<StorageKey>,
 	) -> FutureResult<ReadProof<Block::Hash>>;
 
-	/// Returns the keys with prefix from a child storage,
-	/// leave prefix empty to get all the keys.
-	fn storage_keys(
-		&self,
-		block: Option<Block::Hash>,
-		storage_key: PrefixedStorageKey,
-		prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>>;
-
 	/// Returns the keys with prefix from a child storage with pagination support.
 	fn storage_keys_paged(
 		&self,
@@ -468,15 +444,6 @@ impl<Block, Client> ChildStateApi<Block::Hash> for ChildState<Block, Client>
 		block: Option<Block::Hash>
 	) -> FutureResult<Option<StorageData>> {
 		self.backend.storage(block, storage_key, key)
-	}
-
-	fn storage_keys(
-		&self,
-		storage_key: PrefixedStorageKey,
-		key_prefix: StorageKey,
-		block: Option<Block::Hash>
-	) -> FutureResult<Vec<StorageKey>> {
-		self.backend.storage_keys(block, storage_key, key_prefix)
 	}
 
 	fn storage_keys_paged(

--- a/client/rpc/src/state/state_full.rs
+++ b/client/rpc/src/state/state_full.rs
@@ -260,17 +260,6 @@ impl<BE, Block, Client> StateBackend<Block, Client> for FullState<BE, Block, Cli
 		Box::new(result(r))
 	}
 
-	fn storage_keys(
-		&self,
-		block: Option<Block::Hash>,
-		prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>> {
-		Box::new(result(
-			self.block_or_best(block)
-				.and_then(|block| self.client.storage_keys(&BlockId::Hash(block), &prefix))
-				.map_err(client_err)))
-	}
-
 	fn storage_pairs(
 		&self,
 		block: Option<Block::Hash>,
@@ -594,28 +583,6 @@ impl<BE, Block, Client> ChildStateBackend<Block, Client> for FullState<BE, Block
 				})
 				.map_err(client_err),
 		))
-	}
-
-	fn storage_keys(
-		&self,
-		block: Option<Block::Hash>,
-		storage_key: PrefixedStorageKey,
-		prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>> {
-		Box::new(result(
-			self.block_or_best(block)
-				.and_then(|block| {
-					let child_info = match ChildType::from_prefixed_key(&storage_key) {
-						Some((ChildType::ParentKeyId, storage_key)) => ChildInfo::new_default(storage_key),
-						None => return Err(sp_blockchain::Error::InvalidChildStorageKey),
-					};
-					self.client.child_storage_keys(
-						&BlockId::Hash(block),
-						&child_info,
-						&prefix,
-					)
-				})
-				.map_err(client_err)))
 	}
 
 	fn storage_keys_paged(

--- a/client/rpc/src/state/state_light.rs
+++ b/client/rpc/src/state/state_light.rs
@@ -190,14 +190,6 @@ impl<Block, F, Client> StateBackend<Block, Client> for LightState<Block, F, Clie
 		).boxed().compat())
 	}
 
-	fn storage_keys(
-		&self,
-		_block: Option<Block::Hash>,
-		_prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>> {
-		Box::new(result(Err(client_err(ClientError::NotAvailableOnLightClient))))
-	}
-
 	fn storage_pairs(
 		&self,
 		_block: Option<Block::Hash>,
@@ -497,15 +489,6 @@ impl<Block, F, Client> ChildStateBackend<Block, Client> for LightState<Block, F,
 		_storage_key: PrefixedStorageKey,
 		_keys: Vec<StorageKey>,
 	) -> FutureResult<ReadProof<Block::Hash>> {
-		Box::new(result(Err(client_err(ClientError::NotAvailableOnLightClient))))
-	}
-
-	fn storage_keys(
-		&self,
-		_block: Option<Block::Hash>,
-		_storage_key: PrefixedStorageKey,
-		_prefix: StorageKey,
-	) -> FutureResult<Vec<StorageKey>> {
 		Box::new(result(Err(client_err(ClientError::NotAvailableOnLightClient))))
 	}
 


### PR DESCRIPTION
Key iteration rpc are deprecated (paged api should be use instead).

This PR remove the old rpcs: `childstate_getKeys` and `state_getKeys` in favor of their paged version.

Therefore this is a breaking PR that may require js client update.

There is really no hurry in merging this, just creating the PR so we won't forget to remove those rpc in next major release.

CC\ @jacogr 