### PR TITLE
Keep current block randomness in state

### DIFF
--- a/frame/babe/src/lib.rs
+++ b/frame/babe/src/lib.rs
@@ -256,9 +256,10 @@ pub mod pallet {
 	#[pallet::getter(fn initialized)]
 	pub(super) type Initialized<T> = StorageValue<_, MaybeRandomness>;
 
-	/// Temporary value (cleared at block finalization) that includes the VRF output generated
-	/// at this block. This field should always be populated during block processing unless
+	/// This field should always be populated during block processing unless
 	/// secondary plain slots are enabled (which don't contain a VRF output).
+	///
+	/// It is set in `on_initialize`, before it will contain the value from the last block.
 	#[pallet::storage]
 	#[pallet::getter(fn author_vrf_randomness)]
 	pub(super) type AuthorVrfRandomness<T> = StorageValue<_, MaybeRandomness, ValueQuery>;
@@ -336,9 +337,6 @@ pub mod pallet {
 			if let Some(Some(randomness)) = Initialized::<T>::take() {
 				Self::deposit_randomness(&randomness);
 			}
-
-			// The stored author generated VRF output is ephemeral.
-			AuthorVrfRandomness::<T>::kill();
 
 			// remove temporary "environment" entry from storage
 			Lateness::<T>::kill();

--- a/frame/babe/src/tests.rs
+++ b/frame/babe/src/tests.rs
@@ -95,7 +95,7 @@ fn first_block_epoch_zero_start() {
 		assert_eq!(SegmentIndex::<Test>::get(), 0);
 		assert_eq!(UnderConstruction::<Test>::get(0), vec![vrf_randomness]);
 		assert_eq!(Babe::randomness(), [0; 32]);
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
 		assert_eq!(NextRandomness::<Test>::get(), [0; 32]);
 
 		assert_eq!(header.digest.logs.len(), 2);
@@ -130,14 +130,13 @@ fn author_vrf_output_for_primary() {
 			&primary_pre_digest,
 			Default::default(),
 		);
-		assert_eq!(Babe::author_vrf_randomness(), None);
 
 		Babe::do_initialize(1);
 		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
 
 		Babe::on_finalize(1);
 		System::finalize();
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
 	})
 }
 
@@ -156,14 +155,13 @@ fn author_vrf_output_for_secondary_vrf() {
 			&secondary_vrf_pre_digest,
 			Default::default(),
 		);
-		assert_eq!(Babe::author_vrf_randomness(), None);
 
 		Babe::do_initialize(1);
 		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
 
 		Babe::on_finalize(1);
 		System::finalize();
-		assert_eq!(Babe::author_vrf_randomness(), None);
+		assert_eq!(Babe::author_vrf_randomness(), Some(vrf_randomness));
 	})
 }
 


### PR DESCRIPTION
Instead of killing it at the end of the block, it stays in the block for
inspection. This is required by parachains to get access to this
randomness of the relay chain.

Required for: https://github.com/paritytech/cumulus/issues/463