### PR TITLE
Reduce shared state cache contention

### DIFF
--- a/client/db/src/lib.rs
+++ b/client/db/src/lib.rs
@@ -1643,7 +1643,7 @@ impl<Block: BlockT> Backend<Block> {
 		self.changes_tries_storage.post_commit(changes_trie_cache_ops);
 
 		if let Some((enacted, retracted)) = cache_update {
-			self.shared_cache.lock().sync(&enacted, &retracted);
+			self.shared_cache.write().sync(&enacted, &retracted);
 		}
 
 		for m in meta_updates {
@@ -2052,7 +2052,7 @@ impl<Block: BlockT> sc_client_api::backend::Backend<Block> for Backend<Block> {
 		);
 		let database_cache = MemorySize::from_bytes(0);
 		let state_cache = MemorySize::from_bytes(
-			(*&self.shared_cache).lock().used_storage_cache_size(),
+			(*&self.shared_cache).read().used_storage_cache_size(),
 		);
 		let state_db = self.storage.state_db.memory_info();
 


### PR DESCRIPTION
Closes #9312
This only helps when most requests are cache misses. I.e. when requesting historical data.
Cache hits still require `write` access to a shared lock to update the LRU map. See #9320