### PR TITLE
Check for duplicate members in genesis of pallet-membership & pallet-collective 

### DIFF
--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -212,9 +212,9 @@ decl_storage! {
 		config(phantom): sp_std::marker::PhantomData<I>;
 		config(members): Vec<T::AccountId>;
 		build(|config| {
-			let has_dupes = (1..config.members.len())
-				.any(|i| config.members[i..].contains(&config.members[i - 1]));
-			assert!(!has_dupes, "Members cannot contain duplicate accounts.");
+			use sp_std::collections::btree_set::BTreeSet;
+			let members_set: BTreeSet<_> = config.members.iter().collect();
+			assert!(members_set.len() == config.members.len(), "Members cannot contain duplicate accounts.");
 
 			Module::<T, I>::initialize_members(&config.members)
 		});

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -212,7 +212,6 @@ decl_storage! {
 		config(phantom): sp_std::marker::PhantomData<I>;
 		config(members): Vec<T::AccountId>;
 		build(|config| {
-			// Make sure that members are unique.
 			let has_dupes = (1..config.members.len())
 				.any(|i| config.members[i..].contains(&config.members[i - 1]));
 			assert!(!has_dupes, "Members cannot contain duplicate accounts.");

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -211,7 +211,15 @@ decl_storage! {
 	add_extra_genesis {
 		config(phantom): sp_std::marker::PhantomData<I>;
 		config(members): Vec<T::AccountId>;
-		build(|config| Module::<T, I>::initialize_members(&config.members))
+		build(|config| {
+			// TODO: tests
+			// Make sure that members are unique.
+			let has_dupes = (1..config.members.len())
+				.any(|i| config.members[i..].contains(&config.members[i - 1]));
+			assert!(!has_dupes, "Members cannot contain duplicate accounts.");
+
+			Module::<T, I>::initialize_members(&config.members)
+		});
 	}
 }
 

--- a/frame/collective/src/lib.rs
+++ b/frame/collective/src/lib.rs
@@ -212,7 +212,6 @@ decl_storage! {
 		config(phantom): sp_std::marker::PhantomData<I>;
 		config(members): Vec<T::AccountId>;
 		build(|config| {
-			// TODO: tests
 			// Make sure that members are unique.
 			let has_dupes = (1..config.members.len())
 				.any(|i| config.members[i..].contains(&config.members[i - 1]));
@@ -1744,5 +1743,14 @@ mod tests {
 				record(Event::Collective(RawEvent::Disapproved(hash.clone()))),
 			]);
 		})
+	}
+
+	#[test]
+	#[should_panic(expected = "Members cannot contain duplicate accounts.")]
+	fn genesis_build_panics_with_duplicate_members() {
+		collective::GenesisConfig::<Test> {
+			members: vec![1, 2, 3, 1],
+			phantom: Default::default(),
+		}.build_storage().unwrap();
 	}
 }

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -85,9 +85,9 @@ decl_storage! {
 		build(|config: &Self| {
 			let mut members = config.members.clone();
 
-			let has_dupes = (1..members.len())
-				.any(|i| members[i..].contains(&members[i - 1]));
-			assert!(!has_dupes, "Members cannot contain duplicate accounts.");
+			use sp_std::collections::btree_set::BTreeSet;
+			let members_set: BTreeSet<_> = config.members.iter().collect();
+			assert!(members_set.len() == config.members.len(), "Members cannot contain duplicate accounts.");
 
 			members.sort();
 			T::MembershipInitialized::initialize_members(&members);

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -713,4 +713,13 @@ mod tests {
 			assert_eq!(PRIME.with(|m| *m.borrow()), Membership::prime());
 		});
 	}
+
+	#[test]
+	#[should_panic(expected = "Members cannot contain duplicate accounts.")]
+	fn genesis_build_panics_with_duplicate_members() {
+		pallet_membership::GenesisConfig::<Test> {
+			members: vec![1, 2, 3, 1],
+			phantom: Default::default(),
+		}.build_storage().unwrap();
+	}
 }

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -85,8 +85,6 @@ decl_storage! {
 		build(|config: &Self| {
 			let mut members = config.members.clone();
 
-			// TODO: tests
-			// Assert that members are unique.
 			let has_dupes = (1..members.len())
 				.any(|i| members[i..].contains(&members[i - 1]));
 			assert!(!has_dupes, "Members cannot contain duplicate accounts.");

--- a/frame/membership/src/lib.rs
+++ b/frame/membership/src/lib.rs
@@ -84,6 +84,13 @@ decl_storage! {
 		config(phantom): sp_std::marker::PhantomData<I>;
 		build(|config: &Self| {
 			let mut members = config.members.clone();
+
+			// TODO: tests
+			// Assert that members are unique.
+			let has_dupes = (1..members.len())
+				.any(|i| members[i..].contains(&members[i - 1]));
+			assert!(!has_dupes, "Members cannot contain duplicate accounts.");
+
 			members.sort();
 			T::MembershipInitialized::initialize_members(&members);
 			<Members<T, I>>::put(members);


### PR DESCRIPTION
closes #9268
This PR adds a check in the genesis build of pallet-membership and pallet-collective for duplicate members.
