### PR TITLE
change moonbeam to secp256k1

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -574,7 +574,7 @@
 			"displayName": "Moonbeam",
 			"symbols": ["GLMR"],
 			"decimals": [18],
-			"standardAccount": "*25519",
+			"standardAccount": "secp256k1",
 			"website": "https://moonbeam.network"
 		},
 		{
@@ -583,7 +583,7 @@
 			"displayName": "Moonriver",
 			"symbols": ["MOVR"],
 			"decimals": [18],
-			"standardAccount": "*25519",
+			"standardAccount": "secp256k1",
 			"website": "https://moonbeam.network"
 		},
 		{


### PR DESCRIPTION
Changes the `ss58-registry.json` so that moonbeam networks use secp256k1

closes https://github.com/paritytech/substrate/issues/9318